### PR TITLE
fix(feed): keep content-warned videos paused until View Anyway is tapped

### DIFF
--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -112,6 +112,30 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
   /// scheduler churn.
   final Map<String, VideoErrorType> _lastReportedError = {};
 
+  /// Video ids whose content warning the user dismissed via "View Anyway".
+  ///
+  /// Lives at the feed level (not in the per-item overlay state) because
+  /// [InfiniteVideoFeed.canAutoPlay] must consult it before starting
+  /// playback — a warned video must stay paused until revealed.
+  final Set<String> _revealedContentWarningVideoIds = <String>{};
+
+  /// Whether [video] may start playing: either it has no content-warning
+  /// gate, or the user already chose "View Anyway" for it.
+  bool _canAutoPlayVideo(VideoEvent video) =>
+      !shouldShowContentWarningOverlay(
+        contentWarningLabels: video.contentWarningLabels,
+        warnLabels: video.warnLabels,
+      ) ||
+      _revealedContentWarningVideoIds.contains(video.id);
+
+  /// Marks [videoId] as revealed and starts playback of the active video.
+  void _revealContentWarning(String videoId) {
+    setState(() {
+      _revealedContentWarningVideoIds.add(videoId);
+    });
+    _feedKey.currentState?.resumeCurrentPlayback();
+  }
+
   /// Animates the underlying feed to [index].
   ///
   /// Used by parent screens that hold a [GlobalKey<FeedVideosState>] to
@@ -123,10 +147,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
     int index,
     Map<String, String> httpHeaders,
   ) =>
-      _feedKey.currentState?.retryAt(
-        index,
-        httpHeaders: httpHeaders,
-      ) ??
+      _feedKey.currentState?.retryAt(index, httpHeaders: httpHeaders) ??
       Future.value(false);
 
   @override
@@ -260,6 +281,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
         onVideoLoopCompleted: _handleAutoAdvanceCompleted,
         shouldPortraitExpand: widget.shouldPortraitExpand,
         maxLoopDuration: VideoEditorConstants.maxDuration,
+        canAutoPlay: _canAutoPlayVideo,
         videoBuilder: (context, child, index, controller) {
           if (index < 0 || index >= widget.videos.length) {
             return const SizedBox.shrink();
@@ -351,6 +373,10 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
               index: index,
               isActive: isActive,
               contextTitle: widget.contextTitle,
+              contentWarningRevealed: _revealedContentWarningVideoIds.contains(
+                video.id,
+              ),
+              onContentWarningRevealed: () => _revealContentWarning(video.id),
               onToggleAutoAdvance: _toggleAutoAdvance,
               onSuppressAutoAdvance: _suppressAutoAdvance,
             ),
@@ -368,6 +394,8 @@ class _Overlay extends ConsumerStatefulWidget {
     required this.video,
     required this.index,
     required this.isActive,
+    required this.contentWarningRevealed,
+    required this.onContentWarningRevealed,
     this.onToggleAutoAdvance,
     this.onSuppressAutoAdvance,
   });
@@ -377,6 +405,14 @@ class _Overlay extends ConsumerStatefulWidget {
   final VideoEvent video;
   final int index;
   final bool isActive;
+
+  /// Whether the user already dismissed this video's content warning.
+  /// Owned by [FeedVideosState] so the autoplay gate can read it too.
+  final bool contentWarningRevealed;
+
+  /// Called when the user taps "View Anyway" on the content warning.
+  final VoidCallback onContentWarningRevealed;
+
   final VoidCallback? onToggleAutoAdvance;
   final VoidCallback? onSuppressAutoAdvance;
 
@@ -432,7 +468,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
       contentWarningLabels: widget.video.contentWarningLabels,
       warnLabels: widget.video.warnLabels,
     );
-    if (showWarning && !_contentWarningRevealed) return;
+    if (showWarning && !widget.contentWarningRevealed) return;
 
     final bloc = context.read<VideoInteractionsBloc>();
     final state = bloc.state;
@@ -459,8 +495,6 @@ class __OverlayState extends ConsumerState<_Overlay> {
     }
   }
 
-  bool _contentWarningRevealed = false;
-
   /// Advances the feed to the next page via the cached
   /// [InfiniteVideoFeedState] reference.
   void _skipToNextVideo() {
@@ -481,10 +515,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
       video: widget.video,
       index: widget.index,
       retryPlayback: (httpHeaders) =>
-          _feedState?.retryAt(
-            widget.index,
-            httpHeaders: httpHeaders,
-          ) ??
+          _feedState?.retryAt(widget.index, httpHeaders: httpHeaders) ??
           Future.value(false),
     );
   }
