### PR TITLE
refactor(hashtag): move hashtag REST fetch into VideosRepository (#948)

### DIFF
--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -10,7 +10,6 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/hashtag_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
@@ -90,107 +89,34 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
     setState(() => _subscriptionAttempted = true);
   }
 
-  /// Fetch videos from Funnelcake REST API and update state immediately.
-  /// Fetches trending AND classic videos in parallel, then interleaves 50/50.
+  /// Fetch the interleaved trending+classic hashtag feed from the
+  /// repository and update state immediately.
+  ///
+  /// The repository owns the REST fetch, the trending/classic interleave,
+  /// and the block/mute parse-gate, so blocked authors never reach
+  /// [_popularVideos] (#948).
   Future<void> _fetchFromFunnelcake() async {
-    try {
-      final client = ref.read(funnelcakeApiClientProvider);
+    final repository = ref.read(videosRepositoryProvider);
+    final interleaved = await repository.getHashtagFeedVideos(
+      hashtag: widget.hashtag,
+    );
 
-      // Quick check - skip if API not configured
-      if (!client.isAvailable) {
-        Log.debug(
-          '🏷️ HashtagFeedScreen: Funnelcake not configured, skipping',
-          category: LogCategory.video,
-        );
-        return;
-      }
+    if (!mounted) return;
 
-      // Fetch trending AND classic videos in parallel
-      final results = await Future.wait([
-        client.getVideosByHashtag(hashtag: widget.hashtag),
-        client.getClassicVideosByHashtag(hashtag: widget.hashtag),
-      ]).timeout(const Duration(seconds: 5));
-
-      if (!mounted) return;
-
-      final trendingStats = results[0];
-      final classicStats = results[1];
-      final trendingVideos = trendingStats.toVideoEvents();
-      final classicVideos = classicStats.toVideoEvents();
-
-      Log.info(
-        '🏷️ HashtagFeedScreen: Got ${trendingVideos.length} trending + '
-        '${classicVideos.length} classic videos from Funnelcake '
-        'for #${widget.hashtag}',
-        category: LogCategory.video,
-      );
-
-      // Interleave 50/50 for a balanced feed
-      final interleaved = _interleaveVideos(trendingVideos, classicVideos);
-
-      // Update immediately - don't wait for WebSocket
-      setState(() {
-        _popularVideos = interleaved;
-        // Mark as ready to show content if we have videos
-        if (interleaved.isNotEmpty) {
-          _subscriptionAttempted = true;
-        }
-      });
-    } catch (e) {
-      Log.debug(
-        '🏷️ HashtagFeedScreen: Funnelcake skipped (${e.runtimeType})',
-        category: LogCategory.video,
-      );
-    }
-  }
-
-  /// Interleave trending and classic videos 1:1 for a balanced feed.
-  /// Deduplicates first so a video appearing in both lists isn't shown twice.
-  /// If one list runs out, appends the remainder of the other.
-  List<VideoEvent> _interleaveVideos(
-    List<VideoEvent> trending,
-    List<VideoEvent> classics,
-  ) {
-    // Build set of trending IDs for deduplication
-    final trendingIds = <String>{};
-    for (final v in trending) {
-      if (v.id.isNotEmpty) trendingIds.add(v.id.toLowerCase());
-      if (v.vineId != null && v.vineId!.isNotEmpty) {
-        trendingIds.add(v.vineId!.toLowerCase());
-      }
-    }
-
-    // Remove classics that already appear in trending
-    final uniqueClassics = <VideoEvent>[];
-    for (final video in classics) {
-      final isDuplicate =
-          trendingIds.contains(video.id.toLowerCase()) ||
-          (video.vineId != null &&
-              trendingIds.contains(video.vineId!.toLowerCase()));
-      if (!isDuplicate) {
-        uniqueClassics.add(video);
-      }
-    }
-
-    Log.debug(
-      '🏷️ Interleaving: ${trending.length} trending + '
-      '${uniqueClassics.length} unique classics '
-      '(${classics.length - uniqueClassics.length} duplicates removed)',
+    Log.info(
+      '🏷️ HashtagFeedScreen: Got ${interleaved.length} interleaved videos '
+      'from Funnelcake for #${widget.hashtag}',
       category: LogCategory.video,
     );
 
-    // Interleave 1:1
-    final result = <VideoEvent>[];
-    final maxLen = trending.length > uniqueClassics.length
-        ? trending.length
-        : uniqueClassics.length;
-
-    for (var i = 0; i < maxLen; i++) {
-      if (i < trending.length) result.add(trending[i]);
-      if (i < uniqueClassics.length) result.add(uniqueClassics[i]);
-    }
-
-    return result;
+    // Update immediately - don't wait for WebSocket
+    setState(() {
+      _popularVideos = interleaved;
+      // Mark as ready to show content if we have videos
+      if (interleaved.isNotEmpty) {
+        _subscriptionAttempted = true;
+      }
+    });
   }
 
   /// Subscribe to hashtag via WebSocket for real-time updates.
@@ -211,12 +137,13 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
   }
 
   /// Removes videos whose author is blocked/muted (kind 30000 d=block /
