### PR TITLE
fix(upload): track processing-poll timers so dispose() cancels them

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -128,6 +128,11 @@ class UploadManager {
   final Map<String, StreamSubscription<double>> _progressSubscriptions = {};
   final Map<String, UploadMetrics> _uploadMetrics = {};
   final Map<String, Timer> _retryTimers = {};
+
+  // Processing-completion polls keyed by upload id, so dispose() can
+  // cancel them — an untracked periodic timer would keep firing against
+  // a disposed manager for up to 5 minutes.
+  final Map<String, Timer> _processingPollTimers = {};
   final Map<String, Future<void>> _sessionPersistFutures = {};
 
   bool _isInitialized = false;
@@ -1096,7 +1101,7 @@ class UploadManager {
 
       // If upload is in processing state, start polling for completion
       if (updatedUpload.status == UploadStatus.processing) {
-        _startProcessingPoll(updatedUpload);
+        startProcessingPoll(updatedUpload);
       }
     } else {
       throw BlossomUploadFailureException(
@@ -2640,6 +2645,12 @@ Upload Timeout Failure:
     }
     _retryTimers.clear();
 
+    // Cancel all processing-completion polls
+    for (final timer in _processingPollTimers.values) {
+      timer.cancel();
+    }
+    _processingPollTimers.clear();
+
     // Discard pending session persistence futures
     _sessionPersistFutures.clear();
 
@@ -2667,62 +2678,75 @@ Upload Timeout Failure:
     );
   }
 
