### PR TITLE
fix(startup): allow offline recorder launch

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -72,6 +72,7 @@ import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/back_button_handler.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
@@ -923,6 +924,35 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
   return coordinator;
 }
 
+void _removeSplashWhenStartupAuthSettles(AuthService authService) {
+  unawaited(
+    _waitForStartupAuthTerminalState(authService)
+        .timeout(AuthService.startupAuthRestoreTimeout)
+        .catchError((Object error, StackTrace stackTrace) {
+          Log.warning(
+            '[INIT] Auth startup did not settle before splash timeout: $error',
+            name: 'Main',
+            category: LogCategory.system,
+          );
+        })
+        .whenComplete(FlutterNativeSplash.remove),
+  );
+}
+
+Future<void> _waitForStartupAuthTerminalState(AuthService authService) async {
+  if (_isTerminalStartupAuthState(authService.authState)) return;
+  await authService.authStateStream.firstWhere(_isTerminalStartupAuthState);
+}
+
+bool _isTerminalStartupAuthState(AuthState state) {
+  return switch (state) {
+    AuthState.unauthenticated ||
+    AuthState.awaitingTosAcceptance ||
+    AuthState.authenticated => true,
+    AuthState.checking || AuthState.authenticating => false,
+  };
+}
+
 Future<void> _startOpenVineApp() async {
   // Add timing logs for startup diagnostics
   final startTime = DateTime.now();
@@ -930,13 +960,10 @@ Future<void> _startOpenVineApp() async {
   // Ensure bindings are initialized first (required for everything)
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
 
-  // Keep the native splash visible until auth resolves. AuthService calls
-  // FlutterNativeSplash.remove() in its initialize() finally block once a
-  // terminal auth state is reached. The Future.delayed is a safety net for
-  // catastrophic hangs — 5s is chosen to cover slow bunker/relay reconnects.
-  // See #2749 and #2953 for the investigation.
+  // Keep the native splash visible until startup auth reaches a terminal
+  // state. The release watcher is installed after the ProviderContainer exists
+  // so the UI/native concern stays in app startup instead of AuthService.
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
-  Future.delayed(const Duration(seconds: 5), FlutterNativeSplash.remove);
 
   // Lock app to portrait mode only (portrait up and portrait down)
   // Skip on desktop platforms where orientation lock doesn't apply
@@ -1328,6 +1355,7 @@ Future<void> _startOpenVineApp() async {
   );
 
   final startupCoordinator = _createStartupCoordinator(container);
+  _removeSplashWhenStartupAuthSettles(container.read(authServiceProvider));
   await startupCoordinator.initializeThrough(StartupPhase.critical);
 
   Log.info('Divine starting...', name: 'Main');

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -185,6 +185,43 @@ AuthState currentAuthState(Ref ref) {
   return authService.authState;
 }
 
+/// Boundary-safe auth helper for recorder exits.
+///
+/// UI callers need to know whether auth restore has reached an authenticated
+/// state, but they should not import service-layer auth types directly.
+final recorderExitAuthGateProvider = Provider<RecorderExitAuthGate>((ref) {
+  return RecorderExitAuthGate(ref.watch(authServiceProvider));
+});
+
+class RecorderExitAuthGate {
+  RecorderExitAuthGate(this._authService);
+
+  final AuthService _authService;
+
+  Duration get restoreTimeout => AuthService.startupAuthRestoreTimeout;
+
+  bool get isRestoring => _isStartupAuthRestoreState(_authService.authState);
+
+  Future<bool> waitForAuthenticatedOrTerminal() async {
+    var authState = _authService.authState;
+    if (_isStartupAuthRestoreState(authState)) {
+      try {
+        authState = await _authService.authStateStream
+            .firstWhere((state) => !_isStartupAuthRestoreState(state))
+            .timeout(restoreTimeout);
+      } on TimeoutException {
+        authState = _authService.authState;
+      }
+    }
+
+    return authState == AuthState.authenticated;
+  }
+
+  bool _isStartupAuthRestoreState(AuthState state) {
+    return state == AuthState.checking || state == AuthState.authenticating;
+  }
+}
+
 /// Provider that returns current RPC capability and rebuilds on changes.
 ///
 /// Widgets and repositories should watch this instead of polling

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -305,10 +305,13 @@ DraftStorageService draftStorageService(Ref ref) {
   // Rebuild when account changes so ownerPubkey stays current
   ref.watch(currentAuthStateProvider);
   final authService = ref.watch(authServiceProvider);
+  final ownerPubkey =
+      authService.currentPublicKeyHex ??
+      DraftStorageService.anonymousOwnerPubkey;
   return DraftStorageService(
     draftsDao: db.draftsDao,
     clipsDao: db.clipsDao,
-    ownerPubkey: authService.currentPublicKeyHex,
+    ownerPubkey: ownerPubkey,
   );
 }
 
@@ -319,10 +322,13 @@ ClipLibraryService clipLibraryService(Ref ref) {
   // Rebuild when account changes so ownerPubkey stays current
   ref.watch(currentAuthStateProvider);
   final authService = ref.watch(authServiceProvider);
+  final ownerPubkey =
+      authService.currentPublicKeyHex ??
+      DraftStorageService.anonymousOwnerPubkey;
   return ClipLibraryService(
     clipsDao: db.clipsDao,
     draftsDao: db.draftsDao,
-    ownerPubkey: authService.currentPublicKeyHex,
+    ownerPubkey: ownerPubkey,
   );
 }
 
@@ -407,8 +413,14 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
   // Wire legacy row claim callback so session setup can attribute
   // pre-multi-account drafts/clips to the current user.
   service.onClaimLegacyRows = (String userPubkey) async {
-    await db.draftsDao.claimLegacyRows(userPubkey);
-    await db.clipsDao.claimLegacyRows(userPubkey);
+    await db.draftsDao.claimLegacyRows(
+      userPubkey,
+      sourceOwnerPubkey: DraftStorageService.anonymousOwnerPubkey,
+    );
+    await db.clipsDao.claimLegacyRows(
+      userPubkey,
+      sourceOwnerPubkey: DraftStorageService.anonymousOwnerPubkey,
+    );
   };
 
   return service;

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -373,7 +373,7 @@ final class DraftStorageServiceProvider
 }
 
 String _$draftStorageServiceHash() =>
-    r'1ef3ccee1fdbb86f842c2bdf448b7f72d4e8f629';
+    r'8db9365647df0f383343aa803d5bf85be33b8429';
 
 /// Clip library service for persisting individual video clips
 
@@ -426,7 +426,7 @@ final class ClipLibraryServiceProvider
 }
 
 String _$clipLibraryServiceHash() =>
