### PR TITLE
fix(notifications): consume authoritative FCM target fields in the push path

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -330,32 +330,43 @@ ProfileDeepLinkNavAction resolveProfileDeepLinkNavAction({
   return ProfileDeepLinkNavAction.push;
 }
 
-/// Resolves a push/local payload to a [NotificationTapTarget] and the event id
-/// to navigate to, via the shared [resolveNotificationTapTarget] contract.
+/// Resolves a push/local payload to a [NotificationTapTarget], the event id to
+/// navigate to, and the authoritative video coordinate, via the shared
+/// [resolveNotificationTapTarget] contract.
 ///
-/// `referencedEventId` (the event acted upon) is preferred as the video target;
-/// it is absent for follow/mention, which fall back to `eventId` (the source
-/// event). Extracted and `@visibleForTesting` so the push-side per-kind routing
-/// can be asserted without a navigator — mirrors [resolveVideoDeepLinkNavAction].
+/// `referencedAddress` (the signed NIP-33 coordinate of the referenced video)
+/// is the authoritative target: when it is a usable video coordinate
+/// ([videoAddressableTarget]) it is returned as `videoCoordinate` and the
+/// executor routes to it directly. Otherwise the video target is
+/// `referencedEventId` (the event acted upon), falling back to `eventId` (the
+/// source event) for follow/mention, which the executor walks to a root video.
+/// Extracted and `@visibleForTesting` so the push-side per-kind routing can be
+/// asserted without a navigator — mirrors [resolveVideoDeepLinkNavAction].
 @visibleForTesting
-({NotificationTapTarget target, String? targetEventId})
+({NotificationTapTarget target, String? targetEventId, String? videoCoordinate})
 pushNotificationTapTarget({
+  required String? referencedAddress,
   required String? referencedEventId,
   required String? eventId,
   required String? notificationType,
   required String? senderPubkey,
 }) {
+  final videoCoordinate = videoAddressableTarget(referencedAddress);
   final targetEventId =
       (referencedEventId != null && referencedEventId.isNotEmpty)
       ? referencedEventId
       : eventId;
+  final hasVideoTarget =
+      videoCoordinate != null ||
+      (targetEventId != null && targetEventId.isNotEmpty);
   return (
     target: resolveNotificationTapTarget(
       kind: notificationKindFromPushType(notificationType),
-      hasVideoTarget: targetEventId != null && targetEventId.isNotEmpty,
+      hasVideoTarget: hasVideoTarget,
       actorPubkey: senderPubkey,
     ),
     targetEventId: targetEventId,
+    videoCoordinate: videoCoordinate,
   );
 }
 
@@ -371,13 +382,15 @@ pushNotificationTapTarget({
 /// it opens a profile for follows and is the safe fallback when a video target
 /// cannot be resolved.
 Future<void> _routeNotificationTap({
+  required String? referencedAddress,
   required String? referencedEventId,
   required String? eventId,
   required String? notificationType,
   required String? senderPubkey,
   required ProviderContainer container,
 }) async {
-  final (:target, :targetEventId) = pushNotificationTapTarget(
+  final (:target, :targetEventId, :videoCoordinate) = pushNotificationTapTarget(
+    referencedAddress: referencedAddress,
     referencedEventId: referencedEventId,
     eventId: eventId,
     notificationType: notificationType,
@@ -390,12 +403,23 @@ Future<void> _routeNotificationTap({
     case OpenInboxTarget():
       _navigateToNotificationInbox(container);
     case OpenVideoTarget(:final autoOpenComments):
-      await _resolveAndPushVideoLink(
-        container: container,
-        targetEventId: targetEventId!,
-        autoOpenComments: autoOpenComments,
-        fallbackPubkey: senderPubkey,
-      );
+      if (videoCoordinate != null) {
+        // Authoritative path: the signed NIP-33 coordinate is stable across
+        // metadata replacements and resolves without a relay round-trip, so
+        // push it straight to the video route.
+        _pushVideoDeepLink(
+          container,
+          videoRef: videoCoordinate,
+          autoOpenComments: autoOpenComments,
+        );
+      } else {
+        await _resolveAndPushVideoLink(
+          container: container,
+          targetEventId: targetEventId!,
+          autoOpenComments: autoOpenComments,
+          fallbackPubkey: senderPubkey,
+        );
+      }
   }
 }
 
@@ -441,12 +465,26 @@ Future<void> _resolveAndPushVideoLink({
     return;
   }
 
+  _pushVideoDeepLink(
+    container,
+    videoRef: videoEventId,
+    autoOpenComments: autoOpenComments,
+  );
+}
+
+/// Pushes a video [DeepLink] for [videoRef] (an event id or a NIP-33
+/// `kind:pubkey:d-tag` coordinate) through the shared deep-link stream.
+void _pushVideoDeepLink(
+  ProviderContainer container, {
+  required String videoRef,
+  required bool autoOpenComments,
+}) {
   container
       .read(deepLinkServiceProvider)
       .pushLink(
         DeepLink(
           type: DeepLinkType.video,
-          videoRef: videoEventId,
+          videoRef: videoRef,
           autoOpenComments: autoOpenComments,
         ),
       );
@@ -690,6 +728,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
             );
             unawaited(
               _routeNotificationTap(
+                referencedAddress: parsed.referencedAddress,
                 referencedEventId: parsed.referencedEventId,
                 eventId: parsed.eventId,
                 notificationType: parsed.notificationType,
@@ -716,6 +755,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
           );
           unawaited(
             _routeNotificationTap(
+              referencedAddress: launchTap.referencedAddress,
               referencedEventId: launchTap.referencedEventId,
               eventId: launchTap.eventId,
               notificationType: launchTap.notificationType,
@@ -737,6 +777,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
             );
             unawaited(
               _routeNotificationTap(
+                referencedAddress: parsed.referencedAddress,
                 referencedEventId: parsed.referencedEventId,
                 eventId: parsed.eventId,
                 notificationType: parsed.notificationType,
@@ -1459,6 +1500,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
           );
           unawaited(
             _routeNotificationTap(
+              referencedAddress: tapEvent.referencedAddress,
               referencedEventId: tapEvent.referencedEventId,
               eventId: tapEvent.eventId,
               notificationType: tapEvent.notificationType,

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -2,7 +2,9 @@
 // ABOUTME: One contract shared by in-app row taps, FCM push taps, and local taps.
 
 import 'package:equatable/equatable.dart';
-import 'package:models/models.dart' show NotificationKind;
+import 'package:models/models.dart' show NIP71VideoKinds, NotificationKind;
+import 'package:openvine/services/notification_helpers.dart'
+    show parseAddressableId;
 
 /// Normalized destination for a notification tap.
 ///
@@ -94,6 +96,22 @@ NotificationKind? notificationKindFromPushType(String? type) {
       // should still fall back to the best available target.
       return null;
   }
+}
+
+/// Returns [referencedAddress] when it is a usable video coordinate, else null.
+///
+/// The push service sends `referencedAddress` as the signed NIP-33 coordinate
+/// (`kind:pubkey:d-tag`) of the referenced event. It is only a video *route*
+/// when its kind is one the raw-coordinate route resolver accepts — i.e. a
+/// NIP-71 video kind ([NIP71VideoKinds.isVideoKind]). Gating on the same
+/// predicate guarantees a non-null result resolves to a video, so the executor
+/// can push it directly without a relay round-trip; non-video or malformed
+/// coordinates return null and the caller falls back to the event-id walk.
+String? videoAddressableTarget(String? referencedAddress) {
+  if (referencedAddress == null || referencedAddress.isEmpty) return null;
+  final parsed = parseAddressableId(referencedAddress);
+  if (parsed == null) return null;
+  return NIP71VideoKinds.isVideoKind(parsed.kind) ? referencedAddress : null;
 }
 
 /// Decides where a notification tap should go.

--- a/mobile/lib/services/notification_helpers.dart
+++ b/mobile/lib/services/notification_helpers.dart
@@ -77,6 +77,13 @@ abstract class NotificationPayloadKeys {
   /// follow/mention, which carry no `e` tag).
   static const String referencedEventId = 'referencedEventId';
 
+  /// Authoritative NIP-33 addressable coordinate (`kind:pubkey:d-tag`) of the
+  /// referenced video, taken from the source event's signed `a`/`A` tag. Stable
+  /// across NIP-33 replacements, so the tap router prefers it over
+  /// [referencedEventId]. Present only when the source event carries an `a`/`A`
+  /// tag (like/comment/repost on an addressable video).
+  static const String referencedAddress = 'referencedAddress';
+
   /// The source event itself (the like/comment/follow/mention event).
   static const String eventId = 'eventId';
 
@@ -98,12 +105,18 @@ abstract class NotificationPayloadKeys {
 /// callers see one shape whether the payload came from the FCM wire or a
 /// locally-emitted notification JSON.
 ///
+/// Also surfaces `referencedAddress` (the authoritative NIP-33 coordinate from
+/// the source event's signed `a`/`A` tag) so the tap router can route to the
+/// stable address without walking the event.
+///
 /// Returns `null` only when the payload carries nothing routable — no
-/// `referencedEventId`, no `eventId`, and no `senderPubkey`. A `follow`/
-/// `mention` carries no `referencedEventId` but is still routable (via
-/// `senderPubkey` / `eventId`), so those are no longer dropped.
+/// `referencedAddress`, no `referencedEventId`, no `eventId`, and no
+/// `senderPubkey`. A `follow`/`mention` carries no `referencedEventId` but is
+/// still routable (via `senderPubkey` / `eventId`), so those are no longer
+/// dropped.
 ({
   String? referencedEventId,
+  String? referencedAddress,
   String? eventId,
   String? notificationType,
   String? senderPubkey,
@@ -115,18 +128,23 @@ parseFcmPayload(Map<String, dynamic> data) {
   }
 
   final referencedEventId = nonEmpty(NotificationPayloadKeys.referencedEventId);
+  final referencedAddress = nonEmpty(NotificationPayloadKeys.referencedAddress);
   final eventId = nonEmpty(NotificationPayloadKeys.eventId);
   final senderPubkey = nonEmpty(NotificationPayloadKeys.senderPubkey);
   final notificationType =
       nonEmpty(NotificationPayloadKeys.wireType) ??
       nonEmpty(NotificationPayloadKeys.notificationType);
 
-  if (referencedEventId == null && eventId == null && senderPubkey == null) {
+  if (referencedEventId == null &&
+      referencedAddress == null &&
+      eventId == null &&
+      senderPubkey == null) {
     return null;
   }
 
   return (
     referencedEventId: referencedEventId,
+    referencedAddress: referencedAddress,
     eventId: eventId,
     notificationType: notificationType,
     senderPubkey: senderPubkey,
@@ -151,6 +169,7 @@ Map<String, dynamic> localNotificationTapPayload(Map<String, dynamic> data) {
   final parsed = parseFcmPayload(data);
   return {
     NotificationPayloadKeys.referencedEventId: parsed?.referencedEventId,
+    NotificationPayloadKeys.referencedAddress: parsed?.referencedAddress,
     NotificationPayloadKeys.eventId: parsed?.eventId,
     NotificationPayloadKeys.notificationType: parsed?.notificationType,
     NotificationPayloadKeys.senderPubkey: parsed?.senderPubkey,

--- a/mobile/lib/services/notification_service.dart
+++ b/mobile/lib/services/notification_service.dart
@@ -24,6 +24,7 @@ enum NotificationType {
 class NotificationTapEvent {
   const NotificationTapEvent({
     this.referencedEventId,
+    this.referencedAddress,
     this.eventId,
     this.notificationType,
     this.senderPubkey,
@@ -32,6 +33,12 @@ class NotificationTapEvent {
   /// The event acted upon (present for like/comment/repost). Null for
   /// follow/mention, which the push service sends without an `e` tag.
   final String? referencedEventId;
+
+  /// Authoritative NIP-33 coordinate (`kind:pubkey:d-tag`) of the referenced
+  /// video, taken from the source event's signed `a`/`A` tag. Preferred over
+  /// [referencedEventId] for routing because it is stable across NIP-33
+  /// replacements. Null when the source event carried no `a`/`A` tag.
+  final String? referencedAddress;
 
   /// The source event itself (the like/comment/follow/mention event).
   final String? eventId;
@@ -46,13 +53,19 @@ class NotificationTapEvent {
       identical(this, other) ||
       other is NotificationTapEvent &&
           referencedEventId == other.referencedEventId &&
+          referencedAddress == other.referencedAddress &&
           eventId == other.eventId &&
           notificationType == other.notificationType &&
           senderPubkey == other.senderPubkey;
 
   @override
-  int get hashCode =>
-      Object.hash(referencedEventId, eventId, notificationType, senderPubkey);
+  int get hashCode => Object.hash(
+    referencedEventId,
+    referencedAddress,
+    eventId,
+    notificationType,
+    senderPubkey,
+  );
 }
 
 /// Notification data structure
@@ -517,17 +530,23 @@ class NotificationService {
       final referencedEventId = field(
         NotificationPayloadKeys.referencedEventId,
       );
+      final referencedAddress = field(
+        NotificationPayloadKeys.referencedAddress,
+      );
       final eventId = field(NotificationPayloadKeys.eventId);
       final senderPubkey = field(NotificationPayloadKeys.senderPubkey);
       // A follow/mention carries no referencedEventId but is still routable
-      // via senderPubkey / eventId, so route whenever any of the three exist.
+      // via senderPubkey / eventId, and a referencedAddress alone is a valid
+      // video target, so route whenever any of these exist.
       if (referencedEventId == null &&
+          referencedAddress == null &&
           eventId == null &&
           senderPubkey == null) {
         return null;
       }
       return NotificationTapEvent(
         referencedEventId: referencedEventId,
+        referencedAddress: referencedAddress,
         eventId: eventId,
         notificationType: field(NotificationPayloadKeys.notificationType),
         senderPubkey: senderPubkey,

--- a/mobile/test/main_notification_tap_routing_test.dart
+++ b/mobile/test/main_notification_tap_routing_test.dart
@@ -11,10 +11,12 @@ void main() {
   const videoEvent = 'video_event_id';
   const commentEvent = 'comment_event_id';
   const sourceEvent = 'source_event_id';
+  const videoCoordinate = '34236:owner_hex:my-vine-id';
 
   group('pushNotificationTapTarget', () {
     test('follow opens the actor profile (carries no referencedEventId)', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: null,
         eventId: 'contact_list_event',
         notificationType: 'follow',
@@ -26,6 +28,7 @@ void main() {
 
     test('like opens the referenced video without comments', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: videoEvent,
         eventId: sourceEvent,
         notificationType: 'like',
@@ -38,6 +41,7 @@ void main() {
 
     test('comment opens the referenced video with comments', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: commentEvent,
         eventId: sourceEvent,
         notificationType: 'comment',
@@ -50,6 +54,7 @@ void main() {
 
     test('repost opens the referenced video without comments', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: videoEvent,
         eventId: sourceEvent,
         notificationType: 'repost',
@@ -62,6 +67,7 @@ void main() {
     test('mention uses eventId as the video target (no referencedEventId) '
         'and opens comments', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: null,
         eventId: sourceEvent,
         notificationType: 'mention',
@@ -74,6 +80,7 @@ void main() {
 
     test('mention without a video target falls back to the actor profile', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: null,
         eventId: null,
         notificationType: 'mention',
@@ -86,6 +93,7 @@ void main() {
 
     test('prefers referencedEventId over eventId as the video target', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: videoEvent,
         eventId: sourceEvent,
         notificationType: 'like',
@@ -97,6 +105,7 @@ void main() {
 
     test('nothing routable and no pubkey opens the inbox', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: null,
         eventId: null,
         notificationType: 'follow',
@@ -109,6 +118,7 @@ void main() {
     test('unknown type with a video target opens the video without '
         'comments', () {
       final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
         referencedEventId: videoEvent,
         eventId: null,
         // Capitalized — not the lowercase wire value the service sends.
@@ -117,6 +127,105 @@ void main() {
       );
 
       expect(result.target, const OpenVideoTarget(autoOpenComments: false));
+    });
+
+    test('prefers the authoritative addressable coordinate as the video '
+        'target', () {
+      final result = app.pushNotificationTapTarget(
+        referencedAddress: videoCoordinate,
+        referencedEventId: videoEvent,
+        eventId: sourceEvent,
+        notificationType: 'like',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: false));
+      expect(result.videoCoordinate, equals(videoCoordinate));
+    });
+
+    test('a video coordinate alone is a video target (no event id)', () {
+      final result = app.pushNotificationTapTarget(
+        referencedAddress: videoCoordinate,
+        referencedEventId: null,
+        eventId: null,
+        notificationType: 'like',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: false));
+      expect(result.videoCoordinate, equals(videoCoordinate));
+    });
+
+    test('ignores a non-video addressable coordinate and falls back', () {
+      // A coordinate whose kind is not a NIP-71 video kind cannot be resolved
+      // as a raw video route, so it must not be treated as a video target.
+      final result = app.pushNotificationTapTarget(
+        referencedAddress: '30023:owner_hex:blog-slug',
+        referencedEventId: null,
+        eventId: null,
+        notificationType: 'comment',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenProfileTarget(actor));
+      expect(result.videoCoordinate, isNull);
+    });
+
+    test('falls back to referencedEventId when no coordinate is present', () {
+      final result = app.pushNotificationTapTarget(
+        referencedAddress: null,
+        referencedEventId: videoEvent,
+        eventId: sourceEvent,
+        notificationType: 'like',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: false));
+      expect(result.videoCoordinate, isNull);
+      expect(result.targetEventId, equals(videoEvent));
+    });
+
+    test('ignores a malformed referencedAddress', () {
+      final result = app.pushNotificationTapTarget(
+        referencedAddress: 'not-a-coordinate',
+        referencedEventId: null,
+        eventId: null,
+        notificationType: 'like',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenProfileTarget(actor));
+      expect(result.videoCoordinate, isNull);
+    });
+  });
+
+  group('videoAddressableTarget', () {
+    test('returns the coordinate for a NIP-71 video kind', () {
+      expect(
+        videoAddressableTarget('34236:owner_hex:my-vine-id'),
+        equals('34236:owner_hex:my-vine-id'),
+      );
+    });
+
+    test('preserves a colon-containing d-tag', () {
+      expect(
+        videoAddressableTarget('34236:owner_hex:weird:d:tag'),
+        equals('34236:owner_hex:weird:d:tag'),
+      );
+    });
+
+    test('returns null for a non-video kind', () {
+      expect(videoAddressableTarget('30023:owner_hex:blog-slug'), isNull);
+    });
+
+    test('returns null for a malformed coordinate', () {
+      expect(videoAddressableTarget('34236:only-two-parts'), isNull);
+      expect(videoAddressableTarget('not-a-coordinate'), isNull);
+    });
+
+    test('returns null for empty or null input', () {
+      expect(videoAddressableTarget(''), isNull);
+      expect(videoAddressableTarget(null), isNull);
     });
   });
 }

--- a/mobile/test/services/notification_helpers_test.dart
+++ b/mobile/test/services/notification_helpers_test.dart
@@ -548,6 +548,65 @@ void main() {
       expect(result!.referencedEventId, equals('evt1'));
       expect(result.notificationType, equals('like'));
     });
+
+    test('parses the authoritative referencedAddress coordinate', () {
+      // The push service emits the signed a/A-tag coordinate so the client can
+      // route to the stable NIP-33 address without walking the event.
+      final result = parseFcmPayload(const {
+        'type': 'like',
+        'eventId': 'reaction_event',
+        'referencedEventId': 'video_event',
+        'referencedAddress': '34236:owner_hex:my-vine-id',
+        'senderPubkey': 'actor_hex',
+      });
+
+      expect(result, isNotNull);
+      expect(result!.referencedAddress, equals('34236:owner_hex:my-vine-id'));
+    });
+
+    test('referencedAddress is null when absent', () {
+      final result = parseFcmPayload(const {
+        'type': 'like',
+        'referencedEventId': 'video_event',
+        'senderPubkey': 'actor_hex',
+      });
+
+      expect(result, isNotNull);
+      expect(result!.referencedAddress, isNull);
+    });
+
+    test('referencedAddress empty string normalizes to null', () {
+      final result = parseFcmPayload(const {
+        'type': 'like',
+        'referencedEventId': 'video_event',
+        'referencedAddress': '',
+        'senderPubkey': 'actor_hex',
+      });
+
+      expect(result!.referencedAddress, isNull);
+    });
+
+    test('preserves a colon-containing d-tag in referencedAddress', () {
+      final result = parseFcmPayload(const {
+        'type': 'comment',
+        'referencedEventId': 'comment_event',
+        'referencedAddress': '34236:owner_hex:weird:d:tag',
+        'senderPubkey': 'actor_hex',
+      });
+
+      expect(result!.referencedAddress, equals('34236:owner_hex:weird:d:tag'));
+    });
+
+    test('a payload carrying only referencedAddress is routable', () {
+      // The coordinate alone is a valid video target, so it must not be
+      // dropped as unroutable.
+      final result = parseFcmPayload(const {
+        'referencedAddress': '34236:owner_hex:vine-id',
+      });
+
+      expect(result, isNotNull);
+      expect(result!.referencedAddress, equals('34236:owner_hex:vine-id'));
+    });
   });
 
   group('localNotificationTapPayload', () {
@@ -556,6 +615,7 @@ void main() {
         'type': 'comment',
         'eventId': 'comment_event',
         'referencedEventId': 'video_event',
+        'referencedAddress': '34236:owner_hex:my-vine-id',
         'senderPubkey': 'actor_hex',
         'title': 'New comment',
         'body': 'ignored for routing',
@@ -563,6 +623,7 @@ void main() {
 
       expect(payload, {
         'referencedEventId': 'video_event',
+        'referencedAddress': '34236:owner_hex:my-vine-id',
         'eventId': 'comment_event',
         'notificationType': 'comment',
         'senderPubkey': 'actor_hex',
@@ -597,6 +658,21 @@ void main() {
       expect(payload['eventId'], equals('like_event'));
       expect(payload['notificationType'], equals('like'));
       expect(payload['senderPubkey'], equals('actor_hex'));
+    });
+
+    test('preserves the authoritative referencedAddress coordinate', () {
+      final payload = localNotificationTapPayload(const {
+        'type': 'like',
+        'eventId': 'reaction_event',
+        'referencedEventId': 'video_event',
+        'referencedAddress': '34236:owner_hex:my-vine-id',
+        'senderPubkey': 'actor_hex',
+      });
+
+      expect(
+        payload['referencedAddress'],
+        equals('34236:owner_hex:my-vine-id'),
+      );
     });
   });
 }

--- a/mobile/test/services/notification_service_test.dart
+++ b/mobile/test/services/notification_service_test.dart
@@ -273,6 +273,50 @@ void main() {
       expect(events.single.notificationType, equals('reply'));
     });
 
+    test(
+      'emits the authoritative referencedAddress from JSON payload',
+      () async {
+        final events = <NotificationTapEvent>[];
+        final sub = service.notificationTapStream.listen(events.add);
+        addTearDown(sub.cancel);
+
+        service.handleNotificationTapPayload(
+          jsonEncode({
+            'referencedEventId': 'video_event',
+            'referencedAddress': '34236:owner_hex:my-vine-id',
+            'notificationType': 'like',
+          }),
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        expect(events, hasLength(1));
+        expect(
+          events.single.referencedAddress,
+          equals('34236:owner_hex:my-vine-id'),
+        );
+      },
+    );
+
+    test('routes a payload that carries only referencedAddress', () async {
+      // The coordinate alone is a valid video target — it must still emit.
+      final events = <NotificationTapEvent>[];
+      final sub = service.notificationTapStream.listen(events.add);
+      addTearDown(sub.cancel);
+
+      service.handleNotificationTapPayload(
+        jsonEncode({'referencedAddress': '34236:owner_hex:vine-id'}),
+      );
+
+      await Future<void>.delayed(Duration.zero);
+
+      expect(events, hasLength(1));
+      expect(
+        events.single.referencedAddress,
+        equals('34236:owner_hex:vine-id'),
+      );
+    });
+
     test('emits null type when notificationType missing', () async {
       final events = <NotificationTapEvent>[];
       final sub = service.notificationTapStream.listen(events.add);
@@ -594,20 +638,28 @@ void main() {
     test('uses value equality for event comparisons', () {
       const first = NotificationTapEvent(
         referencedEventId: 'abc123',
+        referencedAddress: '34236:owner:vine',
         notificationType: 'reply',
       );
       const second = NotificationTapEvent(
         referencedEventId: 'abc123',
+        referencedAddress: '34236:owner:vine',
         notificationType: 'reply',
       );
       const third = NotificationTapEvent(
         referencedEventId: 'xyz789',
         notificationType: 'reply',
       );
+      const differsByAddress = NotificationTapEvent(
+        referencedEventId: 'abc123',
+        referencedAddress: '34236:owner:other-vine',
+        notificationType: 'reply',
+      );
 
       expect(first, equals(second));
       expect(first.hashCode, equals(second.hashCode));
       expect(first, isNot(equals(third)));
+      expect(first, isNot(equals(differsByAddress)));
     });
   });
 }


### PR DESCRIPTION
## Description

Push notifications now open the right video using the address the push service signs into the payload, instead of re-deriving it from the source event.

The push service (divine-push-service#21) started sending an authoritative target on like/comment/repost pushes: `referencedAddress`, the signed NIP-33 coordinate (`kind:pubkey:d-tag`) of the referenced video. Mobile ignored it — `parseFcmPayload` only read `referencedEventId`/`eventId`/`senderPubkey`/`type` — so the push-service change was inert and a tap still walked the source event over a relay to find the video.

This change threads `referencedAddress` end-to-end: FCM parser, the local-notification tap event, and the tap router. When the coordinate is a video coordinate, the tap opens that address directly. The coordinate is stable across NIP-33 metadata replacements and resolves without a relay round-trip, so a tap lands on the current version of the video even after it was edited. A non-video, malformed, or absent coordinate falls back to the existing event-id walk, which keeps its profile/inbox fallback.

This mirrors the preference the in-app notification rows already use (`_navigateToVideo` prefers the addressable id). The push executor was the one entry point not yet receiving it.

**Related Issue:** Closes #5003

## Out of Scope

The three component fields the push service also sends (`referencedKind`, `referencedAuthorPubkey`, `referencedDTag`) are not consumed. They are redundant with `referencedAddress` for routing, and the notification text is built backend-side, so mobile has no attribution use for them.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `dart format --output=none --set-exit-if-changed` on all changed files — clean.
- `flutter test` on the notification suites (parser, tap event, tap routing, push service, in-app rows) — 292 pass.
- New tests cover: the parser reads and preserves the coordinate, the tap event carries it through the JSON round-trip, and the router prefers a video coordinate while falling back on a non-video / malformed / absent one.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)