### PR TITLE
feat(funnelcake): log unrecognised list response shapes in _unwrapListResponse

### DIFF
--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -67,6 +67,24 @@ class FunnelcakeApiClient {
   /// Default moderation profile sent with video-bearing Funnelcake requests.
   static const String defaultModerationProfile = 'default';
 
+  static const Set<String> _diagnosticStructuralKeys = {
+    'categories',
+    'data',
+    'error',
+    'followers',
+    'following',
+    'hashtags',
+    'items',
+    'message',
+    'notifications',
+    'pagination',
+    'profiles',
+    'results',
+    'status',
+    'success',
+    'videos',
+  };
+
   /// Sink used to surface warning-level diagnostics from static helpers such
   /// as [_unwrapListResponse].
   ///
@@ -218,14 +236,23 @@ class FunnelcakeApiClient {
   /// response for diagnostic logging.
   ///
   /// Avoids dumping full response bodies (which may be large or contain user
-  /// data); reports the runtime type plus, for maps, the top-level keys.
+  /// data); reports the runtime type plus, for maps, key counts and a small
+  /// allow-list of structural keys. Unknown keys are counted rather than
+  /// emitted because malformed responses may carry user data in key position.
   static String _describeShape(Object? decoded) {
     if (decoded == null) {
       return 'null';
     }
     if (decoded is Map) {
-      final keys = decoded.keys.map((key) => '$key').toList()..sort();
-      return 'Map(keys: [${keys.join(', ')}])';
+      final keys = decoded.keys.map((key) => '$key').toSet();
+      final structuralKeys =
+          keys.where(_diagnosticStructuralKeys.contains).toList()..sort();
+      final unknownKeyCount = keys.length - structuralKeys.length;
+      return 'Map('
+          'keyCount: ${keys.length}, '
+          'structuralKeys: [${structuralKeys.join(', ')}], '
+          'unknownKeyCount: $unknownKeyCount'
+          ')';
     }
     return decoded.runtimeType.toString();
   }

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -3,7 +3,6 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:developer' as developer;
 
 import 'package:funnelcake_api_client/src/exceptions.dart';
 import 'package:funnelcake_api_client/src/leaderboard_period.dart';
@@ -12,6 +11,7 @@ import 'package:http/http.dart' as http;
 import 'package:meta/meta.dart';
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// Source split for the v2 popular feed.
 enum PopularVideosVariant {
@@ -70,15 +70,19 @@ class FunnelcakeApiClient {
   /// Sink used to surface warning-level diagnostics from static helpers such
   /// as [_unwrapListResponse].
   ///
-  /// Defaults to `dart:developer`'s `log()` (level 900 == warning), matching
-  /// the logging style of sibling pure-Dart packages like `nostr_sdk`. Tests
-  /// override this to assert that envelope regressions are surfaced rather
-  /// than silently swallowed; production code should leave it untouched.
+  /// Defaults to routing through `unified_logger`'s [Log.warning] (the
+  /// repo-wide logging contract). Tests override this to assert that envelope
+  /// regressions are surfaced rather than silently swallowed; production code
+  /// should leave it untouched.
   @visibleForTesting
   static void Function(String message) warningLogger = _defaultWarningLogger;
 
   static void _defaultWarningLogger(String message) {
-    developer.log(message, name: 'FunnelcakeApiClient', level: 900);
+    Log.warning(
+      message,
+      name: 'FunnelcakeApiClient',
+      category: LogCategory.api,
+    );
   }
 
   final String _baseUrl;

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:developer' as developer;
 
 import 'package:funnelcake_api_client/src/exceptions.dart';
 import 'package:funnelcake_api_client/src/leaderboard_period.dart';
@@ -65,6 +66,20 @@ class FunnelcakeApiClient {
 
   /// Default moderation profile sent with video-bearing Funnelcake requests.
   static const String defaultModerationProfile = 'default';
+
+  /// Sink used to surface warning-level diagnostics from static helpers such
+  /// as [_unwrapListResponse].
+  ///
+  /// Defaults to `dart:developer`'s `log()` (level 900 == warning), matching
+  /// the logging style of sibling pure-Dart packages like `nostr_sdk`. Tests
+  /// override this to assert that envelope regressions are surfaced rather
+  /// than silently swallowed; production code should leave it untouched.
+  @visibleForTesting
+  static void Function(String message) warningLogger = _defaultWarningLogger;
+
+  static void _defaultWarningLogger(String message) {
+    developer.log(message, name: 'FunnelcakeApiClient', level: 900);
+  }
 
   final String _baseUrl;
   final http.Client _httpClient;
@@ -186,8 +201,29 @@ class FunnelcakeApiClient {
         return (items: data, hasMore: hasMore, nextCursor: nextCursor);
       }
     }
-    // Unrecognised shape — return empty so callers never throw.
+    // Unrecognised shape — log so envelope regressions are visible, then
+    // return empty so callers never throw.
+    warningLogger(
+      'Unrecognised funnelcake list response shape; returning empty list. '
+      'shape=${_describeShape(decoded)}',
+    );
     return (items: const <dynamic>[], hasMore: false, nextCursor: null);
+  }
+
+  /// Builds a short, non-sensitive description of an unrecognised decoded
+  /// response for diagnostic logging.
+  ///
+  /// Avoids dumping full response bodies (which may be large or contain user
+  /// data); reports the runtime type plus, for maps, the top-level keys.
+  static String _describeShape(Object? decoded) {
+    if (decoded == null) {
+      return 'null';
+    }
+    if (decoded is Map) {
+      final keys = decoded.keys.map((key) => '$key').toList()..sort();
+      return 'Map(keys: [${keys.join(', ')}])';
+    }
+    return decoded.runtimeType.toString();
   }
 
   static int? _parseIntPageToken(String? value) {

--- a/mobile/packages/funnelcake_api_client/pubspec.yaml
+++ b/mobile/packages/funnelcake_api_client/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
     path: ../models
   nostr_sdk:
     path: ../nostr_sdk
+  unified_logger:
+    path: ../unified_logger
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -5101,13 +5101,16 @@ void main() {
             expect(videos, isEmpty);
 
             // Observability contract: the regression is surfaced exactly once
-            // with a non-sensitive shape description (keys, not the body).
+            // with a non-sensitive shape description (counts, not body/keys).
             expect(warnings, hasLength(1));
             expect(
               warnings.single,
               allOf(
                 contains('Unrecognised funnelcake list response shape'),
-                contains('Map(keys: [unexpected])'),
+                contains(
+                  'Map(keyCount: 1, structuralKeys: [], unknownKeyCount: 1)',
+                ),
+                isNot(contains('unexpected')),
               ),
             );
           },

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -5078,6 +5078,40 @@ void main() {
             expect(videos, isEmpty);
           },
         );
+
+        test(
+          'unrecognised shape logs a warning while staying non-throwing',
+          () async {
+            final originalLogger = FunnelcakeApiClient.warningLogger;
+            addTearDown(
+              () => FunnelcakeApiClient.warningLogger = originalLogger,
+            );
+
+            final warnings = <String>[];
+            FunnelcakeApiClient.warningLogger = warnings.add;
+
+            when(
+              () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+            ).thenAnswer(
+              (_) async => http.Response('{"unexpected": "shape"}', 200),
+            );
+
+            // Behavior contract: still returns empty, never throws.
+            final videos = await client.getTrendingVideos();
+            expect(videos, isEmpty);
+
+            // Observability contract: the regression is surfaced exactly once
+            // with a non-sensitive shape description (keys, not the body).
+            expect(warnings, hasLength(1));
+            expect(
+              warnings.single,
+              allOf(
+                contains('Unrecognised funnelcake list response shape'),
+                contains('Map(keys: [unexpected])'),
+              ),
+            );
+          },
+        );
       });
 
       group('searchVideos envelope shape', () {


### PR DESCRIPTION
## Description

`_unwrapListResponse()` previously returned an empty list for unrecognised response shapes without any signal. That kept callers from throwing, but it also made envelope regressions look like silent empty feeds.

This change adds a warning-level log on the unrecognised-shape branch while keeping the existing non-throwing, empty-list behavior:

- Logging goes through an injectable static `warningLogger` sink that defaults to `unified_logger`'s `Log.warning`, matching the repo-wide logging contract.
- The log message includes a short, non-sensitive shape description instead of the full response body. Map diagnostics report total key count, a small allow-list of known structural keys, and unknown-key count; arbitrary unknown keys are not emitted.
- The injectable sink (`@visibleForTesting`) lets tests deliberately pin the behavior change: unrecognised shapes still return empty without throwing and now emit exactly one warning describing the shape.

**Related Issue:** Closes #3543 (Relates to #3529, #3521)

## Out of Scope

None. This is the observability hardening called out as a follow-up to the compatibility fix in #3529.

## Verification

- `mise exec -- flutter analyze lib test` in `mobile/packages/funnelcake_api_client` - no issues found
- `mise exec -- flutter test --coverage` in `mobile/packages/funnelcake_api_client` - all 345 tests pass
- `mise exec -- flutter test` in `mobile/packages/categories_repository` - all 9 tests pass
- Pre-push hook analyzer and changed-file tests passed before pushing `177dd369d`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)