### PR TITLE
fix(feed): close check-then-act race in subscribeToVideoFeed

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -166,6 +166,12 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   // Track active subscriptions per type
   final Map<SubscriptionType, String> _activeSubscriptions = {};
   final Map<String, StreamSubscription> _subscriptions = {};
+
+  // Ids claimed by an in-flight subscribeToVideoFeed call — guards the
+  // async gap between the duplicate-id check and registration in
+  // [_subscriptions], so concurrent identical subscribes can't both
+  // issue a relay REQ.
+  final Set<String> _pendingSubscriptionIds = {};
   final List<String> _activeSubscriptionIds = [];
 
   // Global state
@@ -1574,6 +1580,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       }
 
       // BYPASS SubscriptionManager for main video feed - go directly to NostrService
+      // Holds the id claimed in _pendingSubscriptionIds so the catch
+      // below (where subscriptionId is out of scope) can release it.
+      String? pendingClaimId;
       try {
         // Use the filters we already created above which include authors
         Log.info(
@@ -1684,8 +1693,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           includeReposts: includeReposts,
         );
 
-        // Check if we already have this exact subscription
-        if (_subscriptions.containsKey(subscriptionId)) {
+        // Check if we already have this exact subscription — registered
+        // or still being set up by a concurrent call (the setup below
+        // crosses async gaps, so the claim must happen synchronously here).
+        if (_subscriptions.containsKey(subscriptionId) ||
+            _pendingSubscriptionIds.contains(subscriptionId)) {
           Log.info(
             '🔄 Reusing existing subscription $subscriptionId with identical parameters',
             name: 'VideoEventService',
@@ -1695,6 +1707,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           _activeSubscriptions[subscriptionType] = subscriptionId;
           return; // Reuse existing subscription
         }
+        _pendingSubscriptionIds.add(subscriptionId);
+        pendingClaimId = subscriptionId;
 
         // Create direct subscription using NostrService with proper filters
         final subscriptionStartTime = DateTime.now();
@@ -2014,10 +2028,14 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
         // Store the stream subscription for cleanup
         _subscriptions[subscriptionId] = streamSubscription;
+        _pendingSubscriptionIds.remove(subscriptionId);
         _activeSubscriptions[subscriptionType] = subscriptionId;
 
         // Subscription is tracked per type in _activeSubscriptions
       } catch (e, stackTrace) {
+        if (pendingClaimId != null) {
+          _pendingSubscriptionIds.remove(pendingClaimId);
+        }
         Log.error(
           '❌ Failed to create direct subscription: $e',
           name: 'VideoEventService',

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1696,15 +1696,20 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         // Check if we already have this exact subscription — registered
         // or still being set up by a concurrent call (the setup below
         // crosses async gaps, so the claim must happen synchronously here).
-        if (_subscriptions.containsKey(subscriptionId) ||
+        final hasRegisteredSubscription = _subscriptions.containsKey(
+          subscriptionId,
+        );
+        if (hasRegisteredSubscription ||
             _pendingSubscriptionIds.contains(subscriptionId)) {
           Log.info(
             '🔄 Reusing existing subscription $subscriptionId with identical parameters',
             name: 'VideoEventService',
             category: LogCategory.video,
           );
-          // Update active subscription mapping
-          _activeSubscriptions[subscriptionType] = subscriptionId;
+          if (hasRegisteredSubscription) {
+            // Update active subscription mapping
+            _activeSubscriptions[subscriptionType] = subscriptionId;
+          }
           return; // Reuse existing subscription
         }
         _pendingSubscriptionIds.add(subscriptionId);

--- a/mobile/test/services/video_event_service_subscribe_race_test.dart
+++ b/mobile/test/services/video_event_service_subscribe_race_test.dart
@@ -102,5 +102,43 @@ void main() {
         ).called(1);
       },
     );
+
+    test(
+      'pending reuse does not block retry if first setup fails',
+      () async {
+        final firstTraceGate = Completer<void>();
+        var startTraceCalls = 0;
+        when(() => mockPerformanceMonitor.startTrace(any())).thenAnswer((_) {
+          startTraceCalls++;
+          if (startTraceCalls == 1) return firstTraceGate.future;
+          return Future<void>.value();
+        });
+
+        final first = service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+          limit: 10,
+        );
+
+        await service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+          limit: 10,
+        );
+
+        firstTraceGate.completeError(
+          StateError('trace failed'),
+          StackTrace.current,
+        );
+        await first;
+
+        await service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+          limit: 10,
+        );
+
+        verify(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+        ).called(1);
+      },
+    );
   });
 }

