### PR TITLE
fix(feed): open collaborator picker from attribution row

### DIFF
--- a/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
+++ b/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
@@ -20,6 +20,13 @@ import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+const _pickerBaseChildSize = 0.24;
+const _pickerChildSizePerCollaborator = 0.08;
+const _pickerMinInitialChildSize = 0.36;
+const _pickerMaxInitialChildSize = 0.68;
+const _pickerMinChildSize = 0.28;
+const _pickerMaxChildSize = 0.8;
+
 /// Displays collaborator avatars on a video feed item.
 ///
 /// Hides the current user's own avatar when their local invite store says
@@ -125,7 +132,7 @@ class CollaboratorAvatarRowBody extends StatelessWidget {
       child: Semantics(
         identifier: 'collaborator_avatar_row',
         button: true,
-        label: context.l10n.videoCollaboratorCountLabel(visible.length),
+        label: _semanticsLabel(context, visible.length),
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           decoration: BoxDecoration(
@@ -184,16 +191,22 @@ class CollaboratorAvatarRowBody extends StatelessWidget {
         scrollController: scrollController,
       ),
       initialChildSize: _initialPickerSize(pubkeys.length),
-      minChildSize: 0.28,
-      maxChildSize: 0.8,
+      minChildSize: _pickerMinChildSize,
+      maxChildSize: _pickerMaxChildSize,
     );
   }
 
   double _initialPickerSize(int count) {
-    final size = 0.24 + (count * 0.08);
-    if (size < 0.36) return 0.36;
-    if (size > 0.68) return 0.68;
+    final size =
+        _pickerBaseChildSize + (count * _pickerChildSizePerCollaborator);
+    if (size < _pickerMinInitialChildSize) return _pickerMinInitialChildSize;
+    if (size > _pickerMaxInitialChildSize) return _pickerMaxInitialChildSize;
     return size;
+  }
+
+  String _semanticsLabel(BuildContext context, int count) {
+    if (count == 1) return context.l10n.videoCollaboratorCountLabel(count);
+    return '${context.l10n.metadataCollaboratorsLabel}: $count';
   }
 
   void _navigateToCollaborator(BuildContext context, String pubkey) {
@@ -302,8 +315,14 @@ class _CollaboratorPickerTile extends ConsumerWidget {
     final npub = normalizeToNpub(pubkey);
     if (npub == null) return;
 
+    // Dismiss the sheet first, then navigate from the root navigator context.
+    // GoRouter extensions can throw when called from inside a modal bottom
+    // sheet (the router is not in the modal's widget tree).
     final hostContext = Navigator.of(context, rootNavigator: true).context;
     Navigator.of(context).pop();
+    // Defer to the next frame so the modal route's pop has settled in the
+    // route stack before we push the destination route from the root
+    // navigator's context.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!hostContext.mounted) return;
       hostContext.pushWithVideoPause(OtherProfileScreen.pathForNpub(npub));

--- a/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
+++ b/mobile/lib/widgets/video_feed_item/collaborator_avatar_row.dart
@@ -15,6 +15,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -120,7 +121,7 @@ class CollaboratorAvatarRowBody extends StatelessWidget {
     final pendingCount = visibility.pendingCount;
 
     return GestureDetector(
-      onTap: () => _navigateToCollaborator(context, visible.first),
+      onTap: () => _handleTap(context, visible),
       child: Semantics(
         identifier: 'collaborator_avatar_row',
         button: true,
@@ -159,6 +160,42 @@ class CollaboratorAvatarRowBody extends StatelessWidget {
     );
   }
 
+  void _handleTap(BuildContext context, List<String> pubkeys) {
+    if (pubkeys.length == 1) {
+      _navigateToCollaborator(context, pubkeys.first);
+      return;
+    }
+
+    _showCollaboratorPicker(context, pubkeys);
+  }
+
+  Future<void> _showCollaboratorPicker(
+    BuildContext context,
+    List<String> pubkeys,
+  ) {
+    return context.showVideoPausingVineBottomSheet<void>(
+      title: Text(
+        context.l10n.metadataCollaboratorsLabel,
+        style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
+      ),
+      buildScrollBody: (scrollController) => _CollaboratorPickerList(
+        pubkeys: pubkeys,
+        visibility: visibility,
+        scrollController: scrollController,
+      ),
+      initialChildSize: _initialPickerSize(pubkeys.length),
+      minChildSize: 0.28,
+      maxChildSize: 0.8,
+    );
+  }
+
+  double _initialPickerSize(int count) {
+    final size = 0.24 + (count * 0.08);
+    if (size < 0.36) return 0.36;
+    if (size > 0.68) return 0.68;
+    return size;
+  }
+
   void _navigateToCollaborator(BuildContext context, String pubkey) {
     Log.info(
       'Navigating to collaborator profile: $pubkey',
@@ -170,6 +207,107 @@ class CollaboratorAvatarRowBody extends StatelessWidget {
     if (npub != null) {
       context.push(OtherProfileScreen.pathForNpub(npub));
     }
+  }
+}
+
+class _CollaboratorPickerList extends StatelessWidget {
+  const _CollaboratorPickerList({
+    required this.pubkeys,
+    required this.visibility,
+    required this.scrollController,
+  });
+
+  final List<String> pubkeys;
+  final CollaboratorVisibility visibility;
+  final ScrollController scrollController;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      controller: scrollController,
+      padding: const EdgeInsets.only(bottom: 16),
+      itemCount: pubkeys.length,
+      separatorBuilder: (context, index) => const Divider(
+        height: 1,
+        thickness: 1,
+        color: VineTheme.outlineDisabled,
+      ),
+      itemBuilder: (context, index) {
+        final pubkey = pubkeys[index];
+        return _CollaboratorPickerTile(
+          pubkey: pubkey,
+          isPending: visibility.isPendingForInviter(pubkey),
+        );
+      },
+    );
+  }
+}
+
+class _CollaboratorPickerTile extends ConsumerWidget {
+  const _CollaboratorPickerTile({
+    required this.pubkey,
+    required this.isPending,
+  });
+
+  final String pubkey;
+  final bool isPending;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final profileAsync = ref.watch(fetchUserProfileProvider(pubkey));
+    final name =
+        profileAsync.value?.bestDisplayName ??
+        UserProfile.defaultDisplayNameFor(pubkey);
+
+    final tile = Material(
+      type: MaterialType.transparency,
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
+        leading: UserAvatar(
+          imageUrl: profileAsync.value?.picture,
+          name: name,
+          size: 40,
+        ),
+        title: Text(
+          name,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: VineTheme.titleSmallFont(color: VineTheme.onSurface),
+        ),
+        subtitle: isPending
+            ? Text(
+                context.l10n.videoCollaboratorPendingDecoration,
+                style: VineTheme.labelSmallFont(
+                  color: VineTheme.onSurfaceMuted,
+                ),
+              )
+            : null,
+        trailing: const DivineIcon(
+          icon: DivineIconName.caretRight,
+          size: 18,
+          color: VineTheme.onSurfaceVariant,
+        ),
+        onTap: () => _navigateToProfile(context),
+      ),
+    );
+
+    return Semantics(
+      button: true,
+      label: context.l10n.profileChipTapHint(name),
+      child: isPending ? Opacity(opacity: 0.7, child: tile) : tile,
+    );
+  }
+
+  void _navigateToProfile(BuildContext context) {
+    final npub = normalizeToNpub(pubkey);
+    if (npub == null) return;
+
+    final hostContext = Navigator.of(context, rootNavigator: true).context;
+    Navigator.of(context).pop();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!hostContext.mounted) return;
+      hostContext.pushWithVideoPause(OtherProfileScreen.pathForNpub(npub));
+    });
   }
 }
 