-    r'f36b3e22012c58da8f70d620378448bbe500f0cc';
+    r'5ccf19e6775ad70d7ed14468c8929a363e13d9f4';
 
 /// User data cleanup service for handling identity changes
 /// Prevents data leakage between different Nostr accounts
@@ -482,7 +482,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'64f5eb700446e794555f2814668aa37aa863a9f0';
+    r'ce46d352767c246631f008d3742cd5705f978aef';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -232,6 +232,9 @@ int homeInitialIndexFromPathParameters(Map<String, String> pathParameters) {
   return rawIndex < 0 ? 0 : rawIndex;
 }
 
+bool _isPublicRecorderLocation(String location) =>
+    location == VideoRecorderScreen.path;
+
 final goRouterProvider = Provider<GoRouter>((ref) {
   // Use ref.read to avoid recreating the router on auth state changes
   final authService = ref.read(authServiceProvider);
@@ -420,6 +423,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       // Non-authenticated users on protected routes → welcome.
       // awaitingTosAcceptance has no dedicated screen, so treat it like unauthenticated.
       if (!isAuthRoute &&
+          !_isPublicRecorderLocation(location) &&
           (authState == AuthState.unauthenticated ||
               authState == AuthState.awaitingTosAcceptance)) {
         _hasNavigated = false;
@@ -435,6 +439,11 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       return null;
     },
     routes: [
+      GoRoute(
+        path: VideoRecorderScreen.path,
+        name: VideoRecorderScreen.routeName,
+        builder: (_, _) => const VideoRecorderRoute(),
+      ),
       // Shell owns the shared scaffold and bottom navigation. Individual tab
       // route state that must survive a child swap is restored explicitly from
       // route params or tab-position providers.
@@ -1294,12 +1303,6 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             sourceVideo: video,
           );
         },
-      ),
-      // Video editor route (requires video passed via extra)
-      GoRoute(
-        path: VideoRecorderScreen.path,
-        name: VideoRecorderScreen.routeName,
-        builder: (_, _) => const VideoRecorderRoute(),
       ),
       // Video editor route
       GoRoute(

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -9,7 +9,6 @@ import 'dart:convert';
 import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:nostr_client/nostr_client.dart' show Nip89ClientTag;
@@ -158,6 +157,11 @@ typedef BootstrapRelayListCallback =
 /// Callback invoked before AuthService clears the outgoing session identity.
 typedef BeforeSessionTeardownCallback = Future<void> Function();
 
+/// Factory for NIP-46 remote signers. Injected in tests so startup restore can
+/// exercise unreachable signer behavior without opening relay sockets.
+typedef RemoteSignerFactory =
+    NostrRemoteSigner Function(int relayMode, NostrRemoteSignerInfo info);
+
 /// SharedPreferences key prefix for the per-pubkey one-shot flag that records
 /// whether we have already published a bootstrap kind:10002 on this device.
 const _kBootstrapKind10002Prefix = 'bootstrap_kind10002_published_';
@@ -188,8 +192,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     String? primaryRelayUrl,
     RelayDiscoveryService? relayDiscoveryService,
     Nip07Service? nip07ServiceForTest,
+    RemoteSignerFactory? remoteSignerFactory,
     Duration oauthRefreshTimeout = defaultOAuthRefreshTimeout,
     Duration expiredSessionRefreshTimeout = defaultExpiredSessionRefreshTimeout,
+    Duration? startupNetworkOperationTimeout,
   }) : _keyStorage = keyStorage ?? SecureKeyStorage(),
        _nostrKeyManager = nostrKeyManager,
        _userDataCleanupService = userDataCleanupService,
@@ -205,8 +211,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
            oauthConfig ??
            const OAuthConfig(serverUrl: '', clientId: '', redirectUri: ''),
        _injectedNip07ServiceForTest = nip07ServiceForTest,
+       _remoteSignerFactory = remoteSignerFactory ?? NostrRemoteSigner.new,
        _oauthRefreshTimeout = oauthRefreshTimeout,
-       _expiredSessionRefreshTimeout = expiredSessionRefreshTimeout;
+       _expiredSessionRefreshTimeout = expiredSessionRefreshTimeout,
+       _startupNetworkOperationTimeout =
+           startupNetworkOperationTimeout ??
+           defaultStartupNetworkOperationTimeout;
   final SecureKeyStorage _keyStorage;
   final NostrKeyManager? _nostrKeyManager;
   final UserDataCleanupService _userDataCleanupService;
@@ -214,6 +224,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   final FlutterSecureStorage? _flutterSecureStorage;
   final PreFetchFollowingCallback? _preFetchFollowing;
   final String? _profileCheckIndexerUrl;
+  final RemoteSignerFactory _remoteSignerFactory;
+  final Duration _startupNetworkOperationTimeout;
 
   /// Bound applied to the single-flight OAuth token refresh stored in
   /// [_pendingOAuthRefresh]. Injectable so tests can use a short bound.