-  /// Start polling for processing upload completion
-  void _startProcessingPoll(PendingUpload upload) {
+  /// Start polling for processing upload completion.
+  ///
+  /// Visible for testing so the timer lifecycle (cancellation on
+  /// completion, timeout, and [dispose]) can be exercised directly.
+  @visibleForTesting
+  void startProcessingPoll(PendingUpload upload) {
     Log.info(
       '🔄 Starting processing poll for upload: ${upload.id}',
       name: 'UploadManager',
       category: LogCategory.video,
     );
 
+    void stopPoll(Timer timer) {
+      timer.cancel();
+      _processingPollTimers.remove(upload.id);
+    }
+
     // Poll every 10 seconds for up to 5 minutes
-    Timer.periodic(const Duration(seconds: 10), (timer) async {
-      try {
-        // Check if upload still exists and is still processing
-        final currentUpload = getUpload(upload.id);
-        if (currentUpload == null ||
-            currentUpload.status != UploadStatus.processing) {
-          timer.cancel();
-          return;
-        }
+    _processingPollTimers[upload.id]?.cancel();
+    _processingPollTimers[upload.id] = Timer.periodic(
+      const Duration(seconds: 10),
+      (timer) async {
+        try {
+          // Check if upload still exists and is still processing
+          final currentUpload = getUpload(upload.id);
+          if (currentUpload == null ||
+              currentUpload.status != UploadStatus.processing) {
+            stopPoll(timer);
+            return;
+          }
 
-        // Check processing status using Blossom service
-        final isReady = await _checkVideoProcessingStatus(currentUpload);
-        if (isReady) {
-          // Update upload to ready state
-          final readyUpload = currentUpload.copyWith(
-            status: UploadStatus.readyToPublish,
-            uploadProgress: 1.0,
-            completedAt: DateTime.now(),
-          );
-          await _updateUpload(readyUpload);
+          // Check processing status using Blossom service
+          final isReady = await _checkVideoProcessingStatus(currentUpload);
+          if (isReady) {
+            // Update upload to ready state
+            final readyUpload = currentUpload.copyWith(
+              status: UploadStatus.readyToPublish,
+              uploadProgress: 1.0,
+              completedAt: DateTime.now(),
+            );
+            await _updateUpload(readyUpload);
 
-          Log.info(
-            '✅ Video processing complete: ${upload.id}',
+            Log.info(
+              '✅ Video processing complete: ${upload.id}',
+              name: 'UploadManager',
+              category: LogCategory.video,
+            );
+            stopPoll(timer);
+          }
+        } catch (e) {
+          Log.warning(
+            'Error checking processing status: $e',
             name: 'UploadManager',
             category: LogCategory.video,
           );
-          timer.cancel();
         }
-      } catch (e) {
-        Log.warning(
-          'Error checking processing status: $e',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-      }
 
-      // Cancel after 5 minutes to avoid infinite polling
-      if (timer.tick > 30) {
-        // 30 * 10 seconds = 5 minutes
-        timer.cancel();
-        Log.warning(
-          'Processing poll timeout for upload: ${upload.id}',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-      }
-    });
+        // Cancel after 5 minutes to avoid infinite polling
+        if (timer.tick > 30) {
+          // 30 * 10 seconds = 5 minutes
+          stopPoll(timer);
+          Log.warning(
+            'Processing poll timeout for upload: ${upload.id}',
+            name: 'UploadManager',
+            category: LogCategory.video,
+          );
+        }
+      },
+    );
   }
 
   /// Check if video processing is complete

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -2692,7 +2692,9 @@ Upload Timeout Failure:
 
     void stopPoll(Timer timer) {
       timer.cancel();
-      _processingPollTimers.remove(upload.id);
+      if (identical(_processingPollTimers[upload.id], timer)) {
+        _processingPollTimers.remove(upload.id);
+      }
     }
 
     // Poll every 10 seconds for up to 5 minutes

--- a/mobile/test/services/upload_manager_processing_poll_test.dart
+++ b/mobile/test/services/upload_manager_processing_poll_test.dart
@@ -1,0 +1,109 @@
+// ABOUTME: Tests for UploadManager processing-poll timer lifecycle
+// ABOUTME: Verifies dispose() cancels polls instead of leaking periodic timers
+
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/upload_manager.dart';
+
+class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockBlossomUploadService mockBlossomService;
+  late UploadManager uploadManager;
+  late Directory testDir;
+
+  setUp(() async {
+    testDir = await Directory.systemTemp.createTemp(
+      'upload_manager_poll_test_',
+    );
+    Hive.init(testDir.path);
+    if (!Hive.isAdapterRegistered(1)) {
+      Hive.registerAdapter(UploadStatusAdapter());
+    }
+    if (!Hive.isAdapterRegistered(2)) {
+      Hive.registerAdapter(PendingUploadAdapter());
+    }
+
+    mockBlossomService = _MockBlossomUploadService();
+    when(
+      () => mockBlossomService.getBlossomServer(),
+    ).thenAnswer((_) async => null);
+
+    uploadManager = UploadManager(blossomService: mockBlossomService);
+    await uploadManager.initialize();
+  });
+
+  tearDown(() async {
+    uploadManager.dispose();
+    try {
+      await Hive.close();
+    } on PathNotFoundException catch (_) {
+      // Hive may already have removed the lock file during async shutdown.
+    }
+    try {
+      await testDir.delete(recursive: true);
+    } on PathNotFoundException catch (_) {
+      // Lock file may already be deleted by Hive.close().
+    }
+  });
+
+  Future<PendingUpload> seedProcessingUpload() async {
+    final upload = PendingUpload(
+      id: 'poll-test-upload',
+      localVideoPath: '${testDir.path}/video.mp4',
+      nostrPubkey: 'test-pubkey-123',
+      status: UploadStatus.processing,
+      createdAt: DateTime.now(),
+      videoId: 'poll-test-video',
+    );
+    await Hive.box<PendingUpload>('pending_uploads').put(upload.id, upload);
+    return upload;
+  }
+
+  group('processing poll lifecycle', () {
+    test('polls processing status while the upload is processing', () async {
+      final upload = await seedProcessingUpload();
+
+      fakeAsync((fake) {
+        uploadManager.startProcessingPoll(upload);
+
+        fake
+          ..elapse(const Duration(seconds: 10))
+          ..flushMicrotasks();
+
+        verify(() => mockBlossomService.getBlossomServer()).called(1);
+        expect(fake.periodicTimerCount, equals(1));
+      });
+    });
+
+    test('dispose cancels the processing poll timer', () async {
+      final upload = await seedProcessingUpload();
+
+      fakeAsync((fake) {
+        uploadManager.startProcessingPoll(upload);
+        expect(fake.periodicTimerCount, equals(1));
+
+        uploadManager.dispose();
+
+        expect(
+          fake.periodicTimerCount,
+          equals(0),
+          reason: 'dispose must cancel in-flight processing polls',
+        );
+
+        fake
+          ..elapse(const Duration(seconds: 30))
+          ..flushMicrotasks();
+        verifyNever(() => mockBlossomService.getBlossomServer());
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #5098

## Summary

Correctness fix (audit finding COR-12): `UploadManager._startProcessingPoll` created an anonymous `Timer.periodic` that was never stored, so `dispose()` — which carefully cancels `_retryTimers` and `_saveQueueTimer` — could not cancel it. The poll kept firing every 10 seconds for up to 5 minutes after dispose, against a manager whose `_uploadsBox` was nulled, while the shared `pending_uploads` box may already be owned by a successor instance.

## Changes

- New `_processingPollTimers` map keyed by upload id (mirrors `_retryTimers`); an existing poll for the same upload is cancelled before starting a new one.
- All three self-cancel paths (upload gone/ready, processing complete, 5-minute timeout) release the map entry via a shared `stopPoll` helper.
- `dispose()` cancels and clears the map.
- The method is now `startProcessingPoll` with `@visibleForTesting` (precedent: 4 existing uses in this file) so the timer lifecycle can be exercised directly.

## Test plan

- [x] New tests (fakeAsync): poll fires at 10s while processing; `dispose()` drops `periodicTimerCount` to 0 and no Blossom status calls ever fire afterwards — the dispose test fails on main (timer survives), passes with the fix
- [x] All `test/services/upload_manager*` suites: 111 passed, 11 pre-existing skips
- [x] `dart format` / `flutter analyze` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)