### PR TITLE
chore(docs): relax rebase rule — only required at publish, handoff, and on conflicts

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -16,7 +16,7 @@ reviewer to catch the same things.
 Generic Flutter and Dart standards live in `.claude/rules/`:
 
 - `rules/self_review_checklist.md`: consolidated pre-plan / pre-commit / pre-PR checklist
-- `rules/agent_workflow.md`: worktree-from-`origin/main`, rebase-before-push, no-stacked-PRs, no-tech-debt, failing-tests-are-your-fault
+- `rules/agent_workflow.md`: worktree-from-`origin/main`, rebase-at-boundaries, no-stacked-PRs, no-tech-debt, failing-tests-are-your-fault
 - `rules/architecture.md`: layered flow, package boundaries, barrel files
 - `rules/state_management.md`: BLoC-first UI, BlocProvider laziness, cross-route state persistence, Riverpod legacy rules, event transformers
 - `rules/code_style.md`: naming, widget composition, Effective Dart guidance

--- a/.claude/rules/agent_workflow.md
+++ b/.claude/rules/agent_workflow.md
@@ -37,10 +37,11 @@ elsewhere. Do not mix unrelated work into one worktree.
 
 ---
 
-## 2. Always rebase onto `origin/main` before pushing
+## 2. Rebase when publishing, finalizing, or resolving conflicts
 
-Before **every** `git push`, fetch the latest `origin/main` and rebase
-your branch onto it:
+Before publishing a branch, before final handoff, and whenever GitHub
+reports merge conflicts, fetch the latest `origin/main` and rebase your
+branch onto it:
 
 ```bash
 git fetch origin
@@ -49,21 +50,30 @@ git rebase origin/main
 git push --force-with-lease
 ```
 
-Rebasing right before push surfaces conflicts and broken assumptions
-while you still have full context — instead of after CI fails on the PR
-or after a reviewer has already started reading.
+Rebasing before those boundary moments surfaces conflicts and broken
+assumptions while you still have full context — instead of after CI fails
+on the PR or after a reviewer has already started reading.
+
+During PR review, if GitHub reports no merge conflicts and your update
+only addresses review feedback, do not rebase just to refresh history.
+Push the review fix normally. The PR is squash-merged anyway, so a
+history-refresh rebase adds force-push risk without meaningful review
+value.
 
 **Forbidden:**
 
-- `git push` without first `git fetch origin && git rebase origin/main`.
+- Publishing a new branch, making a final handoff push, or pushing a
+  branch with GitHub-reported merge conflicts without first running
+  `git fetch origin && git rebase origin/main`.
 - `git push --force` without `--lease`. `--force-with-lease` is
   mandatory on rebased feature branches so a concurrent push from a
   different machine isn't silently overwritten.
 - Merging `main` into a feature branch instead of rebasing — produces
   noisy "Merge branch 'main' into..." commits and a non-linear history.
 
-This rule still applies even on a branch you've pushed many times.
-Don't push a stale branch.
+The PR-review exception only applies when GitHub reports no merge
+conflicts and the push is narrowly for review feedback. If either stops
+being true, rebase onto fresh `origin/main`.
 
 ---
 
@@ -193,5 +203,8 @@ the local environment differs from CI. Investigate the difference.
 
 - Run the affected test suites locally.
 - Run `flutter analyze lib test integration_test`.
-- Verify the rebase onto `origin/main` did not break anything.
+- If this push requires a rebase under the workflow rules above, verify
+  the rebase onto `origin/main` did not break anything.
+- If this is a PR-review fix without a rebase, verify GitHub reports no
+  merge conflicts before relying on that exception.
 - If anything is red, do not push. Fix it.

--- a/.claude/rules/self_review_checklist.md
+++ b/.claude/rules/self_review_checklist.md
@@ -164,10 +164,13 @@ Then:
 
 ## Before opening or updating a PR
 
