### PR TITLE
fix(feed): preserve For You recommendation order on load-more

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -426,7 +426,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         }
       }
 
-      updatedVideos.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      // For You pages arrive in server-ranked recommendation order;
+      // re-sorting by createdAt would shuffle new videos around the
+      // current play index and resurface already-seen ones.
+      if (state.source.type != VideoFeedSourceType.forYou) {
+        updatedVideos.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      }
 
       // Merge attribution metadata from pagination with existing state.
       final mergedSources = Map.of(state.videoListSources);

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -1233,6 +1233,154 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'preserves forYou recommendation order when next page has newer '
+        'createdAt timestamps',
+        setUp: () {
+          final newerVideos = [
+            createTestVideo('newer-c', createdAt: 5000),
+            createTestVideo('newer-d', createdAt: 4999),
+          ];
+
+          when(
+            () => mockVideosRepository.getRecommendedVideos(
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: newerVideos,
+              paginationCursor: 'rec-page-3',
+              hasMore: true,
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: [
+            createTestVideo('old-a', createdAt: 1000),
+            createTestVideo('old-b', createdAt: 999),
+          ],
+          paginationCursor: 'rec-page-2',
+        ),
+        act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                equals(['old-a', 'old-b', 'newer-c', 'newer-d']),
+              ),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'filters duplicate IDs from the next forYou page while preserving '
+        'order',
+        setUp: () {
+          final nextPage = [
+            createTestVideo('old-b', createdAt: 5000),
+            createTestVideo('newer-c', createdAt: 4999),
+          ];
+
+          when(
+            () => mockVideosRepository.getRecommendedVideos(
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: nextPage,
+              paginationCursor: 'rec-page-3',
+              hasMore: true,
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: [
+            createTestVideo('old-a', createdAt: 1000),
+            createTestVideo('old-b', createdAt: 999),
+          ],
+          paginationCursor: 'rec-page-2',
+        ),
+        act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                equals(['old-a', 'old-b', 'newer-c']),
+              ),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'sorts merged following feed chronologically on load more',
+        setUp: () {
+          final newerVideos = [
+            createTestVideo('newer-c', createdAt: 5000),
+            createTestVideo('newer-d', createdAt: 4999),
+          ];
+
+          when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: newerVideos));
+        },
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          mode: FeedMode.following,
+          videos: [
+            createTestVideo('old-a', createdAt: 1000),
+            createTestVideo('old-b', createdAt: 999),
+          ],
+        ),
+        act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                equals(['newer-c', 'newer-d', 'old-a', 'old-b']),
+              ),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'stops forYou pagination when the current page has no cursor',
         build: createBloc,
         seed: () => VideoFeedBlocState(


### PR DESCRIPTION
## Summary

Fixes the For You feed repeat/jump issue on pagination. `_onLoadMoreRequested` re-sorted the merged video list by `createdAt` descending for every feed type. That sort is correct for chronological feeds, but For You pages arrive in server-ranked recommendation order — when a next page contained newer-timestamped videos, the sort inserted them before/around the current play index, making users re-see videos they had swiped past 10–15 videos earlier.

## Changes

- **`mobile/lib/blocs/video_feed/video_feed_bloc.dart`**: skip the chronological sort in `_onLoadMoreRequested` when `state.source.type == VideoFeedSourceType.forYou`. For You load-more now appends `[existing..., new unique...]`. Dedupe by event ID and the opaque `paginationCursor` flow into `getRecommendedVideos(cursor: ...)` are unchanged. Non-For You feeds keep newest-first sorting.

## Tests

- New: `preserves forYou recommendation order when next page has newer createdAt timestamps` — initial `old-a`, `old-b`; next page `newer-c`, `newer-d` with newer timestamps; asserts final order `[old-a, old-b, newer-c, newer-d]` (failed before the fix).
- New: `filters duplicate IDs from the next forYou page while preserving order` — duplicate `old-b` on page 2 is dropped, order preserved (failed before the fix).
- New: `sorts merged following feed chronologically on load more` — pins unchanged non-For You behavior (passes before and after).

## Verification

- `flutter test test/blocs/video_feed/video_feed_bloc_test.dart` — 88/88 pass
- `flutter test` in `packages/videos_repository` — 412/412 pass (no repo changes)
- `flutter analyze lib test integration_test` — no issues
- `dart format` — clean

No funnelcake/Gorse/ClickHouse changes; no backend watched-history filtering reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)