### PR TITLE
fix(upload): require thumbnail before publish

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -2241,8 +2241,11 @@ class UploadManager {
 
   /// Check if a URL is a valid HTTP/HTTPS URL (not a local file path)
   static bool _isHttpUrl(String? url) {
-    if (url == null || url.isEmpty) return false;
-    return url.startsWith('http://') || url.startsWith('https://');
+    final value = url?.trim();
+    if (value == null || value.isEmpty) return false;
+    final uri = Uri.tryParse(value);
+    if (uri == null || uri.host.isEmpty) return false;
+    return uri.scheme == 'http' || uri.scheme == 'https';
   }
 
   static String? _resultThumbnailUrl(dynamic result) {

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1047,7 +1047,11 @@ class UploadManager {
       }
 
       if (result.success &&
-          !_hasHttpThumbnailUrl(result: result, fallback: thumbnailCdnUrl)) {
+          !_hasHttpThumbnailUrl(
+            result: result,
+            generatedThumbnailUrl: thumbnailCdnUrl,
+            existingThumbnailUrl: upload.thumbnailPath,
+          )) {
         throw StateError('Thumbnail upload failed');
       }
 
@@ -2246,9 +2250,12 @@ class UploadManager {
 
   static bool _hasHttpThumbnailUrl({
     required dynamic result,
-    required String? fallback,
+    required String? generatedThumbnailUrl,
+    required String? existingThumbnailUrl,
   }) {
-    return _isHttpUrl(_resultThumbnailUrl(result)) || _isHttpUrl(fallback);
+    return _isHttpUrl(_resultThumbnailUrl(result)) ||
+        _isHttpUrl(generatedThumbnailUrl) ||
+        _isHttpUrl(existingThumbnailUrl);
   }
 
   /// Create success metrics with calculated values

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1277,9 +1277,14 @@ class UploadManager {
     // Fall back to string matching for non-HTTP errors
     final errorStr = error.toString().toLowerCase();
 
+    // A missing required thumbnail already exhausted the image upload's own
+    // retry path; retrying here would re-upload the full video.
+    if (errorStr.contains('thumbnail upload failed')) {
+      return false;
+    }
+
     // Network and timeout errors are retriable
     if (errorStr.contains('timeout') ||
-        errorStr.contains('thumbnail upload failed') ||
         errorStr.contains('cannot connect') ||
         errorStr.contains('network error') ||
         errorStr.contains('connection') ||
@@ -2607,8 +2612,9 @@ Upload Timeout Failure:
       _updateUploadProgress(upload.id, 0.85);
 
       // Upload thumbnail to Blossom server. Divine relay publishing requires
-      // a CDN thumbnail, so keep the service-level image retry enabled before
-      // the upload pipeline retries the whole video+thumbnail attempt.
+      // a CDN thumbnail, so keep the image upload's own retry enabled here.
+      // If no HTTP thumbnail URL is available after that, the outer video
+      // pipeline treats it as terminal to avoid re-uploading the whole video.
       final uploadResult = await _blossomService.uploadImage(
         imageFile: thumbnailFile,
         nostrPubkey: nostrPubkey,

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1038,13 +1038,20 @@ class UploadManager {
             category: LogCategory.video,
           );
         } else {
-          Log.warning(
-            '❌ Failed to upload thumbnail to CDN',
+          Log.error(
+            '❌ Failed to upload required thumbnail to CDN',
             name: 'UploadManager',
             category: LogCategory.video,
           );
         }
+      }
 
+      if (result.success &&
+          !_hasHttpThumbnailUrl(result: result, fallback: thumbnailCdnUrl)) {
+        throw StateError('Thumbnail upload failed');
+      }
+
+      if (result.success) {
         _updateUploadProgress(upload.id, 1.0);
         onProgress?.call(1.0);
       }
@@ -1268,6 +1275,7 @@ class UploadManager {
 
     // Network and timeout errors are retriable
     if (errorStr.contains('timeout') ||
+        errorStr.contains('thumbnail upload failed') ||
         errorStr.contains('cannot connect') ||
         errorStr.contains('network error') ||
         errorStr.contains('connection') ||
@@ -2110,15 +2118,7 @@ class UploadManager {
 
   /// Create successful upload with metadata
   PendingUpload _createSuccessfulUpload(PendingUpload upload, dynamic result) {
-    // Handle both BlossomUploadResult and DirectUploadResult structures
-    String? resultThumbnailUrl;
-    try {
-      // Get thumbnailUrl from upload result (both services should provide it)
-      resultThumbnailUrl = result.thumbnailUrl as String?;
-    } catch (e) {
-      // Fallback if thumbnailUrl is not available
-      resultThumbnailUrl = null;
-    }
+    final resultThumbnailUrl = _resultThumbnailUrl(result);
 
     final existingThumbnailUrl = upload.thumbnailPath;
     String? thumbnailUrl;
@@ -2234,6 +2234,21 @@ class UploadManager {
   static bool _isHttpUrl(String? url) {
     if (url == null || url.isEmpty) return false;
     return url.startsWith('http://') || url.startsWith('https://');
+  }
+
+  static String? _resultThumbnailUrl(dynamic result) {
+    try {
+      return result.thumbnailUrl as String?;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static bool _hasHttpThumbnailUrl({
+    required dynamic result,
+    required String? fallback,
+  }) {
+    return _isHttpUrl(_resultThumbnailUrl(result)) || _isHttpUrl(fallback);
   }
 
   /// Create success metrics with calculated values
@@ -2584,17 +2599,12 @@ Upload Timeout Failure:
 
       _updateUploadProgress(upload.id, 0.85);
 
-      // Upload thumbnail to Blossom server.
-      //
-      // `maxAttempts: 1` opts out of `BlossomUploadService.uploadImage`'s
-      // service-level retry (added for #3862). UploadManager already wraps
-      // the entire video+thumbnail pipeline in `AsyncUtils.retryWithBackoff`
-      // (see `_uploadHandler` retry config), so retrying again at the
-      // service layer would compound delays without benefit.
+      // Upload thumbnail to Blossom server. Divine relay publishing requires
+      // a CDN thumbnail, so keep the service-level image retry enabled before
+      // the upload pipeline retries the whole video+thumbnail attempt.
       final uploadResult = await _blossomService.uploadImage(
         imageFile: thumbnailFile,
         nostrPubkey: nostrPubkey,
-        maxAttempts: 1,
         onProgress: (progress) {
           // Map thumbnail progress to 85%-100% of total upload
           _updateUploadProgress(upload.id, 0.85 + (progress * 0.15));

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -183,6 +183,18 @@ class VideoPublishService {
         );
       }
 
+      if (_uploadedThumbnailUrl(pendingUpload) == null) {
+        Log.error(
+          '❌ Upload is missing required CDN thumbnail URL',
+          category: .video,
+        );
+        return await _handleUploadError(
+          Exception('Thumbnail upload failed'),
+          StackTrace.current,
+          draft,
+        );
+      }
+
       // Publish Nostr event
       Log.info('📝 Publishing Nostr event...', category: .video);
 
@@ -724,6 +736,10 @@ class VideoPublishService {
         errorString.contains('disk full')) {
       return 'Not enough storage on your device. '
           'Free up some space and try again.';
+    }
+
+    if (errorString.contains('thumbnail upload failed')) {
+      return 'The video uploaded, but the thumbnail could not be prepared. Please try again.';
     }
 
     // Nostr event publish

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -359,9 +359,8 @@ class BlossomUploadService {
 
   /// Default total attempts for a whole-image upload to a single server.
   /// 1 initial + 2 retries; covers transient 5xx and connection blips on
-  /// `media.divine.video` without compounding when a caller (e.g. the
-  /// app-level UploadManager) already wraps the call in its own retry
-  /// loop — those callers pass `maxAttempts: 1`.
+  /// `media.divine.video`. Callers that already wrap the operation in their
+  /// own retry loop can pass `maxAttempts: 1` to avoid compounded delays.
   static const int _defaultUploadImageMaxAttempts = 3;
 
   /// Base delay between retried image upload attempts. Doubled on each retry
@@ -689,9 +688,8 @@ class BlossomUploadService {
   /// Run [attempt] up to [maxAttempts] times with exponential backoff,
   /// stopping early on success or on a non-transient failure.
   ///
-  /// `maxAttempts == 1` disables retry — useful for callers (UploadManager)
-  /// that already wrap the call in their own retry loop and want to avoid
-  /// compounded delays.
+  /// `maxAttempts == 1` disables retry for callers that already wrap the call
+  /// in their own retry loop and want to avoid compounded delays.
   Future<BlossomUploadResult> _uploadWithRetry({
     required Future<BlossomUploadResult> Function() attempt,
     required int maxAttempts,

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -252,6 +252,13 @@ void main() {
         );
       });
 
+      test('returns true for required thumbnail upload failures', () {
+        expect(
+          uploadManager.isRetriableError(StateError('Thumbnail upload failed')),
+          isTrue,
+        );
+      });
+
       test('returns false for file not found', () {
         expect(
           uploadManager.isRetriableError(Exception('File not found')),
@@ -707,8 +714,9 @@ void main() {
     });
 
     /// Stubs [mock] so that [uploadVideo] fails [failCount] times before
-    /// succeeding. [uploadImage] (thumbnail) always returns a graceful
-    /// failure so it doesn't interfere with the upload flow.
+    /// succeeding. The success result includes a server thumbnail URL so these
+    /// retry-counter tests do not depend on thumbnail extraction from fake
+    /// video bytes.
     void stubUploadSequence(
       _MockBlossomUploadService mock, {
       required int failCount,
@@ -748,6 +756,7 @@ void main() {
           videoId: 'vid-ok',
           url: 'https://media.divine.video/vid-ok',
           fallbackUrl: 'https://media.divine.video/vid-ok',
+          thumbnailUrl: 'https://media.divine.video/vid-ok-thumb.jpg',
         );
       });
     }
@@ -791,6 +800,7 @@ void main() {
             videoId: 'vid-status',
             url: 'https://media.divine.video/vid-status',
             fallbackUrl: 'https://media.divine.video/vid-status',
+            thumbnailUrl: 'https://media.divine.video/vid-status-thumb.jpg',
           );
         });
 
@@ -866,6 +876,7 @@ void main() {
             videoId: 'vid-manual',
             url: 'https://media.divine.video/vid-manual',
             fallbackUrl: 'https://media.divine.video/vid-manual',
+            thumbnailUrl: 'https://media.divine.video/vid-manual-thumb.jpg',
           ),
         );
 

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -252,10 +252,10 @@ void main() {
         );
       });
 
-      test('returns true for required thumbnail upload failures', () {
+      test('returns false for required thumbnail upload failures', () {
         expect(
           uploadManager.isRetriableError(StateError('Thumbnail upload failed')),
-          isTrue,
+          isFalse,
         );
       });
 

--- a/mobile/test/services/upload_manager_from_draft_test.dart
+++ b/mobile/test/services/upload_manager_from_draft_test.dart
@@ -65,6 +65,7 @@ void main() {
           videoId: 'test-video-id',
           url: 'https://media.divine.video/test-video-id',
           fallbackUrl: 'https://media.divine.video/test-video-id',
+          thumbnailUrl: 'https://media.divine.video/test-video-id-thumb.jpg',
         ),
       );
       uploadManager = UploadManager(blossomService: mockBlossomService);
@@ -177,8 +178,13 @@ void main() {
           onProgress: any(named: 'onProgress'),
         ),
       ).thenAnswer(
-        (_) async =>
-            const BlossomUploadResult(success: true, videoId: 'rendered-video'),
+        (_) async => const BlossomUploadResult(
+          success: true,
+          videoId: 'rendered-video',
+          url: 'https://media.divine.video/rendered-video',
+          fallbackUrl: 'https://media.divine.video/rendered-video',
+          thumbnailUrl: 'https://media.divine.video/rendered-video-thumb.jpg',
+        ),
       );
 
       final draft = DivineVideoDraft.create(

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:mocktail/mocktail.dart';
@@ -16,6 +17,15 @@ import '../helpers/test_helpers.dart';
 import '../mocks/mock_path_provider_platform.dart';
 
 class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+void _mockConnectivity(String result) {
+  const channel = MethodChannel('dev.fluttercommunity.plus/connectivity');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'check') return [result];
+        return null;
+      });
+}
 
 void main() {
   setUpAll(() async {
@@ -58,6 +68,7 @@ void main() {
       when(
         () => mockBlossomService.isBlossomEnabled(),
       ).thenAnswer((_) async => false);
+      _mockConnectivity('wifi');
 
       uploadManager = UploadManager(
         blossomService: mockBlossomService,
@@ -268,59 +279,56 @@ void main() {
       expect(completedUpload.thumbnailPath, isNot(equals(localThumbnailPath)));
     });
 
-    test(
-      'resumeInterruptedUpload fails when only a stale non-HTTP thumbnail '
-      'exists',
-      () async {
-        const localThumbnailPath = '/var/cache/thumbnails/frame.jpg';
-        final upload =
-            PendingUpload.create(
-              localVideoPath: videoFile.path,
-              nostrPubkey: 'test-pubkey',
-              title: 'Video with stale thumbnail',
-            ).copyWith(
-              status: UploadStatus.uploading,
-              thumbnailPath: localThumbnailPath,
-              uploadProgress: 0.8,
-            );
+    test('resumeInterruptedUpload fails when only a stale non-HTTP thumbnail '
+        'exists', () async {
+      const localThumbnailPath = '/var/cache/thumbnails/frame.jpg';
+      final upload =
+          PendingUpload.create(
+            localVideoPath: videoFile.path,
+            nostrPubkey: 'test-pubkey',
+            title: 'Video with stale thumbnail',
+          ).copyWith(
+            status: UploadStatus.uploading,
+            thumbnailPath: localThumbnailPath,
+            uploadProgress: 0.8,
+          );
 
-        final box = Hive.box<PendingUpload>('pending_uploads');
-        await box.put(upload.id, upload);
+      final box = Hive.box<PendingUpload>('pending_uploads');
+      await box.put(upload.id, upload);
 
-        when(
-          () => mockBlossomService.uploadVideo(
-            videoFile: any(named: 'videoFile'),
-            nostrPubkey: any(named: 'nostrPubkey'),
-            title: any(named: 'title'),
-            description: any(named: 'description'),
-            hashtags: any(named: 'hashtags'),
-            proofManifestJson: any(named: 'proofManifestJson'),
-            resumableSession: any(named: 'resumableSession'),
-            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
-            onProgress: any(named: 'onProgress'),
-          ),
-        ).thenAnswer(
-          (_) async => const BlossomUploadResult(
-            success: true,
-            videoId: 'video-without-thumbnail',
-            url: 'https://media.divine.video/video-without-thumbnail',
-            fallbackUrl: 'https://media.divine.video/video-without-thumbnail',
-          ),
-        );
+      when(
+        () => mockBlossomService.uploadVideo(
+          videoFile: any(named: 'videoFile'),
+          nostrPubkey: any(named: 'nostrPubkey'),
+          title: any(named: 'title'),
+          description: any(named: 'description'),
+          hashtags: any(named: 'hashtags'),
+          proofManifestJson: any(named: 'proofManifestJson'),
+          resumableSession: any(named: 'resumableSession'),
+          onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer(
+        (_) async => const BlossomUploadResult(
+          success: true,
+          videoId: 'video-without-thumbnail',
+          url: 'https://media.divine.video/video-without-thumbnail',
+          fallbackUrl: 'https://media.divine.video/video-without-thumbnail',
+        ),
+      );
 
-        uploadManager.resumeInterruptedUpload(upload.id);
+      uploadManager.resumeInterruptedUpload(upload.id);
 
-        await TestHelpers.waitForCondition(() {
-          final currentUpload = uploadManager.getUpload(upload.id);
-          return currentUpload?.status == UploadStatus.failed;
-        });
+      await TestHelpers.waitForCondition(() {
+        final currentUpload = uploadManager.getUpload(upload.id);
+        return currentUpload?.status == UploadStatus.failed;
+      });
 
-        final completedUpload = uploadManager.getUpload(upload.id);
-        expect(completedUpload, isNotNull);
-        expect(completedUpload!.status, equals(UploadStatus.failed));
-        expect(completedUpload.errorMessage, isNotEmpty);
-      },
-    );
+      final completedUpload = uploadManager.getUpload(upload.id);
+      expect(completedUpload, isNotNull);
+      expect(completedUpload!.status, equals(UploadStatus.failed));
+      expect(completedUpload.errorMessage, isNotEmpty);
+    });
 
     test(
       'resumeInterruptedUpload falls back to failed when session expires',
@@ -484,6 +492,63 @@ void main() {
           ),
         );
         await uploadFuture;
+      },
+    );
+
+    test(
+      'does not re-upload video when required thumbnail upload fails',
+      () async {
+        when(
+          () => mockBlossomService.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).thenAnswer(
+          (_) async => const BlossomUploadResult(
+            success: true,
+            videoId: 'video-without-thumbnail',
+            url: 'https://media.divine.video/video-without-thumbnail',
+            fallbackUrl: 'https://media.divine.video/video-without-thumbnail',
+          ),
+        );
+
+        await expectLater(
+          uploadManager.startUpload(
+            videoFile: videoFile,
+            nostrPubkey: 'test-pubkey',
+            title: 'Video missing thumbnail',
+            thumbnailTimestamp:
+                VideoEditorConstants.defaultThumbnailExtractTime,
+          ),
+          throwsA(isA<Exception>()),
+        );
+
+        verify(
+          () => mockBlossomService.uploadVideo(
+            videoFile: any(named: 'videoFile'),
+            nostrPubkey: any(named: 'nostrPubkey'),
+            title: any(named: 'title'),
+            description: any(named: 'description'),
+            hashtags: any(named: 'hashtags'),
+            proofManifestJson: any(named: 'proofManifestJson'),
+            resumableSession: any(named: 'resumableSession'),
+            onResumableSessionUpdated: any(named: 'onResumableSessionUpdated'),
+            onProgress: any(named: 'onProgress'),
+          ),
+        ).called(1);
+
+        final failedUpload = uploadManager.pendingUploads.singleWhere(
+          (upload) => upload.title == 'Video missing thumbnail',
+        );
+        expect(failedUpload.status, equals(UploadStatus.failed));
+        expect(failedUpload.errorMessage, isNotEmpty);
       },
     );
 

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -516,6 +516,7 @@ void main() {
             videoId: 'video-without-thumbnail',
             url: 'https://media.divine.video/video-without-thumbnail',
             fallbackUrl: 'https://media.divine.video/video-without-thumbnail',
+            thumbnailUrl: 'https://',
           ),
         );
 

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -59,7 +59,13 @@ void main() {
         () => mockBlossomService.isBlossomEnabled(),
       ).thenAnswer((_) async => false);
 
-      uploadManager = UploadManager(blossomService: mockBlossomService);
+      uploadManager = UploadManager(
+        blossomService: mockBlossomService,
+        retryConfig: const UploadRetryConfig(
+          initialDelay: Duration.zero,
+          maxDelay: Duration.zero,
+        ),
+      );
       await uploadManager.initialize();
       await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
     });
@@ -126,6 +132,7 @@ void main() {
             videoId: 'video-123',
             url: 'https://media.divine.video/video-123',
             fallbackUrl: 'https://media.divine.video/video-123',
+            thumbnailUrl: 'https://media.divine.video/video-123-thumb.jpg',
           );
         });
 
@@ -262,8 +269,8 @@ void main() {
     });
 
     test(
-      'resumeInterruptedUpload clears existing non-HTTP thumbnail when result '
-      'does not provide a valid URL',
+      'resumeInterruptedUpload fails when only a stale non-HTTP thumbnail '
+      'exists',
       () async {
         const localThumbnailPath = '/var/cache/thumbnails/frame.jpg';
         final upload =
@@ -305,13 +312,13 @@ void main() {
 
         await TestHelpers.waitForCondition(() {
           final currentUpload = uploadManager.getUpload(upload.id);
-          return currentUpload?.status == UploadStatus.readyToPublish;
+          return currentUpload?.status == UploadStatus.failed;
         });
 
         final completedUpload = uploadManager.getUpload(upload.id);
         expect(completedUpload, isNotNull);
-        expect(completedUpload!.videoId, equals('video-without-thumbnail'));
-        expect(completedUpload.thumbnailPath, isNull);
+        expect(completedUpload!.status, equals(UploadStatus.failed));
+        expect(completedUpload.errorMessage, isNotEmpty);
       },
     );
 
@@ -473,6 +480,7 @@ void main() {
             videoId: 'video-serial',
             url: 'https://media.divine.video/video-serial',
             fallbackUrl: 'https://media.divine.video/video-serial',
+            thumbnailUrl: 'https://media.divine.video/video-serial-thumb.jpg',
           ),
         );
         await uploadFuture;

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -133,6 +133,58 @@ void main() {
       });
 
       test(
+        'returns error and does not publish when upload has no CDN thumbnail',
+        () async {
+          // Arrange
+          _setupSuccessfulPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+            readyUpload: _createPendingUpload(
+              status: UploadStatus.readyToPublish,
+              thumbnailPath: null,
+            ),
+          );
+
+          final draft = _createTestDraft();
+
+          // Act
+          final result = await service.publishVideo(draft: draft);
+
+          // Assert
+          expect(result, isA<PublishError>());
+          expect(
+            (result as PublishError).userMessage,
+            'The video uploaded, but the thumbnail could not be prepared. Please try again.',
+          );
+          verifyNever(
+            () => mockVideoEventPublisher.publishVideoEvent(
+              upload: any(named: 'upload'),
+              title: any(named: 'title'),
+              description: any(named: 'description'),
+              hashtags: any(named: 'hashtags'),
+              expirationTimestamp: any(named: 'expirationTimestamp'),
+              allowAudioReuse: any(named: 'allowAudioReuse'),
+              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
+              inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+              inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+              inspiredByNpub: any(named: 'inspiredByNpub'),
+              selectedAudio: any(named: 'selectedAudio'),
+              selectedAudioEventId: any(named: 'selectedAudioEventId'),
+              selectedAudioRelay: any(named: 'selectedAudioRelay'),
+              language: any(named: 'language'),
+              contentWarning: any(named: 'contentWarning'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+              replyContext: any(named: 'replyContext'),
+              addReplyToFeed: any(named: 'addReplyToFeed'),
+            ),
+          );
+        },
+      );
+
+      test(
         'resolves mentions from description and text overlays before publishing',
         () async {
           _setupSuccessfulPublish(
@@ -379,60 +431,58 @@ void main() {
             creatorPubkey: 'test_pubkey',
             videoAddress: '34236:test_pubkey:test_video_id',
             title: 'Test Video',
+            thumbnailUrl: _defaultThumbnailPath,
             relayHint: 'wss://relay.divine.video',
           ),
         ).called(1);
       });
 
-      test(
-        'collaborator invites include the uploaded thumbnail URL',
-        () async {
-          const thumbnailUrl = 'https://cdn.divine.video/thumbs/test_video.jpg';
-          final readyUpload = _createPendingUpload(
-            status: UploadStatus.readyToPublish,
-            thumbnailPath: thumbnailUrl,
-          );
-          _setupSuccessfulPublish(
-            mockAuthService: mockAuthService,
-            mockUploadManager: mockUploadManager,
-            mockDraftService: mockDraftService,
-            mockVideoEventPublisher: mockVideoEventPublisher,
-            readyUpload: readyUpload,
-          );
-          when(
-            () => mockCollaboratorInviteService.sendInvites(
-              collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
-              creatorPubkey: any(named: 'creatorPubkey'),
-              videoAddress: any(named: 'videoAddress'),
-              title: any(named: 'title'),
-              thumbnailUrl: any(named: 'thumbnailUrl'),
-              relayHint: any(named: 'relayHint'),
-            ),
-          ).thenAnswer(
-            (_) async => const CollaboratorInviteBatchResult(results: {}),
-          );
+      test('collaborator invites include the uploaded thumbnail URL', () async {
+        const thumbnailUrl = 'https://cdn.divine.video/thumbs/test_video.jpg';
+        final readyUpload = _createPendingUpload(
+          status: UploadStatus.readyToPublish,
+          thumbnailPath: thumbnailUrl,
+        );
+        _setupSuccessfulPublish(
+          mockAuthService: mockAuthService,
+          mockUploadManager: mockUploadManager,
+          mockDraftService: mockDraftService,
+          mockVideoEventPublisher: mockVideoEventPublisher,
+          readyUpload: readyUpload,
+        );
+        when(
+          () => mockCollaboratorInviteService.sendInvites(
+            collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+            creatorPubkey: any(named: 'creatorPubkey'),
+            videoAddress: any(named: 'videoAddress'),
+            title: any(named: 'title'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            relayHint: any(named: 'relayHint'),
+          ),
+        ).thenAnswer(
+          (_) async => const CollaboratorInviteBatchResult(results: {}),
+        );
 
-          final draft = _createTestDraft(
-            collaboratorPubkeys: {
-              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-            },
-          );
+        final draft = _createTestDraft(
+          collaboratorPubkeys: {
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          },
+        );
 
-          final result = await service.publishVideo(draft: draft);
+        final result = await service.publishVideo(draft: draft);
 
-          expect(result, isA<PublishSuccess>());
-          verify(
-            () => mockCollaboratorInviteService.sendInvites(
-              collaboratorPubkeys: draft.collaboratorPubkeys,
-              creatorPubkey: 'test_pubkey',
-              videoAddress: '34236:test_pubkey:test_video_id',
-              title: 'Test Video',
-              thumbnailUrl: thumbnailUrl,
-              relayHint: 'wss://relay.divine.video',
-            ),
-          ).called(1);
-        },
-      );
+        expect(result, isA<PublishSuccess>());
+        verify(
+          () => mockCollaboratorInviteService.sendInvites(
+            collaboratorPubkeys: draft.collaboratorPubkeys,
+            creatorPubkey: 'test_pubkey',
+            videoAddress: '34236:test_pubkey:test_video_id',
+            title: 'Test Video',
+            thumbnailUrl: thumbnailUrl,
+            relayHint: 'wss://relay.divine.video',
+          ),
+        ).called(1);
+      });
 
       test(
         'publishes video event before sending collaborator invites',
@@ -474,6 +524,7 @@ void main() {
               expirationTimestamp: any(named: 'expirationTimestamp'),
               allowAudioReuse: any(named: 'allowAudioReuse'),
               collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+              mentionedPubkeys: any(named: 'mentionedPubkeys'),
               inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
               inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
               inspiredByNpub: any(named: 'inspiredByNpub'),
@@ -482,12 +533,16 @@ void main() {
               selectedAudioRelay: any(named: 'selectedAudioRelay'),
               language: any(named: 'language'),
               contentWarning: any(named: 'contentWarning'),
+              thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+              replyContext: any(named: 'replyContext'),
+              addReplyToFeed: any(named: 'addReplyToFeed'),
             ),
             () => mockCollaboratorInviteService.sendInvites(
               collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
               creatorPubkey: any(named: 'creatorPubkey'),
               videoAddress: any(named: 'videoAddress'),
               title: any(named: 'title'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
               relayHint: any(named: 'relayHint'),
             ),
           ]);
@@ -515,9 +570,7 @@ void main() {
             (_) async =>
                 _createPendingUpload(status: UploadStatus.readyToPublish),
           );
-          when(
-            () => mockUploadManager.getUpload(any()),
-          ).thenReturn(
+          when(() => mockUploadManager.getUpload(any())).thenReturn(
             _createPendingUpload(status: UploadStatus.readyToPublish),
           );
           when(
@@ -1493,7 +1546,7 @@ DivineVideoDraft _createTestDraft({
 PendingUpload _createPendingUpload({
   required UploadStatus status,
   String? errorMessage,
-  String? thumbnailPath,
+  Object? thumbnailPath = _defaultThumbnailPath,
 }) {
   return PendingUpload(
     id: 'test_upload_id',
@@ -1505,9 +1558,11 @@ PendingUpload _createPendingUpload({
     uploadProgress: status == UploadStatus.readyToPublish ? 1.0 : 0.5,
     videoId: 'test_video_id',
     cdnUrl: 'https://test.cdn/video.mp4',
-    thumbnailPath: thumbnailPath,
+    thumbnailPath: thumbnailPath as String?,
   );
 }
+
+const String _defaultThumbnailPath = 'https://test.cdn/thumbnail.jpg';
 
 void _setupSuccessfulPublish({
   required MockAuthService mockAuthService,
@@ -1517,10 +1572,7 @@ void _setupSuccessfulPublish({
   PendingUpload? readyUpload,
 }) {
   final upload =
-      readyUpload ??
-      _createPendingUpload(
-        status: UploadStatus.readyToPublish,
-      );
+      readyUpload ?? _createPendingUpload(status: UploadStatus.readyToPublish);
   when(() => mockAuthService.isAuthenticated).thenReturn(true);
   when(() => mockAuthService.currentPublicKeyHex).thenReturn('test_pubkey');
   when(() => mockDraftService.saveDraft(any())).thenAnswer((_) async {});
@@ -1532,12 +1584,8 @@ void _setupSuccessfulPublish({
       nostrPubkey: any(named: 'nostrPubkey'),
       onProgress: any(named: 'onProgress'),
     ),
-  ).thenAnswer(
-    (_) async => upload,
-  );
-  when(
-    () => mockUploadManager.getUpload(any()),
-  ).thenReturn(upload);
+  ).thenAnswer((_) async => upload);
+  when(() => mockUploadManager.getUpload(any())).thenReturn(upload);
   when(
     () => mockVideoEventPublisher.publishVideoEvent(
       upload: any(named: 'upload'),

--- a/mobile/test/unit/services/upload_manager_get_by_path_test.dart
+++ b/mobile/test/unit/services/upload_manager_get_by_path_test.dart
@@ -65,8 +65,13 @@ void main() {
         onProgress: any(named: 'onProgress'),
       ),
     ).thenAnswer(
-      (_) async =>
-          const BlossomUploadResult(success: true, videoId: 'test-video-id'),
+      (_) async => const BlossomUploadResult(
+        success: true,
+        videoId: 'test-video-id',
+        url: 'https://media.divine.video/test-video-id',
+        fallbackUrl: 'https://media.divine.video/test-video-id',
+        thumbnailUrl: 'https://media.divine.video/test-video-id-thumb.jpg',
+      ),
     );
     uploadManager = UploadManager(blossomService: mockUploadService);
 


### PR DESCRIPTION
Closes #5101

## Summary
- fail upload attempts when neither the Blossom result nor generated thumbnail provides an HTTP thumbnail URL
- keep Blossom image retry enabled for required thumbnail uploads, but treat a missing required thumbnail as terminal for the outer video upload retry so the app does not re-upload the whole video
- block publish of reusable ready uploads that are missing a CDN thumbnail, with a clear user-facing retry message
- intentionally fail resumed uploads that only have a stale/non-HTTP thumbnail instead of moving them to `readyToPublish`; those uploads could not publish successfully because the relay requires an HTTP thumbnail
- update publish/upload tests so successful fixtures include required thumbnails, missing-thumbnail publishes never hit Nostr, and thumbnail-only failures do not re-upload the video

## Validation
- `mise exec -- flutter test test/services/upload_manager_error_handling_test.dart test/services/upload_manager_resumable_upload_test.dart`
- `mise exec -- flutter analyze`
- pre-push analyzer and changed-file tests passed
