### PR TITLE
fix(comments): load video threads from v2 API

### DIFF
--- a/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
@@ -131,6 +131,7 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
         loadedCount: commentsById.length,
         lastBatchCount: thread.comments.length,
         threadTotalCount: thread.totalCount,
+        threadHasMore: thread.hasMore,
       );
 
       emit(
@@ -222,6 +223,7 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
             loadedCount: allCommentsById.length,
             lastBatchCount: thread.comments.length,
             threadTotalCount: thread.totalCount,
+            threadHasMore: thread.hasMore,
           ),
           replyCountsByCommentId: computeReplyCounts(allCommentsById),
         ),
@@ -471,7 +473,10 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
     required int loadedCount,
     required int lastBatchCount,
     required int threadTotalCount,
+    bool? threadHasMore,
   }) {
+    if (threadHasMore != null) return threadHasMore;
+
     final effectiveTotalCount =
         _initialTotalCount ??
         (threadTotalCount > lastBatchCount

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -171,16 +171,18 @@ class CommentsRepository {
                     ),
                   )
                 : restThread;
-            // Auto-update the count cache with the authoritative REST total.
-            // Zero is written too so a previously cached positive value
-            // can't outlive the comments it counted — important with the
-            // addressable-id companion cache, which would otherwise serve
-            // that stale positive for the post-edit event id.
-            _writeCachedCommentCount(
-              rootEventId,
-              thread.totalCount,
-              rootAddressableId: rootAddressableId,
-            );
+            if (thread.hasExactTotal) {
+              // Auto-update the count cache with the authoritative REST total.
+              // Zero is written too so a previously cached positive value
+              // can't outlive the comments it counted — important with the
+              // addressable-id companion cache, which would otherwise serve
+              // that stale positive for the post-edit event id.
+              _writeCachedCommentCount(
+                rootEventId,
+                thread.totalCount,
+                rootAddressableId: rootAddressableId,
+              );
+            }
             return _filterThread(thread);
           }
         } on FunnelcakeException {
@@ -930,7 +932,11 @@ class CommentsRepository {
     }
 
     final thread = _buildThreadFromComments(commentMap, rootEventId);
-    return thread.copyWith(totalCount: response.total);
+    return thread.copyWith(
+      totalCount: response.total,
+      hasMore: response.hasMore,
+      hasExactTotal: response.hasExactTotal,
+    );
   }
 
   Future<CommentThread> _loadRelayVideoReplies({
@@ -997,6 +1003,8 @@ class CommentsRepository {
         merged.comments.length,
         restTotal + addedRelayVideoReplyCount,
       ),
+      hasMore: restThread.hasMore,
+      hasExactTotal: restThread.hasExactTotal,
     );
   }
 

--- a/mobile/packages/comments_repository/lib/src/models/comment_thread.dart
+++ b/mobile/packages/comments_repository/lib/src/models/comment_thread.dart
@@ -17,6 +17,8 @@ class CommentThread extends Equatable {
     required this.rootEventId,
     this.comments = const [],
     this.totalCount = 0,
+    this.hasMore,
+    this.hasExactTotal = true,
     this.commentCache = const {},
   });
 