-  /// kind 10000), or who has blocked/muted the current user. The Funnelcake
-  /// hashtag endpoint is called anonymously and applies no per-viewer block
-  /// or mute filtering, so the client is the only place these are enforced.
-  /// Applied at the assembly seam so it covers both the REST and WebSocket
-  /// sources, and re-runs on rebuild (see [blocklistVersionProvider] watch in
-  /// [build]) so unblocked authors reappear without a re-fetch. See #4782.
+  /// kind 10000), or who has blocked/muted the current user.
+  ///
+  /// The REST source is already parse-gated by the repository, so this
+  /// seam mainly covers the WebSocket source and hides a just-blocked
+  /// author immediately (the [blocklistVersionProvider] watch in [build]
+  /// re-runs it). Unblocked authors reappear via the version-triggered
+  /// REST refetch in [build]. See #4782, #948.
   List<VideoEvent> _filterBlockedAuthors(List<VideoEvent> videos) {
     if (videos.isEmpty) return videos;
     final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
@@ -291,6 +218,14 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // The repository parse-gates the REST results, so the cached
+    // _popularVideos never hold a blocked author — an unblock can only
+    // re-show their videos through a refetch. See #948.
+    ref.listen<int>(blocklistVersionProvider, (previous, next) {
+      if (previous == next || !mounted) return;
+      unawaited(_fetchFromFunnelcake());
+    });
+
     final body = Builder(
       builder: (context) {
         Log.debug(
@@ -300,7 +235,7 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
         final hashtagService = ref.watch(hashtagServiceProvider);
 
         // Rebuild when block/unblock/mute actions occur so blocked authors
-        // disappear (and unblocked authors reappear) immediately. See #4782.
+        // disappear immediately (via _filterBlockedAuthors). See #4782.
         ref.watch(blocklistVersionProvider);
 
         // Combine Funnelcake videos (fast, pre-sorted) with WebSocket videos

--- a/mobile/lib/screens/hashtag_feed_screen.dart
+++ b/mobile/lib/screens/hashtag_feed_screen.dart
@@ -97,12 +97,22 @@ class _HashtagFeedScreenState extends ConsumerState<HashtagFeedScreen> {
   /// [_popularVideos] (#948).
   Future<void> _fetchFromFunnelcake() async {
     final repository = ref.read(videosRepositoryProvider);
-    final interleaved = await repository.getHashtagFeedVideos(
+    final result = await repository.getHashtagFeedVideos(
       hashtag: widget.hashtag,
     );
 
     if (!mounted) return;
 
+    if (!result.succeeded && _popularVideos != null) {
+      Log.debug(
+        '🏷️ HashtagFeedScreen: preserving cached Funnelcake videos after '
+        'failed refresh for #${widget.hashtag}',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    final interleaved = result.videos;
     Log.info(
       '🏷️ HashtagFeedScreen: Got ${interleaved.length} interleaved videos '
       'from Funnelcake for #${widget.hashtag}',

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -66,6 +66,27 @@ const Duration _routeRelayTimeout = Duration(seconds: 3);
 const String _popularCacheKey = 'popular';
 const String _popularLegacyBeforeCursorPrefix = 'before:';
 
+/// Result of a hashtag REST feed fetch.
+class HashtagFeedVideosResult {
+  /// Creates a successful hashtag feed result.
+  const HashtagFeedVideosResult.success(this.videos) : succeeded = true;
+
+  /// Creates a failed or skipped hashtag feed result.
+  const HashtagFeedVideosResult.failure()
+    : videos = const [],
+      succeeded = false;
+
+  /// Videos returned by the REST feed in display order.
+  final List<VideoEvent> videos;
+
+  /// Whether the REST fetch completed successfully.
+  ///
+  /// A successful fetch may still contain an empty [videos] list. Callers use
+  /// this to distinguish a real empty feed from a transient failure, timeout,
+  /// or unavailable client.
+  final bool succeeded;
+}
+
 String _encodePopularLegacyBeforeCursor(int before) =>
     '$_popularLegacyBeforeCursorPrefix$before';
 
@@ -1715,34 +1736,28 @@ class VideosRepository {
   /// content preferences. The endpoint is anonymous, so the injected
   /// block filter is the only block/mute enforcement on this path (#948).
   ///
-  /// Returns an empty list when [hashtag] is blank, the API client is
+  /// Returns a failed result when [hashtag] is blank, the API client is
   /// unavailable, or the fetch fails or exceeds [timeout] — the REST feed
-  /// is a fast-path enrichment; callers keep their relay source.
-  Future<List<VideoEvent>> getHashtagFeedVideos({
+  /// is a fast-path enrichment; callers keep their relay source/cache.
+  Future<HashtagFeedVideosResult> getHashtagFeedVideos({
     required String hashtag,
     Duration timeout = const Duration(seconds: 5),
   }) async {
     final trimmed = hashtag.trim();
-    if (trimmed.isEmpty) return [];
+    if (trimmed.isEmpty) return const HashtagFeedVideosResult.failure();
     if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
-      return [];
+      return const HashtagFeedVideosResult.failure();
     }
 
     try {
       final results = await Future.wait([
-        _funnelcakeApiClient.getVideosByHashtag(hashtag: trimmed),
-        _funnelcakeApiClient.getClassicVideosByHashtag(hashtag: trimmed),
+        getVideosByHashtag(hashtag: trimmed, limit: 50),
+        getClassicVideosByHashtag(hashtag: trimmed, limit: 50),
       ]).timeout(timeout);
 
-      final trending = _transformVideoStats(
-        results[0],
-        sortByCreatedAt: false,
+      return HashtagFeedVideosResult.success(
+        _interleaveHashtagVideos(results[0], results[1]),
       );
-      final classics = _transformVideoStats(
-        results[1],
-        sortByCreatedAt: false,
-      );
-      return _interleaveHashtagVideos(trending, classics);
     } on Exception catch (e, stackTrace) {
       Log.error(
         'getHashtagFeedVideos failed for "#$trimmed"',
@@ -1751,7 +1766,7 @@ class VideosRepository {
         error: e,
         stackTrace: stackTrace,
       );
-      return [];
+      return const HashtagFeedVideosResult.failure();
     }
   }
 

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -1705,6 +1705,90 @@ class VideosRepository {
     }
   }
 
+  /// Fetches the hashtag feed from the Funnelcake REST API.
+  ///
+  /// Fetches trending and classic videos for [hashtag] in parallel and
+  /// interleaves them 1:1 (trending first), deduplicating classics that
+  /// also appear in trending (by event ID or vine ID, case-insensitive).
+  /// Both lists pass through the same filtering pipeline as
+  /// [_transformVideoStats] — block filter, transport scheme, expiration,
+  /// content preferences. The endpoint is anonymous, so the injected
+  /// block filter is the only block/mute enforcement on this path (#948).
+  ///
+  /// Returns an empty list when [hashtag] is blank, the API client is
+  /// unavailable, or the fetch fails or exceeds [timeout] — the REST feed
+  /// is a fast-path enrichment; callers keep their relay source.
+  Future<List<VideoEvent>> getHashtagFeedVideos({
+    required String hashtag,
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    final trimmed = hashtag.trim();
+    if (trimmed.isEmpty) return [];
+    if (_funnelcakeApiClient == null || !_funnelcakeApiClient.isAvailable) {
+      return [];
+    }
+
+    try {
+      final results = await Future.wait([
+        _funnelcakeApiClient.getVideosByHashtag(hashtag: trimmed),
+        _funnelcakeApiClient.getClassicVideosByHashtag(hashtag: trimmed),
+      ]).timeout(timeout);
+
+      final trending = _transformVideoStats(
+        results[0],
+        sortByCreatedAt: false,
+      );
+      final classics = _transformVideoStats(
+        results[1],
+        sortByCreatedAt: false,
+      );
+      return _interleaveHashtagVideos(trending, classics);
+    } on Exception catch (e, stackTrace) {
+      Log.error(
+        'getHashtagFeedVideos failed for "#$trimmed"',
+        name: 'VideosRepository',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return [];
+    }
+  }
+
+  /// Interleaves trending and classic hashtag videos 1:1 for a balanced
+  /// feed. Classics that already appear in trending (by event ID or vine
+  /// ID, case-insensitive) are dropped; when one list runs out, the
+  /// remainder of the other is appended.
+  List<VideoEvent> _interleaveHashtagVideos(
+    List<VideoEvent> trending,
+    List<VideoEvent> classics,
+  ) {
+    final trendingIds = <String>{};
+    for (final video in trending) {
+      if (video.id.isNotEmpty) trendingIds.add(video.id.toLowerCase());
+      final vineId = video.vineId;
+      if (vineId != null && vineId.isNotEmpty) {
+        trendingIds.add(vineId.toLowerCase());
+      }
+    }
+
+    final uniqueClassics = classics.where((video) {
+      final vineId = video.vineId;
+      return !trendingIds.contains(video.id.toLowerCase()) &&
+          (vineId == null || !trendingIds.contains(vineId.toLowerCase()));
+    }).toList();
+
+    final result = <VideoEvent>[];
+    final maxLen = trending.length > uniqueClassics.length
+        ? trending.length
+        : uniqueClassics.length;
+    for (var i = 0; i < maxLen; i++) {
+      if (i < trending.length) result.add(trending[i]);
+      if (i < uniqueClassics.length) result.add(uniqueClassics[i]);
+    }
+    return result;
+  }
+
   /// Deduplicates videos by ID and sorts by popularity (loops then time).
   ///
   /// Use this to combine results from [searchVideosLocally] and

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -7427,6 +7427,161 @@ void main() {
       });
     });
 
+    group('getHashtagFeedVideos', () {
+      test('returns empty list when hashtag is blank', () async {
+        expect(await repository.getHashtagFeedVideos(hashtag: '  '), isEmpty);
+      });
+
+      test('returns empty list when funnelcakeApiClient is null', () async {
+        expect(await repository.getHashtagFeedVideos(hashtag: 'bts'), isEmpty);
+      });
+
+      test('returns empty list when the API is unavailable', () async {
+        final mockFunnelcake = MockFunnelcakeApiClient();
+        when(() => mockFunnelcake.isAvailable).thenReturn(false);
+
+        final repoWithApi = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcake,
+        );
+
+        expect(
+          await repoWithApi.getHashtagFeedVideos(hashtag: 'bts'),
+          isEmpty,
+        );
+      });
+
+      test(
+        'interleaves trending and classic 1:1, deduplicating classics',
+        () async {
+          final mockFunnelcake = MockFunnelcakeApiClient();
+          when(() => mockFunnelcake.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcake.getVideosByHashtag(hashtag: 'bts'),
+          ).thenAnswer(
+            (_) async => [
+              _createVideoStats(
+                id: 'trend-1',
+                pubkey: 'pubkey-1',
+                dTag: 'dtag-t1',
+                videoUrl: 'https://example.com/t1.mp4',
+              ),
+              _createVideoStats(
+                id: 'trend-2',
+                pubkey: 'pubkey-2',
+                dTag: 'dtag-t2',
+                videoUrl: 'https://example.com/t2.mp4',
+              ),
+            ],
+          );
+          when(
+            () => mockFunnelcake.getClassicVideosByHashtag(hashtag: 'bts'),
+          ).thenAnswer(
+            (_) async => [
+              // Duplicate of trend-1 — must be dropped.
+              _createVideoStats(
+                id: 'trend-1',
+                pubkey: 'pubkey-1',
+                dTag: 'dtag-t1',
+                videoUrl: 'https://example.com/t1.mp4',
+              ),
+              _createVideoStats(
+                id: 'classic-1',
+                pubkey: 'pubkey-3',
+                dTag: 'dtag-c1',
+                videoUrl: 'https://example.com/c1.mp4',
+              ),
+            ],
+          );
+
+          final repoWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcake,
+          );
+
+          final result = await repoWithApi.getHashtagFeedVideos(hashtag: 'bts');
+
+          expect(result.map((v) => v.id), [
+            'trend-1',
+            'classic-1',
+            'trend-2',
+          ]);
+        },
+      );
+
+      test(
+        'applies block filter to both trending and classic results',
+        () async {
+          final mockFunnelcake = MockFunnelcakeApiClient();
+          when(() => mockFunnelcake.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcake.getVideosByHashtag(hashtag: 'bts'),
+          ).thenAnswer(
+            (_) async => [
+              _createVideoStats(
+                id: 'trend-blocked',
+                pubkey: 'blocked-pubkey',
+                dTag: 'dtag-tb',
+                videoUrl: 'https://example.com/tb.mp4',
+              ),
+              _createVideoStats(
+                id: 'trend-ok',
+                pubkey: 'allowed-pubkey',
+                dTag: 'dtag-to',
+                videoUrl: 'https://example.com/to.mp4',
+              ),
+            ],
+          );
+          when(
+            () => mockFunnelcake.getClassicVideosByHashtag(hashtag: 'bts'),
+          ).thenAnswer(
+            (_) async => [
+              _createVideoStats(
+                id: 'classic-blocked',
+                pubkey: 'blocked-pubkey',
+                dTag: 'dtag-cb',
+                videoUrl: 'https://example.com/cb.mp4',
+              ),
+            ],
+          );
+
+          final blockFilter = TestContentFilter(
+            blockedPubkeys: {'blocked-pubkey'},
+          );
+          final repoWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcake,
+            blockFilter: blockFilter.call,
+          );
+
+          final result = await repoWithApi.getHashtagFeedVideos(hashtag: 'bts');
+
+          expect(result.map((v) => v.id), ['trend-ok']);
+        },
+      );
+
+      test('returns empty list when the API throws', () async {
+        final mockFunnelcake = MockFunnelcakeApiClient();
+        when(() => mockFunnelcake.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcake.getVideosByHashtag(hashtag: 'bts'),
+        ).thenThrow(const FunnelcakeException('boom'));
+        when(
+          () => mockFunnelcake.getClassicVideosByHashtag(hashtag: 'bts'),
+        ).thenAnswer((_) async => []);
+
+        final repoWithApi = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcake,
+        );
+
+        expect(
+          await repoWithApi.getHashtagFeedVideos(hashtag: 'bts'),
+          isEmpty,
+        );
+      });
+    });
+
     group('searchVideos', () {
       test('emits nothing for empty query', () async {
         final stream = repository.searchVideos(query: '');

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -7429,11 +7429,17 @@ void main() {
 
     group('getHashtagFeedVideos', () {
       test('returns empty list when hashtag is blank', () async {
-        expect(await repository.getHashtagFeedVideos(hashtag: '  '), isEmpty);
+        final result = await repository.getHashtagFeedVideos(hashtag: '  ');
+
+        expect(result.succeeded, isFalse);
+        expect(result.videos, isEmpty);
       });
 
       test('returns empty list when funnelcakeApiClient is null', () async {
-        expect(await repository.getHashtagFeedVideos(hashtag: 'bts'), isEmpty);
+        final result = await repository.getHashtagFeedVideos(hashtag: 'bts');
+
+        expect(result.succeeded, isFalse);
+        expect(result.videos, isEmpty);
       });
 
       test('returns empty list when the API is unavailable', () async {
@@ -7445,10 +7451,10 @@ void main() {
           funnelcakeApiClient: mockFunnelcake,
         );
 
-        expect(
-          await repoWithApi.getHashtagFeedVideos(hashtag: 'bts'),
-          isEmpty,
-        );
+        final result = await repoWithApi.getHashtagFeedVideos(hashtag: 'bts');
+
+        expect(result.succeeded, isFalse);
+        expect(result.videos, isEmpty);
       });
 
       test(
@@ -7457,7 +7463,10 @@ void main() {
           final mockFunnelcake = MockFunnelcakeApiClient();
           when(() => mockFunnelcake.isAvailable).thenReturn(true);
           when(
-            () => mockFunnelcake.getVideosByHashtag(hashtag: 'bts'),
+            () => mockFunnelcake.getVideosByHashtag(
+              hashtag: 'bts',
+              limit: any(named: 'limit'),
+            ),
           ).thenAnswer(
             (_) async => [
               _createVideoStats(
@@ -7475,7 +7484,10 @@ void main() {
             ],
           );
           when(
-            () => mockFunnelcake.getClassicVideosByHashtag(hashtag: 'bts'),
+            () => mockFunnelcake.getClassicVideosByHashtag(
+              hashtag: 'bts',
+              limit: any(named: 'limit'),
+            ),
           ).thenAnswer(
             (_) async => [
               // Duplicate of trend-1 — must be dropped.
@@ -7501,11 +7513,32 @@ void main() {
 
           final result = await repoWithApi.getHashtagFeedVideos(hashtag: 'bts');
 
-          expect(result.map((v) => v.id), [
+          expect(result.succeeded, isTrue);
+          expect(result.videos.map((v) => v.id), [
             'trend-1',
             'classic-1',
             'trend-2',
           ]);
+          expect(
+            verify(
+                  () => mockFunnelcake.getVideosByHashtag(
+                    hashtag: 'bts',
+                    limit: captureAny(named: 'limit'),
+                  ),
+                ).captured.single
+                as int,
+            50,
+          );
+          expect(
+            verify(
+                  () => mockFunnelcake.getClassicVideosByHashtag(
+                    hashtag: 'bts',
+                    limit: captureAny(named: 'limit'),
+                  ),
+                ).captured.single
+                as int,
+            50,
+          );
         },
       );
 
@@ -7513,7 +7546,10 @@ void main() {
         final mockFunnelcake = MockFunnelcakeApiClient();
         when(() => mockFunnelcake.isAvailable).thenReturn(true);
         when(
-          () => mockFunnelcake.getVideosByHashtag(hashtag: 'bts'),
+          () => mockFunnelcake.getVideosByHashtag(
+            hashtag: 'bts',
+            limit: any(named: 'limit'),
+          ),
         ).thenAnswer(
           (_) async => [
             _createVideoStats(
@@ -7525,7 +7561,10 @@ void main() {
           ],
         );
         when(
-          () => mockFunnelcake.getClassicVideosByHashtag(hashtag: 'bts'),
+          () => mockFunnelcake.getClassicVideosByHashtag(
+            hashtag: 'bts',
+            limit: any(named: 'limit'),
+          ),
         ).thenAnswer(
           (_) async => [
             _createVideoStats(
@@ -7550,7 +7589,12 @@ void main() {
 
         final result = await repoWithApi.getHashtagFeedVideos(hashtag: 'bts');
 
-        expect(result.map((v) => v.id), ['trend-1', 'classic-1', 'classic-2']);
+        expect(result.succeeded, isTrue);
+        expect(result.videos.map((v) => v.id), [
+          'trend-1',
+          'classic-1',
+          'classic-2',
+        ]);
       });
 
       test(
@@ -7559,7 +7603,10 @@ void main() {
           final mockFunnelcake = MockFunnelcakeApiClient();
           when(() => mockFunnelcake.isAvailable).thenReturn(true);
           when(
-            () => mockFunnelcake.getVideosByHashtag(hashtag: 'bts'),
+            () => mockFunnelcake.getVideosByHashtag(
+              hashtag: 'bts',
+              limit: any(named: 'limit'),
+            ),
           ).thenAnswer(
             (_) async => [
               _createVideoStats(
@@ -7577,7 +7624,10 @@ void main() {
             ],
           );
           when(
-            () => mockFunnelcake.getClassicVideosByHashtag(hashtag: 'bts'),
+            () => mockFunnelcake.getClassicVideosByHashtag(
+              hashtag: 'bts',
+              limit: any(named: 'limit'),
+            ),
           ).thenAnswer(
             (_) async => [
               _createVideoStats(
@@ -7600,7 +7650,8 @@ void main() {
 
           final result = await repoWithApi.getHashtagFeedVideos(hashtag: 'bts');
 
-          expect(result.map((v) => v.id), ['trend-ok']);
+          expect(result.succeeded, isTrue);
+          expect(result.videos.map((v) => v.id), ['trend-ok']);
         },
       );
 
@@ -7608,10 +7659,16 @@ void main() {
         final mockFunnelcake = MockFunnelcakeApiClient();
         when(() => mockFunnelcake.isAvailable).thenReturn(true);
         when(
-          () => mockFunnelcake.getVideosByHashtag(hashtag: 'bts'),
+          () => mockFunnelcake.getVideosByHashtag(
+            hashtag: 'bts',
+            limit: any(named: 'limit'),
+          ),
         ).thenThrow(const FunnelcakeException('boom'));
         when(
-          () => mockFunnelcake.getClassicVideosByHashtag(hashtag: 'bts'),
+          () => mockFunnelcake.getClassicVideosByHashtag(
+            hashtag: 'bts',
+            limit: any(named: 'limit'),
+          ),
         ).thenAnswer((_) async => []);
 
         final repoWithApi = VideosRepository(
@@ -7619,10 +7676,10 @@ void main() {
           funnelcakeApiClient: mockFunnelcake,
         );
 
-        expect(
-          await repoWithApi.getHashtagFeedVideos(hashtag: 'bts'),
-          isEmpty,
-        );
+        final result = await repoWithApi.getHashtagFeedVideos(hashtag: 'bts');
+
+        expect(result.succeeded, isFalse);
+        expect(result.videos, isEmpty);
       });
     });
 

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -7509,6 +7509,50 @@ void main() {
         },
       );
 
+      test('appends remaining classics when they outnumber trending', () async {
+        final mockFunnelcake = MockFunnelcakeApiClient();
+        when(() => mockFunnelcake.isAvailable).thenReturn(true);
+        when(
+          () => mockFunnelcake.getVideosByHashtag(hashtag: 'bts'),
+        ).thenAnswer(
+          (_) async => [
+            _createVideoStats(
+              id: 'trend-1',
+              pubkey: 'pubkey-1',
+              dTag: 'dtag-t1',
+              videoUrl: 'https://example.com/t1.mp4',
+            ),
+          ],
+        );
+        when(
+          () => mockFunnelcake.getClassicVideosByHashtag(hashtag: 'bts'),
+        ).thenAnswer(
+          (_) async => [
+            _createVideoStats(
+              id: 'classic-1',
+              pubkey: 'pubkey-2',
+              dTag: 'dtag-c1',
+              videoUrl: 'https://example.com/c1.mp4',
+            ),
+            _createVideoStats(
+              id: 'classic-2',
+              pubkey: 'pubkey-3',
+              dTag: 'dtag-c2',
+              videoUrl: 'https://example.com/c2.mp4',
+            ),
+          ],
+        );
+
+        final repoWithApi = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcake,
+        );
+
+        final result = await repoWithApi.getHashtagFeedVideos(hashtag: 'bts');
+
+        expect(result.map((v) => v.id), ['trend-1', 'classic-1', 'classic-2']);
+      });
+
       test(
         'applies block filter to both trending and classic results',
         () async {

--- a/mobile/test/screens/hashtag_feed_blocklist_filter_test.dart
+++ b/mobile/test/screens/hashtag_feed_blocklist_filter_test.dart
@@ -1,41 +1,37 @@
-// ABOUTME: Verifies the hashtag feed filters blocked/muted authors out of the
-// ABOUTME: anonymous Funnelcake REST path (no server-side block filter). See #4782.
+// ABOUTME: Verifies the hashtag feed hides blocked/muted authors at the
+// ABOUTME: assembly seam and refetches REST results on blocklist changes.
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/screens/hashtag_feed_screen.dart';
 import 'package:openvine/services/hashtag_service.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
+import 'package:videos_repository/videos_repository.dart';
 
-class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 class _MockHashtagService extends Mock implements HashtagService {}
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
 
-VideoStats _stat(String id, String pubkey) {
-  return VideoStats(
+VideoEvent _video(String id, String pubkey) {
+  final created = DateTime(2026, 3, 30, 12);
+  return VideoEvent(
     id: id,
     pubkey: pubkey,
-    createdAt: DateTime(2026, 3, 30, 12),
-    kind: 22,
-    dTag: id,
+    content: '',
     title: 'Video $id',
-    thumbnail: 'https://example.com/$id.jpg',
     videoUrl: 'https://example.com/$id.mp4',
-    reactions: 0,
-    comments: 0,
-    reposts: 0,
-    engagementScore: 0,
+    thumbnailUrl: 'https://example.com/$id.jpg',
+    createdAt: created.millisecondsSinceEpoch ~/ 1000,
+    timestamp: created,
   );
 }
 
@@ -43,33 +39,27 @@ void main() {
   const blockedPubkey =
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
-  late _MockFunnelcakeApiClient mockFunnelcake;
+  late _MockVideosRepository mockVideosRepository;
   late _MockHashtagService mockHashtagService;
   late _MockContentBlocklistRepository mockBlocklist;
 
   setUp(() {
-    mockFunnelcake = _MockFunnelcakeApiClient();
+    mockVideosRepository = _MockVideosRepository();
     mockHashtagService = _MockHashtagService();
     mockBlocklist = _MockContentBlocklistRepository();
-
-    when(() => mockFunnelcake.isAvailable).thenReturn(true);
-    when(
-      () => mockFunnelcake.getClassicVideosByHashtag(
-        hashtag: any(named: 'hashtag'),
-      ),
-    ).thenAnswer((_) async => <VideoStats>[]);
 
     when(() => mockHashtagService.getVideosByHashtags(any())).thenReturn([]);
     when(() => mockHashtagService.getHashtagStats(any())).thenReturn(null);
     when(
       () => mockHashtagService.subscribeToHashtagVideos(any()),
     ).thenAnswer((_) async {});
+    when(() => mockBlocklist.shouldFilterFromFeeds(any())).thenReturn(false);
   });
 
   Widget buildSubject(String hashtag) {
     return ProviderScope(
       overrides: [
-        funnelcakeApiClientProvider.overrideWithValue(mockFunnelcake),
+        videosRepositoryProvider.overrideWithValue(mockVideosRepository),
         hashtagServiceProvider.overrideWith((ref) => mockHashtagService),
         contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
       ],
@@ -82,13 +72,16 @@ void main() {
   }
 
   testWidgets(
-    "removes a blocked author's video from the hashtag REST feed (#4782)",
+    "the assembly seam removes a blocked author's video even when a source "
+    'bypasses the repository parse-gate (#4782)',
     (tester) async {
-      // REST returns only a blocked author's video; after filtering the feed
-      // must be empty (no grid), proving the REST path consults the blocklist.
+      // Simulate a source that did NOT filter (e.g. the WebSocket path):
+      // the seam filter must still consult the blocklist before rendering.
       when(
-        () => mockFunnelcake.getVideosByHashtag(hashtag: any(named: 'hashtag')),
-      ).thenAnswer((_) async => [_stat('blocked-vid', blockedPubkey)]);
+        () => mockVideosRepository.getHashtagFeedVideos(
+          hashtag: any(named: 'hashtag'),
+        ),
+      ).thenAnswer((_) async => [_video('blocked-vid', blockedPubkey)]);
       when(
         () => mockBlocklist.shouldFilterFromFeeds(blockedPubkey),
       ).thenReturn(true);
@@ -108,6 +101,38 @@ void main() {
       );
       // Mutation note: if the filter were deleted or inverted, the blocked
       // video would render the grid above and this assertion would fail.
+    },
+  );
+
+  testWidgets(
+    'refetches the REST feed when the blocklist changes, so an unblock '
+    're-shows content the parse-gate had dropped (#948)',
+    (tester) async {
+      when(
+        () => mockVideosRepository.getHashtagFeedVideos(
+          hashtag: any(named: 'hashtag'),
+        ),
+      ).thenAnswer((_) async => <VideoEvent>[]);
+
+      await tester.pumpWidget(buildSubject('bts'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      verify(
+        () => mockVideosRepository.getHashtagFeedVideos(hashtag: 'bts'),
+      ).called(1);
+
+      // A block/unblock anywhere in the app bumps the blocklist version.
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(HashtagFeedScreen)),
+      );
+      container.read(blocklistVersionProvider.notifier).increment();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      verify(
+        () => mockVideosRepository.getHashtagFeedVideos(hashtag: 'bts'),
+      ).called(1);
     },
   );
 }

--- a/mobile/test/screens/hashtag_feed_blocklist_filter_test.dart
+++ b/mobile/test/screens/hashtag_feed_blocklist_filter_test.dart
@@ -62,6 +62,7 @@ void main() {
         videosRepositoryProvider.overrideWithValue(mockVideosRepository),
         hashtagServiceProvider.overrideWith((ref) => mockHashtagService),
         contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
+        subscribedListVideoCacheProvider.overrideWithValue(null),
       ],
       child: MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -81,7 +82,11 @@ void main() {
         () => mockVideosRepository.getHashtagFeedVideos(
           hashtag: any(named: 'hashtag'),
         ),
-      ).thenAnswer((_) async => [_video('blocked-vid', blockedPubkey)]);
+      ).thenAnswer(
+        (_) async => HashtagFeedVideosResult.success([
+          _video('blocked-vid', blockedPubkey),
+        ]),
+      );
       when(
         () => mockBlocklist.shouldFilterFromFeeds(blockedPubkey),
       ).thenReturn(true);
@@ -112,7 +117,9 @@ void main() {
         () => mockVideosRepository.getHashtagFeedVideos(
           hashtag: any(named: 'hashtag'),
         ),
-      ).thenAnswer((_) async => <VideoEvent>[]);
+      ).thenAnswer(
+        (_) async => const HashtagFeedVideosResult.success(<VideoEvent>[]),
+      );
 
       await tester.pumpWidget(buildSubject('bts'));
       await tester.pump();
@@ -133,6 +140,50 @@ void main() {
       verify(
         () => mockVideosRepository.getHashtagFeedVideos(hashtag: 'bts'),
       ).called(1);
+    },
+  );
+
+  testWidgets(
+    'preserves an existing REST cache when a blocklist-triggered refetch '
+    'fails',
+    (tester) async {
+      final cachedVideo = _video('cached-vid', 'allowed-pubkey');
+      var callCount = 0;
+      when(
+        () => mockVideosRepository.getHashtagFeedVideos(
+          hashtag: any(named: 'hashtag'),
+        ),
+      ).thenAnswer((_) async {
+        callCount += 1;
+        if (callCount == 1) {
+          return HashtagFeedVideosResult.success([cachedVideo]);
+        }
+        return const HashtagFeedVideosResult.failure();
+      });
+
+      await tester.pumpWidget(buildSubject('bts'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+
+      expect(find.byType(ComposableVideoGrid), findsOneWidget);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(HashtagFeedScreen)),
+      );
+      container.read(blocklistVersionProvider.notifier).increment();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump();
+
+      expect(
+        find.byType(ComposableVideoGrid),
+        findsOneWidget,
+        reason: 'A failed background refetch must not blank a populated feed',
+      );
+      verify(
+        () => mockVideosRepository.getHashtagFeedVideos(hashtag: 'bts'),
+      ).called(2);
     },
   );
 }

--- a/mobile/test/screens/hashtag_feed_startup_contract_test.dart
+++ b/mobile/test/screens/hashtag_feed_startup_contract_test.dart
@@ -3,18 +3,17 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/screens/hashtag_feed_screen.dart';
 import 'package:openvine/services/hashtag_service.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 class _MockHashtagService extends Mock implements HashtagService {}
 
-class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+class _MockVideosRepository extends Mock implements VideosRepository {}
 
 void main() {
   setUpAll(() {
@@ -23,11 +22,11 @@ void main() {
 
   group('HashtagFeedScreen startup contract', () {
     late _MockHashtagService mockHashtagService;
-    late _MockFunnelcakeApiClient mockFunnelcakeApiClient;
+    late _MockVideosRepository mockVideosRepository;
 
     setUp(() {
       mockHashtagService = _MockHashtagService();
-      mockFunnelcakeApiClient = _MockFunnelcakeApiClient();
+      mockVideosRepository = _MockVideosRepository();
 
       when(() => mockHashtagService.getVideosByHashtags(any())).thenReturn([]);
     });
@@ -36,9 +35,7 @@ void main() {
       return ProviderScope(
         overrides: [
           hashtagServiceProvider.overrideWith((ref) => mockHashtagService),
-          funnelcakeApiClientProvider.overrideWithValue(
-            mockFunnelcakeApiClient,
-          ),
+          videosRepositoryProvider.overrideWithValue(mockVideosRepository),
         ],
         child: MaterialApp(
           localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -52,31 +49,21 @@ void main() {
       'keeps loading until the initial source answers, then shows empty state even if websocket subscribe hangs',
       (tester) async {
         final subscribeCompleter = Completer<void>();
-        final trendingCompleter = Completer<List<VideoStats>>();
-        final classicCompleter = Completer<List<VideoStats>>();
+        final feedCompleter = Completer<List<VideoEvent>>();
         addTearDown(() {
           if (!subscribeCompleter.isCompleted) {
             subscribeCompleter.complete();
           }
-          if (!trendingCompleter.isCompleted) {
-            trendingCompleter.complete(const []);
-          }
-          if (!classicCompleter.isCompleted) {
-            classicCompleter.complete(const []);
+          if (!feedCompleter.isCompleted) {
+            feedCompleter.complete(const []);
           }
         });
 
-        when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
         when(
-          () => mockFunnelcakeApiClient.getVideosByHashtag(
+          () => mockVideosRepository.getHashtagFeedVideos(
             hashtag: any(named: 'hashtag'),
           ),
-        ).thenAnswer((_) => trendingCompleter.future);
-        when(
-          () => mockFunnelcakeApiClient.getClassicVideosByHashtag(
-            hashtag: any(named: 'hashtag'),
-          ),
-        ).thenAnswer((_) => classicCompleter.future);
+        ).thenAnswer((_) => feedCompleter.future);
         when(
           () => mockHashtagService.subscribeToHashtagVideos(any()),
         ).thenAnswer((_) => subscribeCompleter.future);
@@ -91,8 +78,7 @@ void main() {
         expect(find.text('Loading videos about #nostr...'), findsOneWidget);
         expect(find.text('No videos found for #nostr'), findsNothing);
 
-        trendingCompleter.complete(const []);
-        classicCompleter.complete(const []);
+        feedCompleter.complete(const []);
 
         await tester.pump();
         await tester.pump();

--- a/mobile/test/screens/hashtag_feed_startup_contract_test.dart
+++ b/mobile/test/screens/hashtag_feed_startup_contract_test.dart
@@ -49,13 +49,15 @@ void main() {
       'keeps loading until the initial source answers, then shows empty state even if websocket subscribe hangs',
       (tester) async {
         final subscribeCompleter = Completer<void>();
-        final feedCompleter = Completer<List<VideoEvent>>();
+        final feedCompleter = Completer<HashtagFeedVideosResult>();
         addTearDown(() {
           if (!subscribeCompleter.isCompleted) {
             subscribeCompleter.complete();
           }
           if (!feedCompleter.isCompleted) {
-            feedCompleter.complete(const []);
+            feedCompleter.complete(
+              const HashtagFeedVideosResult.success(<VideoEvent>[]),
+            );
           }
         });
 
@@ -78,7 +80,9 @@ void main() {
         expect(find.text('Loading videos about #nostr...'), findsOneWidget);
         expect(find.text('No videos found for #nostr'), findsNothing);
 
-        feedCompleter.complete(const []);
+        feedCompleter.complete(
+          const HashtagFeedVideosResult.success(<VideoEvent>[]),
+        );
 
         await tester.pump();
         await tester.pump();


### PR DESCRIPTION
Closes #948

## Description

Part of the #948 completion plan (see the [status comment](https://github.com/divinevideo/divine-mobile/issues/948#issuecomment-4663388444)): the hashtag feed was the last surface whose REST results **bypassed the repository parse-gate** — `hashtag_feed_screen.dart` called `funnelcakeApiClientProvider` directly (UI → Client) and relied on a screen-level `.where(shouldFilterFromFeeds)` for block/mute filtering, exactly the per-surface pattern this issue exists to eliminate (and a blocker for Phase 3's scattered-filter deletion).

### Changes

- **New `VideosRepository.getHashtagFeedVideos`**: fetches trending + classic videos in parallel (5s timeout), runs both through the existing `_transformVideoStats` pipeline (block filter, transport scheme, NIP-40 expiry, content preferences), and interleaves 1:1 with classic-vs-trending dedupe — the logic previously inlined in the screen. Returns `[]` on blank hashtag / unavailable API / error, documented as the fast-path-enrichment contract.
- **Screen slims down** to `repository.getHashtagFeedVideos(...)`; the inline fetch, interleave, and direct client import are gone.
- **Unblock semantics change (intentional)**: the repository drops blocked authors before they reach the screen's cache, so an unblock can no longer re-show content by re-filtering the raw cache (the #4887 approach). The screen now **refetches on `blocklistVersionProvider` changes**, matching the content-policy spec's invalidate-and-refetch model. Blocking still hides immediately via the assembly-seam filter, which also covers the WebSocket source and stays until Phase 3.

### Tests

- Package (`videos_repository`, 411/411): new `getHashtagFeedVideos` group — interleave + dedupe order, block filter on both trending and classic, blank/unavailable/throwing API → empty.
- `hashtag_feed_blocklist_filter_test.dart` re-pins the seam filter (source bypassing the parse-gate still gets filtered) and adds the refetch-on-blocklist-change contract.
- `hashtag_feed_startup_contract_test.dart` updated to stub the repository instead of the client; loading-gate semantics unchanged.

**Related Issue:** #948

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test packages/videos_repository` — 411/411
- `flutter test` on all six hashtag screen test files — pass (21 pre-existing skips untouched)
- `dart format` — clean

## Type of Change

- [x] Refactor (no functional change except the documented unblock-refetch semantics)