@@ -499,7 +530,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
       PlaybackStatus.forbidden => const _OverlayForbiddenMode(),
       PlaybackStatus.ageRestricted => const _OverlayAgeRestrictedMode(),
       _ =>
-        showContentWarningOverlay && !_contentWarningRevealed
+        showContentWarningOverlay && !widget.contentWarningRevealed
             ? _OverlayContentWarningMode(overlayLabels)
             : _OverlayInteractiveMode(isReady: isReady),
     };
@@ -573,9 +604,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
       case _OverlayContentWarningMode(:final labels):
         return ContentWarningBlurOverlay(
           labels: labels,
-          onReveal: () => setState(() {
-            _contentWarningRevealed = true;
-          }),
+          onReveal: widget.onContentWarningRevealed,
           onHideSimilar: () {
             hideContentWarningsLikeThese(
               context: context,
@@ -886,10 +915,7 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
           retryPlayback: (httpHeaders) =>
               context
                   .findAncestorStateOfType<InfiniteVideoFeedState>()
-                  ?.retryAt(
-                    index,
-                    httpHeaders: httpHeaders,
-                  ) ??
+                  ?.retryAt(index, httpHeaders: httpHeaders) ??
               Future.value(false),
         ),
         errorType: VideoErrorType.notFound,

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -52,6 +52,7 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.slowLoadThreshold = const Duration(seconds: 8),
     this.preloadGracePeriod = const Duration(seconds: 3),
     this.isActive = true,
+    this.canAutoPlay,
     super.key,
   });
 
@@ -136,6 +137,17 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// When `false`, the feed pauses the current video and suppresses any
   /// internal resume/play side effects until it becomes active again.
   final bool isActive;
+
+  /// Per-video autoplay gate consulted before the feed starts playback.
+  ///
+  /// Return `false` to keep a video paused while it is the active page —
+  /// e.g. while a content warning overlay is shown. The controller is
+  /// still initialized so the first frame can render behind the overlay.
+  /// Once the gate opens, call [InfiniteVideoFeedState.resumeCurrentPlayback]
+  /// to start playback without a page change.
+  ///
+  /// When `null`, every video is allowed to play.
+  final bool Function(VideoEvent video)? canAutoPlay;
 
   /// Hook: Called when the playback volume changes (mute/unmute/setVolume).
   ///
@@ -314,6 +326,16 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _setPlaybackActive(true);
   }
 
+  /// Re-evaluates playback for the active video and starts it if allowed.
+  ///
+  /// Unlike [resumeActive], this works while the feed is already active —
+  /// use it after an external [InfiniteVideoFeed.canAutoPlay] gate opens
+  /// (e.g. the user dismissed a content warning) so the already
+  /// initialized controller starts playing without a page change.
+  void resumeCurrentPlayback() {
+    _resumeCurrentPlaybackIfReady();
+  }
+
   /// Sets the playback volume (0.0 silent, 1.0 full).
   ///
   /// Only the active controller is updated immediately. Neighbour controllers
@@ -392,6 +414,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     if (widget.isActive != oldWidget.isActive) {
       _setPlaybackActive(widget.isActive);
     }
+    _syncCurrentAutoPlayGate(oldWidget);
     if (widget.videos == oldWidget.videos) return;
 
     // Append-only: the new list starts with exactly the same items in the
@@ -513,6 +536,31 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     unawaited(_activateCurrentController(controller, _currentIndex));
   }
 