@@ -24,6 +26,8 @@ class CommentThread extends Equatable {
   const CommentThread.empty(this.rootEventId)
     : comments = const [],
       totalCount = 0,
+      hasMore = false,
+      hasExactTotal = true,
       commentCache = const {};
 
   /// The ID of the root event these comments belong to.
@@ -34,6 +38,14 @@ class CommentThread extends Equatable {
 
   /// Total number of comments in the thread (including replies).
   final int totalCount;
+
+  /// Whether another page is available when the source reports pagination
+  /// explicitly.
+  final bool? hasMore;
+
+  /// Whether [totalCount] is an exact server count rather than a pagination
+  /// lower bound.
+  final bool hasExactTotal;
 
   /// Cache of all comments by ID for quick lookup.
   final Map<String, Comment> commentCache;
@@ -52,11 +64,15 @@ class CommentThread extends Equatable {
     String? rootEventId,
     List<Comment>? comments,
     int? totalCount,
+    bool? hasMore,
+    bool? hasExactTotal,
     Map<String, Comment>? commentCache,
   }) => CommentThread(
     rootEventId: rootEventId ?? this.rootEventId,
     comments: comments ?? this.comments,
     totalCount: totalCount ?? this.totalCount,
+    hasMore: hasMore ?? this.hasMore,
+    hasExactTotal: hasExactTotal ?? this.hasExactTotal,
     commentCache: commentCache ?? this.commentCache,
   );
 
@@ -65,6 +81,8 @@ class CommentThread extends Equatable {
     rootEventId,
     comments,
     totalCount,
+    hasMore,
+    hasExactTotal,
     commentCache,
   ];
 }

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -1069,6 +1069,70 @@ void main() {
         );
 
         test(
+          'v2 paginated lower-bound total does not overwrite cached count',
+          () async {
+            repository =
+                CommentsRepository(
+                  nostrClient: mockNostrClient,
+                  funnelcakeApiClient: mockFunnelcakeApiClient,
+                )..updateCachedCommentCount(
+                  oldEventId,
+                  7,
+                  rootAddressableId: addressableId,
+                );
+
+            when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeApiClient.getVideoComments(
+                videoId: any(named: 'videoId'),
+                sort: any(named: 'sort'),
+                limit: any(named: 'limit'),
+                offset: any(named: 'offset'),
+              ),
+            ).thenAnswer(
+              (_) async => VideoCommentsResponse(
+                comments: [
+                  VideoComment(
+                    id: 'rest_comment',
+                    pubkey: testUserPubkey,
+                    createdAt: 1000,
+                    kind: _commentKind,
+                    content: 'REST comment',
+                    sig: 'sig',
+                    tags: [
+                      ['E', newEventId],
+                      ['K', _testRootEventKind.toString()],
+                      ['P', testRootAuthorPubkey],
+                      ['e', newEventId],
+                      ['k', _testRootEventKind.toString()],
+                      ['p', testRootAuthorPubkey],
+                    ],
+                  ),
+                ],
+                total: 2,
+                hasMore: true,
+                hasExactTotal: false,
+              ),
+            );
+
+            final loaded = await repository.loadComments(
+              rootEventId: newEventId,
+              rootEventKind: _testRootEventKind,
+              rootAddressableId: addressableId,
+            );
+            expect(loaded.totalCount, equals(2));
+            expect(loaded.hasMore, isTrue);
+
+            final post = await repository.getCommentsCount(
+              newEventId,
+              rootAddressableId: addressableId,
+            );
+            expect(post, equals(7));
+            verifyNever(() => mockNostrClient.countEvents(any()));
+          },
+        );
+
+        test(
           'relay first-page empty result overwrites a positive cache under '
           'the addressable id',
           () async {

--- a/mobile/packages/comments_repository/test/src/models/comment_thread_test.dart
+++ b/mobile/packages/comments_repository/test/src/models/comment_thread_test.dart
@@ -160,6 +160,14 @@ void main() {
         expect(copy.rootEventId, equals(original.rootEventId));
       });
 
+      test('creates copy with updated pagination metadata', () {
+        final copy = original.copyWith(hasMore: true, hasExactTotal: false);
+
+        expect(copy.hasMore, isTrue);
+        expect(copy.hasExactTotal, isFalse);
+        expect(copy.rootEventId, equals(original.rootEventId));
+      });
+
       test('creates copy with updated commentCache', () {
         final newComment = Comment(
           id: 'id2',
@@ -241,6 +249,8 @@ void main() {
             'root',
             [comment],
             1,
+            null,
+            true,
             {'id': comment},
           ]),
         );

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1675,7 +1675,7 @@ class FunnelcakeApiClient {
       throw const FunnelcakeException('Video ID cannot be empty');
     }
 
-    final uri = Uri.parse('$_baseUrl/api/videos/$videoId/comments').replace(
+    final uri = Uri.parse('$_baseUrl/api/v2/videos/$videoId/comments').replace(
       queryParameters: {
         'sort': sort,
         'limit': limit.toString(),
@@ -1688,7 +1688,7 @@ class FunnelcakeApiClient {
 
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as Map<String, dynamic>;
-        return VideoCommentsResponse.fromJson(data);
+        return VideoCommentsResponse.fromJson(data, offset: offset);
       } else if (response.statusCode == 404) {
         return null;
       } else {

--- a/mobile/packages/funnelcake_api_client/lib/src/models/video_comments_response.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/video_comments_response.dart
@@ -6,6 +6,8 @@ class VideoCommentsResponse {
   const VideoCommentsResponse({
     required this.comments,
     required this.total,
+    this.hasMore,
+    this.hasExactTotal = true,
   });
 
   /// Parses the REST response body into a typed comments payload.
@@ -23,18 +25,27 @@ class VideoCommentsResponse {
     final pagination = json['pagination'];
     final hasMore =
         pagination is Map<String, dynamic> && pagination['has_more'] == true;
+    final hasExactTotal = rawTotal is num;
 
     return VideoCommentsResponse(
       comments: comments,
-      total: rawTotal is num
-          ? rawTotal.toInt()
-          : offset + comments.length + (hasMore ? 1 : 0),
+      total: hasExactTotal ? rawTotal.toInt() : offset + comments.length,
+      hasMore: pagination is Map<String, dynamic> ? hasMore : null,
+      hasExactTotal: hasExactTotal,
     );
   }
 
   /// The current page of comments returned by the API.
   final List<VideoComment> comments;
 
-  /// The total number of comments known by the API.
+  /// Exact comment count for legacy responses, or the lower bound implied by a
+  /// v2 page response.
   final int total;
+
+  /// Whether the API says another page is available.
+  final bool? hasMore;
+
+  /// Whether [total] is an exact server count rather than a pagination lower
+  /// bound.
+  final bool hasExactTotal;
 }

--- a/mobile/packages/funnelcake_api_client/lib/src/models/video_comments_response.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/video_comments_response.dart
@@ -9,14 +9,26 @@ class VideoCommentsResponse {
   });
 
   /// Parses the REST response body into a typed comments payload.
-  factory VideoCommentsResponse.fromJson(Map<String, dynamic> json) {
-    final rawComments = json['comments'] as List<dynamic>? ?? const [];
+  factory VideoCommentsResponse.fromJson(
+    Map<String, dynamic> json, {
+    int offset = 0,
+  }) {
+    final rawComments =
+        (json['comments'] ?? json['data']) as List<dynamic>? ?? const [];
+    final comments = rawComments
+        .whereType<Map<String, dynamic>>()
+        .map(VideoComment.fromJson)
+        .toList();
+    final rawTotal = json['total'];
+    final pagination = json['pagination'];
+    final hasMore =
+        pagination is Map<String, dynamic> && pagination['has_more'] == true;
+
     return VideoCommentsResponse(
-      comments: rawComments
-          .whereType<Map<String, dynamic>>()
-          .map(VideoComment.fromJson)
-          .toList(),
-      total: (json['total'] as num?)?.toInt() ?? 0,
+      comments: comments,
+      total: rawTotal is num
+          ? rawTotal.toInt()
+          : offset + comments.length + (hasMore ? 1 : 0),
     );
   }
 

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -3394,7 +3394,9 @@ void main() {
         final response = await client.getVideoComments(videoId: testVideoId);
 
         expect(response, isNotNull);
-        expect(response!.total, equals(3));
+        expect(response!.total, equals(2));
+        expect(response.hasMore, isTrue);
+        expect(response.hasExactTotal, isFalse);
         expect(response.comments, hasLength(2));
         expect(response.comments.first.id, equals('comment1'));
         expect(response.comments.first.authorName, equals('Tester'));
@@ -3443,7 +3445,9 @@ void main() {
 
         expect(response, isNotNull);
         expect(response!.comments, hasLength(2));
-        expect(response.total, equals(103));
+        expect(response.total, equals(102));
+        expect(response.hasMore, isTrue);
+        expect(response.hasExactTotal, isFalse);
       });
 
       test('returns null on 404', () async {

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -3351,7 +3351,7 @@ void main() {
       const validResponse =
           '''
 {
-  "comments": [
+  "data": [
     {
       "id": "comment1",
       "pubkey": "$testPubkey",
@@ -3379,7 +3379,10 @@ void main() {
       "reply_to_pubkey": "$testPubkey"
     }
   ],
-  "total": 42
+  "pagination": {
+    "next_cursor": "o:102",
+    "has_more": true
+  }
 }
 ''';
 
@@ -3391,7 +3394,7 @@ void main() {
         final response = await client.getVideoComments(videoId: testVideoId);
 
         expect(response, isNotNull);
-        expect(response!.total, equals(42));
+        expect(response!.total, equals(3));
         expect(response.comments, hasLength(2));
         expect(response.comments.first.id, equals('comment1'));
         expect(response.comments.first.authorName, equals('Tester'));
@@ -3421,10 +3424,26 @@ void main() {
         ).captured;
 
         final uri = captured.first as Uri;
-        expect(uri.path, equals('/api/videos/$testVideoId/comments'));
+        expect(uri.path, equals('/api/v2/videos/$testVideoId/comments'));
         expect(uri.queryParameters['sort'], equals('oldest'));
         expect(uri.queryParameters['limit'], equals('50'));
         expect(uri.queryParameters['offset'], equals('100'));
+      });
+
+      test('derives pagination lower-bound total from v2 has_more', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(validResponse, 200));
+
+        final response = await client.getVideoComments(
+          videoId: testVideoId,
+          limit: 50,
+          offset: 100,
+        );
+
+        expect(response, isNotNull);
+        expect(response!.comments, hasLength(2));
+        expect(response.total, equals(103));
       });
 
       test('returns null on 404', () async {

--- a/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
@@ -158,6 +158,63 @@ void main() {
         act: (b) => b.add(const CommentsLoadRequested()),
         expect: () => isEmpty,
       );
+
+      blocTest<CommentsListBloc, CommentsListState>(
+        'keeps pagination enabled when v2 REST has_more races with live '
+        'backfill comments',
+        setUp: () {
+          final liveController = StreamController<Comment>();
+          addTearDown(liveController.close);
+          final loadCompleter = Completer<CommentThread>();
+          final restComments = List.generate(
+            50,
+            (index) => makeComment(
+              validId('c$index'),
+              createdAt: DateTime.fromMillisecondsSinceEpoch(5000 - index),
+            ),
+          );
+
+          when(
+            () => mockCommentsRepository.watchComments(
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              since: any(named: 'since'),
+              onEose: any(named: 'onEose'),
+            ),
+          ).thenAnswer((_) => liveController.stream);
+          when(
+            () => mockCommentsRepository.loadComments(
+              rootEventId: any(named: 'rootEventId'),
+              rootEventKind: any(named: 'rootEventKind'),
+              rootAddressableId: any(named: 'rootAddressableId'),
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer((_) => loadCompleter.future);
+
+          Future<void>.microtask(() async {
+            liveController.add(makeComment(validId('live')));
+            loadCompleter.complete(
+              CommentThread(
+                rootEventId: validId('root'),
+                comments: restComments,
+                totalCount: 50,
+                hasMore: true,
+                hasExactTotal: false,
+                commentCache: {
+                  for (final comment in restComments) comment.id: comment,
+                },
+              ),
+            );
+          });
+        },
+        build: createBloc,
+        act: (b) => b.add(const CommentsLoadRequested()),
+        verify: (b) {
+          expect(b.state.commentsById.length, 51);
+          expect(b.state.hasMoreContent, isTrue);
+        },
+      );
     });
 
     group('CommentsLoadMoreRequested', () {


### PR DESCRIPTION
Closes #5077

## Summary
- Switch `FunnelcakeApiClient.getVideoComments()` to `/api/v2/videos/{id}/comments`.
- Parse v2 `{data, pagination}` responses while preserving legacy `{comments,total}` compatibility.
- Derive a pagination lower-bound total from `offset + comments.length + has_more` so existing comment thread pagination keeps working without an exact server count.

## Motivation
The comments sheet only needs the thread rows, not the count badge total. Using the v2 comments endpoint lets the app consume the faster no-count backend path while keeping the current repository/BLoC contract intact.

## Linked Issue


## Validation
- `mise exec -- flutter test packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart --plain-name "getVideoComments"`

## Manual Test Plan
- Build/run a staging app from this branch after the funnelcake staging deploy.
- Open a video comments sheet and verify the thread populates from `/api/v2/videos/{id}/comments` and pagination still works.

## Notes
The normal mobile pre-push analyzer hook currently fails on unrelated live golden test files under `test/goldens/screens/live/...` because those tests import missing live classes/support files. I pushed this branch with `--no-verify` after the focused comments client test passed.