### PR TITLE
fix(lists): make curated list creation reliable and visible

### DIFF
--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -86,7 +86,9 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
               ),
               showBackButton: true,
               onBackPressed: context.pop,
-              actions: [_buildSubscribeAction()],
+              // Subscribing to your own list is meaningless — owners only
+              // get the overflow menu (delete).
+              actions: [if (!_isOwnedList()) _buildSubscribeAction()],
               customActions: _buildListCustomActions(),
             )
           : null,
@@ -324,6 +326,15 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
       videoText,
       style: const TextStyle(color: VineTheme.onSurfaceVariant, fontSize: 12),
     );
+  }
+
+  bool _isOwnedList() {
+    final serviceAsync = ref.watch(curatedListsStateProvider);
+    final service = ref.read(curatedListsStateProvider.notifier).service;
+    return serviceAsync.whenOrNull(
+          data: (_) => service?.isOwnedList(widget.listId),
+        ) ??
+        false;
   }
 
   DiVineAppBarAction _buildSubscribeAction() {

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -33,6 +33,7 @@ import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:openvine/services/top_hashtags_service.dart';
 import 'package:openvine/utils/nostr_apps_platform_support.dart';
 import 'package:openvine/utils/video_controller_cleanup.dart';
+import 'package:openvine/widgets/add_to_list_dialog.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/categories_tab.dart';
 import 'package:openvine/widgets/classic_vines_tab.dart';
@@ -750,6 +751,25 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
             ),
           ),
 
