### PR TITLE
fix(auth): discard stale background RPC refresh after sign-out or account switch

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -585,6 +585,16 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
 
+    // The refresh below runs unawaited across an async gap. If the user
+    // signs out or switches accounts while it is in flight, applying the
+    // result would attach the previous account's RPC signer to whichever
+    // identity is active by then.
+    final upgradeOwnerPubkey =
+        expectedOwnerPubkey ?? session?.userPubkey ?? currentPublicKeyHex;
+    bool upgradeContextStillCurrent() =>
+        _authState == AuthState.authenticated &&
+        currentPublicKeyHex == upgradeOwnerPubkey;
+
     _isRpcUpgradeInProgress = true;
     try {
       if (_oauthClient == null) {
@@ -595,6 +605,16 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       final refreshed = await _refreshOAuthSession(
         expectedOwnerPubkey: expectedOwnerPubkey ?? session?.userPubkey,
       ).timeout(rpcRefreshTimeout);
+
+      if (!upgradeContextStillCurrent()) {
+        Log.warning(
+          'initialize: discarding stale background RPC refresh — '
+          'signed out or switched accounts while it was in flight',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        return;
+      }
 
       if (refreshed != null) {
         Log.info(
@@ -630,6 +650,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Nudge the auth stream so widgets re-evaluate whether the
       // session-expired sheet should be shown now that the upgrade has resolved.
       _authStateController.add(_authState);
+    }
+
+    // A late failure must not downgrade whichever account is active now.
+    if (!upgradeContextStillCurrent()) {
+      return;
     }
 
     _setRpcCapability(AuthRpcCapability.unavailable);

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -3626,6 +3626,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       // Clean up Keycast RPC signer if active
       _keycastSigner = null;
+      _setRpcCapability(AuthRpcCapability.unavailable);
 
       try {
         if (_oauthClient != null) {
@@ -3793,6 +3794,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       await _clearAmberInfo();
     } catch (_) {}
     _keycastSigner = null;
+    _setRpcCapability(AuthRpcCapability.unavailable);
     _keyStorage.clearCache();
 
     try {
@@ -4521,6 +4523,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     // This prevents a Keycast RPC signer from a previous Divine OAuth session
     // from being used when signing events for an anonymous/imported-key account.
     if (source != AuthenticationSource.divineOAuth) {
+      _setRpcCapability(AuthRpcCapability.unavailable);
       if (_keycastSigner != null) {
         Log.info(
           '_setupUserSession: clearing stale Keycast signer '
@@ -5212,7 +5215,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     try {
       if (_oauthClient == null || _keycastSigner == null) return;
 
+      final resumeOwnerPubkey = currentPublicKeyHex;
+      if (resumeOwnerPubkey == null) return;
+      bool resumeContextStillCurrent() =>
+          _authState == AuthState.authenticated &&
+          currentPublicKeyHex == resumeOwnerPubkey;
+
       final session = await _oauthClient.getSession();
+      if (!resumeContextStillCurrent()) return;
       if (session != null) return;
 
       Log.info(
@@ -5220,7 +5230,17 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         name: 'AuthService',
         category: LogCategory.auth,
       );
-      final refreshed = await _refreshOAuthSession();
+      final refreshed = await _refreshOAuthSession(
+        expectedOwnerPubkey: resumeOwnerPubkey,
+      );
+      if (!resumeContextStillCurrent()) {
+        Log.warning(
+          '📱 App resumed - discarding stale OAuth refresh result',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        return;
+      }
       if (refreshed != null) {
         _keycastSigner = KeycastRpc.fromSession(
           _oauthConfig,

--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -12,6 +12,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_identity.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -281,6 +282,90 @@ void main() {
         (error, stack) {
           // Ignore background errors
         },
+      );
+    });
+
+    test('stale background RPC refresh does not resurrect the previous '
+        'account after sign-out and account switch', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final accountAPubkey = arrangeExpiredSessionWithMatchingLocalKeys();
+
+      // The refresh for account A stays in flight across sign-out and
+      // the switch to a fresh account.
+      final refreshCompleter = Completer<KeycastSession?>();
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) => refreshCompleter.future);
+      when(() => mockOAuthClient.logout()).thenAnswer((_) async {});
+
+      final authService = createAuthService();
+
+      // Assertions live OUTSIDE the zone: a failing expect inside
+      // runZonedGuarded is swallowed by the zone handler and the test
+      // hangs to timeout instead of reporting the failure.
+      late bool authenticatedAfterInit;
+      late AuthRpcCapability capabilityAfterInit;
+      late bool authenticatedAfterSignOut;
+      late AuthResult imported;
+      String? accountBPubkey;
+
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
+          authenticatedAfterInit = authService.isAuthenticated;
+          capabilityAfterInit = authService.authRpcCapability;
+
+          await authService.signOut();
+          authenticatedAfterSignOut = authService.isAuthenticated;
+
+          imported = await authService.importFromHex(generatePrivateKey());
+          accountBPubkey = authService.currentPublicKeyHex;
+
+          // Account A's refresh finally resolves with a fresh session.
+          refreshCompleter.complete(
+            KeycastSession(
+              bunkerUrl: 'https://login.divine.video/api/nostr',
+              accessToken: 'fresh_token_for_account_a',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+              userPubkey: accountAPubkey,
+            ),
+          );
+          await pumpEventQueue();
+        },
+        (error, stack) {
+          // Ignore background relay discovery errors
+        },
+      );
+
+      expect(authenticatedAfterInit, isTrue);
+      expect(capabilityAfterInit, equals(AuthRpcCapability.upgrading));
+      expect(authenticatedAfterSignOut, isFalse);
+      expect(imported.success, isTrue);
+      expect(accountBPubkey, isNotNull);
+      expect(accountBPubkey, isNot(equals(accountAPubkey)));
+      expect(
+        authService.currentPublicKeyHex,
+        equals(accountBPubkey),
+        reason: 'stale refresh must not change the active account',
+      );
+      expect(
+        authService.authRpcCapability,
+        isNot(equals(AuthRpcCapability.rpcReady)),
+        reason:
+            "account A's refresh must not grant RPC capability to account B",
+      );
+      expect(
+        authService.currentIdentity,
+        isNot(isA<KeycastNostrIdentity>()),
+        reason:
+            "account A's RPC signer must not be attached to account B's "
+            'identity',
       );
     });
 

--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -100,20 +100,22 @@ void main() {
           });
     });
 
-    /// Helper: stores an expired Keycast session and a valid local nsec
-    /// that matches the session pubkey.
-    String arrangeExpiredSessionWithMatchingLocalKeys() {
+    /// Helper: stores a Keycast session and a valid local nsec that matches
+    /// the session pubkey.
+    String arrangeSessionWithMatchingLocalKeys({
+      required DateTime expiresAt,
+    }) {
       final privateKeyHex = generatePrivateKey();
       final container = SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
       final pubkey = container.publicKeyHex;
 
-      final expiredSession = KeycastSession(
+      final session = KeycastSession(
         bunkerUrl: 'https://login.divine.video/api/nostr',
-        accessToken: 'expired_token_abc123',
-        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        accessToken: 'token_abc123',
+        expiresAt: expiresAt,
         userPubkey: pubkey,
       );
-      secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+      secureStorage['keycast_session'] = jsonEncode(session.toJson());
 
       secureStorage['nostr_primary_key'] =
           'privateKeyHex:$privateKeyHex'
@@ -121,6 +123,14 @@ void main() {
           '|npub:${container.npub}';
 
       return pubkey;
+    }
+
+    /// Helper: stores an expired Keycast session and a valid local nsec
+    /// that matches the session pubkey.
+    String arrangeExpiredSessionWithMatchingLocalKeys() {
+      return arrangeSessionWithMatchingLocalKeys(
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+      );
     }
 
     AuthService createAuthService() {
@@ -366,6 +376,91 @@ void main() {
         reason:
             "account A's RPC signer must not be attached to account B's "
             'identity',
+      );
+    });
+
+    test('stale app-resume OAuth refresh does not attach the previous '
+        'account signer after sign-out and account switch', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final accountAPubkey = arrangeSessionWithMatchingLocalKeys(
+        expiresAt: DateTime.now().add(const Duration(hours: 1)),
+      );
+
+      final refreshCompleter = Completer<KeycastSession?>();
+      when(() => mockOAuthClient.getSession()).thenAnswer((_) async => null);
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) => refreshCompleter.future);
+      when(() => mockOAuthClient.logout()).thenAnswer((_) async {});
+
+      final authService = createAuthService();
+
+      late bool authenticatedAfterInit;
+      late AuthRpcCapability capabilityAfterInit;
+      late bool authenticatedAfterSignOut;
+      late AuthResult imported;
+      String? accountBPubkey;
+
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
+          authenticatedAfterInit = authService.isAuthenticated;
+          capabilityAfterInit = authService.authRpcCapability;
+
+          authService.onAppResumed();
+          await pumpEventQueue();
+
+          await authService.signOut();
+          authenticatedAfterSignOut = authService.isAuthenticated;
+
+          imported = await authService.importFromHex(generatePrivateKey());
+          accountBPubkey = authService.currentPublicKeyHex;
+
+          refreshCompleter.complete(
+            KeycastSession(
+              bunkerUrl: 'https://login.divine.video/api/nostr',
+              accessToken: 'fresh_token_for_account_a',
+              expiresAt: DateTime.now().add(const Duration(hours: 1)),
+              userPubkey: accountAPubkey,
+            ),
+          );
+          await pumpEventQueue();
+        },
+        (error, stack) {
+          // Ignore background relay discovery errors.
+        },
+      );
+
+      expect(authenticatedAfterInit, isTrue);
+      expect(capabilityAfterInit, equals(AuthRpcCapability.rpcReady));
+      expect(authenticatedAfterSignOut, isFalse);
+      expect(imported.success, isTrue);
+      expect(accountBPubkey, isNotNull);
+      expect(accountBPubkey, isNot(equals(accountAPubkey)));
+      expect(
+        authService.currentPublicKeyHex,
+        equals(accountBPubkey),
+        reason: 'stale resume refresh must not change the active account',
+      );
+      expect(
+        authService.authRpcCapability,
+        isNot(equals(AuthRpcCapability.rpcReady)),
+        reason:
+            "account A's resume refresh must not grant RPC capability to "
+            'account B',
+      );
+      expect(
+        authService.currentIdentity,
+        isNot(isA<KeycastNostrIdentity>()),
+        reason:
+            "account A's resume RPC signer must not be attached to account "
+            "B's identity",
       );
     });
 


