### PR TITLE
feat(moderation): canTarget affordance gating + profile-search block filters (#948)

### DIFF
--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -30,6 +30,31 @@ ContentPolicyEngine contentPolicyEngine(Ref ref) {
   return ContentPolicyEngine.defaultRules();
 }
 
+/// Whether the UI may offer interactions that target [pubkey] —
+/// follow, DM, reply, mention, share-to, tag.
+///
+/// When this returns `false` the affordance must be *absent*: no disabled
+/// state, no tooltip, no copy. Revealing why would violate the disclosure
+/// invariant (the app never tells a user someone blocked or muted them).
+///
+/// Under [FeatureFlag.contentPolicyV2] this consults
+/// [ContentPolicyEngine.canTarget] (hidden when the target's published
+/// kind 30000 d=block or kind 10000 names us). With the flag off it
+/// preserves the pre-engine behavior: only an explicit block
+/// (`hasBlockedUs`) hides the affordance.
+@riverpod
+bool canTargetUser(Ref ref, String pubkey) {
+  // Re-evaluate when any block/mute state changes.
+  ref.watch(blocklistVersionProvider);
+  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+  final flagService = ref.watch(featureFlagServiceProvider);
+  if (flagService.isEnabled(FeatureFlag.contentPolicyV2)) {
+    final engine = ref.watch(contentPolicyEngineProvider);
+    return engine.canTarget(pubkey, blocklistRepository.currentState);
+  }
+  return !blocklistRepository.hasBlockedUs(pubkey);
+}
+
 /// Divine-hosted-only filter preference service.
 final divineHostFilterServiceProvider = Provider<DivineHostFilterService>((
   ref,

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -57,6 +57,146 @@ final class ContentPolicyEngineProvider
 String _$contentPolicyEngineHash() =>
     r'3e6e0f8415da251057c220f5873bd5359c6ce9f1';
 
+/// Whether the UI may offer interactions that target [pubkey] —
+/// follow, DM, reply, mention, share-to, tag.
+///
+/// When this returns `false` the affordance must be *absent*: no disabled
+/// state, no tooltip, no copy. Revealing why would violate the disclosure
+/// invariant (the app never tells a user someone blocked or muted them).
+///
+/// Under [FeatureFlag.contentPolicyV2] this consults
+/// [ContentPolicyEngine.canTarget] (hidden when the target's published
+/// kind 30000 d=block or kind 10000 names us). With the flag off it
+/// preserves the pre-engine behavior: only an explicit block
+/// (`hasBlockedUs`) hides the affordance.
+
+@ProviderFor(canTargetUser)
+const canTargetUserProvider = CanTargetUserFamily._();
+
+/// Whether the UI may offer interactions that target [pubkey] —
+/// follow, DM, reply, mention, share-to, tag.
+///
+/// When this returns `false` the affordance must be *absent*: no disabled
+/// state, no tooltip, no copy. Revealing why would violate the disclosure
+/// invariant (the app never tells a user someone blocked or muted them).
+///
+/// Under [FeatureFlag.contentPolicyV2] this consults
+/// [ContentPolicyEngine.canTarget] (hidden when the target's published
+/// kind 30000 d=block or kind 10000 names us). With the flag off it
+/// preserves the pre-engine behavior: only an explicit block
+/// (`hasBlockedUs`) hides the affordance.
+
+final class CanTargetUserProvider extends $FunctionalProvider<bool, bool, bool>
+    with $Provider<bool> {
+  /// Whether the UI may offer interactions that target [pubkey] —
+  /// follow, DM, reply, mention, share-to, tag.
+  ///
+  /// When this returns `false` the affordance must be *absent*: no disabled
+  /// state, no tooltip, no copy. Revealing why would violate the disclosure
+  /// invariant (the app never tells a user someone blocked or muted them).
+  ///
+  /// Under [FeatureFlag.contentPolicyV2] this consults
+  /// [ContentPolicyEngine.canTarget] (hidden when the target's published
+  /// kind 30000 d=block or kind 10000 names us). With the flag off it
+  /// preserves the pre-engine behavior: only an explicit block
+  /// (`hasBlockedUs`) hides the affordance.
+  const CanTargetUserProvider._({
+    required CanTargetUserFamily super.from,
+    required String super.argument,
+  }) : super(
+         retry: null,
+         name: r'canTargetUserProvider',
+         isAutoDispose: true,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$canTargetUserHash();
+
+  @override
+  String toString() {
+    return r'canTargetUserProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  $ProviderElement<bool> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  bool create(Ref ref) {
+    final argument = this.argument as String;
+    return canTargetUser(ref, argument);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(bool value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<bool>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is CanTargetUserProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$canTargetUserHash() => r'3761b5b8a0bb8b3010086a60a2009e9065b9e981';
+
+/// Whether the UI may offer interactions that target [pubkey] —
+/// follow, DM, reply, mention, share-to, tag.
+///
+/// When this returns `false` the affordance must be *absent*: no disabled
+/// state, no tooltip, no copy. Revealing why would violate the disclosure
+/// invariant (the app never tells a user someone blocked or muted them).
+///
+/// Under [FeatureFlag.contentPolicyV2] this consults
+/// [ContentPolicyEngine.canTarget] (hidden when the target's published
+/// kind 30000 d=block or kind 10000 names us). With the flag off it
+/// preserves the pre-engine behavior: only an explicit block
+/// (`hasBlockedUs`) hides the affordance.
+
+final class CanTargetUserFamily extends $Family
+    with $FunctionalFamilyOverride<bool, String> {
+  const CanTargetUserFamily._()
+    : super(
+        retry: null,
+        name: r'canTargetUserProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: true,
+      );
+
+  /// Whether the UI may offer interactions that target [pubkey] —
+  /// follow, DM, reply, mention, share-to, tag.
+  ///
+  /// When this returns `false` the affordance must be *absent*: no disabled
+  /// state, no tooltip, no copy. Revealing why would violate the disclosure
+  /// invariant (the app never tells a user someone blocked or muted them).
+  ///
+  /// Under [FeatureFlag.contentPolicyV2] this consults
+  /// [ContentPolicyEngine.canTarget] (hidden when the target's published
+  /// kind 30000 d=block or kind 10000 names us). With the flag off it
+  /// preserves the pre-engine behavior: only an explicit block
+  /// (`hasBlockedUs`) hides the affordance.
+
+  CanTargetUserProvider call(String pubkey) =>
+      CanTargetUserProvider._(argument: pubkey, from: this);
+
+  @override
+  String toString() => r'canTargetUserProvider';
+}
+
 /// Age verification service for content creation restrictions
 /// keepAlive ensures the service persists and maintains in-memory verification state
 /// even when widgets that watch it dispose and rebuild

--- a/mobile/lib/widgets/profile/follow_from_profile_button.dart
+++ b/mobile/lib/widgets/profile/follow_from_profile_button.dart
@@ -44,7 +44,7 @@ class FollowFromProfileButton extends ConsumerWidget {
     // Watch blocklist to reactively update button state
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
     final isBlocked = blocklistRepository.isBlocked(pubkey);
-    final isBlockedByThem = blocklistRepository.hasBlockedUs(pubkey);
+    final canTargetAuthor = ref.watch(canTargetUserProvider(pubkey));
 
     return BlocProvider(
       create: (_) => MyFollowingBloc(
@@ -56,7 +56,7 @@ class FollowFromProfileButton extends ConsumerWidget {
         displayName: displayName,
         currentUserPubkey: currentUserPubkey,
         isBlocked: isBlocked,
-        isBlockedByThem: isBlockedByThem,
+        canTargetAuthor: canTargetAuthor,
         onBlockedTap: onBlockedTap,
       ),
     );
@@ -75,7 +75,7 @@ class FollowFromProfileButtonView extends StatelessWidget {
     required this.currentUserPubkey,
     super.key,
     this.isBlocked = false,
-    this.isBlockedByThem = false,
+    this.canTargetAuthor = true,
     this.onBlockedTap,
   });
 
@@ -91,16 +91,20 @@ class FollowFromProfileButtonView extends StatelessWidget {
   /// Whether the user is blocked by us.
   final bool isBlocked;
 
-  /// Whether the user has blocked us (prevents following).
-  final bool isBlockedByThem;
+  /// Whether the UI may offer interactions targeting this user.
+  ///
+  /// False when their published block list (or, under contentPolicyV2,
+  /// mute list) names us. The button renders nothing in that case —
+  /// absence, never an explanation (disclosure invariant).
+  final bool canTargetAuthor;
 
   /// Callback when the Blocked button is tapped.
   final VoidCallback? onBlockedTap;
 
   @override
   Widget build(BuildContext context) {
-    // If the other user has blocked us, hide the follow button entirely
-    if (isBlockedByThem) {
+    // If the target doesn't accept interactions from us, render nothing.
+    if (!canTargetAuthor) {
       return const SizedBox.shrink();
     }
 

--- a/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
+++ b/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
@@ -189,7 +189,7 @@ class _OtherProfileButtons extends StatelessWidget {
         if (isFollowing) {
           // Following: [Message (expanded)] [Following] [Share]
           children = [
-            if (canTargetUser)
+            if (canTargetUser) ...[
               Expanded(
                 child: DivineButton(
                   expanded: true,
@@ -200,7 +200,9 @@ class _OtherProfileButtons extends StatelessWidget {
                   onPressed: onMessageUser,
                 ),
               ),
-            followButton,
+              followButton,
+            ] else
+              const Spacer(),
             shareButton,
           ];
         } else {

--- a/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
+++ b/mobile/lib/widgets/profile/profile_action_buttons_widget.dart
@@ -62,7 +62,7 @@ class ProfileActionButtons extends ConsumerWidget {
     ref.watch(blocklistVersionProvider);
 
     final isBlocked = contentBlocklistRepository.isBlocked(userIdHex);
-    final isBlockedByThem = contentBlocklistRepository.hasBlockedUs(userIdHex);
+    final canTargetUser = ref.watch(canTargetUserProvider(userIdHex));
 
     // Create MyFollowingBloc at this level so both the follow button
     // and the row ordering share the same optimistic state.
@@ -76,7 +76,7 @@ class ProfileActionButtons extends ConsumerWidget {
         displayName: displayName,
         currentUserPubkey: nostrClient.publicKey,
         isBlocked: isBlocked,
-        isBlockedByThem: isBlockedByThem,
+        canTargetUser: canTargetUser,
         onMessageUser: onMessageUser,
         onShareProfile: onShareProfile,
         onBlockedTap: onBlockedTap,
@@ -140,7 +140,7 @@ class _OtherProfileButtons extends StatelessWidget {
     required this.displayName,
     required this.currentUserPubkey,
     required this.isBlocked,
-    required this.isBlockedByThem,
+    required this.canTargetUser,
     required this.onMessageUser,
     required this.onShareProfile,
     required this.onBlockedTap,
@@ -150,7 +150,12 @@ class _OtherProfileButtons extends StatelessWidget {
   final String? displayName;
   final String? currentUserPubkey;
   final bool isBlocked;
-  final bool isBlockedByThem;
+
+  /// Whether the UI may offer interactions targeting this user. False
+  /// hides the follow and message affordances entirely — absence, never
+  /// an explanation (disclosure invariant).
+  final bool canTargetUser;
+
   final VoidCallback? onMessageUser;
   final void Function(BuildContext context)? onShareProfile;
   final VoidCallback? onBlockedTap;
@@ -166,7 +171,7 @@ class _OtherProfileButtons extends StatelessWidget {
           displayName: displayName ?? l10n.profileUserFallback,
           currentUserPubkey: currentUserPubkey,
           isBlocked: isBlocked,
-          isBlockedByThem: isBlockedByThem,
+          canTargetAuthor: canTargetUser,
           onBlockedTap: onBlockedTap,
         );
 
@@ -184,30 +189,34 @@ class _OtherProfileButtons extends StatelessWidget {
         if (isFollowing) {
           // Following: [Message (expanded)] [Following] [Share]
           children = [
-            Expanded(
-              child: DivineButton(
-                expanded: true,
-                leadingIcon: .envelopeSimple,
-                type: .secondary,
-                size: .small,
-                label: l10n.profileMessageLabel,
-                onPressed: onMessageUser,
+            if (canTargetUser)
+              Expanded(
+                child: DivineButton(
+                  expanded: true,
+                  leadingIcon: .envelopeSimple,
+                  type: .secondary,
+                  size: .small,
+                  label: l10n.profileMessageLabel,
+                  onPressed: onMessageUser,
+                ),
               ),
-            ),
             followButton,
             shareButton,
           ];
         } else {
           // Not following: [Follow (expanded)] [Message (icon)] [Share]
           children = [
-            Expanded(child: followButton),
-            DivineButton(
-              leadingIcon: .envelopeSimple,
-              type: .secondary,
-              size: .small,
-              label: '',
-              onPressed: onMessageUser,
-            ),
+            if (canTargetUser) ...[
+              Expanded(child: followButton),
+              DivineButton(
+                leadingIcon: .envelopeSimple,
+                type: .secondary,
+                size: .small,
+                label: '',
+                onPressed: onMessageUser,
+              ),
+            ] else
+              const Spacer(),
             shareButton,
           ];
         }

--- a/mobile/lib/widgets/video_feed_item/video_follow_button.dart
+++ b/mobile/lib/widgets/video_feed_item/video_follow_button.dart
@@ -78,6 +78,13 @@ class _VideoFollowButtonState extends ConsumerState<VideoFollowButton> {
       return const SizedBox.shrink();
     }
 
+    // If the author doesn't accept interactions from us (their published
+    // block/mute list names us), render nothing — absence, never an
+    // explanation (disclosure invariant).
+    if (!ref.watch(canTargetUserProvider(widget.pubkey))) {
+      return const SizedBox.shrink();
+    }
+
     return BlocProvider.value(
       value: _bloc!,
       child: VideoFollowButtonView(pubkey: widget.pubkey),

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -876,7 +876,9 @@ class ProfileRepository {
         sortBy: sortBy,
         hasVideos: hasVideos,
       );
-      final profiles = restResults.map((result) => result.toUserProfile());
+      final profiles = restResults
+          .map((result) => result.toUserProfile())
+          .where((p) => !(_blockFilter?.call(p.pubkey) ?? false));
       return _enrichFromCache(profiles.toList());
     } on Exception catch (e) {
       Log.warning(
@@ -973,14 +975,16 @@ class ProfileRepository {
       }
     }
 
-    final profiles = resultMap.values.toList();
+    // Apply the injected block filter, consistent with searchUsersLocally
+    // and searchUsersProgressive. Unblocking happens via the Safety
+    // Settings blocked-users list, not via search findability.
+    final blockFilter = _blockFilter;
+    final profiles = blockFilter == null
+        ? resultMap.values.toList()
+        : resultMap.values.where((p) => !blockFilter(p.pubkey)).toList();
 
     // Enrich profiles from local SQLite cache (fill in missing pictures, etc.)
     final enrichedProfiles = await _enrichFromCache(profiles);
-
-    // Note: blocked users are NOT filtered from search results.
-    // Users need to find blocked profiles in search to unblock them.
-    // Block filtering is applied in video feeds (VideoEventService) instead.
 
     // When server-side sorting is active, trust server order
     if (useServerSort) {

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1823,6 +1823,34 @@ void main() {
         verify(() => mockNostrClient.queryUsers('test', limit: 10)).called(1);
       });
 
+      test('excludes pubkeys hidden by the block filter', () async {
+        final blockedPubkey = 'e' * 64;
+        final blockedEvent = MockEvent();
+        when(() => blockedEvent.kind).thenReturn(0);
+        when(() => blockedEvent.pubkey).thenReturn(blockedPubkey);
+        when(() => blockedEvent.createdAt).thenReturn(1704067200);
+        when(() => blockedEvent.id).thenReturn('f' * 64);
+        when(
+          () => blockedEvent.content,
+        ).thenReturn(jsonEncode({'name': 'Blocked User'}));
+
+        when(
+          () => mockNostrClient.queryUsers('test', limit: 200),
+        ).thenAnswer((_) async => [mockProfileEvent, blockedEvent]);
+
+        final filteringRepository = ProfileRepository(
+          nostrClient: mockNostrClient,
+          userProfilesDao: mockUserProfilesDao,
+          httpClient: mockHttpClient,
+          blockFilter: (pubkey) => pubkey == blockedPubkey,
+        );
+
+        final result = await filteringRepository.searchUsers(query: 'test');
+
+        expect(result, hasLength(1));
+        expect(result.first.pubkey, equals(testPubkey));
+      });
+
       test('returns empty list when NostrClient returns empty list', () async {
         // Arrange
         when(
@@ -2216,6 +2244,51 @@ void main() {
       setUp(() {
         mockFunnelcakeClient = MockFunnelcakeApiClient();
       });
+
+      test(
+        'searchUsersFromApi excludes pubkeys hidden by the block filter',
+        () async {
+          final blockedPubkey = 'e' * 64;
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.searchProfiles(
+              query: any(named: 'query'),
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+              sortBy: any(named: 'sortBy'),
+              hasVideos: any(named: 'hasVideos'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              ProfileSearchResult(
+                pubkey: blockedPubkey,
+                displayName: 'Blocked User',
+                createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              ),
+              ProfileSearchResult(
+                pubkey: 'd' * 64,
+                displayName: 'Visible User',
+                createdAt: DateTime.fromMillisecondsSinceEpoch(1700000000000),
+              ),
+            ],
+          );
+
+          final filteringRepository = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: mockUserProfilesDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            blockFilter: (pubkey) => pubkey == blockedPubkey,
+          );
+
+          final result = await filteringRepository.searchUsersFromApi(
+            query: 'user',
+          );
+
+          expect(result, hasLength(1));
+          expect(result.first.displayName, 'Visible User');
+        },
+      );
 
       test(
         'searchUsersFromApi uses Funnelcake only with server sorting',

--- a/mobile/test/providers/can_target_user_provider_test.dart
+++ b/mobile/test/providers/can_target_user_provider_test.dart
@@ -1,0 +1,129 @@
+// ABOUTME: Tests canTargetUserProvider — affordance gating per the
+// ABOUTME: content-policy interaction invariant (absence, never explanation).
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/features/feature_flags/services/feature_flag_service.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+class _MockFeatureFlagService extends Mock implements FeatureFlagService {}
+
+void main() {
+  const me = '0000000000000000000000000000000000000000000000000000000000000001';
+  const blocker =
+      '0000000000000000000000000000000000000000000000000000000000000002';
+  const muter =
+      '0000000000000000000000000000000000000000000000000000000000000003';
+  const stranger =
+      '0000000000000000000000000000000000000000000000000000000000000004';
+
+  setUpAll(() {
+    registerFallbackValue(FeatureFlag.contentPolicyV2);
+  });
+
+  late _MockContentBlocklistRepository mockBlocklist;
+  late _MockFeatureFlagService mockFlags;
+
+  ContentPolicyState stateWith({
+    Set<String> blockingUs = const {},
+    Set<String> mutingUs = const {},
+  }) {
+    return ContentPolicyState(
+      currentUserPubkey: me,
+      mutedPubkeys: const {},
+      blockedPubkeys: const {},
+      pubkeysBlockingUs: blockingUs,
+      pubkeysMutingUs: mutingUs,
+    );
+  }
+
+  setUp(() {
+    mockBlocklist = _MockContentBlocklistRepository();
+    mockFlags = _MockFeatureFlagService();
+
+    when(() => mockBlocklist.hasBlockedUs(any())).thenReturn(false);
+    when(() => mockBlocklist.currentState).thenReturn(stateWith());
+    when(() => mockFlags.isEnabled(any())).thenReturn(false);
+  });
+
+  ProviderContainer createContainer() {
+    final container = ProviderContainer(
+      overrides: [
+        contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
+        featureFlagServiceProvider.overrideWithValue(mockFlags),
+      ],
+    );
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('canTargetUserProvider', () {
+    group('flag off (legacy behavior)', () {
+      test('allows targeting a stranger', () {
+        final container = createContainer();
+        expect(container.read(canTargetUserProvider(stranger)), isTrue);
+      });
+
+      test('hides affordances for a user whose block list names us', () {
+        when(() => mockBlocklist.hasBlockedUs(blocker)).thenReturn(true);
+        final container = createContainer();
+        expect(container.read(canTargetUserProvider(blocker)), isFalse);
+      });
+
+      test('does not gate on mute lists (pre-engine behavior preserved)', () {
+        when(
+          () => mockBlocklist.currentState,
+        ).thenReturn(stateWith(mutingUs: {muter}));
+        final container = createContainer();
+        expect(container.read(canTargetUserProvider(muter)), isTrue);
+      });
+    });
+
+    group('flag on (content-policy engine)', () {
+      setUp(() {
+        when(
+          () => mockFlags.isEnabled(FeatureFlag.contentPolicyV2),
+        ).thenReturn(true);
+      });
+
+      test('allows targeting a stranger', () {
+        final container = createContainer();
+        expect(container.read(canTargetUserProvider(stranger)), isTrue);
+      });
+
+      test('hides affordances for a user whose block list names us', () {
+        when(
+          () => mockBlocklist.currentState,
+        ).thenReturn(stateWith(blockingUs: {blocker}));
+        final container = createContainer();
+        expect(container.read(canTargetUserProvider(blocker)), isFalse);
+      });
+
+      test('hides affordances for a user whose mute list names us', () {
+        when(
+          () => mockBlocklist.currentState,
+        ).thenReturn(stateWith(mutingUs: {muter}));
+        final container = createContainer();
+        expect(container.read(canTargetUserProvider(muter)), isFalse);
+      });
+    });
+
+    test('re-evaluates when the blocklist version changes', () {
+      final container = createContainer();
+      expect(container.read(canTargetUserProvider(blocker)), isTrue);
+
+      when(() => mockBlocklist.hasBlockedUs(blocker)).thenReturn(true);
+      container.read(blocklistVersionProvider.notifier).increment();
+
+      expect(container.read(canTargetUserProvider(blocker)), isFalse);
+    });
+  });
+}

--- a/mobile/test/widgets/profile/follow_from_profile_button_test.dart
+++ b/mobile/test/widgets/profile/follow_from_profile_button_test.dart
@@ -72,6 +72,40 @@ void main() {
     }
 
     group('button state', () {
+      testWidgets(
+        'renders nothing when the author does not accept interactions from us',
+        (tester) async {
+          when(
+            () => mockMyFollowingBloc.state,
+          ).thenReturn(const MyFollowingState());
+
+          await tester.pumpWidget(
+            MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: BlocProvider<MyFollowingBloc>.value(
+                  value: mockMyFollowingBloc,
+                  child: FollowFromProfileButtonView(
+                    pubkey: validPubkey('author'),
+                    displayName: 'Author',
+                    currentUserPubkey: validPubkey('viewer'),
+                    canTargetAuthor: false,
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pump();
+
+          // Absence, not a disabled state — no button, no text, no tooltip.
+          expect(find.byType(OutlinedButton), findsNothing);
+          expect(find.byType(ElevatedButton), findsNothing);
+          expect(find.text('Follow'), findsNothing);
+          expect(find.byType(Tooltip), findsNothing);
+        },
+      );
+
       testWidgets('shows DivineButton with "Follow" when not following', (
         tester,
       ) async {

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -1,0 +1,120 @@
+// ABOUTME: Tests for profile action button row composition and target gating
+// ABOUTME: Verifies target-directed affordances are absent without explanation
+
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+void main() {
+  const targetPubkey =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const viewerPubkey =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  late MockFollowRepository followRepository;
+  late _MockContentBlocklistRepository blocklistRepository;
+  late MockNostrClient nostrClient;
+
+  setUp(() {
+    followRepository = MockFollowRepository();
+    blocklistRepository = _MockContentBlocklistRepository();
+    nostrClient = createMockNostrService();
+
+    when(() => nostrClient.publicKey).thenReturn(viewerPubkey);
+
+    when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
+    when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
+
+    when(() => followRepository.followingPubkeys).thenReturn(const []);
+    when(() => followRepository.followingStream).thenAnswer(
+      (_) => Stream<List<String>>.value(const []),
+    );
+    when(() => followRepository.watchMyFollowingCached()).thenAnswer(
+      (_) => Stream.value(
+        const CacheResult.live(
+          FollowingSnapshot(pubkeys: <String>[], count: 0),
+        ),
+      ),
+    );
+  });
+
+  Widget buildWidget() {
+    return testMaterialApp(
+      home: Scaffold(
+        body: ProfileActionButtons(
+          userIdHex: targetPubkey,
+          isOwnProfile: false,
+          displayName: 'Target User',
+          onMessageUser: () {},
+          onShareProfile: (_) {},
+        ),
+      ),
+      additionalOverrides: [
+        contentBlocklistRepositoryProvider.overrideWithValue(
+          blocklistRepository,
+        ),
+      ],
+      mockFollowRepository: followRepository,
+      mockNostrService: nostrClient,
+    );
+  }
+
+  testWidgets(
+    'hides follow and message actions when target cannot be targeted',
+    (tester) async {
+      when(() => blocklistRepository.hasBlockedUs(targetPubkey)).thenReturn(
+        true,
+      );
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pump();
+
+      expect(find.text('Follow'), findsNothing);
+      expect(find.text('Message'), findsNothing);
+      expect(find.byType(Tooltip), findsNothing);
+      expect(find.byType(DivineIconButton), findsOneWidget);
+      expect(find.byType(Spacer), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'keeps share right-aligned when already following target cannot be targeted',
+    (tester) async {
+      when(() => blocklistRepository.hasBlockedUs(targetPubkey)).thenReturn(
+        true,
+      );
+      when(
+        () => followRepository.followingPubkeys,
+      ).thenReturn(const [targetPubkey]);
+      when(() => followRepository.followingStream).thenAnswer(
+        (_) => Stream<List<String>>.value(const [targetPubkey]),
+      );
+      when(() => followRepository.watchMyFollowingCached()).thenAnswer(
+        (_) => Stream.value(
+          const CacheResult.live(
+            FollowingSnapshot(pubkeys: [targetPubkey], count: 1),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pump();
+
+      expect(find.text('Follow'), findsNothing);
+      expect(find.text('Message'), findsNothing);
+      expect(find.byType(Tooltip), findsNothing);
+      expect(find.byType(DivineIconButton), findsOneWidget);
+      expect(find.byType(Spacer), findsOneWidget);
+    },
+  );
+}

--- a/mobile/test/widgets/video_feed_item/video_follow_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_follow_button_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Validates follow/unfollow button state, tap behavior, and styling
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -9,10 +10,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/widgets/video_feed_item/video_follow_button.dart';
+
+import '../../helpers/test_provider_overrides.dart';
 
 class _MockMyFollowingBloc extends MockBloc<MyFollowingEvent, MyFollowingState>
     implements MyFollowingBloc {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 void main() {
   group('VideoFollowButtonView', () {
@@ -122,6 +129,60 @@ void main() {
           );
         },
       );
+    });
+  });
+
+  group(VideoFollowButton, () {
+    testWidgets(
+      'renders nothing when the author does not accept interactions from us',
+      (tester) async {
+        final authorPubkey = 'a' * 64;
+        final mockBlocklist = _MockContentBlocklistRepository();
+        when(() => mockBlocklist.hasBlockedUs(authorPubkey)).thenReturn(true);
+        when(() => mockBlocklist.isBlocked(any())).thenReturn(false);
+        when(() => mockBlocklist.isFollowSevered(any())).thenReturn(false);
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: Scaffold(body: VideoFollowButton(pubkey: authorPubkey)),
+            additionalOverrides: [
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                mockBlocklist,
+              ),
+            ],
+          ),
+        );
+        await tester.pump();
+
+        // Absence, not a disabled state — no view, no icon, no tooltip.
+        expect(find.byType(VideoFollowButtonView), findsNothing);
+        expect(find.byType(SvgPicture), findsNothing);
+        expect(find.byType(Tooltip), findsNothing);
+      },
+    );
+
+    testWidgets('renders the follow view for a regular author', (
+      tester,
+    ) async {
+      final authorPubkey = 'a' * 64;
+      final mockBlocklist = _MockContentBlocklistRepository();
+      when(() => mockBlocklist.hasBlockedUs(any())).thenReturn(false);
+      when(() => mockBlocklist.isBlocked(any())).thenReturn(false);
+      when(() => mockBlocklist.isFollowSevered(any())).thenReturn(false);
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          home: Scaffold(body: VideoFollowButton(pubkey: authorPubkey)),
+          additionalOverrides: [
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklist,
+            ),
+          ],
+        ),
+      );
+      await tester.pump();
+
+      expect(find.byType(VideoFollowButtonView), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Closes #948

## Description

Phase 2 of the content-policy plan (interaction gating) plus a repository-layer search gap found while implementing it. Part of the #948 completion plan — see the [status comment](https://github.com/divinevideo/divine-mobile/issues/948#issuecomment-4663388444). Two commits:

### 1. `fix(profile)`: block filter in `searchUsers` / `searchUsersFromApi`

These two `ProfileRepository` paths — the sources behind **@-mention autocomplete** (`mention_search.dart`) and the **DM new-message search** — never consulted the injected `blockFilter`, unlike `searchUsersLocally` and `searchUsersProgressive`. Blocked/muted users (and users who blocked the viewer) still surfaced in those suggestion lists. The code carried an old comment justifying the gap ("users need to find blocked profiles in search to unblock them") — superseded since unblocking lives in Safety Settings → blocked users (`safety_settings_screen.dart`), and the progressive people-search path already filters.

Per the spec, this also covers the "mention autocomplete" and "share-to-user picker" affordances at the correct layer — the suggestion sources — rather than filtering in each picker widget.

### 2. `feat(moderation)`: `canTargetUserProvider` + affordance gating

The interaction invariant: *the app must not offer UI affordances for interactions the recipient has blocked*. Implementation:

- **`canTargetUserProvider(pubkey)`** (`moderation_providers.dart`): under `contentPolicyV2` it consults `ContentPolicyEngine.canTarget` (their published kind 30000 **block** or kind 10000 **mute** list naming us); with the flag off it preserves the shipped behavior exactly (`hasBlockedUs` only — no regression risk). Re-evaluates on `blocklistVersionProvider` bumps.
- **`FollowFromProfileButton`** — migrates its existing scattered `hasBlockedUs` read to the provider (view prop renamed `isBlockedByThem` → `canTargetAuthor` to stay honest about the mute case).
- **Profile Message button** — previously rendered for users who had blocked the viewer; now absent when `canTarget` is false.
- **Feed overlay `VideoFollowButton`** — previously had no gate at all; now absent.
- Gating is **absence** — no disabled state, no tooltip, no copy, per the disclosure invariant.

**Reply-compose gating is intentionally not included**: comments from blocked-by authors are already filtered at `CommentsRepository`, so the reply affordance toward them is unreachable (the spec itself notes this surface is "rarely reachable since content is filtered").

**Related Issue:** #948

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test packages/profile_repository` (very_good, 100% coverage gate) — 215/215, gate held (2 new tests)
- `flutter test test/providers/can_target_user_provider_test.dart` — 7/7 (flag-off legacy parity, flag-on block+mute gating, version reactivity)
- `flutter test test/widgets/video_feed_item/video_follow_button_test.dart test/widgets/profile/follow_from_profile_button_test.dart` — 16/16 (3 new absence tests)
- `flutter test test/widgets/profile/profile_header_widget_test.dart test/blocs/user_search test/blocs/comments test/screens/inbox` — 403/403
- `dart run build_runner build` — generated files committed

## Type of Change

- [x] Bug fix (search-source leak) + feature (flag-gated affordance gating)
