### PR TITLE
fix(video): tombstone addressable deletes

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -603,7 +603,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
   List<VideoEvent> _withoutTombstones(List<VideoEvent> videos) {
     if (videos.isEmpty) return videos;
     return videos
-        .where((v) => !_videoEventService.isVideoLocallyDeleted(v.id))
+        .where((v) => !_videoEventService.isVideoEventLocallyDeleted(v))
         .toList();
   }
 

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -75,10 +75,12 @@ class ContentDeletion {
     required this.originalEventId,
     required this.reason,
     required this.deletedAt,
+    this.addressableId,
     this.additionalContext,
   });
   final String deleteEventId;
   final String originalEventId;
+  final String? addressableId;
   final String reason;
   final DateTime deletedAt;
   final String? additionalContext;
@@ -86,6 +88,7 @@ class ContentDeletion {
   Map<String, dynamic> toJson() => {
     'deleteEventId': deleteEventId,
     'originalEventId': originalEventId,
+    if (addressableId != null) 'addressableId': addressableId,
     'reason': reason,
     'deletedAt': deletedAt.toIso8601String(),
     'additionalContext': additionalContext,
@@ -94,6 +97,7 @@ class ContentDeletion {
   static ContentDeletion fromJson(Map<String, dynamic> json) => ContentDeletion(
     deleteEventId: json['deleteEventId'] as String,
     originalEventId: json['originalEventId'] as String,
+    addressableId: json['addressableId'] as String?,
     reason: json['reason'] as String,
     deletedAt: DateTime.parse(json['deletedAt'] as String),
     additionalContext: json['additionalContext'] as String?,
@@ -185,6 +189,7 @@ class ContentDeletionService {
       // OpenVine only uses kind 34236 (addressable short videos)
       final deleteOutcome = await _createDeleteEvent(
         originalEventId: video.id,
+        addressableId: video.addressableId,
         originalEventKind: NIP71VideoKinds.getPreferredKind(),
         reason: reason,
         additionalContext: additionalContext,
@@ -223,6 +228,7 @@ class ContentDeletionService {
       final deletion = ContentDeletion(
         deleteEventId: deleteEvent.id,
         originalEventId: video.id,
+        addressableId: video.addressableId,
         reason: reason,
         deletedAt: DateTime.now(),
         additionalContext: additionalContext,
@@ -282,14 +288,23 @@ class ContentDeletionService {
   }
 
   /// Check if content has been deleted by user
-  bool hasBeenDeleted(String eventId) =>
-      _deletionHistory.any((deletion) => deletion.originalEventId == eventId);
+  bool hasBeenDeleted(String eventId, {String? addressableId}) =>
+      _deletionHistory.any(
+        (deletion) =>
+            deletion.originalEventId == eventId ||
+            (addressableId != null && deletion.addressableId == addressableId),
+      );
 
   /// Get deletion record for event
-  ContentDeletion? getDeletionForEvent(String eventId) {
+  ContentDeletion? getDeletionForEvent(
+    String eventId, {
+    String? addressableId,
+  }) {
     try {
       return _deletionHistory.firstWhere(
-        (deletion) => deletion.originalEventId == eventId,
+        (deletion) =>
+            deletion.originalEventId == eventId ||
+            (addressableId != null && deletion.addressableId == addressableId),
       );
     } catch (e) {
       return null;
@@ -325,6 +340,7 @@ class ContentDeletionService {
     required String originalEventId,
     required int originalEventKind,
     required String reason,
+    String? addressableId,
     String? additionalContext,
   }) async {
     try {
@@ -337,10 +353,12 @@ class ContentDeletionService {
         return (event: null, failureKind: DeleteFailureKind.notAuthenticated);
       }
 
-      // Build NIP-09 compliant tags (kind 5)
-      // Per NIP-09: 'e' tag references event to delete, 'k' tag specifies event kind
+      // Build NIP-09 compliant tags (kind 5). Addressable videos need an
+      // `a` tag so every replacement for the same d-tag is tombstoned.
       final tags = <List<String>>[
         ['e', originalEventId], // Event being deleted
+        if (addressableId != null && addressableId.isNotEmpty)
+          ['a', addressableId],
         [
           'k',
           originalEventKind.toString(),

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -185,11 +185,13 @@ class ContentDeletionService {
         );
       }
 
+      final addressableId = _addressableDeletionTarget(video);
+
       // Create NIP-09 delete event (kind 5)
       // OpenVine only uses kind 34236 (addressable short videos)
       final deleteOutcome = await _createDeleteEvent(
         originalEventId: video.id,
-        addressableId: video.addressableId,
+        addressableId: addressableId,
         originalEventKind: NIP71VideoKinds.getPreferredKind(),
         reason: reason,
         additionalContext: additionalContext,
@@ -228,7 +230,7 @@ class ContentDeletionService {
       final deletion = ContentDeletion(
         deleteEventId: deleteEvent.id,
         originalEventId: video.id,
-        addressableId: video.addressableId,
+        addressableId: addressableId,
         reason: reason,
         deletedAt: DateTime.now(),
         additionalContext: additionalContext,
@@ -435,6 +437,14 @@ class ContentDeletionService {
     final userPubkey = _authService.currentPublicKeyHex;
 
     return video.pubkey == userPubkey;
+  }
+
+  String? _addressableDeletionTarget(VideoEvent video) {
+    final vineId = video.vineId;
+    if (vineId == null || vineId.isEmpty || vineId == video.id) {
+      return null;
+    }
+    return video.addressableId;
   }
 
   /// Get delete reason text for common cases

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1102,9 +1102,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // compatible. If the video was not in any active feed, still emit the
     // requested id because a fullscreen route may be holding it in BLoC state.
     if (!_removedVideoIdsController.isClosed) {
-      final idsToEmit = removedVideoIds.isEmpty
-          ? {primaryEventId}
-          : removedVideoIds;
+      final idsToEmit = {primaryEventId, ...removedVideoIds};
       for (final id in idsToEmit) {
         _removedVideoIdsController.add(id);
       }
@@ -1153,7 +1151,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   }
 
   String _localDeletionCoordinateKey(VideoEvent video) =>
-      '${video.pubkey}:${video.stableId}'.toLowerCase();
+      '${video.pubkey.toLowerCase()}:${video.stableId}';
 
   /// Emits a video id whenever the service has marked it removed —
   /// today this is user-initiated deletion via [removeVideoCompletely];

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -205,6 +205,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
   // Track locally deleted videos to prevent resurrection from pagination
   final Set<String> _locallyDeletedVideoIds = {};
+  final Set<String> _locallyDeletedVideoCoordinateKeys = {};
 
   // Broadcasts video ids the moment they are removed (deletion / future
   // block / mute). Subscribers — fullscreen feed bloc, profile feed
@@ -992,17 +993,53 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// This mirrors the `updateVideoEvent()` pattern for comprehensive state updates.
   /// Call this after successfully publishing a NIP-09 delete event.
   void removeVideoCompletely(String videoId) {
+    _removeVideoCompletely(
+      primaryEventId: videoId,
+      coordinateKey: null,
+      logIdentity: videoId,
+    );
+  }
+
+  /// Remove every cached version of an addressable video from all feeds.
+  ///
+  /// Kind 34236 videos are parameterized replaceable events: edits can create
+  /// new event ids while preserving the same `pubkey:d-tag` identity. Deleting
+  /// by event id alone lets an older/newer replacement reappear, so user
+  /// deletion paths should pass the full [VideoEvent] when available.
+  void removeVideoEventCompletely(VideoEvent video) {
+    _removeVideoCompletely(
+      primaryEventId: video.id,
+      coordinateKey: _localDeletionCoordinateKey(video),
+      logIdentity: video.addressableId ?? video.id,
+    );
+  }
+
+  void _removeVideoCompletely({
+    required String primaryEventId,
+    required String? coordinateKey,
+    required String logIdentity,
+  }) {
     var removedCount = 0;
+    final removedVideoIds = <String>{};
+
+    bool shouldRemove(VideoEvent video) =>
+        video.id == primaryEventId ||
+        (coordinateKey != null &&
+            _localDeletionCoordinateKey(video) == coordinateKey);
 
     // Remove from all subscription types (mirrors updateVideoEvent pattern)
     for (final entry in _eventLists.entries) {
       final initialLength = entry.value.length;
-      entry.value.removeWhere((video) => video.id == videoId);
+      entry.value.removeWhere((video) {
+        final remove = shouldRemove(video);
+        if (remove) removedVideoIds.add(video.id);
+        return remove;
+      });
       final removed = initialLength - entry.value.length;
       if (removed > 0) {
         removedCount += removed;
         Log.debug(
-          'Removed video $videoId from ${entry.key} (${entry.value.length} remaining)',
+          'Removed video $logIdentity from ${entry.key} (${entry.value.length} remaining)',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -1012,12 +1049,16 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // Remove from all author buckets
     for (final entry in _authorBuckets.entries) {
       final initialLength = entry.value.length;
-      entry.value.removeWhere((video) => video.id == videoId);
+      entry.value.removeWhere((video) {
+        final remove = shouldRemove(video);
+        if (remove) removedVideoIds.add(video.id);
+        return remove;
+      });
       final removed = initialLength - entry.value.length;
       if (removed > 0) {
         removedCount += removed;
         Log.debug(
-          'Removed video $videoId from author bucket ${entry.key}',
+          'Removed video $logIdentity from author bucket ${entry.key}',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -1027,12 +1068,16 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // Remove from all hashtag buckets
     for (final entry in _hashtagBuckets.entries) {
       final initialLength = entry.value.length;
-      entry.value.removeWhere((video) => video.id == videoId);
+      entry.value.removeWhere((video) {
+        final remove = shouldRemove(video);
+        if (remove) removedVideoIds.add(video.id);
+        return remove;
+      });
       final removed = initialLength - entry.value.length;
       if (removed > 0) {
         removedCount += removed;
         Log.debug(
-          'Removed video $videoId from hashtag bucket ${entry.key}',
+          'Removed video $logIdentity from hashtag bucket ${entry.key}',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
@@ -1042,26 +1087,32 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     // Mark as locally deleted to prevent pagination resurrection.
     //
     // Semantics: removal is permanent for the lifetime of this service.
-    // Even if subsequent relay queries return the same event id, it will
-    // be filtered out via [isVideoLocallyDeleted]. This is intentional —
-    // a session-only removal avoids surprising the user by re-adding a
-    // video they just swiped past when the fullscreen feed paginates.
-    // The set is cleared only when the service is recreated (app
-    // restart or test tearDown).
-    _locallyDeletedVideoIds.add(videoId);
+    // Even if subsequent relay queries return the same event id, or another
+    // event id for the same addressable video, it will be filtered out.
+    _locallyDeletedVideoIds.add(primaryEventId);
+    _locallyDeletedVideoIds.addAll(removedVideoIds);
+    if (coordinateKey != null) {
+      _locallyDeletedVideoCoordinateKeys.add(coordinateKey);
+    }
 
     // Emit on the side-channel BEFORE notifyListeners so that subscribers
     // who react via the stream (e.g. FullscreenFeedBloc) update their
     // state in the same frame as ChangeNotifier consumers. Emit
-    // unconditionally — even when the video wasn't in any active feed,
-    // a fullscreen route may still be holding it in BLoC-local state.
+    // concrete event ids so existing fullscreen/grid consumers remain
+    // compatible. If the video was not in any active feed, still emit the
+    // requested id because a fullscreen route may be holding it in BLoC state.
     if (!_removedVideoIdsController.isClosed) {
-      _removedVideoIdsController.add(videoId);
+      final idsToEmit = removedVideoIds.isEmpty
+          ? {primaryEventId}
+          : removedVideoIds;
+      for (final id in idsToEmit) {
+        _removedVideoIdsController.add(id);
+      }
     }
 
     if (removedCount > 0) {
       Log.info(
-        'Removed video $videoId from $removedCount location(s) across all feeds',
+        'Removed video $logIdentity from $removedCount location(s) across all feeds',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
@@ -1069,7 +1120,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       notifyListeners();
     } else {
       Log.info(
-        'Video $videoId marked as deleted (was not in any active feeds)',
+        'Video $logIdentity marked as deleted (was not in any active feeds)',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
@@ -1091,6 +1142,18 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   bool isVideoLocallyDeleted(String videoId) {
     return _locallyDeletedVideoIds.contains(videoId);
   }
+
+  /// Check whether this concrete video or its addressable identity has been
+  /// locally deleted.
+  bool isVideoEventLocallyDeleted(VideoEvent video) {
+    return _locallyDeletedVideoIds.contains(video.id) ||
+        _locallyDeletedVideoCoordinateKeys.contains(
+          _localDeletionCoordinateKey(video),
+        );
+  }
+
+  String _localDeletionCoordinateKey(VideoEvent video) =>
+      '${video.pubkey}:${video.stableId}'.toLowerCase();
 
   /// Emits a video id whenever the service has marked it removed —
   /// today this is user-initiated deletion via [removeVideoCompletely];
@@ -4152,7 +4215,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     bool isHistorical = false,
   }) {
     // CRITICAL: Filter out locally deleted videos to prevent pagination resurrection
-    if (isVideoLocallyDeleted(videoEvent.id)) {
+    if (isVideoEventLocallyDeleted(videoEvent)) {
       Log.debug(
         'Filtering out locally deleted video ${videoEvent.id} from $subscriptionType feed',
         name: 'VideoEventService',

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -438,7 +438,7 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
       // Remove video from local feeds after successful deletion
       if (result.success) {
         final videoEventService = ref.read(videoEventServiceProvider);
-        videoEventService.removeVideoCompletely(video.id);
+        videoEventService.removeVideoEventCompletely(video);
       }
 
       if (context.mounted) {

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -1112,7 +1112,7 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
         // Remove video from all local feeds after successful deletion
         if (result.success) {
           final videoEventService = ref.read(videoEventServiceProvider);
-          videoEventService.removeVideoCompletely(widget.video.id);
+          videoEventService.removeVideoEventCompletely(widget.video);
           Log.info(
             'Video removed from all local feeds after deletion: ${widget.video.id}',
             name: 'ShareVideoMenu',

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
@@ -134,7 +134,7 @@ class _VideoMetadataEditBottomBarState
 
       if (result.success) {
         final videoEventService = ref.read(videoEventServiceProvider);
-        videoEventService.removeVideoCompletely(widget.video.id);
+        videoEventService.removeVideoEventCompletely(widget.video);
 
         Log.info(
           'Video deleted successfully: ${widget.video.id}',

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -185,23 +185,30 @@ class NostrClient {
     await _deleteCachedEventsForDeletion(
       eventIds: targetEventIds,
       addressableIds: targetAddressableIds,
+      deletionPubkey: deletionEvent.pubkey,
+      deletionCreatedAt: deletionEvent.createdAt,
     );
   }
 
   Future<void> _deleteCachedEventsForDeletion({
     required List<String> eventIds,
     required List<AId> addressableIds,
+    required String deletionPubkey,
+    required int deletionCreatedAt,
   }) async {
     final dao = _nostrEventsDao;
     if (dao == null) return;
 
     final idsToDelete = eventIds.toSet();
     for (final addressableId in addressableIds) {
+      if (addressableId.pubkey != deletionPubkey) continue;
+
       final matches = await dao.getEventsByFilter(
         Filter(
           kinds: [addressableId.kind],
           authors: [addressableId.pubkey],
           d: [addressableId.dTag],
+          until: deletionCreatedAt,
         ),
       );
       idsToDelete.addAll(matches.map((event) => event.id));
@@ -209,6 +216,15 @@ class NostrClient {
 
     if (idsToDelete.isEmpty) return;
     await dao.deleteEventsByIds(idsToDelete.toList());
+  }
+
+  Future<void> _handleDeletionEventAfterPublish(Event deletionEvent) async {
+    try {
+      await _handleDeletionEvent(deletionEvent);
+    } on Object {
+      // Cache cleanup is best effort after a relay accepted the deletion.
+      // Local DAO failures must not change the publish outcome.
+    }
   }
 
   /// Tracks whether dispose() has been called
@@ -363,7 +379,7 @@ class NostrClient {
     // Handle successful send
     if (sentEvent.kind == EventKind.eventDeletion) {
       // NIP-09: Remove target events from cache
-      await _handleDeletionEvent(sentEvent);
+      await _handleDeletionEventAfterPublish(sentEvent);
     } else if (!useOptimisticCache) {
       // Cache replaceable events on success (not optimistically)
       _cacheEvent(sentEvent);
@@ -457,7 +473,7 @@ class NostrClient {
 
     // Relay confirmed acceptance — apply post-publish cache effects.
     if (event.kind == EventKind.eventDeletion) {
-      await _handleDeletionEvent(event);
+      await _handleDeletionEventAfterPublish(event);
     } else if (!useOptimisticCache) {
       _cacheEvent(event);
     }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -157,32 +157,58 @@ class NostrClient {
   /// Handles a NIP-09 deletion event (Kind 5) by removing target events
   /// from the local database.
   ///
-  /// Extracts event IDs from 'e' tags and deletes them from both the events
-  /// table and video_metrics table.
+  /// Extracts event IDs from `e` tags and addressable coordinates from `a`
+  /// tags, then deletes matching cached events.
   ///
-  /// Fire-and-forget pattern - errors are silently ignored.
-  void _handleDeletionEvent(Event deletionEvent) {
+  Future<void> _handleDeletionEvent(Event deletionEvent) async {
     if (deletionEvent.kind != EventKind.eventDeletion) return;
 
-    // Extract target event IDs from 'e' tags
     final targetEventIds = <String>[];
+    final targetAddressableIds = <AId>[];
     for (final dynamic tag in deletionEvent.tags) {
-      if (tag is List && tag.isNotEmpty && tag[0] == 'e' && tag.length > 1) {
-        final eventId = tag[1];
-        if (eventId is String) {
-          targetEventIds.add(eventId);
+      if (tag is List && tag.length > 1) {
+        final tagName = tag[0];
+        final tagValue = tag[1];
+        if (tagName == 'e' && tagValue is String) {
+          targetEventIds.add(tagValue);
+        } else if (tagName == 'a' && tagValue is String) {
+          final addressableId = AId.fromString(tagValue);
+          if (addressableId != null) {
+            targetAddressableIds.add(addressableId);
+          }
         }
       }
     }
 
-    if (targetEventIds.isEmpty) return;
+    if (targetEventIds.isEmpty && targetAddressableIds.isEmpty) return;
 
-    // Delete target events from the database (fire-and-forget)
-    try {
-      unawaited(_nostrEventsDao?.deleteEventsByIds(targetEventIds));
-    } on Object {
-      // Ignore deletion errors
+    await _deleteCachedEventsForDeletion(
+      eventIds: targetEventIds,
+      addressableIds: targetAddressableIds,
+    );
+  }
+
+  Future<void> _deleteCachedEventsForDeletion({
+    required List<String> eventIds,
+    required List<AId> addressableIds,
+  }) async {
+    final dao = _nostrEventsDao;
+    if (dao == null) return;
+
+    final idsToDelete = eventIds.toSet();
+    for (final addressableId in addressableIds) {
+      final matches = await dao.getEventsByFilter(
+        Filter(
+          kinds: [addressableId.kind],
+          authors: [addressableId.pubkey],
+          d: [addressableId.dTag],
+        ),
+      );
+      idsToDelete.addAll(matches.map((event) => event.id));
     }
+
+    if (idsToDelete.isEmpty) return;
+    await dao.deleteEventsByIds(idsToDelete.toList());
   }
 
   /// Tracks whether dispose() has been called
@@ -337,7 +363,7 @@ class NostrClient {
     // Handle successful send
     if (sentEvent.kind == EventKind.eventDeletion) {
       // NIP-09: Remove target events from cache
-      _handleDeletionEvent(sentEvent);
+      await _handleDeletionEvent(sentEvent);
     } else if (!useOptimisticCache) {
       // Cache replaceable events on success (not optimistically)
       _cacheEvent(sentEvent);
@@ -431,7 +457,7 @@ class NostrClient {
 
     // Relay confirmed acceptance — apply post-publish cache effects.
     if (event.kind == EventKind.eventDeletion) {
-      _handleDeletionEvent(event);
+      await _handleDeletionEvent(event);
     } else if (!useOptimisticCache) {
       _cacheEvent(event);
     }
@@ -677,7 +703,7 @@ class NostrClient {
       (event) {
         // Handle NIP-09 deletion events by removing target events from DB
         if (event.kind == EventKind.eventDeletion) {
-          _handleDeletionEvent(event);
+          unawaited(_handleDeletionEvent(event).catchError((Object _) {}));
         } else {
           // Auto-cache non-deletion events (fire-and-forget)
           try {
@@ -1017,7 +1043,6 @@ class NostrClient {
       targetRelays: targetRelays ?? tempRelays,
     );
     if (result case PublishSuccess(:final event)) {
-      _handleDeletionEvent(event);
       return event;
     }
     return null;
@@ -1044,7 +1069,6 @@ class NostrClient {
       targetRelays: targetRelays ?? tempRelays,
     );
     if (result case PublishSuccess(:final event)) {
-      _handleDeletionEvent(event);
       return event;
     }
     return null;

--- a/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
+++ b/mobile/packages/nostr_client/test/src/nip89_client_tag_test.dart
@@ -36,6 +36,8 @@ void main() {
     Nip89ClientTag.resetForTest();
   });
 
+  tearDown(Nip89ClientTag.resetForTest);
+
   group('Nip89ClientTag', () {
     test('adds the canonical Divine tag', () async {
       final event = _event();

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -615,6 +615,91 @@ void main() {
           ).called(1);
         },
       );
+
+      test(
+        'removes addressable target events from cache after confirmed deletion',
+        () async {
+          final mockDbClient = _MockAppDbClient();
+          final mockDatabase = _MockAppDatabase();
+          final mockNostrEventsDao = _MockNostrEventsDao();
+          when(() => mockDbClient.database).thenReturn(mockDatabase);
+          when(
+            () => mockDatabase.nostrEventsDao,
+          ).thenReturn(mockNostrEventsDao);
+
+          final cachedReplacement = Event(
+            testPublicKey,
+            34236,
+            [
+              ['d', 'shared-vine-id'],
+            ],
+            'replacement',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          )..id = 'replacement_event_id';
+          when(
+            () => mockNostrEventsDao.getEventsByFilter(any()),
+          ).thenAnswer((_) async => [cachedReplacement]);
+          when(
+            () => mockNostrEventsDao.deleteEventsByIds(any()),
+          ).thenAnswer((_) async => 2);
+
+          final clientWithCache = NostrClient.forTesting(
+            nostr: mockNostr,
+            relayManager: mockRelayManager,
+            dbClient: mockDbClient,
+          );
+
+          const addressableId = '34236:$testPublicKey:shared-vine-id';
+          final deleteEvent = Event(
+            testPublicKey,
+            EventKind.eventDeletion,
+            [
+              ['e', 'target_event_id'],
+              ['a', addressableId],
+              ['k', '34236'],
+            ],
+            'deleted',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          )..sig = 'test_sig';
+
+          when(() => mockRelayManager.connectedRelays).thenReturn([
+            'wss://relay.test',
+          ]);
+          when(
+            () => mockNostr.sendEventAwaitOk(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          final outcome = await clientWithCache.publishEventAwaitOk(
+            deleteEvent,
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(outcome.confirmed, isTrue);
+          final capturedFilter =
+              verify(
+                    () => mockNostrEventsDao.getEventsByFilter(captureAny()),
+                  ).captured.single
+                  as Filter;
+          expect(capturedFilter.kinds, equals([34236]));
+          expect(capturedFilter.authors, equals([testPublicKey]));
+          expect(capturedFilter.d, equals(['shared-vine-id']));
+          verify(
+            () => mockNostrEventsDao.deleteEventsByIds(
+              any(
+                that: unorderedEquals([
+                  'target_event_id',
+                  'replacement_event_id',
+                ]),
+              ),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('queryEvents', () {

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -73,7 +73,6 @@ void main() {
     late NostrClient client;
 
     setUpAll(() {
-      SharedPreferences.setMockInitialValues(const <String, Object>{});
       registerFallbackValue(_FakeEvent());
       registerFallbackValue(_FakeFilter());
       registerFallbackValue(_FakeContactList());
@@ -86,6 +85,8 @@ void main() {
     });
 
     setUp(() {
+      SharedPreferences.setMockInitialValues(const <String, Object>{});
+      Nip89ClientTag.resetForTest();
       mockNostr = _MockNostr();
       mockRelayManager = _MockRelayManager();
 
@@ -105,6 +106,7 @@ void main() {
     });
 
     tearDown(() {
+      Nip89ClientTag.resetForTest();
       reset(mockNostr);
       reset(mockRelayManager);
     });
@@ -139,11 +141,7 @@ void main() {
 
         expect(result, isA<PublishSuccess>());
         expect((result as PublishSuccess).event, equals(event));
-        verify(
-          () => mockNostr.sendEvent(
-            event,
-          ),
-        ).called(1);
+        verify(() => mockNostr.sendEvent(event)).called(1);
       });
 
       test('publishes event with target relays', () async {
@@ -208,11 +206,7 @@ void main() {
         expect(result, isA<PublishSuccess>());
         expect((result as PublishSuccess).event, equals(event));
         verify(mockRelayManager.retryDisconnectedRelays).called(1);
-        verify(
-          () => mockNostr.sendEvent(
-            event,
-          ),
-        ).called(1);
+        verify(() => mockNostr.sendEvent(event)).called(1);
       });
 
       test('returns PublishNoRelays when reconnection fails', () async {
@@ -255,11 +249,7 @@ void main() {
         expect(result, isA<PublishSuccess>());
         expect((result as PublishSuccess).event, equals(event));
         verifyNever(mockRelayManager.retryDisconnectedRelays);
-        verify(
-          () => mockNostr.sendEvent(
-            event,
-          ),
-        ).called(1);
+        verify(() => mockNostr.sendEvent(event)).called(1);
       });
 
       group('optimistic cache rollback on reconnection failure', () {
@@ -399,9 +389,9 @@ void main() {
 
       test('returns confirmed outcome when relay accepts the event', () async {
         final event = _createTestEvent();
-        when(() => mockRelayManager.connectedRelays).thenReturn([
-          'wss://relay.test',
-        ]);
+        when(
+          () => mockRelayManager.connectedRelays,
+        ).thenReturn(['wss://relay.test']);
         when(
           () => mockNostr.sendEventAwaitOk(
             any(),
@@ -417,117 +407,102 @@ void main() {
         expect(outcome.acceptedBy, equals(['wss://relay.test']));
       });
 
-      test(
-        'returns failed outcome and rolls back optimistic cache when relay '
-        'rejects',
-        () async {
-          final mockDbClient = _MockAppDbClient();
-          final mockDatabase = _MockAppDatabase();
-          final mockNostrEventsDao = _MockNostrEventsDao();
-          when(() => mockDbClient.database).thenReturn(mockDatabase);
-          when(
-            () => mockDatabase.nostrEventsDao,
-          ).thenReturn(mockNostrEventsDao);
-          when(
-            () => mockNostrEventsDao.upsertEvent(any()),
-          ).thenAnswer((_) async {});
-          when(
-            () => mockNostrEventsDao.deleteEventsByIds(any()),
-          ).thenAnswer((_) async => 1);
+      test('returns failed outcome and rolls back optimistic cache when relay '
+          'rejects', () async {
+        final mockDbClient = _MockAppDbClient();
+        final mockDatabase = _MockAppDatabase();
+        final mockNostrEventsDao = _MockNostrEventsDao();
+        when(() => mockDbClient.database).thenReturn(mockDatabase);
+        when(() => mockDatabase.nostrEventsDao).thenReturn(mockNostrEventsDao);
+        when(
+          () => mockNostrEventsDao.upsertEvent(any()),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockNostrEventsDao.deleteEventsByIds(any()),
+        ).thenAnswer((_) async => 1);
 
-          final clientWithCache = NostrClient.forTesting(
-            nostr: mockNostr,
-            relayManager: mockRelayManager,
-            dbClient: mockDbClient,
-          );
+        final clientWithCache = NostrClient.forTesting(
+          nostr: mockNostr,
+          relayManager: mockRelayManager,
+          dbClient: mockDbClient,
+        );
 
-          final event = _createTestEvent(kind: EventKind.textNote);
-          when(() => mockRelayManager.connectedRelays).thenReturn([
-            'wss://relay.test',
-          ]);
-          when(
-            () => mockNostr.sendEventAwaitOk(
-              any(),
-              tempRelays: any(named: 'tempRelays'),
-              targetRelays: any(named: 'targetRelays'),
-              timeout: any(named: 'timeout'),
-            ),
-          ).thenAnswer((_) async => rejected(event.id));
+        final event = _createTestEvent(kind: EventKind.textNote);
+        when(
+          () => mockRelayManager.connectedRelays,
+        ).thenReturn(['wss://relay.test']);
+        when(
+          () => mockNostr.sendEventAwaitOk(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => rejected(event.id));
 
-          final outcome = await clientWithCache.publishEventAwaitOk(event);
+        final outcome = await clientWithCache.publishEventAwaitOk(event);
 
-          expect(outcome.failed, isTrue);
-          verify(() => mockNostrEventsDao.upsertEvent(event)).called(1);
-          verify(
-            () => mockNostrEventsDao.deleteEventsByIds([event.id]),
-          ).called(1);
-        },
-      );
+        expect(outcome.failed, isTrue);
+        verify(() => mockNostrEventsDao.upsertEvent(event)).called(1);
+        verify(
+          () => mockNostrEventsDao.deleteEventsByIds([event.id]),
+        ).called(1);
+      });
 
-      test(
-        'returns failed outcome without attempting send when no relays are '
-        'reachable',
-        () async {
-          final event = _createTestEvent();
-          when(() => mockRelayManager.connectedRelays).thenReturn([]);
-          when(
-            mockRelayManager.retryDisconnectedRelays,
-          ).thenAnswer((_) async {});
+      test('returns failed outcome without attempting send when no relays are '
+          'reachable', () async {
+        final event = _createTestEvent();
+        when(() => mockRelayManager.connectedRelays).thenReturn([]);
+        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {});
 
-          final outcome = await client.publishEventAwaitOk(event);
+        final outcome = await client.publishEventAwaitOk(event);
 
-          expect(outcome.failed, isTrue);
-          expect(outcome.eventId, equals(event.id));
-          verify(mockRelayManager.retryDisconnectedRelays).called(1);
-          verifyNever(
-            () => mockNostr.sendEventAwaitOk(
-              any(),
-              tempRelays: any(named: 'tempRelays'),
-              targetRelays: any(named: 'targetRelays'),
-              timeout: any(named: 'timeout'),
-            ),
-          );
-        },
-      );
+        expect(outcome.failed, isTrue);
+        expect(outcome.eventId, equals(event.id));
+        verify(mockRelayManager.retryDisconnectedRelays).called(1);
+        verifyNever(
+          () => mockNostr.sendEventAwaitOk(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        );
+      });
 
-      test(
-        'attempts explicit target relays without retrying disconnected pool '
-        'relays',
-        () async {
-          final event = _createTestEvent();
-          const targetRelays = ['wss://relay.divine.video'];
-          const timeout = Duration(seconds: 5);
-          when(() => mockRelayManager.connectedRelays).thenReturn([]);
-          when(
-            mockRelayManager.retryDisconnectedRelays,
-          ).thenAnswer((_) async {});
-          when(
-            () => mockNostr.sendEventAwaitOk(
-              any(),
-              tempRelays: any(named: 'tempRelays'),
-              targetRelays: any(named: 'targetRelays'),
-              timeout: any(named: 'timeout'),
-            ),
-          ).thenAnswer((_) async => accepted(event.id));
+      test('attempts explicit target relays without retrying disconnected pool '
+          'relays', () async {
+        final event = _createTestEvent();
+        const targetRelays = ['wss://relay.divine.video'];
+        const timeout = Duration(seconds: 5);
+        when(() => mockRelayManager.connectedRelays).thenReturn([]);
+        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {});
+        when(
+          () => mockNostr.sendEventAwaitOk(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => accepted(event.id));
 
-          final outcome = await client.publishEventAwaitOk(
+        final outcome = await client.publishEventAwaitOk(
+          event,
+          targetRelays: targetRelays,
+          timeout: timeout,
+        );
+
+        expect(outcome.confirmed, isTrue);
+        verifyNever(mockRelayManager.retryDisconnectedRelays);
+        verify(
+          () => mockNostr.sendEventAwaitOk(
             event,
             targetRelays: targetRelays,
+            tempRelays: targetRelays,
             timeout: timeout,
-          );
-
-          expect(outcome.confirmed, isTrue);
-          verifyNever(mockRelayManager.retryDisconnectedRelays);
-          verify(
-            () => mockNostr.sendEventAwaitOk(
-              event,
-              targetRelays: targetRelays,
-              tempRelays: targetRelays,
-              timeout: timeout,
-            ),
-          ).called(1);
-        },
-      );
+          ),
+        ).called(1);
+      });
 
       test('forwards caller diagnostic tag to the SDK publish path', () async {
         final event = _createTestEvent();
@@ -593,9 +568,9 @@ void main() {
             createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
           )..sig = 'test_sig';
 
-          when(() => mockRelayManager.connectedRelays).thenReturn([
-            'wss://relay.test',
-          ]);
+          when(
+            () => mockRelayManager.connectedRelays,
+          ).thenReturn(['wss://relay.test']);
           when(
             () => mockNostr.sendEventAwaitOk(
               any(),
@@ -662,9 +637,9 @@ void main() {
             createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
           )..sig = 'test_sig';
 
-          when(() => mockRelayManager.connectedRelays).thenReturn([
-            'wss://relay.test',
-          ]);
+          when(
+            () => mockRelayManager.connectedRelays,
+          ).thenReturn(['wss://relay.test']);
           when(
             () => mockNostr.sendEventAwaitOk(
               any(),
@@ -677,7 +652,6 @@ void main() {
           final outcome = await clientWithCache.publishEventAwaitOk(
             deleteEvent,
           );
-          await Future<void>.delayed(Duration.zero);
 
           expect(outcome.confirmed, isTrue);
           final capturedFilter =
@@ -688,6 +662,7 @@ void main() {
           expect(capturedFilter.kinds, equals([34236]));
           expect(capturedFilter.authors, equals([testPublicKey]));
           expect(capturedFilter.d, equals(['shared-vine-id']));
+          expect(capturedFilter.until, equals(deleteEvent.createdAt));
           verify(
             () => mockNostrEventsDao.deleteEventsByIds(
               any(
@@ -698,6 +673,112 @@ void main() {
               ),
             ),
           ).called(1);
+        },
+      );
+
+      test(
+        'ignores addressable deletion tags from a different pubkey',
+        () async {
+          final mockDbClient = _MockAppDbClient();
+          final mockDatabase = _MockAppDatabase();
+          final mockNostrEventsDao = _MockNostrEventsDao();
+          when(() => mockDbClient.database).thenReturn(mockDatabase);
+          when(
+            () => mockDatabase.nostrEventsDao,
+          ).thenReturn(mockNostrEventsDao);
+
+          final clientWithCache = NostrClient.forTesting(
+            nostr: mockNostr,
+            relayManager: mockRelayManager,
+            dbClient: mockDbClient,
+          );
+
+          const victimPubkey =
+              'ffffffffffffffffffffffffffffffff'
+              'ffffffffffffffffffffffffffffffff';
+          const addressableId = '34236:$victimPubkey:shared-vine-id';
+          final deleteEvent = Event(
+            testPublicKey,
+            EventKind.eventDeletion,
+            [
+              ['a', addressableId],
+              ['k', '34236'],
+            ],
+            'deleted',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          )..sig = 'test_sig';
+
+          when(
+            () => mockRelayManager.connectedRelays,
+          ).thenReturn(['wss://relay.test']);
+          when(
+            () => mockNostr.sendEventAwaitOk(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          final outcome = await clientWithCache.publishEventAwaitOk(
+            deleteEvent,
+          );
+
+          expect(outcome.confirmed, isTrue);
+          verifyNever(() => mockNostrEventsDao.getEventsByFilter(any()));
+          verifyNever(() => mockNostrEventsDao.deleteEventsByIds(any()));
+        },
+      );
+
+      test(
+        'keeps confirmed deletion publishes successful when cache cleanup '
+        'fails',
+        () async {
+          final mockDbClient = _MockAppDbClient();
+          final mockDatabase = _MockAppDatabase();
+          final mockNostrEventsDao = _MockNostrEventsDao();
+          when(() => mockDbClient.database).thenReturn(mockDatabase);
+          when(
+            () => mockDatabase.nostrEventsDao,
+          ).thenReturn(mockNostrEventsDao);
+          when(
+            () => mockNostrEventsDao.deleteEventsByIds(any()),
+          ).thenThrow(StateError('database unavailable'));
+
+          final clientWithCache = NostrClient.forTesting(
+            nostr: mockNostr,
+            relayManager: mockRelayManager,
+            dbClient: mockDbClient,
+          );
+
+          final deleteEvent = Event(
+            testPublicKey,
+            EventKind.eventDeletion,
+            [
+              ['e', 'target_event_id'],
+              ['k', '34236'],
+            ],
+            'deleted',
+            createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          )..sig = 'test_sig';
+
+          when(
+            () => mockRelayManager.connectedRelays,
+          ).thenReturn(['wss://relay.test']);
+          when(
+            () => mockNostr.sendEventAwaitOk(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          final outcome = await clientWithCache.publishEventAwaitOk(
+            deleteEvent,
+          );
+
+          expect(outcome.confirmed, isTrue);
         },
       );
     });
@@ -1565,9 +1646,7 @@ void main() {
           ),
         ).thenAnswer((_) async => sentEvent);
 
-        final result = await client.sendProfile(
-          profileContent: profileContent,
-        );
+        final result = await client.sendProfile(profileContent: profileContent);
 
         expect(result, isA<PublishSuccess>());
         expect((result as PublishSuccess).event, equals(sentEvent));
@@ -1610,40 +1689,33 @@ void main() {
         },
       );
 
-      test(
-        'retries disconnected relays and returns PublishSuccess',
-        () async {
-          final sentEvent = _createTestEvent(kind: EventKind.metadata);
-          final connectedRelays = ['wss://relay1.example.com'];
+      test('retries disconnected relays and returns PublishSuccess', () async {
+        final sentEvent = _createTestEvent(kind: EventKind.metadata);
+        final connectedRelays = ['wss://relay1.example.com'];
 
-          when(() => mockRelayManager.connectedRelays).thenReturn([]);
-          when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {
-            when(
-              () => mockRelayManager.connectedRelays,
-            ).thenReturn(connectedRelays);
-          });
+        when(() => mockRelayManager.connectedRelays).thenReturn([]);
+        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {
           when(
-            () => mockNostr.sendEvent(
-              any(),
-              tempRelays: any(named: 'tempRelays'),
-              targetRelays: any(named: 'targetRelays'),
-            ),
-          ).thenAnswer((_) async => sentEvent);
+            () => mockRelayManager.connectedRelays,
+          ).thenReturn(connectedRelays);
+        });
+        when(
+          () => mockNostr.sendEvent(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => sentEvent);
 
-          final result = await client.sendProfile(
-            profileContent: {'display_name': 'Alice'},
-          );
+        final result = await client.sendProfile(
+          profileContent: {'display_name': 'Alice'},
+        );
 
-          expect(result, isA<PublishSuccess>());
-          expect((result as PublishSuccess).event, equals(sentEvent));
-          verify(mockRelayManager.retryDisconnectedRelays).called(1);
-          verify(
-            () => mockNostr.sendEvent(
-              any(),
-            ),
-          ).called(1);
-        },
-      );
+        expect(result, isA<PublishSuccess>());
+        expect((result as PublishSuccess).event, equals(sentEvent));
+        verify(mockRelayManager.retryDisconnectedRelays).called(1);
+        verify(() => mockNostr.sendEvent(any())).called(1);
+      });
 
       test('returns PublishFailed when sendEvent returns null', () async {
         when(
@@ -1732,10 +1804,11 @@ void main() {
         );
         final captured = verification.captured.single as Event;
         expect(captured.content, content);
-        expect(
-          captured.tags.firstWhere((tag) => tag[0] == 'e'),
-          ['e', eventId, relayAddr],
-        );
+        expect(captured.tags.firstWhere((tag) => tag[0] == 'e'), [
+          'e',
+          eventId,
+          relayAddr,
+        ]);
       });
 
       test('returns null when sendRepost fails', () async {
@@ -2182,50 +2255,44 @@ void main() {
         },
       );
 
-      test(
-        'returns "Nostr <base64>" without payload tag when payload is not '
-        'provided',
-        () async {
-          when(() => mockNostr.signEvent(any())).thenAnswer((invocation) {
-            invocation.positionalArguments[0] as Event
-              ..id = 'id'
-              ..sig = 'sig';
-            return Future.value();
-          });
+      test('returns "Nostr <base64>" without payload tag when payload is not '
+          'provided', () async {
+        when(() => mockNostr.signEvent(any())).thenAnswer((invocation) {
+          invocation.positionalArguments[0] as Event
+            ..id = 'id'
+            ..sig = 'sig';
+          return Future.value();
+        });
 
-          const url = 'https://divine.video/api/username/claim';
-          final authHeader = await client.createNip98AuthHeader(
-            url: url,
-            method: 'POST',
-          );
-          final decoded =
-              jsonDecode(utf8.decode(base64Decode(authHeader!.split(' ')[1])))
-                  as Map<String, dynamic>;
-          final tags = (decoded['tags'] as List).cast<List<dynamic>>();
+        const url = 'https://divine.video/api/username/claim';
+        final authHeader = await client.createNip98AuthHeader(
+          url: url,
+          method: 'POST',
+        );
+        final decoded =
+            jsonDecode(utf8.decode(base64Decode(authHeader!.split(' ')[1])))
+                as Map<String, dynamic>;
+        final tags = (decoded['tags'] as List).cast<List<dynamic>>();
 
-          expect(authHeader, startsWith('Nostr '));
-          expect(decoded['kind'], equals(EventKind.httpAuth));
-          expect(tags[0][1], equals(url));
-          expect(tags[1][1], equals('POST'));
-          expect(tags.length, equals(2));
-        },
-      );
+        expect(authHeader, startsWith('Nostr '));
+        expect(decoded['kind'], equals(EventKind.httpAuth));
+        expect(tags[0][1], equals(url));
+        expect(tags[1][1], equals('POST'));
+        expect(tags.length, equals(2));
+      });
 
-      test(
-        'returns null when signing fails',
-        () async {
-          when(
-            () => mockNostr.signEvent(any()),
-          ).thenAnswer((_) => Future.value());
+      test('returns null when signing fails', () async {
+        when(
+          () => mockNostr.signEvent(any()),
+        ).thenAnswer((_) => Future.value());
 
-          const url = 'https://divine.video/api/username/claim';
-          final authHeader = await client.createNip98AuthHeader(
-            url: url,
-            method: 'POST',
-          );
-          expect(authHeader, isNull);
-        },
-      );
+        const url = 'https://divine.video/api/username/claim';
+        final authHeader = await client.createNip98AuthHeader(
+          url: url,
+          method: 'POST',
+        );
+        expect(authHeader, isNull);
+      });
     });
 
     group('dispose', () {
@@ -2436,12 +2503,8 @@ void main() {
           final filters = [
             Filter(kinds: [EventKind.textNote], limit: 10),
           ];
-          final cachedEvents = [
-            _createTestEvent(content: 'cached 1'),
-          ];
-          final wsEvents = [
-            _createTestEvent(content: 'from websocket'),
-          ];
+          final cachedEvents = [_createTestEvent(content: 'cached 1')];
+          final wsEvents = [_createTestEvent(content: 'from websocket')];
 
           when(
             () => mockNostrEventsDao.getEventsByFilter(any()),
@@ -2913,12 +2976,7 @@ void main() {
           ),
         ).thenReturn('search-sub-id');
 
-        client.searchVideos(
-          query,
-          since: since,
-          until: until,
-          limit: limit,
-        );
+        client.searchVideos(query, since: since, until: until, limit: limit);
 
         // Verify subscribe was called with filter containing search
         final captured = verify(

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -66,7 +66,7 @@ class _Harness {
     when(
       () => ves.filterVideoList(any()),
     ).thenAnswer((i) => i.positionalArguments[0] as List<VideoEvent>);
-    when(() => ves.isVideoLocallyDeleted(any())).thenReturn(false);
+    when(() => ves.isVideoEventLocallyDeleted(any())).thenReturn(false);
     when(() => ves.subscribeToUserVideos(any())).thenAnswer((_) async {});
     when(
       () => ves.queryHistoricalUserVideos(any(), until: any(named: 'until')),
@@ -147,6 +147,7 @@ class _Harness {
 
 void main() {
   setUpAll(() {
+    registerFallbackValue(_video('fallback'));
     registerFallbackValue(<VideoEvent>[]);
     registerFallbackValue(() {});
     registerFallbackValue((VideoEvent _) {});
@@ -574,7 +575,11 @@ void main() {
     });
 
     test('tombstoned videos are excluded from emitted state', () async {
-      when(() => h.ves.isVideoLocallyDeleted('a')).thenReturn(true);
+      when(
+        () => h.ves.isVideoEventLocallyDeleted(
+          any(that: isA<VideoEvent>().having((v) => v.id, 'id', 'a')),
+        ),
+      ).thenReturn(true);
       final cubit = await buildReady(_result([_video('a'), _video('b')]));
       addTearDown(cubit.close);
 

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -100,6 +100,7 @@ void main() {
         34236,
         [
           ['title', 'Test Video'],
+          ['d', 'test-vine-id'],
           ['url', 'https://example.com/video.mp4'],
         ],
         'Test video content',
@@ -121,6 +122,7 @@ void main() {
             kind: 5,
             tags: [
               ['e', video.id],
+              ['a', video.addressableId!],
               ['k', '34236'],
             ],
             content: 'CONTENT DELETION',
@@ -149,6 +151,13 @@ void main() {
           expect(result.success, isTrue);
           expect(result.deleteEventId, equals(deleteEvent.id));
           expect(service.hasBeenDeleted(video.id), isTrue);
+          expect(
+            service.hasBeenDeleted(
+              'replacement-event-id',
+              addressableId: video.addressableId,
+            ),
+            isTrue,
+          );
 
           verify(
             () => mockAuthService.createAndSignEvent(
@@ -170,6 +179,7 @@ void main() {
             kind: 5,
             tags: [
               ['e', video.id],
+              ['a', video.addressableId!],
               ['k', '34236'],
             ],
             content: 'CONTENT DELETION',
@@ -211,6 +221,7 @@ void main() {
           kind: 5,
           tags: [
             ['e', video.id],
+            ['a', video.addressableId!],
             ['k', '34236'],
           ],
           content: 'CONTENT DELETION',
@@ -243,7 +254,7 @@ void main() {
       });
 
       test(
-        'includes the k tag with the original video kind per NIP-09',
+        'includes e, a, and k tags for addressable videos per NIP-09',
         () async {
           final video = createTestVideoEvent(testPublicKey);
           final deleteEvent = createTestEvent(
@@ -251,6 +262,7 @@ void main() {
             kind: 5,
             tags: [
               ['e', video.id],
+              ['a', video.addressableId!],
               ['k', '34236'],
             ],
             content: 'CONTENT DELETION',
@@ -282,6 +294,8 @@ void main() {
           ).captured;
 
           final tags = captured.first as List<List<String>>;
+          expect(tags, contains(equals(['e', video.id])));
+          expect(tags, contains(equals(['a', video.addressableId])));
           final kTag = tags.firstWhere(
             (tag) => tag.isNotEmpty && tag[0] == 'k',
             orElse: () => <String>[],
@@ -350,6 +364,7 @@ void main() {
           kind: 5,
           tags: [
             ['e', video.id],
+            ['a', video.addressableId!],
             ['k', '34236'],
           ],
           content: 'CONTENT DELETION',

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -94,13 +94,16 @@ void main() {
       await service.initialize();
     });
 
-    VideoEvent createTestVideoEvent(String pubkey) {
+    VideoEvent createTestVideoEvent(
+      String pubkey, {
+      String? dTag = 'test-vine-id',
+    }) {
       final event = Event(
         pubkey,
         34236,
         [
           ['title', 'Test Video'],
-          ['d', 'test-vine-id'],
+          if (dTag != null) ['d', dTag],
           ['url', 'https://example.com/video.mp4'],
         ],
         'Test video content',
@@ -109,6 +112,18 @@ void main() {
       event.id = 'test_event_id_${DateTime.now().millisecondsSinceEpoch}';
       event.sig = 'test_signature';
       return VideoEvent.fromNostrEvent(event);
+    }
+
+    VideoEvent createRestShapedVideoEvent(String pubkey) {
+      return VideoEvent(
+        id: 'rest_event_id',
+        pubkey: pubkey,
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        content: 'Test video content',
+        timestamp: DateTime.now(),
+        videoUrl: 'https://example.com/video.mp4',
+        vineId: 'rest-vine-id',
+      );
     }
 
     group('deleteContent', () {
@@ -303,6 +318,99 @@ void main() {
 
           expect(kTag, isNotEmpty);
           expect(kTag[1], equals('34236'));
+        },
+      );
+
+      test(
+        'does not include synthetic a tag when the video has no real d tag',
+        () async {
+          final video = createTestVideoEvent(testPublicKey, dTag: null);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+              ['k', '34236'],
+            ],
+            content: 'CONTENT DELETION',
+          );
+
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          await service.deleteContent(video: video, reason: 'Personal choice');
+
+          final captured = verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: captureAny(named: 'tags'),
+            ),
+          ).captured;
+
+          final tags = captured.first as List<List<String>>;
+          expect(tags, contains(equals(['e', video.id])));
+          expect(tags.any((tag) => tag.isNotEmpty && tag[0] == 'a'), isFalse);
+          expect(tags, contains(equals(['k', '34236'])));
+        },
+      );
+
+      test(
+        'includes a tag for REST-shaped videos with a real vine id',
+        () async {
+          final video = createRestShapedVideoEvent(testPublicKey);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+              ['a', video.addressableId!],
+              ['k', '34236'],
+            ],
+            content: 'CONTENT DELETION',
+          );
+
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          await service.deleteContent(video: video, reason: 'Personal choice');
+
+          final captured = verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: captureAny(named: 'tags'),
+            ),
+          ).captured;
+
+          final tags = captured.first as List<List<String>>;
+          expect(tags, contains(equals(['e', video.id])));
+          expect(tags, contains(equals(['a', video.addressableId])));
+          expect(tags, contains(equals(['k', '34236'])));
         },
       );
 

--- a/mobile/test/services/video_event_service_deletion_test.dart
+++ b/mobile/test/services/video_event_service_deletion_test.dart
@@ -5,6 +5,7 @@
 @Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
@@ -14,6 +15,27 @@ import 'package:openvine/services/video_event_service.dart';
 class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+VideoEvent _videoEvent({
+  required String id,
+  required String pubkey,
+  required String dTag,
+}) {
+  final event =
+      Event(
+          pubkey,
+          34236,
+          [
+            ['d', dTag],
+            ['url', 'https://example.com/$id.mp4'],
+          ],
+          'test video',
+          createdAt: 1000,
+        )
+        ..id = id
+        ..sig = 'sig-$id';
+  return VideoEvent.fromNostrEvent(event);
+}
 
 void main() {
   setUpAll(() {
@@ -30,6 +52,11 @@ void main() {
       subscriptionManager = _MockSubscriptionManager();
       when(() => nostrClient.isInitialized).thenReturn(true);
       when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(
+        () => nostrClient.publicKey,
+      ).thenReturn(
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      );
       when(
         () => nostrClient.subscribe(any()),
       ).thenAnswer((_) => const Stream<Event>.empty());
@@ -102,6 +129,40 @@ void main() {
       await earlySub.cancel();
       await lateSub.cancel();
     });
+
+    test(
+      'addressable removal emits requested id when only a sibling is cached',
+      () async {
+        const pubkey =
+            'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+        final emitted = <String>[];
+        final sub = service.removedVideoIds.listen(emitted.add);
+
+        final deletedVideo = _videoEvent(
+          id: 'held-fullscreen-id',
+          pubkey: pubkey,
+          dTag: 'shared-vine-id',
+        );
+        final cachedSibling = _videoEvent(
+          id: 'cached-replacement-id',
+          pubkey: pubkey,
+          dTag: 'shared-vine-id',
+        );
+
+        service.addVideoEventForTesting(
+          cachedSibling,
+          SubscriptionType.discovery,
+          isHistorical: false,
+        );
+
+        service.removeVideoEventCompletely(deletedVideo);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(emitted, contains('held-fullscreen-id'));
+        expect(emitted, contains('cached-replacement-id'));
+        await sub.cancel();
+      },
+    );
 
     test('isVideoLocallyDeleted reflects the tombstone after emit', () {
       service.removeVideoCompletely('vid-1');

--- a/mobile/test/unit/services/video_event_service_deletion_test.dart
+++ b/mobile/test/unit/services/video_event_service_deletion_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
@@ -37,6 +38,28 @@ class TestSubscriptionManager extends Mock implements SubscriptionManager {
 }
 
 class FakeFilter extends Fake implements Filter {}
+
+VideoEvent _videoEvent({
+  required String id,
+  required String pubkey,
+  required String dTag,
+  int createdAt = 1000,
+}) {
+  final event =
+      Event(
+          pubkey,
+          34236,
+          [
+            ['d', dTag],
+            ['url', 'https://example.com/$id.mp4'],
+          ],
+          'test video',
+          createdAt: createdAt,
+        )
+        ..id = id
+        ..sig = 'sig-$id';
+  return VideoEvent.fromNostrEvent(event);
+}
 
 void main() {
   setUpAll(() {
@@ -131,5 +154,38 @@ void main() {
         // ensuring they don't "resurrect" when new data loads
       },
     );
+
+    test('tombstones replacement event ids for the same addressable video', () {
+      const pubkey =
+          'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+      final deletedVideo = _videoEvent(
+        id: 'event-id-before-delete',
+        pubkey: pubkey,
+        dTag: 'shared-vine-id',
+      );
+      final replacementVersion = _videoEvent(
+        id: 'event-id-after-delete',
+        pubkey: pubkey,
+        dTag: 'shared-vine-id',
+        createdAt: 1001,
+      );
+      final unrelatedVideo = _videoEvent(
+        id: 'unrelated-event-id',
+        pubkey: pubkey,
+        dTag: 'different-vine-id',
+      );
+
+      videoEventService.removeVideoEventCompletely(deletedVideo);
+
+      expect(videoEventService.isVideoLocallyDeleted(deletedVideo.id), isTrue);
+      expect(
+        videoEventService.isVideoEventLocallyDeleted(replacementVersion),
+        isTrue,
+      );
+      expect(
+        videoEventService.isVideoEventLocallyDeleted(unrelatedVideo),
+        isFalse,
+      );
+    });
   });
 }

--- a/mobile/test/widgets/profile/profile_video_feed_view_test.dart
+++ b/mobile/test/widgets/profile/profile_video_feed_view_test.dart
@@ -35,6 +35,8 @@ class _FakeSystemVolumeListener implements SystemVolumeListener {
   }
 }
 
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
 const _profilePubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
@@ -62,6 +64,10 @@ void main() {
     late _MockVideoEventService videoEventService;
     late _MockContentBlocklistRepository blocklistRepository;
 
+    setUpAll(() {
+      registerFallbackValue(_FakeVideoEvent());
+    });
+
     setUp(() {
       videosRepository = _MockVideosRepository();
       videoEventService = _MockVideoEventService();
@@ -74,7 +80,7 @@ void main() {
         () => videoEventService.filterVideoList(any()),
       ).thenAnswer((i) => i.positionalArguments.first as List<VideoEvent>);
       when(
-        () => videoEventService.isVideoLocallyDeleted(any()),
+        () => videoEventService.isVideoEventLocallyDeleted(any()),
       ).thenReturn(false);
       when(
         () => videoEventService.subscribeToUserVideos(any()),


### PR DESCRIPTION
## Summary

Fixes #5029 by making video deletion use the addressable Nostr identity for kind 34236 videos instead of only the current event id.

## What Changed

- Add the NIP-09 `a` tag alongside the existing `e` and `k` tags when deleting addressable videos.
- Persist deletion history with the addressable id when available, while keeping event-id lookup compatibility.
- Add coordinate-aware local tombstones in `VideoEventService` so replacement event ids with the same `pubkey:d-tag` do not reappear in-session.
- Keep `removedVideoIds` event-id based for existing fullscreen/grid consumers, while delete call sites pass the full `VideoEvent` for coordinate-aware removal.
- Extend `NostrClient` deletion handling to honor incoming `a` tags by deleting cached events matching kind/pubkey/d-tag.

## Validation

- `mise exec flutter@3.44.0 -- flutter test test/services/content_deletion_service_test.dart test/unit/services/video_event_service_deletion_test.dart test/services/video_event_service_deletion_test.dart test/blocs/profile_feed/profile_feed_cubit_test.dart test/widgets/profile/profile_video_feed_view_test.dart packages/nostr_client/test/src/nostr_client_test.dart`
- `mise exec flutter@3.44.0 -- flutter analyze`
- Pre-push hook: analyzer and changed-file tests passed