### PR TITLE
fix(feed): paginate for you recommendations

### DIFF
--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -103,7 +103,9 @@ class ForYouFeed extends _$ForYouFeed {
     return _fetchRecommendations();
   }
 
-  Future<VideoFeedState> _fetchRecommendations({String? cursor}) async {
+  Future<VideoFeedState> _fetchRecommendations({
+    bool preserveExistingOnError = false,
+  }) async {
     try {
       final authService = ref.read(authServiceProvider);
       final currentUserPubkey = authService.currentPublicKeyHex;
@@ -116,7 +118,6 @@ class ForYouFeed extends _$ForYouFeed {
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
         limit: _pageSize,
-        cursor: cursor,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
@@ -153,6 +154,7 @@ class ForYouFeed extends _$ForYouFeed {
         name: 'ForYouFeedProvider',
         category: LogCategory.video,
       );
+      if (preserveExistingOnError) rethrow;
       return VideoFeedState(
         videos: const [],
         hasMoreContent: false,
@@ -214,9 +216,11 @@ class ForYouFeed extends _$ForYouFeed {
             .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
             .toList(),
       );
-      final existingIds = currentState.videos.map((video) => video.id).toSet();
+      final existingIds = currentState.videos
+          .map((video) => video.id.toLowerCase())
+          .toSet();
       final newVideos = filteredVideos
-          .where((video) => existingIds.add(video.id))
+          .where((video) => existingIds.add(video.id.toLowerCase()))
           .toList();
       final mergedVideos = [...currentState.videos, ...newVideos];
       final newEventsLoaded = newVideos.length;
@@ -228,12 +232,12 @@ class ForYouFeed extends _$ForYouFeed {
       );
 
       _nextCursor = response.nextCursor;
+      final cursorAdvanced = _nextCursor != null && _nextCursor != cursor;
 
       state = AsyncData(
         VideoFeedState(
           videos: mergedVideos,
-          hasMoreContent:
-              response.hasMore && _nextCursor != null && newEventsLoaded > 0,
+          hasMoreContent: response.hasMore && cursorAdvanced,
           lastUpdated: DateTime.now(),
         ),
       );
@@ -265,7 +269,7 @@ class ForYouFeed extends _$ForYouFeed {
       getCurrentState: () => state,
       isMounted: () => ref.mounted,
       setState: (s) => state = s,
-      fetchFresh: _fetchRecommendations,
+      fetchFresh: () => _fetchRecommendations(preserveExistingOnError: true),
     );
   }
 }

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -24,7 +24,9 @@ part 'for_you_provider.g.dart';
 /// Currently only enabled on staging environment for testing.
 @Riverpod(keepAlive: true)
 class ForYouFeed extends _$ForYouFeed {
-  int _currentLimit = 50;
+  static const int _pageSize = 50;
+
+  String? _nextCursor;
 
   @override
   Future<VideoFeedState> build() async {
@@ -97,10 +99,11 @@ class ForYouFeed extends _$ForYouFeed {
       return const VideoFeedState(videos: [], hasMoreContent: false);
     }
 
-    return _fetchRecommendations(limit: _currentLimit);
+    _nextCursor = null;
+    return _fetchRecommendations();
   }
 
-  Future<VideoFeedState> _fetchRecommendations({required int limit}) async {
+  Future<VideoFeedState> _fetchRecommendations({String? cursor}) async {
     try {
       final authService = ref.read(authServiceProvider);
       final currentUserPubkey = authService.currentPublicKeyHex;
@@ -112,7 +115,8 @@ class ForYouFeed extends _$ForYouFeed {
       final hints = await readFeedViewerPreferenceHints(ref.read);
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
-        limit: limit,
+        limit: _pageSize,
+        cursor: cursor,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
@@ -135,9 +139,12 @@ class ForYouFeed extends _$ForYouFeed {
             .toList(),
       );
 
+      _nextCursor = response.nextCursor;
+      final hasMore = response.hasMore && _nextCursor != null;
+
       return VideoFeedState(
         videos: filteredVideos,
-        hasMoreContent: filteredVideos.length >= 20,
+        hasMoreContent: hasMore,
         lastUpdated: DateTime.now(),
       );
     } catch (e) {
@@ -180,11 +187,18 @@ class ForYouFeed extends _$ForYouFeed {
       }
 
       final client = ref.read(funnelcakeApiClientProvider);
-      final newLimit = _currentLimit + 30;
+      final cursor = _nextCursor;
+      if (cursor == null) {
+        state = AsyncData(
+          currentState.copyWith(isLoadingMore: false, hasMoreContent: false),
+        );
+        return;
+      }
       final hints = await readFeedViewerPreferenceHints(ref.read);
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
-        limit: newLimit,
+        limit: _pageSize,
+        cursor: cursor,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
@@ -200,21 +214,26 @@ class ForYouFeed extends _$ForYouFeed {
             .where((v) => !blocklistRepository.shouldFilterFromFeeds(v.pubkey))
             .toList(),
       );
-      final newEventsLoaded =
-          filteredVideos.length - currentState.videos.length;
+      final existingIds = currentState.videos.map((video) => video.id).toSet();
+      final newVideos = filteredVideos
+          .where((video) => existingIds.add(video.id))
+          .toList();
+      final mergedVideos = [...currentState.videos, ...newVideos];
+      final newEventsLoaded = newVideos.length;
 
       Log.info(
-        '🎯 ForYouFeed: Loaded $newEventsLoaded more recommendations (total: ${filteredVideos.length})',
+        '🎯 ForYouFeed: Loaded $newEventsLoaded more recommendations (total: ${mergedVideos.length})',
         name: 'ForYouFeedProvider',
         category: LogCategory.video,
       );
 
-      _currentLimit = newLimit;
+      _nextCursor = response.nextCursor;
 
       state = AsyncData(
         VideoFeedState(
-          videos: filteredVideos,
-          hasMoreContent: newEventsLoaded > 0,
+          videos: mergedVideos,
+          hasMoreContent:
+              response.hasMore && _nextCursor != null && newEventsLoaded > 0,
           lastUpdated: DateTime.now(),
         ),
       );
@@ -242,13 +261,11 @@ class ForYouFeed extends _$ForYouFeed {
       category: LogCategory.video,
     );
 
-    _currentLimit = 50; // Reset limit on refresh
-
     await staleWhileRevalidate(
       getCurrentState: () => state,
       isMounted: () => ref.mounted,
       setState: (s) => state = s,
-      fetchFresh: () => _fetchRecommendations(limit: _currentLimit),
+      fetchFresh: _fetchRecommendations,
     );
   }
 }

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -232,12 +232,11 @@ class ForYouFeed extends _$ForYouFeed {
       );
 
       _nextCursor = response.nextCursor;
-      final cursorAdvanced = _nextCursor != null && _nextCursor != cursor;
 
       state = AsyncData(
         VideoFeedState(
           videos: mergedVideos,
-          hasMoreContent: response.hasMore && cursorAdvanced,
+          hasMoreContent: response.hasMore && _nextCursor != null,
           lastUpdated: DateTime.now(),
         ),
       );
@@ -248,8 +247,6 @@ class ForYouFeed extends _$ForYouFeed {
         category: LogCategory.video,
       );
 
-      if (!ref.mounted) return;
-      final currentState = await future;
       if (!ref.mounted) return;
       state = AsyncData(
         currentState.copyWith(isLoadingMore: false, error: e.toString()),

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'a4f75c7c0d25ec1acd62e83211c2657399315e53';
+String _$forYouFeedHash() => r'296daaf5700ab45f77cc6b04927a42b6648b5106';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'12746d77ebf27e31e6b9678f5301528d3d6b5438';
+String _$forYouFeedHash() => r'a4f75c7c0d25ec1acd62e83211c2657399315e53';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'296daaf5700ab45f77cc6b04927a42b6648b5106';
+String _$forYouFeedHash() => r'48c8a6027b0bbc85ffae4a7305c97b8a0b4c5991';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -590,6 +590,9 @@ void main() {
           () => mockFunnelcakeApiClient.getRecommendations(
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            cursor: any(named: 'cursor'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
@@ -660,6 +663,79 @@ void main() {
           'for-you-refreshed',
         ]);
         expect(finalState.isRefreshing, isFalse);
+      },
+    );
+
+    test(
+      'for you preserves existing videos when refresh fails',
+      () async {
+        var requestCount = 0;
+
+        when(
+          () => mockFunnelcakeApiClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            cursor: any(named: 'cursor'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((_) {
+          requestCount += 1;
+          if (requestCount == 1) {
+            return Future.value(
+              _recommendationsResponse(
+                ['for-you-initial'],
+                nextCursor: 'cursor-2',
+              ),
+            );
+          }
+          throw StateError('recommendations refresh failed');
+        });
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            funnelcakeApiClientProvider.overrideWithValue(
+              mockFunnelcakeApiClient,
+            ),
+            authServiceProvider.overrideWithValue(mockAuthService),
+            funnelcakeAvailableProvider.overrideWith(
+              _AlwaysAvailableFunnelcake.new,
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final subscription = container.listen(forYouFeedProvider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final initialState = await container.read(forYouFeedProvider.future);
+        expect(initialState.videos.map((video) => video.id), [
+          'for-you-initial',
+        ]);
+        expect(initialState.hasMoreContent, isTrue);
+
+        await container.read(forYouFeedProvider.notifier).refresh();
+
+        final refreshedState = container.read(forYouFeedProvider).value;
+        expect(refreshedState, isNotNull);
+        expect(refreshedState!.videos.map((video) => video.id), [
+          'for-you-initial',
+        ]);
+        expect(refreshedState.hasMoreContent, isTrue);
+        expect(refreshedState.isRefreshing, isFalse);
+        expect(
+          refreshedState.error,
+          contains('recommendations refresh failed'),
+        );
       },
     );
 
@@ -739,6 +815,104 @@ void main() {
         ]);
         expect(loadedState.hasMoreContent, isTrue);
         expect(requestedCursors, [null, 'cursor-2']);
+      },
+    );
+
+    test(
+      'for you keeps loading when a cursor page adds no visible videos',
+      () async {
+        final requestedCursors = <String?>[];
+        var recommendationsCallCount = 0;
+
+        when(
+          () => mockFunnelcakeApiClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            cursor: any(named: 'cursor'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((invocation) {
+          requestedCursors.add(invocation.namedArguments[#cursor] as String?);
+          recommendationsCallCount += 1;
+          if (recommendationsCallCount == 1) {
+            return Future.value(
+              _recommendationsResponse([
+                'for-you-a',
+                'for-you-b',
+              ], nextCursor: 'cursor-2'),
+            );
+          }
+          if (recommendationsCallCount == 2) {
+            return Future.value(
+              _recommendationsResponse([
+                'FOR-YOU-A',
+                'for-you-b',
+              ], nextCursor: 'cursor-3'),
+            );
+          }
+          return Future.value(
+            _recommendationsResponse(
+              ['for-you-c'],
+              nextCursor: 'cursor-4',
+              hasMore: false,
+            ),
+          );
+        });
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            funnelcakeApiClientProvider.overrideWithValue(
+              mockFunnelcakeApiClient,
+            ),
+            authServiceProvider.overrideWithValue(mockAuthService),
+            funnelcakeAvailableProvider.overrideWith(
+              _AlwaysAvailableFunnelcake.new,
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final subscription = container.listen(forYouFeedProvider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final initialState = await container.read(forYouFeedProvider.future);
+        expect(initialState.videos.map((video) => video.id), [
+          'for-you-a',
+          'for-you-b',
+        ]);
+        expect(initialState.hasMoreContent, isTrue);
+
+        await container.read(forYouFeedProvider.notifier).loadMore();
+
+        final duplicatePageState = container.read(forYouFeedProvider).value;
+        expect(duplicatePageState, isNotNull);
+        expect(duplicatePageState!.videos.map((video) => video.id), [
+          'for-you-a',
+          'for-you-b',
+        ]);
+        expect(duplicatePageState.hasMoreContent, isTrue);
+
+        await container.read(forYouFeedProvider.notifier).loadMore();
+
+        final nextPageState = container.read(forYouFeedProvider).value;
+        expect(nextPageState, isNotNull);
+        expect(nextPageState!.videos.map((video) => video.id), [
+          'for-you-a',
+          'for-you-b',
+          'for-you-c',
+        ]);
+        expect(nextPageState.hasMoreContent, isFalse);
+        expect(requestedCursors, [null, 'cursor-2', 'cursor-3']);
       },
     );
 

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -663,6 +663,148 @@ void main() {
       },
     );
 
+    test(
+      'for you load more uses recommendation cursor and appends unseen videos',
+      () async {
+        final requestedCursors = <String?>[];
+        var recommendationsCallCount = 0;
+
+        when(
+          () => mockFunnelcakeApiClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            cursor: any(named: 'cursor'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((invocation) {
+          requestedCursors.add(invocation.namedArguments[#cursor] as String?);
+          recommendationsCallCount += 1;
+          if (recommendationsCallCount == 1) {
+            return Future.value(
+              _recommendationsResponse([
+                'for-you-a',
+                'for-you-b',
+              ], nextCursor: 'cursor-2'),
+            );
+          }
+          return Future.value(
+            _recommendationsResponse([
+              'for-you-b',
+              'for-you-c',
+            ], nextCursor: 'cursor-3'),
+          );
+        });
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            funnelcakeApiClientProvider.overrideWithValue(
+              mockFunnelcakeApiClient,
+            ),
+            authServiceProvider.overrideWithValue(mockAuthService),
+            funnelcakeAvailableProvider.overrideWith(
+              _AlwaysAvailableFunnelcake.new,
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final subscription = container.listen(forYouFeedProvider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final initialState = await container.read(forYouFeedProvider.future);
+        expect(initialState.videos.map((video) => video.id), [
+          'for-you-a',
+          'for-you-b',
+        ]);
+        expect(initialState.hasMoreContent, isTrue);
+
+        await container.read(forYouFeedProvider.notifier).loadMore();
+
+        final loadedState = container.read(forYouFeedProvider).value;
+        expect(loadedState, isNotNull);
+        expect(loadedState!.videos.map((video) => video.id), [
+          'for-you-a',
+          'for-you-b',
+          'for-you-c',
+        ]);
+        expect(loadedState.hasMoreContent, isTrue);
+        expect(requestedCursors, [null, 'cursor-2']);
+      },
+    );
+
+    test(
+      'for you stops load more when recommendations omit pagination cursor',
+      () async {
+        var recommendationsCallCount = 0;
+
+        when(
+          () => mockFunnelcakeApiClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            cursor: any(named: 'cursor'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((_) {
+          recommendationsCallCount += 1;
+          return Future.value(
+            _recommendationsResponse(['for-you-legacy']),
+          );
+        });
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            funnelcakeApiClientProvider.overrideWithValue(
+              mockFunnelcakeApiClient,
+            ),
+            authServiceProvider.overrideWithValue(mockAuthService),
+            funnelcakeAvailableProvider.overrideWith(
+              _AlwaysAvailableFunnelcake.new,
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final subscription = container.listen(forYouFeedProvider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final initialState = await container.read(forYouFeedProvider.future);
+        expect(initialState.videos.map((video) => video.id), [
+          'for-you-legacy',
+        ]);
+        expect(initialState.hasMoreContent, isFalse);
+
+        await container.read(forYouFeedProvider.notifier).loadMore();
+
+        final loadedState = container.read(forYouFeedProvider).value;
+        expect(loadedState, isNotNull);
+        expect(loadedState!.videos.map((video) => video.id), [
+          'for-you-legacy',
+        ]);
+        expect(loadedState.hasMoreContent, isFalse);
+        expect(recommendationsCallCount, 1);
+      },
+    );
+
     // Regression for #3849. Pre-fix, popular_now's refresh() flipped a sticky
     // _usingRestApi=false in the catch fall-through, so the *next* refresh
     // skipped REST entirely and stayed on Nostr until app restart. The fix
@@ -765,6 +907,19 @@ WatchingVideosResponse _watchingResponse(
 }) {
   return WatchingVideosResponse(
     videos: ids.map(_videoStats).toList(),
+    nextCursor: nextCursor,
+    hasMore: hasMore,
+  );
+}
+
+RecommendationsResponse _recommendationsResponse(
+  List<String> ids, {
+  String? nextCursor,
+  bool hasMore = true,
+}) {
+  return RecommendationsResponse(
+    videos: ids.map(_videoStats).toList(),
+    source: 'personalized',
     nextCursor: nextCursor,
     hasMore: hasMore,
   );


### PR DESCRIPTION
Closes #5073

## Summary
- replace For You top-N limit growth with cursor-backed recommendation paging
- append only unseen recommendation IDs on load-more
- stop legacy/non-cursor responses from offering endless load-more loops
- include regenerated Riverpod provider metadata

## Root cause
ForYouFeed.loadMore re-requested a larger top-N recommendation window instead of sending the recommendation endpoint cursor. Ranking endpoints return the same top items repeatedly, so the feed could cycle the same creators.

## Validation
- mise exec -- flutter test test/providers/explore_feed_refresh_retention_test.dart
- mise exec -- flutter analyze
- mise exec -- dart run build_runner build --delete-conflicting-outputs
- pre-push hook: analyzer + generated-file verification + changed-file tests