### PR TITLE
fix(blocklist): reset per-account state on identity change (#4969)

### DIFF
--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -24,6 +24,11 @@ const _mutedUsersPrefsKey = 'muted_users_list';
 /// SharedPreferences key for severed followers (follow broken by block)
 const _severedFollowersPrefsKey = 'severed_followers_list';
 
+/// SharedPreferences key recording which account's per-account state the
+/// persisted sets belong to. Written on identity adoption so the next
+/// construction hydrates the right account before auth resolves.
+const _activePubkeyPrefsKey = 'blocklist_active_pubkey';
+
 /// Service for managing content blocklist
 ///
 /// This service maintains an internal blocklist of npubs whose content
@@ -47,6 +52,7 @@ class ContentBlocklistRepository {
        _onChanged = onChanged {
     // Initialize with the specific npub requested
     _addInitialBlockedContent();
+    _activeAccountPubkey = _prefs?.getString(_activePubkeyPrefsKey);
     _loadBlockedUsers();
     _loadMutedUsers();
     _loadSeveredFollowers();
@@ -108,6 +114,11 @@ class ContentBlocklistRepository {
   bool _mutualMuteSyncStarted = false;
   String? _ourPubkey;
 
+  // Account whose persisted sets are currently loaded. Seeded from prefs at
+  // construction so hydration covers the window before auth resolves;
+  // corrected by [_adoptIdentity] once the session identity is known.
+  String? _activeAccountPubkey;
+
   // Subscription tracking for block list sync
   bool _blockListSyncStarted = false;
 
@@ -167,12 +178,119 @@ class ContentBlocklistRepository {
     // Users can still block individuals via the app UI
   }
 
+  /// Storage key for [base] scoped to the active account.
+  ///
+  /// Falls back to the legacy un-namespaced key while no account has been
+  /// adopted yet (pre-auth or pre-migration installs).
+  String _scopedKey(String base) {
+    final account = _activeAccountPubkey;
+    return account == null ? base : '$base.$account';
+  }
+
+  /// Adopts [pubkey] as the session identity, resetting state that
+  /// belongs to a different account.
+  ///
+  /// All in-memory sets are keyed to one identity: `_blockedByOthers` /
+  /// `_mutualMuteBlocklist` hold who blocks/mutes *us*, and the persisted
+  /// sets are stored per account. Before this existed, the keepAlive
+  /// repository carried account A's state into account B after a switch,
+  /// filtering the wrong authors and showing false "account not
+  /// available" gates (#4969).
+  void _adoptIdentity(String pubkey) {
+    if (_ourPubkey == pubkey) return;
+    final isSwitch = _ourPubkey != null;
+    final storedAccountDiffers =
+        _activeAccountPubkey != null && _activeAccountPubkey != pubkey;
+
+    _ourPubkey = pubkey;
+
+    if (isSwitch || storedAccountDiffers) {
+      _runtimeBlocklist.clear();
+      _mutedPubkeys.clear();
+      _mutualMuteBlocklist.clear();
+      _blockedByOthers.clear();
+      _latestMuteListEventCreatedAtByAuthor.clear();
+      _latestBlockListEventCreatedAtByAuthor.clear();
+      _severedFollowers.clear();
+      // Force fresh subscriptions filtered on the new pubkey.
+      _mutualMuteSyncStarted = false;
+      _blockListSyncStarted = false;
+    } else {
+      // First identity on this install: legacy un-namespaced data was
+      // written by this account before per-account keys existed.
+      _migrateLegacyKeys(pubkey);
+    }
+
+    _activeAccountPubkey = pubkey;
+    unawaited(_saveActiveAccountPubkey(pubkey));
+
+    if (isSwitch || storedAccountDiffers) {
+      _loadBlockedUsers();
+      _loadMutedUsers();
+      _loadSeveredFollowers();
+      _notifyChanged();
+      Log.info(
+        'Adopted new identity; blocklist state reset and reloaded '
+        '(${_runtimeBlocklist.length} persisted blocks)',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  /// Persists which account the per-account sets belong to.
+  ///
+  /// Failures are logged and swallowed — persistence must never break
+  /// the in-memory blocklist, matching the other save methods.
+  Future<void> _saveActiveAccountPubkey(String pubkey) async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+    try {
+      await prefs.setString(_activePubkeyPrefsKey, pubkey);
+    } on Object catch (e) {
+      Log.error(
+        'Failed to persist active blocklist account: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  /// Moves legacy un-namespaced persisted sets to [pubkey]'s scoped keys.
+  ///
+  /// Runs only while no account was ever adopted on this install, so a
+  /// pre-migration user's data follows the first identity that signs in.
+  /// Failures are logged and swallowed — the in-memory sets already hold
+  /// the legacy data, so a failed move only delays the migration.
+  void _migrateLegacyKeys(String pubkey) {
+    final prefs = _prefs;
+    if (prefs == null || _activeAccountPubkey != null) return;
+    for (final base in [
+      _blockedUsersPrefsKey,
+      _mutedUsersPrefsKey,
+      _severedFollowersPrefsKey,
+    ]) {
+      try {
+        final legacy = prefs.getString(base);
+        if (legacy == null || legacy.isEmpty) continue;
+        unawaited(prefs.setString('$base.$pubkey', legacy));
+        unawaited(prefs.remove(base));
+      } on Object catch (e) {
+        Log.error(
+          'Failed to migrate legacy blocklist key $base: $e',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+      }
+    }
+  }
+
   /// Load persisted blocked users from SharedPreferences
   void _loadBlockedUsers() {
     final prefs = _prefs;
     if (prefs == null) return;
 
-    final stored = prefs.getString(_blockedUsersPrefsKey);
+    final stored = prefs.getString(_scopedKey(_blockedUsersPrefsKey));
     if (stored == null || stored.isEmpty) return;
 
     try {
@@ -201,7 +319,7 @@ class ContentBlocklistRepository {
 
     try {
       final json = jsonEncode(_runtimeBlocklist.toList());
-      await prefs.setString(_blockedUsersPrefsKey, json);
+      await prefs.setString(_scopedKey(_blockedUsersPrefsKey), json);
     } on Object catch (e) {
       Log.error(
         'Failed to persist blocked users: $e',
@@ -219,7 +337,7 @@ class ContentBlocklistRepository {
     final prefs = _prefs;
     if (prefs == null) return;
 
-    final stored = prefs.getString(_mutedUsersPrefsKey);
+    final stored = prefs.getString(_scopedKey(_mutedUsersPrefsKey));
     if (stored == null || stored.isEmpty) return;
 
     try {
@@ -248,7 +366,7 @@ class ContentBlocklistRepository {
 
     try {
       final json = jsonEncode(_mutedPubkeys.toList());
-      await prefs.setString(_mutedUsersPrefsKey, json);
+      await prefs.setString(_scopedKey(_mutedUsersPrefsKey), json);
     } on Object catch (e) {
       Log.error(
         'Failed to persist muted authors: $e',
@@ -263,7 +381,7 @@ class ContentBlocklistRepository {
     final prefs = _prefs;
     if (prefs == null) return;
 
-    final stored = prefs.getString(_severedFollowersPrefsKey);
+    final stored = prefs.getString(_scopedKey(_severedFollowersPrefsKey));
     if (stored == null || stored.isEmpty) return;
 
     try {
@@ -292,7 +410,7 @@ class ContentBlocklistRepository {
 
     try {
       final json = jsonEncode(_severedFollowers.toList());
-      await prefs.setString(_severedFollowersPrefsKey, json);
+      await prefs.setString(_scopedKey(_severedFollowersPrefsKey), json);
     } on Object catch (e) {
       Log.error(
         'Failed to persist severed followers: $e',
@@ -579,6 +697,10 @@ class ContentBlocklistRepository {
     NostrClient nostrService,
     String ourPubkey,
   ) async {
+    // Reset per-account state (and the started flags) if the identity
+    // changed, so the subscription below filters on the new pubkey (#4969).
+    _adoptIdentity(ourPubkey);
+
     // If the NostrClient changed (e.g., account switch), the old subscription
     // was on a disposed client. Reset so we create a fresh subscription.
     if (_mutualMuteSyncStarted && _nostrClient != nostrService) {
@@ -593,8 +715,6 @@ class ContentBlocklistRepository {
       );
       return;
     }
-
-    _ourPubkey = ourPubkey;
 
     // Store references for Nostr publishing
     _nostrClient = nostrService;
@@ -655,6 +775,10 @@ class ContentBlocklistRepository {
     BlockListSigner signer,
     String ourPubkey,
   ) async {
+    // Reset per-account state (and the started flags) if the identity
+    // changed, so the subscription below filters on the new pubkey (#4969).
+    _adoptIdentity(ourPubkey);
+
     // If the NostrClient changed (e.g., account switch), the old subscription
     // was on a disposed client. Reset so we create a fresh subscription.
     if (_blockListSyncStarted && _nostrClient != nostrService) {
@@ -670,7 +794,6 @@ class ContentBlocklistRepository {
       return;
     }
 
-    _ourPubkey = ourPubkey;
     _signer = signer;
     _nostrClient = nostrService;
 

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -53,6 +53,13 @@ class ContentBlocklistRepository {
     // Initialize with the specific npub requested
     _addInitialBlockedContent();
     _activeAccountPubkey = _prefs?.getString(_activePubkeyPrefsKey);
+    final seededAccount = _activeAccountPubkey;
+    _scopedBasesPresentAtConstruction = seededAccount == null
+        ? const <String>{}
+        : <String>{
+            for (final base in _legacySetsByBase.keys)
+              if (_prefs?.getString('$base.$seededAccount') != null) base,
+          };
     _loadBlockedUsers();
     _loadMutedUsers();
     _loadSeveredFollowers();
@@ -101,6 +108,20 @@ class ContentBlocklistRepository {
   // Persists across unblocking so these users remain hidden from our
   // followers list until they explicitly re-follow.
   final Set<String> _severedFollowers = <String>{};
+
+  // Persisted sets that migrate from legacy un-namespaced keys, by key.
+  late final Map<String, Set<String>> _legacySetsByBase = {
+    _blockedUsersPrefsKey: _runtimeBlocklist,
+    _mutedUsersPrefsKey: _mutedPubkeys,
+    _severedFollowersPrefsKey: _severedFollowers,
+  };
+
+  // Scoped keys of the seeded account that already held data when this
+  // instance hydrated. _migrateLegacyKeys treats those as authoritative
+  // over the legacy snapshot; a scoped key that appears later in the
+  // session was written by a save racing the migration and must be
+  // merged with the legacy data, not preferred over it.
+  late final Set<String> _scopedBasesPresentAtConstruction;
 
   final _stateController = StreamController<ContentPolicyState>.broadcast();
 
@@ -212,14 +233,19 @@ class ContentBlocklistRepository {
       _latestMuteListEventCreatedAtByAuthor.clear();
       _latestBlockListEventCreatedAtByAuthor.clear();
       _severedFollowers.clear();
-      // Force fresh subscriptions filtered on the new pubkey.
+      // Force fresh subscriptions filtered on the new pubkey. On a
+      // same-client switch the old subscription's listener is
+      // intentionally left in place (no handle is retained to cancel
+      // it); its deliveries stay harmless because every handler
+      // re-checks the live _ourPubkey at delivery time.
       _mutualMuteSyncStarted = false;
       _blockListSyncStarted = false;
-    } else {
-      // First identity on this install: legacy un-namespaced data was
-      // written by this account before per-account keys existed.
-      _migrateLegacyKeys(pubkey);
     }
+
+    // Legacy un-namespaced data predates per-account keys and follows
+    // the first identity that signed in; the move no-ops for any other
+    // account. Must run before _activeAccountPubkey is reassigned.
+    unawaited(_migrateLegacyKeys(pubkey));
 
     _activeAccountPubkey = pubkey;
     unawaited(_saveActiveAccountPubkey(pubkey));
@@ -258,26 +284,94 @@ class ContentBlocklistRepository {
 
   /// Moves legacy un-namespaced persisted sets to [pubkey]'s scoped keys.
   ///
-  /// Runs only while no account was ever adopted on this install, so a
-  /// pre-migration user's data follows the first identity that signs in.
-  /// Failures are logged and swallowed — the in-memory sets already hold
-  /// the legacy data, so a failed move only delays the migration.
-  void _migrateLegacyKeys(String pubkey) {
+  /// Runs while no account was ever adopted on this install, or while
+  /// [pubkey] is the recorded account — so a move that failed on a
+  /// previous launch is retried instead of orphaning the legacy data.
+  /// Legacy values merge into the in-memory sets synchronously (a no-op
+  /// when construction already hydrated them) and persist via full-set
+  /// writes; a legacy key is removed only once its data is confirmed
+  /// under the scoped key, so a partial failure never destroys data.
+  Future<void> _migrateLegacyKeys(String pubkey) async {
     final prefs = _prefs;
-    if (prefs == null || _activeAccountPubkey != null) return;
-    for (final base in [
-      _blockedUsersPrefsKey,
-      _mutedUsersPrefsKey,
-      _severedFollowersPrefsKey,
-    ]) {
+    if (prefs == null) return;
+    if (_activeAccountPubkey != null && _activeAccountPubkey != pubkey) {
+      return;
+    }
+
+    // Decide and merge synchronously so no concurrent write can land
+    // between reading a legacy value and folding it into memory.
+    final pendingMoves = <String, Set<String>>{};
+    final staleBases = <String>[];
+    var recovered = false;
+    for (final entry in _legacySetsByBase.entries) {
+      final base = entry.key;
+      final legacy = prefs.getString(base);
+      if (legacy == null || legacy.isEmpty) continue;
+      final scopedExists = prefs.getString('$base.$pubkey') != null;
+      if (scopedExists &&
+          (_scopedBasesPresentAtConstruction.contains(base) ||
+              _activeAccountPubkey == null)) {
+        // A scoped value that predates this adoption is authoritative:
+        // merging the stale legacy snapshot could resurrect entries
+        // deleted since the original copy. (Before first adoption,
+        // saves write the legacy key itself, so a scoped value can
+        // only be a leftover from an earlier partially-failed
+        // migration — while for the recorded account, one that was
+        // absent at construction was written by a save racing this
+        // migration and is merged below instead.)
+        staleBases.add(base);
+        continue;
+      }
       try {
-        final legacy = prefs.getString(base);
-        if (legacy == null || legacy.isEmpty) continue;
-        unawaited(prefs.setString('$base.$pubkey', legacy));
-        unawaited(prefs.remove(base));
+        final decoded = (jsonDecode(legacy) as List<dynamic>).cast<String>();
+        final target = entry.value;
+        final sizeBefore = target.length;
+        target.addAll(decoded);
+        recovered = recovered || target.length != sizeBefore;
+        pendingMoves[base] = target;
       } on Object catch (e) {
         Log.error(
-          'Failed to migrate legacy blocklist key $base: $e',
+          'Skipping corrupt legacy blocklist key $base: $e',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+      }
+    }
+    if (recovered) {
+      // A retried move recovered data that construction could not see;
+      // notify so watchers re-filter with it this session.
+      _notifyChanged();
+    }
+
+    for (final base in staleBases) {
+      try {
+        await prefs.remove(base);
+      } on Object catch (e) {
+        Log.error(
+          'Failed to drop stale legacy blocklist key $base: $e',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+      }
+    }
+
+    for (final entry in pendingMoves.entries) {
+      // Re-checked before every write: after a mid-flight account
+      // switch the live sets belong to the new identity and must not
+      // be serialized under [pubkey]'s keys.
+      if (_activeAccountPubkey != null && _activeAccountPubkey != pubkey) {
+        return;
+      }
+      try {
+        final written = await prefs.setString(
+          '${entry.key}.$pubkey',
+          jsonEncode(entry.value.toList()),
+        );
+        if (!written) continue;
+        await prefs.remove(entry.key);
+      } on Object catch (e) {
+        Log.error(
+          'Failed to migrate legacy blocklist key ${entry.key}: $e',
           name: 'ContentBlocklistRepository',
           category: LogCategory.system,
         );

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1071,6 +1071,290 @@ void main() {
       service.dispose();
     });
 
+    test('keeps the legacy key when the scoped copy reports failure', () async {
+      final mockPrefs = _MockSharedPreferences();
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(
+        () => mockPrefs.getString('blocked_users_list'),
+      ).thenReturn(jsonEncode([blockerX]));
+      when(
+        () => mockPrefs.setString(any(), any()),
+      ).thenAnswer((_) async => false);
+      when(() => mockPrefs.remove(any())).thenAnswer((_) async => true);
+
+      final service = ContentBlocklistRepository(prefs: mockPrefs);
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await Future<void>.delayed(Duration.zero);
+
+      // The scoped copy never landed, so the legacy data must survive
+      // for the next attempt.
+      verifyNever(() => mockPrefs.remove('blocked_users_list'));
+      expect(service.isBlocked(blockerX), isTrue);
+
+      service.dispose();
+    });
+
+    test('survives an asynchronous setString failure during '
+        'migration', () async {
+      final mockPrefs = _MockSharedPreferences();
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(
+        () => mockPrefs.getString('blocked_users_list'),
+      ).thenReturn(jsonEncode([blockerX]));
+      when(
+        () => mockPrefs.setString(any(), any()),
+      ).thenAnswer((_) => Future.error(Exception('platform write failed')));
+      when(() => mockPrefs.remove(any())).thenAnswer((_) async => true);
+
+      final service = ContentBlocklistRepository(prefs: mockPrefs);
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      // Flush the unawaited migration; a rejection it failed to catch
+      // would surface as an unhandled error and fail this test.
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => mockPrefs.remove('blocked_users_list'));
+      expect(service.isBlocked(blockerX), isTrue);
+
+      service.dispose();
+    });
+
+    test('retries a failed legacy migration on the next launch and '
+        'recovers the data in-session', () async {
+      // An earlier launch recorded the active account but its legacy
+      // move failed: the data still sits at the un-namespaced keys.
+      SharedPreferences.setMockInitialValues({
+        'blocklist_active_pubkey': accountA,
+        'blocked_users_list': jsonEncode([blockerX]),
+        'severed_followers_list': jsonEncode([someoneElse]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      var changeCount = 0;
+      final service = ContentBlocklistRepository(
+        prefs: prefs,
+        onChanged: () => changeCount++,
+      );
+
+      // Hydration reads the (empty) scoped keys, so the data starts
+      // invisible.
+      expect(service.isBlocked(blockerX), isFalse);
+      expect(service.isFollowSevered(someoneElse), isFalse);
+      final changesBefore = changeCount;
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(prefs.getString('blocked_users_list'), isNull);
+      expect(
+        prefs.getString('blocked_users_list.$accountA'),
+        equals(jsonEncode([blockerX])),
+      );
+      expect(prefs.getString('severed_followers_list'), isNull);
+      expect(
+        prefs.getString('severed_followers_list.$accountA'),
+        equals(jsonEncode([someoneElse])),
+      );
+      expect(service.isBlocked(blockerX), isTrue);
+      expect(service.isFollowSevered(someoneElse), isTrue);
+      expect(
+        changeCount,
+        greaterThan(changesBefore),
+        reason: 'watchers must re-filter with the recovered data',
+      );
+
+      service.dispose();
+    });
+
+    test('merges legacy data with a scoped value written by a save '
+        'that raced the migration', () async {
+      // The recorded account's scoped key was absent at construction,
+      // so a value appearing there mid-session comes from this
+      // session's own saves — those entries and the legacy entries
+      // must both survive.
+      SharedPreferences.setMockInitialValues({
+        'blocklist_active_pubkey': accountA,
+        'blocked_users_list': jsonEncode([blockerX]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      // A user action lands before the session identity resolves.
+      await service.blockUser(someoneElse);
+      expect(prefs.getString('blocked_users_list.$accountA'), isNotNull);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(prefs.getString('blocked_users_list'), isNull);
+      final scoped =
+          (jsonDecode(prefs.getString('blocked_users_list.$accountA')!)
+                  as List<dynamic>)
+              .cast<String>();
+      expect(scoped, containsAll([blockerX, someoneElse]));
+      expect(service.isBlocked(blockerX), isTrue);
+      expect(service.isBlocked(someoneElse), isTrue);
+
+      service.dispose();
+    });
+
+    test('prefers a pre-adoption scoped value over the legacy snapshot '
+        'when no account was recorded', () async {
+      // A previous launch copied the legacy data but failed to remove
+      // it and to record the account: the scoped value may hold newer
+      // writes, so it wins and the stale legacy key is dropped.
+      SharedPreferences.setMockInitialValues({
+        'blocked_users_list': jsonEncode([blockerX]),
+        'blocked_users_list.$accountA': jsonEncode([blockerX, someoneElse]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(prefs.getString('blocked_users_list'), isNull);
+      expect(
+        prefs.getString('blocked_users_list.$accountA'),
+        equals(jsonEncode([blockerX, someoneElse])),
+      );
+
+      service.dispose();
+    });
+
+    test('skips a corrupt legacy value without dropping it', () async {
+      SharedPreferences.setMockInitialValues({
+        'blocked_users_list': 'not-json',
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(prefs.getString('blocked_users_list'), equals('not-json'));
+      expect(prefs.getString('blocked_users_list.$accountA'), isNull);
+
+      service.dispose();
+    });
+
+    test('tolerates a failed stale legacy cleanup', () async {
+      final mockPrefs = _MockSharedPreferences();
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(
+        () => mockPrefs.getString('blocklist_active_pubkey'),
+      ).thenReturn(accountA);
+      when(
+        () => mockPrefs.getString('blocked_users_list'),
+      ).thenReturn(jsonEncode([blockerX]));
+      when(
+        () => mockPrefs.getString('blocked_users_list.$accountA'),
+      ).thenReturn(jsonEncode([someoneElse]));
+      when(
+        () => mockPrefs.setString(any(), any()),
+      ).thenAnswer((_) async => true);
+      when(() => mockPrefs.remove(any())).thenThrow(Exception('disk error'));
+
+      final service = ContentBlocklistRepository(prefs: mockPrefs);
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await Future<void>.delayed(Duration.zero);
+
+      // The cleanup failure is swallowed and the hydrated state stays
+      // usable; the stale key is retried on the next launch.
+      verify(() => mockPrefs.remove('blocked_users_list')).called(1);
+      expect(service.isBlocked(someoneElse), isTrue);
+
+      service.dispose();
+    });
+
+    test('stops migrating remaining keys when the account switches '
+        'mid-flight', () async {
+      final mockPrefs = _MockSharedPreferences();
+      final firstWrite = Completer<bool>();
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(
+        () => mockPrefs.getString('blocklist_active_pubkey'),
+      ).thenReturn(accountA);
+      when(
+        () => mockPrefs.getString('blocked_users_list'),
+      ).thenReturn(jsonEncode([blockerX]));
+      when(
+        () => mockPrefs.getString('severed_followers_list'),
+      ).thenReturn(jsonEncode([someoneElse]));
+      when(
+        () => mockPrefs.setString(any(), any()),
+      ).thenAnswer((_) async => true);
+      when(
+        () => mockPrefs.setString('blocked_users_list.$accountA', any()),
+      ).thenAnswer((_) => firstWrite.future);
+      when(() => mockPrefs.remove(any())).thenAnswer((_) async => true);
+
+      final service = ContentBlocklistRepository(prefs: mockPrefs);
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      // The first key's platform write is in flight when the session
+      // switches identity.
+      await service.syncMuteListsInBackground(mockNostrService, accountB);
+      firstWrite.complete(true);
+      await Future<void>.delayed(Duration.zero);
+
+      // The in-flight write already serialized account A's set, so its
+      // move completes — but the remaining legacy key must not be
+      // serialized under the new identity.
+      verify(() => mockPrefs.remove('blocked_users_list')).called(1);
+      verifyNever(
+        () => mockPrefs.setString('severed_followers_list.$accountA', any()),
+      );
+      verifyNever(() => mockPrefs.remove('severed_followers_list'));
+
+      service.dispose();
+    });
+
+    test('does not clobber newer scoped data when retrying the legacy '
+        'move', () async {
+      // An earlier copy landed but its remove failed, and the scoped
+      // set has been written since: the legacy snapshot is stale.
+      SharedPreferences.setMockInitialValues({
+        'blocklist_active_pubkey': accountA,
+        'blocked_users_list': jsonEncode([blockerX]),
+        'blocked_users_list.$accountA': jsonEncode([someoneElse]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(prefs.getString('blocked_users_list'), isNull);
+      expect(
+        prefs.getString('blocked_users_list.$accountA'),
+        equals(jsonEncode([someoneElse])),
+      );
+      expect(service.isBlocked(someoneElse), isTrue);
+      expect(service.isBlocked(blockerX), isFalse);
+
+      service.dispose();
+    });
+
+    test('leaves legacy data untouched when a different account than '
+        'its owner signs in', () async {
+      SharedPreferences.setMockInitialValues({
+        'blocklist_active_pubkey': accountA,
+        'blocked_users_list': jsonEncode([blockerX]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountB);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        prefs.getString('blocked_users_list'),
+        equals(jsonEncode([blockerX])),
+      );
+      expect(prefs.getString('blocked_users_list.$accountB'), isNull);
+      expect(service.isBlocked(blockerX), isFalse);
+
+      service.dispose();
+    });
+
     test('adopting a different identity than the stored account resets '
         'hydrated state', () async {
       SharedPreferences.setMockInitialValues({

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -901,6 +901,215 @@ void main() {
     });
   });
 
+  group('ContentBlocklistRepository - identity change (#4969)', () {
+    const accountA =
+        '00000000000000000000000000000000000000000000000000000000000000aa';
+    const accountB =
+        '00000000000000000000000000000000000000000000000000000000000000bb';
+    const blockerX =
+        '0000000000000000000000000000000000000000000000000000000000000011';
+    const someoneElse =
+        '0000000000000000000000000000000000000000000000000000000000000022';
+
+    late _MockNostrClient mockNostrService;
+    late StreamController<Event> controller;
+
+    Event blockListEvent({
+      required String author,
+      required List<String> blockedPubkeys,
+      required int createdAt,
+      String id = 'block-event-id',
+    }) =>
+        Event(
+            author,
+            30000,
+            [
+              ['d', 'block'],
+              for (final pubkey in blockedPubkeys) ['p', pubkey],
+            ],
+            '',
+            createdAt: createdAt,
+          )
+          ..id = id
+          ..sig = 'signature';
+
+    setUp(() {
+      mockNostrService = _MockNostrClient();
+      controller = StreamController<Event>.broadcast();
+      when(
+        () => mockNostrService.subscribe(any()),
+      ).thenAnswer((_) => controller.stream);
+    });
+
+    tearDown(() async {
+      await controller.close();
+    });
+
+    test(
+      'switching accounts clears relay-synced blocked-by and mute state',
+      () async {
+        final service = ContentBlocklistRepository();
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+        await service.syncBlockListsInBackground(
+          mockNostrService,
+          _MockBlockListSigner(),
+          accountA,
+        );
+        controller.add(
+          blockListEvent(
+            author: blockerX,
+            blockedPubkeys: [accountA],
+            createdAt: now,
+          ),
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+        expect(service.hasBlockedUs(blockerX), isTrue);
+
+        // Switch to account B: X never blocked B, so the gate must clear.
+        await service.syncBlockListsInBackground(
+          mockNostrService,
+          _MockBlockListSigner(),
+          accountB,
+        );
+        expect(service.hasBlockedUs(blockerX), isFalse);
+        expect(service.shouldFilterFromFeeds(blockerX), isFalse);
+        expect(service.hasMutedUs(blockerX), isFalse);
+        expect(service.currentState.pubkeysBlockingUs, isEmpty);
+        expect(service.currentState.mutedPubkeys, isEmpty);
+
+        service.dispose();
+      },
+    );
+
+    test('switching accounts re-subscribes with the new pubkey', () async {
+      final captured = <List<dynamic>>[];
+      when(() => mockNostrService.subscribe(any())).thenAnswer((invocation) {
+        captured.add(invocation.positionalArguments[0] as List);
+        return controller.stream;
+      });
+
+      final service = ContentBlocklistRepository();
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await service.syncMuteListsInBackground(mockNostrService, accountB);
+
+      expect(captured, hasLength(2));
+      final secondMutual = captured[1][0] as Filter;
+      expect(secondMutual.p, contains(accountB));
+      final secondOwn = captured[1][1] as Filter;
+      expect(secondOwn.authors, contains(accountB));
+
+      service.dispose();
+    });
+
+    test('per-account blocks do not leak across a switch and survive '
+        'switching back', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      await service.blockUser(blockerX);
+      expect(service.isBlocked(blockerX), isTrue);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountB);
+      expect(
+        service.isBlocked(blockerX),
+        isFalse,
+        reason: "account A's blocks must not apply to account B",
+      );
+      await service.blockUser(someoneElse);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      expect(service.isBlocked(blockerX), isTrue);
+      expect(service.isBlocked(someoneElse), isFalse);
+
+      service.dispose();
+    });
+
+    test('first identity adopts legacy un-namespaced persisted data', () async {
+      SharedPreferences.setMockInitialValues({
+        'blocked_users_list': jsonEncode([blockerX]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      // Legacy data hydrates before any identity is known.
+      expect(service.isBlocked(blockerX), isTrue);
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      expect(service.isBlocked(blockerX), isTrue);
+
+      // A fresh instance over the same prefs loads the migrated,
+      // account-scoped data.
+      final rehydrated = ContentBlocklistRepository(prefs: prefs);
+      expect(rehydrated.isBlocked(blockerX), isTrue);
+      expect(prefs.getString('blocked_users_list'), isNull);
+
+      service.dispose();
+      rehydrated.dispose();
+    });
+
+    test('continues when legacy key migration throws', () async {
+      final mockPrefs = _MockSharedPreferences();
+      when(() => mockPrefs.getString(any())).thenReturn(null);
+      when(
+        () => mockPrefs.getString('blocked_users_list'),
+      ).thenReturn(jsonEncode([blockerX]));
+      when(
+        () => mockPrefs.setString(any(), any()),
+      ).thenThrow(Exception('disk full'));
+
+      final service = ContentBlocklistRepository(prefs: mockPrefs);
+      expect(service.isBlocked(blockerX), isTrue);
+
+      // Adoption triggers migration; the failed move must not throw and
+      // the in-memory state must survive.
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      expect(service.isBlocked(blockerX), isTrue);
+
+      service.dispose();
+    });
+
+    test('adopting a different identity than the stored account resets '
+        'hydrated state', () async {
+      SharedPreferences.setMockInitialValues({
+        'blocklist_active_pubkey': accountA,
+        'blocked_users_list.$accountA': jsonEncode([blockerX]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final service = ContentBlocklistRepository(prefs: prefs);
+
+      // Construction hydrates account A's persisted blocks.
+      expect(service.isBlocked(blockerX), isTrue);
+
+      // The session resolves to account B: A's blocks must not apply.
+      await service.syncMuteListsInBackground(mockNostrService, accountB);
+      expect(service.isBlocked(blockerX), isFalse);
+
+      service.dispose();
+    });
+
+    test('notifies listeners when a switch resets state', () async {
+      var changeCount = 0;
+      final service = ContentBlocklistRepository(
+        onChanged: () => changeCount++,
+      );
+
+      await service.syncMuteListsInBackground(mockNostrService, accountA);
+      final before = changeCount;
+
+      await service.syncMuteListsInBackground(mockNostrService, accountB);
+      expect(
+        changeCount,
+        greaterThan(before),
+        reason: 'watchers must re-filter after an account switch',
+      );
+
+      service.dispose();
+    });
+  });
+
   group('ContentBlocklistRepository - Block List Sync', () {
     late ContentBlocklistRepository service;
     late _MockNostrClient mockNostrService;


### PR DESCRIPTION
## Description

PR 2 of the #948 completion plan (see the [status comment](https://github.com/divinevideo/divine-mobile/issues/948#issuecomment-4663388444)) — the account-switch correctness bug from #4969.

`contentBlocklistRepositoryProvider` is keepAlive and was never reset on identity change. Consequences for multi-account users:

- `_blockedByOthers` / `_mutualMuteBlocklist` (and, since #5012, `_mutedPubkeys`) stayed keyed to the **previous** account — if X blocked account A, account B incorrectly saw X gated as "Account not available" and X's content filtered from every feed.
- The persisted own-blocks/mutes/severed-followers lived under un-namespaced SharedPreferences keys, so account A's blocks silently applied to account B across restarts.

### Changes

- Both sync entry points (`syncMuteListsInBackground` / `syncBlockListsInBackground`) now call `_adoptIdentity(pubkey)` first. On a switch it: clears every in-memory set and replaceable-event timestamp guard, resets the started-flags so fresh relay subscriptions form with the **new** pubkey's filters, reloads the new account's persisted sets, and fires the change notification (`blocklistVersionProvider` bump) so all watchers re-filter.
- Persisted sets are **namespaced per account** (`blocked_users_list.<pubkey>` etc.), with the active account recorded so construction hydrates the right one before auth resolves. Switching A→B→A restores A's blocks locally, no relay round-trip needed.
- **Legacy migration**: un-namespaced data from existing installs follows the first identity that signs in (moved to scoped keys, legacy keys removed).
- All new prefs writes are failure-tolerant (logged, never thrown), matching the file's existing persistence contract.
- No wiring changes — the existing `blocklistSyncBridge` already re-invokes the sync methods on session changes; the repository now does the right thing when the identity differs.

**Related Issue:** Closes #4969 · part of #948

## Verification

- `very_good test --coverage --min-coverage 100` on the package — 84/84, gate held (7 new tests: blocked-by reset on switch, re-subscription with new pubkey filters, per-account block round-trip A→B→A, legacy migration, stored-account mismatch reset, change notification on switch, migration-failure tolerance)
- `flutter analyze lib test integration_test` — no issues
- `flutter test test/services/video_event_service_blocklist_sweep_test.dart test/providers/video_events_provider_blocklist_test.dart test/providers/can_target_user_provider_test.dart` — 19/19
- `dart format` — clean

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