@@ -436,6 +448,16 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// bound so the outer flow does not detach from a live refresh.
   @visibleForTesting
   static const defaultExpiredSessionRefreshTimeout = Duration(seconds: 40);
+
+  /// Default upper bound for one startup network operation while restoring a
+  /// saved remote auth session. A bunker restore can do connect + pubkey pull,
+  /// so callers that need an end-to-end budget should use
+  /// [startupAuthRestoreTimeout].
+  @visibleForTesting
+  static const defaultStartupNetworkOperationTimeout = Duration(seconds: 10);
+
+  /// Worst-case auth restore budget used by app startup splash handling.
+  static const startupAuthRestoreTimeout = Duration(seconds: 21);
 
   /// Local-first Divine OAuth initialization.
   ///
@@ -941,7 +963,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     if (_oauthClient == null) return null;
     try {
       final pubkey = expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
-      final refreshed = await _oauthClient.refreshSession(userPubkey: pubkey);
+      final refreshed = await _oauthClient
+          .refreshSession(userPubkey: pubkey)
+          .timeout(_startupNetworkOperationTimeout);
       if (refreshed == null || !refreshed.hasRpcAccess) return null;
 
       _hasExpiredOAuthSession = false;
@@ -1270,13 +1294,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
       // Set state synchronously to prevent loading screen deadlock
       _setAuthState(AuthState.unauthenticated);
-    } finally {
-      // Release the native splash that was preserved at startup. This is
-      // idempotent — safe if the 5s timeout guard in main.dart fires first.
-      // Calling remove() here (synchronously after the terminal auth state is
-      // set) ensures GoRouter's refreshListenable has already been notified,
-      // so the next frame the platform sees is the correct route. See #2749.
-      FlutterNativeSplash.remove();
     }
   }
 
@@ -2427,9 +2444,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Create and connect the remote signer
       // Don't send a new connect request - the bunker already authorized us
       // during the initial connection. We just need to reconnect to the relay.
-      _bunkerSigner = NostrRemoteSigner(RelayMode.baseMode, info);
+      _bunkerSigner = _remoteSignerFactory(RelayMode.baseMode, info);
       _setupBunkerAuthCallback();
-      await _bunkerSigner!.connect(sendConnectRequest: false);
+      await _bunkerSigner!
+          .connect(sendConnectRequest: false)
+          .timeout(_startupNetworkOperationTimeout);
 
       // Use saved public key if available, otherwise request it from bunker
       var userPubkey = info.userPubkey;
