### PR TITLE
fix(feed): retry the failed feed type after connection errors, not discovery

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -130,10 +130,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     EventRouter? eventRouter,
     VideoFilterBuilder? videoFilterBuilder,
     PerformanceTraceMonitor? performanceMonitor,
+    ConnectionStatusService? connectionService,
   }) : _subscriptionManager = subscriptionManager,
        _profileRepository = profileRepository,
        _eventRouter = eventRouter,
        _videoFilterBuilder = videoFilterBuilder,
+       _connectionService = connectionService ?? ConnectionStatusService(),
+       _ownsConnectionService = connectionService == null,
        _performanceMonitor =
            performanceMonitor ?? PerformanceMonitoringService.instance {
     _initializePaginationStates();
@@ -145,7 +148,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   final EventRouter? _eventRouter;
   final VideoFilterBuilder? _videoFilterBuilder;
   final PerformanceTraceMonitor _performanceMonitor;
-  final ConnectionStatusService _connectionService = ConnectionStatusService();
+  final ConnectionStatusService _connectionService;
+  final bool _ownsConnectionService;
 
   // REFACTORED: Separate event lists per subscription type
   final Map<SubscriptionType, List<VideoEvent>> _eventLists = {
@@ -1280,6 +1284,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     NIP50SortMode?
     nip50Sort, // NIP-50 search sorting (e.g., sort:hot, sort:top)
     bool force = false, // Force refresh even if parameters match
+    bool scheduleOnlineRetry = true,
     List<String>?
     collaboratorPubkeys, // Legacy no-op until Funnelcake edge expansion exists
   }) async {
@@ -1303,6 +1308,21 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       return;
     }
 
+    // Store retry/duplicate parameters before connection checks so an
+    // offline first subscribe can retry the requested feed instead of
+    // falling back to a parameterless feed when connectivity returns.
+    _subscriptionParams[subscriptionType] = {
+      'authors': authors,
+      'hashtags': hashtags,
+      'group': group,
+      'since': since,
+      'until': until,
+      'limit': limit,
+      'includeReposts': includeReposts,
+      'sortBy': sortBy,
+      'nip50Sort': nip50Sort,
+    };
+
     // Check connection status
     if (!_connectionService.isOnline) {
       _isLoading = false;
@@ -1312,7 +1332,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         name: 'VideoEventService',
         category: LogCategory.video,
       );
-      _scheduleRetryWhenOnline(subscriptionType);
+      if (scheduleOnlineRetry) {
+        _scheduleRetryWhenOnline(subscriptionType);
+      }
       throw const VideoEventServiceException('Device is offline');
     }
 
@@ -1665,19 +1687,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             );
           }
         }
-
-        // Store current subscription parameters for duplicate detection BEFORE any early returns
-        _subscriptionParams[subscriptionType] = {
-          'authors': authors,
-          'hashtags': hashtags,
-          'group': group,
-          'since': since,
-          'until': until,
-          'limit': limit,
-          'includeReposts': includeReposts,
-          'sortBy': sortBy,
-          'nip50Sort': nip50Sort,
-        };
 
         // Set per-subscription loading state to show loading UI
         final paginationState = _paginationStates[subscriptionType];
@@ -2089,7 +2098,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           name: 'VideoEventService',
           category: LogCategory.video,
         );
-        _scheduleRetryWhenOnline(subscriptionType);
+        if (scheduleOnlineRetry) {
+          _scheduleRetryWhenOnline(subscriptionType);
+        } else {
+          rethrow;
+        }
       }
     } finally {
       _isLoading = false;
@@ -4154,6 +4167,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         return;
       }
       if (_typesAwaitingRetry.isEmpty || _retryAttempts >= _maxRetryAttempts) {
+        _typesAwaitingRetry.clear();
         timer.cancel();
         return;
       }
@@ -4191,6 +4205,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             sortBy: params?['sortBy'] as VideoSortField?,
             nip50Sort: params?['nip50Sort'] as NIP50SortMode?,
             force: true,
