### PR TITLE
feat(moderation): enable contentPolicyV2 by default (#948)

### DIFF
--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -41,7 +41,13 @@ class BuildConfiguration {
       case FeatureFlag.profileListFeatures:
         return const bool.fromEnvironment('FF_PROFILE_LIST_FEATURES');
       case FeatureFlag.contentPolicyV2:
-        return const bool.fromEnvironment('FF_CONTENT_POLICY_V2');
+        // Phase 3 of the content-policy migration (#948): the engine is
+        // the default enforcement; the env var remains as an emergency
+        // off switch until Phase 4 removes the flag entirely.
+        return const bool.fromEnvironment(
+          'FF_CONTENT_POLICY_V2',
+          defaultValue: true,
+        );
       case FeatureFlag.videoReplies:
         const isReleaseBuild = bool.fromEnvironment('dart.vm.product');
         return const bool.fromEnvironment(

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -43,7 +43,8 @@ class BuildConfiguration {
       case FeatureFlag.contentPolicyV2:
         // Phase 3 of the content-policy migration (#948): the engine is
         // the default enforcement; the env var remains as an emergency
-        // off switch until Phase 4 removes the flag entirely.
+        // off switch.
+        // TODO(#5047): Remove the flag in content-policy Phase 4.
         return const bool.fromEnvironment(
           'FF_CONTENT_POLICY_V2',
           defaultValue: true,

--- a/mobile/lib/notifications/providers/notification_repository_provider.dart
+++ b/mobile/lib/notifications/providers/notification_repository_provider.dart
@@ -39,13 +39,14 @@ final notificationRepositoryProvider = Provider<NotificationRepository?>((ref) {
   final nip98AuthService = ref.watch(nip98AuthServiceProvider);
   final userPubkey = authService.currentPublicKeyHex ?? '';
 
-  final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
   final repository = NotificationRepository(
     funnelcakeApiClient: funnelcakeApiClient,
     profileRepository: profileRepository,
     notificationsDao: db.notificationsDao,
     userPubkey: userPubkey,
-    blockFilter: blocklistRepository.shouldFilterFromFeeds,
+    // Flag-switched factory: content-policy engine by default, legacy
+    // shouldFilterFromFeeds under the emergency off switch.
+    blockFilter: createBlockedAuthorFilter(ref),
     authHeadersProvider: (url, method, {body}) async {
       final httpMethod = switch (method.toUpperCase()) {
         'POST' => HttpMethod.post,

--- a/mobile/lib/notifications/providers/notification_repository_provider.dart
+++ b/mobile/lib/notifications/providers/notification_repository_provider.dart
@@ -46,6 +46,7 @@ final notificationRepositoryProvider = Provider<NotificationRepository?>((ref) {
     userPubkey: userPubkey,
     // Flag-switched factory: content-policy engine by default, legacy
     // shouldFilterFromFeeds under the emergency off switch.
+    // TODO(#5047): Collapse to the engine filter in content-policy Phase 4.
     blockFilter: createBlockedAuthorFilter(ref),
     authHeadersProvider: (url, method, {body}) async {
       final httpMethod = switch (method.toUpperCase()) {

--- a/mobile/test/services/build_config_test.dart
+++ b/mobile/test/services/build_config_test.dart
@@ -99,6 +99,15 @@ void main() {
       expect(config.getDefault(FeatureFlag.curatedLists), isTrue);
     });
 
+    test('contentPolicyV2 should default to true', () {
+      // Phase 3 of the content-policy migration (#948): the engine is the
+      // default enforcement. Reverting this default would silently fall
+      // back to the legacy predicate everywhere.
+      const config = BuildConfiguration();
+
+      expect(config.getDefault(FeatureFlag.contentPolicyV2), isTrue);
+    });
+
     test('integratedApps should map to FF_INTEGRATED_APPS env var', () {
       const config = BuildConfiguration();
 

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Verifies target-directed affordances are absent without explanation
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -34,6 +35,9 @@ void main() {
 
     when(() => blocklistRepository.isBlocked(any())).thenReturn(false);
     when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
+    when(
+      () => blocklistRepository.currentState,
+    ).thenReturn(ContentPolicyState.empty());
 
     when(() => followRepository.followingPubkeys).thenReturn(const []);
     when(() => followRepository.followingStream).thenAnswer(
@@ -75,6 +79,15 @@ void main() {
       when(() => blocklistRepository.hasBlockedUs(targetPubkey)).thenReturn(
         true,
       );
+      when(() => blocklistRepository.currentState).thenReturn(
+        ContentPolicyState(
+          currentUserPubkey: viewerPubkey,
+          mutedPubkeys: const {},
+          blockedPubkeys: const {},
+          pubkeysBlockingUs: const {targetPubkey},
+          pubkeysMutingUs: const {},
+        ),
+      );
 
       await tester.pumpWidget(buildWidget());
       await tester.pump();
@@ -92,6 +105,15 @@ void main() {
     (tester) async {
       when(() => blocklistRepository.hasBlockedUs(targetPubkey)).thenReturn(
         true,
+      );
+      when(() => blocklistRepository.currentState).thenReturn(
+        ContentPolicyState(
+          currentUserPubkey: viewerPubkey,
+          mutedPubkeys: const {},
+          blockedPubkeys: const {},
+          pubkeysBlockingUs: const {targetPubkey},
+          pubkeysMutingUs: const {},
+        ),
       );
       when(
         () => followRepository.followingPubkeys,

--- a/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_action_buttons_widget_test.dart
@@ -80,12 +80,12 @@ void main() {
         true,
       );
       when(() => blocklistRepository.currentState).thenReturn(
-        ContentPolicyState(
+        const ContentPolicyState(
           currentUserPubkey: viewerPubkey,
-          mutedPubkeys: const {},
-          blockedPubkeys: const {},
-          pubkeysBlockingUs: const {targetPubkey},
-          pubkeysMutingUs: const {},
+          mutedPubkeys: {},
+          blockedPubkeys: {},
+          pubkeysBlockingUs: {targetPubkey},
+          pubkeysMutingUs: {},
         ),
       );
 
@@ -107,12 +107,12 @@ void main() {
         true,
       );
       when(() => blocklistRepository.currentState).thenReturn(
-        ContentPolicyState(
+        const ContentPolicyState(
           currentUserPubkey: viewerPubkey,
-          mutedPubkeys: const {},
-          blockedPubkeys: const {},
-          pubkeysBlockingUs: const {targetPubkey},
-          pubkeysMutingUs: const {},
+          mutedPubkeys: {},
+          blockedPubkeys: {},
+          pubkeysBlockingUs: {targetPubkey},
+          pubkeysMutingUs: {},
         ),
       );
       when(

--- a/mobile/test/widgets/video_feed_item/video_follow_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/video_follow_button_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -141,6 +142,15 @@ void main() {
         when(() => mockBlocklist.hasBlockedUs(authorPubkey)).thenReturn(true);
         when(() => mockBlocklist.isBlocked(any())).thenReturn(false);
         when(() => mockBlocklist.isFollowSevered(any())).thenReturn(false);
+        when(() => mockBlocklist.currentState).thenReturn(
+          ContentPolicyState(
+            currentUserPubkey: 'b' * 64,
+            mutedPubkeys: const {},
+            blockedPubkeys: const {},
+            pubkeysBlockingUs: {authorPubkey},
+            pubkeysMutingUs: const {},
+          ),
+        );
 
         await tester.pumpWidget(
           testMaterialApp(
@@ -169,6 +179,9 @@ void main() {
       when(() => mockBlocklist.hasBlockedUs(any())).thenReturn(false);
       when(() => mockBlocklist.isBlocked(any())).thenReturn(false);
       when(() => mockBlocklist.isFollowSevered(any())).thenReturn(false);
+      when(
+        () => mockBlocklist.currentState,
+      ).thenReturn(ContentPolicyState.empty());
 
       await tester.pumpWidget(
         testMaterialApp(


### PR DESCRIPTION
## Description

**Phase 3 of the content-policy migration — the step the spec ties to closing #948.**

`contentPolicyV2` now defaults to **on**: the `ContentPolicyEngine` (parse-gated, rule-ordered, self-reference-guarded) is the default block/mute enforcement at every repository seam (videos incl. search/hashtag, profiles, comments, notifications, likes/reposts) and at the `canTargetUser` affordance gates. `FF_CONTENT_POLICY_V2=false` remains as an emergency off switch until Phase 4 removes the flag.

### Functional deltas vs the legacy predicate

The engine reads the same four sets as `shouldFilterFromFeeds`, so filtering behavior is equivalent except for two intentional changes:

1. **`SelfReferenceRule`** — the user's own content can never be filtered by a malformed mute/block list that includes their own pubkey (the #2192 failure mode, now structurally impossible).
2. **Interaction affordances** (follow/Message buttons) now also hide for users whose **mute** list names us, not just block lists — completing the spec's interaction invariant.

### Also in this PR

- The notifications wiring switches to the shared flag-aware `createBlockedAuthorFilter` — it was the last seam reading `shouldFilterFromFeeds` directly instead of through the flag-switched factory.
- The canTarget gating tests now stub the engine path (`currentState`) so they pin the new default.

### Deliberate deviation from the spec's Task 3.2, documented

The spec planned to delete the per-surface reactive `.where(shouldFilterFromFeeds)` re-filters once the parse-gate owned ingress. They stay, for a reason the spec's model didn't anticipate: the codebase satisfies block-mid-session reactivity by **re-filtering held state in place** (the #4921 contract, pinned by its regression tests) rather than the spec's invalidate-and-refetch. Ingress gates keep caches clean; the surface filters only handle the transition window for already-rendered state. Deleting them would either regress #4921 or force a network refetch on every block. The remaining direct call sites are exactly: that reactive set, the VES ingress seam, and the legacy factory branches that Phase 4 deletes with the flag.

### QA note: persisted debug-screen overrides take precedence

`FeatureFlagService.initialize()` gives a stored `ff_contentPolicyV2` value precedence over the build default — anyone who toggled the flag in the debug Feature Flags screen (even on-then-off) stays on whatever they persisted, not the new default. Fine for the internal/debug audience; the override path disappears with the flag in Phase 4 (#5047).

**Related Issue:** Closes #948 · Phase 4 tracked in #5047

## Verification

- **Full app suite with the flag on by default: 9674 tests pass** (`flutter test`), including the per-surface blocked-author regression tests and the disclosure-invariant scan
- `flutter analyze lib test integration_test` — no issues
- `dart format` — clean
- Suggested QA pass before release: the original #948 repro (block a user → Videos tab search) plus one pass per surface in the [status comment](https://github.com/divinevideo/divine-mobile/issues/948#issuecomment-4663388444)

## Type of Change

- [x] Feature flag default change (architectural completion)