@@ -2439,7 +2458,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        userPubkey = await _bunkerSigner!.pullPubkey();
+        userPubkey = await _bunkerSigner!.pullPubkey().timeout(
+          _startupNetworkOperationTimeout,
+        );
       } else {
         Log.info(
           'Using saved userPubkey: $userPubkey',
@@ -2994,7 +3015,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         category: LogCategory.auth,
       );
 
-      _bunkerSigner = NostrRemoteSigner(RelayMode.baseMode, bunkerInfo);
+      _bunkerSigner = _remoteSignerFactory(RelayMode.baseMode, bunkerInfo);
       _setupBunkerAuthCallback();
 
       String? connectResult;
@@ -3237,7 +3258,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Create and connect the NostrRemoteSigner
       // Note: Don't send connect request since we're already connected via
       // nostrconnect://
-      _bunkerSigner = NostrRemoteSigner(RelayMode.baseMode, result.info);
+      _bunkerSigner = _remoteSignerFactory(RelayMode.baseMode, result.info);
       _setupBunkerAuthCallback();
       await _bunkerSigner!.connect(sendConnectRequest: false);
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -749,9 +749,22 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       category: LogCategory.auth,
     );
     if (_oauthClient != null) {
-      final refreshed = await _refreshOAuthSession(
-        expectedOwnerPubkey: session?.userPubkey,
-      );
+      final KeycastSession? refreshed;
+      try {
+        refreshed = await _refreshOAuthSession(
+          expectedOwnerPubkey: session?.userPubkey,
+        ).timeout(_startupNetworkOperationTimeout);
+      } on TimeoutException {
+        Log.warning(
+          'initialize: synchronous refresh timed out '
+          '(${_startupNetworkOperationTimeout.inSeconds}s)',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        _hasExpiredOAuthSession = true;
+        _setAuthState(AuthState.unauthenticated);
+        return;
+      }
 
       if (refreshed != null) {
         // Apply the same cross-account guard to the refreshed session.
@@ -963,9 +976,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     if (_oauthClient == null) return null;
     try {
       final pubkey = expectedOwnerPubkey ?? _currentProfile?.publicKeyHex;
-      final refreshed = await _oauthClient
-          .refreshSession(userPubkey: pubkey)
-          .timeout(_startupNetworkOperationTimeout);
+      final refreshed = await _oauthClient.refreshSession(userPubkey: pubkey);
       if (refreshed == null || !refreshed.hasRpcAccess) return null;
 
       _hasExpiredOAuthSession = false;
@@ -1221,7 +1232,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           );
           final bunkerInfo = await _loadBunkerInfo();
           if (bunkerInfo != null) {
-            await _reconnectBunker(bunkerInfo);
+            await _reconnectBunker(bunkerInfo, boundedByStartupTimeout: true);
             return;
           }
           // Bunker info not found — fall back to unauthenticated
@@ -2431,7 +2442,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   }
 
   /// Reconnect to a bunker using saved connection info
-  Future<void> _reconnectBunker(NostrRemoteSignerInfo info) async {
+  Future<void> _reconnectBunker(
+    NostrRemoteSignerInfo info, {
+    bool boundedByStartupTimeout = false,
+  }) async {
     Log.info(
       'Reconnecting to bunker...',
       name: 'AuthService',
@@ -2446,9 +2460,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // during the initial connection. We just need to reconnect to the relay.
       _bunkerSigner = _remoteSignerFactory(RelayMode.baseMode, info);
       _setupBunkerAuthCallback();
-      await _bunkerSigner!
-          .connect(sendConnectRequest: false)
-          .timeout(_startupNetworkOperationTimeout);
+      final connect = _bunkerSigner!.connect(sendConnectRequest: false);
+      if (boundedByStartupTimeout) {
+        await connect.timeout(_startupNetworkOperationTimeout);
+      } else {
+        await connect;
+      }
 
       // Use saved public key if available, otherwise request it from bunker
       var userPubkey = info.userPubkey;
@@ -2458,9 +2475,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        userPubkey = await _bunkerSigner!.pullPubkey().timeout(
-          _startupNetworkOperationTimeout,
-        );
+        final pullPubkey = _bunkerSigner!.pullPubkey();
+        userPubkey = boundedByStartupTimeout
+            ? await pullPubkey.timeout(_startupNetworkOperationTimeout)
+            : await pullPubkey;
       } else {
         Log.info(
           'Using saved userPubkey: $userPubkey',
@@ -2504,6 +2522,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         name: 'AuthService',
         category: LogCategory.auth,
       );
+      _bunkerSigner?.close();
       _bunkerSigner = null;
       _setAuthState(AuthState.unauthenticated);
     }

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -30,6 +30,13 @@ class DraftStorageService {
   /// with this owner and queries filter by it (plus legacy NULL rows).
   final String? ownerPubkey;
 
+  /// Owner marker for drafts captured before a user is signed in.
+  ///
+  /// Do not store new signed-out drafts as NULL: NULL is the legacy migration
+  /// shape that signed-in services intentionally claim for backward
+  /// compatibility.
+  static const anonymousOwnerPubkey = '__anonymous_offline_draft__';
+
   static const String _storageKey = 'vine_drafts';
 
   /// Migrate drafts from SharedPreferences to Drift database.

--- a/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_library_button.dart
@@ -78,7 +78,7 @@ class _VideoRecorderLibraryButtonState
         child: InkWell(
           onTap: hasClips
               ? () async {
-                  await openRecorderLibrary(context);
+                  await openRecorderLibrary(context, ref);
 
                   // Refresh library thumbnail after returning — user may have
                   // deleted clips or new thumbnails may have been recovered.

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -5,12 +5,15 @@
 
 import 'dart:async';
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
@@ -39,6 +42,23 @@ Future<void> openVideoEditorFromRecorder(
   BuildContext context,
   WidgetRef ref,
 ) async {
+  if (!ref.read(authServiceProvider).isAuthenticated) {
+    final saved = await ref
+        .read(videoEditorProvider.notifier)
+        .saveAsDraft(enforceCreateNewDraft: true);
+    if (!context.mounted) return;
+
+    if (saved) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.uploadFailureSheetSavedToDraftsSnackbar),
+        ),
+      );
+    }
+    context.go(WelcomeScreen.path);
+    return;
+  }
+
   final bloc = context.read<VideoRecorderBloc>();
   final recorderMode = bloc.state.recorderMode;
 

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -42,22 +42,8 @@ Future<void> openVideoEditorFromRecorder(
   BuildContext context,
   WidgetRef ref,
 ) async {
-  if (!ref.read(authServiceProvider).isAuthenticated) {
-    final saved = await ref
-        .read(videoEditorProvider.notifier)
-        .saveAsDraft(enforceCreateNewDraft: true);
-    if (!context.mounted) return;
-
-    if (saved) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.uploadFailureSheetSavedToDraftsSnackbar),
-        ),
-      );
-    }
-    context.go(WelcomeScreen.path);
-    return;
-  }
+  if (!await _ensureAuthenticatedForRecorderExit(context, ref)) return;
+  if (!context.mounted) return;
 
   final bloc = context.read<VideoRecorderBloc>();
   final recorderMode = bloc.state.recorderMode;
@@ -80,7 +66,10 @@ Future<void> openVideoEditorFromRecorder(
 
 /// Navigates to the clips-only library, releasing the camera during the
 /// transition and re-initializing it on return.
-Future<void> openRecorderLibrary(BuildContext context) async {
+Future<void> openRecorderLibrary(BuildContext context, WidgetRef ref) async {
+  if (!await _ensureAuthenticatedForRecorderExit(context, ref)) return;
+  if (!context.mounted) return;
+
   final bloc = context.read<VideoRecorderBloc>();
 
   final navigation = context.pushNamed(LibraryScreen.clipsOnlyRouteName);
@@ -91,6 +80,51 @@ Future<void> openRecorderLibrary(BuildContext context) async {
   await navigation;
   if (!context.mounted) return;
   bloc.add(const VideoRecorderInitializeRequested());
+}
+
+Future<bool> _ensureAuthenticatedForRecorderExit(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final authGate = ref.read(recorderExitAuthGateProvider);
+  final showedRestoreSnackbar = authGate.isRestoring;
+  if (showedRestoreSnackbar && context.mounted) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(context.l10n.authSigningYouIn),
+        duration: authGate.restoreTimeout,
+      ),
+    );
+  }
+
+  final authenticated = await authGate.waitForAuthenticatedOrTerminal();
+  if (showedRestoreSnackbar) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+    }
+  }
+
+  if (authenticated) return true;
+
+  final saved = await ref
+      .read(videoEditorProvider.notifier)
+      .saveAsDraft(enforceCreateNewDraft: true);
+  if (!context.mounted) return false;
+
+  ScaffoldMessenger.of(context).showSnackBar(
+    SnackBar(
+      content: Text(
+        saved
+            ? context.l10n.uploadFailureSheetSavedToDraftsSnackbar
+            : context.l10n.videoMetadataFailedToSaveSnackbar,
+      ),
+    ),
+  );
+
+  if (saved) {
+    context.go(WelcomeScreen.path);
+  }
+  return false;
 }
 
 /// Waits for the current route's push transition to finish before returning.