+            scheduleOnlineRetry: false,
           )
           .then((_) {
             _typesAwaitingRetry.remove(type);
@@ -4211,6 +4226,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               category: LogCategory.video,
             );
             if (_retryAttempts >= _maxRetryAttempts) {
+              _typesAwaitingRetry.clear();
               timer.cancel();
               Log.warning(
                 'Max retry attempts reached for video feed subscription',
@@ -5234,7 +5250,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     _likeCountBatchTimer?.cancel();
     _authStateSubscription?.cancel();
     unawaited(_blocklistChangesSubscription?.cancel());
-    _connectionService.dispose();
+    if (_ownsConnectionService) {
+      _connectionService.dispose();
+    }
     unsubscribeFromVideoFeed();
     unawaited(_removedVideoIdsController.close());
     super.dispose();

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -178,6 +178,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   bool _isLoading = false;
   String? _error;
   Timer? _retryTimer;
+
+  // Feed types whose relay subscription failed on a connection error and
+  // should be re-established by the online-retry cycle.
+  final Set<SubscriptionType> _typesAwaitingRetry = {};
   int _retryAttempts = 0;
 
   // Track subscription parameters per type
@@ -1308,7 +1312,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         name: 'VideoEventService',
         category: LogCategory.video,
       );
-      _scheduleRetryWhenOnline();
+      _scheduleRetryWhenOnline(subscriptionType);
       throw const VideoEventServiceException('Device is offline');
     }
 
@@ -2085,7 +2089,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           name: 'VideoEventService',
           category: LogCategory.video,
         );
-        _scheduleRetryWhenOnline();
+        _scheduleRetryWhenOnline(subscriptionType);
       }
     } finally {
       _isLoading = false;
@@ -2768,7 +2772,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         name: 'VideoEventService',
         category: LogCategory.video,
       );
-      _scheduleRetryWhenOnline();
+      _scheduleRetryWhenOnline(subscriptionType);
     }
   }
 
@@ -4125,57 +4129,97 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         errorString.contains('unreachable');
   }
 