--- a/mobile/test/services/video_event_service_subscribe_race_test.dart
+++ b/mobile/test/services/video_event_service_subscribe_race_test.dart
@@ -1,0 +1,106 @@
+// ABOUTME: Regression test for the subscribeToVideoFeed check-then-act race
+// ABOUTME: Concurrent identical subscribes must produce exactly one relay REQ
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+class _MockPerformanceTraceMonitor extends Mock
+    implements PerformanceTraceMonitor {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeFilter());
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('subscribeToVideoFeed concurrency', () {
+    late _MockNostrClient mockNostrService;
+    late _MockSubscriptionManager mockSubscriptionManager;
+    late _MockPerformanceTraceMonitor mockPerformanceMonitor;
+    late VideoEventService service;
+
+    setUp(() {
+      mockNostrService = _MockNostrClient();
+      mockSubscriptionManager = _MockSubscriptionManager();
+      mockPerformanceMonitor = _MockPerformanceTraceMonitor();
+
+      when(() => mockNostrService.isInitialized).thenReturn(true);
+      when(() => mockNostrService.publicKey).thenReturn('');
+      when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((_) => StreamController<Event>.broadcast().stream);
+
+      when(
+        () => mockPerformanceMonitor.stopTrace(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockPerformanceMonitor.setMetric(any(), any(), any()),
+      ).thenReturn(null);
+      when(
+        () => mockPerformanceMonitor.putAttribute(any(), any(), any()),
+      ).thenReturn(null);
+
+      service = VideoEventService(
+        mockNostrService,
+        subscriptionManager: mockSubscriptionManager,
+        performanceMonitor: mockPerformanceMonitor,
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test(
+      'concurrent identical subscribes create exactly one relay subscription',
+      () async {
+        // Hold the FIRST subscribe call inside its async gap (between the
+        // duplicate-id check and subscription registration) by blocking its
+        // performance-trace await; later calls proceed immediately.
+        final firstTraceGate = Completer<void>();
+        var startTraceCalls = 0;
+        when(() => mockPerformanceMonitor.startTrace(any())).thenAnswer((_) {
+          startTraceCalls++;
+          if (startTraceCalls == 1) return firstTraceGate.future;
+          return Future<void>.value();
+        });
+
+        // First call enters the async gap and parks on the trace gate.
+        final first = service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+          limit: 10,
+        );
+
+        // Second identical call races through while the first is parked.
+        final second = service.subscribeToVideoFeed(
+          subscriptionType: SubscriptionType.discovery,
+          limit: 10,
+        );
+        await second;
+
+        // Release the first call and let it finish.
+        firstTraceGate.complete();
+        await first;
+
+        verify(
+          () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+        ).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #5097

## Summary

Correctness fix (audit finding COR-04): in `VideoEventService.subscribeToVideoFeed`, the duplicate-subscription check (`_subscriptions.containsKey(subscriptionId)`) and the registration (`_subscriptions[subscriptionId] = streamSubscription`) are separated by two awaits (`startTrace`, `_loadCachedEvents`). Two concurrent calls with identical parameters — e.g. the online-retry periodic timer or `_scheduleReconnection` racing a user-triggered subscribe — both pass the check, both issue a relay REQ, and the second overwrites the first in the map. The first listener and its relay-side REQ leak unconditionally (compounding the NostrClient subscription-leak family from the audit).

## Changes

- New `_pendingSubscriptionIds` set: the subscription id is claimed **synchronously** at the duplicate check, before the first await. Concurrent identical calls hit the claim and take the existing reuse-and-return path.
- The claim is released on successful registration and in the failure path (`pendingClaimId` holder, since `subscriptionId` is out of scope in the catch).
- Pending-claim reuse no longer marks `_activeSubscriptions` until a real stream subscription exists, so a failed first setup cannot leave stale active state that blocks the next retry.

## Test plan

- [x] New regression test parks the first subscribe inside its async gap (completer-gated `PerformanceTraceMonitor.startTrace`), races a second identical subscribe, and asserts exactly one `NostrClient.subscribe` call — fails on main (2 calls), passes with the fix
- [x] New failure-path regression test verifies pending reuse does not block the next subscribe if the first setup fails before stream registration
- [x] All `test/services/video_event_service*` suites: 90 passed, 16 pre-existing skips
- [x] `dart format` / `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
