### PR TITLE
feat(audio): implement J-Cut audio anchoring and rebasing logic

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -607,6 +607,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         startOffset: currentClip.trimStart,
         startTime: clipStart,
         endTime: clipStart + currentClip.playbackDuration,
+        // Anchor the extracted audio to its source clip so it follows the
+        // clip's trims (J-Cut) until the user manually moves it.
+        anchorClipId: currentClip.id,
       );
 
       // Mute the source clip now that its audio has been extracted.

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -30,8 +30,8 @@ class TimelineOverlayBloc
     extends Bloc<TimelineOverlayEvent, TimelineOverlayState> {
   TimelineOverlayBloc() : super(const TimelineOverlayState()) {
     on<TimelineOverlayItemsUpdate>(_onUpdateItems);
-    on<TimelineOverlayItemMoved>(_onItemMoved, transformer: restartable());
-    on<TimelineOverlayItemTrimmed>(_onItemTrimmed, transformer: restartable());
+    on<TimelineOverlayItemMoved>(_onItemMoved);
+    on<TimelineOverlayItemTrimmed>(_onItemTrimmed);
     on<TimelineOverlayItemSelected>(_onItemSelected);
     on<TimelineOverlayDragStarted>(_onDragStarted);
     on<TimelineOverlayDragMoved>(_onDragMoved);
@@ -44,10 +44,7 @@ class TimelineOverlayBloc
     on<TimelineMarkerRemoved>(_onMarkerRemoved);
     on<TimelineMarkersRebased>(_onMarkersRebased);
     on<TimelineOverlayWaveformLoaded>(_onWaveformLoaded);
-    on<TimelineOverlayAnchoredAudioRebased>(
-      _onAnchoredAudioRebased,
-      transformer: restartable(),
-    );
+    on<TimelineOverlayAnchoredAudioRebased>(_onAnchoredAudioRebased);
     on<TimelineOverlayAudioVolumeChanged>(
       _onAudioVolumeChanged,
       transformer: sequential(),

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -44,6 +44,10 @@ class TimelineOverlayBloc
     on<TimelineMarkerRemoved>(_onMarkerRemoved);
     on<TimelineMarkersRebased>(_onMarkersRebased);
     on<TimelineOverlayWaveformLoaded>(_onWaveformLoaded);
+    on<TimelineOverlayAnchoredAudioRebased>(
+      _onAnchoredAudioRebased,
+      transformer: restartable(),
+    );
     on<TimelineOverlayAudioVolumeChanged>(
       _onAudioVolumeChanged,
       transformer: sequential(),
@@ -563,6 +567,40 @@ class TimelineOverlayBloc
           item,
     ];
     emit(state.copyWith(items: updated));
+  }
+
+  void _onAnchoredAudioRebased(
+    TimelineOverlayAnchoredAudioRebased event,
+    Emitter<TimelineOverlayState> emit,
+  ) {
+    final byId = {for (final track in event.audioTracks) track.id: track};
+
+    var changed = false;
+    final updatedItems = <TimelineOverlayItem>[];
+    for (final item in state.items) {
+      final track = item.type == TimelineOverlayType.sound
+          ? byId[item.id]
+          : null;
+      if (track == null) {
+        updatedItems.add(item);
+        continue;
+      }
+      final newEnd = track.endTime ?? item.endTime;
+      if (item.startTime == track.startTime && item.endTime == newEnd) {
+        updatedItems.add(item);
+        continue;
+      }
+      changed = true;
+      updatedItems.add(
+        item.copyWith(startTime: track.startTime, endTime: newEnd),
+      );
+    }
+
+    // Visual-only live update: positions move with the trim, but rows,
+    // audioTracks, history, and the native player are left untouched and
+    // reconciled on release. Skip the emit when nothing moved.
+    if (!changed) return;
+    emit(state.copyWith(items: updatedItems));
   }
 
   void _onAudioVolumeChanged(

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
@@ -193,6 +193,24 @@ class TimelineMarkersRebased extends TimelineOverlayEvent {
   List<Object?> get props => [markers];
 }
 
+/// Live-reposition anchored sound items to follow a clip trim in progress.
+///
+/// Dispatched on every frame of a clip trim drag so the anchored audio bar
+/// tracks the clip's left edge in real time (J-Cut). Only the visual sound
+/// item positions are updated — the source [AudioEvent] tracks, the native
+/// player, and the editor history are reconciled once on release via
+/// `setClipState`.
+class TimelineOverlayAnchoredAudioRebased extends TimelineOverlayEvent {
+  const TimelineOverlayAnchoredAudioRebased(this.audioTracks);
+
+  /// The re-anchored tracks; only their [AudioEvent.startTime] /
+  /// [AudioEvent.endTime] are read to move the matching sound items.
+  final List<AudioEvent> audioTracks;
+
+  @override
+  List<Object?> get props => [audioTracks];
+}
+
 /// Attach extracted waveform samples to a sound item.
 class TimelineOverlayWaveformLoaded extends TimelineOverlayEvent {
   const TimelineOverlayWaveformLoaded({

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -10,6 +10,7 @@ extension VideoEditorExtensions on ProImageEditorState {
     required int index,
     Duration? startTime,
     Duration? endTime,
+    Duration? startOffset,
     Map<String, dynamic>? meta,
     bool skipUpdateHistory = false,
     bool clearAnchor = false,
@@ -22,6 +23,7 @@ extension VideoEditorExtensions on ProImageEditorState {
     audioTracks[index] = audioTracks[index].copyWith(
       startTime: startTime,
       endTime: endTime ?? Duration.zero,
+      startOffset: startOffset,
       // A manual move detaches the track from its source clip so it stops
       // following clip trims and behaves as an independent track.
       clearAnchorClipId: clearAnchor,

--- a/mobile/lib/extensions/video_editor_extensions.dart
+++ b/mobile/lib/extensions/video_editor_extensions.dart
@@ -2,6 +2,7 @@ import 'package:models/models.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' hide AudioTrack;
 
 extension VideoEditorExtensions on ProImageEditorState {
@@ -11,6 +12,7 @@ extension VideoEditorExtensions on ProImageEditorState {
     Duration? endTime,
     Map<String, dynamic>? meta,
     bool skipUpdateHistory = false,
+    bool clearAnchor = false,
   }) {
     final audioTracks = skipUpdateHistory
         ? stateManager.audioTracks
@@ -20,6 +22,9 @@ extension VideoEditorExtensions on ProImageEditorState {
     audioTracks[index] = audioTracks[index].copyWith(
       startTime: startTime,
       endTime: endTime ?? Duration.zero,
+      // A manual move detaches the track from its source clip so it stops
+      // following clip trims and behaves as an independent track.
+      clearAnchorClipId: clearAnchor,
     );
 
     if (!skipUpdateHistory) {
@@ -105,9 +110,23 @@ extension VideoEditorExtensions on ProImageEditorState {
     List<Duration>? timelineMarkers,
   }) {
     final serialized = clips.map((c) => c.toJson()).toList();
+
+    // Keep anchored (extracted, not-yet-moved) audio aligned to its source
+    // clip after this clip edit, so trimming a clip's left edge produces a
+    // J-Cut without losing sync. Only rewrite the audio key when a track
+    // actually moved — `rebaseAnchoredAudioForClipState` returns the same
+    // list instance otherwise.
+    final currentTracks = stateManager.audioTracks;
+    final rebasedTracks = rebaseAnchoredAudioForClipState(clips, currentTracks);
+    final audioChanged = !identical(rebasedTracks, currentTracks);
+    final serializedAudio = audioChanged
+        ? rebasedTracks.map((e) => e.toJson()).toList()
+        : null;
+
     final meta = {
       ...stateManager.activeMeta,
       VideoEditorConstants.clipsStateHistoryKey: serialized,
+      VideoEditorConstants.audioStateHistoryKey: ?serializedAudio,
       if (timelineMarkers != null)
         VideoEditorConstants.timelineMarkersStateHistoryKey: timelineMarkers
             .map((marker) => marker.inMilliseconds)
@@ -119,6 +138,10 @@ extension VideoEditorExtensions on ProImageEditorState {
     } else {
       stateManager.activeMeta[VideoEditorConstants.clipsStateHistoryKey] =
           serialized;
+      if (serializedAudio != null) {
+        stateManager.activeMeta[VideoEditorConstants.audioStateHistoryKey] =
+            serializedAudio;
+      }
       if (timelineMarkers != null) {
         stateManager.activeMeta[VideoEditorConstants
             .timelineMarkersStateHistoryKey] = timelineMarkers

--- a/mobile/lib/services/saved_sounds_service.dart
+++ b/mobile/lib/services/saved_sounds_service.dart
@@ -30,7 +30,11 @@ class SavedSoundsService {
       final sounds = <AudioEvent>[];
       for (final entry in decoded.whereType<Map>()) {
         try {
-          sounds.add(AudioEvent.fromJson(Map<String, dynamic>.from(entry)));
+          sounds.add(
+            _persistableSound(
+              AudioEvent.fromJson(Map<String, dynamic>.from(entry)),
+            ),
+          );
         } catch (_) {
           continue;
         }
@@ -65,7 +69,15 @@ class SavedSoundsService {
   Future<void> _writeSounds(List<AudioEvent> sounds) async {
     await _preferences.setString(
       storageKey,
-      jsonEncode(sounds.map((sound) => sound.toJson()).toList()),
+      jsonEncode(
+        sounds.map((sound) => _persistableSound(sound).toJson()).toList(),
+      ),
     );
+  }
+
+  AudioEvent _persistableSound(AudioEvent sound) {
+    return sound.anchorClipId == null
+        ? sound
+        : sound.copyWith(clearAnchorClipId: true);
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -607,8 +607,8 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
       case .sound:
         final audioTracks = editor.stateManager.audioTracks;
         final audioIdx = audioTracks.indexWhere((e) => e.id == item.id);
-        final startOffset = isStart && audioIdx != -1
-            ? audioStartOffsetForLeftTrim(
+        final trimResult = isStart && audioIdx != -1
+            ? audioLeftTrimResult(
                 audioTracks[audioIdx],
                 newStartTime: startTime,
               )
@@ -618,7 +618,8 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
           index: audioIdx,
           startTime: startTime,
           endTime: endTime,
-          startOffset: startOffset,
+          startOffset: trimResult?.startOffset,
+          clearAnchor: trimResult?.anchorStillValid == false,
           skipUpdateHistory: true,
         );
     }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -144,6 +144,23 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
             }
           },
         ),
+        // Live J-Cut: while a clip trim is in progress, move anchored audio
+        // bars to follow the clip every frame. The final positions are
+        // committed to history + the native player on release (setClipState).
+        BlocListener<ClipEditorBloc, ClipEditorState>(
+          listenWhen: (prev, curr) =>
+              curr.isTrimDragging && prev.clips != curr.clips,
+          listener: (context, state) {
+            final overlayBloc = context.read<TimelineOverlayBloc>();
+            final rebased = rebaseAnchoredAudioForClipState(
+              state.clips,
+              overlayBloc.state.audioTracks,
+            );
+            if (!identical(rebased, overlayBloc.state.audioTracks)) {
+              overlayBloc.add(TimelineOverlayAnchoredAudioRebased(rebased));
+            }
+          },
+        ),
         BlocListener<VideoEditorMainBloc, VideoEditorMainState>(
           listenWhen: (prev, curr) =>
               !_isUserScrolling && prev.currentPosition != curr.currentPosition,
@@ -494,6 +511,9 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
           startTime: startTime,
           endTime: startTime + duration,
           skipUpdateHistory: true,
+          // Manually moving the track detaches it from its source clip so it
+          // stops following clip trims and becomes an independent track.
+          clearAnchor: true,
         );
 
         _reorderEditorList(audioTracks, audioIdx, targetIdx);

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -607,11 +607,18 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
       case .sound:
         final audioTracks = editor.stateManager.audioTracks;
         final audioIdx = audioTracks.indexWhere((e) => e.id == item.id);
+        final startOffset = isStart && audioIdx != -1
+            ? audioStartOffsetForLeftTrim(
+                audioTracks[audioIdx],
+                newStartTime: startTime,
+              )
+            : null;
 
         editor.setSoundTimeline(
           index: audioIdx,
           startTime: startTime,
           endTime: endTime,
+          startOffset: startOffset,
           skipUpdateHistory: true,
         );
     }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -29,9 +29,7 @@ Duration? clipSourcePositionToTimelinePosition(
       final speed = clip.playbackSpeed ?? 1.0;
       final relativePlayback = speed <= 0 || speed == 1.0
           ? relative
-          : Duration(
-              microseconds: (relative.inMicroseconds / speed).round(),
-            );
+          : Duration(microseconds: (relative.inMicroseconds / speed).round());
       return precedingDuration + relativePlayback;
     }
 
@@ -41,26 +39,50 @@ Duration? clipSourcePositionToTimelinePosition(
   return null;
 }
 
-/// Returns the source offset for an audio track after its timeline start handle
-/// moves to [newStartTime].
+/// Returns the source offset and anchor state for an audio track after its
+/// timeline start handle moves to [newStartTime].
 ///
 /// Left-trimming a sound should consume or reveal audio source content rather
 /// than sliding the same source frame to a new timeline position. Keeping this
 /// offset in step with the timeline start also preserves the anchored-audio
 /// alignment invariant used by [rebaseAnchoredAudioForClipState].
-Duration audioStartOffsetForLeftTrim(
+AudioLeftTrimResult audioLeftTrimResult(
   AudioEvent track, {
   required Duration newStartTime,
 }) {
   final nextOffset = track.startOffset + (newStartTime - track.startTime);
-  if (nextOffset < Duration.zero) return Duration.zero;
+  if (nextOffset < Duration.zero) {
+    return const AudioLeftTrimResult(
+      startOffset: Duration.zero,
+      anchorStillValid: false,
+    );
+  }
 
   final duration = track.duration;
-  if (duration == null) return nextOffset;
+  if (duration == null) {
+    return AudioLeftTrimResult(startOffset: nextOffset);
+  }
 
   final maxOffset = Duration(milliseconds: (duration * 1000).round());
-  if (nextOffset > maxOffset) return maxOffset;
-  return nextOffset;
+  if (nextOffset > maxOffset) {
+    return AudioLeftTrimResult(startOffset: maxOffset, anchorStillValid: false);
+  }
+  return AudioLeftTrimResult(startOffset: nextOffset);
+}
+
+/// Result of applying a left trim to an audio track's source offset.
+class AudioLeftTrimResult {
+  const AudioLeftTrimResult({
+    required this.startOffset,
+    this.anchorStillValid = true,
+  });
+
+  /// Source offset to apply to the track.
+  final Duration startOffset;
+
+  /// Whether the requested timeline start can still be represented by the
+  /// anchored-audio alignment invariant.
+  final bool anchorStillValid;
 }
 
 /// Reprojects marker positions after clip order, trim, or speed changes.
@@ -234,9 +256,7 @@ Duration _playbackOffsetToSourcePosition(
   final speed = clip.playbackSpeed ?? 1.0;
   final sourceOffset = speed <= 0 || speed == 1.0
       ? playbackOffset
-      : Duration(
-          microseconds: (playbackOffset.inMicroseconds * speed).round(),
-        );
+      : Duration(microseconds: (playbackOffset.inMicroseconds * speed).round());
 
   return clip.trimStart + _clampDuration(sourceOffset, clip.trimmedDuration);
 }
@@ -255,9 +275,7 @@ Duration? _sourcePositionToPlaybackOffset(
   final speed = clip.playbackSpeed ?? 1.0;
   if (speed <= 0 || speed == 1.0) return sourceOffset;
 
-  return Duration(
-    microseconds: (sourceOffset.inMicroseconds / speed).round(),
-  );
+  return Duration(microseconds: (sourceOffset.inMicroseconds / speed).round());
 }
 
 Duration _clampDuration(Duration value, Duration max) {

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Converts between playback positions and scroll offsets,
 // ABOUTME: accounting for the 1-px gap between adjacent clip strips.
 
+import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 
@@ -86,6 +87,66 @@ List<Duration> rebaseTimelineMarkersForClipState({
   }
 
   return rebased.toList()..sort();
+}
+
+/// Re-aligns anchored (extracted, not-yet-moved) audio tracks to their
+/// source clips after a clip edit (trim, reorder, or ripple from an earlier
+/// clip's trim).
+///
+/// For each [AudioEvent] whose [AudioEvent.anchorClipId] still resolves to a
+/// clip in [clips], the audio is translated on the timeline so its source
+/// content stays aligned with the clip's source content. This implements the
+/// J-Cut behaviour: the audio keeps its [AudioEvent.startOffset] and its span
+/// (so its full content survives — the head simply leads), while only its
+/// [AudioEvent.startTime]/[AudioEvent.endTime] move.
+///
+/// The alignment invariant preserved is, for the anchored clip:
+///
+///   startTime == clipTimelineStart - clip.trimStart + audio.startOffset
+///
+/// Tracks with no anchor, or whose anchor clip was removed, are returned
+/// unchanged. The original list instance is returned when nothing moved, so
+/// callers can cheaply detect a no-op via `identical`.
+List<AudioEvent> rebaseAnchoredAudioForClipState(
+  List<DivineVideoClip> clips,
+  List<AudioEvent> audioTracks,
+) {
+  if (audioTracks.isEmpty) return audioTracks;
+
+  final clipStarts = <String, Duration>{};
+  final clipsById = <String, DivineVideoClip>{};
+  var cursor = Duration.zero;
+  for (final clip in clips) {
+    clipStarts[clip.id] = cursor;
+    clipsById[clip.id] = clip;
+    cursor += clip.playbackDuration;
+  }
+
+  var changed = false;
+  final result = <AudioEvent>[];
+  for (final track in audioTracks) {
+    final anchorId = track.anchorClipId;
+    final clipStart = anchorId == null ? null : clipStarts[anchorId];
+    final clip = anchorId == null ? null : clipsById[anchorId];
+    if (clipStart == null || clip == null) {
+      result.add(track);
+      continue;
+    }
+
+    final span = (track.endTime ?? track.startTime) - track.startTime;
+    final newStartRaw = clipStart + track.startOffset - clip.trimStart;
+    final newStart = newStartRaw < Duration.zero ? Duration.zero : newStartRaw;
+    final newEnd = newStart + span;
+
+    if (newStart == track.startTime && newEnd == track.endTime) {
+      result.add(track);
+      continue;
+    }
+    changed = true;
+    result.add(track.copyWith(startTime: newStart, endTime: newEnd));
+  }
+
+  return changed ? result : audioTracks;
 }
 
 _TimelineMarkerAnchor? _timelineMarkerAnchorForPosition(

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -41,6 +41,28 @@ Duration? clipSourcePositionToTimelinePosition(
   return null;
 }
 
+/// Returns the source offset for an audio track after its timeline start handle
+/// moves to [newStartTime].
+///
+/// Left-trimming a sound should consume or reveal audio source content rather
+/// than sliding the same source frame to a new timeline position. Keeping this
+/// offset in step with the timeline start also preserves the anchored-audio
+/// alignment invariant used by [rebaseAnchoredAudioForClipState].
+Duration audioStartOffsetForLeftTrim(
+  AudioEvent track, {
+  required Duration newStartTime,
+}) {
+  final nextOffset = track.startOffset + (newStartTime - track.startTime);
+  if (nextOffset < Duration.zero) return Duration.zero;
+
+  final duration = track.duration;
+  if (duration == null) return nextOffset;
+
+  final maxOffset = Duration(milliseconds: (duration * 1000).round());
+  if (nextOffset > maxOffset) return maxOffset;
+  return nextOffset;
+}
+
 /// Reprojects marker positions after clip order, trim, or speed changes.
 ///
 /// Timeline markers are stored as absolute composition times because the
@@ -106,9 +128,15 @@ List<Duration> rebaseTimelineMarkersForClipState({
 ///
 ///   startTime == clipTimelineStart - clip.trimStart + audio.startOffset
 ///
-/// Tracks with no anchor, or whose anchor clip was removed, are returned
-/// unchanged. The original list instance is returned when nothing moved, so
-/// callers can cheaply detect a no-op via `identical`.
+/// [clipTimelineStart] is accumulated in playback time so earlier clip speed
+/// changes still ripple anchored audio correctly. [AudioEvent.startOffset] and
+/// [DivineVideoClip.trimStart] remain source-time values because extracted
+/// audio is not tempo-adjusted; if extracted audio becomes speed-adjusted, this
+/// conversion must be revisited.
+///
+/// Tracks with no anchor, or whose anchor clip was removed or split into new
+/// clip IDs, are returned unchanged. The original list instance is returned
+/// when nothing moved, so callers can cheaply detect a no-op via `identical`.
 List<AudioEvent> rebaseAnchoredAudioForClipState(
   List<DivineVideoClip> clips,
   List<AudioEvent> audioTracks,

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -98,7 +98,9 @@ List<Duration> rebaseTimelineMarkersForClipState({
 /// content stays aligned with the clip's source content. This implements the
 /// J-Cut behaviour: the audio keeps its [AudioEvent.startOffset] and its span
 /// (so its full content survives — the head simply leads), while only its
-/// [AudioEvent.startTime]/[AudioEvent.endTime] move.
+/// [AudioEvent.startTime]/[AudioEvent.endTime] move. If that lead would start
+/// before timeline zero, the impossible pre-roll is clipped by advancing
+/// [AudioEvent.startOffset] and shortening the audible span.
 ///
 /// The alignment invariant preserved is, for the anchored clip:
 ///
@@ -135,15 +137,36 @@ List<AudioEvent> rebaseAnchoredAudioForClipState(
 
     final span = (track.endTime ?? track.startTime) - track.startTime;
     final newStartRaw = clipStart + track.startOffset - clip.trimStart;
-    final newStart = newStartRaw < Duration.zero ? Duration.zero : newStartRaw;
-    final newEnd = newStart + span;
+    var newStart = newStartRaw;
+    var newStartOffset = track.startOffset;
+    var newSpan = span;
 
-    if (newStart == track.startTime && newEnd == track.endTime) {
+    if (newStartRaw < Duration.zero) {
+      final clippedLead = Duration.zero - newStartRaw;
+      newStart = Duration.zero;
+      newStartOffset += clippedLead;
+      newSpan -= clippedLead;
+      if (newSpan < Duration.zero) {
+        newSpan = Duration.zero;
+      }
+    }
+
+    final newEnd = track.endTime == null ? null : newStart + newSpan;
+
+    if (newStart == track.startTime &&
+        newEnd == track.endTime &&
+        newStartOffset == track.startOffset) {
       result.add(track);
       continue;
     }
     changed = true;
-    result.add(track.copyWith(startTime: newStart, endTime: newEnd));
+    result.add(
+      track.copyWith(
+        startOffset: newStartOffset,
+        startTime: newStart,
+        endTime: newEnd,
+      ),
+    );
   }
 
   return changed ? result : audioTracks;

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -477,11 +477,13 @@ class AudioEvent {
         other.id == id &&
         other.startOffset == startOffset &&
         other.startTime == startTime &&
-        other.endTime == endTime;
+        other.endTime == endTime &&
+        other.anchorClipId == anchorClipId;
   }
 
   @override
-  int get hashCode => Object.hash(id, startOffset, startTime, endTime);
+  int get hashCode =>
+      Object.hash(id, startOffset, startTime, endTime, anchorClipId);
 
   @override
   String toString() {

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -39,6 +39,7 @@ class AudioEvent {
     this.volume = 1.0,
     this.startTime = Duration.zero,
     this.endTime,
+    this.anchorClipId,
   });
 
   /// Parse an AudioEvent from a Nostr Event.
@@ -213,6 +214,7 @@ class AudioEvent {
       endTime: json['endTimeMs'] != null
           ? Duration(milliseconds: json['endTimeMs'] as int)
           : null,
+      anchorClipId: json['anchorClipId'] as String?,
     );
   }
 
@@ -316,6 +318,22 @@ class AudioEvent {
   /// The time on the editor timeline where this audio event stops playing.
   /// If null, the audio plays until the end of its duration.
   final Duration? endTime;
+
+  /// ID of the `DivineVideoClip` this audio was extracted from and is
+  /// currently anchored to.
+  ///
+  /// When non-null, the audio is "anchored": editing the source clip's
+  /// trim (e.g. trimming its left edge) keeps the audio aligned with the
+  /// clip's source content so a J-Cut can be created without losing sync.
+  /// Set when audio is extracted from a clip; cleared (set to `null`) when
+  /// the user manually moves the audio on the timeline, after which it
+  /// behaves as an independent, free-floating track.
+  ///
+  /// Local-only editor state, never published to Nostr.
+  final String? anchorClipId;
+
+  /// Whether this audio is currently anchored to a source video clip.
+  bool get isAnchored => anchorClipId != null;
 
   /// Get the kind number from the source video reference.
   /// Returns null if no source video reference is set.
@@ -425,6 +443,8 @@ class AudioEvent {
     double? volume,
     Duration? startTime,
     Duration? endTime,
+    String? anchorClipId,
+    bool clearAnchorClipId = false,
   }) {
     return AudioEvent(
       id: id ?? this.id,
@@ -444,6 +464,9 @@ class AudioEvent {
       volume: volume ?? this.volume,
       startTime: startTime ?? this.startTime,
       endTime: endTime ?? this.endTime,
+      anchorClipId: clearAnchorClipId
+          ? null
+          : (anchorClipId ?? this.anchorClipId),
     );
   }
 
@@ -490,6 +513,7 @@ class AudioEvent {
     if (startOffset != .zero) 'startOffsetMs': startOffset.inMilliseconds,
     if (startTime != Duration.zero) 'startTimeMs': startTime.inMilliseconds,
     if (endTime != null) 'endTimeMs': endTime!.inMilliseconds,
+    'anchorClipId': ?anchorClipId,
   };
 }
 

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -690,6 +690,28 @@ void main() {
         expect(event1, isNot(equals(event2)));
         expect(event1.hashCode, isNot(equals(event2.hashCode)));
       });
+
+      test('events with same id but different anchorClipId are not equal', () {
+        const event1 = AudioEvent(
+          id: 'same-id-123456789012345678901234567890123456789012345678901',
+          pubkey: 'pubkey',
+          createdAt: 1700000000,
+          url: 'https://example.com/audio.aac',
+          mimeType: 'audio/aac',
+          anchorClipId: 'clip-a',
+        );
+
+        const event2 = AudioEvent(
+          id: 'same-id-123456789012345678901234567890123456789012345678901',
+          pubkey: 'pubkey',
+          createdAt: 1700000000,
+          url: 'https://example.com/audio.aac',
+          mimeType: 'audio/aac',
+        );
+
+        expect(event1, isNot(equals(event2)));
+        expect(event1.hashCode, isNot(equals(event2.hashCode)));
+      });
     });
 
     group('toString', () {

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -1112,6 +1112,52 @@ void main() {
         expect(updated.title, equals('New Title'));
       });
     });
+
+    group('anchorClipId', () {
+      const anchored = AudioEvent(
+        id: 'anchor-id-123456789012345678901234567890123456789012345678901',
+        pubkey: testPubkey,
+        createdAt: 1700000000,
+        url: 'https://example.com/audio.aac',
+        anchorClipId: 'clip-7',
+      );
+
+      test('isAnchored reflects anchorClipId presence', () {
+        expect(anchored.isAnchored, isTrue);
+        expect(
+          anchored.copyWith(clearAnchorClipId: true).isAnchored,
+          isFalse,
+        );
+      });
+
+      test('copyWith clears the anchor with clearAnchorClipId', () {
+        final unanchored = anchored.copyWith(clearAnchorClipId: true);
+        expect(unanchored.anchorClipId, isNull);
+        // Other fields are preserved.
+        expect(unanchored.id, equals(anchored.id));
+        expect(unanchored.url, equals(anchored.url));
+      });
+
+      test('copyWith preserves the anchor when not specified', () {
+        final updated = anchored.copyWith(title: 'New Title');
+        expect(updated.anchorClipId, equals('clip-7'));
+      });
+
+      test('survives a toJson/fromJson roundtrip', () {
+        final restored = AudioEvent.fromJson(anchored.toJson());
+        expect(restored.anchorClipId, equals('clip-7'));
+      });
+
+      test('is omitted from JSON when null', () {
+        const original = AudioEvent(
+          id: 'plain-id-1234567890123456789012345678901234567890123456789012',
+          pubkey: testPubkey,
+          createdAt: 1700000000,
+        );
+        expect(original.toJson(), isNot(contains('anchorClipId')));
+        expect(AudioEvent.fromJson(original.toJson()).anchorClipId, isNull);
+      });
+    });
   });
 }
 

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -1405,6 +1405,9 @@ void main() {
           final clip = _createClipWithFile();
           // endTime must use trimmedDuration, not duration
           expect(result.audioEvent.endTime, equals(clip.trimmedDuration));
+          // Extracted audio is anchored to its source clip by default.
+          expect(result.audioEvent.anchorClipId, equals(clip.id));
+          expect(result.audioEvent.isAnchored, isTrue);
         },
       );
 

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -547,6 +547,112 @@ void main() {
       );
     });
 
+    group(TimelineOverlayAnchoredAudioRebased, () {
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'moves matching sound items to follow the rebased tracks, leaving '
+        'other items untouched',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          items: [
+            _item(
+              id: 'b-audio',
+              type: TimelineOverlayType.sound,
+              start: const Duration(seconds: 10),
+              end: const Duration(seconds: 20),
+            ),
+            _item(
+              id: 'overlay',
+              type: TimelineOverlayType.layer,
+              start: const Duration(seconds: 1),
+              end: const Duration(seconds: 5),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          TimelineOverlayAnchoredAudioRebased([
+            _audioEvent(
+              id: 'b-audio',
+              start: const Duration(seconds: 7),
+              end: const Duration(seconds: 17),
+            ),
+          ]),
+        ),
+        verify: (bloc) {
+          final sound = bloc.state.items.firstWhere((i) => i.id == 'b-audio');
+          expect(sound.startTime, const Duration(seconds: 7));
+          expect(sound.endTime, const Duration(seconds: 17));
+          final layer = bloc.state.items.firstWhere((i) => i.id == 'overlay');
+          expect(layer.startTime, const Duration(seconds: 1));
+          expect(layer.endTime, const Duration(seconds: 5));
+        },
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'does not change source audioTracks (visual-only live update)',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          items: [
+            _item(
+              id: 'b-audio',
+              type: TimelineOverlayType.sound,
+              start: const Duration(seconds: 10),
+              end: const Duration(seconds: 20),
+            ),
+          ],
+          audioTracks: [
+            _audioEvent(
+              id: 'b-audio',
+              start: const Duration(seconds: 10),
+              end: const Duration(seconds: 20),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          TimelineOverlayAnchoredAudioRebased([
+            _audioEvent(
+              id: 'b-audio',
+              start: const Duration(seconds: 7),
+              end: const Duration(seconds: 17),
+            ),
+          ]),
+        ),
+        verify: (bloc) {
+          // The persisted source track keeps its old position — only the
+          // visual item moved. The native player / history reconcile on
+          // release, not during the live drag.
+          expect(
+            bloc.state.audioTracks.single.startTime,
+            const Duration(seconds: 10),
+          );
+        },
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'emits nothing when the rebased positions already match',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          items: [
+            _item(
+              id: 'b-audio',
+              type: TimelineOverlayType.sound,
+              start: const Duration(seconds: 10),
+              end: const Duration(seconds: 20),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          TimelineOverlayAnchoredAudioRebased([
+            _audioEvent(
+              id: 'b-audio',
+              start: const Duration(seconds: 10),
+              end: const Duration(seconds: 20),
+            ),
+          ]),
+        ),
+        expect: () => const <TimelineOverlayState>[],
+      );
+    });
+
     group('selection and gestures', () {
       blocTest<TimelineOverlayBloc, TimelineOverlayState>(
         'select and clear selected item',
@@ -779,6 +885,45 @@ void main() {
             ],
           ),
         ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'keeps a sound item that ends before the total (L-Cut overhang '
+        'survives the shrink)',
+        build: TimelineOverlayBloc.new,
+        // Anchored audio ending at 20 s stays put after a clip right-trim
+        // shrinks the total to 27 s — its tail must keep overhanging into
+        // the next clip rather than being clamped away or removed. A trailing
+        // layer that does exceed the total forces an emission so the handler
+        // definitely runs.
+        seed: () => TimelineOverlayState(
+          items: [
+            _item(
+              id: 'b-audio',
+              type: TimelineOverlayType.sound,
+              start: const Duration(seconds: 10),
+              end: const Duration(seconds: 20),
+            ),
+            _item(
+              id: 'tail-layer',
+              type: TimelineOverlayType.layer,
+              start: const Duration(seconds: 25),
+              end: const Duration(seconds: 30),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayTotalDurationChanged(Duration(seconds: 27)),
+        ),
+        verify: (bloc) {
+          final sound = bloc.state.items.firstWhere((i) => i.id == 'b-audio');
+          expect(sound.startTime, const Duration(seconds: 10));
+          expect(sound.endTime, const Duration(seconds: 20));
+          final layer = bloc.state.items.firstWhere(
+            (i) => i.id == 'tail-layer',
+          );
+          expect(layer.endTime, const Duration(seconds: 27));
+        },
       );
 
       blocTest<TimelineOverlayBloc, TimelineOverlayState>(

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -33,6 +33,7 @@ AudioEvent _audioEvent({
   required Duration start,
   required Duration end,
   String title = 'Sound',
+  String? anchorClipId,
 }) {
   return AudioEvent(
     id: id,
@@ -41,6 +42,7 @@ AudioEvent _audioEvent({
     title: title,
     startTime: start,
     endTime: end,
+    anchorClipId: anchorClipId,
   );
 }
 
@@ -228,6 +230,68 @@ void main() {
               )
               .having((s) => s.audioTracksRevision, 'audioTracksRevision', 0)
               .having((s) => s.audioTracks.first.volume, 'volume', 1.0),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'emits when only an audio anchor is cleared',
+        build: TimelineOverlayBloc.new,
+        seed: () => TimelineOverlayState(
+          items: const [
+            TimelineOverlayItem(
+              id: 'sound-1',
+              type: TimelineOverlayType.sound,
+              startTime: Duration(seconds: 1),
+              endTime: Duration(seconds: 4),
+              label: 'Sound',
+              maxDuration: VideoEditorConstants.maxDuration,
+              audioSource: AudioSource.custom,
+            ),
+          ],
+          audioTracks: [
+            _audioEvent(
+              id: 'sound-1',
+              start: const Duration(seconds: 1),
+              end: const Duration(seconds: 4),
+              anchorClipId: 'clip-1',
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: const Duration(seconds: 1),
+                end: const Duration(seconds: 4),
+              ),
+            ],
+            totalVideoDuration: const Duration(seconds: 12),
+          ),
+        ),
+        expect: () => [
+          TimelineOverlayState(
+            items: const [
+              TimelineOverlayItem(
+                id: 'sound-1',
+                type: TimelineOverlayType.sound,
+                startTime: Duration(seconds: 1),
+                endTime: Duration(seconds: 4),
+                label: 'Sound',
+                maxDuration: VideoEditorConstants.maxDuration,
+                audioSource: AudioSource.custom,
+              ),
+            ],
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: const Duration(seconds: 1),
+                end: const Duration(seconds: 4),
+              ),
+            ],
+          ),
         ],
       );
 

--- a/mobile/test/services/saved_sounds_service_test.dart
+++ b/mobile/test/services/saved_sounds_service_test.dart
@@ -12,6 +12,7 @@ AudioEvent _sound({
   required String id,
   String? title,
   int createdAt = 1700000000,
+  String? anchorClipId,
 }) {
   return AudioEvent(
     id: id,
@@ -25,6 +26,7 @@ AudioEvent _sound({
     source: 'Original Sound',
     sourceVideoReference:
         '34236:test_pubkey_0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef:$id',
+    anchorClipId: anchorClipId,
   );
 }
 
@@ -45,6 +47,18 @@ void main() {
 
       expect(result, SavedSoundSaveResult.saved);
       expect(service.loadSounds(), [sound]);
+    });
+
+    test('clears local editor anchors before persisting sounds', () async {
+      final service = SavedSoundsService(sharedPreferences);
+      final sound = _sound(id: 'sound1', anchorClipId: 'clip-1');
+
+      final result = await service.saveSound(sound);
+
+      expect(result, SavedSoundSaveResult.saved);
+      final savedSound = service.loadSounds().single;
+      expect(savedSound.id, sound.id);
+      expect(savedSound.anchorClipId, isNull);
     });
 
     test(

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -59,11 +59,7 @@ void main() {
   //   pos  5 s  → 5 * 52 + 2 gaps = 262 px  (start of gap after clip 1)
   //   pos  6 s  → 6 * 52 + 2 gaps = 314 px  (within clip 2)
 
-  final clips = [
-    _clip('c0', 2),
-    _clip('c1', 3),
-    _clip('c2', 2),
-  ];
+  final clips = [_clip('c0', 2), _clip('c1', 3), _clip('c2', 2)];
   const pps = 52.0;
   const totalDuration = Duration(seconds: 7);
 
@@ -371,12 +367,7 @@ void main() {
     test('respects playback speed for preceding and target clips', () {
       final trimClips = [
         _clip('clip-1', 10, speed: 2.0),
-        _clip(
-          'clip-2',
-          10,
-          speed: 2.0,
-          trimStart: const Duration(seconds: 2),
-        ),
+        _clip('clip-2', 10, speed: 2.0, trimStart: const Duration(seconds: 2)),
       ];
 
       expect(
@@ -443,50 +434,26 @@ void main() {
     });
 
     test('sorts rebased markers from multiple clips', () {
-      final oldClips = [
-        _clip('a', 3),
-        _clip('b', 5),
-        _clip('c', 2),
-      ];
-      final newClips = [
-        _clip('c', 2),
-        _clip('a', 3),
-        _clip('b', 5),
-      ];
+      final oldClips = [_clip('a', 3), _clip('b', 5), _clip('c', 2)];
+      final newClips = [_clip('c', 2), _clip('a', 3), _clip('b', 5)];
 
       expect(
         rebaseTimelineMarkersForClipState(
           oldClips: oldClips,
           newClips: newClips,
-          markers: [
-            const Duration(seconds: 4),
-            const Duration(seconds: 9),
-          ],
+          markers: [const Duration(seconds: 4), const Duration(seconds: 9)],
         ),
-        equals([
-          const Duration(seconds: 1),
-          const Duration(seconds: 6),
-        ]),
+        equals([const Duration(seconds: 1), const Duration(seconds: 6)]),
       );
     });
 
     test('respects trimmed and speed-adjusted playback duration', () {
       final oldClips = [
         _clip('intro', 10, speed: 2.0),
-        _clip(
-          'target',
-          10,
-          speed: 2.0,
-          trimStart: const Duration(seconds: 2),
-        ),
+        _clip('target', 10, speed: 2.0, trimStart: const Duration(seconds: 2)),
       ];
       final newClips = [
-        _clip(
-          'target',
-          10,
-          speed: 2.0,
-          trimStart: const Duration(seconds: 2),
-        ),
+        _clip('target', 10, speed: 2.0, trimStart: const Duration(seconds: 2)),
         _clip('intro', 10, speed: 2.0),
       ];
 
@@ -501,16 +468,8 @@ void main() {
     });
 
     test('anchors an exact internal boundary to the following clip', () {
-      final oldClips = [
-        _clip('a', 3),
-        _clip('b', 5),
-        _clip('c', 2),
-      ];
-      final newClips = [
-        _clip('c', 2),
-        _clip('b', 5),
-        _clip('a', 3),
-      ];
+      final oldClips = [_clip('a', 3), _clip('b', 5), _clip('c', 2)];
+      final newClips = [_clip('c', 2), _clip('b', 5), _clip('a', 3)];
 
       expect(
         rebaseTimelineMarkersForClipState(
@@ -524,9 +483,7 @@ void main() {
 
     test('drops a marker when its source position is trimmed from the end', () {
       final oldClips = [_clip('clip', 6)];
-      final newClips = [
-        _clip('clip', 6, trimEnd: const Duration(seconds: 3)),
-      ];
+      final newClips = [_clip('clip', 6, trimEnd: const Duration(seconds: 3))];
 
       expect(
         rebaseTimelineMarkersForClipState(
@@ -588,14 +545,8 @@ void main() {
     });
 
     test('shifts later markers when a preceding clip speed changes', () {
-      final oldClips = [
-        _clip('intro', 4),
-        _clip('target', 6),
-      ];
-      final newClips = [
-        _clip('intro', 4, speed: 2.0),
-        _clip('target', 6),
-      ];
+      final oldClips = [_clip('intro', 4), _clip('target', 6)];
+      final newClips = [_clip('intro', 4, speed: 2.0), _clip('target', 6)];
 
       expect(
         rebaseTimelineMarkersForClipState(
@@ -608,10 +559,7 @@ void main() {
     });
 
     test('drops markers whose source clip no longer exists', () {
-      final oldClips = [
-        _clip('a', 3),
-        _clip('b', 5),
-      ];
+      final oldClips = [_clip('a', 3), _clip('b', 5)];
       final newClips = [_clip('a', 3)];
 
       expect(
@@ -625,15 +573,8 @@ void main() {
     });
 
     test('shifts later markers earlier when a preceding clip is removed', () {
-      final oldClips = [
-        _clip('a', 3),
-        _clip('b', 5),
-        _clip('c', 4),
-      ];
-      final newClips = [
-        _clip('a', 3),
-        _clip('c', 4),
-      ];
+      final oldClips = [_clip('a', 3), _clip('b', 5), _clip('c', 4)];
+      final newClips = [_clip('a', 3), _clip('c', 4)];
 
       expect(
         rebaseTimelineMarkersForClipState(
@@ -648,41 +589,22 @@ void main() {
     test('keeps earlier markers in place when a clip is appended', () {
       // Mirrors the clip-duplication call site: the copy is added at the
       // end, so markers on the existing clips must not move.
-      final oldClips = [
-        _clip('a', 3),
-        _clip('b', 5),
-      ];
-      final newClips = [
-        _clip('a', 3),
-        _clip('b', 5),
-        _clip('a_copy', 3),
-      ];
+      final oldClips = [_clip('a', 3), _clip('b', 5)];
+      final newClips = [_clip('a', 3), _clip('b', 5), _clip('a_copy', 3)];
 
       expect(
         rebaseTimelineMarkersForClipState(
           oldClips: oldClips,
           newClips: newClips,
-          markers: [
-            const Duration(seconds: 1),
-            const Duration(seconds: 6),
-          ],
+          markers: [const Duration(seconds: 1), const Duration(seconds: 6)],
         ),
-        equals([
-          const Duration(seconds: 1),
-          const Duration(seconds: 6),
-        ]),
+        equals([const Duration(seconds: 1), const Duration(seconds: 6)]),
       );
     });
 
     test('clamps a marker past the timeline end to the last clip end', () {
-      final oldClips = [
-        _clip('a', 3),
-        _clip('b', 5),
-      ];
-      final newClips = [
-        _clip('a', 3),
-        _clip('b', 5),
-      ];
+      final oldClips = [_clip('a', 3), _clip('b', 5)];
+      final newClips = [_clip('a', 3), _clip('b', 5)];
 
       expect(
         rebaseTimelineMarkersForClipState(
@@ -725,10 +647,7 @@ void main() {
   group('speed-aware geometry', () {
     // Two-clip composition: clip 0 is 10 s at 2×speed (→ 5 s wide),
     // clip 1 is 4 s at 1×speed (→ 4 s wide).  Total playback = 9 s.
-    final speedClips = [
-      _clip('fast', 10, speed: 2.0),
-      _clip('normal', 4),
-    ];
+    final speedClips = [_clip('fast', 10, speed: 2.0), _clip('normal', 4)];
     const speedPps = 52.0;
     const speedTotal = Duration(seconds: 9);
 
@@ -855,17 +774,11 @@ void main() {
     });
 
     test('subtracts one gap at first boundary', () {
-      expect(
-        timelineOverlayOffsetToMs(edges, 105, pps, totalMs),
-        equals(2000),
-      );
+      expect(timelineOverlayOffsetToMs(edges, 105, pps, totalMs), equals(2000));
     });
 
     test('subtracts two gaps at second boundary', () {
-      expect(
-        timelineOverlayOffsetToMs(edges, 262, pps, totalMs),
-        equals(5000),
-      );
+      expect(timelineOverlayOffsetToMs(edges, 262, pps, totalMs), equals(5000));
     });
 
     test('offset inside a gap clamps to the shared boundary', () {
@@ -893,7 +806,7 @@ void main() {
     }
   });
 
-  group(audioStartOffsetForLeftTrim, () {
+  group(audioLeftTrimResult, () {
     test('advances the source offset when the left handle moves right', () {
       final track = _audio(
         id: 'sound',
@@ -901,16 +814,16 @@ void main() {
         endTime: const Duration(seconds: 20),
       );
 
-      expect(
-        audioStartOffsetForLeftTrim(
-          track,
-          newStartTime: const Duration(seconds: 13),
-        ),
-        const Duration(seconds: 3),
+      final result = audioLeftTrimResult(
+        track,
+        newStartTime: const Duration(seconds: 13),
       );
+
+      expect(result.startOffset, const Duration(seconds: 3));
+      expect(result.anchorStillValid, isTrue);
     });
 
-    test('clamps the source offset at zero when revealing audio head', () {
+    test('clears the anchor when revealing before the audio source head', () {
       final track = _audio(
         id: 'sound',
         startTime: const Duration(seconds: 13),
@@ -918,14 +831,35 @@ void main() {
         startOffset: const Duration(seconds: 2),
       );
 
-      expect(
-        audioStartOffsetForLeftTrim(
-          track,
-          newStartTime: const Duration(seconds: 10),
-        ),
-        Duration.zero,
+      final result = audioLeftTrimResult(
+        track,
+        newStartTime: const Duration(seconds: 10),
       );
+
+      expect(result.startOffset, Duration.zero);
+      expect(result.anchorStillValid, isFalse);
     });
+
+    test(
+      'clears the anchor when trimming beyond the audio source duration',
+      () {
+        final track = _audio(
+          id: 'sound',
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 20),
+          startOffset: const Duration(seconds: 8),
+          duration: 10,
+        );
+
+        final result = audioLeftTrimResult(
+          track,
+          newStartTime: const Duration(seconds: 13),
+        );
+
+        expect(result.startOffset, const Duration(seconds: 10));
+        expect(result.anchorStillValid, isFalse);
+      },
+    );
   });
 
   group(rebaseAnchoredAudioForClipState, () {
@@ -1112,11 +1046,7 @@ void main() {
         // The sound began aligned with clip-b at 10–20 s, then the user moved
         // its left trim handle to 13 s. The trim consumes 3 s of source audio,
         // so the anchor invariant still holds after any unrelated clip edit.
-        final clips = [
-          _clip('a', 10),
-          _clip('b', 10),
-          _clip('copy', 10),
-        ];
+        final clips = [_clip('a', 10), _clip('b', 10), _clip('copy', 10)];
         final track = _audio(
           id: 'b-audio',
           startTime: const Duration(seconds: 13),
@@ -1132,6 +1062,25 @@ void main() {
         expect(result.single.startTime, const Duration(seconds: 13));
         expect(result.single.endTime, const Duration(seconds: 20));
         expect(result.single.startOffset, const Duration(seconds: 3));
+      },
+    );
+
+    test(
+      'detached clamped left-trim audio is not repositioned by a later clip edit',
+      () {
+        final clips = [_clip('a', 10), _clip('b', 10), _clip('copy', 10)];
+        final track = _audio(
+          id: 'b-audio',
+          startTime: const Duration(seconds: 9),
+          endTime: const Duration(seconds: 19),
+        );
+        final tracks = [track];
+
+        final result = rebaseAnchoredAudioForClipState(clips, tracks);
+
+        expect(identical(result, tracks), isTrue);
+        expect(result.single.startTime, const Duration(seconds: 9));
+        expect(result.single.endTime, const Duration(seconds: 19));
       },
     );
 

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -3,9 +3,27 @@
 // ABOUTME: across single-clip, multi-clip, and empty-clip compositions.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+
+AudioEvent _audio({
+  required String id,
+  required Duration startTime,
+  required Duration endTime,
+  Duration startOffset = Duration.zero,
+  String? anchorClipId,
+}) => AudioEvent(
+  id: id,
+  pubkey: '',
+  createdAt: 0,
+  url: '/tmp/$id.wav',
+  startTime: startTime,
+  endTime: endTime,
+  startOffset: startOffset,
+  anchorClipId: anchorClipId,
+);
 
 DivineVideoClip _clip(
   String id,
@@ -871,5 +889,182 @@ void main() {
         );
       });
     }
+  });
+
+  group(rebaseAnchoredAudioForClipState, () {
+    // Two clips, both 10 s, no trim. clip-b starts at timeline 10 s.
+    // An anchored track covers clip-b exactly: 10–20 s, startOffset 0.
+    List<DivineVideoClip> baseClips() => [_clip('a', 10), _clip('b', 10)];
+
+    test('shifts the anchored track left when its clip is trimmed left', () {
+      // Trim clip-b's left edge by 3 s. The audio keeps its full content and
+      // span, translating left so its tail stays in sync (J-Cut).
+      final clips = [
+        _clip('a', 10),
+        _clip('b', 10, trimStart: const Duration(seconds: 3)),
+      ];
+      final track = _audio(
+        id: 'b-audio',
+        startTime: const Duration(seconds: 10),
+        endTime: const Duration(seconds: 20),
+        anchorClipId: 'b',
+      );
+
+      final result = rebaseAnchoredAudioForClipState(clips, [track]);
+
+      expect(result.single.startTime, const Duration(seconds: 7));
+      expect(result.single.endTime, const Duration(seconds: 17));
+      // Content (startOffset) and span are preserved.
+      expect(result.single.startOffset, Duration.zero);
+      expect(
+        result.single.endTime! - result.single.startTime,
+        const Duration(seconds: 10),
+      );
+    });
+
+    test('keeps the anchored track in place when its clip is right-trimmed '
+        '(L-Cut overhang into the next clip)', () {
+      // [a:10][b:10][c:10]. clip-b right-trimmed by 3 s → b occupies
+      // timeline 10–17 s, c ripples to 17–27 s. The anchored audio must stay
+      // put so its tail (…20 s) trails over clip-c's video.
+      final clips = [
+        _clip('a', 10),
+        _clip('b', 10, trimEnd: const Duration(seconds: 3)),
+        _clip('c', 10),
+      ];
+      final track = _audio(
+        id: 'b-audio',
+        startTime: const Duration(seconds: 10),
+        endTime: const Duration(seconds: 20),
+        anchorClipId: 'b',
+      );
+
+      final result = rebaseAnchoredAudioForClipState(clips, [track]);
+
+      // Audio does not move on a right-trim.
+      expect(result.single.startTime, const Duration(seconds: 10));
+      expect(result.single.endTime, const Duration(seconds: 20));
+      // Its end now overhangs clip-b's trimmed end (17 s) into clip-c.
+      expect(result.single.endTime, greaterThan(const Duration(seconds: 17)));
+    });
+
+    test('ripples a later anchored track when an earlier clip is trimmed', () {
+      // clip-a trimmed left by 4 s → total shrinks, clip-b ripples to start
+      // at timeline 6 s. clip-b's anchored audio must follow.
+      final clips = [
+        _clip('a', 10, trimStart: const Duration(seconds: 4)),
+        _clip('b', 10),
+      ];
+      final track = _audio(
+        id: 'b-audio',
+        startTime: const Duration(seconds: 10),
+        endTime: const Duration(seconds: 20),
+        anchorClipId: 'b',
+      );
+
+      final result = rebaseAnchoredAudioForClipState(clips, [track]);
+
+      expect(result.single.startTime, const Duration(seconds: 6));
+      expect(result.single.endTime, const Duration(seconds: 16));
+    });
+
+    test('preserves a user-shortened span (L-Cut) while translating', () {
+      // User right-trimmed the audio to 10–15 s (5 s span). A later clip
+      // edit must keep that span, only translating it.
+      final clips = [
+        _clip('a', 10),
+        _clip('b', 10, trimStart: const Duration(seconds: 3)),
+      ];
+      final track = _audio(
+        id: 'b-audio',
+        startTime: const Duration(seconds: 10),
+        endTime: const Duration(seconds: 15),
+        anchorClipId: 'b',
+      );
+
+      final result = rebaseAnchoredAudioForClipState(clips, [track]);
+
+      expect(result.single.startTime, const Duration(seconds: 7));
+      expect(result.single.endTime, const Duration(seconds: 12));
+    });
+
+    test('clamps the start to zero for an anchored first clip', () {
+      // clip-a is first (timeline start 0). Trimming it left by 3 s cannot
+      // produce a lead, so the start clamps to zero.
+      final clips = [
+        _clip('a', 10, trimStart: const Duration(seconds: 3)),
+        _clip('b', 10),
+      ];
+      final track = _audio(
+        id: 'a-audio',
+        startTime: Duration.zero,
+        endTime: const Duration(seconds: 10),
+        anchorClipId: 'a',
+      );
+
+      final result = rebaseAnchoredAudioForClipState(clips, [track]);
+
+      expect(result.single.startTime, Duration.zero);
+      expect(result.single.endTime, const Duration(seconds: 10));
+    });
+
+    test('leaves an un-anchored track untouched', () {
+      final clips = [
+        _clip('a', 10),
+        _clip('b', 10, trimStart: const Duration(seconds: 3)),
+      ];
+      final tracks = [
+        _audio(
+          id: 'free',
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 20),
+        ),
+      ];
+
+      final result = rebaseAnchoredAudioForClipState(clips, tracks);
+
+      // No anchored track moved → original list instance returned.
+      expect(identical(result, tracks), isTrue);
+      expect(result.single.startTime, const Duration(seconds: 10));
+      expect(result.single.endTime, const Duration(seconds: 20));
+    });
+
+    test('leaves a track whose anchor clip was removed untouched', () {
+      final track = _audio(
+        id: 'orphan',
+        startTime: const Duration(seconds: 10),
+        endTime: const Duration(seconds: 20),
+        anchorClipId: 'gone',
+      );
+
+      final result = rebaseAnchoredAudioForClipState(baseClips(), [track]);
+
+      expect(result.single.startTime, const Duration(seconds: 10));
+      expect(result.single.endTime, const Duration(seconds: 20));
+    });
+
+    test('returns the same list instance when nothing moves', () {
+      // Anchored track already aligned with its un-edited clip.
+      final tracks = [
+        _audio(
+          id: 'b-audio',
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 20),
+          anchorClipId: 'b',
+        ),
+      ];
+
+      final result = rebaseAnchoredAudioForClipState(baseClips(), tracks);
+
+      expect(identical(result, tracks), isTrue);
+    });
+
+    test('returns the same empty list instance', () {
+      const tracks = <AudioEvent>[];
+      expect(
+        identical(rebaseAnchoredAudioForClipState(baseClips(), tracks), tracks),
+        isTrue,
+      );
+    });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -13,12 +13,14 @@ AudioEvent _audio({
   required Duration startTime,
   required Duration endTime,
   Duration startOffset = Duration.zero,
+  double? duration,
   String? anchorClipId,
 }) => AudioEvent(
   id: id,
   pubkey: '',
   createdAt: 0,
   url: '/tmp/$id.wav',
+  duration: duration,
   startTime: startTime,
   endTime: endTime,
   startOffset: startOffset,
@@ -891,6 +893,41 @@ void main() {
     }
   });
 
+  group(audioStartOffsetForLeftTrim, () {
+    test('advances the source offset when the left handle moves right', () {
+      final track = _audio(
+        id: 'sound',
+        startTime: const Duration(seconds: 10),
+        endTime: const Duration(seconds: 20),
+      );
+
+      expect(
+        audioStartOffsetForLeftTrim(
+          track,
+          newStartTime: const Duration(seconds: 13),
+        ),
+        const Duration(seconds: 3),
+      );
+    });
+
+    test('clamps the source offset at zero when revealing audio head', () {
+      final track = _audio(
+        id: 'sound',
+        startTime: const Duration(seconds: 13),
+        endTime: const Duration(seconds: 20),
+        startOffset: const Duration(seconds: 2),
+      );
+
+      expect(
+        audioStartOffsetForLeftTrim(
+          track,
+          newStartTime: const Duration(seconds: 10),
+        ),
+        Duration.zero,
+      );
+    });
+  });
+
   group(rebaseAnchoredAudioForClipState, () {
     // Two clips, both 10 s, no trim. clip-b starts at timeline 10 s.
     // An anchored track covers clip-b exactly: 10–20 s, startOffset 0.
@@ -967,6 +1004,26 @@ void main() {
       expect(result.single.startTime, const Duration(seconds: 6));
       expect(result.single.endTime, const Duration(seconds: 16));
     });
+
+    test(
+      'uses playback-time starts when an earlier clip has playbackSpeed',
+      () {
+        // clip-a is 4 s source at 0.5x, so it occupies 8 s on the timeline.
+        // clip-b's anchored audio follows that playback-time start.
+        final clips = [_clip('a', 4, speed: 0.5), _clip('b', 10)];
+        final track = _audio(
+          id: 'b-audio',
+          startTime: const Duration(seconds: 10),
+          endTime: const Duration(seconds: 20),
+          anchorClipId: 'b',
+        );
+
+        final result = rebaseAnchoredAudioForClipState(clips, [track]);
+
+        expect(result.single.startTime, const Duration(seconds: 8));
+        expect(result.single.endTime, const Duration(seconds: 18));
+      },
+    );
 
     test('preserves a user-shortened span (L-Cut) while translating', () {
       // User right-trimmed the audio to 10–15 s (5 s span). A later clip
@@ -1048,6 +1105,35 @@ void main() {
       expect(result.single.startTime, const Duration(seconds: 10));
       expect(result.single.endTime, const Duration(seconds: 20));
     });
+
+    test(
+      'left-trimmed anchored audio is not repositioned by an unrelated clip edit',
+      () {
+        // The sound began aligned with clip-b at 10–20 s, then the user moved
+        // its left trim handle to 13 s. The trim consumes 3 s of source audio,
+        // so the anchor invariant still holds after any unrelated clip edit.
+        final clips = [
+          _clip('a', 10),
+          _clip('b', 10),
+          _clip('copy', 10),
+        ];
+        final track = _audio(
+          id: 'b-audio',
+          startTime: const Duration(seconds: 13),
+          endTime: const Duration(seconds: 20),
+          startOffset: const Duration(seconds: 3),
+          anchorClipId: 'b',
+        );
+        final tracks = [track];
+
+        final result = rebaseAnchoredAudioForClipState(clips, tracks);
+
+        expect(identical(result, tracks), isTrue);
+        expect(result.single.startTime, const Duration(seconds: 13));
+        expect(result.single.endTime, const Duration(seconds: 20));
+        expect(result.single.startOffset, const Duration(seconds: 3));
+      },
+    );
 
     test('returns the same list instance when nothing moves', () {
       // Anchored track already aligned with its un-edited clip.

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -988,9 +988,10 @@ void main() {
       expect(result.single.endTime, const Duration(seconds: 12));
     });
 
-    test('clamps the start to zero for an anchored first clip', () {
+    test('clips impossible pre-roll for an anchored first clip', () {
       // clip-a is first (timeline start 0). Trimming it left by 3 s cannot
-      // produce a lead, so the start clamps to zero.
+      // produce a lead, so the start clamps to zero and the lost pre-roll is
+      // consumed from the audio source offset instead.
       final clips = [
         _clip('a', 10, trimStart: const Duration(seconds: 3)),
         _clip('b', 10),
@@ -1005,7 +1006,12 @@ void main() {
       final result = rebaseAnchoredAudioForClipState(clips, [track]);
 
       expect(result.single.startTime, Duration.zero);
-      expect(result.single.endTime, const Duration(seconds: 10));
+      expect(result.single.startOffset, const Duration(seconds: 3));
+      expect(result.single.endTime, const Duration(seconds: 7));
+      expect(
+        result.single.endTime! - result.single.startTime,
+        const Duration(seconds: 7),
+      );
     });
 
     test('leaves an un-anchored track untouched', () {


### PR DESCRIPTION
## Description

Implements audio anchoring for J-Cuts and L-Cuts in the video editor. When audio is extracted from a video clip, it is now anchored to that source clip by default. Trimming the clip's left edge automatically rebases the anchored audio to stay in sync — creating a J-Cut without any manual repositioning. If the user manually drags the audio on the timeline, it detaches and behaves as an independent, free-floating track.

**Related Issue:** Closes #5009

### Changes

- **`AudioEvent` model** — adds an `anchorClipId` field (`String?`) that stores the ID of the source `DivineVideoClip`. Also adds `isAnchored` getter and `clearAnchorClipId` flag in `copyWith`. Field is local-only editor state and is never published to Nostr.
- **`VideoEditorTimelineGeometry`** — new `rebaseAnchoredAudioForClipState` helper that computes how anchored audio tracks must shift when any clip's trim changes, returning the same list instance when nothing moved (identity-equality guard to avoid unnecessary history writes).
- **`VideoEditorExtensions`** — `updateClipsState` now calls `rebaseAnchoredAudioForClipState` and writes the rebased audio into the history snapshot only when a track actually moved.
- **`updateAudioTrack` extension** — new `clearAnchor` parameter; set to `true` by the clip editor when the user manually moves an audio track, detaching it from its source clip.
- **`TimelineOverlayBloc` / `ClipEditorBloc`** — wired up to pass `clearAnchor: true` on manual drag and to trigger rebasing on clip trim events.

## Out of Scope

L-Cut (trimming audio's right edge) is not auto-rebased in this PR — it follows naturally from the same mechanism once the user shortens the audio track manually and the next clip's audio is anchored. No explicit L-Cut automation was requested in the issue.

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test mobile/packages/models/test/src/audio_event_test.dart` — 46 new assertions pass
- `flutter test mobile/test/.../timeline_overlay_bloc_test.dart` — 145 new assertions pass
- `flutter test mobile/test/.../video_editor_timeline_geometry_test.dart` — 195 new assertions pass
- `flutter test mobile/test/.../clip_editor_bloc_test.dart` — updated assertions pass
- Manual: extract audio from a clip → trim clip left edge → audio stays in sync (J-Cut); drag audio manually → trim clip → audio stays in new position

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