+  /// Whether [InfiniteVideoFeed.canAutoPlay] allows the video at [index]
+  /// to start playing. Defaults to `true` when no gate is provided.
+  bool _canAutoPlayAt(int index) {
+    return _canAutoPlayAtFor(widget, index);
+  }
+
+  bool _canAutoPlayAtFor(InfiniteVideoFeed source, int index) {
+    final gate = source.canAutoPlay;
+    if (gate == null) return true;
+    if (index < 0 || index >= source.videos.length) return true;
+    return gate(source.videos[index]);
+  }
+
+  void _syncCurrentAutoPlayGate(InfiniteVideoFeed oldWidget) {
+    if (!_isActive) return;
+    final wasAllowed = _canAutoPlayAtFor(oldWidget, _currentIndex);
+    final isAllowed = _canAutoPlayAt(_currentIndex);
+    if (wasAllowed == isAllowed) return;
+    if (isAllowed) {
+      _resumeCurrentPlaybackIfReady();
+    } else {
+      _pauseCurrentPlayback();
+    }
+  }
+
   Future<void> _activateCurrentController(
     DivineVideoPlayerController controller,
     int index,
@@ -520,6 +568,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     if (!_isActive || index != _currentIndex || !controller.isInitialized) {
       return;
     }
+    if (!_canAutoPlayAt(index)) return;
     await controller.setVolume(_volume);
     if (!_isActive || index != _currentIndex) return;
     await controller.play();
@@ -898,10 +947,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   Future<bool> retryAt(
     int index, {
     Map<String, String> httpHeaders = const {},
-  }) => _retryController(
-    index,
-    httpHeaders: httpHeaders,
-  );
+  }) => _retryController(index, httpHeaders: httpHeaders);
 
   Future<bool> _retryController(
     int index, {
@@ -970,7 +1016,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           httpHeaders: _httpHeadersByIndex[index] ?? const {},
         ),
       );