-  /// Schedule retry when device comes back online
-  void _scheduleRetryWhenOnline() {
-    _retryTimer?.cancel();
+  /// Schedule retry of [subscriptionType] when the device is back online.
+  ///
+  /// The failed type is recorded so the retry re-establishes the feed
+  /// that actually broke (with its original parameters) — previously the
+  /// retry hardcoded the discovery feed, so home/hashtag/profile feeds
+  /// never recovered through this path.
+  void _scheduleRetryWhenOnline(SubscriptionType subscriptionType) {
+    _typesAwaitingRetry.add(subscriptionType);
+
+    // An active cycle keeps its attempt budget. A fresh cycle starts
+    // over — previously an exhausted counter was never reset, leaving
+    // retries dead for the rest of the session.
+    if (_retryTimer?.isActive ?? false) return;
+    _retryAttempts = 0;
 
     _retryTimer = Timer.periodic(_retryDelay, (timer) {
-      if (_connectionService.isOnline && _retryAttempts < _maxRetryAttempts) {
-        _retryAttempts++;
-        Log.warning(
-          'Attempting to resubscribe to video feed (attempt $_retryAttempts/$_maxRetryAttempts)',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-
-        subscribeToVideoFeed(subscriptionType: SubscriptionType.discovery)
-            .then((_) {
-              // Success - cancel retry timer
-              timer.cancel();
-              _retryAttempts = 0;
-              Log.info(
-                'Successfully resubscribed to video feed',
-                name: 'VideoEventService',
-                category: LogCategory.video,
-              );
-            })
-            .catchError((e) {
-              Log.error(
-                'Retry attempt $_retryAttempts failed: $e',
-                name: 'VideoEventService',
-                category: LogCategory.video,
-              );
-
-              if (_retryAttempts >= _maxRetryAttempts) {
-                timer.cancel();
-                Log.warning(
-                  'Max retry attempts reached for video feed subscription',
-                  name: 'VideoEventService',
-                  category: LogCategory.video,
-                );
-              }
-            });
-      } else if (!_connectionService.isOnline) {
+      if (!_connectionService.isOnline) {
         Log.debug(
           '⏳ Still offline, waiting for connection...',
           name: 'VideoEventService',
           category: LogCategory.video,
         );
-      } else {
-        // Max retries reached
+        return;
+      }
+      if (_typesAwaitingRetry.isEmpty || _retryAttempts >= _maxRetryAttempts) {
         timer.cancel();
+        return;
+      }
+
+      _retryAttempts++;
+      Log.warning(
+        'Attempting to resubscribe to '
+        '${_typesAwaitingRetry.map((t) => t.name).join(", ")} '
+        '(attempt $_retryAttempts/$_maxRetryAttempts)',
+        name: 'VideoEventService',
+        category: LogCategory.video,
+      );
+
+      for (final type in Set<SubscriptionType>.of(_typesAwaitingRetry)) {
+        _retrySubscription(type, timer);
       }
     });
+  }
+
+  /// Re-issue the relay subscription for [type] using its last-known
+  /// parameters, forcing past duplicate detection (the dead subscription
+  /// is still registered after an onError, so a non-forced call no-ops).
+  void _retrySubscription(SubscriptionType type, Timer timer) {
+    final params = _subscriptionParams[type];
+    unawaited(
+      subscribeToVideoFeed(
+            subscriptionType: type,
+            authors: params?['authors'] as List<String>?,
+            hashtags: params?['hashtags'] as List<String>?,
+            group: params?['group'] as String?,
+            since: params?['since'] as int?,
+            until: params?['until'] as int?,
+            limit: (params?['limit'] as int?) ?? 200,
+            includeReposts: (params?['includeReposts'] as bool?) ?? false,
+            sortBy: params?['sortBy'] as VideoSortField?,
+            nip50Sort: params?['nip50Sort'] as NIP50SortMode?,
+            force: true,
+          )
+          .then((_) {
+            _typesAwaitingRetry.remove(type);
+            Log.info(
+              'Successfully resubscribed to ${type.name} feed',
+              name: 'VideoEventService',
+              category: LogCategory.video,
+            );
+            if (_typesAwaitingRetry.isEmpty) {
+              timer.cancel();
+              _retryAttempts = 0;
+            }
+          })
+          .catchError((Object e) {
+            Log.error(
+              'Retry attempt $_retryAttempts for ${type.name} failed: $e',
+              name: 'VideoEventService',
+              category: LogCategory.video,
+            );
+            if (_retryAttempts >= _maxRetryAttempts) {
+              timer.cancel();
+              Log.warning(
+                'Max retry attempts reached for video feed subscription',
+                name: 'VideoEventService',
+                category: LogCategory.video,
+              );
+            }
+          }),
+    );
   }
 
   /// Get connection status for debugging

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -1267,6 +1267,31 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
+  void _storeSubscriptionParams({
+    required SubscriptionType subscriptionType,
+    required List<String>? authors,
+    required List<String>? hashtags,
+    required String? group,
+    required int? since,
+    required int? until,
+    required int limit,
+    required bool includeReposts,
+    required VideoSortField? sortBy,
+    required NIP50SortMode? nip50Sort,
+  }) {
+    _subscriptionParams[subscriptionType] = {
+      'authors': authors,
+      'hashtags': hashtags,
+      'group': group,
+      'since': since,
+      'until': until,
+      'limit': limit,
+      'includeReposts': includeReposts,
+      'sortBy': sortBy,
+      'nip50Sort': nip50Sort,
+    };
+  }
+
   /// Subscribe to NIP-71 video events with proper subscription type separation
   Future<void> subscribeToVideoFeed({
     required SubscriptionType subscriptionType,
@@ -1308,21 +1333,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       return;
     }
 
-    // Store retry/duplicate parameters before connection checks so an
-    // offline first subscribe can retry the requested feed instead of
-    // falling back to a parameterless feed when connectivity returns.
-    _subscriptionParams[subscriptionType] = {
-      'authors': authors,
-      'hashtags': hashtags,
-      'group': group,
-      'since': since,
-      'until': until,
-      'limit': limit,
-      'includeReposts': includeReposts,
-      'sortBy': sortBy,
-      'nip50Sort': nip50Sort,
-    };
-
     // Check connection status
     if (!_connectionService.isOnline) {
       _isLoading = false;
@@ -1333,6 +1343,20 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         category: LogCategory.video,
       );
       if (scheduleOnlineRetry) {
+        // Store retry parameters before the offline early return so a first
+        // subscribe can retry the requested feed when connectivity returns.
+        _storeSubscriptionParams(
+          subscriptionType: subscriptionType,
+          authors: authors,
+          hashtags: hashtags,
+          group: group,
+          since: since,
+          until: until,
+          limit: limit,
+          includeReposts: includeReposts,
+          sortBy: sortBy,
+          nip50Sort: nip50Sort,
+        );
         _scheduleRetryWhenOnline(subscriptionType);
       }
       throw const VideoEventServiceException('Device is offline');
@@ -1687,6 +1711,20 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             );
           }
         }
+
+        // Store current subscription parameters for duplicate detection BEFORE any early returns
+        _storeSubscriptionParams(
+          subscriptionType: subscriptionType,
+          authors: authors,
+          hashtags: hashtags,
+          group: group,
+          since: since,
+          until: until,
+          limit: limit,
+          includeReposts: includeReposts,
+          sortBy: sortBy,
+          nip50Sort: nip50Sort,
+        );
 
         // Set per-subscription loading state to show loading UI
         final paginationState = _paginationStates[subscriptionType];

--- a/mobile/test/services/video_event_service_online_retry_test.dart
+++ b/mobile/test/services/video_event_service_online_retry_test.dart
@@ -1,0 +1,139 @@
+// ABOUTME: Tests for the online-retry cycle after subscription errors
+// ABOUTME: Retries must re-establish the FAILED feed, not hardcode discovery
+
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+class _MockPerformanceTraceMonitor extends Mock
+    implements PerformanceTraceMonitor {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeFilter());
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('online retry after subscription error', () {
+    const followedAuthor =
+        '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+
+    late _MockNostrClient mockNostrService;
+    late _MockSubscriptionManager mockSubscriptionManager;
+    late _MockPerformanceTraceMonitor mockPerformanceMonitor;
+    late VideoEventService service;
+    late List<List<Filter>> subscribeCalls;
+    late List<StreamController<Event>> streamControllers;
+
+    setUp(() {
+      mockNostrService = _MockNostrClient();
+      mockSubscriptionManager = _MockSubscriptionManager();
+      mockPerformanceMonitor = _MockPerformanceTraceMonitor();
+      subscribeCalls = [];
+      streamControllers = [];
+
+      when(() => mockNostrService.isInitialized).thenReturn(true);
+      when(() => mockNostrService.publicKey).thenReturn('');
+      when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
+      ).thenAnswer((invocation) {
+        subscribeCalls.add(
+          (invocation.positionalArguments.first as List<Filter>).toList(),
+        );
+        // Single-subscription controller with an async onCancel: broadcast
+        // subscriptions' cancel() futures cannot be driven by fakeAsync
+        // (the service awaits cancel() when force-replacing), so the test
+        // would hang at that await with a broadcast controller.
+        final controller = StreamController<Event>(onCancel: () async {});
+        streamControllers.add(controller);
+        return controller.stream;
+      });
+      when(() => mockNostrService.unsubscribe(any())).thenAnswer((_) async {});
+
+      when(
+        () => mockPerformanceMonitor.startTrace(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockPerformanceMonitor.stopTrace(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockPerformanceMonitor.setMetric(any(), any(), any()),
+      ).thenReturn(null);
+      when(
+        () => mockPerformanceMonitor.putAttribute(any(), any(), any()),
+      ).thenReturn(null);
+
+      service = VideoEventService(
+        mockNostrService,
+        subscriptionManager: mockSubscriptionManager,
+        performanceMonitor: mockPerformanceMonitor,
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test('connection error on home feed retries the home feed with its '
+        'original authors', () {
+      fakeAsync((fake) {
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.homeFeed,
+            authors: [followedAuthor],
+          ),
+        );
+        fake.flushMicrotasks();
+        expect(subscribeCalls, hasLength(1));
+
+        // Relay connection drops — the subscription stream errors out.
+        streamControllers.first.addError(
+          Exception('websocket connection failed'),
+        );
+        fake.flushMicrotasks();
+
+        // First retry tick.
+        fake
+          ..elapse(const Duration(seconds: 10))
+          ..flushMicrotasks();
+
+        expect(
+          subscribeCalls,
+          hasLength(2),
+          reason: 'the retry cycle must re-issue a relay subscription',
+        );
+        final retryFilters = subscribeCalls[1];
+        expect(
+          retryFilters.any(
+            (filter) => filter.authors?.contains(followedAuthor) ?? false,
+          ),
+          isTrue,
+          reason:
+              'the retry must re-establish the FAILED home feed with its '
+              'original authors, not a parameterless discovery feed',
+        );
+
+        // The successful retry ends the cycle — no further re-subscribes.
+        fake
+          ..elapse(const Duration(seconds: 30))
+          ..flushMicrotasks();
+        expect(subscribeCalls, hasLength(2));
+      });
+    });
+  });
+}

--- a/mobile/test/services/video_event_service_online_retry_test.dart
+++ b/mobile/test/services/video_event_service_online_retry_test.dart
@@ -9,6 +9,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -21,6 +22,24 @@ class _MockPerformanceTraceMonitor extends Mock
     implements PerformanceTraceMonitor {}
 
 class _FakeFilter extends Fake implements Filter {}
+
+class _FakeConnectionStatusService extends ConnectionStatusService {
+  bool online = true;
+  final List<bool> onlineReads = [];
+
+  @override
+  bool get isOnline =>
+      onlineReads.isNotEmpty ? onlineReads.removeAt(0) : online;
+
+  @override
+  bool get isConnected => online;
+
+  @override
+  Map<String, dynamic> getConnectionInfo() => {
+    'isConnected': online,
+    'scriptedReads': onlineReads.length,
+  };
+}
 
 void main() {
   setUpAll(() {
@@ -35,6 +54,7 @@ void main() {
     late _MockNostrClient mockNostrService;
     late _MockSubscriptionManager mockSubscriptionManager;
     late _MockPerformanceTraceMonitor mockPerformanceMonitor;
+    late _FakeConnectionStatusService connectionService;
     late VideoEventService service;
     late List<List<Filter>> subscribeCalls;
     late List<StreamController<Event>> streamControllers;
@@ -43,6 +63,7 @@ void main() {
       mockNostrService = _MockNostrClient();
       mockSubscriptionManager = _MockSubscriptionManager();
       mockPerformanceMonitor = _MockPerformanceTraceMonitor();
+      connectionService = _FakeConnectionStatusService();
       subscribeCalls = [];
       streamControllers = [];
 
@@ -82,11 +103,13 @@ void main() {
         mockNostrService,
         subscriptionManager: mockSubscriptionManager,
         performanceMonitor: mockPerformanceMonitor,
+        connectionService: connectionService,
       );
     });
 
     tearDown(() {
       service.dispose();
+      connectionService.dispose();
     });
 
     test('connection error on home feed retries the home feed with its '
@@ -133,6 +156,117 @@ void main() {
           ..elapse(const Duration(seconds: 30))
           ..flushMicrotasks();
         expect(subscribeCalls, hasLength(2));
+      });
+    });
+
+    test('first subscribe while offline retries with the original authors', () {
+      fakeAsync((fake) {
+        connectionService.online = false;
+        Object? caughtError;
+
+        unawaited(
+          service
+              .subscribeToVideoFeed(
+                subscriptionType: SubscriptionType.homeFeed,
+                authors: [followedAuthor],
+              )
+              .catchError((Object error) {
+                caughtError = error;
+              }),
+        );
+        fake.flushMicrotasks();
+
+        expect(caughtError, isA<VideoEventServiceException>());
+        expect(subscribeCalls, isEmpty);
+
+        connectionService.online = true;
+        fake
+          ..elapse(const Duration(seconds: 10))
+          ..flushMicrotasks();
+
+        expect(subscribeCalls, hasLength(1));
+        expect(
+          subscribeCalls.single.any(
+            (filter) => filter.authors?.contains(followedAuthor) ?? false,
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    test('exhausted retry entries do not leak into a later retry cycle', () {
+      fakeAsync((fake) {
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.homeFeed,
+            authors: [followedAuthor],
+          ),
+        );
+        fake.flushMicrotasks();
+        expect(subscribeCalls, hasLength(1));
+
+        streamControllers.first.addError(
+          Exception('websocket connection failed'),
+        );
+        fake.flushMicrotasks();
+
+        connectionService.onlineReads.addAll([
+          true,
+          false,
+          true,
+          false,
+          true,
+          false,
+        ]);
+
+        for (var i = 0; i < 3; i++) {
+          fake
+            ..elapse(const Duration(seconds: 10))
+            ..flushMicrotasks();
+        }
+
+        expect(
+          subscribeCalls,
+          hasLength(1),
+          reason: 'offline retry attempts throw before creating relay REQs',
+        );
+
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.hashtag,
+            hashtags: const ['Fresh'],
+          ),
+        );
+        fake.flushMicrotasks();
+        expect(subscribeCalls, hasLength(2));
+
+        streamControllers.last.addError(Exception('network disconnected'));
+        fake.flushMicrotasks();
+
+        connectionService.online = true;
+        fake
+          ..elapse(const Duration(seconds: 10))
+          ..flushMicrotasks();
+
+        final laterRetryCalls = subscribeCalls.skip(2).toList();
+        expect(
+          laterRetryCalls.any(
+            (filters) =>
+                filters.any((filter) => filter.t?.contains('fresh') ?? false),
+          ),
+          isTrue,
+        );
+        expect(
+          laterRetryCalls.any(
+            (filters) => filters.any(
+              (filter) => filter.authors?.contains(followedAuthor) ?? false,
+            ),
+          ),
+          isFalse,
+          reason:
+              'the exhausted home-feed retry must not leak into the later '
+              'hashtag retry cycle',
+        );
       });
     });
   });


### PR DESCRIPTION
Closes #5099

## Summary

Correctness fix (audit finding COR-11): `VideoEventService._scheduleRetryWhenOnline` hardcoded `SubscriptionType.discovery` with default parameters and no `force` flag. Three compounding problems:

1. **Wrong feed**: a connection error on the home/hashtag/profile feed retried *discovery* — the broken feed never recovered through this path.
2. **No-op retry**: after an `onError` the dead subscription stays registered, so a non-forced identical re-subscribe hits duplicate detection ("Reusing existing subscription") and never issues a relay REQ.
3. **Dead after exhaustion**: `_retryAttempts` was never reset once max attempts were reached, so every later retry cycle cancelled itself on its first tick for the rest of the session.

## Changes

- New `_typesAwaitingRetry` set: each connection-error site records the failed `subscriptionType` (all three callers had it in scope).
- The retry tick re-subscribes each pending type with its stored `_subscriptionParams` (authors/hashtags/group/since/until/limit/includeReposts/sortBy/nip50Sort) and `force: true`, which takes the replace path that cancels the dead subscription before re-subscribing.
- A fresh retry cycle (no active timer) resets the attempt budget; a still-active cycle keeps it, so a single retry cycle still terminates at max attempts.
- Stores subscription params before the offline early return so a first subscribe while offline retries the requested feed with the original filters.
- Clears exhausted retry entries and prevents timer-driven retry attempts from recursively scheduling themselves, so stale feed types do not leak into later retry cycles.
- Allows `ConnectionStatusService` constructor injection in `VideoEventService`, preserving default ownership while making retry edge cases testable without hidden global state.

## Test plan

- [x] New regression test (fakeAsync): home-feed subscription errors with a connection failure -> at the 10s tick exactly one new relay subscription is issued **with the original authors filter** — fails on main (parameterless discovery filter), passes with the fix; a successful retry ends the cycle (no further REQs at +30s).
- [x] New regression test: first home-feed subscribe while offline retries with the original authors once connectivity returns.
- [x] New regression test: exhausted home-feed retry state does not leak into a later hashtag retry cycle.
- [x] `mise exec -- flutter analyze`
- [x] `mise exec -- flutter test test/services/video_event_service_online_retry_test.dart`
- [x] `mise exec -- flutter test test/services/video_event_service_subscribe_race_test.dart`
- [x] `mise exec -- flutter test test/unit/services/video_event_service_subscription_test.dart`
- [x] `mise exec -- flutter test test/unit/services/video_event_service_subscription_test.dart test/services/video_event_service_*_test.dart`: 100 passed, 17 pre-existing skips.

Note for reviewers: the retry test uses a single-subscription `StreamController` with an async `onCancel` — broadcast subscriptions' `cancel()` futures cannot be driven by `fakeAsync`, and the force-replace path awaits `cancel()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
