### PR TITLE
fix(audio): enhance audio extraction with playback speed adjustments

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -729,7 +729,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     emit(state.copyWith(isExtractingAudio: true));
 
     try {
-      final result = await _audioExtractionService.extractAudio(videoPath);
+      final result = await _audioExtractionService.extractAudio(
+        videoPath: videoPath,
+        speed: clip.playbackSpeed,
+      );
 
       // Reconcile against current state after the async gap.
       // Other event handlers (remove, split, insert) may have mutated
@@ -772,9 +775,11 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         mimeType: result.mimeType,
         sha256: result.sha256Hash,
         fileSize: result.fileSize,
-        duration: currentClip.duration.inMilliseconds / 1000,
+        duration: result.duration,
         title: event.clipTitle,
-        startOffset: currentClip.trimStart,
+        startOffset: currentClip.sourceDurationToPlaybackDuration(
+          currentClip.trimStart,
+        ),
         startTime: clipStart,
         endTime: clipStart + currentClip.playbackDuration,
         // Anchor the extracted audio to its source clip so it follows the

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -680,10 +680,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       onFinalClipInvalidated.call();
     } catch (e, stackTrace) {
       final error = switch (e) {
-        StateError() || TypeError() || RangeError() => Reportable(
-          e,
-          context: '_onClipReverseRequested',
-        ),
+        StateError() ||
+        TypeError() ||
+        RangeError() => Reportable(e, context: '_onClipReverseRequested'),
         _ => e,
       };
       addError(error, stackTrace);
@@ -713,6 +712,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
     final clip = clips[state.currentClipIndex];
     final videoPath = clip.video.file?.path;
+    final extractionSpeed = _effectiveAudioExtractionSpeed(clip);
 
     if (videoPath == null) {
       Log.warning(
@@ -731,7 +731,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     try {
       final result = await _audioExtractionService.extractAudio(
         videoPath: videoPath,
-        speed: clip.playbackSpeed,
+        speed: extractionSpeed,
       );
 
       // Reconcile against current state after the async gap.
@@ -749,6 +749,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           name: 'ClipEditorBloc',
           category: LogCategory.video,
         );
+        await _cleanupDiscardedAudioExtraction(result.audioFilePath);
         emit(
           state.copyWith(
             isExtractingAudio: false,
@@ -759,6 +760,27 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
       }
 
       final currentClip = currentClips[currentIndex];
+      final currentVideoPath = currentClip.video.file?.path;
+      final currentExtractionSpeed = _effectiveAudioExtractionSpeed(
+        currentClip,
+      );
+      if (currentVideoPath != videoPath ||
+          currentExtractionSpeed != extractionSpeed) {
+        Log.warning(
+          '⚠️ Audio extraction result discarded: clip ${clip.id} source '
+          'changed while extraction was running',
+          name: 'ClipEditorBloc',
+          category: LogCategory.video,
+        );
+        await _cleanupDiscardedAudioExtraction(result.audioFilePath);
+        emit(
+          state.copyWith(
+            isExtractingAudio: false,
+            lastAudioExtraction: ClipAudioExtractionDiscarded(),
+          ),
+        );
+        return;
+      }
 
       // Recompute absolute start from current state so clips inserted
       // or removed before this one are accounted for.
@@ -840,6 +862,23 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           isExtractingAudio: false,
           lastAudioExtraction: ClipAudioExtractionFailure(),
         ),
+      );
+    }
+  }
+
+  double _effectiveAudioExtractionSpeed(DivineVideoClip clip) {
+    final speed = clip.playbackSpeed;
+    return speed != null && speed > 0 ? speed : 1.0;
+  }
+
+  Future<void> _cleanupDiscardedAudioExtraction(String audioFilePath) async {
+    try {
+      await _audioExtractionService.cleanupAudioFile(audioFilePath);
+    } catch (e) {
+      Log.warning(
+        '⚠️ Failed to cleanup discarded extracted audio: $e',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
       );
     }
   }

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -104,11 +104,16 @@ class DivineVideoClip {
   /// i.e. [trimmedDuration] divided by [playbackSpeed].
   ///
   /// A 10 s clip at 2× speed occupies 5 s of playback time.
-  Duration get playbackDuration {
+  Duration get playbackDuration =>
+      sourceDurationToPlaybackDuration(trimmedDuration);
+
+  /// Converts a duration measured in this clip's source media time into the
+  /// wall-clock duration it occupies after [playbackSpeed] is applied.
+  Duration sourceDurationToPlaybackDuration(Duration sourceDuration) {
     final speed = playbackSpeed ?? 1.0;
-    if (speed <= 0 || speed == 1.0) return trimmedDuration;
+    if (speed <= 0 || speed == 1.0) return sourceDuration;
     return Duration(
-      microseconds: (trimmedDuration.inMicroseconds / speed).round(),
+      microseconds: (sourceDuration.inMicroseconds / speed).round(),
     );
   }
 

--- a/mobile/lib/services/audio_extraction_service.dart
+++ b/mobile/lib/services/audio_extraction_service.dart
@@ -70,14 +70,14 @@ class AudioExtractionException implements Exception {
 /// Service for extracting audio tracks from video files.
 ///
 /// Uses ProVideoEditor to extract the audio track from a video file and save it
-/// as a separate AAC file. This is used by the audio reuse feature when
+/// as a separate WAV file. This is used by the audio reuse feature when
 /// a user publishes a video with "Allow others to use this audio" enabled.
 ///
 /// Usage:
 /// ```dart
 /// final service = AudioExtractionService();
 /// try {
-///   final result = await service.extractAudio('/path/to/video.mp4');
+///   final result = await service.extractAudio(videoPath: '/path/to/video.mp4');
 ///   print('Audio extracted: ${result.audioFilePath}');
 ///   print('Duration: ${result.duration}s');
 ///   print('Hash: ${result.sha256Hash}');
@@ -102,6 +102,7 @@ class AudioExtractionService {
   /// cannot be copied without re-encoding (e.g. LPCM).
   ///
   /// [videoPath] - Path to the source video file.
+  /// [speed] - Optional playback speed to apply to the extracted audio.
   ///
   /// Returns an [AudioExtractionResult] containing the path to the extracted
   /// audio file and metadata (duration, file size, SHA-256 hash, MIME type).
@@ -110,7 +111,12 @@ class AudioExtractionService {
   /// - The video file does not exist
   /// - The video has no audio track
   /// - Audio extraction fails
-  Future<AudioExtractionResult> extractAudio(String videoPath) async {
+  Future<AudioExtractionResult> extractAudio({
+    required String videoPath,
+    double? speed,
+  }) async {
+    final effectiveSpeed = speed != null && speed > 0 ? speed : 1.0;
+
     Log.info(
       'Starting audio extraction from: $videoPath',
       name: _logName,
@@ -167,6 +173,7 @@ class AudioExtractionService {
         outputPath,
         AudioExtractConfigs(
           video: EditorVideo.file(videoPath),
+          speed: effectiveSpeed,
           format: AudioFormat.wav,
         ),
       );
@@ -208,8 +215,10 @@ class AudioExtractionService {
       name: _logName,
       category: _logCategory,
     );
+    final adjustedDuration = videoDuration / effectiveSpeed;
+
     Log.debug(
-      'Audio details: duration=${videoDuration.toStringAsFixed(2)}s, '
+      'Audio details: duration=${adjustedDuration.toStringAsFixed(2)}s, '
       'size=${(hashResult.size / 1024).toStringAsFixed(2)}KB, '
       'hash=${hashResult.hash}',
       name: _logName,
@@ -218,7 +227,7 @@ class AudioExtractionService {
 
     return AudioExtractionResult(
       audioFilePath: outputPath,
-      duration: videoDuration,
+      duration: adjustedDuration,
       fileSize: hashResult.size,
       sha256Hash: hashResult.hash,
       mimeType: _wavMimeType,

--- a/mobile/lib/services/audio_extraction_service.dart
+++ b/mobile/lib/services/audio_extraction_service.dart
@@ -34,7 +34,7 @@ class AudioExtractionResult {
   /// SHA-256 hash of the audio file (hex string).
   final String sha256Hash;
 
-  /// MIME type of the audio file (e.g., "audio/m4a").
+  /// MIME type of the audio file (e.g., "audio/wav").
   final String mimeType;
 
   @override

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1468,7 +1468,9 @@ class VideoEventPublisher {
         category: LogCategory.video,
       );
 
-      extractionResult = await audioExtractionService.extractAudio(videoPath);
+      extractionResult = await audioExtractionService.extractAudio(
+        videoPath: videoPath,
+      );
 
       Log.info(
         'Audio extraction successful: ${extractionResult.audioFilePath}',

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -42,7 +42,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       onDelete: isLastClip ? null : () => _deleteClip(context),
       onDuplicated: () => _duplicateClip(context),
       onSplit: isSplitting ? null : () => _splitClip(context),
-      onSpeed: () => _setPlaybackSpeed(context),
+      onSpeed: isExtractingAudio ? null : () => _setPlaybackSpeed(context),
       onExtractAudio: () => _requestExtractAudio(context),
       onReversed: () => _reverseClip(context),
       isReversed: isReversed,

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart
@@ -148,13 +148,14 @@ List<Duration> rebaseTimelineMarkersForClipState({
 ///
 /// The alignment invariant preserved is, for the anchored clip:
 ///
-///   startTime == clipTimelineStart - clip.trimStart + audio.startOffset
+///   startTime == clipTimelineStart
+///       - playbackDuration(clip.trimStart)
+///       + audio.startOffset
 ///
 /// [clipTimelineStart] is accumulated in playback time so earlier clip speed
-/// changes still ripple anchored audio correctly. [AudioEvent.startOffset] and
-/// [DivineVideoClip.trimStart] remain source-time values because extracted
-/// audio is not tempo-adjusted; if extracted audio becomes speed-adjusted, this
-/// conversion must be revisited.
+/// changes still ripple anchored audio correctly. [AudioEvent.startOffset] is
+/// measured in the extracted audio file's own time, so a source trim offset is
+/// converted through the anchor clip's [DivineVideoClip.playbackSpeed].
 ///
 /// Tracks with no anchor, or whose anchor clip was removed or split into new
 /// clip IDs, are returned unchanged. The original list instance is returned
@@ -186,7 +187,11 @@ List<AudioEvent> rebaseAnchoredAudioForClipState(
     }
 
     final span = (track.endTime ?? track.startTime) - track.startTime;
-    final newStartRaw = clipStart + track.startOffset - clip.trimStart;
+    final clipTrimStartInAudioTime = clip.sourceDurationToPlaybackDuration(
+      clip.trimStart,
+    );
+    final newStartRaw =
+        clipStart + track.startOffset - clipTrimStartInAudioTime;
     var newStart = newStartRaw;
     var newStartOffset = track.startOffset;
     var newSpan = span;

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1832,10 +1832,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "2f74363e49e0c94d42ac66639049b912a43962bf541550b29543ff6dc3051f5c"
+      sha256: "4e83988955909810791938b611a3dd6a02f15623cd98f73da976ae98eb917f7f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.6"
+    version: "1.18.0"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -298,7 +298,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.17.6
+  pro_video_editor: ^1.18.0
   pro_image_editor: ^12.4.8
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -1193,9 +1193,8 @@ void main() {
         'keeps clips unmodifiable',
         build: buildBloc,
         seed: () => ClipEditorState(clips: twoClips),
-        act: (bloc) => bloc.add(
-          const ClipEditorAllClipsVolumeChanged(volume: -1.0),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorAllClipsVolumeChanged(volume: -1.0)),
         expect: () => [
           isA<ClipEditorState>()
               .having(
@@ -1221,9 +1220,8 @@ void main() {
               .map((c) => c.copyWith(volume: 0.5))
               .toList(growable: false),
         ),
-        act: (bloc) => bloc.add(
-          const ClipEditorAllClipsVolumeChanged(volume: 2.0),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorAllClipsVolumeChanged(volume: 2.0)),
         expect: () => [
           isA<ClipEditorState>().having(
             (s) => s.clips.map((c) => c.volume).toList(),
@@ -1237,9 +1235,8 @@ void main() {
         'is no-op when there are no clips',
         build: buildBloc,
         seed: () => const ClipEditorState(),
-        act: (bloc) => bloc.add(
-          const ClipEditorAllClipsVolumeChanged(volume: 0.0),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorAllClipsVolumeChanged(volume: 0.0)),
         expect: () => <ClipEditorState>[],
       );
 
@@ -1247,9 +1244,8 @@ void main() {
         'is no-op when every clip already has the clamped target volume',
         build: buildBloc,
         seed: () => ClipEditorState(clips: twoClips),
-        act: (bloc) => bloc.add(
-          const ClipEditorAllClipsVolumeChanged(volume: 2.0),
-        ),
+        act: (bloc) =>
+            bloc.add(const ClipEditorAllClipsVolumeChanged(volume: 2.0)),
         expect: () => <ClipEditorState>[],
       );
     });
@@ -1651,6 +1647,9 @@ void main() {
 
       setUp(() {
         mockService = _MockAudioExtractionService();
+        when(
+          () => mockService.cleanupAudioFile(any()),
+        ).thenAnswer((_) async {});
       });
 
       blocTest<ClipEditorBloc, ClipEditorState>(
@@ -1713,10 +1712,7 @@ void main() {
           final clip = _createClipWithFile();
           // endTime must use playbackDuration, not raw duration.
           expect(result.audioEvent.endTime, equals(clip.playbackDuration));
-          expect(
-            result.audioEvent.duration,
-            equals(5.0),
-          );
+          expect(result.audioEvent.duration, equals(5.0));
           expect(result.audioEvent.startOffset, equals(clip.trimStart));
           // Extracted audio is anchored to its source clip by default.
           expect(result.audioEvent.anchorClipId, equals(clip.id));
@@ -1749,9 +1745,8 @@ void main() {
           );
           return buildBloc(audioExtractionService: mockService);
         },
-        seed: () => ClipEditorState(
-          clips: [_createClipWithFile(playbackSpeed: 2.0)],
-        ),
+        seed: () =>
+            ClipEditorState(clips: [_createClipWithFile(playbackSpeed: 2.0)]),
         act: (bloc) => bloc.add(
           const ClipEditorAudioExtractionRequested(clipTitle: 'Test'),
         ),
@@ -1761,10 +1756,7 @@ void main() {
           final clip = _createClipWithFile(playbackSpeed: 2.0);
           expect(result.audioEvent.startTime, equals(Duration.zero));
           expect(result.audioEvent.endTime, equals(clip.playbackDuration));
-          expect(
-            result.audioEvent.duration,
-            equals(2.5),
-          );
+          expect(result.audioEvent.duration, equals(2.5));
           expect(
             result.audioEvent.startOffset,
             equals(clip.sourceDurationToPlaybackDuration(clip.trimStart)),
@@ -1833,6 +1825,64 @@ void main() {
           );
         },
       );
+
+      test('discards extraction result when clip speed changes during '
+          'in-flight extraction', () async {
+        final completer = Completer<AudioExtractionResult>();
+        when(
+          () => mockService.extractAudio(
+            videoPath: any(named: 'videoPath'),
+            speed: any(named: 'speed'),
+          ),
+        ).thenAnswer((_) => completer.future);
+
+        final clip = _createClipWithFile(playbackSpeed: 2.0);
+        final bloc = buildBloc(audioExtractionService: mockService);
+
+        bloc.add(ClipEditorInitialized([clip]));
+        await Future<void>.delayed(Duration.zero);
+
+        bloc.add(const ClipEditorAudioExtractionRequested(clipTitle: 'Test'));
+        await Future<void>.delayed(Duration.zero);
+        expect(bloc.state.isExtractingAudio, isTrue);
+
+        bloc.add(
+          ClipEditorClipUpdated(
+            clipId: clip.id,
+            clip: clip.copyWith(playbackSpeed: 0.5),
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        completer.complete(
+          const AudioExtractionResult(
+            audioFilePath: '/tmp/stale-speed-audio.wav',
+            duration: 2.5,
+            fileSize: 12345,
+            sha256Hash: 'abc123',
+            mimeType: 'audio/wav',
+          ),
+        );
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.isExtractingAudio, isFalse);
+        expect(bloc.state.clips.single.volume, equals(1));
+        expect(
+          bloc.state.lastAudioExtraction,
+          isA<ClipAudioExtractionDiscarded>(),
+        );
+        verify(
+          () => mockService.extractAudio(
+            videoPath: '/path/clip-local.mp4',
+            speed: 2.0,
+          ),
+        ).called(1);
+        verify(
+          () => mockService.cleanupAudioFile('/tmp/stale-speed-audio.wav'),
+        ).called(1);
+
+        await bloc.close();
+      });
 
       blocTest<ClipEditorBloc, ClipEditorState>(
         'emits isExtractingAudio then ClipAudioExtractionFailure on AudioExtractionException',
@@ -1956,6 +2006,7 @@ void main() {
           bloc.state.lastAudioExtraction,
           isA<ClipAudioExtractionDiscarded>(),
         );
+        verify(() => mockService.cleanupAudioFile('/tmp/audio.m4a')).called(1);
 
         await bloc.close();
       });

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -60,6 +60,7 @@ DivineVideoClip _createClipWithFile({
   Duration duration = const Duration(seconds: 5),
   Duration trimStart = const Duration(seconds: 1),
   Duration trimEnd = const Duration(milliseconds: 500),
+  double? playbackSpeed,
 }) {
   return DivineVideoClip(
     id: id,
@@ -68,6 +69,7 @@ DivineVideoClip _createClipWithFile({
     recordedAt: DateTime(2025),
     targetAspectRatio: .vertical,
     originalAspectRatio: 9 / 16,
+    playbackSpeed: playbackSpeed,
   ).copyWith(trimStart: trimStart, trimEnd: trimEnd);
 }
 
@@ -1670,7 +1672,12 @@ void main() {
       blocTest<ClipEditorBloc, ClipEditorState>(
         'emits isExtractingAudio then success with muted clip and correct endTime',
         build: () {
-          when(() => mockService.extractAudio(any())).thenAnswer(
+          when(
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
+          ).thenAnswer(
             (_) async => const AudioExtractionResult(
               audioFilePath: '/tmp/audio.m4a',
               duration: 5,
@@ -1704,18 +1711,86 @@ void main() {
           final result =
               bloc.state.lastAudioExtraction! as ClipAudioExtractionSuccess;
           final clip = _createClipWithFile();
-          // endTime must use trimmedDuration, not duration
-          expect(result.audioEvent.endTime, equals(clip.trimmedDuration));
+          // endTime must use playbackDuration, not raw duration.
+          expect(result.audioEvent.endTime, equals(clip.playbackDuration));
+          expect(
+            result.audioEvent.duration,
+            equals(5.0),
+          );
+          expect(result.audioEvent.startOffset, equals(clip.trimStart));
           // Extracted audio is anchored to its source clip by default.
           expect(result.audioEvent.anchorClipId, equals(clip.id));
           expect(result.audioEvent.isAnchored, isTrue);
+          verify(
+            () => mockService.extractAudio(
+              videoPath: '/path/clip-local.mp4',
+              speed: any(named: 'speed'),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'uses playback duration and forwards speed for extracted source clip',
+        build: () {
+          when(
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
+          ).thenAnswer(
+            (_) async => const AudioExtractionResult(
+              audioFilePath: '/tmp/audio.m4a',
+              duration: 2.5,
+              fileSize: 12345,
+              sha256Hash: 'abc123',
+              mimeType: 'audio/mp4',
+            ),
+          );
+          return buildBloc(audioExtractionService: mockService);
+        },
+        seed: () => ClipEditorState(
+          clips: [_createClipWithFile(playbackSpeed: 2.0)],
+        ),
+        act: (bloc) => bloc.add(
+          const ClipEditorAudioExtractionRequested(clipTitle: 'Test'),
+        ),
+        verify: (bloc) {
+          final result =
+              bloc.state.lastAudioExtraction! as ClipAudioExtractionSuccess;
+          final clip = _createClipWithFile(playbackSpeed: 2.0);
+          expect(result.audioEvent.startTime, equals(Duration.zero));
+          expect(result.audioEvent.endTime, equals(clip.playbackDuration));
+          expect(
+            result.audioEvent.duration,
+            equals(2.5),
+          );
+          expect(
+            result.audioEvent.startOffset,
+            equals(clip.sourceDurationToPlaybackDuration(clip.trimStart)),
+          );
+          expect(
+            result.audioEvent.endTime! - result.audioEvent.startTime,
+            equals(clip.playbackDuration),
+          );
+          verify(
+            () => mockService.extractAudio(
+              videoPath: '/path/clip-local.mp4',
+              speed: 2.0,
+            ),
+          ).called(1);
         },
       );
 
       blocTest<ClipEditorBloc, ClipEditorState>(
         'uses playback-time offsets when an extracted clip follows a slowed clip',
         build: () {
-          when(() => mockService.extractAudio(any())).thenAnswer(
+          when(
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
+          ).thenAnswer(
             (_) async => const AudioExtractionResult(
               audioFilePath: '/tmp/audio.m4a',
               duration: 5,
@@ -1763,7 +1838,10 @@ void main() {
         'emits isExtractingAudio then ClipAudioExtractionFailure on AudioExtractionException',
         build: () {
           when(
-            () => mockService.extractAudio(any()),
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
           ).thenThrow(const AudioExtractionException('Extraction failed'));
           return buildBloc(audioExtractionService: mockService);
         },
@@ -1792,7 +1870,10 @@ void main() {
         'wraps unexpected extraction errors in Reportable with context',
         build: () {
           when(
-            () => mockService.extractAudio(any()),
+            () => mockService.extractAudio(
+              videoPath: any(named: 'videoPath'),
+              speed: any(named: 'speed'),
+            ),
           ).thenThrow(StateError('boom'));
           return buildBloc(audioExtractionService: mockService);
         },
@@ -1831,7 +1912,10 @@ void main() {
           'when source clip is removed during in-flight extraction', () async {
         final completer = Completer<AudioExtractionResult>();
         when(
-          () => mockService.extractAudio(any()),
+          () => mockService.extractAudio(
+            videoPath: any(named: 'videoPath'),
+            speed: any(named: 'speed'),
+          ),
         ).thenAnswer((_) => completer.future);
 
         final clip = _createClipWithFile();

--- a/mobile/test/models/recording_clip_test.dart
+++ b/mobile/test/models/recording_clip_test.dart
@@ -112,6 +112,23 @@ void main() {
         expect(clip.trimmedDurationInSeconds, equals(3.5));
       });
 
+      test('sourceDurationToPlaybackDuration applies playbackSpeed', () {
+        final clip = DivineVideoClip(
+          id: 'clip_001',
+          video: EditorVideo.file('/path/to/video.mp4'),
+          duration: const Duration(seconds: 10),
+          recordedAt: DateTime(2025),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+          playbackSpeed: 2.0,
+        );
+
+        expect(
+          clip.sourceDurationToPlaybackDuration(const Duration(seconds: 3)),
+          equals(const Duration(milliseconds: 1500)),
+        );
+      });
+
       test('copyWith preserves trim values', () {
         final clip = DivineVideoClip(
           id: 'clip_001',

--- a/mobile/test/services/audio_extraction_service_test.dart
+++ b/mobile/test/services/audio_extraction_service_test.dart
@@ -19,6 +19,7 @@ class _MockProVideoEditor extends ProVideoEditor {
   bool shouldThrowNoTrack = false;
   bool shouldThrowOnHasAudio = false;
   bool shouldThrowOnGetMetadata = false;
+  AudioExtractConfigs? lastAudioExtractConfigs;
 
   @override
   void initializeStream() {
@@ -57,6 +58,7 @@ class _MockProVideoEditor extends ProVideoEditor {
     AudioExtractConfigs value, {
     NativeLogLevel? nativeLogLevel,
   }) async {
+    lastAudioExtractConfigs = value;
     if (shouldThrowNoTrack) throw const AudioNoTrackException();
     if (shouldThrowOnExtract) throw Exception('extraction failed');
     // Create a small file to simulate extraction
@@ -160,7 +162,7 @@ void main() {
       const nonExistentPath = '/path/that/does/not/exist/video.mp4';
 
       expect(
-        () => service.extractAudio(nonExistentPath),
+        () => service.extractAudio(videoPath: nonExistentPath),
         throwsA(
           isA<AudioExtractionException>().having(
             (e) => e.message,
@@ -256,7 +258,7 @@ void main() {
     });
 
     test('extractAudio returns result when video has audio', () async {
-      final result = await service.extractAudio(fakeVideoFile.path);
+      final result = await service.extractAudio(videoPath: fakeVideoFile.path);
 
       expect(result.audioFilePath, endsWith('.wav'));
       expect(result.duration, equals(6));
@@ -272,11 +274,27 @@ void main() {
       }
     });
 
+    test('extractAudio forwards playback speed to ProVideoEditor', () async {
+      final result = await service.extractAudio(
+        videoPath: fakeVideoFile.path,
+        speed: 0.5,
+      );
+
+      expect(mockEditor.lastAudioExtractConfigs?.speed, equals(0.5));
+      expect(result.duration, equals(12.0));
+
+      // Cleanup extraction output
+      final outputFile = File(result.audioFilePath);
+      if (outputFile.existsSync()) {
+        await outputFile.delete();
+      }
+    });
+
     test('extractAudio throws when video has no audio track', () async {
       mockEditor.hasAudio = false;
 
       expect(
-        () => service.extractAudio(fakeVideoFile.path),
+        () => service.extractAudio(videoPath: fakeVideoFile.path),
         throwsA(
           isA<AudioExtractionException>().having(
             (e) => e.message,
@@ -291,7 +309,7 @@ void main() {
       mockEditor.shouldThrowOnHasAudio = true;
 
       expect(
-        () => service.extractAudio(fakeVideoFile.path),
+        () => service.extractAudio(videoPath: fakeVideoFile.path),
         throwsA(
           isA<AudioExtractionException>().having(
             (e) => e.message,
@@ -306,7 +324,7 @@ void main() {
       mockEditor.shouldThrowOnGetMetadata = true;
 
       expect(
-        () => service.extractAudio(fakeVideoFile.path),
+        () => service.extractAudio(videoPath: fakeVideoFile.path),
         throwsA(
           isA<AudioExtractionException>().having(
             (e) => e.message,
@@ -321,7 +339,7 @@ void main() {
       mockEditor.videoDuration = Duration.zero;
 
       expect(
-        () => service.extractAudio(fakeVideoFile.path),
+        () => service.extractAudio(videoPath: fakeVideoFile.path),
         throwsA(
           isA<AudioExtractionException>().having(
             (e) => e.message,
@@ -338,7 +356,7 @@ void main() {
         mockEditor.shouldThrowNoTrack = true;
 
         expect(
-          () => service.extractAudio(fakeVideoFile.path),
+          () => service.extractAudio(videoPath: fakeVideoFile.path),
           throwsA(
             isA<AudioExtractionException>().having(
               (e) => e.message,
@@ -354,7 +372,7 @@ void main() {
       mockEditor.shouldThrowOnExtract = true;
 
       expect(
-        () => service.extractAudio(fakeVideoFile.path),
+        () => service.extractAudio(videoPath: fakeVideoFile.path),
         throwsA(
           isA<AudioExtractionException>().having(
             (e) => e.message,
@@ -368,7 +386,7 @@ void main() {
     test('extractAudio uses correct duration from video metadata', () async {
       mockEditor.videoDuration = const Duration(seconds: 3, milliseconds: 500);
 
-      final result = await service.extractAudio(fakeVideoFile.path);
+      final result = await service.extractAudio(videoPath: fakeVideoFile.path);
 
       expect(result.duration, equals(3.5));
 

--- a/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
+++ b/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
@@ -319,7 +319,7 @@ void main() {
 
       const audioPath = '/tmp/openvine_test_audio.m4a';
       when(
-        () => audioExtractionService.extractAudio('/tmp/test.mp4'),
+        () => audioExtractionService.extractAudio(videoPath: '/tmp/test.mp4'),
       ).thenAnswer(
         (_) async => const AudioExtractionResult(
           audioFilePath: audioPath,

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -127,5 +127,20 @@ void main() {
         );
       },
     );
+
+    testWidgets(
+      'Speed button is hidden while isExtractingAudio',
+      (tester) async {
+        when(
+          () => bloc.state,
+        ).thenReturn(const ClipEditorState(isExtractingAudio: true));
+        await tester.pumpWidget(build());
+
+        final controls = tester.widget<VideoEditorTimelineControls>(
+          find.byType(VideoEditorTimelineControls),
+        );
+        expect(controls.onSpeed, isNull);
+      },
+    );
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_geometry_test.dart
@@ -959,6 +959,33 @@ void main() {
       },
     );
 
+    test('uses audio-file time when the anchored clip has playbackSpeed', () {
+      // The track was extracted from clip-b when trimStart was 3 s at 2x:
+      // source offset 3 s maps to audio-file offset 1.5 s. Advancing the
+      // clip trim to 4 s should create a 0.5 s audio lead, not a 1 s lead.
+      final clips = [
+        _clip('a', 10),
+        _clip('b', 10, speed: 2.0, trimStart: const Duration(seconds: 4)),
+      ];
+      final track = _audio(
+        id: 'b-audio',
+        startTime: const Duration(seconds: 10),
+        endTime: const Duration(milliseconds: 13500),
+        startOffset: const Duration(milliseconds: 1500),
+        anchorClipId: 'b',
+      );
+
+      final result = rebaseAnchoredAudioForClipState(clips, [track]);
+
+      expect(result.single.startTime, const Duration(milliseconds: 9500));
+      expect(result.single.endTime, const Duration(seconds: 13));
+      expect(result.single.startOffset, const Duration(milliseconds: 1500));
+      expect(
+        result.single.endTime! - result.single.startTime,
+        const Duration(milliseconds: 3500),
+      );
+    });
+
     test('preserves a user-shortened span (L-Cut) while translating', () {
       // User right-trimmed the audio to 10–15 s (5 s span). A later clip
       // edit must keep that span, only translating it.


### PR DESCRIPTION
## Description

Fixes audio extraction to correctly account for clip playback speed when extracting audio tracks. Previously, audio was extracted at 1× speed regardless of the clip's `playbackSpeed` setting, causing a mismatch between the exported video (speed-adjusted) and the extracted audio (original speed). This also caused the reported audio duration to be wrong.

**Changes:**

- **`AudioExtractionService`** – `extractAudio` now accepts an optional `speed` parameter and passes it to `AudioExtractConfigs`. The reported duration is adjusted (`videoDuration / effectiveSpeed`) so it reflects the actual wall-clock length of the extracted audio.
- **`DivineVideoClip`** – Extracted the speed-conversion logic from `playbackDuration` into a new helper method `sourceDurationToPlaybackDuration(Duration)`, making it reusable by the service without duplicating the formula.
- **`ClipEditorBloc`** – Passes the clip's `playbackSpeed` to `AudioExtractionService.extractAudio` when triggering audio extraction.
- **`VideoEventPublisher`** – Minor cleanup to align with the updated `extractAudio` named-parameter signature.
- **`VideoEditorTimelineGeometry`** – Related geometry calculations updated/confirmed consistent with the speed model.

**Related Issue:** Relates to #

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test`
- `flutter test` for affected tests:
  - `clip_editor_bloc_test.dart`
  - `audio_extraction_service_test.dart`
  - `recording_clip_test.dart`
  - `video_editor_timeline_geometry_test.dart`
  - `video_event_publisher_publish_confirmation_test.dart`

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