--- a/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/clips_dao.dart
@@ -259,15 +259,23 @@ class ClipsDao extends DatabaseAccessor<AppDatabase> with _$ClipsDaoMixin {
     return (delete(clips)..where((t) => t.ownerPubkey.equals(userPubkey))).go();
   }
 
-  /// Claim legacy clips (NULL ownerPubkey) for [ownerPubkey].
+  /// Claim legacy clips (NULL ownerPubkey) or rows owned by the optional
+  /// [sourceOwnerPubkey] marker for [newOwnerPubkey].
   ///
   /// Called during session setup so that pre-multi-account clips are
-  /// attributed to the user who created them and stop being visible
-  /// to other accounts via the `_ownedOrLegacy` filter.
-  Future<int> claimLegacyRows(String ownerPubkey) {
-    return (update(clips)..where((t) => t.ownerPubkey.isNull())).write(
-      ClipsCompanion(ownerPubkey: Value(ownerPubkey)),
-    );
+  /// attributed to the user who created them and signed-out recorder clips
+  /// are claimed by the next successful sign-in.
+  Future<int> claimLegacyRows(
+    String newOwnerPubkey, {
+    String? sourceOwnerPubkey,
+  }) {
+    return (update(clips)..where(
+          (t) => sourceOwnerPubkey == null
+              ? t.ownerPubkey.isNull()
+              : t.ownerPubkey.isNull() |
+                    t.ownerPubkey.equals(sourceOwnerPubkey),
+        ))
+        .write(ClipsCompanion(ownerPubkey: Value(newOwnerPubkey)));
   }
 
   /// Check if a filename is referenced by any clip's file_path

--- a/mobile/packages/db_client/lib/src/database/daos/drafts_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/drafts_dao.dart
@@ -239,15 +239,23 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
     )..where((t) => t.ownerPubkey.equals(userPubkey))).go();
   }
 
-  /// Claim legacy drafts (NULL ownerPubkey) for [ownerPubkey].
+  /// Claim legacy drafts (NULL ownerPubkey) or rows owned by the optional
+  /// [sourceOwnerPubkey] marker for [newOwnerPubkey].
   ///
   /// Called during session setup so that pre-multi-account drafts are
