### PR TITLE
fix(publish): require relay OK before marking videos published

### DIFF
--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -15,6 +15,7 @@ import 'package:models/models.dart'
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/relay/relay_pool.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
@@ -73,7 +74,7 @@ const Duration _outerPublishTimeoutCeiling = Duration(seconds: 60);
 const Duration _outerPublishTimeoutBuffer = RelayPool.perRelaySendTimeout;
 
 /// Computes the outer timeout that bounds the call into
-/// [NostrClient.publishEvent] inside `_publishEventToNostr`.
+/// [NostrClient.publishEventAwaitOk] inside `_publishEventToNostr`.
 ///
 /// Derivation: `RelayPool.perRelaySendTimeout * relayCount + buffer`,
 /// clamped to `[floor, ceiling]`. Encoding the relationship in code
@@ -171,7 +172,7 @@ class VideoEventPublisher {
   DateTime? _lastPublishTime;
 
   /// The outer timeout that will bound the next call into
-  /// [NostrClient.publishEvent] inside [_publishEventToNostr], computed
+  /// [NostrClient.publishEventAwaitOk] inside [_publishEventToNostr], computed
   /// live from [outerPublishTimeoutFor] and the current
   /// [NostrClient.configuredRelayCount].
   ///
@@ -232,18 +233,23 @@ class VideoEventPublisher {
   }
 
   /// Publishes a signed Nostr [event] to the configured relays and returns
-  /// `true` iff at least one relay acknowledged the event as
-  /// [PublishSuccess].
+  /// `true` iff at least one relay confirmed acceptance with a NIP-20
+  /// `OK true` response ([PublishOutcome.confirmed]).
+  ///
+  /// A successful WebSocket send is NOT sufficient — relays can accept
+  /// the frame and still reject the event at the protocol level (e.g.
+  /// the divine relay's policy rejections). Treating a bare send as
+  /// success used to mark rejected videos as published while they were
+  /// silently dropped relay-side.
   ///
   /// **Failure contract** (returns `false`):
-  /// 1. `TimeoutException` — the outer `Future.timeout` (bound by
-  ///    [currentOuterPublishTimeout]) fires before
-  ///    [NostrClient.publishEvent] completes. Derived from
-  ///    `RelayPool.perRelaySendTimeout × relayCount + buffer`; see
-  ///    [outerPublishTimeoutFor].
-  /// 2. Relay rejection — `publishResult` is not [PublishSuccess]
-  ///    (all configured relays rejected the event or the SDK reported
-  ///    no acknowledgement).
+  /// 1. `TimeoutException` — the inner OK-wait (bound by
+  ///    [currentOuterPublishTimeout], which the publish tracker starts
+  ///    before the send fan-out) or the outer backstop
+  ///    `Future.timeout` fires first. See [outerPublishTimeoutFor].
+  /// 2. Relay rejection / no response — [PublishOutcome.failed]: every
+  ///    targeted relay rejected the event with `OK false` or never
+  ///    responded.
   /// 3. Inner exception — any throw inside the outer try/catch is
   ///    logged via `Log.error` and converted to `false`.
   ///
@@ -387,52 +393,46 @@ class VideoEventPublisher {
         );
       }
 
-      // Use the existing Nostr service to publish.
+      // Publish and wait for a NIP-20 `OK` from at least one relay. The
+      // [outerPublishTimeoutFor]-derived bound (perRelaySendTimeout ×
+      // relayCount + buffer) is passed as the OK-wait timeout — the SDK's
+      // publish tracker starts that timer before the send fan-out, so it
+      // covers both the sequential sends and the OK wait.
       //
