### PR TITLE
fix(firebase): guard default app initialization

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -11,7 +11,6 @@ import 'package:cache_sync/cache_sync.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart'
     show DivineVideoPlayerController;
-import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
@@ -80,6 +79,7 @@ import 'package:openvine/services/corrupted_video_repair_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/services/deep_link_service.dart';
+import 'package:openvine/services/firebase_initialization.dart';
 import 'package:openvine/services/locale_preference_service.dart';
 import 'package:openvine/services/logging_config_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
@@ -134,7 +134,7 @@ bool shouldRenderLocalPushNotification(RemoteMessage message) {
 /// Top-level background message handler required by Firebase.
 @pragma('vm:entry-point')
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
-  await Firebase.initializeApp();
+  await ensureDefaultFirebaseInitialized();
 
   // The OS already presents iOS alert pushes (aps.alert); only render a local
   // notification for data-only messages so we don't double-render (#4731).

--- a/mobile/lib/services/crash_reporting_service.dart
+++ b/mobile/lib/services/crash_reporting_service.dart
@@ -2,10 +2,9 @@
 // ABOUTME: Uses Firebase Crashlytics to capture and report crashes from TestFlight/production
 
 import 'dart:async';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
-import 'package:openvine/firebase_options.dart';
+import 'package:openvine/services/firebase_initialization.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/utils/platform_support.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -32,10 +31,7 @@ class CrashReportingService {
     }
 
     try {
-      // Initialize Firebase with platform-specific options
-      await Firebase.initializeApp(
-        options: DefaultFirebaseOptions.currentPlatform,
-      );
+      await ensureDefaultFirebaseInitialized();
 
       // Pass all uncaught errors from the framework to Crashlytics
       FlutterError.onError = (errorDetails) {

--- a/mobile/lib/services/firebase_initialization.dart
+++ b/mobile/lib/services/firebase_initialization.dart
@@ -1,0 +1,20 @@
+// ABOUTME: Shared Firebase initialization guard for app and background isolates.
+// ABOUTME: Reuses native auto-initialized default apps to avoid duplicate-app errors.
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:openvine/firebase_options.dart';
+
+/// Ensures the default Firebase app exists exactly once.
+///
+/// Android can auto-create the default app before Dart startup via the
+/// google-services plugin. Calling [Firebase.initializeApp] again in that state
+/// throws `[core/duplicate-app]`, which disables downstream Firebase services.
+Future<void> ensureDefaultFirebaseInitialized({
+  FirebaseOptions? options,
+}) async {
+  if (Firebase.apps.isNotEmpty) return;
+
+  await Firebase.initializeApp(
+    options: options ?? DefaultFirebaseOptions.currentPlatform,
+  );
+}

--- a/mobile/lib/services/firebase_initialization.dart
+++ b/mobile/lib/services/firebase_initialization.dart
@@ -4,6 +4,10 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:openvine/firebase_options.dart';
 
+typedef FirebaseAppsProvider = List<FirebaseApp> Function();
+typedef FirebaseInitializer =
+    Future<FirebaseApp> Function({FirebaseOptions? options});
+
 /// Ensures the default Firebase app exists exactly once.
 ///
 /// Android can auto-create the default app before Dart startup via the
@@ -11,10 +15,12 @@ import 'package:openvine/firebase_options.dart';
 /// throws `[core/duplicate-app]`, which disables downstream Firebase services.
 Future<void> ensureDefaultFirebaseInitialized({
   FirebaseOptions? options,
+  FirebaseAppsProvider? appsProvider,
+  FirebaseInitializer? initializeApp,
 }) async {
-  if (Firebase.apps.isNotEmpty) return;
+  if ((appsProvider ?? () => Firebase.apps)().isNotEmpty) return;
 
-  await Firebase.initializeApp(
+  await (initializeApp ?? Firebase.initializeApp)(
     options: options ?? DefaultFirebaseOptions.currentPlatform,
   );
 }

--- a/mobile/test/services/firebase_initialization_test.dart
+++ b/mobile/test/services/firebase_initialization_test.dart
@@ -1,76 +1,70 @@
 // ABOUTME: Regression tests for idempotent Firebase default app initialization.
 // ABOUTME: Covers Android native auto-init before Dart startup.
 
-import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/firebase_initialization.dart';
-import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-class _FakeFirebaseCore extends Fake
-    with MockPlatformInterfaceMixin
-    implements FirebasePlatform {
-  _FakeFirebaseCore({required this.hasDefaultApp});
-
-  final bool hasDefaultApp;
-  int initializeAppCalls = 0;
-
-  @override
-  FirebaseAppPlatform app([String name = defaultFirebaseAppName]) =>
-      _FakeFirebaseApp();
-
-  @override
-  Future<FirebaseAppPlatform> initializeApp({
-    String? name,
-    FirebaseOptions? options,
-  }) async {
-    initializeAppCalls++;
-    return _FakeFirebaseApp();
-  }
-
-  @override
-  List<FirebaseAppPlatform> get apps =>
-      hasDefaultApp ? [_FakeFirebaseApp()] : const [];
-}
-
-class _FakeFirebaseApp extends Fake
-    with MockPlatformInterfaceMixin
-    implements FirebaseAppPlatform {
-  @override
-  String get name => defaultFirebaseAppName;
-
-  @override
-  FirebaseOptions get options => const FirebaseOptions(
-    apiKey: 'test-api-key',
-    appId: 'test-app-id',
-    messagingSenderId: 'test-sender-id',
-    projectId: 'test-project-id',
-  );
-}
+const _firebaseOptions = FirebaseOptions(
+  apiKey: 'test-api-key',
+  appId: 'test-app-id',
+  messagingSenderId: 'test-sender-id',
+  projectId: 'test-project-id',
+);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('ensureDefaultFirebaseInitialized', () {
     test('initializes Firebase when no default app exists', () async {
-      final fakeFirebase = _FakeFirebaseCore(hasDefaultApp: false);
-      FirebasePlatform.instance = fakeFirebase;
+      var initializeAppCalls = 0;
 
       await ensureDefaultFirebaseInitialized(
-        options: _FakeFirebaseApp().options,
+        options: _firebaseOptions,
+        appsProvider: () => const [],
+        initializeApp: ({FirebaseOptions? options}) async {
+          initializeAppCalls++;
+          expect(options?.projectId, 'test-project-id');
+          return _FakeFirebaseApp();
+        },
       );
 
-      expect(fakeFirebase.initializeAppCalls, 1);
+      expect(initializeAppCalls, 1);
     });
 
     test('reuses an existing default Firebase app', () async {
-      final fakeFirebase = _FakeFirebaseCore(hasDefaultApp: true);
-      FirebasePlatform.instance = fakeFirebase;
+      var initializeAppCalls = 0;
 
       await ensureDefaultFirebaseInitialized(
-        options: _FakeFirebaseApp().options,
+        options: _firebaseOptions,
+        appsProvider: () => [_FakeFirebaseApp()],
+        initializeApp: ({FirebaseOptions? options}) async {
+          initializeAppCalls++;
+          return _FakeFirebaseApp();
+        },
       );
 
-      expect(fakeFirebase.initializeAppCalls, isZero);
+      expect(initializeAppCalls, isZero);
     });
   });
+}
+
+class _FakeFirebaseApp implements FirebaseApp {
+  @override
+  String get name => defaultFirebaseAppName;
+
+  @override
+  FirebaseOptions get options => _firebaseOptions;
+
+  @override
+  Future<void> delete() async {}
+
+  @override
+  bool get isAutomaticDataCollectionEnabled => false;
+
+  @override
+  Future<void> setAutomaticDataCollectionEnabled(bool enabled) async {}
+
+  @override
+  Future<void> setAutomaticResourceManagementEnabled(bool enabled) async {}
 }

--- a/mobile/test/services/firebase_initialization_test.dart
+++ b/mobile/test/services/firebase_initialization_test.dart
@@ -1,0 +1,76 @@
+// ABOUTME: Regression tests for idempotent Firebase default app initialization.
+// ABOUTME: Covers Android native auto-init before Dart startup.
+
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/firebase_initialization.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _FakeFirebaseCore extends Fake
+    with MockPlatformInterfaceMixin
+    implements FirebasePlatform {
+  _FakeFirebaseCore({required this.hasDefaultApp});
+
+  final bool hasDefaultApp;
+  int initializeAppCalls = 0;
+
+  @override
+  FirebaseAppPlatform app([String name = defaultFirebaseAppName]) =>
+      _FakeFirebaseApp();
+
+  @override
+  Future<FirebaseAppPlatform> initializeApp({
+    String? name,
+    FirebaseOptions? options,
+  }) async {
+    initializeAppCalls++;
+    return _FakeFirebaseApp();
+  }
+
+  @override
+  List<FirebaseAppPlatform> get apps =>
+      hasDefaultApp ? [_FakeFirebaseApp()] : const [];
+}
+
+class _FakeFirebaseApp extends Fake
+    with MockPlatformInterfaceMixin
+    implements FirebaseAppPlatform {
+  @override
+  String get name => defaultFirebaseAppName;
+
+  @override
+  FirebaseOptions get options => const FirebaseOptions(
+    apiKey: 'test-api-key',
+    appId: 'test-app-id',
+    messagingSenderId: 'test-sender-id',
+    projectId: 'test-project-id',
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ensureDefaultFirebaseInitialized', () {
+    test('initializes Firebase when no default app exists', () async {
+      final fakeFirebase = _FakeFirebaseCore(hasDefaultApp: false);
+      FirebasePlatform.instance = fakeFirebase;
+
+      await ensureDefaultFirebaseInitialized(
+        options: _FakeFirebaseApp().options,
+      );
+
+      expect(fakeFirebase.initializeAppCalls, 1);
+    });
+
+    test('reuses an existing default Firebase app', () async {
+      final fakeFirebase = _FakeFirebaseCore(hasDefaultApp: true);
+      FirebasePlatform.instance = fakeFirebase;
+
+      await ensureDefaultFirebaseInitialized(
+        options: _FakeFirebaseApp().options,
+      );
+
+      expect(fakeFirebase.initializeAppCalls, isZero);
+    });
+  });
+}


### PR DESCRIPTION
Closes #5071

## Summary
- add a shared Firebase default-app initialization guard
- use it from CrashReportingService and the FCM background handler
- add regression coverage for native auto-initialized default apps

## Root cause
Android can create the default Firebase app before Dart startup. Calling Firebase.initializeApp again throws [core/duplicate-app], leaving CrashReportingService uninitialized and dropping later Crashlytics breadcrumbs/errors.

## Validation
- mise exec -- flutter test test/services/firebase_initialization_test.dart test/startup/app_startup_test.dart test/main_push_duplicate_render_test.dart
- mise exec -- flutter analyze
- pre-push hook: analyzer + changed-file tests