--- a/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
+++ b/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
@@ -17,6 +17,8 @@ const _collab1 =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 const _collab2 =
     'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+const _collab3 =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
 const _thirdPartyPubkey =
     'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
@@ -285,5 +287,46 @@ void main() {
         );
       },
     );
+
+    testWidgets('multi-collaborator row opens picker with every collaborator', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const CollaboratorAvatarRowBody(
+            visibility: CollaboratorVisibility.fallback(
+              taggedPubkeys: [_collab1, _collab2, _collab3],
+            ),
+          ),
+          overrides: [
+            fetchUserProfileProvider(
+              _collab1,
+            ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
+            fetchUserProfileProvider(
+              _collab2,
+            ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
+            fetchUserProfileProvider(
+              _collab3,
+            ).overrideWith((ref) async => _makeProfile(_collab3, 'Casey')),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(_l10n.videoCollaboratorWithMore('Alice', 2)),
+        findsOneWidget,
+      );
+
+      await tester.tap(
+        find.text(_l10n.videoCollaboratorWithMore('Alice', 2)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(_l10n.metadataCollaboratorsLabel), findsOneWidget);
+      expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('Bob'), findsOneWidget);
+      expect(find.text('Casey'), findsOneWidget);
+    });
   });
 }

--- a/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
+++ b/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
@@ -317,6 +317,22 @@ void main() {
         find.text(_l10n.videoCollaboratorWithMore('Alice', 2)),
         findsOneWidget,
       );
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Semantics &&
+              w.properties.label == '${_l10n.metadataCollaboratorsLabel}: 3',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is Semantics &&
+              w.properties.label == _l10n.videoCollaboratorCountLabel(3),
+        ),
+        findsNothing,
+      );
 
       await tester.tap(
         find.text(_l10n.videoCollaboratorWithMore('Alice', 2)),


### PR DESCRIPTION
Closes #5038

## Summary
- Open a Vine bottom sheet when the feed collaborator attribution row has multiple people instead of navigating to only the first collaborator.
- List every visible collaborator with avatar/name and preserve direct profile navigation from each row.
- Add a widget regression test for the `with @name +N` case so hidden collaborators appear in the picker.

## Test Plan
- mise exec -- flutter analyze lib/widgets/video_feed_item/collaborator_avatar_row.dart test/widgets/video_feed_item/collaborator_avatar_row_test.dart
- mise exec -- flutter test test/widgets/video_feed_item/collaborator_avatar_row_test.dart
- git push pre-push hook: analyzer + changed widget test