### PR TITLE
fix(auth): preserve secure storage on Android errors

### DIFF
--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -64,9 +64,11 @@ OAuthConfig oauthConfig(Ref ref) {
 @Riverpod(keepAlive: true)
 FlutterSecureStorage flutterSecureStorage(Ref ref) =>
     const FlutterSecureStorage(
+      // Do not enable AndroidOptions.resetOnError here. This storage holds
+      // OAuth/Keycast and pending-verification credentials; silently deleting
+      // them after a transient Android Keystore read error logs users out.
       aOptions: AndroidOptions(
         encryptedSharedPreferences: true,
-        resetOnError: true,
       ),
     );
 

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -146,7 +146,7 @@ final class FlutterSecureStorageProvider
 }
 
 String _$flutterSecureStorageHash() =>
-    r'983539a9d4eced8052f719fe7f4a011a3beb2c2a';
+    r'4d4ab3d09f7188871974df552778d4799beabcd8';
 
 @ProviderFor(secureKeycastStorage)
 const secureKeycastStorageProvider = SecureKeycastStorageProvider._();

--- a/mobile/test/providers/auth_providers_test.dart
+++ b/mobile/test/providers/auth_providers_test.dart
@@ -1,0 +1,21 @@
+// ABOUTME: Tests for authentication provider wiring.
+// ABOUTME: Guards secure storage options that affect session persistence.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/auth_providers.dart';
+
+void main() {
+  group('flutterSecureStorageProvider', () {
+    test('keeps Android secure storage encrypted without reset-on-error', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final storage = container.read(flutterSecureStorageProvider);
+      final androidOptions = storage.aOptions.toMap();
+
+      expect(androidOptions['encryptedSharedPreferences'], 'true');
+      expect(androidOptions['resetOnError'], 'false');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- stop enabling Android resetOnError for the shared FlutterSecureStorage auth provider
- keep encryptedSharedPreferences enabled for OAuth/Keycast/pending-verification storage
- add a provider regression test that asserts resetOnError remains false
- regenerate auth_providers.g.dart for the provider hash change

Closes #5121

## Validation
- mise exec -- dart run build_runner build --delete-conflicting-outputs
- mise exec -- flutter test test/providers/auth_providers_test.dart
- mise exec -- flutter analyze
- pre-push analyzer, generated-file verification, and changed-file test passed