### PR DESCRIPTION
Closes #5058

## Summary

Correctness fix (audit finding COR-05): `_upgradeDivineRpcInBackground` is launched `unawaited` and can spend up to `rpcRefreshTimeout` (10s) awaiting `_refreshOAuthSession`. On success it unconditionally reinstated `_keycastSigner`, rebuilt `_currentIdentity`, and set `AuthRpcCapability.rpcReady` — with no re-check that the world hadn't changed during the await.

If the user signs out and signs into a different account during that window, the stale refresh attaches **account A's RPC signer to account B's identity** (a `KeycastNostrIdentity` with B's pubkey and A's RPC session) and flips B's capability to `rpcReady`. That's a signing-as-the-wrong-identity hazard on the auth hot path.

## Changes

- Capture the upgrade's owner pubkey before the await; after the refresh resolves, bail out unless still `authenticated` **and** the active pubkey matches the captured owner.
- The failure fall-through (`_setRpcCapability(unavailable)`) gets the same guard so a late timeout from the old account's upgrade can't downgrade the new account's capability.

## Test plan

- [x] New regression test (init account A with in-flight refresh → sign out → import account B → resolve A's refresh): fails on main with `rpcReady` granted to account B; passes with the fix
- [x] Full `test/services/auth_service*` suites: 182/182 pass
- [x] `dart format` / `flutter analyze` clean

Note for reviewers: the new test keeps assertions **outside** `runZonedGuarded` — a failing `expect` inside the zone is swallowed by the zone handler and hangs the test to timeout instead of reporting. Worth knowing for the other tests in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)