+          // Create New List button - ALWAYS VISIBLE
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+            child: DivineButton(
+              leadingIcon: .plus,
+              label: context.l10n.listCreateNewList,
+              onPressed: () {
+                Log.info(
+                  'Tapped Create New List button',
+                  category: LogCategory.ui,
+                );
+                showDialog<void>(
+                  context: context,
+                  builder: (_) => const CreateListDialog(),
+                );
+              },
+            ),
+          ),
+
           // Help text - ALWAYS VISIBLE
           Container(
             margin: const EdgeInsets.symmetric(horizontal: 16),
@@ -874,10 +894,12 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
             skipLoadingOnRefresh: true,
             data: (data) {
               final userLists = data.userLists;
-              final myLists = data.curatedLists.where((list) {
-                // Lists without nostrEventId are local-only user lists
-                return list.nostrEventId == null;
-              }).toList();
+              // Owned lists stay visible after publishing — filtering on a
+              // null nostrEventId hid lists once they reached the relay.
+              final service = ref
+                  .read(curatedListsStateProvider.notifier)
+                  .service;
+              final myLists = service?.myLists ?? const <CuratedList>[];
 
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -217,6 +217,22 @@ class CuratedListService extends ChangeNotifier {
     );
   }
 
+  /// Generates a list ID that is unique within the cached lists.
+  ///
+  /// Two lists created within the same millisecond would otherwise share an
+  /// ID, and ID-based lookups (e.g. the post-publish copyWith) would then
+  /// overwrite the wrong list.
+  String _generateListId(DateTime now) {
+    final base = 'list_${now.millisecondsSinceEpoch}';
+    var listId = base;
+    var suffix = 1;
+    while (_lists.any((list) => list.id == listId)) {
+      listId = '${base}_$suffix';
+      suffix++;
+    }
+    return listId;
+  }
+
   /// Internal method to create a list with optional explicit ID
   Future<CuratedList?> _createList({
     required String name,
@@ -232,7 +248,7 @@ class CuratedListService extends ChangeNotifier {
   }) async {
     try {
       final now = DateTime.now();
-      final listId = id ?? 'list_${now.millisecondsSinceEpoch}';
+      final listId = id ?? _generateListId(now);
       final ownerPubkey = _currentAuthenticatedPubkey();
 
       final newList = CuratedList(

--- a/mobile/lib/services/curated_list_service.dart
+++ b/mobile/lib/services/curated_list_service.dart
@@ -102,6 +102,23 @@ class CuratedListService extends ChangeNotifier {
         .toList();
   }
 
+  /// Lists belonging to the current user: lists they own (by pubkey) plus
+  /// local-only lists that have not been published to Nostr yet.
+  ///
+  /// Owned lists keep showing here after a successful publish — filtering
+  /// only on a null [CuratedList.nostrEventId] made lists vanish from the
+  /// "My Lists" UI the moment they reached the relay.
+  List<CuratedList> get myLists {
+    final currentPubkey = _currentAuthenticatedPubkey();
+    return _lists
+        .where(
+          (list) =>
+              list.nostrEventId == null ||
+              (currentPubkey != null && list.pubkey == currentPubkey),
+        )
+        .toList();
+  }
+
   /// Initialize the service and create default list if needed.
   ///
   /// This method returns quickly after loading local cache.
@@ -993,8 +1010,14 @@ class CuratedListService extends ChangeNotifier {
     );
   }
 
-  /// Publish list to Nostr as NIP-51 kind 30005 event
-  Future<void> _publishListToNostr(CuratedList list) async {
+  /// Publish list to Nostr as NIP-51 kind 30005 event.
+  ///
+  /// Empty lists are published too — a freshly created public list must
+  /// reach the relay immediately or it exists only on this device.
+  ///
+  /// Returns `true` when the relay accepted the event. Failures are logged
+  /// and leave the local list intact with a null [CuratedList.nostrEventId].
+  Future<bool> _publishListToNostr(CuratedList list) async {
     try {
       if (!_authService.isAuthenticated) {
         Log.warning(
@@ -1002,17 +1025,7 @@ class CuratedListService extends ChangeNotifier {
           name: 'CuratedListService',
           category: LogCategory.system,
         );
-        return;
-      }
-
-      // Don't spam relay with empty lists
-      if (list.videoEventIds.isEmpty) {
-        Log.debug(
-          'Skipping publish of empty list: ${list.name}',
-          name: 'CuratedListService',
-          category: LogCategory.system,
-        );
-        return;
+        return false;
       }
 
       final content = list.description ?? 'Curated video list: ${list.name}';
@@ -1024,28 +1037,46 @@ class CuratedListService extends ChangeNotifier {
         tags: tags,
       );
 
-      if (event != null) {
-        final sentEvent = await _nostrService.publishEvent(event);
-        if (sentEvent is PublishSuccess) {
-          // Update local list with Nostr event ID
-          final listIndex = _lists.indexWhere((l) => l.id == list.id);
-          if (listIndex != -1) {
-            _lists[listIndex] = list.copyWith(nostrEventId: event.id);
-            await _saveLists();
-          }
-          Log.debug(
-            'Published list to Nostr: ${list.name} (${event.id})',
-            name: 'CuratedListService',
-            category: LogCategory.system,
-          );
-        }
+      if (event == null) {
+        Log.warning(
+          'Failed to sign curated list event: ${list.name} (${list.id})',
+          name: 'CuratedListService',
+          category: LogCategory.system,
+        );
+        return false;
       }
+
+      final publishResult = await _nostrService.publishEvent(event);
+      final failureReason = publishResult.failureReason;
+      if (failureReason != null) {
+        Log.warning(
+          'Failed to publish curated list: ${list.name} (${list.id}): '
+          '$failureReason',
+          name: 'CuratedListService',
+          category: LogCategory.system,
+        );
+        return false;
+      }
+
+      // Update local list with Nostr event ID
+      final listIndex = _lists.indexWhere((l) => l.id == list.id);
+      if (listIndex != -1) {
+        _lists[listIndex] = list.copyWith(nostrEventId: event.id);
+        await _saveLists();
+      }
+      Log.debug(
+        'Published list to Nostr: ${list.name} (${event.id})',
+        name: 'CuratedListService',
+        category: LogCategory.system,
+      );
+      return true;
     } catch (e) {
       Log.error(
         'Failed to publish list to Nostr: $e',
         name: 'CuratedListService',
         category: LogCategory.system,
       );
+      return false;
     }
   }
 

--- a/mobile/lib/utils/nostr_event_ext.dart
+++ b/mobile/lib/utils/nostr_event_ext.dart
@@ -58,6 +58,7 @@ extension NostrEventExt on Event {
     return CuratedList(
       id: dTag,
       name: name,
+      pubkey: pubkey,
       description: description ?? content,
       imageUrl: imageUrl,
       videoEventIds: videoEventIds,

--- a/mobile/lib/widgets/add_to_list_dialog.dart
+++ b/mobile/lib/widgets/add_to_list_dialog.dart
@@ -144,10 +144,10 @@ class SelectListDialog extends StatelessWidget {
   }
 }
 
-/// Dialog for creating a new curated list and adding a video to it.
+/// Dialog for creating a new curated list, optionally adding [video] to it.
 class CreateListDialog extends ConsumerStatefulWidget {
-  const CreateListDialog({required this.video, super.key});
-  final VideoEvent video;
+  const CreateListDialog({this.video, super.key});
+  final VideoEvent? video;
 
   @override
   ConsumerState<CreateListDialog> createState() => _CreateListDialogState();
@@ -226,14 +226,22 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
         isPublic: _isPublic,
       );
 
-      if (newList != null && mounted) {
-        // Add the video to the new list
-        await listService?.addVideoToList(newList.id, widget.video.id);
+      if (!mounted) return;
 
-        if (mounted) {
-          // Close dialog and return the list name
-          context.pop();
-        }
+      // createList catches its own exceptions and returns null — without
+      // feedback here the dialog used to sit open doing nothing.
+      if (newList == null) {
+        _showCreateFailed();
+        return;
+      }
+
+      final video = widget.video;
+      if (video != null) {
+        await listService?.addVideoToList(newList.id, video.id);
+      }
+
+      if (mounted) {
+        context.pop();
       }
     } catch (e) {
       Log.error(
@@ -243,16 +251,19 @@ class _CreateListDialogState extends ConsumerState<CreateListDialog> {
       );
 
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.listCreateFailed),
-            duration: const Duration(seconds: 2),
-          ),
-        );
-        // Return null to indicate failure
-        context.pop();
+        _showCreateFailed();
       }
     }
+  }
+
+  // Keeps the dialog open so the typed name and description survive a retry.
+  void _showCreateFailed() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.listCreateFailed),
+        duration: const Duration(seconds: 2),
+      ),
+    );
   }
 
   @override

