### PR TITLE
fix(deep-link): profile links use push/go/skip parity with video links

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -283,6 +283,54 @@ VideoDeepLinkNavAction resolveVideoDeepLinkNavAction({
   return VideoDeepLinkNavAction.push;
 }
 
+/// Describes the router action to take when navigating to a profile deep link.
+///
+/// Mirrors [VideoDeepLinkNavAction] so profile links get the same nav-stack
+/// parity video links already have: `push` keeps the previous route (e.g. home)
+/// underneath so back returns there, `go` replaces an existing profile route
+/// in-place, and `skip` dedupes a navigation to the route already shown.
+@visibleForTesting
+enum ProfileDeepLinkNavAction {
+  /// Navigate to the route, keeping the current route in the back stack.
+  push,
+
+  /// Replace the current route in-place (already on a profile route).
+  go,
+
+  /// The router is already on the target route with nothing new to do.
+  skip,
+}
+
+/// Determines which router action to take for a profile deep-link navigation
+/// given the current router location and the incoming target path.
+///
+/// Mirrors [resolveVideoDeepLinkNavAction]: extracted for testability — the
+/// caller executes the action; this function only decides what it should be.
+///
+/// Before this existed, the profile case always called `router.go()`, which
+/// replaces the entire navigation stack and stranded the user wherever they
+/// were (mid-settings, camera, DMs, …) with no back button to return.
+@visibleForTesting
+ProfileDeepLinkNavAction resolveProfileDeepLinkNavAction({
+  required String currentLocation,
+  required String targetPath,
+}) {
+  if (currentLocation == targetPath) {
+    // Already on the exact target route. Duplicate navigation with nothing new
+    // to do (e.g. GoRouter's universal-link redirect already navigated here, or
+    // getInitialLink + uriLinkStream both fire for the same URL). Safe to skip.
+    return ProfileDeepLinkNavAction.skip;
+  }
+  if (currentLocation.startsWith('${ProfileScreenRouter.path}/')) {
+    // A different profile is already showing — replace it in-place, matching
+    // the video-replaces-video behaviour.
+    return ProfileDeepLinkNavAction.go;
+  }
+  // Coming from a non-profile route — push so back returns to where the user
+  // was instead of obliterating the navigation stack.
+  return ProfileDeepLinkNavAction.push;
+}
+
 /// Resolves a push/local payload to a [NotificationTapTarget] and the event id
 /// to navigate to, via the shared [resolveNotificationTapTarget] contract.
 ///
@@ -1653,11 +1701,25 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
                 try {
-                  // GoRouter's universal-link redirect may have already
-                  // navigated here; skip the duplicate go() to avoid a
-                  // second navigation frame on the same target.
-                  if (currentLocation == targetPath) break;
-                  router.go(targetPath);
+                  final action = resolveProfileDeepLinkNavAction(
+                    currentLocation: currentLocation,
+                    targetPath: targetPath,
+                  );
+                  switch (action) {
+                    case ProfileDeepLinkNavAction.skip:
+                      // GoRouter's universal-link redirect may have already
+                      // navigated here; skip the duplicate navigation to avoid
+                      // a second navigation frame on the same target.
+                      break;
+                    case ProfileDeepLinkNavAction.go:
+                      // Another profile is already showing — replace it
+                      // in-place instead of stacking it.
+                      router.go(targetPath);
+                    case ProfileDeepLinkNavAction.push:
+                      // Keep the current route underneath so back returns to
+                      // wherever the user was instead of wiping the stack.
+                      router.push(targetPath);
+                  }
                   Log.info(
                     '✅ Navigation completed to: $targetPath',
                     name: 'DeepLinkHandler',

--- a/mobile/test/main_profile_deep_link_nav_action_test.dart
+++ b/mobile/test/main_profile_deep_link_nav_action_test.dart
@@ -1,0 +1,111 @@
+// ABOUTME: Regression tests for resolveProfileDeepLinkNavAction routing decision
+// ABOUTME: Verifies profile deep links push (keeping the stack), go (replacing
+// ABOUTME: an existing profile route), or skip (dedup) instead of always
+// ABOUTME: calling router.go() which obliterated the navigation stack.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/screens/profile_screen_router.dart';
+
+void main() {
+  const npub =
+      'npub1abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx';
+  final targetPath = ProfileScreenRouter.pathForNpub(npub);
+
+  group('resolveProfileDeepLinkNavAction', () {
+    group('same route (currentLocation == targetPath)', () {
+      test(
+        'returns skip when already on the profile — duplicate link event, '
+        'nothing new to do',
+        () {
+          final action = app.resolveProfileDeepLinkNavAction(
+            currentLocation: targetPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.ProfileDeepLinkNavAction.skip));
+        },
+      );
+
+      test(
+        'returns skip when already on the feed-mode profile route',
+        () {
+          final feedPath = ProfileScreenRouter.pathForIndex(npub, 2);
+          final action = app.resolveProfileDeepLinkNavAction(
+            currentLocation: feedPath,
+            targetPath: feedPath,
+          );
+          expect(action, equals(app.ProfileDeepLinkNavAction.skip));
+        },
+      );
+    });
+
+    group('a different profile is already showing (replacing in-place)', () {
+      test(
+        'returns go when another profile is currently visible',
+        () {
+          const otherNpub =
+              'npub1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
+          final otherPath = ProfileScreenRouter.pathForNpub(otherNpub);
+
+          final action = app.resolveProfileDeepLinkNavAction(
+            currentLocation: otherPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.ProfileDeepLinkNavAction.go));
+        },
+      );
+
+      test(
+        'returns go when moving from another profile feed route to a profile',
+        () {
+          const otherNpub =
+              'npub1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz';
+          final otherFeedPath = ProfileScreenRouter.pathForIndex(otherNpub, 1);
+
+          final action = app.resolveProfileDeepLinkNavAction(
+            currentLocation: otherFeedPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.ProfileDeepLinkNavAction.go));
+        },
+      );
+    });
+
+    group('coming from a non-profile route', () {
+      // Regression: a profile deep link from the home feed used to call
+      // router.go(), wiping the navigation stack and leaving no way back.
+      test(
+        'returns push from the home feed so back returns to the main screen',
+        () {
+          final action = app.resolveProfileDeepLinkNavAction(
+            currentLocation: '/home/0',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.ProfileDeepLinkNavAction.push));
+        },
+      );
+
+      test(
+        'returns push from a settings / mid-flow route so back returns there',
+        () {
+          final action = app.resolveProfileDeepLinkNavAction(
+            currentLocation: '/settings',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.ProfileDeepLinkNavAction.push));
+        },
+      );
+
+      test(
+        'returns push from a video route (cross-type navigation)',
+        () {
+          final action = app.resolveProfileDeepLinkNavAction(
+            currentLocation: '/video/abc123',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.ProfileDeepLinkNavAction.push));
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #4331

## Problem

When a profile deep link arrived (shared `https://divine.video/profile/npub1...` URL or a notification), the handler in `_DivineAppState.build()` always called `router.go(targetPath)`. `go()` replaces the entire navigation stack, so the user lost wherever they were (mid-settings flow, camera, DMs, etc.) with no back button to return.

Video deep links were already fixed to use `push()` (keeps home underneath) / `go()` (when already on a video route) / `skip` (dedup) via `resolveVideoDeepLinkNavAction()`. Profile links were never given the same treatment, leaving the two code paths inconsistent.

## Fix

Mirror `resolveVideoDeepLinkNavAction`: add `ProfileDeepLinkNavAction { push, go, skip }` and `resolveProfileDeepLinkNavAction(currentLocation, targetPath)`, then wire the `DeepLinkType.profile` case in `build()` to execute the resolved action.

Behaviour now matches the issue's expectations:
- On home feed → tap profile link → **push** `/profile/<npub>` (home stays underneath, back returns home).
- Already on `/profile/<npub>` → tap same link → **skip** (dedup, no double navigation — preserves the prior universal-link-redirect guard).
- On a different `/profile/<other-npub>` → tap a new profile link → **go** (replace in-place, same as video-replaces-video).

## Testing

- Added `mobile/test/main_profile_deep_link_nav_action_test.dart` covering all three branches, including the home-feed → push nav-stack regression and a cross-type (video → profile) push case.
- `flutter analyze` clean on changed files.
- New test (7 cases) + existing video nav-action test (7 cases) all pass.

## Notes

The three `skip: true` widget tests in `test/screens/profile_screen_router_test.dart` are full feed-provider widget tests unrelated to the nav-action decision and remain out of scope for this focused change; the nav-stack regression requested in the issue is covered by the new pure-function test instead.