-      if (index == _currentIndex && _isActive) {
+      if (index == _currentIndex && _isActive && _canAutoPlayAt(index)) {
         await controller.setVolume(_volume);
         await controller.play();
         if (index == _currentIndex && _isActive) {

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -737,38 +737,106 @@ void main() {
         }
       });
 
+      testWidgets('initializes next controller before current first frame '
+          'or grace period', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(
+          playerIds: const <int>[0, 1],
+          firstFrameRenderedOnListen: false,
+        );
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('current'), _makeVideo('next')],
+                cache: cache,
+                prefetchCount: 0,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.methodCalls, contains('player_1:setClips'));
+          await harness.sendEvent(0, const <Object?, Object?>{
+            'status': 'ready',
+            'videoWidth': 1280,
+            'videoHeight': 720,
+            'isFirstFrameRendered': true,
+          });
+          await tester.pump();
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('does not autoplay when canAutoPlay returns false', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('gated_video')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                canAutoPlay: (_) => false,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(0));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
       testWidgets(
-        'initializes next controller before current first frame '
-        'or grace period',
+        'resumeCurrentPlayback starts playback after canAutoPlay gate opens',
         (tester) async {
           DivineVideoPlayerController.resetIdCounterForTesting();
           final harness = _NativePlayerHarness(tester);
-          await harness.install(
-            playerIds: const <int>[0, 1],
-            firstFrameRenderedOnListen: false,
-          );
+          await harness.install(playerIds: const <int>[0]);
+          final key = GlobalKey<InfiniteVideoFeedState>();
+          var allowPlay = false;
 
           try {
             await tester.pumpWidget(
               _wrapFeed(
                 InfiniteVideoFeed(
-                  videos: [_makeVideo('current'), _makeVideo('next')],
+                  key: key,
+                  videos: [_makeVideo('gate_opens')],
                   cache: cache,
                   prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  canAutoPlay: (_) => allowPlay,
                 ),
               ),
             );
             await tester.pump();
             await tester.pump();
 
-            expect(harness.methodCalls, contains('player_1:setClips'));
-            await harness.sendEvent(0, const <Object?, Object?>{
-              'status': 'ready',
-              'videoWidth': 1280,
-              'videoHeight': 720,
-              'isFirstFrameRendered': true,
-            });
+            expect(harness.countCalls('play'), equals(0));
+
+            allowPlay = true;
+            key.currentState!.resumeCurrentPlayback();
             await tester.pump();
+            await tester.pump();
+
+            expect(harness.countCalls('play'), equals(1));
           } finally {
             await tester.pumpWidget(const SizedBox.shrink());
             await tester.pump();
@@ -776,6 +844,99 @@ void main() {
           }
         },
       );
+
+      testWidgets('pauses active playback when canAutoPlay gate closes', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+        final video = _makeVideo('gate_closes');
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [video],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                canAutoPlay: (_) => true,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(1));
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [video],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                canAutoPlay: (_) => false,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(harness.countCalls('pause'), equals(1));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('resumes active playback when canAutoPlay gate reopens', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0]);
+        final video = _makeVideo('gate_reopens');
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [video],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                canAutoPlay: (_) => false,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(0));
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [video],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                canAutoPlay: (_) => true,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(harness.countCalls('play'), equals(1));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
 
       testWidgets('does not autoplay after becoming inactive mid-init', (
         tester,

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -461,6 +461,65 @@ void main() {
       },
     );
 
+    testWidgets('gates autoplay for warned video until View Anyway is tapped', (
+      tester,
+    ) async {
+      final video = _makeVideo(warnLabels: ['nsfw']);
+      final cubit = _MockVideoPlaybackStatusCubit()
+        ..stub(PlaybackStatus.ready, video.id);
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        videoPlaybackStatusCubit: cubit,
+      );
+      await tester.pump();
+
+      final feed = tester.widget<InfiniteVideoFeed>(
+        find.byType(InfiniteVideoFeed),
+      );
+      expect(feed.canAutoPlay, isNotNull);
+      expect(
+        feed.canAutoPlay!(video),
+        isFalse,
+        reason: 'a warned video must not autoplay behind the overlay',
+      );
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      await tester.tap(find.text(l10n.contentWarningViewAnyway));
+      await tester.pump();
+
+      expect(find.byType(ContentWarningBlurOverlay), findsNothing);
+      final revealedFeed = tester.widget<InfiniteVideoFeed>(
+        find.byType(InfiniteVideoFeed),
+      );
+      expect(
+        revealedFeed.canAutoPlay!(video),
+        isTrue,
+        reason: 'View Anyway opens the autoplay gate for this video',
+      );
+    });
+
+    testWidgets('allows autoplay for video without content warning', (
+      tester,
+    ) async {
+      final video = _makeVideo();
+      final cubit = _MockVideoPlaybackStatusCubit()
+        ..stub(PlaybackStatus.ready, video.id);
+
+      await _pumpFeedVideos(
+        tester,
+        videos: [video],
+        videoPlaybackStatusCubit: cubit,
+      );
+      await tester.pump();
+
+      final feed = tester.widget<InfiniteVideoFeed>(
+        find.byType(InfiniteVideoFeed),
+      );
+      expect(feed.canAutoPlay!(video), isTrue);
+    });
+
     testWidgets('exposes localized semantics label and hint', (tester) async {
       final semantics = tester.ensureSemantics();
       try {
@@ -507,9 +566,7 @@ void main() {
 
     testWidgets(
       'mounts $DivineVideoMetricsTracker for active native playback',
-      (
-        tester,
-      ) async {
+      (tester) async {
         InfiniteVideoFeed.debugIsSupportedOverride = true;
         final video = _makeVideo();
 


### PR DESCRIPTION
## Description

When a video carries a content warning ("Sensitive Content" overlay), the feed was **playing the video — with audio — behind the blur**. The overlay was purely cosmetic: `InfiniteVideoFeed` autoplayed the active index unconditionally, and "View Anyway" only flipped a per-item display flag.

After this change:
- A warned video stays **paused** while the warning overlay is up (the controller still initializes, so the blurred first frame renders behind the overlay — no playback, no audio).
- Tapping **View Anyway** reveals the video *and starts playback*.
- "Hide all content like this" behavior is unchanged.

## How

- **`infinite_video_feed` package**: new optional `canAutoPlay(video)` gate, consulted at both play sites (`_activateCurrentController` and the source-failover replay), plus a public `InfiniteVideoFeedState.resumeCurrentPlayback()` that re-evaluates and starts the already-initialized active controller once a gate opens (`resumeActive()` can't be reused — it no-ops while the feed is already active).
- **`FeedVideos` (app)**: the revealed flag moves from the per-item `_Overlay` state up to `FeedVideosState` (`_revealedContentWarningVideoIds`, keyed by video id) so the gate can read it; the overlay receives `contentWarningRevealed` / `onContentWarningRevealed` props. View Anyway marks the video revealed and calls `resumeCurrentPlayback()`.
- All feed surfaces (home, hashtag, fullscreen "New Videos") route through `FeedVideos`, so they all inherit the fix.

## Testing

- Package: `does not autoplay when canAutoPlay returns false` and `resumeCurrentPlayback starts playback after canAutoPlay gate opens` — assert on native `play` method-channel calls via the existing player harness. Full package suite green with randomized ordering (174 tests).
- App: `gates autoplay for warned video until View Anyway is tapped` (asserts the gate closed → tap View Anyway → overlay gone + gate open) and `allows autoplay for video without content warning`. Full `feed_videos_test.dart` green (13 tests).
- `dart format` + `flutter analyze` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)