-  /// attributed to the user who created them and stop being visible
-  /// to other accounts via the `_ownedOrLegacy` filter.
-  Future<int> claimLegacyRows(String ownerPubkey) {
-    return (update(drafts)..where((t) => t.ownerPubkey.isNull())).write(
-      DraftsCompanion(ownerPubkey: Value(ownerPubkey)),
-    );
+  /// attributed to the user who created them and signed-out recorder drafts
+  /// are claimed by the next successful sign-in.
+  Future<int> claimLegacyRows(
+    String newOwnerPubkey, {
+    String? sourceOwnerPubkey,
+  }) {
+    return (update(drafts)..where(
+          (t) => sourceOwnerPubkey == null
+              ? t.ownerPubkey.isNull()
+              : t.ownerPubkey.isNull() |
+                    t.ownerPubkey.equals(sourceOwnerPubkey),
+        ))
+        .write(DraftsCompanion(ownerPubkey: Value(newOwnerPubkey)));
   }
 
   /// Check if a filename is referenced by any draft's

--- a/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/clips_dao_test.dart
@@ -1180,6 +1180,7 @@ void main() {
       const pubkeyB =
           'bbbb2222bbbb2222bbbb2222bbbb2222'
           'bbbb2222bbbb2222bbbb2222bbbb2222';
+      const anonymousOwner = '__anonymous_offline_draft__';
 
       test('claims NULL-owner rows for the given pubkey', () async {
         await dao.upsertClip(
@@ -1250,6 +1251,52 @@ void main() {
         );
 
         await dao.claimLegacyRows(pubkeyA);
+
+        final clipsB = await dao.getAllClips(ownerPubkey: pubkeyB);
+        expect(clipsB, isEmpty);
+      });
+
+      test(
+        'anonymous rows do not leak to signed-in owners before claim',
+        () async {
+          await dao.upsertClip(
+            id: 'clip_anonymous',
+            orderIndex: 0,
+            durationMs: 1000,
+            recordedAt: DateTime(2023, 11, 14, 10),
+            filePath: 'anonymous.mp4',
+            thumbnailPath: 'anonymous.jpeg',
+            data: '{}',
+            ownerPubkey: anonymousOwner,
+          );
+
+          final clipsB = await dao.getAllClips(ownerPubkey: pubkeyB);
+
+          expect(clipsB, isEmpty);
+        },
+      );
+
+      test('claims anonymous rows for the next signed-in owner', () async {
+        await dao.upsertClip(
+          id: 'clip_anonymous',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime(2023, 11, 14, 10),
+          filePath: 'anonymous.mp4',
+          thumbnailPath: 'anonymous.jpeg',
+          data: '{}',
+          ownerPubkey: anonymousOwner,
+        );
+
+        final claimed = await dao.claimLegacyRows(
+          pubkeyA,
+          sourceOwnerPubkey: anonymousOwner,
+        );
+
+        expect(claimed, equals(1));
+        final clipsA = await dao.getAllClips(ownerPubkey: pubkeyA);
+        expect(clipsA.map((clip) => clip.id), contains('clip_anonymous'));
+        expect(clipsA.single.ownerPubkey, equals(pubkeyA));
 
         final clipsB = await dao.getAllClips(ownerPubkey: pubkeyB);
         expect(clipsB, isEmpty);

--- a/mobile/packages/db_client/test/src/database/daos/drafts_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/drafts_dao_test.dart
@@ -398,6 +398,7 @@ void main() {
       const pubkeyB =
           'bbbb2222bbbb2222bbbb2222bbbb2222'
           'bbbb2222bbbb2222bbbb2222bbbb2222';
+      const anonymousOwner = '__anonymous_offline_draft__';
 
       Future<void> insertDraft({
         required String id,
@@ -445,6 +446,34 @@ void main() {
         await insertDraft(id: 'draft_legacy');
 
         await dao.claimLegacyRows(pubkeyA);
+
+        final draftsB = await dao.getAllDrafts(ownerPubkey: pubkeyB);
+        expect(draftsB, isEmpty);
+      });
+
+      test(
+        'anonymous rows do not leak to signed-in owners before claim',
+        () async {
+          await insertDraft(id: 'draft_anonymous', ownerPubkey: anonymousOwner);
+
+          final draftsB = await dao.getAllDrafts(ownerPubkey: pubkeyB);
+
+          expect(draftsB, isEmpty);
+        },
+      );
+
+      test('claims anonymous rows for the next signed-in owner', () async {
+        await insertDraft(id: 'draft_anonymous', ownerPubkey: anonymousOwner);
+
+        final claimed = await dao.claimLegacyRows(
+          pubkeyA,
+          sourceOwnerPubkey: anonymousOwner,
+        );
+
+        expect(claimed, equals(1));
+        final draftsA = await dao.getAllDrafts(ownerPubkey: pubkeyA);
+        expect(draftsA.map((draft) => draft.id), contains('draft_anonymous'));
+        expect(draftsA.single.ownerPubkey, equals(pubkeyA));
 
         final draftsB = await dao.getAllDrafts(ownerPubkey: pubkeyB);
         expect(draftsB, isEmpty);

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -337,5 +338,47 @@ void main() {
       );
       expect(homeInitialIndexFromPathParameters(const {}), equals(0));
     });
+  });
+
+  group('Offline recorder route', () {
+    test(
+      'unauthenticated users can navigate to recorder but not protected routes',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final sharedPreferences = await SharedPreferences.getInstance();
+        final authStateController = StreamController<AuthState>.broadcast(
+          sync: true,
+        );
+        addTearDown(authStateController.close);
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            authServiceProvider.overrideWith((ref) {
+              final authService = _MockAuthService();
+              when(
+                () => authService.authStateStream,
+              ).thenAnswer((_) => authStateController.stream);
+              when(
+                () => authService.authState,
+              ).thenReturn(AuthState.unauthenticated);
+              when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+              return authService;
+            }),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final router = container.read(goRouterProvider);
+
+        router.go(VideoRecorderScreen.path);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          router.routeInformationProvider.value.uri.toString(),
+          equals(VideoRecorderScreen.path),
+        );
+      },
+    );
   });
 }

--- a/mobile/test/services/auth_service_bunker_lifecycle_test.dart
+++ b/mobile/test/services/auth_service_bunker_lifecycle_test.dart
@@ -37,6 +37,9 @@ void main() {
     when(() => mockKeyStorage.initialize()).thenAnswer((_) async {});
     when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
     when(() => mockKeyStorage.dispose()).thenReturn(null);
+    when(
+      () => mockFlutterSecureStorage.read(key: any(named: 'key')),
+    ).thenAnswer((_) async => null);
 
     authService = AuthService(
       userDataCleanupService: mockCleanupService,
@@ -160,6 +163,39 @@ void main() {
         expect(true, isTrue); // Documentation test
       },
     );
+
+    test('startup restore times out unreachable bunker signer', () async {
+      await authService.dispose();
+
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'bunker',
+      });
+      const bunkerUrl =
+          'bunker://deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678'
+          '?relay=wss://relay.example.com';
+
+      when(
+        () => mockFlutterSecureStorage.read(key: any(named: 'key')),
+      ).thenAnswer((_) async => bunkerUrl);
+      when(
+        () => mockBunkerSigner.connect(sendConnectRequest: false),
+      ).thenAnswer((_) => Future<String?>.delayed(const Duration(hours: 1)));
+
+      authService = AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: mockKeyStorage,
+        flutterSecureStorage: mockFlutterSecureStorage,
+        remoteSignerFactory: (_, _) => mockBunkerSigner,
+        startupNetworkOperationTimeout: const Duration(milliseconds: 1),
+      );
+
+      await authService.initialize();
+
+      expect(authService.authState, AuthState.unauthenticated);
+      verify(
+        () => mockBunkerSigner.connect(sendConnectRequest: false),
+      ).called(1);
+    });
   });
 
   group('AuthService dispose cleanup', () {

--- a/mobile/test/services/auth_service_bunker_lifecycle_test.dart
+++ b/mobile/test/services/auth_service_bunker_lifecycle_test.dart
@@ -195,6 +195,7 @@ void main() {
       verify(
         () => mockBunkerSigner.connect(sendConnectRequest: false),
       ).called(1);
+      verify(() => mockBunkerSigner.close()).called(1);
     });
   });
 

--- a/mobile/test/services/auth_service_bunker_lifecycle_test.dart
+++ b/mobile/test/services/auth_service_bunker_lifecycle_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Tests for AuthService bunker lifecycle management
 // ABOUTME: Tests clearError, pause/resume, dispose with bunker signer
 
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -196,6 +199,60 @@ void main() {
         () => mockBunkerSigner.connect(sendConnectRequest: false),
       ).called(1);
       verify(() => mockBunkerSigner.close()).called(1);
