### PR TITLE
fix(auth): redact BYOK verifier (embeds raw nsec) in verification error log

### DIFF
--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -291,10 +291,13 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
           if (result.code != null && _pendingVerifier != null) {
             await _exchangeCodeAndLogin(result.code!, _pendingVerifier!);
           } else {
-            // Edge case: completion detected but missing code or verifier
+            // Edge case: completion detected but missing code or verifier.
+            // Log presence only — BYOK verifiers embed the raw nsec and
+            // captured logs are uploaded with bug reports.
             Log.error(
               'Verification complete but missing code or verifier! '
-              'code=${result.code}, verifier=$_pendingVerifier',
+              'code=${result.code != null}, '
+              'verifier=${_pendingVerifier != null}',
               name: 'EmailVerificationCubit',
               category: LogCategory.auth,
             );

--- a/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+++ b/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
@@ -106,6 +106,59 @@ void main() {
           expect(cubit.state.pendingEmail, testEmail);
         },
       );
+
+      // BYOK verifiers embed the raw nsec (see PKCE.generateVerifier), and
+      // captured logs are uploaded with bug reports — the verifier value
+      // must never reach a log message.
+      test('never logs raw verifier when completion is missing the code', () {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult(status: PollStatus.complete));
+
+        const nsecVerifier =
+            'prefix.nsec1qwertyuiopasdfghjklzxcvbnm0123456789abcdef';
+
+        fakeAsync((fake) {
+          final cubit = buildCubit();
+          cubit.startPolling(
+            deviceCode: testDeviceCode,
+            verifier: nsecVerifier,
+            email: testEmail,
+          );
+
+          fake.elapse(const Duration(seconds: 4));
+
+          expect(cubit.state.status, EmailVerificationStatus.failure);
+          expect(cubit.state.errorCode, EmailVerificationError.missingAuthCode);
+
+          final messages = LogCaptureService().getRecentLogs().map(
+            (entry) => entry.message,
+          );
+          expect(
+            messages.where(
+              (message) =>
+                  message.contains(nsecVerifier) || message.contains('nsec1'),
+            ),
+            isEmpty,
+            reason:
+                'the BYOK verifier embeds the raw nsec and must never be '
+                'logged',
+          );
+          expect(
+            messages.where(
+              (message) =>
+                  message.startsWith('Verification complete but missing'),
+            ),
+            isNotEmpty,
+            reason: 'the edge-case error log itself must still fire',
+          );
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
     });
 
     group('invite activation', () {


### PR DESCRIPTION
Closes #5095

## Summary

Security fix (audit finding SEC-02): the `PollStatus.complete` edge-case error log in `EmailVerificationCubit` printed `verifier=$_pendingVerifier` in full. In the BYOK flow the PKCE verifier embeds the **raw nsec** (`PKCE.generateVerifier(nsec:)` in `keycast_flutter`), and the unified-log ring buffer is uploaded off-device by bug reports (`BugReportService`) — so a user hitting the "complete but missing code" edge case who then filed a bug report exfiltrated their private key.

The adjacent completion log (line 286) already redacts the same field to a presence boolean; this site was missed. Both `code` and `verifier` now log presence only.

## Changes

- `email_verification_cubit.dart`: log `code=${result.code != null}` / `verifier=${_pendingVerifier != null}` instead of raw values in the missing-code error path.
- Regression test: drives a `PollStatus.complete` poll with a null code and an nsec-bearing verifier, then asserts no captured log message contains the verifier (or any `nsec1` string) while the edge-case error log still fires.

## Test plan

- [x] New test fails on main (raw verifier present in captured log), passes with the fix
- [x] `flutter test test/blocs/email_verification/email_verification_cubit_test.dart` — 33/33 pass
- [x] `dart format` / `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)