### PR TITLE
fix(video-player): guard millisecond conversions against NaN/infinite AVFoundation times

### DIFF
--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -776,7 +776,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         guard let player, let sink = eventSink else { return }
 
         let currentTime = CMTimeGetSeconds(player.currentTime())
-        let actualPositionMs = Int(max(currentTime, 0) * 1000)
+        let actualPositionMs = currentTime.millisecondsClamped
         let positionMs: Int
         if let overrideMs = reportedPositionOverrideMs {
             if player.rate > 0 && Int64(actualPositionMs) >= overrideMs {
@@ -789,7 +789,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             positionMs = actualPositionMs
         }
         let reportedTime = Double(positionMs) / 1000.0
-        let durationMs = Int(totalDuration * 1000)
+        let durationMs = totalDuration.millisecondsClamped
 
         // Determine current clip index.
         var clipIndex = 0
@@ -940,7 +940,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         let bufferedEnd = CMTimeGetSeconds(
             CMTimeAdd(range.start, range.duration)
         )
-        return Int(max(bufferedEnd, 0) * 1000)
+        return bufferedEnd.millisecondsClamped
     }
 
     // MARK: - App Lifecycle
@@ -1010,6 +1010,18 @@ private enum CompositionError: Error, LocalizedError {
         case .invalidRenderSize:
             return "Video composition has an invalid render size."
         }
+    }
+}
+
+private extension Double {
+    /// Millisecond conversion safe against NaN and ±infinity, which
+    /// `Int.init(_: Double)` traps on. AVFoundation time queries can
+    /// return non-numeric values — e.g. `loadedTimeRanges` yields an
+    /// indefinite CMTime at the readyToPlay transition on macOS 26,
+    /// and `max(NaN, 0)` returns NaN rather than 0.
+    var millisecondsClamped: Int {
+        guard isFinite else { return 0 }
+        return Int(max(self, 0) * 1000)
     }
 }
 

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -720,7 +720,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         guard let player, let sink = eventSink else { return }
 
         let currentTime = CMTimeGetSeconds(player.currentTime())
-        let actualPositionMs = Int(max(currentTime, 0) * 1000)
+        let actualPositionMs = currentTime.millisecondsClamped
         let positionMs: Int
         if let overrideMs = reportedPositionOverrideMs {
             if player.rate > 0 && Int64(actualPositionMs) >= overrideMs {
@@ -733,7 +733,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             positionMs = actualPositionMs
         }
         let reportedTime = Double(positionMs) / 1000.0
-        let durationMs = Int(totalDuration * 1000)
+        let durationMs = totalDuration.millisecondsClamped
 
         var clipIndex = 0
         for i in 0..<clipOffsets.count {
@@ -871,7 +871,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         let bufferedEnd = CMTimeGetSeconds(
             CMTimeAdd(range.start, range.duration)
         )
-        return Int(max(bufferedEnd, 0) * 1000)
+        return bufferedEnd.millisecondsClamped
     }
 
     // MARK: - App Lifecycle
@@ -939,6 +939,18 @@ private enum CompositionError: Error, LocalizedError {
         case .invalidRenderSize:
             return "Video composition has an invalid render size."
         }
+    }
+}
+
+private extension Double {
+    /// Millisecond conversion safe against NaN and ±infinity, which
+    /// `Int.init(_: Double)` traps on. AVFoundation time queries can
+    /// return non-numeric values — e.g. `loadedTimeRanges` yields an
+    /// indefinite CMTime at the readyToPlay transition on macOS 26,
+    /// and `max(NaN, 0)` returns NaN rather than 0.
+    var millisecondsClamped: Int {
+        guard isFinite else { return 0 }
+        return Int(max(self, 0) * 1000)
     }
 }
 


### PR DESCRIPTION
Closes #5035

## Description

Fixes the macOS crash-on-video-play reported via TestFlight (Crashlytics issue `5e57a012831eb6171a4810683d08f851`, first seen 1.0.12, last seen 1.0.15, EXC_BREAKPOINT, DESKTOP only).

**Root cause:** on macOS 26 (both iOS-on-Mac and native macOS), `AVPlayerItem.loadedTimeRanges` can yield an indefinite `CMTime` at the exact instant `status` flips to `readyToPlay`. `CMTimeGetSeconds` then returns NaN — and because Swift's `max(NaN, 0)` returns NaN rather than 0, `Int(max(bufferedEnd, 0) * 1000)` hits the fatal Double→Int conversion trap on the main thread, inside the status KVO handler. The app dies the moment a video starts playing.

Symbolicated crash (TestFlight 1.0.15 (750), macOS 26.2):

```
at DivineVideoPlayerInstance.bufferedPositionMs(for:)   ← trap
at DivineVideoPlayerInstance.sendStateUpdateOnMain()
at closure #1 in DivineVideoPlayerInstance.observeStatus(for:)
at … AVPlayerItem KVO (readyToPlay transition)
```

**Fix:** route all seconds→milliseconds conversions in the state-update path (position, duration, buffered position) through a `millisecondsClamped` helper on `Double` that returns 0 for non-finite input — in both the `ios/` and `macos/` plugin implementations (the files are intentionally identical, and the "Mac" TestFlight app is the iOS build running on Apple silicon, so both copies are live).

Audited the remaining `Int(Double)` sites in the native classes: `videoWidth`/`videoHeight` are already guarded (`isPositive` checks `isFinite`), `AudioOverlayManager`'s drift check is comparison-only (NaN-safe), and `Int(max(overrideMs, 0))` is an Int64→Int conversion that cannot trap on 64-bit.

## Testing

- Reproduced the crash signature from the local `.ips` crash report and the Crashlytics symbolicated sample event.
- No native Swift test target exists for this plugin; verified by building both platforms with the fix:
  - `flutter build macos --debug` ✓
  - `flutter build ios --debug --no-codesign` ✓
- Manually verified on macOS 26.2 (the OS where the crash reproduces): video playback in the debug build works without crashing.

## Checklist

- [x] Fix verified on the crashing OS (macOS 26.2)
- [x] Both platform copies updated symmetrically
- [x] No unrelated changes in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)