-      // Defense-in-depth: outer timeout so a misbehaving relay (e.g. stuck
-      // in connecting / reconnect backoff) cannot freeze the publish flow
-      // indefinitely. The retry loop in [publishDirectUpload] picks up
-      // after each failed attempt.
-      //
-      // The bound is derived from [RelayPool.perRelaySendTimeout] and the
-      // configured relay count (see [outerPublishTimeoutFor]) so it stays
-      // strictly above the worst-case sequential fan-out inside
-      // [_sendCollect]. Hard-coding the outer timeout would silently break
-      // the moment a user adds a relay or the SDK retunes the per-relay
-      // cap; the derivation encodes the invariant in code.
+      // Defense-in-depth: the outer `Future.timeout` (one extra
+      // [RelayPool.perRelaySendTimeout] of slack so the inner tracker
+      // normally fires first) guards the code that runs before the
+      // tracker exists — e.g. `retryDisconnectedRelays` stuck in
+      // reconnect backoff. The retry loop in [publishDirectUpload] picks
+      // up after each failed attempt.
       //
       // We use try/catch on [TimeoutException] rather than `.timeout(
-      // onTimeout: ...)`. The `onTimeout` closure has its return type
-      // runtime-checked against the source future's `T`, and mocktail-
-      // stubbed Futures (`thenAnswer((_) async => event)`) infer their
-      // runtime type as `Future<Event>` — non-nullable — even when the
-      // declared signature is `Future<Event?>`. That mismatch makes
-      // `onTimeout: () => null` throw at runtime in tests. The try/catch
-      // shape sidesteps the closure-cast entirely; behaviour against a
-      // real `NostrClient` is identical.
+      // onTimeout: ...)`: `publishEventAwaitOk` returns a non-nullable
+      // [PublishOutcome], so an `onTimeout` closure could not return
+      // null, and the try/catch shape also avoids the mocktail
+      // runtime-type mismatch on stubbed futures.
       final outerTimeout = currentOuterPublishTimeout;
-      PublishResult? publishResult;
+      PublishOutcome? publishOutcome;
       try {
-        publishResult = await _nostrService
-            .publishEvent(event)
-            .timeout(outerTimeout);
+        publishOutcome = await _nostrService
+            .publishEventAwaitOk(event, timeout: outerTimeout)
+            .timeout(outerTimeout + RelayPool.perRelaySendTimeout);
       } on TimeoutException {
         Log.error(
-          '⏱️ publishEvent timed out after ${outerTimeout.inSeconds}s for '
-          'event ${event.id} '
+          '⏱️ publishEventAwaitOk timed out after '
+          '${outerTimeout.inSeconds}s for event ${event.id} '
           '(relayCount=${_nostrService.configuredRelayCount})',
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );
-        publishResult = null;
+        publishOutcome = null;
       }
 