-- [ ] **Rebased onto fresh `origin/main`** before pushing
-  (`git fetch origin && git rebase origin/main`), and pushed with
-  `--force-with-lease`. See
-  [`agent_workflow.md`](agent_workflow.md#2-always-rebase-onto-originmain-before-pushing).
+- [ ] **Rebased onto fresh `origin/main`** before publishing or final
+  handoff, and whenever GitHub reports merge conflicts
+  (`git fetch origin && git rebase origin/main`), then pushed with
+  `--force-with-lease`. During PR review, if GitHub reports no merge
+  conflicts and the push only addresses review feedback, push normally
+  without a history-refresh rebase. See
+  [`agent_workflow.md`](agent_workflow.md#2-rebase-when-publishing-finalizing-or-resolving-conflicts).
 - [ ] PR targets `main`. **Never `--base <other-branch>`** — if this
   work depends on another in-flight branch, combine them into one PR.
   See [`agent_workflow.md`](agent_workflow.md#3-never-stack-prs--combine-dependent-features-into-one-bigger-pr).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@
   - `git worktree add .worktrees/<task-name> -b <branch-name> origin/main`
 - Keep one task per worktree. Do not mix unrelated fixes, reviews, or experiments in the same tree.
 - If the current checkout is dirty, do not start new work there. Commit it, stash it intentionally, or discard it intentionally first.
-- **Rebase onto fresh `origin/main` before every push**, even on a branch you've already pushed:
+- **Rebase onto fresh `origin/main` before publishing or final handoff**, and whenever GitHub reports merge conflicts:
   - `git fetch origin && git rebase origin/main`
   - `git push --force-with-lease` (never `--force` without `--lease`)
+- During PR review, if GitHub reports no merge conflicts and the update is only addressing review feedback, do not rebase just to refresh history. Push the review fix normally; the PR is squash-merged anyway.
 - Never merge `main` into a feature branch — always rebase.
 
 ## PR Guardrails

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,9 @@ Rules:
 
 - Never start new work in a dirty checkout.
 - Keep one task per worktree.
-- Rebase onto fresh `origin/main` before every push.
+- Rebase onto fresh `origin/main` before publishing or final handoff, and
+  whenever GitHub reports merge conflicts. During PR review with no
+  reported conflicts, push review fixes without a history-refresh rebase.
 - Never merge `main` into a feature branch. Always rebase.
 - Never stack PRs. Every PR targets `main`.
 
@@ -303,7 +305,9 @@ Requirements:
   description, related issue, out-of-scope notes, verification details, and
   type-of-change checklist.
 - End with a clean `git status`.
-- Rebase on `origin/main` before pushing.
+- Rebase on `origin/main` before publishing or final handoff, and whenever
+  GitHub reports merge conflicts; skip the rebase for review-only pushes
+  when GitHub reports no conflicts.
 - Each PR should address a single GitHub issue whenever possible. Assign that
   issue to yourself before starting work when you have permission to do so. If
   you do not, ask a maintainer to assign or confirm ownership before you begin


### PR DESCRIPTION
Closes #5050

## Description

Relaxes the rebase-before-push rule across all documentation and agent guidelines. The previous rule required a `git rebase origin/main` before **every** push, which was unnecessarily strict during PR review iterations: it added force-push risk and rewrote history that reviewers were already reading, without adding value since PRs are squash-merged anyway.

**New rule:** Rebase onto fresh `origin/main` only at these boundaries:
- Before publishing (first push of) a new branch
- Before final handoff / requesting review after significant new main activity
- Whenever GitHub reports merge conflicts

**Exception:** During an active PR review, if GitHub reports no merge conflicts and the push only addresses review feedback, push normally without a history-refresh rebase.

**Files changed:**

- `.claude/rules/agent_workflow.md` — renamed section heading, rewrote rule body to describe the three rebase boundaries, added the PR-review exception, updated the "Before every push" verification list to condition the rebase check
- `.claude/rules/self_review_checklist.md` — updated checklist bullet text + fixed broken anchor link to the renamed heading
- `AGENTS.md` — aligned bullet with new phrasing, added the PR-review exception sentence
- `CONTRIBUTING.md` — updated two places that stated the old "before every push" requirement

**Related Issue:** Relates to #

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` (docs-only change, no Dart files touched)

## Type of Change

- [x] 📝 Documentation
- [x] 🗑️ Chore