--- a/mobile/test/screens/curated_list_feed_screen_test.dart
+++ b/mobile/test/screens/curated_list_feed_screen_test.dart
@@ -132,6 +132,31 @@ void main() {
       expect(appBar.customActions, isEmpty);
     });
 
+    testWidgets('shows subscribe action for external list', (tester) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      final appBar = tester.widget<DiVineAppBar>(find.byType(DiVineAppBar));
+      expect(appBar.actions, hasLength(1));
+    });
+
+    testWidgets('hides subscribe action for owned list', (tester) async {
+      when(() => mockService.isSubscribedToList('owned-list')).thenReturn(true);
+      when(() => mockService.isOwnedList('owned-list')).thenReturn(true);
+
+      await tester.pumpWidget(
+        buildSubject(
+          listId: 'owned-list',
+          listName: 'Owned List',
+          authorPubkey: 'owned-pubkey',
+        ),
+      );
+      await tester.pump();
+
+      final appBar = tester.widget<DiVineAppBar>(find.byType(DiVineAppBar));
+      expect(appBar.actions, isEmpty);
+    });
+
     testWidgets('shows delete action for owned subscribed list', (
       tester,
     ) async {

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -337,6 +337,25 @@ void main() {
         expect(list.playOrder, PlayOrder.shuffle);
       });
 
+      test(
+        'rapidly created lists get unique ids and keep their data',
+        () async {
+          for (var i = 0; i < 10; i++) {
+            await service.createList(name: 'List $i');
+          }
+
+          expect(service.lists, hasLength(10));
+          expect(service.lists.map((l) => l.id).toSet(), hasLength(10));
+          expect(
+            service.lists.map((l) => l.name).toSet(),
+            hasLength(10),
+            reason:
+                'an ID collision makes the post-publish update '
+                'overwrite a sibling list',
+          );
+        },
+      );
+
       test('adds created list to lists collection', () async {
         expect(service.lists, isEmpty);
 

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -297,6 +297,32 @@ void main() {
         // Should have called subscribeToEvents
         verify(() => mockNostr.subscribe(any())).called(1);
       });
+
+      test('relay-synced own lists stay in myLists', () async {
+        when(() => mockNostr.subscribe(any())).thenAnswer(
+          (_) => Stream.value(
+            Event.fromJson({
+              'id': 'relay_list_event',
+              'pubkey': _ownerPubkey,
+              'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+              'kind': 30005,
+              'tags': [
+                ['d', 'relay_list_1'],
+                ['title', 'Relay List'],
+              ],
+              'content': 'List from relay',
+              'sig': 'test_signature',
+            }),
+          ),
+        );
+
+        await service.fetchUserListsFromRelays();
+
+        final relayList = service.getListById('relay_list_1');
+        expect(relayList, isNotNull);
+        expect(relayList!.pubkey, _ownerPubkey);
+        expect(service.myLists.map((list) => list.id), contains(relayList.id));
+      });
     });
 
     group('createList()', () {

--- a/mobile/test/services/curated_list_service_crud_test.dart
+++ b/mobile/test/services/curated_list_service_crud_test.dart
@@ -58,9 +58,7 @@ void main() {
       // Mock successful event publishing
       when(() => mockNostr.publishEvent(any())).thenAnswer((invocation) {
         return Future<PublishResult>.value(
-          PublishSuccess(
-            event: invocation.positionalArguments[0] as Event,
-          ),
+          PublishSuccess(event: invocation.positionalArguments[0] as Event),
         );
       });
 
@@ -348,14 +346,11 @@ void main() {
         expect(service.lists.first.name, 'Test List');
       });
 
-      test('publishes public list to Nostr when it has videos', () async {
-        // Create list, add a video, then verify publish
-        final list = await service.createList(name: 'Public List');
+      test('publishes empty public list to Nostr on creation', () async {
+        final list = await service.createList(name: 'Empty Public List');
 
-        // Add a video to the list so it will publish
-        await service.addVideoToList(list!.id, 'test_video_id');
-
-        // Should create and sign event when video is added (not when empty)
+        // An unpublished list exists only on this device, so even empty
+        // lists publish immediately.
         verify(
           () => mockAuth.createAndSignEvent(
             kind: 30005,
@@ -363,22 +358,48 @@ void main() {
             tags: any(named: 'tags'),
           ),
         ).called(1);
+        verify(() => mockNostr.publishEvent(any())).called(1);
+        expect(service.getListById(list!.id)!.nostrEventId, isNotNull);
+      });
 
-        // Should publish event
+      test('publishes again when a video is added', () async {
+        final list = await service.createList(name: 'Public List');
+        reset(mockNostr);
+        when(() => mockNostr.publishEvent(any())).thenAnswer(
+          (invocation) async =>
+              PublishSuccess(event: invocation.positionalArguments[0] as Event),
+        );
+
+        await service.addVideoToList(list!.id, 'test_video_id');
+
         verify(() => mockNostr.publishEvent(any())).called(1);
       });
 
-      test('does not publish empty public list to Nostr', () async {
-        await service.createList(name: 'Empty Public List');
+      test('keeps list locally when publish fails', () async {
+        when(
+          () => mockNostr.publishEvent(any()),
+        ).thenAnswer((_) => Future<PublishResult>.value(const PublishFailed()));
 
-        // Empty lists should not be published to avoid relay spam
-        verifyNever(
+        final list = await service.createList(name: 'Unlucky List');
+
+        expect(list, isNotNull);
+        expect(service.getListById(list!.id), isNotNull);
+        expect(service.getListById(list.id)!.nostrEventId, isNull);
+      });
+
+      test('keeps list locally when event signing fails', () async {
+        when(
           () => mockAuth.createAndSignEvent(
             kind: any(named: 'kind'),
             content: any(named: 'content'),
             tags: any(named: 'tags'),
           ),
-        );
+        ).thenAnswer((_) async => null);
+
+        final list = await service.createList(name: 'Unsigned List');
+
+        expect(list, isNotNull);
+        expect(service.getListById(list!.id)!.nostrEventId, isNull);
         verifyNever(() => mockNostr.publishEvent(any()));
       });
 
@@ -492,7 +513,6 @@ void main() {
 
       test('publishes update to Nostr for public list with videos', () async {
         final list = await service.createList(name: 'Test List');
-        // Add a video so the list will be published (empty lists don't publish)
         await service.addVideoToList(list!.id, 'test_video_id');
         reset(mockNostr); // Clear previous invocations
 
@@ -623,6 +643,13 @@ void main() {
     group('deleteOwnedList()', () {
       test('publishes NIP-09 deletion for owned kind 30005 list', () async {
         final list = await service.createList(name: 'Owned Public List');
+        // Creation publishes the kind 30005 event; reset so the capture
+        // below only sees the deletion event.
+        reset(mockNostr);
+        when(() => mockNostr.publishEvent(any())).thenAnswer(
+          (invocation) async =>
+              PublishSuccess(event: invocation.positionalArguments[0] as Event),
+        );
 
         final result = await service.deleteOwnedList(list!.id);
 
@@ -630,9 +657,7 @@ void main() {
         expect(service.getListById(list.id), isNull);
 
         final published =
-            verify(
-                  () => mockNostr.publishEvent(captureAny()),
-                ).captured.single
+            verify(() => mockNostr.publishEvent(captureAny())).captured.single
                 as Event;
         expect(published.kind, EventKind.eventDeletion);
         expect(published.content, 'Deleted curated list ${list.id}');
@@ -646,9 +671,9 @@ void main() {
       test('keeps local list when publish fails', () async {
         final list = await service.createList(name: 'Owned Public List');
         reset(mockNostr);
-        when(() => mockNostr.publishEvent(any())).thenAnswer(
-          (_) => Future<PublishResult>.value(const PublishFailed()),
-        );
+        when(
+          () => mockNostr.publishEvent(any()),
+        ).thenAnswer((_) => Future<PublishResult>.value(const PublishFailed()));
 
         final result = await service.deleteOwnedList(list!.id);
 

--- a/mobile/test/services/curated_list_service_ownership_test.dart
+++ b/mobile/test/services/curated_list_service_ownership_test.dart
@@ -147,4 +147,84 @@ void main() {
       },
     );
   });
+
+  group('CuratedListService.myLists', () {
+    const currentPubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const otherPubkey =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+    late CuratedListService service;
+    late _MockAuthService mockAuth;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      final mockNostr = _MockNostrClient();
+      mockAuth = _MockAuthService();
+
+      when(() => mockAuth.isAuthenticated).thenReturn(true);
+      when(() => mockAuth.currentPublicKeyHex).thenReturn(currentPubkey);
+
+      service = CuratedListService(
+        nostrService: mockNostr,
+        authService: mockAuth,
+        prefs: prefs,
+      );
+    });
+
+    CuratedList remoteList({required String id, String? pubkey}) {
+      final now = DateTime(2026);
+      return CuratedList(
+        id: id,
+        name: 'List $id',
+        videoEventIds: const [],
+        pubkey: pubkey,
+        nostrEventId: 'event_$id',
+        createdAt: now,
+        updatedAt: now,
+      );
+    }
+
+    test('includes local-only list that has not published', () async {
+      final list = await service.createList(name: 'Local List');
+
+      expect(service.myLists.map((l) => l.id), contains(list!.id));
+    });
+
+    test('includes published list owned by the current user', () async {
+      await service.subscribeToList(
+        'published-own-list',
+        remoteList(id: 'published-own-list', pubkey: currentPubkey),
+      );
+
+      expect(service.myLists.map((l) => l.id), contains('published-own-list'));
+    });
+
+    test('excludes published list owned by another user', () async {
+      await service.subscribeToList(
+        'other-user-list',
+        remoteList(id: 'other-user-list', pubkey: otherPubkey),
+      );
+
+      expect(
+        service.myLists.map((l) => l.id),
+        isNot(contains('other-user-list')),
+      );
+    });
+
+    test('excludes other-user published list when not authenticated', () async {
+      when(() => mockAuth.isAuthenticated).thenReturn(false);
+
+      await service.subscribeToList(
+        'other-user-list',
+        remoteList(id: 'other-user-list', pubkey: otherPubkey),
+      );
+
+      expect(
+        service.myLists.map((l) => l.id),
+        isNot(contains('other-user-list')),
+      );
+    });
+  });
 }

--- a/mobile/test/widgets/add_to_list_dialog_test.dart
+++ b/mobile/test/widgets/add_to_list_dialog_test.dart
@@ -11,6 +11,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
 
+import '../helpers/go_router.dart';
 import '../helpers/test_provider_overrides.dart';
 
 class _MockCuratedListService extends Mock implements CuratedListService {}
@@ -255,6 +256,7 @@ void main() {
   group(CreateListDialog, () {
     late VideoEvent testVideo;
     late _MockCuratedListService mockListService;
+    final l10n = lookupAppLocalizations(const Locale('en'));
 
     setUp(() {
       testVideo = VideoEvent(
@@ -271,16 +273,33 @@ void main() {
       _fakeService = mockListService;
     });
 
-    Widget buildSubject() => testProviderScope(
-      additionalOverrides: [
-        curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
-      ],
-      child: MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(body: CreateListDialog(video: testVideo)),
-      ),
+    CuratedList createdList(String name) => CuratedList(
+      id: 'list_created_456789abcdef0123456789abcdef0123456789abcdef012345',
+      pubkey:
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      name: name,
+      videoEventIds: const [],
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
     );
+
+    Widget buildSubject({VideoEvent? video, MockGoRouter? goRouter}) {
+      final dialog = CreateListDialog(video: video);
+      return testProviderScope(
+        additionalOverrides: [
+          curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+        ],
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: goRouter == null
+                ? dialog
+                : MockGoRouterProvider(goRouter: goRouter, child: dialog),
+          ),
+        ),
+      );
+    }
 
     testWidgets('renders Create New List form', (tester) async {
       await tester.pumpWidget(buildSubject());
@@ -335,6 +354,89 @@ void main() {
           isPublic: any(named: 'isPublic'),
         ),
       );
+    });
+
+    testWidgets('creates list and pops without adding video when no video '
+        'is provided', (tester) async {
+      final goRouter = MockGoRouter();
+      when(goRouter.canPop).thenReturn(true);
+      when(() => goRouter.pop<Object?>()).thenReturn(null);
+      when(
+        () => mockListService.createList(
+          name: any(named: 'name'),
+          description: any(named: 'description'),
+          isPublic: any(named: 'isPublic'),
+        ),
+      ).thenAnswer((_) async => createdList('Fresh List'));
+
+      await tester.pumpWidget(buildSubject(goRouter: goRouter));
+      await tester.enterText(find.byType(TextField).first, 'Fresh List');
+      await tester.tap(find.text(l10n.listCreate));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockListService.createList(
+          name: 'Fresh List',
+          description: any(named: 'description'),
+          isPublic: any(named: 'isPublic'),
+        ),
+      ).called(1);
+      verifyNever(() => mockListService.addVideoToList(any(), any()));
+      verify(() => goRouter.pop<Object?>()).called(1);
+    });
+
+    testWidgets('creates list and adds video when a video is provided', (
+      tester,
+    ) async {
+      final goRouter = MockGoRouter();
+      when(goRouter.canPop).thenReturn(true);
+      when(() => goRouter.pop<Object?>()).thenReturn(null);
+      final newList = createdList('Video List');
+      when(
+        () => mockListService.createList(
+          name: any(named: 'name'),
+          description: any(named: 'description'),
+          isPublic: any(named: 'isPublic'),
+        ),
+      ).thenAnswer((_) async => newList);
+      when(
+        () => mockListService.addVideoToList(any(), any()),
+      ).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(
+        buildSubject(video: testVideo, goRouter: goRouter),
+      );
+      await tester.enterText(find.byType(TextField).first, 'Video List');
+      await tester.tap(find.text(l10n.listCreate));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockListService.addVideoToList(newList.id, testVideo.id),
+      ).called(1);
+      verify(() => goRouter.pop<Object?>()).called(1);
+    });
+
+    testWidgets('shows failure snackbar and keeps dialog open when '
+        'createList returns null', (tester) async {
+      final goRouter = MockGoRouter();
+      when(goRouter.canPop).thenReturn(true);
+      when(
+        () => mockListService.createList(
+          name: any(named: 'name'),
+          description: any(named: 'description'),
+          isPublic: any(named: 'isPublic'),
+        ),
+      ).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(buildSubject(goRouter: goRouter));
+      await tester.enterText(find.byType(TextField).first, 'Doomed List');
+      await tester.tap(find.text(l10n.listCreate));
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.listCreateFailed), findsOneWidget);
+      expect(find.text(l10n.listCreateNewList), findsOneWidget);
+      verifyNever(() => mockListService.addVideoToList(any(), any()));
+      verifyNever(() => goRouter.pop<Object?>());
     });
   });
 }


### PR DESCRIPTION
## Description

A user reported "I tried to create a list and it just failed." Log + code analysis showed list creation was broken end to end:

1. **No create entry point** — the Explore Lists tab only had "Discover Lists"; the sole way to create a video list was buried in a video's share menu. Users flailed at the screen (the exported logs show eight Subscribe/Unsubscribe toggles on the user's own empty default list).
2. **Silent failure in `CreateListDialog`** — `CuratedListService.createList` catches its own exceptions and returns `null`, and the dialog did nothing on `null`: no snackbar, no pop, it just sat there.
3. **Empty lists never published** — `_publishListToNostr` skipped lists with no videos, so a freshly created list existed only on one device (relay query for the reporting user's kind 30005 events confirmed zero).
4. **Publish failures swallowed** — only `PublishSuccess` was handled; `PublishNoRelays`/`PublishFailed` produced no log and no feedback.
5. **Published lists vanished from "My Lists"** — the section filtered on `nostrEventId == null`, so the moment a list reached the relay it disappeared from the UI.

Changes:

- Add a **Create New List** button to the Explore Lists tab; `CreateListDialog.video` is now optional.
- On `createList == null`, show the `listCreateFailed` snackbar and keep the dialog open so the typed name/description survive a retry.
- Publish empty public lists on creation; log a warning with `failureReason` when signing or publishing fails; `_publishListToNostr` now returns a success bool.
- New `CuratedListService.myLists` getter (owned-by-pubkey OR not-yet-published local lists) backs the "My Lists" section, so lists stay visible after publishing.
- Hide the Subscribe (+) app-bar button on lists the current user owns — owners get the overflow menu (delete) only.

**Related Issue:** None (user log report `openvine_full_logs_2026-06-10T11-52-21`)

## Out of Scope

- The pre-existing possibility that a subscribed own list shows in both "My Lists" and "Subscribed lists" (unchanged behavior).
- Migrating `CuratedListService` to the BLoC/repository architecture.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/services/curated_list_service_*` — 186 passing
- `flutter test test/widgets/add_to_list_dialog_test.dart test/screens/curated_list_feed_screen_test.dart` — 25 passing (3 new dialog tests, 2 new app-bar tests, 4 new `myLists` tests, publish-on-create + failure-path service tests)
- `flutter test test/screens/explore_screen_* test/widgets/share_video_menu_comprehensive_test.dart test/providers/list_providers_test.dart` — passing

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)