-      // Check if publish was successful
-      if (publishResult is PublishSuccess) {
+      if (publishOutcome != null && publishOutcome.confirmed) {
         Log.info(
-          '📡 Event sent to relays, awaiting visibility confirmation: '
-          '${event.id} '
-          '(configured=${_nostrService.configuredRelayCount}, '
+          '📡 Event confirmed by relay(s): ${event.id} '
+          '(${publishOutcome.summary}, '
+          'configured=${_nostrService.configuredRelayCount}, '
           'connected=${_nostrService.connectedRelayCount})',
           name: 'VideoEventPublisher',
           category: LogCategory.video,
@@ -440,7 +440,7 @@ class VideoEventPublisher {
 
         return true;
       } else {
-        final failureReason = publishResult?.failureReason ?? 'timeout';
+        final failureReason = publishOutcome?.summary ?? 'timeout';
         Log.error(
           '❌ Event publish failed for ${event.id}: $failureReason '
           '(configured=${_nostrService.configuredRelayCount}, '
@@ -1197,11 +1197,10 @@ class VideoEventPublisher {
         category: LogCategory.video,
       );
 
-      // Retry up to 3 times with exponential backoff.
-      // A successful send (relay accepted the event) is treated as success.
-      // We intentionally skip read-back verification because relay indexing
-      // lag can cause timeouts even though the event was accepted and is
-      // already being delivered via subscriptions.
+      // Retry up to 3 times with exponential backoff. Success means a
+      // relay confirmed acceptance with `OK true` (NIP-20). We still skip
+      // read-back verification — indexing lag can delay queries even
+      // after a relay has accepted the event.
       const maxRetries = 3;
       var publishResult = false;
 

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1762,7 +1762,11 @@ class VideoEventPublisher {
       return false;
     }
 
-    // Optimistically update local cache
+    // Publish to relays before updating local cache. A WebSocket send is not
+    // enough here; rejected subtitle republishes must not appear locally.
+    final published = await _publishEventToNostr(event);
+    if (!published) return false;
+
     try {
       _videoEventService?.addVideoEvent(VideoEvent.fromNostrEvent(event));
     } catch (e) {
@@ -1773,8 +1777,7 @@ class VideoEventPublisher {
       );
     }
 
-    // Publish to relays
-    return _publishEventToNostr(event);
+    return true;
   }
 
   /// Check if a URL is a valid HTTP/HTTPS URL (not a local file path)

--- a/mobile/test/services/video_event_publisher_cawg_identity_test.dart
+++ b/mobile/test/services/video_event_publisher_cawg_identity_test.dart
@@ -6,6 +6,7 @@ import 'package:models/models.dart' show NativeProofData, VideoEvent;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/upload_manager.dart';
@@ -35,6 +36,7 @@ void main() {
     registerFallbackValue(UploadStatus.pending);
     registerFallbackValue(_FakeFilter());
     registerFallbackValue(<Filter>[]);
+    registerFallbackValue(Duration.zero);
   });
 
   group('VideoEventPublisher - CAWG identity tag integration', () {
@@ -95,11 +97,17 @@ void main() {
         return capturedEvent!;
       });
 
-      when(() => mockNostrService.publishEvent(any())).thenAnswer((
-        invocation,
-      ) async {
-        return PublishSuccess(
-          event: invocation.positionalArguments[0] as Event,
+      when(
+        () => mockNostrService.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((invocation) async {
+        return PublishOutcome(
+          eventId: (invocation.positionalArguments[0] as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
         );
       });
       when(

--- a/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_collaborator_tags_test.dart
@@ -7,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -55,6 +56,7 @@ void main() {
     registerFallbackValue(_FakeFilter());
     registerFallbackValue(<Filter>[]);
     registerFallbackValue(UploadStatus.pending);
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -128,8 +130,18 @@ void main() {
     });
 
     when(
-      () => nostrClient.publishEvent(any()),
-    ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
+      () => nostrClient.publishEventAwaitOk(
+        any(),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => PublishOutcome(
+        eventId: publishedEvent.id,
+        acceptedBy: const ['wss://relay.divine.video'],
+        rejectedBy: const {},
+        noResponseFrom: const [],
+      ),
+    );
     when(
       () => nostrClient.queryEvents(
         any(),

--- a/mobile/test/services/video_event_publisher_language_tag_test.dart
+++ b/mobile/test/services/video_event_publisher_language_tag_test.dart
@@ -7,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -48,6 +49,7 @@ void main() {
     registerFallbackValue(_FakeFilter());
     registerFallbackValue(<Filter>[]);
     registerFallbackValue(UploadStatus.pending);
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -128,8 +130,18 @@ void main() {
     });
 
     when(
-      () => mockNostrClient.publishEvent(any()),
-    ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
+      () => mockNostrClient.publishEventAwaitOk(
+        any(),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => PublishOutcome(
+        eventId: publishedEvent.id,
+        acceptedBy: const ['wss://relay.divine.video'],
+        rejectedBy: const {},
+        noResponseFrom: const [],
+      ),
+    );
     when(
       () => mockNostrClient.queryEvents(
         any(),

--- a/mobile/test/services/video_event_publisher_native_proof_test.dart
+++ b/mobile/test/services/video_event_publisher_native_proof_test.dart
@@ -9,6 +9,7 @@ import 'package:models/models.dart' show NativeProofData;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/upload_manager.dart';
@@ -40,6 +41,7 @@ void main() {
     registerFallbackValue(UploadStatus.pending);
     registerFallbackValue(_FakeFilter());
     registerFallbackValue(<Filter>[]);
+    registerFallbackValue(Duration.zero);
   });
 
   group('VideoEventPublisher - Native ProofMode Integration', () {
@@ -124,11 +126,17 @@ void main() {
       });
 
       // Mock publish to succeed
-      when(() => mockNostrService.publishEvent(any())).thenAnswer((
-        invocation,
-      ) async {
-        return PublishSuccess(
-          event: invocation.positionalArguments[0] as Event,
+      when(
+        () => mockNostrService.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((invocation) async {
+        return PublishOutcome(
+          eventId: (invocation.positionalArguments[0] as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
         );
       });
       when(
@@ -268,11 +276,17 @@ void main() {
         return Future.value(capturedEvent);
       });
 
-      when(() => mockNostrService.publishEvent(any())).thenAnswer((
-        invocation,
-      ) async {
-        return PublishSuccess(
-          event: invocation.positionalArguments[0] as Event,
+      when(
+        () => mockNostrService.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((invocation) async {
+        return PublishOutcome(
+          eventId: (invocation.positionalArguments[0] as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
         );
       });
 
@@ -337,11 +351,17 @@ void main() {
         return Future.value(capturedEvent);
       });
 
-      when(() => mockNostrService.publishEvent(any())).thenAnswer((
-        invocation,
-      ) async {
-        return PublishSuccess(
-          event: invocation.positionalArguments[0] as Event,
+      when(
+        () => mockNostrService.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer((invocation) async {
+        return PublishOutcome(
+          eventId: (invocation.positionalArguments[0] as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
         );
       });
 

--- a/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
+++ b/mobile/test/services/video_event_publisher_publish_confirmation_test.dart
@@ -6,6 +6,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show AudioEvent, VideoEvent, audioEventKind;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
@@ -53,6 +54,7 @@ void main() {
     registerFallbackValue(_FakeVideoEvent());
     registerFallbackValue(UploadStatus.pending);
     registerFallbackValue(File(''));
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -137,8 +139,18 @@ void main() {
 
   void stubPublish(Event event) {
     when(
-      () => mockNostrClient.publishEvent(any()),
-    ).thenAnswer((_) async => PublishSuccess(event: event));
+      () => mockNostrClient.publishEventAwaitOk(
+        any(),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => PublishOutcome(
+        eventId: event.id,
+        acceptedBy: const ['wss://relay.divine.video'],
+        rejectedBy: const {},
+        noResponseFrom: const [],
+      ),
+    );
   }
 
   bool containsTag(List<List<String>> tags, List<String> expected) {
@@ -170,15 +182,64 @@ void main() {
       verify(() => mockVideoEventService.addVideoEvent(any())).called(1);
     });
 
+    test('does not mark published when relays reject with OK false despite '
+        'successful send', () async {
+      final signedEvent = createSignedEvent();
+      stubSigning(signedEvent);
+      // WebSocket frame accepted by the pool...
+      when(
+        () => mockNostrClient.publishEvent(any()),
+      ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
+      // ...but every relay rejects the event at the protocol level
+      // (NIP-20 `OK false`, e.g. divine relay policy rejection).
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: signedEvent.id,
+          acceptedBy: const [],
+          rejectedBy: const {
+            'wss://relay.divine.video': 'blocked: event rejected by policy',
+          },
+          noResponseFrom: const [],
+        ),
+      );
+
+      final result = await publisher.publishDirectUpload(createUpload());
+
+      expect(result, isFalse);
+      verifyNever(
+        () => mockUploadManager.updateUploadStatus(
+          any(),
+          UploadStatus.published,
+          nostrEventId: any(named: 'nostrEventId'),
+        ),
+      );
+      verifyNever(() => mockVideoEventService.addVideoEvent(any()));
+    });
+
     test(
       'returns false when relay rejects the event on all attempts',
       () async {
         final signedEvent = createSignedEvent();
         stubSigning(signedEvent);
-        // Relay rejects the event (publishEvent returns PublishFailed).
+        // Relay rejects the event (no relay accepts the publish).
         when(
-          () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => const PublishFailed());
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (_) async => PublishOutcome(
+            eventId: signedEvent.id,
+            acceptedBy: const [],
+            rejectedBy: const {'wss://relay.divine.video': 'rejected'},
+            noResponseFrom: const [],
+          ),
+        );
 
         final result = await publisher.publishDirectUpload(createUpload());
 
@@ -213,7 +274,12 @@ void main() {
           tags: any(named: 'tags'),
         ),
       );
-      verify(() => mockNostrClient.publishEvent(signedEvent)).called(1);
+      verify(
+        () => mockNostrClient.publishEventAwaitOk(
+          signedEvent,
+          timeout: any(named: 'timeout'),
+        ),
+      ).called(1);
     });
 
     test('adds selected audio tag only for valid Nostr event ids', () async {
@@ -235,9 +301,17 @@ void main() {
           'video content',
         );
       });
-      when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(
-          event: invocation.positionalArguments.single as Event,
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
         ),
       );
 
@@ -277,9 +351,17 @@ void main() {
           'video content',
         );
       });
-      when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(
-          event: invocation.positionalArguments.single as Event,
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
         ),
       );
 
@@ -369,9 +451,17 @@ void main() {
         videoTags = tags;
         return Event(testPubkey, kind, tags, 'video content');
       });
-      when(() => mockNostrClient.publishEvent(any())).thenAnswer(
-        (invocation) async => PublishSuccess(
-          event: invocation.positionalArguments.single as Event,
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
         ),
       );
 

--- a/mobile/test/services/video_event_publisher_reply_tags_test.dart
+++ b/mobile/test/services/video_event_publisher_reply_tags_test.dart
@@ -9,6 +9,7 @@ import 'package:models/models.dart'
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/models/video_reply_context.dart';
@@ -63,6 +64,7 @@ void main() {
     registerFallbackValue(_FakeVideoEvent());
     registerFallbackValue(<Filter>[]);
     registerFallbackValue(UploadStatus.pending);
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -136,8 +138,18 @@ void main() {
     });
 
     when(
-      () => nostrClient.publishEvent(any()),
-    ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
+      () => nostrClient.publishEventAwaitOk(
+        any(),
+        timeout: any(named: 'timeout'),
+      ),
+    ).thenAnswer(
+      (_) async => PublishOutcome(
+        eventId: publishedEvent.id,
+        acceptedBy: const ['wss://relay.divine.video'],
+        rejectedBy: const {},
+        noResponseFrom: const [],
+      ),
+    );
     when(
       () => nostrClient.queryEvents(
         any(),

--- a/mobile/test/services/video_event_publisher_subtitle_test.dart
+++ b/mobile/test/services/video_event_publisher_subtitle_test.dart
@@ -446,7 +446,7 @@ void main() {
       );
     });
 
-    test('optimistically updates local cache', () async {
+    test('updates local cache after relay confirms acceptance', () async {
       when(
         () => mockAuthService.createAndSignEvent(
           kind: any(named: 'kind'),
@@ -477,6 +477,40 @@ void main() {
       );
 
       verify(() => mockVideoEventService.addVideoEvent(any())).called(1);
+    });
+
+    test('does not update local cache when relay rejects republish', () async {
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => createSignedEvent(existingTags));
+
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const [],
+          rejectedBy: const {
+            'wss://relay.divine.video': 'blocked: event rejected by policy',
+          },
+          noResponseFrom: const [],
+        ),
+      );
+
+      final result = await publisher.republishWithSubtitles(
+        existingEvent: existingEvent,
+        textTrackRef: textTrackRef,
+      );
+
+      expect(result, isFalse);
+      verifyNever(() => mockVideoEventService.addVideoEvent(any()));
     });
   });
 }

--- a/mobile/test/services/video_event_publisher_subtitle_test.dart
+++ b/mobile/test/services/video_event_publisher_subtitle_test.dart
@@ -7,6 +7,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' hide NIP71VideoKinds;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/upload_manager.dart';
@@ -43,6 +44,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(_FakeEvent());
     registerFallbackValue(_FakeVideoEvent());
+    registerFallbackValue(Duration.zero);
   });
 
   setUp(() {
@@ -120,8 +122,18 @@ void main() {
         });
 
         when(
-          () => mockNostrClient.publishEvent(any()),
-        ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (invocation) async => PublishOutcome(
+            eventId: (invocation.positionalArguments.first as Event).id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          ),
+        );
 
         when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -180,8 +192,18 @@ void main() {
       });
 
       when(
-        () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -210,8 +232,18 @@ void main() {
       ).thenAnswer((_) async => createSignedEvent(existingTags));
 
       when(
-        () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -241,8 +273,18 @@ void main() {
       ).thenAnswer((_) async => signedEvent);
 
       when(
-        () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -251,7 +293,12 @@ void main() {
         textTrackRef: textTrackRef,
       );
 
-      verify(() => mockNostrClient.publishEvent(any())).called(1);
+      verify(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).called(1);
     });
 
     test('returns false when signing fails', () async {
@@ -269,7 +316,12 @@ void main() {
       );
 
       expect(result, isFalse);
-      verifyNever(() => mockNostrClient.publishEvent(any()));
+      verifyNever(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      );
     });
 
     test('does not duplicate text-track tag if one already exists', () async {
@@ -311,8 +363,18 @@ void main() {
       });
 
       when(
-        () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -350,8 +412,18 @@ void main() {
       });
 
       when(
-        () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 
@@ -384,8 +456,18 @@ void main() {
       ).thenAnswer((_) async => createSignedEvent(existingTags));
 
       when(
-        () => mockNostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: _FakeEvent()));
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
 
       when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
 

--- a/mobile/test/services/video_event_publisher_test.dart
+++ b/mobile/test/services/video_event_publisher_test.dart
@@ -14,6 +14,7 @@ import 'package:models/models.dart' show AudioEvent, audioEventKind;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/relay/relay_pool.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/models/pending_upload.dart';
@@ -512,6 +513,7 @@ void main() {
           createdAt: 0,
         ),
       );
+      registerFallbackValue(Duration.zero);
     });
 
     setUp(() {
@@ -585,8 +587,18 @@ void main() {
       });
 
       when(
-        () => nostrClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: publishedEvent));
+        () => nostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (_) async => PublishOutcome(
+          eventId: publishedEvent.id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
     }
 
     test('publishVideoEvent passes generic mention p-tags through', () async {
@@ -648,10 +660,18 @@ void main() {
         });
 
         when(
-          () => nostrClient.publishEvent(any()),
+          () => nostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
         ).thenAnswer((invocation) async {
           final event = invocation.positionalArguments.first as Event;
-          return PublishSuccess(event: event);
+          return PublishOutcome(
+            eventId: event.id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          );
         });
       });
 


### PR DESCRIPTION
Closes #5122

## Summary

Correctness fix (audit finding COR-03): `VideoEventPublisher._publishEventToNostr` treated a successful WebSocket send (`publishEvent` → `PublishSuccess`) as publish success. Per the SDK's own contract, a send does NOT mean the relay accepted the event — the divine relay rejects policy-violating kind-34236 events with NIP-20 `OK false` (e.g. missing thumbnail). Those uploads were marked `UploadStatus.published` and injected into the local discovery cache while the video was silently dropped relay-side: the user sees it as live, nobody else ever does.

## Changes

- `_publishEventToNostr` now calls `publishEventAwaitOk` and returns true only when at least one relay confirms with `OK true` (`PublishOutcome.confirmed`). Rejection / no-response / timeout feed the existing 3-attempt retry loop and then the failed flow, exactly as other failures already did.
- The `outerPublishTimeoutFor`-derived bound is passed as the OK-wait timeout (the SDK's publish tracker starts it before the send fan-out, so it covers send + OK wait); the outer `Future.timeout` keeps one `perRelaySendTimeout` of slack as backstop for pre-tracker stalls (`retryDisconnectedRelays`).
- All four `_publishEventToNostr` call sites (direct video publish, both audio-event paths, `republishWithSubtitles`) get OK-confirmation semantics; none publish ephemeral kinds, so NIP-20 responses are expected.
- New regression test: WS send succeeds but every relay rejects with `OK false` → upload is NOT marked published, video NOT injected into the feed.
- Mechanically migrated the existing publisher test stubs from `publishEvent` to `publishEventAwaitOk` (8 files); stale comments updated.

## Test plan

- [x] New regression test fails on main (upload marked published despite rejection), passes with the fix
- [x] All 11 VideoEventPublisher/VideoPublishService suites: 113 passed, 1 pre-existing skip
- [x] `dart format` / `flutter analyze lib/services test/services` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)