### PR TITLE
fix(library): name imported clips before saving

### DIFF
--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -397,11 +397,17 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     }
 
     try {
-      final result = await importer.importToLibrary(_video);
+      final result = await importer.importToLibrary(
+        _video,
+        libraryTitle: event.libraryTitle,
+      );
       emit(
         state.copyWith(
           actionResult: ShareSheetVideoClipImportResult(
             succeeded: result is VideoClipImportSuccess,
+            libraryTitle: result is VideoClipImportSuccess
+                ? result.clip.libraryTitle
+                : null,
           ),
         ),
       );

--- a/mobile/lib/blocs/share_sheet/share_sheet_event.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_event.dart
@@ -60,7 +60,12 @@ class ShareSheetSaveRequested extends ShareSheetEvent {
 
 /// Add a video (classic Vine or own video) to the local clip library.
 class ShareSheetAddVideoToClipsRequested extends ShareSheetEvent {
-  const ShareSheetAddVideoToClipsRequested();
+  const ShareSheetAddVideoToClipsRequested({this.libraryTitle});
+
+  final String? libraryTitle;
+
+  @override
+  List<Object?> get props => [libraryTitle];
 }
 
 /// Copy share link to clipboard.

--- a/mobile/lib/blocs/share_sheet/share_sheet_state.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_state.dart
@@ -66,9 +66,13 @@ class ShareSheetSaveResult extends ShareSheetActionResult {
 }
 
 class ShareSheetVideoClipImportResult extends ShareSheetActionResult {
-  ShareSheetVideoClipImportResult({required this.succeeded});
+  ShareSheetVideoClipImportResult({
+    required this.succeeded,
+    this.libraryTitle,
+  });
 
   final bool succeeded;
+  final String? libraryTitle;
 }
 
 /// Generic failure for utility actions (copy link, share via, etc.).

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1508,10 +1508,6 @@
     "@shareSheetAddToClips": {
         "description": "Share sheet action label for importing a classic Vine into the clip library"
     },
-    "shareSheetAddedToClips": "ወደ ቅንጥቦች ታክሏል።",
-    "@shareSheetAddedToClips": {
-        "description": "Snackbar shown after successfully importing a classic Vine into the clip library"
-    },
     "shareSheetAddToClipsFailed": "ወደ ቅንጥቦች ማከል አልተቻለም",
     "@shareSheetAddToClipsFailed": {
         "description": "Snackbar shown when importing a classic Vine into the clip library fails"

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1308,7 +1308,6 @@
     "shareSheetSaveWithWatermark": "حفظ مع العلامة المائية",
     "shareSheetSaveVideo": "حفظ الفيديو",
     "shareSheetAddToClips": "إضافة إلى المقاطع",
-    "shareSheetAddedToClips": "تمت الإضافة إلى المقاطع",
     "shareSheetAddToClipsFailed": "تعذّرت الإضافة إلى المقاطع",
     "shareSheetAddToList": "إضافة إلى قائمة",
     "shareSheetCopy": "نسخ",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1395,10 +1395,6 @@
     "@shareSheetAddToClips": {
         "description": "Share sheet action label for importing a classic Vine into the clip library"
     },
-    "shareSheetAddedToClips": "Добавен към клипове",
-    "@shareSheetAddedToClips": {
-        "description": "Snackbar shown after successfully importing a classic Vine into the clip library"
-    },
     "shareSheetAddToClipsFailed": "Не можа да се добави към клипове",
     "@shareSheetAddToClipsFailed": {
         "description": "Snackbar shown when importing a classic Vine into the clip library fails"

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1318,7 +1318,6 @@
     "shareSheetSaveWithWatermark": "Mit Wasserzeichen speichern",
     "shareSheetSaveVideo": "Video speichern",
     "shareSheetAddToClips": "Zu Clips hinzufügen",
-    "shareSheetAddedToClips": "Zu Clips hinzugefügt",
     "shareSheetAddToClipsFailed": "Konnte nicht zu Clips hinzufügen",
     "shareSheetAddToList": "Zur Liste hinzufügen",
     "shareSheetCopy": "Kopieren",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1693,6 +1693,35 @@
   "@shareSheetAddedToClips": {
     "description": "Snackbar shown after successfully importing a classic Vine into the clip library"
   },
+  "shareSheetNameClipTitle": "Name this clip",
+  "@shareSheetNameClipTitle": {
+    "description": "Title for the sheet that lets a user choose the local library title for an imported clip"
+  },
+  "shareSheetNameClipSubtitle": "Pick a name you'll recognize in your library.",
+  "@shareSheetNameClipSubtitle": {
+    "description": "Subtitle for the sheet that lets a user choose the local library title for an imported clip"
+  },
+  "shareSheetClipTitleLabel": "Clip title",
+  "@shareSheetClipTitleLabel": {
+    "description": "Label for the text field where the user names an imported clip"
+  },
+  "shareSheetSaveClip": "Save clip",
+  "@shareSheetSaveClip": {
+    "description": "Button label confirming the imported clip title and saving it to the local library"
+  },
+  "shareSheetSavedClipToClips": "Saved \"{title}\" to clips",
+  "@shareSheetSavedClipToClips": {
+    "description": "Snackbar shown after importing a clip into the local library with its chosen title",
+    "placeholders": {
+      "title": {
+        "type": "String"
+      }
+    }
+  },
+  "shareSheetUntitledClip": "Untitled clip",
+  "@shareSheetUntitledClip": {
+    "description": "Fallback title if a saved clip somehow has no local library title"
+  },
   "shareSheetAddToClipsFailed": "Couldn't add to clips",
   "@shareSheetAddToClipsFailed": {
     "description": "Snackbar shown when importing a classic Vine into the clip library fails"

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1689,10 +1689,6 @@
   "@shareSheetAddToClips": {
     "description": "Share sheet action label for importing a classic Vine into the clip library"
   },
-  "shareSheetAddedToClips": "Added to clips",
-  "@shareSheetAddedToClips": {
-    "description": "Snackbar shown after successfully importing a classic Vine into the clip library"
-  },
   "shareSheetNameClipTitle": "Name this clip",
   "@shareSheetNameClipTitle": {
     "description": "Title for the sheet that lets a user choose the local library title for an imported clip"

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1322,7 +1322,6 @@
     "shareSheetSaveWithWatermark": "Guardar con marca de agua",
     "shareSheetSaveVideo": "Guardar video",
     "shareSheetAddToClips": "Agregar a clips",
-    "shareSheetAddedToClips": "Agregado a clips",
     "shareSheetAddToClipsFailed": "No se pudo agregar a clips",
     "shareSheetAddToList": "Agregar a lista",
     "shareSheetCopy": "Copiar",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -833,7 +833,6 @@
     "shareSheetSaveWithWatermark": "I-save na may Watermark",
     "shareSheetSaveVideo": "I-save ang Video",
     "shareSheetAddToClips": "Idagdag sa clips",
-    "shareSheetAddedToClips": "Naidagdag sa clips",
     "shareSheetAddToClipsFailed": "Hindi naidagdag sa clips",
     "shareSheetAddToList": "Idagdag sa List",
     "shareSheetCopy": "Kopyahin",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1318,7 +1318,6 @@
     "shareSheetSaveWithWatermark": "Enregistrer avec filigrane",
     "shareSheetSaveVideo": "Enregistrer la vidéo",
     "shareSheetAddToClips": "Ajouter aux clips",
-    "shareSheetAddedToClips": "Ajouté aux clips",
     "shareSheetAddToClipsFailed": "Impossible d'ajouter aux clips",
     "shareSheetAddToList": "Ajouter à une liste",
     "shareSheetCopy": "Copier",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1315,7 +1315,6 @@
     "shareSheetSaveWithWatermark": "Simpan dengan Watermark",
     "shareSheetSaveVideo": "Simpan Video",
     "shareSheetAddToClips": "Tambahkan ke klip",
-    "shareSheetAddedToClips": "Ditambahkan ke klip",
     "shareSheetAddToClipsFailed": "Tidak dapat menambahkan ke klip",
     "shareSheetAddToList": "Tambah ke Daftar",
     "shareSheetCopy": "Salin",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1318,7 +1318,6 @@
     "shareSheetSaveWithWatermark": "Salva con filigrana",
     "shareSheetSaveVideo": "Salva video",
     "shareSheetAddToClips": "Aggiungi ai clip",
-    "shareSheetAddedToClips": "Aggiunto ai clip",
     "shareSheetAddToClipsFailed": "Impossibile aggiungere ai clip",
     "shareSheetAddToList": "Aggiungi a lista",
     "shareSheetCopy": "Copia",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1308,7 +1308,6 @@
     "shareSheetSaveWithWatermark": "ウォーターマーク付きで保存",
     "shareSheetSaveVideo": "動画を保存",
     "shareSheetAddToClips": "クリップに追加",
-    "shareSheetAddedToClips": "クリップに追加しました",
     "shareSheetAddToClipsFailed": "クリップに追加できませんでした",
     "shareSheetAddToList": "リストに追加",
     "shareSheetCopy": "コピー",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -758,7 +758,6 @@
     "shareSheetSaveWithWatermark": "워터마크와 함께 저장",
     "shareSheetSaveVideo": "영상 저장",
     "shareSheetAddToClips": "클립에 추가",
-    "shareSheetAddedToClips": "클립에 추가했어요",
     "shareSheetAddToClipsFailed": "클립에 추가할 수 없어요",
     "shareSheetAddToList": "리스트에 추가",
     "shareSheetCopy": "복사",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1318,7 +1318,6 @@
     "shareSheetSaveWithWatermark": "Opslaan met watermerk",
     "shareSheetSaveVideo": "Video opslaan",
     "shareSheetAddToClips": "Toevoegen aan clips",
-    "shareSheetAddedToClips": "Toegevoegd aan clips",
     "shareSheetAddToClipsFailed": "Kon niet toevoegen aan clips",
     "shareSheetAddToList": "Toevoegen aan lijst",
     "shareSheetCopy": "Kopiëren",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1318,7 +1318,6 @@
     "shareSheetSaveWithWatermark": "Zapisz ze znakiem wodnym",
     "shareSheetSaveVideo": "Zapisz film",
     "shareSheetAddToClips": "Dodaj do klipów",
-    "shareSheetAddedToClips": "Dodano do klipów",
     "shareSheetAddToClipsFailed": "Nie można dodać do klipów",
     "shareSheetAddToList": "Dodaj do listy",
     "shareSheetCopy": "Kopiuj",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1318,7 +1318,6 @@
     "shareSheetSaveWithWatermark": "Salvar com marca d'água",
     "shareSheetSaveVideo": "Salvar vídeo",
     "shareSheetAddToClips": "Adicionar aos clipes",
-    "shareSheetAddedToClips": "Adicionado aos clipes",
     "shareSheetAddToClipsFailed": "Não foi possível adicionar aos clipes",
     "shareSheetAddToList": "Adicionar à lista",
     "shareSheetCopy": "Copiar",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1318,7 +1318,6 @@
     "shareSheetSaveWithWatermark": "Salvează cu filigran",
     "shareSheetSaveVideo": "Salvează videoclipul",
     "shareSheetAddToClips": "Adaugă la clipuri",
-    "shareSheetAddedToClips": "Adăugat la clipuri",
     "shareSheetAddToClipsFailed": "Nu s-a putut adăuga la clipuri",
     "shareSheetAddToList": "Adaugă la listă",
     "shareSheetCopy": "Copiază",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1318,7 +1318,6 @@
     "shareSheetSaveWithWatermark": "Spara med vattenmärke",
     "shareSheetSaveVideo": "Spara video",
     "shareSheetAddToClips": "Lägg till i klipp",
-    "shareSheetAddedToClips": "Tillagt i klipp",
     "shareSheetAddToClipsFailed": "Kunde inte lägga till i klipp",
     "shareSheetAddToList": "Lägg till i lista",
     "shareSheetCopy": "Kopiera",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1315,7 +1315,6 @@
     "shareSheetSaveWithWatermark": "Filigranlı Kaydet",
     "shareSheetSaveVideo": "Videoyu Kaydet",
     "shareSheetAddToClips": "Kliplere ekle",
-    "shareSheetAddedToClips": "Kliplere eklendi",
     "shareSheetAddToClipsFailed": "Kliplere eklenemedi",
     "shareSheetAddToList": "Listeye Ekle",
     "shareSheetCopy": "Kopyala",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5522,6 +5522,42 @@ abstract class AppLocalizations {
   /// **'Added to clips'**
   String get shareSheetAddedToClips;
 
+  /// Title for the sheet that lets a user choose the local library title for an imported clip
+  ///
+  /// In en, this message translates to:
+  /// **'Name this clip'**
+  String get shareSheetNameClipTitle;
+
+  /// Subtitle for the sheet that lets a user choose the local library title for an imported clip
+  ///
+  /// In en, this message translates to:
+  /// **'Pick a name you\'ll recognize in your library.'**
+  String get shareSheetNameClipSubtitle;
+
+  /// Label for the text field where the user names an imported clip
+  ///
+  /// In en, this message translates to:
+  /// **'Clip title'**
+  String get shareSheetClipTitleLabel;
+
+  /// Button label confirming the imported clip title and saving it to the local library
+  ///
+  /// In en, this message translates to:
+  /// **'Save clip'**
+  String get shareSheetSaveClip;
+
+  /// Snackbar shown after importing a clip into the local library with its chosen title
+  ///
+  /// In en, this message translates to:
+  /// **'Saved \"{title}\" to clips'**
+  String shareSheetSavedClipToClips(String title);
+
+  /// Fallback title if a saved clip somehow has no local library title
+  ///
+  /// In en, this message translates to:
+  /// **'Untitled clip'**
+  String get shareSheetUntitledClip;
+
   /// Snackbar shown when importing a classic Vine into the clip library fails
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5516,12 +5516,6 @@ abstract class AppLocalizations {
   /// **'Add to clips'**
   String get shareSheetAddToClips;
 
-  /// Snackbar shown after successfully importing a classic Vine into the clip library
-  ///
-  /// In en, this message translates to:
-  /// **'Added to clips'**
-  String get shareSheetAddedToClips;
-
   /// Title for the sheet that lets a user choose the local library title for an imported clip
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3079,9 +3079,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get shareSheetAddToClips => 'ወደ ቅንጥቦች ያክሉ';
 
   @override
-  String get shareSheetAddedToClips => 'ወደ ቅንጥቦች ታክሏል።';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -3082,6 +3082,27 @@ class AppLocalizationsAm extends AppLocalizations {
   String get shareSheetAddedToClips => 'ወደ ቅንጥቦች ታክሏል።';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'ወደ ቅንጥቦች ማከል አልተቻለም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3101,9 +3101,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shareSheetAddToClips => 'إضافة إلى المقاطع';
 
   @override
-  String get shareSheetAddedToClips => 'تمت الإضافة إلى المقاطع';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -3104,6 +3104,27 @@ class AppLocalizationsAr extends AppLocalizations {
   String get shareSheetAddedToClips => 'تمت الإضافة إلى المقاطع';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'تعذّرت الإضافة إلى المقاطع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3185,6 +3185,27 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shareSheetAddedToClips => 'Добавен към клипове';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Не можа да се добави към клипове';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3182,9 +3182,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get shareSheetAddToClips => 'Добави към клипове';
 
   @override
-  String get shareSheetAddedToClips => 'Добавен към клипове';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3177,6 +3177,27 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shareSheetAddedToClips => 'Zu Clips hinzugefügt';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Konnte nicht zu Clips hinzufügen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3174,9 +3174,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get shareSheetAddToClips => 'Zu Clips hinzufügen';
 
   @override
-  String get shareSheetAddedToClips => 'Zu Clips hinzugefügt';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3138,9 +3138,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareSheetAddToClips => 'Add to clips';
 
   @override
-  String get shareSheetAddedToClips => 'Added to clips';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -3141,6 +3141,27 @@ class AppLocalizationsEn extends AppLocalizations {
   String get shareSheetAddedToClips => 'Added to clips';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Couldn\'t add to clips';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3173,9 +3173,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareSheetAddToClips => 'Agregar a clips';
 
   @override
-  String get shareSheetAddedToClips => 'Agregado a clips';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3176,6 +3176,27 @@ class AppLocalizationsEs extends AppLocalizations {
   String get shareSheetAddedToClips => 'Agregado a clips';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'No se pudo agregar a clips';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3190,6 +3190,27 @@ class AppLocalizationsFil extends AppLocalizations {
   String get shareSheetAddedToClips => 'Naidagdag sa clips';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Hindi naidagdag sa clips';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3187,9 +3187,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get shareSheetAddToClips => 'Idagdag sa clips';
 
   @override
-  String get shareSheetAddedToClips => 'Naidagdag sa clips';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3186,6 +3186,27 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareSheetAddedToClips => 'Ajouté aux clips';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Impossible d\'ajouter aux clips';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3183,9 +3183,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get shareSheetAddToClips => 'Ajouter aux clips';
 
   @override
-  String get shareSheetAddedToClips => 'Ajouté aux clips';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3113,9 +3113,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareSheetAddToClips => 'Tambahkan ke klip';
 
   @override
-  String get shareSheetAddedToClips => 'Ditambahkan ke klip';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -3116,6 +3116,27 @@ class AppLocalizationsId extends AppLocalizations {
   String get shareSheetAddedToClips => 'Ditambahkan ke klip';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Tidak dapat menambahkan ke klip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3172,9 +3172,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get shareSheetAddToClips => 'Aggiungi ai clip';
 
   @override
-  String get shareSheetAddedToClips => 'Aggiunto ai clip';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3175,6 +3175,27 @@ class AppLocalizationsIt extends AppLocalizations {
   String get shareSheetAddedToClips => 'Aggiunto ai clip';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Impossibile aggiungere ai clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2985,9 +2985,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shareSheetAddToClips => 'クリップに追加';
 
   @override
-  String get shareSheetAddedToClips => 'クリップに追加しました';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2988,6 +2988,27 @@ class AppLocalizationsJa extends AppLocalizations {
   String get shareSheetAddedToClips => 'クリップに追加しました';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'クリップに追加できませんでした';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3001,6 +3001,27 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shareSheetAddedToClips => '클립에 추가했어요';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => '클립에 추가할 수 없어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2998,9 +2998,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get shareSheetAddToClips => '클립에 추가';
 
   @override
-  String get shareSheetAddedToClips => '클립에 추가했어요';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3151,6 +3151,27 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareSheetAddedToClips => 'Toegevoegd aan clips';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Kon niet toevoegen aan clips';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3148,9 +3148,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get shareSheetAddToClips => 'Toevoegen aan clips';
 
   @override
-  String get shareSheetAddedToClips => 'Toegevoegd aan clips';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3214,6 +3214,27 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shareSheetAddedToClips => 'Dodano do klipów';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Nie można dodać do klipów';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3211,9 +3211,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get shareSheetAddToClips => 'Dodaj do klipów';
 
   @override
-  String get shareSheetAddedToClips => 'Dodano do klipów';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3165,6 +3165,27 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareSheetAddedToClips => 'Adicionado aos clipes';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed =>
       'Não foi possível adicionar aos clipes';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3162,9 +3162,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get shareSheetAddToClips => 'Adicionar aos clipes';
 
   @override
-  String get shareSheetAddedToClips => 'Adicionado aos clipes';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3232,6 +3232,27 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shareSheetAddedToClips => 'Adăugat la clipuri';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Nu s-a putut adăuga la clipuri';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3229,9 +3229,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get shareSheetAddToClips => 'Adaugă la clipuri';
 
   @override
-  String get shareSheetAddedToClips => 'Adăugat la clipuri';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3133,9 +3133,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get shareSheetAddToClips => 'Lägg till i klipp';
 
   @override
-  String get shareSheetAddedToClips => 'Tillagt i klipp';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -3136,6 +3136,27 @@ class AppLocalizationsSv extends AppLocalizations {
   String get shareSheetAddedToClips => 'Tillagt i klipp';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Kunde inte lägga till i klipp';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3122,6 +3122,27 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareSheetAddedToClips => 'Kliplere eklendi';
 
   @override
+  String get shareSheetNameClipTitle => 'Name this clip';
+
+  @override
+  String get shareSheetNameClipSubtitle =>
+      'Pick a name you\'ll recognize in your library.';
+
+  @override
+  String get shareSheetClipTitleLabel => 'Clip title';
+
+  @override
+  String get shareSheetSaveClip => 'Save clip';
+
+  @override
+  String shareSheetSavedClipToClips(String title) {
+    return 'Saved \"$title\" to clips';
+  }
+
+  @override
+  String get shareSheetUntitledClip => 'Untitled clip';
+
+  @override
   String get shareSheetAddToClipsFailed => 'Kliplere eklenemedi';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -3119,9 +3119,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get shareSheetAddToClips => 'Kliplere ekle';
 
   @override
-  String get shareSheetAddedToClips => 'Kliplere eklendi';
-
-  @override
   String get shareSheetNameClipTitle => 'Name this clip';
 
   @override

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -18,6 +18,7 @@ class DivineVideoClip {
     required this.recordedAt,
     required this.targetAspectRatio,
     required double? originalAspectRatio,
+    this.libraryTitle,
     this.thumbnailPath,
     Duration? thumbnailTimestamp,
     this.processingCompleter,
@@ -37,6 +38,7 @@ class DivineVideoClip {
 
   final String id;
   final EditorVideo video;
+  final String? libraryTitle;
   final Duration duration;
   final DateTime recordedAt;
   final String? thumbnailPath;
@@ -142,6 +144,8 @@ class DivineVideoClip {
   DivineVideoClip copyWith({
     String? id,
     EditorVideo? video,
+    String? libraryTitle,
+    bool clearLibraryTitle = false,
     Duration? duration,
     DateTime? recordedAt,
     String? thumbnailPath,
@@ -170,6 +174,9 @@ class DivineVideoClip {
     return DivineVideoClip(
       id: id ?? this.id,
       video: video ?? this.video,
+      libraryTitle: clearLibraryTitle
+          ? null
+          : (libraryTitle ?? this.libraryTitle),
       duration: duration ?? this.duration,
       recordedAt: recordedAt ?? this.recordedAt,
       thumbnailPath: thumbnailPath ?? this.thumbnailPath,
@@ -210,6 +217,7 @@ class DivineVideoClip {
     return {
       'id': id,
       'filePath': videoPath != null ? p.basename(videoPath) : null,
+      if (libraryTitle != null) 'libraryTitle': libraryTitle,
       'durationMs': duration.inMilliseconds,
       'recordedAt': recordedAt.toIso8601String(),
       'thumbnailPath': thumbnailPath != null
@@ -253,6 +261,7 @@ class DivineVideoClip {
           useOriginalPath: useOriginalPath,
         ),
       ),
+      libraryTitle: json['libraryTitle'] as String?,
       duration: Duration(milliseconds: json['durationMs'] as int),
       recordedAt: DateTime.parse(
         (json['recordedAt'] ?? json['createdAt']) as String,

--- a/mobile/lib/services/video_clip_import_service.dart
+++ b/mobile/lib/services/video_clip_import_service.dart
@@ -7,6 +7,7 @@ import 'package:models/models.dart' as models;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/clip_library_service.dart';
+import 'package:openvine/services/subtitle_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -96,8 +97,9 @@ class VideoClipImportService {
   final VideoMetadataReader _readVideoMetadata;
 
   Future<VideoClipImportResult> importToLibrary(
-    models.VideoEvent video,
-  ) async {
+    models.VideoEvent video, {
+    String? libraryTitle,
+  }) async {
     final playableUrl = await video.getPlayableUrl();
     if (playableUrl == null || playableUrl.isEmpty) {
       return const VideoClipImportFailure(
@@ -122,7 +124,8 @@ class VideoClipImportService {
       );
     }
 
-    final clipId = _clipIdFor(video);
+    final importedAt = _now();
+    final clipId = _clipIdFor(video, importedAt);
     final duration = _durationFor(video);
 
     try {
@@ -147,8 +150,13 @@ class VideoClipImportService {
       final clip = DivineVideoClip(
         id: clipId,
         video: EditorVideo.file(copiedVideo.path),
+        libraryTitle: defaultLibraryTitleFor(
+          video,
+          libraryTitle: libraryTitle,
+          fallbackTime: importedAt,
+        ),
         duration: duration,
-        recordedAt: _now(),
+        recordedAt: importedAt,
         thumbnailPath: thumbnail?.path,
         thumbnailTimestamp: thumbnail?.timestamp,
         originalAspectRatio: actualRatio ?? 1,
@@ -179,6 +187,68 @@ class VideoClipImportService {
     }
   }
 
+  static String defaultLibraryTitleFor(
+    models.VideoEvent video, {
+    String? libraryTitle,
+    DateTime? fallbackTime,
+  }) {
+    final explicit = _normalizedTitle(libraryTitle);
+    if (explicit != null) return explicit;
+
+    final title = _normalizedTitle(video.displayTitle);
+    if (title != null) return title;
+
+    final description = _normalizedTitle(video.displayContent);
+    if (description != null) return description;
+
+    final subtitle = _subtitleTitle(video.textTrackContent);
+    if (subtitle != null) return subtitle;
+
+    return _fallbackTitle(fallbackTime ?? DateTime.now());
+  }
+
+  static String? _subtitleTitle(String? textTrackContent) {
+    if (textTrackContent == null || textTrackContent.trim().isEmpty) {
+      return null;
+    }
+    final cues = SubtitleService.parseVtt(textTrackContent);
+    for (final cue in cues) {
+      final text = _normalizedTitle(cue.text);
+      if (text != null) return text;
+    }
+    return null;
+  }
+
+  static String? _normalizedTitle(String? value) {
+    final trimmed = value?.replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    if (trimmed.length <= 80) return trimmed;
+    return '${trimmed.substring(0, 77).trimRight()}...';
+  }
+
+  static String _fallbackTitle(DateTime time) {
+    const months = [
+      'Jan',
+      'Feb',
+      'Mar',
+      'Apr',
+      'May',
+      'Jun',
+      'Jul',
+      'Aug',
+      'Sep',
+      'Oct',
+      'Nov',
+      'Dec',
+    ];
+    final local = time.toLocal();
+    final month = months[local.month - 1];
+    final hour12 = local.hour % 12 == 0 ? 12 : local.hour % 12;
+    final minute = local.minute.toString().padLeft(2, '0');
+    final marker = local.hour >= 12 ? 'PM' : 'AM';
+    return 'Clip $month ${local.day}, $hour12:$minute $marker';
+  }
+
   Future<File> _copyVideoIntoDocuments(
     File source,
     String documentsPath,
@@ -190,13 +260,13 @@ class VideoClipImportService {
     return source.copy(targetPath);
   }
 
-  String _clipIdFor(models.VideoEvent video) {
+  String _clipIdFor(models.VideoEvent video, DateTime importedAt) {
     final safeStableId = video.stableId.replaceAll(
       RegExp('[^a-zA-Z0-9_-]'),
       '_',
     );
     final prefix = video.isOriginalVine ? 'classic_vine' : 'own_video';
-    return '${prefix}_${safeStableId}_${_now().microsecondsSinceEpoch}';
+    return '${prefix}_${safeStableId}_${importedAt.microsecondsSinceEpoch}';
   }
 
   Duration _durationFor(models.VideoEvent video) {

--- a/mobile/lib/widgets/video_clip/video_clip_preview.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_preview.dart
@@ -209,6 +209,17 @@ class _VideoClipPreviewSheetState extends ConsumerState<VideoClipPreview> {
                     ),
                   ),
 
+                  if (widget.clip.libraryTitle case final title?)
+                    Text(
+                      title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      style: VineTheme.titleMediumFont(
+                        color: VineTheme.onSurface,
+                      ),
+                    ),
+
                   // Action buttons row
                   _ActionButtonsRow(
                     isSaving: _isSaving,

--- a/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
+++ b/mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart
@@ -110,6 +110,12 @@ class _VideoClipThumbnailCardState extends State<VideoClipThumbnailCard> {
                     if (widget.showDurationBadge)
                       _DurationBadge(clip: widget.clip),
 
+                    if (widget.clip.libraryTitle case final title?)
+                      _TitleBadge(
+                        title: title,
+                        bottomOffset: widget.showDurationBadge ? 32 : 8,
+                      ),
+
                     /// Selection check circle - top right
                     if (widget.showSelectionIndicator)
                       _SelectionOverlay(selectionIndex: widget.selectionIndex),
@@ -175,6 +181,37 @@ class _ThumbnailState extends State<_Thumbnail> {
       icon: DivineIconName.videoCamera,
       color: VineTheme.lightText,
       size: 32,
+    );
+  }
+}
+
+class _TitleBadge extends StatelessWidget {
+  const _TitleBadge({required this.title, required this.bottomOffset});
+
+  final String title;
+  final double bottomOffset;
+
+  @override
+  Widget build(BuildContext context) {
+    return PositionedDirectional(
+      start: 8,
+      end: 8,
+      bottom: bottomOffset,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: VineTheme.scrim65,
+          borderRadius: .circular(4),
+        ),
+        child: Padding(
+          padding: const .symmetric(horizontal: 6, vertical: 3),
+          child: Text(
+            title,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: VineTheme.labelSmallFont(),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_clip_import_provider.dart';
+import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/watermark_text_resolver.dart';
@@ -185,11 +186,7 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
           onAddToList: _handleAddToList,
           onSaveOriginal: isOwnContent ? _handleSaveOriginal : null,
           onSaveWithWatermark: _handleSaveWithWatermark,
-          onAddVideoToClips: canAddVideoToClips
-              ? () => _shareSheetBloc.add(
-                  const ShareSheetAddVideoToClipsRequested(),
-                )
-              : null,
+          onAddVideoToClips: canAddVideoToClips ? _handleAddVideoToClips : null,
         ),
       ),
     );
@@ -240,9 +237,14 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
             widget.inheritedLookupContext,
           );
         }
-      case ShareSheetVideoClipImportResult(:final succeeded):
+      case ShareSheetVideoClipImportResult(
+        :final succeeded,
+        :final libraryTitle,
+      ):
         final snackText = succeeded
-            ? context.l10n.shareSheetAddedToClips
+            ? context.l10n.shareSheetSavedClipToClips(
+                libraryTitle ?? context.l10n.shareSheetUntitledClip,
+              )
             : context.l10n.shareSheetAddToClipsFailed;
         _safePop(context);
         messenger.showSnackBar(
@@ -285,6 +287,21 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
           ),
         );
     }
+  }
+
+  Future<void> _handleAddVideoToClips() async {
+    final initialTitle = VideoClipImportService.defaultLibraryTitleFor(
+      widget.video,
+    );
+    final libraryTitle = await _ClipTitleSheet.show(
+      context: context,
+      initialTitle: initialTitle,
+    );
+    if (!mounted || libraryTitle == null) return;
+
+    _shareSheetBloc.add(
+      ShareSheetAddVideoToClipsRequested(libraryTitle: libraryTitle),
+    );
   }
 
   Future<void> _handleFindPeople() async {
@@ -363,6 +380,117 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
     await Future<void>.delayed(Duration.zero);
     if (!mounted || !hostContext.mounted) return null;
     return presenter(hostContext);
+  }
+}
+
+class _ClipTitleSheet extends StatefulWidget {
+  const _ClipTitleSheet({required this.initialTitle});
+
+  final String initialTitle;
+
+  static Future<String?> show({
+    required BuildContext context,
+    required String initialTitle,
+  }) {
+    return VineBottomSheet.show<String>(
+      context: context,
+      showHeaderDivider: false,
+      body: _ClipTitleSheet(initialTitle: initialTitle),
+    );
+  }
+
+  @override
+  State<_ClipTitleSheet> createState() => _ClipTitleSheetState();
+}
+
+class _ClipTitleSheetState extends State<_ClipTitleSheet> {
+  late final TextEditingController _controller;
+
+  bool get _canSave => _controller.text.trim().isNotEmpty;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialTitle)
+      ..addListener(_onTitleChanged);
+  }
+
+  @override
+  void dispose() {
+    _controller
+      ..removeListener(_onTitleChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onTitleChanged() => setState(() {});
+
+  void _save() {
+    final title = _controller.text.trim();
+    if (title.isEmpty) return;
+    Navigator.of(context).pop(title);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      top: false,
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: EdgeInsets.fromLTRB(
+            16,
+            20,
+            16,
+            16 + MediaQuery.viewInsetsOf(context).bottom,
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                context.l10n.shareSheetNameClipTitle,
+                textAlign: TextAlign.center,
+                style: VineTheme.headlineSmallFont(),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                context.l10n.shareSheetNameClipSubtitle,
+                textAlign: TextAlign.center,
+                style: VineTheme.bodyLargeFont(
+                  color: VineTheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 24),
+              DivineTextField(
+                controller: _controller,
+                labelText: context.l10n.shareSheetClipTitleLabel,
+                maxLength: 80,
+                maxLines: 1,
+                textInputAction: TextInputAction.done,
+                inputFormatters: [
+                  FilteringTextInputFormatter.singleLineFormatter,
+                ],
+                onSubmitted: (_) => _save(),
+                primaryWhenFilled: true,
+              ),
+              const SizedBox(height: 24),
+              DivineButton(
+                label: context.l10n.shareSheetSaveClip,
+                onPressed: _canSave ? _save : null,
+                expanded: true,
+              ),
+              const SizedBox(height: 12),
+              DivineButton(
+                label: context.l10n.commonCancel,
+                type: DivineButtonType.secondary,
+                onPressed: () => Navigator.of(context).pop(),
+                expanded: true,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -15,6 +15,7 @@ import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/bookmark_service.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:profile_repository/profile_repository.dart';
 
 class _MockVideoSharingService extends Mock implements VideoSharingService {}
@@ -34,7 +35,17 @@ class _MockFile extends Mock implements File {}
 
 class _FakeVideoEvent extends Fake implements VideoEvent {}
 
-class _FakeDivineVideoClip extends Fake implements DivineVideoClip {}
+DivineVideoClip _clip({String? libraryTitle}) {
+  return DivineVideoClip(
+    id: 'clip-1',
+    video: EditorVideo.file('/tmp/clip.mp4'),
+    libraryTitle: libraryTitle,
+    duration: const Duration(seconds: 6),
+    recordedAt: DateTime.utc(2026),
+    targetAspectRatio: .square,
+    originalAspectRatio: 1,
+  );
+}
 
 /// A [VideoEvent] whose [toJson] always throws, used to test error paths.
 class _ThrowingJsonVideoEvent extends Fake implements VideoEvent {
@@ -857,32 +868,59 @@ void main() {
       blocTest<ShareSheetBloc, ShareSheetState>(
         'emits import success when video is added to clips',
         setUp: () {
-          when(() => mockImporter.importToLibrary(any())).thenAnswer(
-            (_) async => VideoClipImportSuccess(_FakeDivineVideoClip()),
+          when(
+            () => mockImporter.importToLibrary(
+              any(),
+              libraryTitle: any(named: 'libraryTitle'),
+            ),
+          ).thenAnswer(
+            (_) async => VideoClipImportSuccess(
+              _clip(libraryTitle: 'My local cut'),
+            ),
           );
         },
         build: () => createBloc(videoClipImportService: mockImporter),
-        act: (bloc) => bloc.add(const ShareSheetAddVideoToClipsRequested()),
+        act: (bloc) => bloc.add(
+          const ShareSheetAddVideoToClipsRequested(
+            libraryTitle: 'My local cut',
+          ),
+        ),
         expect: () => [
           isA<ShareSheetState>().having(
             (state) => state.actionResult,
             'actionResult',
-            isA<ShareSheetVideoClipImportResult>().having(
-              (result) => result.succeeded,
-              'succeeded',
-              isTrue,
-            ),
+            isA<ShareSheetVideoClipImportResult>()
+                .having(
+                  (result) => result.succeeded,
+                  'succeeded',
+                  isTrue,
+                )
+                .having(
+                  (result) => result.libraryTitle,
+                  'libraryTitle',
+                  'My local cut',
+                ),
           ),
         ],
         verify: (_) {
-          verify(() => mockImporter.importToLibrary(testVideo)).called(1);
+          verify(
+            () => mockImporter.importToLibrary(
+              testVideo,
+              libraryTitle: 'My local cut',
+            ),
+          ).called(1);
         },
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
         'emits import failure when importer cannot add the clip',
         setUp: () {
-          when(() => mockImporter.importToLibrary(any())).thenAnswer(
+          when(
+            () => mockImporter.importToLibrary(
+              any(),
+              libraryTitle: any(named: 'libraryTitle'),
+            ),
+          ).thenAnswer(
             (_) async => const VideoClipImportFailure(
               VideoClipImportFailureReason.downloadFailed,
             ),
@@ -924,7 +962,10 @@ void main() {
         'emits import failure AND addError when importer throws (#3715)',
         setUp: () {
           when(
-            () => mockImporter.importToLibrary(any()),
+            () => mockImporter.importToLibrary(
+              any(),
+              libraryTitle: any(named: 'libraryTitle'),
+            ),
           ).thenThrow(Exception('download failed'));
         },
         build: () => createBloc(videoClipImportService: mockImporter),

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -752,6 +752,13 @@ const _knownUntranslatedDebt = {
   'videoClipSaveTo',
   'videoClipDelete',
   'inspiredByAttributionSemanticLabel',
+  // Added by the current l10n/UI pass. English ships; other locales fall back until the next translation pass.
+  'shareSheetClipTitleLabel',
+  'shareSheetNameClipSubtitle',
+  'shareSheetNameClipTitle',
+  'shareSheetSaveClip',
+  'shareSheetSavedClipToClips',
+  'shareSheetUntitledClip',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -330,6 +330,7 @@ void main() {
       final original = DivineVideoClip(
         id: 'test_clip',
         video: EditorVideo.file('/path/to/video.mp4'),
+        libraryTitle: 'Saved rooftop loop',
         thumbnailPath: '/path/to/thumb.jpg',
         duration: const Duration(milliseconds: 2500),
         recordedAt: DateTime.now(),
@@ -341,11 +342,13 @@ void main() {
       // toJson stores only filenames for iOS compatibility
       expect(json['filePath'], 'video.mp4');
       expect(json['thumbnailPath'], 'thumb.jpg');
+      expect(json['libraryTitle'], 'Saved rooftop loop');
 
       // Roundtrip with same base path restores paths
       final restored = DivineVideoClip.fromJson(json, '/path/to');
 
       expect(restored.id, original.id);
+      expect(restored.libraryTitle, original.libraryTitle);
       // Path uses platform separator, check it ends with filename
       expect(await restored.video.safeFilePath(), endsWith('video.mp4'));
       expect(restored.thumbnailPath, endsWith('thumb.jpg'));
@@ -370,6 +373,22 @@ void main() {
       final restored = DivineVideoClip.fromJson(json, '/path/to');
 
       expect(restored.thumbnailPath, isNull);
+    });
+
+    test('handles missing libraryTitle in legacy JSON', () {
+      final clip = DivineVideoClip(
+        id: 'legacy_title',
+        video: EditorVideo.file('/path/to/video.mp4'),
+        duration: const Duration(seconds: 3),
+        recordedAt: DateTime.now(),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      final json = clip.toJson()..remove('libraryTitle');
+      final restored = DivineVideoClip.fromJson(json, '/path/to');
+
+      expect(restored.libraryTitle, isNull);
     });
 
     test('durationInSeconds returns correct value', () {

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -207,6 +207,31 @@ First useful caption
     expect(success.clip.libraryTitle, 'First useful caption');
   });
 
+  test('uses a timestamp fallback when metadata has no title text', () {
+    final title = VideoClipImportService.defaultLibraryTitleFor(
+      _video(title: '', content: '', textTrackContent: ''),
+      fallbackTime: DateTime(2026, 6, 13, 15, 45),
+    );
+
+    expect(title, 'Clip Jun 13, 3:45 PM');
+  });
+
+  test('normalizes whitespace and truncates long library titles', () {
+    final title = VideoClipImportService.defaultLibraryTitleFor(
+      _video(
+        title:
+            '  This title has     extra spaces and it keeps going past the eighty character limit for local clip names  ',
+        content: 'fallback description',
+      ),
+    );
+
+    expect(title, hasLength(80));
+    expect(
+      title,
+      'This title has extra spaces and it keeps going past the eighty character limi...',
+    );
+  });
+
   test('imports an own (non-classic) video as a saved library clip', () async {
     final service = buildService();
 

--- a/mobile/test/services/video_clip_import_service_test.dart
+++ b/mobile/test/services/video_clip_import_service_test.dart
@@ -25,21 +25,26 @@ models.VideoEvent _video({
   String? dimensions = '480x480',
   Map<String, String> rawTags = const {'platform': 'vine'},
   String? vineId = _defaultVineId,
+  String? title,
+  String content = 'classic vine',
+  String? textTrackContent,
 }) {
   return models.VideoEvent(
     id: id,
     pubkey: 'classic-vine-author-pubkey',
     createdAt: 1451606400,
-    content: 'classic vine',
+    content: content,
     timestamp: DateTime.fromMillisecondsSinceEpoch(
       1451606400 * 1000,
       isUtc: true,
     ),
+    title: title,
     videoUrl: videoUrl,
     duration: duration,
     dimensions: dimensions,
     rawTags: rawTags,
     vineId: vineId,
+    textTrackContent: textTrackContent,
   );
 }
 
@@ -131,6 +136,7 @@ void main() {
     expect(success.clip.thumbnailPath, endsWith('thumb.jpg'));
     expect(success.clip.ghostFramePath, endsWith('ghost.jpg'));
     expect(success.clip.video.file!.path, startsWith(docsDir.path));
+    expect(success.clip.libraryTitle, 'classic vine');
     expect(
       File(success.clip.video.file!.path).readAsBytesSync(),
       sourceVideo.readAsBytesSync(),
@@ -142,6 +148,63 @@ void main() {
             ).captured.single
             as DivineVideoClip;
     expect(captured.id, success.clip.id);
+  });
+
+  test('uses an explicit user title when importing to the library', () async {
+    final service = buildService();
+
+    final result = await service.importToLibrary(
+      _video(title: 'Published title'),
+      libraryTitle: 'My local cut',
+    );
+
+    final success = result as VideoClipImportSuccess;
+    expect(success.clip.libraryTitle, 'My local cut');
+  });
+
+  test('derives the default library title from post title first', () async {
+    final service = buildService();
+
+    final result = await service.importToLibrary(
+      _video(title: 'Published title', content: 'Published description'),
+    );
+
+    final success = result as VideoClipImportSuccess;
+    expect(success.clip.libraryTitle, 'Published title');
+  });
+
+  test(
+    'derives the default library title from description when title is empty',
+    () async {
+      final service = buildService();
+
+      final result = await service.importToLibrary(
+        _video(title: '  ', content: 'A useful description'),
+      );
+
+      final success = result as VideoClipImportSuccess;
+      expect(success.clip.libraryTitle, 'A useful description');
+    },
+  );
+
+  test('derives the default library title from embedded subtitles', () async {
+    final service = buildService();
+
+    final result = await service.importToLibrary(
+      _video(
+        title: '',
+        content: '',
+        textTrackContent: '''
+WEBVTT
+
+00:00.000 --> 00:02.000
+First useful caption
+''',
+      ),
+    );
+
+    final success = result as VideoClipImportSuccess;
+    expect(success.clip.libraryTitle, 'First useful caption');
   });
 
   test('imports an own (non-classic) video as a saved library clip', () async {

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -42,7 +42,10 @@ class _MockVideoClipImportService extends Mock
 
 class _FakeVideoEvent extends Fake implements VideoEvent {}
 
-class _FakeDivineVideoClip extends Fake implements DivineVideoClip {}
+class _FakeDivineVideoClip extends Fake implements DivineVideoClip {
+  @override
+  String? get libraryTitle => 'My local cut';
+}
 
 /// Fake notifier that provides test data for curatedListsStateProvider.
 ///
@@ -108,7 +111,10 @@ void main() {
     _FakeCuratedListsState.fakeLists = [];
 
     when(
-      () => mockVideoClipImportService.importToLibrary(any()),
+      () => mockVideoClipImportService.importToLibrary(
+        any(),
+        libraryTitle: any(named: 'libraryTitle'),
+      ),
     ).thenAnswer(
       (_) async => VideoClipImportSuccess(_FakeDivineVideoClip()),
     );
@@ -245,7 +251,7 @@ void main() {
     );
 
     testWidgets(
-      'More actions row shows Add to clips for non-classic video owned by current user',
+      'More actions row prompts for a clip title and confirms saved title for owned videos',
       (tester) async {
         final authService = createMockAuthService();
         when(() => authService.isAuthenticated).thenReturn(true);
@@ -264,14 +270,29 @@ void main() {
         await tester.tap(find.text('Add to clips'));
         await tester.pumpAndSettle();
 
-        expect(find.text('Added to clips'), findsOneWidget);
+        expect(find.text('Name this clip'), findsOneWidget);
+        expect(
+          tester.widget<TextField>(find.byType(TextField)).controller?.text,
+          'Test Video Title',
+        );
+
+        await tester.enterText(find.byType(TextField), 'My local cut');
+        await tester.tap(find.text('Save clip'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Saved "My local cut" to clips'), findsOneWidget);
         verify(
-          () => mockVideoClipImportService.importToLibrary(testVideo),
+          () => mockVideoClipImportService.importToLibrary(
+            testVideo,
+            libraryTitle: 'My local cut',
+          ),
         ).called(1);
       },
     );
 
-    testWidgets('tapping Add to clips shows success snackbar', (tester) async {
+    testWidgets('tapping Add to clips shows success snackbar with clip title', (
+      tester,
+    ) async {
       final classicVideo = _testVideo(
         rawTags: const {'platform': 'vine'},
         vineId: 'classic-vine-id',
@@ -284,9 +305,17 @@ void main() {
       await tester.tap(find.text('Add to clips'));
       await tester.pumpAndSettle();
 
-      expect(find.text('Added to clips'), findsOneWidget);
+      expect(find.text('Name this clip'), findsOneWidget);
+
+      await tester.tap(find.text('Save clip'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Saved "My local cut" to clips'), findsOneWidget);
       verify(
-        () => mockVideoClipImportService.importToLibrary(classicVideo),
+        () => mockVideoClipImportService.importToLibrary(
+          classicVideo,
+          libraryTitle: 'Test Video Title',
+        ),
       ).called(1);
     });
 

--- a/mobile/test/widgets/video_clip/video_clip_preview_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_preview_test.dart
@@ -49,6 +49,7 @@ void main() {
     final testClip = DivineVideoClip(
       id: 'test-clip-1',
       video: EditorVideo.file('/path/to/video.mp4'),
+      libraryTitle: 'Rooftop loop',
       duration: const Duration(seconds: 5),
       recordedAt: DateTime(2026),
       targetAspectRatio: .vertical,
@@ -92,6 +93,7 @@ void main() {
       await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.byType(DivineVideoPlayer), findsOneWidget);
+      expect(find.text('Rooftop loop'), findsOneWidget);
       expect(
         find.byWidgetPredicate(
           (w) => w is DivineIcon && w.icon == DivineIconName.downloadSimple,

--- a/mobile/test/widgets/video_clip/video_clip_thumbnail_card_test.dart
+++ b/mobile/test/widgets/video_clip/video_clip_thumbnail_card_test.dart
@@ -14,10 +14,12 @@ void main() {
     DivineVideoClip createClip({
       String id = 'clip-1',
       Duration duration = const Duration(seconds: 5),
+      String? libraryTitle,
     }) {
       return DivineVideoClip(
         id: id,
         video: EditorVideo.file('/path/to/clip.mp4'),
+        libraryTitle: libraryTitle,
         duration: duration,
         recordedAt: DateTime(2026),
         targetAspectRatio: .vertical,
@@ -55,6 +57,14 @@ void main() {
         );
 
         expect(find.text('3.00'), findsOneWidget);
+      });
+
+      testWidgets('library title when present', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(clip: createClip(libraryTitle: 'Rooftop loop')),
+        );
+
+        expect(find.text('Rooftop loop'), findsOneWidget);
       });
 
       testWidgets('selection index when selected', (tester) async {


### PR DESCRIPTION
Closes #5123

## Summary
- add a local libraryTitle to imported clips and persist it safely
- prompt for a clip name before adding videos to the local clip library
- derive the default name from post title, description, embedded subtitles, then timestamp fallback
- show the saved clip name in confirmations, thumbnails, and preview
- remove the obsolete shareSheetAddedToClips localization key and regenerate l10n

## Verification
- mise exec -- flutter test test/services/video_clip_import_service_test.dart
- mise exec -- flutter test test/l10n/arb_consistency_test.dart
- mise exec -- flutter analyze lib/services/video_clip_import_service.dart test/services/video_clip_import_service_test.dart test/l10n/arb_consistency_test.dart
- pre-push hook: analyzer + changed-file tests (131 passed)
- GitHub checks: Generated Files, Build Flutter Web Preview, Format, Analyze, Tests, VGV Tag Gate, semantic PR, mergeability, CLA