+    });
+
+    test('interactive signInForAccount reconnect is unbounded for an '
+        'unreachable bunker signer', () async {
+      await authService.dispose();
+
+      const pubkeyHex =
+          'deadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
+      const bunkerUrl = 'bunker://$pubkeyHex?relay=wss://relay.example.com';
+
+      when(
+        () => mockFlutterSecureStorage.read(key: any(named: 'key')),
+      ).thenAnswer((_) async => bunkerUrl);
+      when(
+        () => mockFlutterSecureStorage.write(
+          key: any(named: 'key'),
+          value: any(named: 'value'),
+        ),
+      ).thenAnswer((_) async {});
+
+      // connect() never resolves: the bunker relay is unreachable.
+      final neverResolves = Completer<String?>();
+      when(
+        () => mockBunkerSigner.connect(sendConnectRequest: false),
+      ).thenAnswer((_) => neverResolves.future);
+
+      authService = AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: mockKeyStorage,
+        flutterSecureStorage: mockFlutterSecureStorage,
+        remoteSignerFactory: (_, _) => mockBunkerSigner,
+      );
+
+      fakeAsync((async) {
+        var completed = false;
+        unawaited(
+          authService
+              .signInForAccount(pubkeyHex, AuthenticationSource.bunker)
+              .then((_) => completed = true)
+              .catchError((Object _) => completed = true),
+        );
+
+        // Unlike the bounded startup path, the interactive reconnect applies
+        // no startup timeout: even after twice the startup budget elapses the
+        // call is still pending.
+        async.elapse(
+          AuthService.defaultStartupNetworkOperationTimeout * 2,
+        );
+
+        expect(completed, isFalse);
+        verify(
+          () => mockBunkerSigner.connect(sendConnectRequest: false),
+        ).called(1);
+      });
     });
   });
 

--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -568,5 +568,48 @@ void main() {
         },
       );
     });
+
+    test(
+      'startup refresh timeout keeps OAuth refresh single-flight occupied',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        final expiredSession = KeycastSession(
+          bunkerUrl: 'https://login.divine.video/api/nostr',
+          accessToken: 'expired_token',
+          expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+        );
+        secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+
+        final refreshCompleter = Completer<KeycastSession?>();
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) => refreshCompleter.future);
+
+        final authService = createAuthService(
+          startupNetworkOperationTimeout: const Duration(milliseconds: 1),
+        );
+
+        await authService.initialize();
+        expect(authService.authState, equals(AuthState.unauthenticated));
+
+        final retry = authService.tryRefreshExpiredSession();
+        await Future<void>.delayed(Duration.zero);
+
+        verify(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).called(1);
+
+        refreshCompleter.complete(null);
+        expect(await retry, isFalse);
+      },
+    );
   });
 }

--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -133,7 +133,7 @@ void main() {
       );
     }
 
-    AuthService createAuthService() {
+    AuthService createAuthService({Duration? startupNetworkOperationTimeout}) {
       final keyStorage = SecureKeyStorage(
         securityConfig: const SecurityConfig(requireHardwareBacked: false),
       );
@@ -141,6 +141,7 @@ void main() {
         userDataCleanupService: mockCleanupService,
         keyStorage: keyStorage,
         oauthClient: mockOAuthClient,
+        startupNetworkOperationTimeout: startupNetworkOperationTimeout,
       );
     }
 
@@ -518,6 +519,42 @@ void main() {
       ).thenAnswer((_) async => null);
 
       final authService = createAuthService();
+
+      await runZonedGuarded(
+        () async {
+          await authService.initialize();
+
+          expect(authService.authState, equals(AuthState.unauthenticated));
+          expect(authService.hasExpiredOAuthSession, isTrue);
+        },
+        (error, stack) {
+          // Ignore background errors
+        },
+      );
+    });
+
+    test('no local key + hanging refresh reaches unauthenticated', () async {
+      SharedPreferences.setMockInitialValues({
+        'authentication_source': 'divineOAuth',
+        'tos_accepted': true,
+      });
+
+      final expiredSession = KeycastSession(
+        bunkerUrl: 'https://login.divine.video/api/nostr',
+        accessToken: 'expired_token',
+        expiresAt: DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      secureStorage['keycast_session'] = jsonEncode(expiredSession.toJson());
+
+      when(
+        () => mockOAuthClient.refreshSession(
+          userPubkey: any(named: 'userPubkey'),
+        ),
+      ).thenAnswer((_) => Completer<KeycastSession?>().future);
+
+      final authService = createAuthService(
+        startupNetworkOperationTimeout: const Duration(milliseconds: 1),
+      );
 
       await runZonedGuarded(
         () async {

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -1,0 +1,227 @@
+// ABOUTME: Tests for the recorder-exit auth gate in video_recorder_navigation.
+// ABOUTME: Covers the authenticated (proceed) and restore-then-terminal
+// ABOUTME: (draft + route to Welcome) paths for both recorder-exit entries.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/screens/library_screen.dart';
+import 'package:openvine/screens/video_editor/video_editor_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockVideoRecorderBloc
+    extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
+    implements VideoRecorderBloc {}
+
+class _FakeVideoEditorNotifier extends VideoEditorNotifier {
+  bool saveAsDraftCalled = false;
+  bool startRenderVideoCalled = false;
+  bool saveResult = true;
+
+  @override
+  VideoEditorProviderState build() => VideoEditorProviderState();
+
+  @override
+  Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
+    saveAsDraftCalled = true;
+    return saveResult;
+  }
+
+  @override
+  Future<void> startRenderVideo() async {
+    startRenderVideoCalled = true;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockAuthService mockAuthService;
+  late _MockVideoRecorderBloc recorderBloc;
+  late _FakeVideoEditorNotifier fakeEditor;
+
+  setUp(() {
+    mockAuthService = _MockAuthService();
+    recorderBloc = _MockVideoRecorderBloc();
+    fakeEditor = _FakeVideoEditorNotifier();
+
+    when(() => recorderBloc.state).thenReturn(const VideoRecorderBlocState());
+    when(
+      () => mockAuthService.authStateStream,
+    ).thenAnswer((_) => const Stream<AuthState>.empty());
+  });
+
+  Widget buildHarness() {
+    final router = GoRouter(
+      initialLocation: '/recorder',
+      routes: [
+        GoRoute(
+          path: '/recorder',
+          builder: (context, state) => BlocProvider<VideoRecorderBloc>.value(
+            value: recorderBloc,
+            child: const _RecorderHarness(),
+          ),
+        ),
+        GoRoute(
+          path: VideoEditorScreen.path,
+          builder: (_, _) => const _StubScreen(label: 'editor'),
+        ),
+        GoRoute(
+          path: '/library-clips',
+          name: LibraryScreen.clipsOnlyRouteName,
+          builder: (_, _) => const _StubScreen(label: 'library'),
+        ),
+        GoRoute(
+          path: WelcomeScreen.path,
+          builder: (_, _) => const _StubScreen(label: 'welcome'),
+        ),
+      ],
+    );
+
+    return ProviderScope(
+      overrides: [
+        authServiceProvider.overrideWithValue(mockAuthService),
+        videoEditorProvider.overrideWith(() => fakeEditor),
+      ],
+      child: MaterialApp.router(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        routerConfig: router,
+      ),
+    );
+  }
+
+  group('recorder-exit auth gate', () {
+    group('when already authenticated', () {
+      setUp(() {
+        when(
+          () => mockAuthService.authState,
+        ).thenReturn(AuthState.authenticated);
+      });
+
+      testWidgets('openVideoEditorFromRecorder proceeds to the editor '
+          'without saving a draft', (tester) async {
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('open-editor')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('editor'), findsOneWidget);
+        expect(fakeEditor.saveAsDraftCalled, isFalse);
+      });
+
+      testWidgets('openRecorderLibrary proceeds to the library '
+          'without saving a draft', (tester) async {
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('open-library')));
+        await tester.pumpAndSettle();
+
+        expect(find.text('library'), findsOneWidget);
+        expect(fakeEditor.saveAsDraftCalled, isFalse);
+      });
+    });
+
+    group('when restore resolves to terminal unauthenticated', () {
+      setUp(() {
+        when(() => mockAuthService.authState).thenReturn(AuthState.checking);
+        when(
+          () => mockAuthService.authStateStream,
+        ).thenAnswer((_) => Stream<AuthState>.value(AuthState.unauthenticated));
+      });
+
+      testWidgets('openVideoEditorFromRecorder saves a draft, shows the '
+          'snackbar, and routes to Welcome', (tester) async {
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.tap(find.byKey(const Key('open-editor')));
+        await tester.pumpAndSettle();
+
+        expect(fakeEditor.saveAsDraftCalled, isTrue);
+        expect(
+          find.text(l10n.uploadFailureSheetSavedToDraftsSnackbar),
+          findsOneWidget,
+        );
+        expect(find.text('welcome'), findsOneWidget);
+        expect(find.text('editor'), findsNothing);
+
+        await tester.pumpAndSettle(const Duration(seconds: 5));
+      });
+
+      testWidgets('openRecorderLibrary saves a draft, shows the snackbar, '
+          'and routes to Welcome', (tester) async {
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.tap(find.byKey(const Key('open-library')));
+        await tester.pumpAndSettle();
+
+        expect(fakeEditor.saveAsDraftCalled, isTrue);
+        expect(
+          find.text(l10n.uploadFailureSheetSavedToDraftsSnackbar),
+          findsOneWidget,
+        );
+        expect(find.text('welcome'), findsOneWidget);
+        expect(find.text('library'), findsNothing);
+
+        await tester.pumpAndSettle(const Duration(seconds: 5));
+      });
+    });
+  });
+}
+
+class _RecorderHarness extends ConsumerWidget {
+  const _RecorderHarness();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: Column(
+        children: [
+          ElevatedButton(
+            key: const Key('open-editor'),
+            onPressed: () =>
+                unawaited(openVideoEditorFromRecorder(context, ref)),
+            child: const Text('open editor'),
+          ),
+          ElevatedButton(
+            key: const Key('open-library'),
+            onPressed: () => unawaited(openRecorderLibrary(context, ref)),
+            child: const Text('open library'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StubScreen extends StatelessWidget {
+  const _StubScreen({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(body: Center(child: Text(label)));
+  }
+}


### PR DESCRIPTION
## Summary
- bound only startup auth restore waits so offline OAuth/bunker restore reaches a terminal state without changing shared OAuth refresh, app-resume refresh, mid-session 401 recovery, or interactive account switching semantics
- decoupled native splash removal from AuthService and removed the arbitrary 5s splash timer in favor of auth-state completion with a bounded fallback
- made the recorder route public/outside the authenticated shell and added one restore-aware recorder exit guard for both editor and library exits
- saved signed-out recordings under an explicit anonymous owner marker, claimed those rows on the next sign-in, and kept NULL-owner rows reserved for legacy migration
- closed timed-out bunker signers before dropping them and replaced the brittle route assertion with behavior coverage

Fixes #5053

## Verification
- mise exec flutter@3.44.0 -- flutter test test/services/auth_service_local_first_startup_test.dart test/services/auth_service_bunker_lifecycle_test.dart test/router/app_router_test.dart
- mise exec flutter@3.44.0 -- flutter test test/src/database/daos/drafts_dao_test.dart test/src/database/daos/clips_dao_test.dart (from mobile/packages/db_client)
- mise exec flutter@3.44.0 -- flutter analyze
- pre-push hook: merge-conflict check, analyzer, generated-file verification, and changed-file tests