### PR TITLE
feat(analytics): track mobile surface performance

### DIFF
--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -1,13 +1,16 @@
 # Analytics Observability
 
-Status: Current contract, implementation-in-progress baseline
+Status: Current contract with semantic route screen views and comments sheet
+surface load instrumentation live.
 Baseline validated against: `mobile/lib/services/screen_analytics_service.dart`,
 `mobile/lib/services/page_load_observer.dart`,
 `mobile/lib/screens/comments/comments_screen.dart`.
 
 Current code still contains legacy `screen_load` and `screen_data_loaded`
-analytics paths. The `surface_load` event and required semantic `screen_view`
-parameters below are the contract for the follow-up implementation tasks.
+analytics paths for compatibility. The required semantic `screen_view`
+parameters are implemented for routes, and `surface_load` is live for
+`comments_sheet`. Additional user-visible surfaces should use the same
+`surface_load` contract as they are instrumented.
 
 ## Purpose
 
@@ -72,7 +75,7 @@ Optional safe parameters:
 
 ## Comments Sheet
 
-The comments sheet must measure:
+The comments sheet measures:
 
 - tap/open intent to first rendered sheet frame
 - tap/open intent to comments success, empty state, or failure

--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -1,9 +1,13 @@
 # Analytics Observability
 
-Status: Current
-Validated against: `mobile/lib/services/screen_analytics_service.dart`,
+Status: Current contract, implementation-in-progress baseline
+Baseline validated against: `mobile/lib/services/screen_analytics_service.dart`,
 `mobile/lib/services/page_load_observer.dart`,
 `mobile/lib/screens/comments/comments_screen.dart`.
+
+Current code still contains legacy `screen_load` and `screen_data_loaded`
+analytics paths. The `surface_load` event and required semantic `screen_view`
+parameters below are the contract for the follow-up implementation tasks.
 
 ## Purpose
 

--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -1,0 +1,110 @@
+# Analytics Observability
+
+Status: Current
+Validated against: `mobile/lib/services/screen_analytics_service.dart`,
+`mobile/lib/services/page_load_observer.dart`,
+`mobile/lib/screens/comments/comments_screen.dart`.
+
+## Purpose
+
+Analytics must answer operational questions:
+
+- Which user-visible screens or surfaces are slow?
+- How slow are they at p50, p75, p95, and p99?
+- Did the user see real content, an empty state, or an error?
+- Is slowness isolated to an entry point, platform, app version, network type,
+  or feature flag?
+
+## Naming
+
+Use semantic snake_case names, never Flutter/native class names.
+
+Examples:
+
+- `home_feed`
+- `explore`
+- `profile`
+- `video_detail`
+- `comments_sheet`
+- `settings`
+- `notifications`
+
+Do not log Nostr event IDs, pubkeys, npubs, nsecs, user-entered search text,
+comment text, or raw URLs in analytics parameters.
+
+## Core Events
+
+### `screen_view`
+
+Logged when the user navigates to a full-screen route.
+
+Required parameters:
+
+- `screen_name`
+- `entry_point`
+- `route_name`
+
+### `surface_load`
+
+Logged once when a user-visible surface reaches a terminal load state.
+
+Required parameters:
+
+- `surface_name`
+- `entry_point`
+- `result`: `success`, `empty`, `failure`, or `dismissed`
+- `visible_ms`
+- `data_ms`
+- `total_ms`
+- `slow_bucket`: `under_1s`, `1_3s`, `3_5s`, `5_10s`, or `over_10s`
+
+Optional safe parameters:
+
+- `item_count`
+- `initial_count`
+- `has_more`
+- `sort_mode`
+- `feature_flag`
+
+## Comments Sheet
+
+The comments sheet must measure:
+
+- tap/open intent to first rendered sheet frame
+- tap/open intent to comments success, empty state, or failure
+- count loaded
+- whether video replies were enabled
+- whether the user dismissed before data loaded
+
+## Firebase Console Checks
+
+Use Firebase Analytics events to inspect:
+
+- `surface_load` filtered by `surface_name = comments_sheet`
+- `slow_bucket` distribution
+- p95/p99 in BigQuery export when available
+- app version and platform breakdowns
+
+Use Firebase Performance to inspect:
+
+- network request traces for media/API domains
+- custom traces only when the span represents a real user wait
+
+## Divine Brain Check
+
+Divine Brain is read-only from agent tooling. To make this contract discoverable
+there, keep this document and the implementation PR detailed enough for the
+GitHub ingest pipeline.
+
+Before changing analytics behavior, search Divine Brain for recent context:
+
+```text
+Firebase Analytics mobile screen_view surface_load observability divine-mobile
+```
+
+After this PR merges and Brain's hourly ingest has run, verify that Brain can
+find this contract by searching:
+
+```text
+analytics observability comments_sheet surface_load divine-mobile
+```

--- a/docs/ANALYTICS_OBSERVABILITY.md
+++ b/docs/ANALYTICS_OBSERVABILITY.md
@@ -94,6 +94,23 @@ Use Firebase Performance to inspect:
 - network request traces for media/API domains
 - custom traces only when the span represents a real user wait
 
+## First Dashboard To Build
+
+Create a Firebase/GA4 exploration or BigQuery query for:
+
+- event name: `surface_load`
+- dimension: `surface_name`
+- dimension: `slow_bucket`
+- dimension: `result`
+- metric: event count
+- metric: p95/p99 of `total_ms`
+
+First target filter:
+
+```text
+surface_name = comments_sheet
+```
+
 ## Divine Brain Check
 
 Divine Brain is read-only from agent tooling. To make this contract discoverable

--- a/docs/superpowers/plans/2026-06-12-surface-analytics-observability.md
+++ b/docs/superpowers/plans/2026-06-12-surface-analytics-observability.md
@@ -1,0 +1,1202 @@
+# Surface Analytics Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Firebase analytics useful for diagnosing slow user-visible screens and overlays, starting with the comments sheet.
+
+**Architecture:** Disable native automatic screen reporting that produces `FlutterViewController` / `MainActivity` rows, replace generic route logging with app-owned semantic screen names, and add surface load telemetry that measures the milestones users actually wait on: intent, first frame, first meaningful content, completion, and failure. Keep BLoCs free of Firebase dependencies by recording comments load outcomes from UI listeners around existing BLoC state transitions.
+
+**Tech Stack:** Flutter, Dart, go_router, Firebase Analytics, Firebase Performance, BLoC, Riverpod, `ScreenAnalyticsService`, `PageLoadHistory`, widget/service tests
+
+---
+
+## Current Evidence
+
+- `PageLoadObserver` is installed in `mobile/lib/router/app_router.dart`, but it skips `PopupRoute`s, so modal surfaces like comments sheets are not globally timed.
+- `ScreenAnalyticsService` already emits `screen_load`, `screen_data_loaded`, `screen_time`, and `screen_view`, but most screens do not call `trackScreenView` and many route names are missing.
+- Firebase currently shows native class rows like `FlutterViewController` and `MainActivity`, which are not actionable screen names.
+- `CommentsScreen.show` opens comments as a modal bottom sheet and wires `CommentsListBloc`, but does not record timing from tap/open to comments success, empty state, or failure.
+- Divine Brain search for prior mobile analytics/performance-monitoring decisions returned no relevant results for: `Firebase Analytics performance monitoring screen_view screen_load screen_data_loaded mobile observability slow screens comments divine-mobile`.
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `docs/ANALYTICS_OBSERVABILITY.md` | Create | Current analytics contract, event vocabulary, dashboard queries, Divine Brain verification workflow |
+| `mobile/lib/services/analytics_surface.dart` | Create | Stable semantic names and parameter keys for screens/surfaces |
+| `mobile/lib/services/analytics_event_sink.dart` | Create | Testable abstraction over Firebase Analytics |
+| `mobile/lib/services/firebase_analytics_event_sink.dart` | Create | Firebase-backed analytics sink |
+| `mobile/lib/services/surface_performance_tracker.dart` | Create | Surface lifecycle timing and one terminal event per load |
+| `mobile/lib/services/screen_analytics_service.dart` | Modify | Use semantic names, optional sink injection, keep legacy event compatibility where useful |
+| `mobile/lib/services/page_load_observer.dart` | Modify | Log semantic route screen views and page visible timings through the app-owned service |
+| `mobile/lib/router/app_router.dart` | Modify | Remove generic `FirebaseAnalyticsObserver`, add route names for high-value routes, keep `PageLoadObserver` |
+| `mobile/ios/Runner/Info.plist` | Modify | Disable Firebase automatic native screen reporting |
+| `mobile/android/app/src/main/AndroidManifest.xml` | Modify | Disable Firebase automatic native screen reporting |
+| `mobile/lib/screens/comments/comments_screen.dart` | Modify | Instrument comments sheet open, visible, success, empty, failure, and dismiss |
+| `mobile/test/services/*analytics*` | Modify/Create | Unit coverage for schema, screen naming, and surface timing |
+| `mobile/test/screens/comments/comments_screen_test.dart` | Modify/Create if existing | Widget coverage for comments sheet telemetry |
+
+---
+
+### Task 1: Document The Analytics Contract And Divine Brain Check
+
+**Files:**
+- Create: `docs/ANALYTICS_OBSERVABILITY.md`
+
+- [ ] **Step 1: Create the current analytics contract doc**
+
+Create `docs/ANALYTICS_OBSERVABILITY.md`:
+
+```markdown
+# Analytics Observability
+
+Status: Current
+Validated against: `mobile/lib/services/screen_analytics_service.dart`,
+`mobile/lib/services/page_load_observer.dart`,
+`mobile/lib/screens/comments/comments_screen.dart`.
+
+## Purpose
+
+Analytics must answer operational questions:
+
+- Which user-visible screens or surfaces are slow?
+- How slow are they at p50, p75, p95, and p99?
+- Did the user see real content, an empty state, or an error?
+- Is slowness isolated to an entry point, platform, app version, network type,
+  or feature flag?
+
+## Naming
+
+Use semantic snake_case names, never Flutter/native class names.
+
+Examples:
+
+- `home_feed`
+- `explore`
+- `profile`
+- `video_detail`
+- `comments_sheet`
+- `settings`
+- `notifications`
+
+Do not log Nostr event IDs, pubkeys, npubs, nsecs, user-entered search text,
+comment text, or raw URLs in analytics parameters.
+
+## Core Events
+
+### `screen_view`
+
+Logged when the user navigates to a full-screen route.
+
+Required parameters:
+
+- `screen_name`
+- `entry_point`
+- `route_name`
+
+### `surface_load`
+
+Logged once when a user-visible surface reaches a terminal load state.
+
+Required parameters:
+
+- `surface_name`
+- `entry_point`
+- `result`: `success`, `empty`, `failure`, or `dismissed`
+- `visible_ms`
+- `data_ms`
+- `total_ms`
+- `slow_bucket`: `under_1s`, `1_3s`, `3_5s`, `5_10s`, or `over_10s`
+
+Optional safe parameters:
+
+- `item_count`
+- `initial_count`
+- `has_more`
+- `sort_mode`
+- `feature_flag`
+
+## Comments Sheet
+
+The comments sheet must measure:
+
+- tap/open intent to first rendered sheet frame
+- tap/open intent to comments success, empty state, or failure
+- count loaded
+- whether video replies were enabled
+- whether the user dismissed before data loaded
+
+## Firebase Console Checks
+
+Use Firebase Analytics events to inspect:
+
+- `surface_load` filtered by `surface_name = comments_sheet`
+- `slow_bucket` distribution
+- p95/p99 in BigQuery export when available
+- app version and platform breakdowns
+
+Use Firebase Performance to inspect:
+
+- network request traces for media/API domains
+- custom traces only when the span represents a real user wait
+
+## Divine Brain Check
+
+Divine Brain is read-only from agent tooling. To make this contract discoverable
+there, keep this document and the implementation PR detailed enough for the
+GitHub ingest pipeline.
+
+Before changing analytics behavior, search Divine Brain for recent context:
+
+```text
+Firebase Analytics mobile screen_view surface_load observability divine-mobile
+```
+
+After this PR merges and Brain's hourly ingest has run, verify that Brain can
+find this contract by searching:
+
+```text
+analytics observability comments_sheet surface_load divine-mobile
+```
+```
+
+- [ ] **Step 2: Commit the documentation contract**
+
+Run:
+
+```bash
+git add docs/ANALYTICS_OBSERVABILITY.md docs/superpowers/plans/2026-06-12-surface-analytics-observability.md
+git commit -m "docs(analytics): define mobile observability contract"
+```
+
+Expected: commit succeeds. This is the durable "add it to Divine Brain" path once the PR is merged and Brain ingests GitHub.
+
+---
+
+### Task 2: Stop Useless Native Screen Rows
+
+**Files:**
+- Modify: `mobile/ios/Runner/Info.plist`
+- Modify: `mobile/android/app/src/main/AndroidManifest.xml`
+- Modify: `mobile/lib/router/app_router.dart`
+- Test: `mobile/test/services/page_load_observer_test.dart`
+
+- [ ] **Step 1: Add native config regression checks**
+
+Create or extend a native config test under `mobile/test/services/analytics_native_config_test.dart`:
+
+```dart
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Firebase Analytics native config', () {
+    test('iOS disables automatic native screen reporting', () {
+      final plist = File('ios/Runner/Info.plist').readAsStringSync();
+
+      expect(plist, contains('<key>FirebaseAutomaticScreenReportingEnabled</key>'));
+      expect(plist, contains('<false/>'));
+    });
+
+    test('Android disables automatic native screen reporting', () {
+      final manifest = File(
+        'android/app/src/main/AndroidManifest.xml',
+      ).readAsStringSync();
+
+      expect(
+        manifest,
+        contains('google_analytics_automatic_screen_reporting_enabled'),
+      );
+      expect(manifest, contains('android:value="false"'));
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the native config test and verify it fails**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/services/analytics_native_config_test.dart
+```
+
+Expected: FAIL because neither platform disables automatic native screen reporting yet.
+
+- [ ] **Step 3: Disable native automatic screen reporting**
+
+Add this to `mobile/ios/Runner/Info.plist` near existing Firebase keys:
+
+```xml
+<key>FirebaseAutomaticScreenReportingEnabled</key>
+<false/>
+```
+
+Add this inside the `<application>` block in `mobile/android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<meta-data
+    android:name="google_analytics_automatic_screen_reporting_enabled"
+    android:value="false" />
+```
+
+- [ ] **Step 4: Remove the generic Firebase route observer**
+
+Modify `_buildRouterObservers()` in `mobile/lib/router/app_router.dart` so it no longer adds `FirebaseAnalyticsObserver`.
+
+Keep:
+
+```dart
+final observers = <NavigatorObserver>[
+  routeObserver,
+  PageLoadObserver(),
+  VideoStopNavigatorObserver(),
+];
+```
+
+Remove:
+
+```dart
+if (Firebase.apps.isNotEmpty) {
+  observers.add(
+    FirebaseAnalyticsObserver(analytics: FirebaseAnalytics.instance),
+  );
+}
+```
+
+Also remove imports that become unused.
+
+- [ ] **Step 5: Run the config and observer tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/services/analytics_native_config_test.dart test/services/page_load_observer_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/ios/Runner/Info.plist mobile/android/app/src/main/AndroidManifest.xml mobile/lib/router/app_router.dart mobile/test/services/analytics_native_config_test.dart mobile/test/services/page_load_observer_test.dart
+git commit -m "fix(analytics): disable native automatic screen reporting"
+```
+
+---
+
+### Task 3: Add Semantic Analytics Names And A Testable Sink
+
+**Files:**
+- Create: `mobile/lib/services/analytics_surface.dart`
+- Create: `mobile/lib/services/analytics_event_sink.dart`
+- Create: `mobile/lib/services/firebase_analytics_event_sink.dart`
+- Test: `mobile/test/services/analytics_surface_test.dart`
+- Test: `mobile/test/services/analytics_event_sink_test.dart`
+
+- [ ] **Step 1: Write surface-name tests**
+
+Create `mobile/test/services/analytics_surface_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/analytics_surface.dart';
+
+void main() {
+  group('AnalyticsSurface', () {
+    test('core surface names are stable snake_case values', () {
+      expect(AnalyticsSurface.homeFeed, 'home_feed');
+      expect(AnalyticsSurface.explore, 'explore');
+      expect(AnalyticsSurface.profile, 'profile');
+      expect(AnalyticsSurface.videoDetail, 'video_detail');
+      expect(AnalyticsSurface.commentsSheet, 'comments_sheet');
+      expect(AnalyticsSurface.settings, 'settings');
+    });
+
+    test('slowBucket classifies user-visible waits', () {
+      expect(AnalyticsSurface.slowBucket(999), 'under_1s');
+      expect(AnalyticsSurface.slowBucket(1000), '1_3s');
+      expect(AnalyticsSurface.slowBucket(3000), '3_5s');
+      expect(AnalyticsSurface.slowBucket(5000), '5_10s');
+      expect(AnalyticsSurface.slowBucket(10000), 'over_10s');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/services/analytics_surface_test.dart
+```
+
+Expected: FAIL because `analytics_surface.dart` does not exist.
+
+- [ ] **Step 3: Create semantic names**
+
+Create `mobile/lib/services/analytics_surface.dart`:
+
+```dart
+// ABOUTME: Stable semantic names and safe parameter helpers for analytics.
+
+abstract final class AnalyticsSurface {
+  static const homeFeed = 'home_feed';
+  static const explore = 'explore';
+  static const notifications = 'notifications';
+  static const inbox = 'inbox';
+  static const profile = 'profile';
+  static const videoDetail = 'video_detail';
+  static const commentsSheet = 'comments_sheet';
+  static const settings = 'settings';
+  static const searchResults = 'search_results';
+  static const videoRecorder = 'video_recorder';
+  static const videoEditor = 'video_editor';
+  static const unknownRoute = 'unknown_route';
+
+  static String slowBucket(int totalMs) {
+    if (totalMs < 1000) return 'under_1s';
+    if (totalMs < 3000) return '1_3s';
+    if (totalMs < 5000) return '3_5s';
+    if (totalMs < 10000) return '5_10s';
+    return 'over_10s';
+  }
+
+  static String sanitizeName(String value) {
+    final normalized = value
+        .trim()
+        .replaceAll(RegExp(r'[^A-Za-z0-9_]+'), '_')
+        .replaceAll(RegExp(r'_+'), '_')
+        .toLowerCase();
+    return normalized.isEmpty ? unknownRoute : normalized;
+  }
+}
+
+abstract final class AnalyticsParam {
+  static const screenName = 'screen_name';
+  static const surfaceName = 'surface_name';
+  static const routeName = 'route_name';
+  static const entryPoint = 'entry_point';
+  static const result = 'result';
+  static const visibleMs = 'visible_ms';
+  static const dataMs = 'data_ms';
+  static const totalMs = 'total_ms';
+  static const slowBucket = 'slow_bucket';
+  static const itemCount = 'item_count';
+  static const initialCount = 'initial_count';
+  static const hasMore = 'has_more';
+  static const featureFlag = 'feature_flag';
+}
+
+abstract final class SurfaceLoadResult {
+  static const success = 'success';
+  static const empty = 'empty';
+  static const failure = 'failure';
+  static const dismissed = 'dismissed';
+}
+```
+
+- [ ] **Step 4: Add a testable analytics sink**
+
+Create `mobile/lib/services/analytics_event_sink.dart`:
+
+```dart
+// ABOUTME: Testable abstraction over analytics event delivery.
+
+abstract interface class AnalyticsEventSink {
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  });
+
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  });
+}
+
+class NoOpAnalyticsEventSink implements AnalyticsEventSink {
+  const NoOpAnalyticsEventSink();
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
+```
+
+Create `mobile/lib/services/firebase_analytics_event_sink.dart`:
+
+```dart
+// ABOUTME: Firebase-backed implementation of the analytics event sink.
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:openvine/services/analytics_event_sink.dart';
+
+class FirebaseAnalyticsEventSink implements AnalyticsEventSink {
+  FirebaseAnalyticsEventSink({FirebaseAnalytics? analytics})
+    : _analytics = analytics ?? FirebaseAnalytics.instance;
+
+  final FirebaseAnalytics _analytics;
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) {
+    return _analytics.logEvent(name: name, parameters: parameters);
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) {
+    return _analytics.logScreenView(
+      screenName: screenName,
+      screenClass: screenClass,
+      parameters: parameters,
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Run the surface tests**
+
+```bash
+flutter test test/services/analytics_surface_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/services/analytics_surface.dart mobile/lib/services/analytics_event_sink.dart mobile/lib/services/firebase_analytics_event_sink.dart mobile/test/services/analytics_surface_test.dart
+git commit -m "feat(analytics): add semantic surface names"
+```
+
+---
+
+### Task 4: Replace Generic Route Screen Views With App-Owned Screen Views
+
+**Files:**
+- Modify: `mobile/lib/services/page_load_observer.dart`
+- Modify: `mobile/lib/services/screen_analytics_service.dart`
+- Modify: `mobile/lib/router/app_router.dart`
+- Test: `mobile/test/services/page_load_observer_test.dart`
+- Test: `mobile/test/services/screen_analytics_service_test.dart`
+
+- [ ] **Step 1: Add tests for route name normalization**
+
+Extend `mobile/test/services/page_load_observer_test.dart` with a test that pushes a named route and verifies the observer can use the semantic name without crashing:
+
+```dart
+testWidgets('uses semantic route settings names for analytics', (tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      navigatorObservers: [observer],
+      home: const Scaffold(body: Text('Home')),
+      onGenerateRoute: (settings) {
+        if (settings.name == '/video/123') {
+          return MaterialPageRoute<void>(
+            settings: const RouteSettings(name: 'video_detail'),
+            builder: (_) => const Scaffold(body: Text('Video Detail')),
+          );
+        }
+        return null;
+      },
+    ),
+  );
+
+  final context = tester.element(find.text('Home'));
+  Navigator.of(context).pushNamed('/video/123');
+  await tester.pumpAndSettle();
+
+  expect(find.text('Video Detail'), findsOneWidget);
+});
+```
+
+- [ ] **Step 2: Update `ScreenAnalyticsService` to use `AnalyticsEventSink`**
+
+Change the test constructor to accept an `AnalyticsEventSink` and default production construction to `FirebaseAnalyticsEventSink` when Firebase is available. Keep existing public methods so current call sites keep compiling:
+
+```dart
+ScreenAnalyticsService._({
+  AnalyticsEventSink? sink,
+}) : _sink = sink ?? _createFirebaseSink(),
+     _bypassAnalytics = false;
+
+@visibleForTesting
+ScreenAnalyticsService.testInstance({AnalyticsEventSink? sink})
+  : _sink = sink ?? const NoOpAnalyticsEventSink(),
+    _bypassAnalytics = true;
+```
+
+Replace direct `_analytics?.logEvent(...)` and `_analytics?.logScreenView(...)` calls with `_sink.logEvent(...)` and `_sink.logScreenView(...)`.
+
+- [ ] **Step 3: Make route screen view logging explicit**
+
+In `PageLoadObserver.didPush`, after deriving the semantic screen name, call:
+
+```dart
+_analytics.trackScreenView(
+  screenName,
+  params: {
+    AnalyticsParam.routeName: screenName,
+    AnalyticsParam.entryPoint: 'navigation',
+  },
+);
+```
+
+Keep `startScreenLoad` and `markContentVisible` so the existing `screen_load` event and developer options history still work.
+
+- [ ] **Step 4: Add names to high-volume routes**
+
+In `mobile/lib/router/app_router.dart`, add `name:` for the routes that should dominate Firebase reports:
+
+```dart
+GoRoute(
+  name: AnalyticsSurface.homeFeed,
+  path: VideoFeedPage.pathWithIndex,
+  ...
+)
+GoRoute(
+  name: AnalyticsSurface.explore,
+  path: ExploreScreen.path,
+  ...
+)
+GoRoute(
+  name: AnalyticsSurface.notifications,
+  path: NotificationsPage.pathWithIndex,
+  ...
+)
+GoRoute(
+  name: AnalyticsSurface.inbox,
+  path: InboxPage.path,
+  ...
+)
+GoRoute(
+  name: AnalyticsSurface.profile,
+  path: ProfileScreenRouter.path,
+  ...
+)
+GoRoute(
+  name: AnalyticsSurface.videoDetail,
+  path: VideoDetailScreen.path,
+  ...
+)
+GoRoute(
+  name: AnalyticsSurface.settings,
+  path: SettingsScreen.path,
+  ...
+)
+```
+
+Do not change paths or navigation behavior.
+
+- [ ] **Step 5: Run focused tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/services/screen_analytics_service_test.dart test/services/page_load_observer_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/services/screen_analytics_service.dart mobile/lib/services/page_load_observer.dart mobile/lib/router/app_router.dart mobile/test/services/screen_analytics_service_test.dart mobile/test/services/page_load_observer_test.dart
+git commit -m "fix(analytics): log semantic route screen views"
+```
+
+---
+
+### Task 5: Add Surface Performance Tracking
+
+**Files:**
+- Create: `mobile/lib/services/surface_performance_tracker.dart`
+- Test: `mobile/test/services/surface_performance_tracker_test.dart`
+- Modify: `mobile/lib/widgets/app_lifecycle_handler.dart`
+
+- [ ] **Step 1: Write failing service tests**
+
+Create `mobile/test/services/surface_performance_tracker_test.dart`:
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/analytics_event_sink.dart';
+import 'package:openvine/services/analytics_surface.dart';
+import 'package:openvine/services/surface_performance_tracker.dart';
+
+class RecordingAnalyticsEventSink implements AnalyticsEventSink {
+  final events = <({String name, Map<String, Object> parameters})>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
+
+void main() {
+  group(SurfacePerformanceTracker, () {
+    late RecordingAnalyticsEventSink sink;
+    late SurfacePerformanceTracker tracker;
+
+    setUp(() {
+      sink = RecordingAnalyticsEventSink();
+      tracker = SurfacePerformanceTracker.testInstance(sink: sink);
+    });
+
+    test('logs one surface_load event with semantic parameters', () async {
+      tracker.startSurfaceLoad(
+        AnalyticsSurface.commentsSheet,
+        params: const {
+          AnalyticsParam.entryPoint: 'feed_button',
+          AnalyticsParam.initialCount: 12,
+        },
+      );
+      tracker.markSurfaceVisible(AnalyticsSurface.commentsSheet);
+      await tracker.completeSurfaceLoad(
+        AnalyticsSurface.commentsSheet,
+        result: SurfaceLoadResult.success,
+        metrics: const {
+          AnalyticsParam.itemCount: 10,
+          AnalyticsParam.hasMore: true,
+        },
+      );
+
+      expect(sink.events, hasLength(1));
+      expect(sink.events.single.name, 'surface_load');
+      expect(
+        sink.events.single.parameters[AnalyticsParam.surfaceName],
+        AnalyticsSurface.commentsSheet,
+      );
+      expect(
+        sink.events.single.parameters[AnalyticsParam.result],
+        SurfaceLoadResult.success,
+      );
+      expect(sink.events.single.parameters[AnalyticsParam.itemCount], 10);
+    });
+
+    test('dismissed surfaces complete instead of leaking active sessions', () async {
+      tracker.startSurfaceLoad(AnalyticsSurface.commentsSheet);
+      await tracker.completeSurfaceLoad(
+        AnalyticsSurface.commentsSheet,
+        result: SurfaceLoadResult.dismissed,
+      );
+
+      expect(tracker.activeSessionCount, 0);
+      expect(sink.events.single.parameters[AnalyticsParam.result], 'dismissed');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/services/surface_performance_tracker_test.dart
+```
+
+Expected: FAIL because `SurfacePerformanceTracker` does not exist.
+
+- [ ] **Step 3: Implement `SurfacePerformanceTracker`**
+
+Create `mobile/lib/services/surface_performance_tracker.dart`:
+
+```dart
+// ABOUTME: Tracks user-visible surface load timing with semantic analytics.
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:openvine/services/analytics_event_sink.dart';
+import 'package:openvine/services/analytics_surface.dart';
+import 'package:openvine/services/firebase_analytics_event_sink.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+const _maxSurfaceSessionAge = Duration(seconds: 60);
+
+class SurfacePerformanceTracker {
+  factory SurfacePerformanceTracker() =>
+      _instance ??= SurfacePerformanceTracker._();
+
+  SurfacePerformanceTracker._({AnalyticsEventSink? sink})
+      : _sink = sink ?? FirebaseAnalyticsEventSink();
+
+  @visibleForTesting
+  SurfacePerformanceTracker.testInstance({AnalyticsEventSink? sink})
+      : _sink = sink ?? const NoOpAnalyticsEventSink();
+
+  static SurfacePerformanceTracker? _instance;
+
+  @visibleForTesting
+  static void resetInstance() {
+    _instance?._activeSessions.clear();
+    _instance = null;
+  }
+
+  final AnalyticsEventSink _sink;
+  final Map<String, _SurfaceLoadSession> _activeSessions = {};
+
+  int get activeSessionCount => _activeSessions.length;
+
+  void resetAllSessions() {
+    _activeSessions.clear();
+  }
+
+  void startSurfaceLoad(String surfaceName, {Map<String, Object>? params}) {
+    final safeName = AnalyticsSurface.sanitizeName(surfaceName);
+    _activeSessions[safeName] = _SurfaceLoadSession(
+      surfaceName: safeName,
+      startedAt: DateTime.now(),
+      params: params ?? const {},
+    );
+  }
+
+  void markSurfaceVisible(String surfaceName) {
+    final session = _sessionFor(surfaceName);
+    if (session == null) return;
+    session.visibleAt ??= DateTime.now();
+  }
+
+  Future<void> completeSurfaceLoad(
+    String surfaceName, {
+    required String result,
+    Map<String, Object>? metrics,
+  }) async {
+    final safeName = AnalyticsSurface.sanitizeName(surfaceName);
+    final session = _activeSessions.remove(safeName);
+    if (session == null || _isStale(session)) return;
+
+    final completedAt = DateTime.now();
+    final visibleMs = session.visibleAt == null
+        ? -1
+        : session.visibleAt!.difference(session.startedAt).inMilliseconds;
+    final totalMs = completedAt.difference(session.startedAt).inMilliseconds;
+
+    final params = <String, Object>{
+      AnalyticsParam.surfaceName: safeName,
+      AnalyticsParam.result: result,
+      AnalyticsParam.visibleMs: visibleMs,
+      AnalyticsParam.dataMs: totalMs,
+      AnalyticsParam.totalMs: totalMs,
+      AnalyticsParam.slowBucket: AnalyticsSurface.slowBucket(totalMs),
+      ...session.params,
+      ...?metrics,
+    };
+
+    await _sink.logEvent(name: 'surface_load', parameters: params);
+
+    final slowFlag = totalMs >= 3000 ? ' [SLOW]' : '';
+    UnifiedLogger.info(
+      'PERF: $safeName surface result=$result total=${totalMs}ms$slowFlag',
+      name: 'SurfacePerf',
+    );
+  }
+
+  _SurfaceLoadSession? _sessionFor(String surfaceName) {
+    final safeName = AnalyticsSurface.sanitizeName(surfaceName);
+    final session = _activeSessions[safeName];
+    if (session == null) return null;
+    if (_isStale(session)) {
+      _activeSessions.remove(safeName);
+      return null;
+    }
+    return session;
+  }
+
+  bool _isStale(_SurfaceLoadSession session) {
+    return DateTime.now().difference(session.startedAt) > _maxSurfaceSessionAge;
+  }
+}
+
+class _SurfaceLoadSession {
+  _SurfaceLoadSession({
+    required this.surfaceName,
+    required this.startedAt,
+    required this.params,
+  });
+
+  final String surfaceName;
+  final DateTime startedAt;
+  final Map<String, Object> params;
+  DateTime? visibleAt;
+}
+```
+
+- [ ] **Step 4: Reset surface sessions on app resume**
+
+In `mobile/lib/widgets/app_lifecycle_handler.dart`, wherever `ScreenAnalyticsService().resetAllSessions()` is called on resume, also call:
+
+```dart
+SurfacePerformanceTracker().resetAllSessions();
+```
+
+- [ ] **Step 5: Run tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/services/surface_performance_tracker_test.dart test/services/screen_analytics_service_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add mobile/lib/services/surface_performance_tracker.dart mobile/lib/widgets/app_lifecycle_handler.dart mobile/test/services/surface_performance_tracker_test.dart
+git commit -m "feat(analytics): add surface performance tracker"
+```
+
+---
+
+### Task 6: Instrument Comments Sheet Perceived Load
+
+**Files:**
+- Modify: `mobile/lib/screens/comments/comments_screen.dart`
+- Test: `mobile/test/screens/comments/comments_screen_test.dart`
+
+- [ ] **Step 1: Add comments telemetry widget coverage**
+
+Add or extend comments screen tests to verify that comments success logs a terminal surface event. Use `SurfacePerformanceTracker.testInstance` with `RecordingAnalyticsEventSink` from the service test, or move that helper into `mobile/test/helpers/recording_analytics_event_sink.dart`.
+
+The test should exercise:
+
+```dart
+expect(
+  sink.events.where((event) => event.name == 'surface_load'),
+  hasLength(1),
+);
+expect(
+  sink.events.single.parameters[AnalyticsParam.surfaceName],
+  AnalyticsSurface.commentsSheet,
+);
+expect(
+  sink.events.single.parameters[AnalyticsParam.result],
+  anyOf(SurfaceLoadResult.success, SurfaceLoadResult.empty),
+);
+```
+
+- [ ] **Step 2: Run the comments telemetry test and verify it fails**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/screens/comments/comments_screen_test.dart
+```
+
+Expected: FAIL because comments does not call `SurfacePerformanceTracker` yet.
+
+- [ ] **Step 3: Start the comments surface load on open**
+
+In `CommentsScreen.show`, before `context.showVideoPausingVineBottomSheet`, add:
+
+```dart
+final surfaceTracker = SurfacePerformanceTracker();
+surfaceTracker.startSurfaceLoad(
+  AnalyticsSurface.commentsSheet,
+  params: {
+    AnalyticsParam.entryPoint: 'feed_comment_button',
+    if (seedCommentCount != null) AnalyticsParam.initialCount: seedCommentCount,
+    AnalyticsParam.featureFlag: showVideoReplies
+        ? 'video_replies_enabled'
+        : 'video_replies_disabled',
+  },
+);
+```
+
+- [ ] **Step 4: Mark the sheet visible after first frame**
+
+Wrap the comments sheet body in a small stateful widget or add an existing body `initState` callback that runs:
+
+```dart
+WidgetsBinding.instance.addPostFrameCallback((_) {
+  SurfacePerformanceTracker().markSurfaceVisible(
+    AnalyticsSurface.commentsSheet,
+  );
+});
+```
+
+- [ ] **Step 5: Complete on comments success, empty, or failure**
+
+Add a `BlocListener<CommentsListBloc, CommentsListState>` around the comments body. When `status` changes from `loading` to `success`:
+
+```dart
+final result = state.commentsById.isEmpty
+    ? SurfaceLoadResult.empty
+    : SurfaceLoadResult.success;
+unawaited(
+  SurfacePerformanceTracker().completeSurfaceLoad(
+    AnalyticsSurface.commentsSheet,
+    result: result,
+    metrics: {
+      AnalyticsParam.itemCount: state.commentsById.length,
+      AnalyticsParam.hasMore: state.hasMoreContent,
+      'sort_mode': state.sortMode.name,
+    },
+  ),
+);
+```
+
+When `status` changes from `loading` to `failure`:
+
+```dart
+unawaited(
+  SurfacePerformanceTracker().completeSurfaceLoad(
+    AnalyticsSurface.commentsSheet,
+    result: SurfaceLoadResult.failure,
+    metrics: const {'failure_type': 'comments_load_failed'},
+  ),
+);
+```
+
+- [ ] **Step 6: Complete as dismissed if the sheet closes before data finishes**
+
+Await the `showVideoPausingVineBottomSheet` future and then call dismissed completion. This is safe because `completeSurfaceLoad` is a no-op after success/failure removes the active session:
+
+```dart
+return context
+    .showVideoPausingVineBottomSheet<void>(...)
+    .whenComplete(() {
+      unawaited(
+        SurfacePerformanceTracker().completeSurfaceLoad(
+          AnalyticsSurface.commentsSheet,
+          result: SurfaceLoadResult.dismissed,
+        ),
+      );
+    });
+```
+
+- [ ] **Step 7: Run comments tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/screens/comments/comments_screen_test.dart test/services/surface_performance_tracker_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add mobile/lib/screens/comments/comments_screen.dart mobile/test/screens/comments/comments_screen_test.dart
+git commit -m "feat(comments): track comments sheet load performance"
+```
+
+---
+
+### Task 7: Add Debug Visibility And Dashboard Handoff
+
+**Files:**
+- Modify: `mobile/lib/services/page_load_history.dart`
+- Modify: `mobile/lib/screens/developer_options_screen.dart`
+- Modify: `docs/ANALYTICS_OBSERVABILITY.md`
+- Test: `mobile/test/services/page_load_history_test.dart`
+
+- [ ] **Step 1: Add a `surfaceName`/`result` capable record shape**
+
+Extend `PageLoadRecord` only if needed to display `surface_load` records in Developer Options. Keep existing fields compatible:
+
+```dart
+final String? result;
+final String? source;
+```
+
+Use `source = 'route'` for route loads and `source = 'surface'` for comments sheet loads.
+
+- [ ] **Step 2: Show recent slow surfaces in Developer Options**
+
+Add a small section under existing page load history that shows:
+
+- surface/screen name
+- result
+- visible ms
+- data/total ms
+- slow marker
+
+No user-facing production copy changes are required because Developer Options is internal/debug.
+
+- [ ] **Step 3: Update the analytics doc with Firebase dashboard instructions**
+
+Append:
+
+```markdown
+## First Dashboard To Build
+
+Create a Firebase/GA4 exploration or BigQuery query for:
+
+- event name: `surface_load`
+- dimension: `surface_name`
+- dimension: `slow_bucket`
+- dimension: `result`
+- metric: event count
+- metric: p95/p99 of `total_ms`
+
+First target filter:
+
+```text
+surface_name = comments_sheet
+```
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test test/services/page_load_history_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mobile/lib/services/page_load_history.dart mobile/lib/screens/developer_options_screen.dart mobile/test/services/page_load_history_test.dart docs/ANALYTICS_OBSERVABILITY.md
+git commit -m "feat(analytics): show slow surfaces in developer options"
+```
+
+---
+
+### Task 8: Verification, Firebase Sanity Check, And Divine Brain Follow-Up
+
+**Files:**
+- Review all touched files
+- No new code files
+
+- [ ] **Step 1: Run focused service and comments tests**
+
+Run from `mobile/`:
+
+```bash
+flutter test \
+  test/services/analytics_surface_test.dart \
+  test/services/analytics_native_config_test.dart \
+  test/services/screen_analytics_service_test.dart \
+  test/services/page_load_observer_test.dart \
+  test/services/surface_performance_tracker_test.dart \
+  test/screens/comments/comments_screen_test.dart
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run analyzer for touched app paths**
+
+Run from `mobile/`:
+
+```bash
+flutter analyze \
+  lib/services \
+  lib/router/app_router.dart \
+  lib/screens/comments/comments_screen.dart \
+  lib/widgets/app_lifecycle_handler.dart \
+  test/services \
+  test/screens/comments
+```
+
+Expected: no analyzer errors.
+
+- [ ] **Step 3: Manually verify Firebase event shape in a debug/profile run**
+
+Run the app, open a feed video's comments, wait for comments to load, then close the sheet.
+
+Expected debug logs include:
+
+```text
+PERF: comments_sheet surface result=success total=<n>ms
+```
+
+Expected Firebase DebugView or next-day console data includes:
+
+- `screen_view` with useful `screen_name` values like `home_feed`, `explore`, `video_detail`
+- no new `FlutterViewController` / `MainActivity` rows from app-owned logging
+- `surface_load` with `surface_name = comments_sheet`
+- `slow_bucket` for comments loads over 3 seconds
+
+- [ ] **Step 4: Search Divine Brain before PR description**
+
+Run a Divine Brain search:
+
+```text
+Firebase Analytics mobile screen_view surface_load observability divine-mobile
+```
+
+Expected: either this plan/docs appear if already ingested, or no prior context appears. Include the result in the PR description.
+
+- [ ] **Step 5: Open the PR**
+
+Run:
+
+```bash
+git status --short
+git log --oneline origin/main..HEAD
+gh pr create \
+  --base main \
+  --title "feat(analytics): track semantic mobile surface performance" \
+  --body "$(cat <<'EOF'
+## Summary
+- disables Firebase native automatic screen rows that produce `FlutterViewController` / `MainActivity`
+- logs app-owned semantic screen names
+- adds `surface_load` timing for user-visible surfaces
+- instruments the comments sheet as the first slow-surface target
+- documents the analytics contract and Divine Brain verification workflow
+
+## Verification
+- flutter test test/services/analytics_surface_test.dart test/services/analytics_native_config_test.dart test/services/screen_analytics_service_test.dart test/services/page_load_observer_test.dart test/services/surface_performance_tracker_test.dart test/screens/comments/comments_screen_test.dart
+- flutter analyze lib/services lib/router/app_router.dart lib/screens/comments/comments_screen.dart lib/widgets/app_lifecycle_handler.dart test/services test/screens/comments
+
+## Divine Brain
+- Pre-implementation search found no prior mobile analytics contract for this exact topic.
+- After merge, Brain should ingest docs/ANALYTICS_OBSERVABILITY.md from GitHub.
+EOF
+)"
+```
+
+Expected: PR opens against `main` with a semantic title.
+
+- [ ] **Step 6: Verify post-merge Brain ingest**
+
+After the PR merges and the hourly Divine Brain ingest has run, search:
+
+```text
+analytics observability comments_sheet surface_load divine-mobile
+```
+
+Expected: Brain returns the analytics contract or implementation PR. If not, inspect Brain's GitHub ingest status.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan fixes useless Firebase screen rows, adds semantic screen names, adds real perceived-load telemetry for comments, and makes the analytics contract discoverable through the GitHub-to-Divine-Brain ingest path.
+- Placeholder scan: No unresolved placeholders or unspecified test commands remain.
+- Type consistency: `AnalyticsSurface`, `AnalyticsParam`, `SurfaceLoadResult`, `AnalyticsEventSink`, and `SurfacePerformanceTracker` names are consistent across tasks.
+- Scope check: This is intentionally scoped to route screen naming plus comments sheet performance. Other slow surfaces should be added after this lands by reusing `SurfacePerformanceTracker`.

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -93,6 +93,9 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="openvine_push" />
+        <meta-data
+            android:name="google_analytics_automatic_screen_reporting_enabled"
+            android:value="false" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -47,6 +47,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>FirebaseCrashlyticsCollectionEnabled</key>
 	<true/>
+	<key>FirebaseAutomaticScreenReportingEnabled</key>
+	<false/>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/mobile/lib/blocs/comments/comments_surface_performance_telemetry.dart
+++ b/mobile/lib/blocs/comments/comments_surface_performance_telemetry.dart
@@ -44,7 +44,7 @@ class CommentsSurfacePerformanceTelemetry {
       metrics: {
         AnalyticsParam.itemCount: itemCount,
         AnalyticsParam.hasMore: hasMore,
-        'sort_mode': sortMode,
+        AnalyticsParam.sortMode: sortMode,
       },
     );
   }

--- a/mobile/lib/blocs/comments/comments_surface_performance_telemetry.dart
+++ b/mobile/lib/blocs/comments/comments_surface_performance_telemetry.dart
@@ -1,0 +1,65 @@
+// ABOUTME: Comments-specific adapter for surface performance analytics.
+
+import 'package:openvine/services/analytics_surface.dart';
+import 'package:openvine/services/surface_performance_tracker.dart';
+
+class CommentsSurfacePerformanceTelemetry {
+  CommentsSurfacePerformanceTelemetry()
+    : this.withTracker(SurfacePerformanceTracker());
+
+  CommentsSurfacePerformanceTelemetry.withTracker(this._tracker);
+
+  final SurfacePerformanceTracker _tracker;
+
+  void start({
+    required bool videoRepliesEnabled,
+    int? initialCount,
+  }) {
+    _tracker.startSurfaceLoad(
+      AnalyticsSurface.commentsSheet,
+      params: {
+        AnalyticsParam.entryPoint: 'feed_comment_button',
+        AnalyticsParam.initialCount: ?initialCount,
+        AnalyticsParam.featureFlag: videoRepliesEnabled
+            ? 'video_replies_enabled'
+            : 'video_replies_disabled',
+      },
+    );
+  }
+
+  void markVisible() {
+    _tracker.markSurfaceVisible(AnalyticsSurface.commentsSheet);
+  }
+
+  Future<void> completeDataLoaded({
+    required int itemCount,
+    required bool hasMore,
+    required String sortMode,
+  }) {
+    return _tracker.completeSurfaceLoad(
+      AnalyticsSurface.commentsSheet,
+      result: itemCount == 0
+          ? SurfaceLoadResult.empty
+          : SurfaceLoadResult.success,
+      metrics: {
+        AnalyticsParam.itemCount: itemCount,
+        AnalyticsParam.hasMore: hasMore,
+        'sort_mode': sortMode,
+      },
+    );
+  }
+
+  Future<void> completeFailure() {
+    return _tracker.completeSurfaceLoad(
+      AnalyticsSurface.commentsSheet,
+      result: SurfaceLoadResult.failure,
+    );
+  }
+
+  Future<void> completeDismissed() {
+    return _tracker.completeSurfaceLoad(
+      AnalyticsSurface.commentsSheet,
+      result: SurfaceLoadResult.dismissed,
+    );
+  }
+}

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -4,8 +4,6 @@
 import 'dart:async';
 
 import 'package:dm_repository/dm_repository.dart';
-import 'package:firebase_analytics/firebase_analytics.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -1458,12 +1456,6 @@ List<NavigatorObserver> _buildRouterObservers() {
     PageLoadObserver(),
     VideoStopNavigatorObserver(),
   ];
-
-  if (Firebase.apps.isNotEmpty) {
-    observers.add(
-      FirebaseAnalyticsObserver(analytics: FirebaseAnalytics.instance),
-    );
-  }
 
   return observers;
 }

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -12,6 +12,7 @@ import 'package:models/models.dart' hide NIP71VideoKinds;
 import 'package:openvine/blocs/comments/comment_composer/comment_composer_bloc.dart';
 import 'package:openvine/blocs/comments/comment_reactions/comment_reactions_bloc.dart';
 import 'package:openvine/blocs/comments/comments_list/comments_list_bloc.dart';
+import 'package:openvine/blocs/comments/comments_surface_performance_telemetry.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -22,8 +23,6 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_reply_context_provider.dart';
 import 'package:openvine/screens/comments/widgets/widgets.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
-import 'package:openvine/services/analytics_surface.dart';
-import 'package:openvine/services/surface_performance_tracker.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 
@@ -144,16 +143,10 @@ abstract final class CommentsScreen {
       isFeatureEnabledProvider(FeatureFlag.videoReplies),
     );
     final seedCommentCount = initialCommentCount ?? liveCommentCountSeed(video);
-    final surfacePerformanceTracker = SurfacePerformanceTracker()
-      ..startSurfaceLoad(
-        AnalyticsSurface.commentsSheet,
-        params: {
-          AnalyticsParam.entryPoint: 'feed_comment_button',
-          AnalyticsParam.initialCount: ?seedCommentCount,
-          AnalyticsParam.featureFlag: showVideoReplies
-              ? 'video_replies_enabled'
-              : 'video_replies_disabled',
-        },
+    final surfaceTelemetry = CommentsSurfacePerformanceTelemetry()
+      ..start(
+        videoRepliesEnabled: showVideoReplies,
+        initialCount: seedCommentCount,
       );
 
     // The draggable scroll controller is created inside buildScrollBody but
@@ -249,7 +242,7 @@ abstract final class CommentsScreen {
           buildScrollBody: (scrollController) {
             activeScrollController = scrollController;
             return CommentsSheetLoadTelemetry(
-              tracker: surfacePerformanceTracker,
+              telemetry: surfaceTelemetry,
               child: _CommentsScreenBody(
                 videoEvent: video,
                 sheetScrollController: scrollController,
@@ -258,10 +251,7 @@ abstract final class CommentsScreen {
           },
         )
         .whenComplete(
-          () => surfacePerformanceTracker.completeSurfaceLoad(
-            AnalyticsSurface.commentsSheet,
-            result: SurfaceLoadResult.dismissed,
-          ),
+          surfaceTelemetry.completeDismissed,
         );
   }
 }
@@ -407,12 +397,12 @@ class OutboxBridges extends StatelessWidget {
 @visibleForTesting
 class CommentsSheetLoadTelemetry extends StatefulWidget {
   const CommentsSheetLoadTelemetry({
-    required this.tracker,
+    required this.telemetry,
     required this.child,
     super.key,
   });
 
-  final SurfacePerformanceTracker tracker;
+  final CommentsSurfacePerformanceTelemetry telemetry;
   final Widget child;
 
   @override
@@ -427,7 +417,7 @@ class _CommentsSheetLoadTelemetryState
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      widget.tracker.markSurfaceVisible(AnalyticsSurface.commentsSheet);
+      widget.telemetry.markVisible();
     });
   }
 
@@ -442,25 +432,14 @@ class _CommentsSheetLoadTelemetryState
         switch (state.status) {
           case CommentsStatus.success:
             unawaited(
-              widget.tracker.completeSurfaceLoad(
-                AnalyticsSurface.commentsSheet,
-                result: state.commentsById.isEmpty
-                    ? SurfaceLoadResult.empty
-                    : SurfaceLoadResult.success,
-                metrics: {
-                  AnalyticsParam.itemCount: state.commentsById.length,
-                  AnalyticsParam.hasMore: state.hasMoreContent,
-                  'sort_mode': state.sortMode.name,
-                },
+              widget.telemetry.completeDataLoaded(
+                itemCount: state.commentsById.length,
+                hasMore: state.hasMoreContent,
+                sortMode: state.sortMode.name,
               ),
             );
           case CommentsStatus.failure:
-            unawaited(
-              widget.tracker.completeSurfaceLoad(
-                AnalyticsSurface.commentsSheet,
-                result: SurfaceLoadResult.failure,
-              ),
-            );
+            unawaited(widget.telemetry.completeFailure());
           case CommentsStatus.initial:
           case CommentsStatus.loading:
             break;

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -22,6 +22,8 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_reply_context_provider.dart';
 import 'package:openvine/screens/comments/widgets/widgets.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
+import 'package:openvine/services/analytics_surface.dart';
+import 'package:openvine/services/surface_performance_tracker.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 
@@ -142,104 +144,125 @@ abstract final class CommentsScreen {
       isFeatureEnabledProvider(FeatureFlag.videoReplies),
     );
     final seedCommentCount = initialCommentCount ?? liveCommentCountSeed(video);
+    final surfacePerformanceTracker = SurfacePerformanceTracker()
+      ..startSurfaceLoad(
+        AnalyticsSurface.commentsSheet,
+        params: {
+          AnalyticsParam.entryPoint: 'feed_comment_button',
+          AnalyticsParam.initialCount: ?seedCommentCount,
+          AnalyticsParam.featureFlag: showVideoReplies
+              ? 'video_replies_enabled'
+              : 'video_replies_disabled',
+        },
+      );
 
     // The draggable scroll controller is created inside buildScrollBody but
     // is also needed by the title's "new comments" pill (which lives above
     // the scrollable region). Share it through a closure-captured holder.
     ScrollController? activeScrollController;
 
-    return context.showVideoPausingVineBottomSheet<void>(
-      snap: true,
-      snapSizes: const [0.7, 0.93],
-      initialChildSize: 0.7,
-      minChildSize: 0.5,
-      maxChildSize: 0.93,
-      // Wrap the whole sheet subtree in a MultiBlocProvider so every slot
-      // (title, trailing, bottomInput, buildScrollBody) shares the same
-      // three blocs. BlocProvider owns lifecycle — it closes each BLoC
-      // automatically when the sheet is disposed, so we don't need a manual
-      // try/finally around the await.
-      contentWrapper: (context, child) => MultiBlocProvider(
-        providers: [
-          BlocProvider<CommentsListBloc>(
-            create: (_) => CommentsListBloc(
-              commentsRepository: commentsRepository,
-              rootEventId: video.id,
-              rootEventKind: NIP71VideoKinds.addressableShortVideo,
-              rootAuthorPubkey: video.pubkey,
-              rootAddressableId: video.addressableId,
-              initialTotalCount: seedCommentCount,
-              includeVideoReplies: showVideoReplies,
-            )..add(const CommentsLoadRequested()),
-          ),
-          BlocProvider<CommentComposerBloc>(
-            create: (innerContext) {
-              // Captured at create-time. CommentsListBloc is provided above
-              // in the same MultiBlocProvider so it's available here via
-              // inheritance; the reference is stable for the sheet's life.
-              // The callback re-reads `state.commentsById` on every search
-              // so suggestions reflect the latest loaded comments.
-              final listBloc = innerContext.read<CommentsListBloc>();
-              return CommentComposerBloc(
-                commentsRepository: commentsRepository,
-                authService: authService,
-                rootEventId: video.id,
-                rootEventKind: NIP71VideoKinds.addressableShortVideo,
-                rootAuthorPubkey: video.pubkey,
-                rootAddressableId: video.addressableId,
-                profileRepository: profileRepository,
-                mentionCandidatePubkeysProvider: () => <String>[
-                  // Thread participants first — restored after the split
-                  // (pre-split CommentsBloc seeded these from state.commentsById).
-                  ...listBloc.state.commentsById.values.map(
-                    (c) => c.authorPubkey,
-                  ),
-                  ...followRepository.followingPubkeys,
-                ],
-              );
-            },
-          ),
-          BlocProvider<CommentReactionsBloc>(
-            create: (_) => CommentReactionsBloc(
-              authService: authService,
-              likesRepository: likesRepository,
-              commentsRepository: commentsRepository,
-              contentReportingServiceFuture: contentReportingServiceFuture,
-              contentBlocklistRepository: contentBlocklistRepository,
-              followRepository: followRepository,
-              rootEventId: video.id,
-              rootAddressableId: video.addressableId,
+    return context
+        .showVideoPausingVineBottomSheet<void>(
+          snap: true,
+          snapSizes: const [0.7, 0.93],
+          initialChildSize: 0.7,
+          minChildSize: 0.5,
+          maxChildSize: 0.93,
+          // Wrap the whole sheet subtree in a MultiBlocProvider so every slot
+          // (title, trailing, bottomInput, buildScrollBody) shares the same
+          // three blocs. BlocProvider owns lifecycle — it closes each BLoC
+          // automatically when the sheet is disposed, so we don't need a manual
+          // try/finally around the await.
+          contentWrapper: (context, child) => MultiBlocProvider(
+            providers: [
+              BlocProvider<CommentsListBloc>(
+                create: (_) => CommentsListBloc(
+                  commentsRepository: commentsRepository,
+                  rootEventId: video.id,
+                  rootEventKind: NIP71VideoKinds.addressableShortVideo,
+                  rootAuthorPubkey: video.pubkey,
+                  rootAddressableId: video.addressableId,
+                  initialTotalCount: seedCommentCount,
+                  includeVideoReplies: showVideoReplies,
+                )..add(const CommentsLoadRequested()),
+              ),
+              BlocProvider<CommentComposerBloc>(
+                create: (innerContext) {
+                  // Captured at create-time. CommentsListBloc is provided above
+                  // in the same MultiBlocProvider so it's available here via
+                  // inheritance; the reference is stable for the sheet's life.
+                  // The callback re-reads `state.commentsById` on every search
+                  // so suggestions reflect the latest loaded comments.
+                  final listBloc = innerContext.read<CommentsListBloc>();
+                  return CommentComposerBloc(
+                    commentsRepository: commentsRepository,
+                    authService: authService,
+                    rootEventId: video.id,
+                    rootEventKind: NIP71VideoKinds.addressableShortVideo,
+                    rootAuthorPubkey: video.pubkey,
+                    rootAddressableId: video.addressableId,
+                    profileRepository: profileRepository,
+                    mentionCandidatePubkeysProvider: () => <String>[
+                      // Thread participants first — restored after the split
+                      // (pre-split CommentsBloc seeded these from state.commentsById).
+                      ...listBloc.state.commentsById.values.map(
+                        (c) => c.authorPubkey,
+                      ),
+                      ...followRepository.followingPubkeys,
+                    ],
+                  );
+                },
+              ),
+              BlocProvider<CommentReactionsBloc>(
+                create: (_) => CommentReactionsBloc(
+                  authService: authService,
+                  likesRepository: likesRepository,
+                  commentsRepository: commentsRepository,
+                  contentReportingServiceFuture: contentReportingServiceFuture,
+                  contentBlocklistRepository: contentBlocklistRepository,
+                  followRepository: followRepository,
+                  rootEventId: video.id,
+                  rootAddressableId: video.addressableId,
+                ),
+              ),
+            ],
+            child: OutboxBridges(
+              onCommentCountChanged: onCommentCountChanged,
+              child: child,
             ),
           ),
-        ],
-        child: OutboxBridges(
-          onCommentCountChanged: onCommentCountChanged,
-          child: child,
-        ),
-      ),
-      title: _CommentsTitle(
-        initialCount: seedCommentCount ?? 0,
-        onNewCommentsPillTap: () {
-          final controller = activeScrollController;
-          if (controller != null && controller.hasClients) {
-            controller.animateTo(
-              0,
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeOut,
+          title: _CommentsTitle(
+            initialCount: seedCommentCount ?? 0,
+            onNewCommentsPillTap: () {
+              final controller = activeScrollController;
+              if (controller != null && controller.hasClients) {
+                controller.animateTo(
+                  0,
+                  duration: const Duration(milliseconds: 300),
+                  curve: Curves.easeOut,
+                );
+              }
+            },
+          ),
+          trailing: const _CommentsSortToggle(),
+          bottomInput: const _MainCommentInput(),
+          buildScrollBody: (scrollController) {
+            activeScrollController = scrollController;
+            return CommentsSheetLoadTelemetry(
+              tracker: surfacePerformanceTracker,
+              child: _CommentsScreenBody(
+                videoEvent: video,
+                sheetScrollController: scrollController,
+              ),
             );
-          }
-        },
-      ),
-      trailing: const _CommentsSortToggle(),
-      bottomInput: const _MainCommentInput(),
-      buildScrollBody: (scrollController) {
-        activeScrollController = scrollController;
-        return _CommentsScreenBody(
-          videoEvent: video,
-          sheetScrollController: scrollController,
+          },
+        )
+        .whenComplete(
+          () => surfacePerformanceTracker.completeSurfaceLoad(
+            AnalyticsSurface.commentsSheet,
+            result: SurfaceLoadResult.dismissed,
+          ),
         );
-      },
-    );
   }
 }
 
@@ -375,6 +398,76 @@ class OutboxBridges extends StatelessWidget {
         listBloc.add(CommentsRemovedByAuthorFromStore(authorPubkey));
     }
     ctx.read<CommentReactionsBloc>().add(const ReactionsOutboxConsumed());
+  }
+}
+
+/// Tracks perceived comments-sheet visibility and initial data completion.
+///
+/// Public-by-test only: production callers should use [CommentsScreen.show].
+@visibleForTesting
+class CommentsSheetLoadTelemetry extends StatefulWidget {
+  const CommentsSheetLoadTelemetry({
+    required this.tracker,
+    required this.child,
+    super.key,
+  });
+
+  final SurfacePerformanceTracker tracker;
+  final Widget child;
+
+  @override
+  State<CommentsSheetLoadTelemetry> createState() =>
+      _CommentsSheetLoadTelemetryState();
+}
+
+class _CommentsSheetLoadTelemetryState
+    extends State<CommentsSheetLoadTelemetry> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      widget.tracker.markSurfaceVisible(AnalyticsSurface.commentsSheet);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<CommentsListBloc, CommentsListState>(
+      listenWhen: (prev, next) =>
+          prev.status == CommentsStatus.loading &&
+          (next.status == CommentsStatus.success ||
+              next.status == CommentsStatus.failure),
+      listener: (_, state) {
+        switch (state.status) {
+          case CommentsStatus.success:
+            unawaited(
+              widget.tracker.completeSurfaceLoad(
+                AnalyticsSurface.commentsSheet,
+                result: state.commentsById.isEmpty
+                    ? SurfaceLoadResult.empty
+                    : SurfaceLoadResult.success,
+                metrics: {
+                  AnalyticsParam.itemCount: state.commentsById.length,
+                  AnalyticsParam.hasMore: state.hasMoreContent,
+                  'sort_mode': state.sortMode.name,
+                },
+              ),
+            );
+          case CommentsStatus.failure:
+            unawaited(
+              widget.tracker.completeSurfaceLoad(
+                AnalyticsSurface.commentsSheet,
+                result: SurfaceLoadResult.failure,
+              ),
+            );
+          case CommentsStatus.initial:
+          case CommentsStatus.loading:
+            break;
+        }
+      },
+      child: widget.child,
+    );
   }
 }
 

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -29,7 +29,7 @@ Color _getSpeedColor(PageLoadRecord record) {
 }
 
 String _recordTitle(PageLoadRecord record) {
-  if (record.source == 'route') return record.screenName;
+  if (record.source == PageLoadSource.route) return record.screenName;
   return '${record.screenName} (${record.source})';
 }
 

--- a/mobile/lib/screens/developer_options_screen.dart
+++ b/mobile/lib/screens/developer_options_screen.dart
@@ -28,6 +28,25 @@ Color _getSpeedColor(PageLoadRecord record) {
   return VineTheme.vineGreen;
 }
 
+String _recordTitle(PageLoadRecord record) {
+  if (record.source == 'route') return record.screenName;
+  return '${record.screenName} (${record.source})';
+}
+
+String _recordTimingText(BuildContext context, PageLoadRecord record) {
+  return context.l10n.devOptionsPageLoadVisible(
+    record.contentVisibleMs?.toString() ?? '\u2014',
+    record.dataLoadedMs?.toString() ?? '\u2014',
+  );
+}
+
+String _recordDetailsText(BuildContext context, PageLoadRecord record) {
+  final timing = _recordTimingText(context, record);
+  final result = record.result;
+  if (result == null) return timing;
+  return '$timing | result: $result';
+}
+
 class _FormatOption {
   const _FormatOption({
     required this.format,
@@ -206,7 +225,7 @@ class _DeveloperOptionsScreenState
                 ...recentRecords.map((record) {
                   return ListTile(
                     title: Text(
-                      record.screenName,
+                      _recordTitle(record),
                       style: const TextStyle(
                         color: VineTheme.primaryText,
                         fontSize: 14,
@@ -214,10 +233,7 @@ class _DeveloperOptionsScreenState
                       ),
                     ),
                     subtitle: Text(
-                      context.l10n.devOptionsPageLoadVisible(
-                        record.contentVisibleMs?.toString() ?? '\u2014',
-                        record.dataLoadedMs?.toString() ?? '\u2014',
-                      ),
+                      _recordDetailsText(context, record),
                       style: const TextStyle(
                         color: VineTheme.secondaryText,
                         fontSize: 12,
@@ -253,9 +269,12 @@ class _DeveloperOptionsScreenState
                 ),
                 ...slowestRecords.map((record) {
                   final dataMs = record.dataLoadedMs ?? 0;
+                  final result = record.result == null
+                      ? ''
+                      : ' | result: ${record.result}';
                   return ListTile(
                     title: Text(
-                      record.screenName,
+                      _recordTitle(record),
                       style: const TextStyle(
                         color: VineTheme.primaryText,
                         fontSize: 14,
@@ -263,7 +282,7 @@ class _DeveloperOptionsScreenState
                       ),
                     ),
                     subtitle: Text(
-                      '${dataMs}ms',
+                      '${record.source} | data: ${dataMs}ms$result',
                       style: TextStyle(
                         color: _getSpeedColor(record),
                         fontSize: 12,

--- a/mobile/lib/screens/explore_screen.dart
+++ b/mobile/lib/screens/explore_screen.dart
@@ -205,9 +205,8 @@ class _ExploreScreenState extends ConsumerState<ExploreScreen>
 
     _initTabController();
 
-    // Track screen load
+    // Track Explore-specific data load completion from child tabs.
     _screenAnalytics.startScreenLoad('explore_screen');
-    _screenAnalytics.trackScreenView('explore_screen');
 
     // Load top hashtags for trending navigation
     _loadHashtags();

--- a/mobile/lib/services/analytics_event_sink.dart
+++ b/mobile/lib/services/analytics_event_sink.dart
@@ -1,0 +1,31 @@
+// ABOUTME: Testable abstraction over analytics event delivery.
+
+abstract interface class AnalyticsEventSink {
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  });
+
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  });
+}
+
+class NoOpAnalyticsEventSink implements AnalyticsEventSink {
+  const NoOpAnalyticsEventSink();
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {}
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}

--- a/mobile/lib/services/analytics_surface.dart
+++ b/mobile/lib/services/analytics_surface.dart
@@ -23,13 +23,35 @@ abstract final class AnalyticsSurface {
   }
 
   static String sanitizeName(String value) {
-    final normalized = value
+    final camelSeparated = value.trim().replaceAllMapped(
+      RegExp('([a-z0-9])([A-Z])'),
+      (match) => '${match.group(1)}_${match.group(2)}',
+    );
+    final normalized = camelSeparated
         .trim()
         .replaceAll(RegExp('[^A-Za-z0-9_]+'), '_')
         .replaceAll(RegExp('_+'), '_')
         .replaceAll(RegExp(r'^_+|_+$'), '')
         .toLowerCase();
     return normalized.isEmpty ? unknownRoute : normalized;
+  }
+
+  static String routeSurfaceName(String? routeName) {
+    if (routeName == null || routeName.trim().isEmpty) {
+      return unknownRoute;
+    }
+    if (routeName.trim() == '/') {
+      return homeFeed;
+    }
+
+    final sanitized = sanitizeName(routeName);
+    return switch (sanitized) {
+      'home' => homeFeed,
+      'video' => videoDetail,
+      'video_recorder' => videoRecorder,
+      'video_editor' => videoEditor,
+      _ => sanitized,
+    };
   }
 }
 

--- a/mobile/lib/services/analytics_surface.dart
+++ b/mobile/lib/services/analytics_surface.dart
@@ -69,6 +69,7 @@ abstract final class AnalyticsParam {
   static const initialCount = 'initial_count';
   static const hasMore = 'has_more';
   static const featureFlag = 'feature_flag';
+  static const sortMode = 'sort_mode';
 }
 
 abstract final class SurfaceLoadResult {

--- a/mobile/lib/services/analytics_surface.dart
+++ b/mobile/lib/services/analytics_surface.dart
@@ -27,6 +27,7 @@ abstract final class AnalyticsSurface {
         .trim()
         .replaceAll(RegExp('[^A-Za-z0-9_]+'), '_')
         .replaceAll(RegExp('_+'), '_')
+        .replaceAll(RegExp(r'^_+|_+$'), '')
         .toLowerCase();
     return normalized.isEmpty ? unknownRoute : normalized;
   }

--- a/mobile/lib/services/analytics_surface.dart
+++ b/mobile/lib/services/analytics_surface.dart
@@ -1,0 +1,56 @@
+// ABOUTME: Stable semantic names and safe parameter helpers for analytics.
+
+abstract final class AnalyticsSurface {
+  static const homeFeed = 'home_feed';
+  static const explore = 'explore';
+  static const notifications = 'notifications';
+  static const inbox = 'inbox';
+  static const profile = 'profile';
+  static const videoDetail = 'video_detail';
+  static const commentsSheet = 'comments_sheet';
+  static const settings = 'settings';
+  static const searchResults = 'search_results';
+  static const videoRecorder = 'video_recorder';
+  static const videoEditor = 'video_editor';
+  static const unknownRoute = 'unknown_route';
+
+  static String slowBucket(int totalMs) {
+    if (totalMs < 1000) return 'under_1s';
+    if (totalMs < 3000) return '1_3s';
+    if (totalMs < 5000) return '3_5s';
+    if (totalMs < 10000) return '5_10s';
+    return 'over_10s';
+  }
+
+  static String sanitizeName(String value) {
+    final normalized = value
+        .trim()
+        .replaceAll(RegExp('[^A-Za-z0-9_]+'), '_')
+        .replaceAll(RegExp('_+'), '_')
+        .toLowerCase();
+    return normalized.isEmpty ? unknownRoute : normalized;
+  }
+}
+
+abstract final class AnalyticsParam {
+  static const screenName = 'screen_name';
+  static const surfaceName = 'surface_name';
+  static const routeName = 'route_name';
+  static const entryPoint = 'entry_point';
+  static const result = 'result';
+  static const visibleMs = 'visible_ms';
+  static const dataMs = 'data_ms';
+  static const totalMs = 'total_ms';
+  static const slowBucket = 'slow_bucket';
+  static const itemCount = 'item_count';
+  static const initialCount = 'initial_count';
+  static const hasMore = 'has_more';
+  static const featureFlag = 'feature_flag';
+}
+
+abstract final class SurfaceLoadResult {
+  static const success = 'success';
+  static const empty = 'empty';
+  static const failure = 'failure';
+  static const dismissed = 'dismissed';
+}

--- a/mobile/lib/services/firebase_analytics_event_sink.dart
+++ b/mobile/lib/services/firebase_analytics_event_sink.dart
@@ -1,0 +1,32 @@
+// ABOUTME: Firebase-backed implementation of the analytics event sink.
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:openvine/services/analytics_event_sink.dart';
+
+class FirebaseAnalyticsEventSink implements AnalyticsEventSink {
+  FirebaseAnalyticsEventSink({FirebaseAnalytics? analytics})
+    : _analytics = analytics ?? FirebaseAnalytics.instance;
+
+  final FirebaseAnalytics _analytics;
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) {
+    return _analytics.logEvent(name: name, parameters: parameters);
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) {
+    return _analytics.logScreenView(
+      screenName: screenName,
+      screenClass: screenClass,
+      parameters: parameters,
+    );
+  }
+}

--- a/mobile/lib/services/page_load_history.dart
+++ b/mobile/lib/services/page_load_history.dart
@@ -76,14 +76,18 @@ class PageLoadHistory {
 
     // Search from newest to oldest (end of queue)
     for (final record in _records.toList().reversed) {
-      if (record.source == candidate.source &&
-          record.screenName == candidate.screenName &&
-          record.dataLoadedMs == null) {
-        return record;
+      if (record.source != candidate.source) {
+        continue;
       }
-      // Only look back ~5 seconds to avoid stale matches
+
+      // Only look back ~5 seconds to avoid stale matches.
       if (DateTime.now().difference(record.timestamp).inSeconds > 5) {
         break;
+      }
+
+      if (record.screenName == candidate.screenName &&
+          record.dataLoadedMs == null) {
+        return record;
       }
     }
     return null;

--- a/mobile/lib/services/page_load_history.dart
+++ b/mobile/lib/services/page_load_history.dart
@@ -3,6 +3,11 @@
 
 import 'dart:collection';
 
+abstract final class PageLoadSource {
+  static const route = 'route';
+  static const surface = 'surface';
+}
+
 /// A single page load performance record.
 class PageLoadRecord {
   PageLoadRecord({
@@ -11,7 +16,7 @@ class PageLoadRecord {
     this.contentVisibleMs,
     this.dataLoadedMs,
     this.result,
-    this.source = 'route',
+    this.source = PageLoadSource.route,
     this.dataMetrics = const {},
   });
 
@@ -72,7 +77,7 @@ class PageLoadHistory {
 
   /// Find a recent record for this screen that doesn't have dataLoadedMs yet.
   PageLoadRecord? _findRecentRecord(PageLoadRecord candidate) {
-    if (candidate.source != 'route') return null;
+    if (candidate.source != PageLoadSource.route) return null;
 
     // Search from newest to oldest (end of queue)
     for (final record in _records.toList().reversed) {

--- a/mobile/lib/services/page_load_history.dart
+++ b/mobile/lib/services/page_load_history.dart
@@ -10,6 +10,8 @@ class PageLoadRecord {
     required this.timestamp,
     this.contentVisibleMs,
     this.dataLoadedMs,
+    this.result,
+    this.source = 'route',
     this.dataMetrics = const {},
   });
 
@@ -17,6 +19,8 @@ class PageLoadRecord {
   final DateTime timestamp;
   int? contentVisibleMs;
   int? dataLoadedMs;
+  final String? result;
+  final String source;
   final Map<String, dynamic> dataMetrics;
 
   /// Whether data load was slow (>3s).
@@ -48,7 +52,7 @@ class PageLoadHistory {
   /// it will be updated rather than creating a duplicate.
   void addOrUpdate(PageLoadRecord record) {
     // Check if there's a recent record for this screen that can be updated
-    final existing = _findRecentRecord(record.screenName);
+    final existing = _findRecentRecord(record);
     if (existing != null) {
       // Update the existing record
       if (record.contentVisibleMs != null) {
@@ -67,10 +71,14 @@ class PageLoadHistory {
   }
 
   /// Find a recent record for this screen that doesn't have dataLoadedMs yet.
-  PageLoadRecord? _findRecentRecord(String screenName) {
+  PageLoadRecord? _findRecentRecord(PageLoadRecord candidate) {
+    if (candidate.source != 'route') return null;
+
     // Search from newest to oldest (end of queue)
     for (final record in _records.toList().reversed) {
-      if (record.screenName == screenName && record.dataLoadedMs == null) {
+      if (record.source == candidate.source &&
+          record.screenName == candidate.screenName &&
+          record.dataLoadedMs == null) {
         return record;
       }
       // Only look back ~5 seconds to avoid stale matches

--- a/mobile/lib/services/page_load_observer.dart
+++ b/mobile/lib/services/page_load_observer.dart
@@ -2,11 +2,15 @@
 // ABOUTME: Records screen load start on push, content visible after frame render, and cleanup on pop
 
 import 'package:flutter/material.dart';
+import 'package:openvine/services/analytics_surface.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class PageLoadObserver extends NavigatorObserver {
-  final ScreenAnalyticsService _analytics = ScreenAnalyticsService();
+  PageLoadObserver({ScreenAnalyticsService? analytics})
+    : _analytics = analytics ?? ScreenAnalyticsService();
+
+  final ScreenAnalyticsService _analytics;
 
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
@@ -18,6 +22,13 @@ class PageLoadObserver extends NavigatorObserver {
 
     final screenName = _screenName(route);
     _analytics.startScreenLoad(screenName);
+    _analytics.trackScreenView(
+      screenName,
+      params: {
+        AnalyticsParam.routeName: screenName,
+        AnalyticsParam.entryPoint: 'navigation',
+      },
+    );
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _analytics.markContentVisible(screenName);

--- a/mobile/lib/services/page_load_observer.dart
+++ b/mobile/lib/services/page_load_observer.dart
@@ -60,6 +60,10 @@ class PageLoadObserver extends NavigatorObserver {
   }
 
   String _screenName(Route<dynamic> route) {
-    return route.settings.name ?? route.runtimeType.toString();
+    final routeName = route.settings.name;
+    if (routeName == null || routeName.isEmpty) {
+      return AnalyticsSurface.unknownRoute;
+    }
+    return routeName;
   }
 }

--- a/mobile/lib/services/page_load_observer.dart
+++ b/mobile/lib/services/page_load_observer.dart
@@ -20,12 +20,13 @@ class PageLoadObserver extends NavigatorObserver {
       return;
     }
 
-    final screenName = _screenName(route);
+    final routeName = _routeName(route);
+    final screenName = AnalyticsSurface.routeSurfaceName(route.settings.name);
     _analytics.startScreenLoad(screenName);
     _analytics.trackScreenView(
       screenName,
       params: {
-        AnalyticsParam.routeName: screenName,
+        AnalyticsParam.routeName: routeName,
         AnalyticsParam.entryPoint: 'navigation',
       },
     );
@@ -49,7 +50,7 @@ class PageLoadObserver extends NavigatorObserver {
       return;
     }
 
-    final screenName = _screenName(route);
+    final screenName = AnalyticsSurface.routeSurfaceName(route.settings.name);
     _analytics.endScreen(screenName);
 
     Log.debug(
@@ -59,11 +60,14 @@ class PageLoadObserver extends NavigatorObserver {
     );
   }
 
-  String _screenName(Route<dynamic> route) {
+  String _routeName(Route<dynamic> route) {
     final routeName = route.settings.name;
     if (routeName == null || routeName.isEmpty) {
       return AnalyticsSurface.unknownRoute;
     }
-    return routeName;
+    if (routeName.trim() == '/') {
+      return 'root';
+    }
+    return AnalyticsSurface.sanitizeName(routeName);
   }
 }

--- a/mobile/lib/services/screen_analytics_service.dart
+++ b/mobile/lib/services/screen_analytics_service.dart
@@ -1,8 +1,12 @@
 // ABOUTME: Screen navigation and performance analytics service
 // ABOUTME: Tracks screen load times, navigation patterns, and user engagement metrics
 
+import 'dart:async';
+
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:openvine/services/analytics_event_sink.dart';
+import 'package:openvine/services/firebase_analytics_event_sink.dart';
 import 'package:openvine/services/page_load_history.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -16,7 +20,8 @@ const _maxScreenSessionAge = Duration(seconds: 60);
 /// Service for tracking screen navigation, performance, and user engagement
 class ScreenAnalyticsService {
   factory ScreenAnalyticsService() => _instance ??= ScreenAnalyticsService._();
-  ScreenAnalyticsService._() : _bypassAnalytics = false;
+  ScreenAnalyticsService._({AnalyticsEventSink? sink})
+    : _sink = sink ?? _createAnalyticsSink();
 
   static ScreenAnalyticsService? _instance;
 
@@ -33,25 +38,22 @@ class ScreenAnalyticsService {
 
   /// Creates a testable instance that does not touch [FirebaseAnalytics].
   @visibleForTesting
-  ScreenAnalyticsService.testInstance({FirebaseAnalytics? analytics})
-    : _analyticsOverride = analytics,
-      _bypassAnalytics = true;
+  ScreenAnalyticsService.testInstance({
+    AnalyticsEventSink? sink,
+    FirebaseAnalytics? analytics,
+  }) : _sink =
+           sink ??
+           (analytics != null
+               ? FirebaseAnalyticsEventSink(analytics: analytics)
+               : const NoOpAnalyticsEventSink());
 
-  // Lazy-init to avoid crashing when Firebase isn't initialized (e.g. tests).
-  FirebaseAnalytics? _analyticsOverride;
-  FirebaseAnalytics? _analyticsInstance;
-  final bool _bypassAnalytics;
+  final AnalyticsEventSink _sink;
 
-  FirebaseAnalytics? get _analytics {
-    if (_bypassAnalytics) return _analyticsOverride;
-    return _analyticsOverride ?? (_analyticsInstance ??= _initAnalytics());
-  }
-
-  static FirebaseAnalytics? _initAnalytics() {
+  static AnalyticsEventSink _createAnalyticsSink() {
     try {
-      return FirebaseAnalytics.instance;
+      return FirebaseAnalyticsEventSink();
     } catch (_) {
-      return null;
+      return const NoOpAnalyticsEventSink();
     }
   }
 
@@ -114,14 +116,15 @@ class ScreenAnalyticsService {
       name: 'ScreenAnalytics',
     );
 
-    // Log to Firebase
-    _analytics?.logEvent(
-      name: 'screen_load',
-      parameters: {
-        'screen_name': screenName,
-        'load_time_ms': loadTime,
-        ...session.params,
-      },
+    unawaited(
+      _sink.logEvent(
+        name: 'screen_load',
+        parameters: _parameters({
+          'screen_name': screenName,
+          'load_time_ms': loadTime,
+          ...session.params,
+        }),
+      ),
     );
 
     // Record to page load history
@@ -161,15 +164,16 @@ class ScreenAnalyticsService {
       name: 'ScreenAnalytics',
     );
 
-    // Log to Firebase
-    _analytics?.logEvent(
-      name: 'screen_data_loaded',
-      parameters: {
-        'screen_name': screenName,
-        'data_load_time_ms': dataLoadTime,
-        ...?dataMetrics,
-        ...session.params,
-      },
+    unawaited(
+      _sink.logEvent(
+        name: 'screen_data_loaded',
+        parameters: _parameters({
+          'screen_name': screenName,
+          'data_load_time_ms': dataLoadTime,
+          ...?dataMetrics,
+          ...session.params,
+        }),
+      ),
     );
 
     // Record to page load history
@@ -205,12 +209,14 @@ class ScreenAnalyticsService {
           .difference(_currentScreenStartTime!)
           .inSeconds;
 
-      _analytics?.logEvent(
-        name: 'screen_time',
-        parameters: {
-          'screen_name': _currentScreen!,
-          'time_spent_seconds': timeSpent,
-        },
+      unawaited(
+        _sink.logEvent(
+          name: 'screen_time',
+          parameters: _parameters({
+            'screen_name': _currentScreen,
+            'time_spent_seconds': timeSpent,
+          }),
+        ),
       );
 
       UnifiedLogger.info(
@@ -224,9 +230,11 @@ class ScreenAnalyticsService {
     _currentScreenStartTime = DateTime.now();
 
     // Log screen view
-    _analytics?.logScreenView(
-      screenName: screenName,
-      parameters: params?.cast<String, Object>(),
+    unawaited(
+      _sink.logScreenView(
+        screenName: screenName,
+        parameters: _optionalParameters(params),
+      ),
     );
 
     UnifiedLogger.info(
@@ -241,13 +249,15 @@ class ScreenAnalyticsService {
     String interactionType, {
     Map<String, dynamic>? params,
   }) {
-    _analytics?.logEvent(
-      name: 'user_interaction',
-      parameters: {
-        'screen_name': screenName,
-        'interaction_type': interactionType,
-        ...?params,
-      },
+    unawaited(
+      _sink.logEvent(
+        name: 'user_interaction',
+        parameters: _parameters({
+          'screen_name': screenName,
+          'interaction_type': interactionType,
+          ...?params,
+        }),
+      ),
     );
 
     UnifiedLogger.debug(
@@ -262,9 +272,15 @@ class ScreenAnalyticsService {
     required String to,
     String? trigger,
   }) {
-    _analytics?.logEvent(
-      name: 'screen_navigation',
-      parameters: {'from_screen': from, 'to_screen': to, 'trigger': ?trigger},
+    unawaited(
+      _sink.logEvent(
+        name: 'screen_navigation',
+        parameters: _parameters({
+          'from_screen': from,
+          'to_screen': to,
+          'trigger': trigger,
+        }),
+      ),
     );
 
     UnifiedLogger.info(
@@ -280,14 +296,16 @@ class ScreenAnalyticsService {
     required int itemsViewed,
     int? totalItems,
   }) {
-    _analytics?.logEvent(
-      name: 'screen_scroll',
-      parameters: {
-        'screen_name': screenName,
-        'scroll_depth': scrollDepth,
-        'items_viewed': itemsViewed,
-        'total_items': ?totalItems,
-      },
+    unawaited(
+      _sink.logEvent(
+        name: 'screen_scroll',
+        parameters: _parameters({
+          'screen_name': screenName,
+          'scroll_depth': scrollDepth,
+          'items_viewed': itemsViewed,
+          'total_items': totalItems,
+        }),
+      ),
     );
   }
 
@@ -298,14 +316,16 @@ class ScreenAnalyticsService {
     required int resultsCount,
     required int loadTimeMs,
   }) {
-    _analytics?.logEvent(
-      name: 'search_performed',
-      parameters: {
-        'screen_name': screenName,
-        'query_length': query.length,
-        'results_count': resultsCount,
-        'load_time_ms': loadTimeMs,
-      },
+    unawaited(
+      _sink.logEvent(
+        name: 'search_performed',
+        parameters: _parameters({
+          'screen_name': screenName,
+          'query_length': query.length,
+          'results_count': resultsCount,
+          'load_time_ms': loadTimeMs,
+        }),
+      ),
     );
 
     UnifiedLogger.info(
@@ -316,9 +336,14 @@ class ScreenAnalyticsService {
 
   /// Track tab changes
   void trackTabChange({required String screenName, required String tabName}) {
-    _analytics?.logEvent(
-      name: 'tab_changed',
-      parameters: {'screen_name': screenName, 'tab_name': tabName},
+    unawaited(
+      _sink.logEvent(
+        name: 'tab_changed',
+        parameters: _parameters({
+          'screen_name': screenName,
+          'tab_name': tabName,
+        }),
+      ),
     );
   }
 
@@ -329,17 +354,19 @@ class ScreenAnalyticsService {
     required String errorMessage,
     Map<String, dynamic>? context,
   }) {
-    _analytics?.logEvent(
-      name: 'screen_error',
-      parameters: {
-        'screen_name': screenName,
-        'error_type': errorType,
-        'error_message': errorMessage.substring(
-          0,
-          errorMessage.length > 100 ? 100 : errorMessage.length,
-        ),
-        ...?context,
-      },
+    unawaited(
+      _sink.logEvent(
+        name: 'screen_error',
+        parameters: _parameters({
+          'screen_name': screenName,
+          'error_type': errorType,
+          'error_message': errorMessage.substring(
+            0,
+            errorMessage.length > 100 ? 100 : errorMessage.length,
+          ),
+          ...?context,
+        }),
+      ),
     );
 
     UnifiedLogger.error(
@@ -351,6 +378,24 @@ class ScreenAnalyticsService {
   /// End screen session
   void endScreen(String screenName) {
     _activeSessions.remove(screenName);
+  }
+
+  static Map<String, Object>? _optionalParameters(
+    Map<String, dynamic>? parameters,
+  ) {
+    if (parameters == null) return null;
+    return _parameters(parameters);
+  }
+
+  static Map<String, Object> _parameters(Map<String, dynamic> parameters) {
+    final filtered = <String, Object>{};
+    for (final entry in parameters.entries) {
+      final value = entry.value;
+      if (value != null) {
+        filtered[entry.key] = value as Object;
+      }
+    }
+    return filtered;
   }
 
   /// Whether a session's start time is older than [_maxScreenSessionAge].

--- a/mobile/lib/services/surface_performance_tracker.dart
+++ b/mobile/lib/services/surface_performance_tracker.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:openvine/services/analytics_event_sink.dart';
 import 'package:openvine/services/analytics_surface.dart';
 import 'package:openvine/services/firebase_analytics_event_sink.dart';
+import 'package:openvine/services/page_load_history.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Maximum age for a session before it is considered stale and discarded.
@@ -137,6 +138,7 @@ class SurfacePerformanceTracker {
         : session.visibleAt!.difference(session.startedAt).inMilliseconds;
     final totalMs = completedAt.difference(session.startedAt).inMilliseconds;
     final dataMs = result == SurfaceLoadResult.dismissed ? -1 : totalMs;
+    final slowBucket = AnalyticsSurface.slowBucket(totalMs);
 
     final parameters = <String, Object>{
       AnalyticsParam.surfaceName: safeName,
@@ -144,12 +146,27 @@ class SurfacePerformanceTracker {
       AnalyticsParam.visibleMs: visibleMs,
       AnalyticsParam.dataMs: dataMs,
       AnalyticsParam.totalMs: totalMs,
-      AnalyticsParam.slowBucket: AnalyticsSurface.slowBucket(totalMs),
+      AnalyticsParam.slowBucket: slowBucket,
       ...session.params,
       ..._safeParameters(metrics),
     };
 
     await _logSurfaceLoad(parameters);
+    PageLoadHistory().addOrUpdate(
+      PageLoadRecord(
+        screenName: safeName,
+        timestamp: session.startedAt,
+        contentVisibleMs: visibleMs >= 0 ? visibleMs : null,
+        dataLoadedMs: dataMs >= 0 ? dataMs : null,
+        result: result,
+        source: 'surface',
+        dataMetrics: {
+          AnalyticsParam.slowBucket: slowBucket,
+          ...session.params,
+          ..._safeParameters(metrics),
+        },
+      ),
+    );
 
     final slowFlag = totalMs >= 3000 ? ' [SLOW]' : '';
     UnifiedLogger.info(

--- a/mobile/lib/services/surface_performance_tracker.dart
+++ b/mobile/lib/services/surface_performance_tracker.dart
@@ -136,12 +136,13 @@ class SurfacePerformanceTracker {
         ? -1
         : session.visibleAt!.difference(session.startedAt).inMilliseconds;
     final totalMs = completedAt.difference(session.startedAt).inMilliseconds;
+    final dataMs = result == SurfaceLoadResult.dismissed ? -1 : totalMs;
 
     final parameters = <String, Object>{
       AnalyticsParam.surfaceName: safeName,
       AnalyticsParam.result: result,
       AnalyticsParam.visibleMs: visibleMs,
-      AnalyticsParam.dataMs: totalMs,
+      AnalyticsParam.dataMs: dataMs,
       AnalyticsParam.totalMs: totalMs,
       AnalyticsParam.slowBucket: AnalyticsSurface.slowBucket(totalMs),
       ...session.params,
@@ -153,7 +154,7 @@ class SurfacePerformanceTracker {
     final slowFlag = totalMs >= 3000 ? ' [SLOW]' : '';
     UnifiedLogger.info(
       'PERF: $safeName surface result=$result visible=${visibleMs}ms, '
-      'data=${totalMs}ms, total=${totalMs}ms$slowFlag',
+      'data=${dataMs}ms, total=${totalMs}ms$slowFlag',
       name: 'SurfacePerf',
     );
   }
@@ -200,10 +201,22 @@ class SurfacePerformanceTracker {
   static Map<String, Object> _safeParameters(Map<String, Object>? parameters) {
     if (parameters == null) return const {};
 
-    return {
-      for (final entry in parameters.entries)
-        if (_safeSurfaceParamKeys.contains(entry.key)) entry.key: entry.value,
-    };
+    final safe = <String, Object>{};
+    for (final entry in parameters.entries) {
+      if (!_safeSurfaceParamKeys.contains(entry.key)) continue;
+
+      final value = _firebaseSafeValue(entry.value);
+      if (value != null) {
+        safe[entry.key] = value;
+      }
+    }
+    return safe;
+  }
+
+  static Object? _firebaseSafeValue(Object value) {
+    if (value is bool) return value ? 1 : 0;
+    if (value is String || value is num) return value;
+    return null;
   }
 }
 

--- a/mobile/lib/services/surface_performance_tracker.dart
+++ b/mobile/lib/services/surface_performance_tracker.dart
@@ -22,7 +22,7 @@ const Set<String> _safeSurfaceParamKeys = {
   AnalyticsParam.itemCount,
   AnalyticsParam.hasMore,
   AnalyticsParam.featureFlag,
-  'sort_mode',
+  AnalyticsParam.sortMode,
 };
 
 /// Tracks perceived load performance for user-visible surfaces.
@@ -159,7 +159,7 @@ class SurfacePerformanceTracker {
         contentVisibleMs: visibleMs >= 0 ? visibleMs : null,
         dataLoadedMs: dataMs >= 0 ? dataMs : null,
         result: result,
-        source: 'surface',
+        source: PageLoadSource.surface,
         dataMetrics: {
           AnalyticsParam.slowBucket: slowBucket,
           ...session.params,

--- a/mobile/lib/services/surface_performance_tracker.dart
+++ b/mobile/lib/services/surface_performance_tracker.dart
@@ -1,0 +1,221 @@
+// ABOUTME: Tracks user-visible surface load timing with semantic analytics.
+// ABOUTME: Emits safe terminal surface_load events for sheets and panels.
+
+import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:openvine/services/analytics_event_sink.dart';
+import 'package:openvine/services/analytics_surface.dart';
+import 'package:openvine/services/firebase_analytics_event_sink.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Maximum age for a session before it is considered stale and discarded.
+///
+/// App background/resume cycles can leave old sessions active. Dropping
+/// sessions older than this avoids logging inflated load times.
+const _maxSurfaceSessionAge = Duration(seconds: 60);
+
+const _surfaceLoadEventName = 'surface_load';
+
+const Set<String> _safeSurfaceParamKeys = {
+  AnalyticsParam.entryPoint,
+  AnalyticsParam.initialCount,
+  AnalyticsParam.itemCount,
+  AnalyticsParam.hasMore,
+  AnalyticsParam.featureFlag,
+  'sort_mode',
+};
+
+/// Tracks perceived load performance for user-visible surfaces.
+class SurfacePerformanceTracker {
+  factory SurfacePerformanceTracker() =>
+      _instance ??= SurfacePerformanceTracker._();
+
+  SurfacePerformanceTracker._({
+    AnalyticsEventSink? sink,
+    DateTime Function()? now,
+  }) : _sink = sink ?? _createAnalyticsSink(),
+       _now = now ?? DateTime.now;
+
+  static SurfacePerformanceTracker? _instance;
+
+  /// Resets the singleton so tests do not leak active sessions across files.
+  @visibleForTesting
+  static void resetInstance() {
+    _instance?._activeSessions.clear();
+    _instance = null;
+  }
+
+  /// Creates a testable instance that does not touch Firebase.
+  @visibleForTesting
+  SurfacePerformanceTracker.testInstance({
+    AnalyticsEventSink? sink,
+    DateTime Function()? now,
+  }) : _sink = sink ?? const NoOpAnalyticsEventSink(),
+       _now = now ?? DateTime.now;
+
+  AnalyticsEventSink _sink;
+  final DateTime Function() _now;
+  final Map<String, _SurfaceLoadSession> _activeSessions = {};
+
+  /// Number of active tracking sessions.
+  int get activeSessionCount => _activeSessions.length;
+
+  static AnalyticsEventSink _createAnalyticsSink() {
+    try {
+      return FirebaseAnalyticsEventSink();
+    } catch (_) {
+      return const NoOpAnalyticsEventSink();
+    }
+  }
+
+  /// Clear all active sessions.
+  ///
+  /// Call this when the app resumes from background to prevent stale start
+  /// times from producing inaccurate surface load measurements.
+  void resetAllSessions() {
+    if (_activeSessions.isNotEmpty) {
+      UnifiedLogger.info(
+        'Resetting ${_activeSessions.length} stale surface '
+        'performance sessions on app resume',
+        name: 'SurfacePerf',
+      );
+      _activeSessions.clear();
+    }
+  }
+
+  /// Start tracking a surface load.
+  void startSurfaceLoad(String surfaceName, {Map<String, Object>? params}) {
+    final safeName = AnalyticsSurface.sanitizeName(surfaceName);
+    _activeSessions[safeName] = _SurfaceLoadSession(
+      surfaceName: safeName,
+      startedAt: _now(),
+      params: _safeParameters(params),
+    );
+
+    UnifiedLogger.info(
+      'Surface load started: $safeName',
+      name: 'SurfacePerf',
+    );
+  }
+
+  /// Mark when the surface is first visible.
+  void markSurfaceVisible(String surfaceName) {
+    final session = _sessionFor(surfaceName);
+    if (session == null) return;
+
+    session.visibleAt ??= _now();
+    final visibleMs = session.visibleAt!
+        .difference(session.startedAt)
+        .inMilliseconds;
+
+    UnifiedLogger.info(
+      'Surface visible: ${session.surfaceName} in ${visibleMs}ms',
+      name: 'SurfacePerf',
+    );
+  }
+
+  /// Complete the surface load with a terminal result.
+  ///
+  /// Missing or stale sessions are ignored. Completion always removes the
+  /// active session so dismissed/failed surfaces do not leak.
+  Future<void> completeSurfaceLoad(
+    String surfaceName, {
+    required String result,
+    Map<String, Object>? metrics,
+  }) async {
+    final safeName = AnalyticsSurface.sanitizeName(surfaceName);
+    final session = _activeSessions.remove(safeName);
+    if (session == null) return;
+
+    if (_isStale(session)) {
+      _logStaleDiscard(session);
+      return;
+    }
+
+    final completedAt = _now();
+    final visibleMs = session.visibleAt == null
+        ? -1
+        : session.visibleAt!.difference(session.startedAt).inMilliseconds;
+    final totalMs = completedAt.difference(session.startedAt).inMilliseconds;
+
+    final parameters = <String, Object>{
+      AnalyticsParam.surfaceName: safeName,
+      AnalyticsParam.result: result,
+      AnalyticsParam.visibleMs: visibleMs,
+      AnalyticsParam.dataMs: totalMs,
+      AnalyticsParam.totalMs: totalMs,
+      AnalyticsParam.slowBucket: AnalyticsSurface.slowBucket(totalMs),
+      ...session.params,
+      ..._safeParameters(metrics),
+    };
+
+    await _logSurfaceLoad(parameters);
+
+    final slowFlag = totalMs >= 3000 ? ' [SLOW]' : '';
+    UnifiedLogger.info(
+      'PERF: $safeName surface result=$result visible=${visibleMs}ms, '
+      'data=${totalMs}ms, total=${totalMs}ms$slowFlag',
+      name: 'SurfacePerf',
+    );
+  }
+
+  _SurfaceLoadSession? _sessionFor(String surfaceName) {
+    final safeName = AnalyticsSurface.sanitizeName(surfaceName);
+    final session = _activeSessions[safeName];
+    if (session == null) return null;
+
+    if (_isStale(session)) {
+      _activeSessions.remove(safeName);
+      _logStaleDiscard(session);
+      return null;
+    }
+
+    return session;
+  }
+
+  bool _isStale(_SurfaceLoadSession session) {
+    return _now().difference(session.startedAt) > _maxSurfaceSessionAge;
+  }
+
+  Future<void> _logSurfaceLoad(Map<String, Object> parameters) async {
+    try {
+      await _sink.logEvent(name: _surfaceLoadEventName, parameters: parameters);
+    } catch (error) {
+      _sink = const NoOpAnalyticsEventSink();
+      UnifiedLogger.warning(
+        'Surface performance analytics disabled after log failure: $error',
+        name: 'SurfacePerf',
+      );
+    }
+  }
+
+  void _logStaleDiscard(_SurfaceLoadSession session) {
+    final age = _now().difference(session.startedAt);
+    UnifiedLogger.warning(
+      'Discarding stale surface session "${session.surfaceName}" '
+      '(started ${age.inSeconds}s ago)',
+      name: 'SurfacePerf',
+    );
+  }
+
+  static Map<String, Object> _safeParameters(Map<String, Object>? parameters) {
+    if (parameters == null) return const {};
+
+    return {
+      for (final entry in parameters.entries)
+        if (_safeSurfaceParamKeys.contains(entry.key)) entry.key: entry.value,
+    };
+  }
+}
+
+class _SurfaceLoadSession {
+  _SurfaceLoadSession({
+    required this.surfaceName,
+    required this.startedAt,
+    required this.params,
+  });
+
+  final String surfaceName;
+  final DateTime startedAt;
+  final Map<String, Object> params;
+  DateTime? visibleAt;
+}

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -16,6 +16,7 @@ import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
+import 'package:openvine/services/surface_performance_tracker.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -110,6 +111,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         // 27+ hours) when providers re-fire on resume.
         FeedPerformanceTracker().resetAllSessions();
         ScreenAnalyticsService().resetAllSessions();
+        SurfacePerformanceTracker().resetAllSessions();
 
         // Notify foreground state provider - enables visibility detection
         ref.read(appForegroundProvider.notifier).setForeground(true);

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -275,7 +275,7 @@ void main() {
           );
           expect(
             sink.events.single.parameters,
-            containsPair('sort_mode', 'topEngagement'),
+            containsPair(AnalyticsParam.sortMode, 'topEngagement'),
           );
         },
       );
@@ -317,7 +317,7 @@ void main() {
         );
         expect(
           sink.events.single.parameters,
-          containsPair('sort_mode', 'oldest'),
+          containsPair(AnalyticsParam.sortMode, 'oldest'),
         );
       });
 

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -20,8 +20,11 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/comments/comments.dart';
+import 'package:openvine/services/analytics_event_sink.dart';
+import 'package:openvine/services/analytics_surface.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 import 'package:openvine/services/social_service.dart';
+import 'package:openvine/services/surface_performance_tracker.dart';
 
 import '../../builders/comment_builder.dart';
 import '../../helpers/test_helpers.dart';
@@ -43,6 +46,25 @@ class _MockCommentComposerBloc
 class _MockCommentReactionsBloc
     extends MockBloc<CommentReactionsEvent, CommentReactionsState>
     implements CommentReactionsBloc {}
+
+class _RecordingAnalyticsEventSink implements AnalyticsEventSink {
+  final events = <({String name, Map<String, Object> parameters})>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
 
 // Full 64-character test IDs.
 const testVideoEventId =
@@ -131,6 +153,7 @@ void main() {
 
     tearDown(() {
       scrollController.dispose();
+      SurfacePerformanceTracker.resetInstance();
     });
 
     Widget buildTestWidget({
@@ -176,6 +199,155 @@ void main() {
         ),
       );
     }
+
+    Widget buildTelemetryWidget({
+      required SurfacePerformanceTracker tracker,
+      Widget child = const SizedBox.shrink(),
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: BlocProvider<CommentsListBloc>.value(
+            value: mockListBloc,
+            child: CommentsSheetLoadTelemetry(
+              tracker: tracker,
+              child: child,
+            ),
+          ),
+        ),
+      );
+    }
+
+    group('surface load telemetry', () {
+      late _RecordingAnalyticsEventSink sink;
+      late SurfacePerformanceTracker tracker;
+
+      setUp(() {
+        sink = _RecordingAnalyticsEventSink();
+        tracker = SurfacePerformanceTracker.testInstance(sink: sink);
+      });
+
+      testWidgets(
+        'completes success with comment metrics after loading state',
+        (tester) async {
+          final comment = CommentBuilder()
+              .withId(TestCommentIds.comment1Id)
+              .withContent('Loaded comment')
+              .build();
+          final loaded = CommentsListState(
+            rootEventId: testVideoEventId,
+            rootAuthorPubkey: testVideoAuthorPubkey,
+            status: CommentsStatus.success,
+            commentsById: {comment.id: comment},
+            hasMoreContent: false,
+            sortMode: CommentsSortMode.topEngagement,
+          );
+          whenListen(
+            mockListBloc,
+            Stream.fromIterable([
+              const CommentsListState(status: CommentsStatus.loading),
+              loaded,
+            ]),
+            initialState: const CommentsListState(
+              status: CommentsStatus.loading,
+            ),
+          );
+          tracker.startSurfaceLoad(AnalyticsSurface.commentsSheet);
+
+          await tester.pumpWidget(buildTelemetryWidget(tracker: tracker));
+          await tester.pump();
+
+          expect(sink.events, hasLength(1));
+          expect(sink.events.single.name, 'surface_load');
+          expect(
+            sink.events.single.parameters,
+            containsPair(AnalyticsParam.result, SurfaceLoadResult.success),
+          );
+          expect(
+            sink.events.single.parameters,
+            containsPair(AnalyticsParam.itemCount, 1),
+          );
+          expect(
+            sink.events.single.parameters,
+            containsPair(AnalyticsParam.hasMore, 0),
+          );
+          expect(
+            sink.events.single.parameters,
+            containsPair('sort_mode', 'topEngagement'),
+          );
+        },
+      );
+
+      testWidgets('completes empty when loading resolves with no comments', (
+        tester,
+      ) async {
+        const loaded = CommentsListState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.success,
+          sortMode: CommentsSortMode.oldest,
+        );
+        whenListen(
+          mockListBloc,
+          Stream.fromIterable([
+            const CommentsListState(status: CommentsStatus.loading),
+            loaded,
+          ]),
+          initialState: const CommentsListState(status: CommentsStatus.loading),
+        );
+        tracker.startSurfaceLoad(AnalyticsSurface.commentsSheet);
+
+        await tester.pumpWidget(buildTelemetryWidget(tracker: tracker));
+        await tester.pump();
+
+        expect(sink.events, hasLength(1));
+        expect(
+          sink.events.single.parameters,
+          containsPair(AnalyticsParam.result, SurfaceLoadResult.empty),
+        );
+        expect(
+          sink.events.single.parameters,
+          containsPair(AnalyticsParam.itemCount, 0),
+        );
+        expect(
+          sink.events.single.parameters,
+          containsPair(AnalyticsParam.hasMore, 1),
+        );
+        expect(
+          sink.events.single.parameters,
+          containsPair('sort_mode', 'oldest'),
+        );
+      });
+
+      testWidgets('completes failure without unsafe failure type metric', (
+        tester,
+      ) async {
+        const failed = CommentsListState(
+          rootEventId: testVideoEventId,
+          rootAuthorPubkey: testVideoAuthorPubkey,
+          status: CommentsStatus.failure,
+          error: CommentsListError.loadFailed,
+        );
+        whenListen(
+          mockListBloc,
+          Stream.fromIterable([
+            const CommentsListState(status: CommentsStatus.loading),
+            failed,
+          ]),
+          initialState: const CommentsListState(status: CommentsStatus.loading),
+        );
+        tracker.startSurfaceLoad(AnalyticsSurface.commentsSheet);
+
+        await tester.pumpWidget(buildTelemetryWidget(tracker: tracker));
+        await tester.pump();
+
+        expect(sink.events, hasLength(1));
+        expect(
+          sink.events.single.parameters,
+          containsPair(AnalyticsParam.result, SurfaceLoadResult.failure),
+        );
+        expect(sink.events.single.parameters, isNot(contains('failure_type')));
+      });
+    });
 
     group('widget structure', () {
       testWidgets('renders CommentsDragHandle', (tester) async {

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/comments/comment_composer/comment_composer_bloc.dart';
 import 'package:openvine/blocs/comments/comment_reactions/comment_reactions_bloc.dart';
 import 'package:openvine/blocs/comments/comments_list/comments_list_bloc.dart';
+import 'package:openvine/blocs/comments/comments_surface_performance_telemetry.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -209,7 +210,9 @@ void main() {
           body: BlocProvider<CommentsListBloc>.value(
             value: mockListBloc,
             child: CommentsSheetLoadTelemetry(
-              tracker: tracker,
+              telemetry: CommentsSurfacePerformanceTelemetry.withTracker(
+                tracker,
+              ),
               child: child,
             ),
           ),

--- a/mobile/test/services/analytics_event_sink_test.dart
+++ b/mobile/test/services/analytics_event_sink_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/analytics_event_sink.dart';
+
+void main() {
+  group(NoOpAnalyticsEventSink, () {
+    test('accepts event and screen view calls without side effects', () async {
+      const sink = NoOpAnalyticsEventSink();
+
+      await sink.logEvent(
+        name: 'surface_load',
+        parameters: const {'surface_name': 'comments_sheet'},
+      );
+      await sink.logScreenView(
+        screenName: 'video_detail',
+        screenClass: 'Route',
+        parameters: const {'route_name': 'video'},
+      );
+    });
+  });
+}

--- a/mobile/test/services/analytics_native_config_test.dart
+++ b/mobile/test/services/analytics_native_config_test.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('native analytics config', () {
+    test('disables Firebase automatic screen reporting on iOS', () {
+      final plist = File('ios/Runner/Info.plist').readAsStringSync();
+
+      expect(plist, contains('FirebaseAutomaticScreenReportingEnabled'));
+      expect(plist, contains('<false/>'));
+    });
+
+    test('disables Firebase automatic screen reporting on Android', () {
+      final manifest = File(
+        'android/app/src/main/AndroidManifest.xml',
+      ).readAsStringSync();
+
+      expect(
+        manifest,
+        contains('google_analytics_automatic_screen_reporting_enabled'),
+      );
+      expect(manifest, contains('android:value="false"'));
+    });
+  });
+}

--- a/mobile/test/services/analytics_native_config_test.dart
+++ b/mobile/test/services/analytics_native_config_test.dart
@@ -7,20 +7,43 @@ void main() {
     test('disables Firebase automatic screen reporting on iOS', () {
       final plist = File('ios/Runner/Info.plist').readAsStringSync();
 
-      expect(plist, contains('FirebaseAutomaticScreenReportingEnabled'));
-      expect(plist, contains('<false/>'));
+      expect(
+        plist,
+        matches(
+          RegExp(
+            r'<key>\s*FirebaseAutomaticScreenReportingEnabled\s*</key>\s*'
+            r'<false\s*/>',
+          ),
+        ),
+      );
     });
 
     test('disables Firebase automatic screen reporting on Android', () {
       final manifest = File(
         'android/app/src/main/AndroidManifest.xml',
       ).readAsStringSync();
+      final applicationBlock = RegExp(
+        r'<application\b[\s\S]*?</application>',
+      ).firstMatch(manifest);
 
       expect(
-        manifest,
-        contains('google_analytics_automatic_screen_reporting_enabled'),
+        applicationBlock,
+        isNotNull,
+        reason: 'AndroidManifest.xml must contain an <application> block.',
       );
-      expect(manifest, contains('android:value="false"'));
+
+      final disablesAutomaticScreenReporting = RegExp(
+        r'<meta-data\b'
+        r'(?=[^>]*\bandroid:name\s*=\s*"google_analytics_automatic_screen_reporting_enabled")'
+        r'(?=[^>]*\bandroid:value\s*=\s*"false")'
+        r'[^>]*/\s*>',
+        multiLine: true,
+      );
+
+      expect(
+        applicationBlock!.group(0),
+        matches(disablesAutomaticScreenReporting),
+      );
     });
   });
 }

--- a/mobile/test/services/analytics_surface_test.dart
+++ b/mobile/test/services/analytics_surface_test.dart
@@ -19,5 +19,20 @@ void main() {
       expect(AnalyticsSurface.slowBucket(5000), '5_10s');
       expect(AnalyticsSurface.slowBucket(10000), 'over_10s');
     });
+
+    test('sanitizeName normalizes route and surface names', () {
+      expect(AnalyticsSurface.sanitizeName('video-detail'), 'video_detail');
+      expect(AnalyticsSurface.sanitizeName('/settings'), 'settings');
+      expect(AnalyticsSurface.sanitizeName('  Home Feed  '), 'home_feed');
+      expect(
+        AnalyticsSurface.sanitizeName('home---feed///detail'),
+        'home_feed_detail',
+      );
+      expect(AnalyticsSurface.sanitizeName(''), AnalyticsSurface.unknownRoute);
+      expect(
+        AnalyticsSurface.sanitizeName('///'),
+        AnalyticsSurface.unknownRoute,
+      );
+    });
   });
 }

--- a/mobile/test/services/analytics_surface_test.dart
+++ b/mobile/test/services/analytics_surface_test.dart
@@ -23,6 +23,7 @@ void main() {
     test('sanitizeName normalizes route and surface names', () {
       expect(AnalyticsSurface.sanitizeName('video-detail'), 'video_detail');
       expect(AnalyticsSurface.sanitizeName('/settings'), 'settings');
+      expect(AnalyticsSurface.sanitizeName('originalSound'), 'original_sound');
       expect(AnalyticsSurface.sanitizeName('settings/'), 'settings');
       expect(AnalyticsSurface.sanitizeName('__settings__'), 'settings');
       expect(AnalyticsSurface.sanitizeName('  Home Feed  '), 'home_feed');
@@ -33,6 +34,38 @@ void main() {
       expect(AnalyticsSurface.sanitizeName(''), AnalyticsSurface.unknownRoute);
       expect(
         AnalyticsSurface.sanitizeName('///'),
+        AnalyticsSurface.unknownRoute,
+      );
+    });
+
+    test('routeSurfaceName maps app route names to semantic surfaces', () {
+      expect(AnalyticsSurface.routeSurfaceName('/'), AnalyticsSurface.homeFeed);
+      expect(
+        AnalyticsSurface.routeSurfaceName('home'),
+        AnalyticsSurface.homeFeed,
+      );
+      expect(
+        AnalyticsSurface.routeSurfaceName('video'),
+        AnalyticsSurface.videoDetail,
+      );
+      expect(
+        AnalyticsSurface.routeSurfaceName('video-recorder'),
+        AnalyticsSurface.videoRecorder,
+      );
+      expect(
+        AnalyticsSurface.routeSurfaceName('video-editor'),
+        AnalyticsSurface.videoEditor,
+      );
+      expect(
+        AnalyticsSurface.routeSurfaceName('developer-options'),
+        'developer_options',
+      );
+      expect(
+        AnalyticsSurface.routeSurfaceName('originalSound'),
+        'original_sound',
+      );
+      expect(
+        AnalyticsSurface.routeSurfaceName(null),
         AnalyticsSurface.unknownRoute,
       );
     });

--- a/mobile/test/services/analytics_surface_test.dart
+++ b/mobile/test/services/analytics_surface_test.dart
@@ -23,6 +23,8 @@ void main() {
     test('sanitizeName normalizes route and surface names', () {
       expect(AnalyticsSurface.sanitizeName('video-detail'), 'video_detail');
       expect(AnalyticsSurface.sanitizeName('/settings'), 'settings');
+      expect(AnalyticsSurface.sanitizeName('settings/'), 'settings');
+      expect(AnalyticsSurface.sanitizeName('__settings__'), 'settings');
       expect(AnalyticsSurface.sanitizeName('  Home Feed  '), 'home_feed');
       expect(
         AnalyticsSurface.sanitizeName('home---feed///detail'),

--- a/mobile/test/services/analytics_surface_test.dart
+++ b/mobile/test/services/analytics_surface_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/analytics_surface.dart';
+
+void main() {
+  group('AnalyticsSurface', () {
+    test('core surface names are stable snake_case values', () {
+      expect(AnalyticsSurface.homeFeed, 'home_feed');
+      expect(AnalyticsSurface.explore, 'explore');
+      expect(AnalyticsSurface.profile, 'profile');
+      expect(AnalyticsSurface.videoDetail, 'video_detail');
+      expect(AnalyticsSurface.commentsSheet, 'comments_sheet');
+      expect(AnalyticsSurface.settings, 'settings');
+    });
+
+    test('slowBucket classifies user-visible waits', () {
+      expect(AnalyticsSurface.slowBucket(999), 'under_1s');
+      expect(AnalyticsSurface.slowBucket(1000), '1_3s');
+      expect(AnalyticsSurface.slowBucket(3000), '3_5s');
+      expect(AnalyticsSurface.slowBucket(5000), '5_10s');
+      expect(AnalyticsSurface.slowBucket(10000), 'over_10s');
+    });
+  });
+}

--- a/mobile/test/services/firebase_analytics_event_sink_test.dart
+++ b/mobile/test/services/firebase_analytics_event_sink_test.dart
@@ -1,0 +1,68 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/firebase_analytics_event_sink.dart';
+
+class _MockFirebaseAnalytics extends Mock implements FirebaseAnalytics {}
+
+void main() {
+  group(FirebaseAnalyticsEventSink, () {
+    late FirebaseAnalytics analytics;
+    late FirebaseAnalyticsEventSink sink;
+
+    setUp(() {
+      analytics = _MockFirebaseAnalytics();
+      sink = FirebaseAnalyticsEventSink(analytics: analytics);
+    });
+
+    test('forwards custom events to Firebase Analytics', () async {
+      const parameters = <String, Object>{
+        'surface_name': 'comments_sheet',
+        'total_ms': 3250,
+      };
+      when(
+        () => analytics.logEvent(
+          name: 'surface_load',
+          parameters: parameters,
+        ),
+      ).thenAnswer((_) async {});
+
+      await sink.logEvent(name: 'surface_load', parameters: parameters);
+
+      verify(
+        () => analytics.logEvent(
+          name: 'surface_load',
+          parameters: parameters,
+        ),
+      ).called(1);
+    });
+
+    test('forwards screen views to Firebase Analytics', () async {
+      const parameters = <String, Object>{
+        'route_name': 'video',
+        'entry_point': 'navigation',
+      };
+      when(
+        () => analytics.logScreenView(
+          screenName: 'video_detail',
+          screenClass: 'Route',
+          parameters: parameters,
+        ),
+      ).thenAnswer((_) async {});
+
+      await sink.logScreenView(
+        screenName: 'video_detail',
+        screenClass: 'Route',
+        parameters: parameters,
+      );
+
+      verify(
+        () => analytics.logScreenView(
+          screenName: 'video_detail',
+          screenClass: 'Route',
+          parameters: parameters,
+        ),
+      ).called(1);
+    });
+  });
+}

--- a/mobile/test/services/page_load_history_test.dart
+++ b/mobile/test/services/page_load_history_test.dart
@@ -29,6 +29,16 @@ void main() {
         expect(history.records.first.contentVisibleMs, equals(100));
       });
 
+      test('defaults to route source with no terminal result', () {
+        final record = PageLoadRecord(
+          screenName: 'home',
+          timestamp: DateTime.now(),
+        );
+
+        expect(record.source, equals('route'));
+        expect(record.result, isNull);
+      });
+
       test('updates existing record without dataLoadedMs', () {
         final now = DateTime.now();
         history.addOrUpdate(
@@ -101,6 +111,36 @@ void main() {
         final names = history.records.map((r) => r.screenName).toList();
         expect(names, isNot(contains('screen_0')));
         expect(names, contains('screen_${PageLoadHistory.maxRecords + 4}'));
+      });
+
+      test('adds terminal surface records to recent history', () {
+        final startedAt = DateTime(2026, 6, 12, 12);
+
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'comments_sheet',
+            timestamp: startedAt,
+            contentVisibleMs: 80,
+            result: 'dismissed',
+            source: 'surface',
+          ),
+        );
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'comments_sheet',
+            timestamp: startedAt.add(const Duration(seconds: 1)),
+            contentVisibleMs: 60,
+            dataLoadedMs: 420,
+            result: 'success',
+            source: 'surface',
+          ),
+        );
+
+        final recent = history.getRecent(2);
+        expect(recent, hasLength(2));
+        expect(recent.first.source, equals('surface'));
+        expect(recent.first.result, equals('success'));
+        expect(recent.last.result, equals('dismissed'));
       });
     });
 
@@ -205,6 +245,53 @@ void main() {
         final slowest = history.getSlowest(5);
         expect(slowest, hasLength(1));
         expect(slowest.first.screenName, equals('with_data'));
+      });
+
+      test('includes surface records with dataLoadedMs', () {
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'home',
+            timestamp: DateTime.now(),
+            dataLoadedMs: 500,
+          ),
+        );
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'comments_sheet',
+            timestamp: DateTime.now(),
+            dataLoadedMs: 3500,
+            result: 'success',
+            source: 'surface',
+          ),
+        );
+
+        final slowest = history.getSlowest(1);
+        expect(slowest.single.screenName, equals('comments_sheet'));
+        expect(slowest.single.source, equals('surface'));
+        expect(slowest.single.result, equals('success'));
+      });
+
+      test('excludes dismissed surface records without dataLoadedMs', () {
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'comments_sheet',
+            timestamp: DateTime.now(),
+            contentVisibleMs: 75,
+            result: 'dismissed',
+            source: 'surface',
+          ),
+        );
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'home',
+            timestamp: DateTime.now(),
+            dataLoadedMs: 900,
+          ),
+        );
+
+        final slowest = history.getSlowest(5);
+        expect(slowest, hasLength(1));
+        expect(slowest.single.screenName, equals('home'));
       });
     });
 

--- a/mobile/test/services/page_load_history_test.dart
+++ b/mobile/test/services/page_load_history_test.dart
@@ -142,6 +142,43 @@ void main() {
         expect(recent.first.result, equals('success'));
         expect(recent.last.result, equals('dismissed'));
       });
+
+      test('unrelated stale surface record does not block route update', () {
+        final now = DateTime.now();
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'home',
+            timestamp: now,
+            contentVisibleMs: 120,
+          ),
+        );
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'comments_sheet',
+            timestamp: now.subtract(const Duration(seconds: 10)),
+            contentVisibleMs: 80,
+            result: 'dismissed',
+            source: 'surface',
+          ),
+        );
+
+        history.addOrUpdate(
+          PageLoadRecord(
+            screenName: 'home',
+            timestamp: now,
+            dataLoadedMs: 450,
+          ),
+        );
+
+        final routeRecords = history.records
+            .where((record) => record.source == 'route')
+            .toList();
+        expect(routeRecords, hasLength(1));
+        expect(routeRecords.single.screenName, equals('home'));
+        expect(routeRecords.single.contentVisibleMs, equals(120));
+        expect(routeRecords.single.dataLoadedMs, equals(450));
+        expect(history.records, hasLength(2));
+      });
     });
 
     group('records', () {

--- a/mobile/test/services/page_load_history_test.dart
+++ b/mobile/test/services/page_load_history_test.dart
@@ -35,7 +35,7 @@ void main() {
           timestamp: DateTime.now(),
         );
 
-        expect(record.source, equals('route'));
+        expect(record.source, equals(PageLoadSource.route));
         expect(record.result, isNull);
       });
 
@@ -122,7 +122,7 @@ void main() {
             timestamp: startedAt,
             contentVisibleMs: 80,
             result: 'dismissed',
-            source: 'surface',
+            source: PageLoadSource.surface,
           ),
         );
         history.addOrUpdate(
@@ -132,13 +132,13 @@ void main() {
             contentVisibleMs: 60,
             dataLoadedMs: 420,
             result: 'success',
-            source: 'surface',
+            source: PageLoadSource.surface,
           ),
         );
 
         final recent = history.getRecent(2);
         expect(recent, hasLength(2));
-        expect(recent.first.source, equals('surface'));
+        expect(recent.first.source, equals(PageLoadSource.surface));
         expect(recent.first.result, equals('success'));
         expect(recent.last.result, equals('dismissed'));
       });
@@ -158,7 +158,7 @@ void main() {
             timestamp: now.subtract(const Duration(seconds: 10)),
             contentVisibleMs: 80,
             result: 'dismissed',
-            source: 'surface',
+            source: PageLoadSource.surface,
           ),
         );
 
@@ -171,7 +171,7 @@ void main() {
         );
 
         final routeRecords = history.records
-            .where((record) => record.source == 'route')
+            .where((record) => record.source == PageLoadSource.route)
             .toList();
         expect(routeRecords, hasLength(1));
         expect(routeRecords.single.screenName, equals('home'));
@@ -298,13 +298,13 @@ void main() {
             timestamp: DateTime.now(),
             dataLoadedMs: 3500,
             result: 'success',
-            source: 'surface',
+            source: PageLoadSource.surface,
           ),
         );
 
         final slowest = history.getSlowest(1);
         expect(slowest.single.screenName, equals('comments_sheet'));
-        expect(slowest.single.source, equals('surface'));
+        expect(slowest.single.source, equals(PageLoadSource.surface));
         expect(slowest.single.result, equals('success'));
       });
 
@@ -315,7 +315,7 @@ void main() {
             timestamp: DateTime.now(),
             contentVisibleMs: 75,
             result: 'dismissed',
-            source: 'surface',
+            source: PageLoadSource.surface,
           ),
         );
         history.addOrUpdate(

--- a/mobile/test/services/page_load_observer_test.dart
+++ b/mobile/test/services/page_load_observer_test.dart
@@ -2,8 +2,44 @@ import 'package:firebase_core_platform_interface/firebase_core_platform_interfac
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/services/analytics_event_sink.dart';
+import 'package:openvine/services/analytics_surface.dart';
 import 'package:openvine/services/page_load_observer.dart';
+import 'package:openvine/services/screen_analytics_service.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _RecordingAnalyticsEventSink implements AnalyticsEventSink {
+  final events = <({String name, Map<String, Object> parameters})>[];
+  final screenViews =
+      <
+        ({
+          String screenName,
+          String? screenClass,
+          Map<String, Object>? parameters,
+        })
+      >[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {
+    screenViews.add((
+      screenName: screenName,
+      screenClass: screenClass,
+      parameters: parameters,
+    ));
+  }
+}
 
 class _FakeFirebaseCore extends Fake
     with MockPlatformInterfaceMixin
@@ -45,11 +81,18 @@ void main() {
   FirebasePlatform.instance = _FakeFirebaseCore();
 
   group(PageLoadObserver, () {
+    late _RecordingAnalyticsEventSink sink;
     late PageLoadObserver observer;
 
     setUp(() {
-      observer = PageLoadObserver();
+      ScreenAnalyticsService.resetInstance();
+      sink = _RecordingAnalyticsEventSink();
+      observer = PageLoadObserver(
+        analytics: ScreenAnalyticsService.testInstance(sink: sink),
+      );
     });
+
+    tearDown(ScreenAnalyticsService.resetInstance);
 
     test('creates an instance', () {
       expect(observer, isA<NavigatorObserver>());
@@ -129,6 +172,44 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Home'), findsOneWidget);
+    });
+
+    testWidgets('logs semantic screen view for named routes', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          navigatorObservers: [observer],
+          home: const Scaffold(body: Text('Home')),
+          onGenerateRoute: (settings) {
+            if (settings.name == '/video/123') {
+              return MaterialPageRoute<void>(
+                settings: const RouteSettings(name: 'video_detail'),
+                builder: (_) => const Scaffold(body: Text('Video Detail')),
+              );
+            }
+            return null;
+          },
+        ),
+      );
+
+      final context = tester.element(find.text('Home'));
+      Navigator.of(context).pushNamed('/video/123');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Video Detail'), findsOneWidget);
+      expect(
+        sink.screenViews.map((event) => event.screenName),
+        contains('video_detail'),
+      );
+      expect(
+        sink.screenViews.last.parameters,
+        containsPair(AnalyticsParam.routeName, 'video_detail'),
+      );
+      expect(
+        sink.screenViews.last.parameters,
+        containsPair(AnalyticsParam.entryPoint, 'navigation'),
+      );
     });
   });
 }

--- a/mobile/test/services/page_load_observer_test.dart
+++ b/mobile/test/services/page_load_observer_test.dart
@@ -189,7 +189,7 @@ void main() {
           onGenerateRoute: (settings) {
             if (settings.name == '/video/123') {
               return MaterialPageRoute<void>(
-                settings: const RouteSettings(name: 'video_detail'),
+                settings: const RouteSettings(name: 'video'),
                 builder: (_) => const Scaffold(body: Text('Video Detail')),
               );
             }
@@ -209,11 +209,57 @@ void main() {
       );
       expect(
         sink.screenViews.last.parameters,
-        containsPair(AnalyticsParam.routeName, 'video_detail'),
+        containsPair(AnalyticsParam.routeName, 'video'),
       );
       expect(
         sink.screenViews.last.parameters,
         containsPair(AnalyticsParam.entryPoint, 'navigation'),
+      );
+    });
+
+    testWidgets('normalizes app route names before logging screen views', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          navigatorObservers: [observer],
+          home: const Scaffold(body: Text('Home')),
+          onGenerateRoute: (settings) {
+            final routeName = switch (settings.name) {
+              '/developer-options' => 'developer-options',
+              '/original-sound' => 'originalSound',
+              _ => null,
+            };
+            if (routeName == null) {
+              return null;
+            }
+            return MaterialPageRoute<void>(
+              settings: RouteSettings(name: routeName),
+              builder: (_) => Scaffold(body: Text(settings.name!)),
+            );
+          },
+        ),
+      );
+
+      final context = tester.element(find.text('Home'));
+      Navigator.of(context).pushNamed('/developer-options');
+      await tester.pumpAndSettle();
+      Navigator.of(context).pushNamed('/original-sound');
+      await tester.pumpAndSettle();
+
+      expect(
+        sink.screenViews.map((event) => event.screenName),
+        containsAllInOrder(['developer_options', 'original_sound']),
+      );
+      expect(
+        sink.screenViews.map((event) => event.screenName),
+        isNot(contains('developer-options')),
+      );
+      expect(
+        sink.screenViews.map((event) => event.screenName),
+        isNot(contains('originalSound')),
       );
     });
 

--- a/mobile/test/services/page_load_observer_test.dart
+++ b/mobile/test/services/page_load_observer_test.dart
@@ -138,10 +138,15 @@ void main() {
         ),
       );
 
+      final baselineScreenViewCount = sink.screenViews.length;
+      final baselineEventCount = sink.events.length;
+
       await tester.tap(find.text('Open Dialog'));
       await tester.pumpAndSettle();
 
       expect(find.text('Dialog'), findsOneWidget);
+      expect(sink.screenViews, hasLength(baselineScreenViewCount));
+      expect(sink.events, hasLength(baselineEventCount));
     });
 
     testWidgets('tracks didPop for regular routes', (tester) async {
@@ -209,6 +214,44 @@ void main() {
       expect(
         sink.screenViews.last.parameters,
         containsPair(AnalyticsParam.entryPoint, 'navigation'),
+      );
+    });
+
+    testWidgets('uses unknown route for unnamed regular route screen views', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          navigatorObservers: [observer],
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const Scaffold(body: Text('Unnamed')),
+                  ),
+                );
+              },
+              child: const Text('Open Unnamed'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open Unnamed'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Unnamed'), findsOneWidget);
+      expect(sink.screenViews.last.screenName, AnalyticsSurface.unknownRoute);
+      expect(
+        sink.screenViews.last.parameters,
+        containsPair(AnalyticsParam.routeName, AnalyticsSurface.unknownRoute),
+      );
+      expect(
+        sink.screenViews.map((event) => event.screenName),
+        isNot(contains('MaterialPageRoute<void>')),
       );
     });
   });

--- a/mobile/test/services/screen_analytics_service_test.dart
+++ b/mobile/test/services/screen_analytics_service_test.dart
@@ -3,7 +3,42 @@
 // ABOUTME: clears all active sessions on app resume.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/analytics_event_sink.dart';
+import 'package:openvine/services/analytics_surface.dart';
 import 'package:openvine/services/screen_analytics_service.dart';
+
+class RecordingAnalyticsEventSink implements AnalyticsEventSink {
+  final events = <({String name, Map<String, Object> parameters})>[];
+  final screenViews =
+      <
+        ({
+          String screenName,
+          String? screenClass,
+          Map<String, Object>? parameters,
+        })
+      >[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {
+    screenViews.add((
+      screenName: screenName,
+      screenClass: screenClass,
+      parameters: parameters,
+    ));
+  }
+}
 
 void main() {
   group(ScreenAnalyticsService, () {
@@ -105,6 +140,37 @@ void main() {
 
         service.endScreen('ExploreScreen');
         expect(service.activeSessionCount, 0);
+      });
+    });
+
+    group('trackScreenView', () {
+      test('logs screen view through the analytics sink', () {
+        final sink = RecordingAnalyticsEventSink();
+        final instance = ScreenAnalyticsService.testInstance(sink: sink);
+
+        instance.trackScreenView(
+          'video_detail',
+          params: const {
+            AnalyticsParam.routeName: 'video_detail',
+            AnalyticsParam.entryPoint: 'navigation',
+            'nullable_value': null,
+          },
+        );
+
+        expect(sink.screenViews, hasLength(1));
+        expect(sink.screenViews.single.screenName, 'video_detail');
+        expect(
+          sink.screenViews.single.parameters,
+          containsPair(AnalyticsParam.routeName, 'video_detail'),
+        );
+        expect(
+          sink.screenViews.single.parameters,
+          containsPair(AnalyticsParam.entryPoint, 'navigation'),
+        );
+        expect(
+          sink.screenViews.single.parameters,
+          isNot(contains('nullable_value')),
+        );
       });
     });
   });

--- a/mobile/test/services/surface_performance_tracker_test.dart
+++ b/mobile/test/services/surface_performance_tracker_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/analytics_event_sink.dart';
 import 'package:openvine/services/analytics_surface.dart';
+import 'package:openvine/services/page_load_history.dart';
 import 'package:openvine/services/surface_performance_tracker.dart';
 
 class RecordingAnalyticsEventSink implements AnalyticsEventSink {
@@ -37,6 +38,7 @@ void main() {
 
     setUp(() {
       SurfacePerformanceTracker.resetInstance();
+      PageLoadHistory().clear();
       sink = RecordingAnalyticsEventSink();
       now = DateTime(2026, 6, 12, 12);
       tracker = SurfacePerformanceTracker.testInstance(
@@ -45,7 +47,10 @@ void main() {
       );
     });
 
-    tearDown(SurfacePerformanceTracker.resetInstance);
+    tearDown(() {
+      SurfacePerformanceTracker.resetInstance();
+      PageLoadHistory().clear();
+    });
 
     test('logs one surface_load event with semantic parameters', () async {
       tracker.startSurfaceLoad(
@@ -91,6 +96,37 @@ void main() {
         AnalyticsParam.featureFlag: 0,
       });
       expect(tracker.activeSessionCount, 0);
+    });
+
+    test('records completed surface loads in page load history', () async {
+      final startedAt = now;
+      tracker.startSurfaceLoad(
+        'Comments Sheet',
+        params: const {AnalyticsParam.entryPoint: 'feed_button'},
+      );
+      elapse(const Duration(milliseconds: 90));
+
+      tracker.markSurfaceVisible('Comments Sheet');
+      elapse(const Duration(milliseconds: 3160));
+
+      await tracker.completeSurfaceLoad(
+        'Comments Sheet',
+        result: SurfaceLoadResult.success,
+        metrics: const {AnalyticsParam.itemCount: 7},
+      );
+
+      final record = PageLoadHistory().records.single;
+      expect(record.screenName, AnalyticsSurface.commentsSheet);
+      expect(record.timestamp, startedAt);
+      expect(record.contentVisibleMs, 90);
+      expect(record.dataLoadedMs, 3250);
+      expect(record.result, SurfaceLoadResult.success);
+      expect(record.source, 'surface');
+      expect(record.dataMetrics, {
+        AnalyticsParam.slowBucket: '3_5s',
+        AnalyticsParam.entryPoint: 'feed_button',
+        AnalyticsParam.itemCount: 7,
+      });
     });
 
     test(

--- a/mobile/test/services/surface_performance_tracker_test.dart
+++ b/mobile/test/services/surface_performance_tracker_test.dart
@@ -72,7 +72,7 @@ void main() {
         metrics: {
           AnalyticsParam.itemCount: 10,
           AnalyticsParam.hasMore: true,
-          'sort_mode': DateTime(2026),
+          AnalyticsParam.sortMode: DateTime(2026),
         },
       );
       await tracker.completeSurfaceLoad(
@@ -121,7 +121,7 @@ void main() {
       expect(record.contentVisibleMs, 90);
       expect(record.dataLoadedMs, 3250);
       expect(record.result, SurfaceLoadResult.success);
-      expect(record.source, 'surface');
+      expect(record.source, PageLoadSource.surface);
       expect(record.dataMetrics, {
         AnalyticsParam.slowBucket: '3_5s',
         AnalyticsParam.entryPoint: 'feed_button',

--- a/mobile/test/services/surface_performance_tracker_test.dart
+++ b/mobile/test/services/surface_performance_tracker_test.dart
@@ -1,0 +1,150 @@
+// ABOUTME: Tests for user-visible surface performance analytics.
+// ABOUTME: Verifies terminal surface_load events and stale session cleanup.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/analytics_event_sink.dart';
+import 'package:openvine/services/analytics_surface.dart';
+import 'package:openvine/services/surface_performance_tracker.dart';
+
+class RecordingAnalyticsEventSink implements AnalyticsEventSink {
+  final events = <({String name, Map<String, Object> parameters})>[];
+
+  @override
+  Future<void> logEvent({
+    required String name,
+    required Map<String, Object> parameters,
+  }) async {
+    events.add((name: name, parameters: parameters));
+  }
+
+  @override
+  Future<void> logScreenView({
+    required String screenName,
+    String? screenClass,
+    Map<String, Object>? parameters,
+  }) async {}
+}
+
+void main() {
+  group(SurfacePerformanceTracker, () {
+    late RecordingAnalyticsEventSink sink;
+    late DateTime now;
+    late SurfacePerformanceTracker tracker;
+
+    void elapse(Duration duration) {
+      now = now.add(duration);
+    }
+
+    setUp(() {
+      SurfacePerformanceTracker.resetInstance();
+      sink = RecordingAnalyticsEventSink();
+      now = DateTime(2026, 6, 12, 12);
+      tracker = SurfacePerformanceTracker.testInstance(
+        sink: sink,
+        now: () => now,
+      );
+    });
+
+    tearDown(SurfacePerformanceTracker.resetInstance);
+
+    test('logs one surface_load event with semantic parameters', () async {
+      tracker.startSurfaceLoad(
+        'Comments Sheet',
+        params: const {
+          AnalyticsParam.entryPoint: 'feed_button',
+          AnalyticsParam.initialCount: 12,
+        },
+      );
+      elapse(const Duration(milliseconds: 120));
+
+      tracker.markSurfaceVisible('Comments Sheet');
+      elapse(const Duration(milliseconds: 680));
+
+      await tracker.completeSurfaceLoad(
+        'Comments Sheet',
+        result: SurfaceLoadResult.success,
+        metrics: const {
+          AnalyticsParam.itemCount: 10,
+          AnalyticsParam.hasMore: true,
+        },
+      );
+      await tracker.completeSurfaceLoad(
+        'Comments Sheet',
+        result: SurfaceLoadResult.success,
+      );
+
+      expect(sink.events, hasLength(1));
+      expect(sink.events.single.name, 'surface_load');
+      expect(sink.events.single.parameters, {
+        AnalyticsParam.surfaceName: AnalyticsSurface.commentsSheet,
+        AnalyticsParam.result: SurfaceLoadResult.success,
+        AnalyticsParam.visibleMs: 120,
+        AnalyticsParam.dataMs: 800,
+        AnalyticsParam.totalMs: 800,
+        AnalyticsParam.slowBucket: 'under_1s',
+        AnalyticsParam.entryPoint: 'feed_button',
+        AnalyticsParam.initialCount: 12,
+        AnalyticsParam.itemCount: 10,
+        AnalyticsParam.hasMore: true,
+      });
+      expect(tracker.activeSessionCount, 0);
+    });
+
+    test(
+      'completing dismissed removes the session and logs dismissed',
+      () async {
+        tracker.startSurfaceLoad(AnalyticsSurface.commentsSheet);
+        elapse(const Duration(milliseconds: 50));
+
+        await tracker.completeSurfaceLoad(
+          AnalyticsSurface.commentsSheet,
+          result: SurfaceLoadResult.dismissed,
+        );
+
+        expect(tracker.activeSessionCount, 0);
+        expect(sink.events, hasLength(1));
+        expect(
+          sink.events.single.parameters[AnalyticsParam.result],
+          SurfaceLoadResult.dismissed,
+        );
+      },
+    );
+
+    test(
+      'resetAllSessions clears active sessions and later completion is no-op',
+      () async {
+        tracker
+          ..startSurfaceLoad(AnalyticsSurface.commentsSheet)
+          ..startSurfaceLoad(AnalyticsSurface.profile);
+
+        expect(tracker.activeSessionCount, 2);
+
+        tracker.resetAllSessions();
+        await tracker.completeSurfaceLoad(
+          AnalyticsSurface.commentsSheet,
+          result: SurfaceLoadResult.success,
+        );
+
+        expect(tracker.activeSessionCount, 0);
+        expect(sink.events, isEmpty);
+      },
+    );
+
+    test(
+      'stale sessions older than 60s are discarded without logging',
+      () async {
+        tracker.startSurfaceLoad(AnalyticsSurface.commentsSheet);
+        elapse(const Duration(seconds: 61));
+
+        tracker.markSurfaceVisible(AnalyticsSurface.commentsSheet);
+        await tracker.completeSurfaceLoad(
+          AnalyticsSurface.commentsSheet,
+          result: SurfaceLoadResult.success,
+        );
+
+        expect(tracker.activeSessionCount, 0);
+        expect(sink.events, isEmpty);
+      },
+    );
+  });
+}

--- a/mobile/test/services/surface_performance_tracker_test.dart
+++ b/mobile/test/services/surface_performance_tracker_test.dart
@@ -53,6 +53,7 @@ void main() {
         params: const {
           AnalyticsParam.entryPoint: 'feed_button',
           AnalyticsParam.initialCount: 12,
+          AnalyticsParam.featureFlag: false,
         },
       );
       elapse(const Duration(milliseconds: 120));
@@ -63,9 +64,10 @@ void main() {
       await tracker.completeSurfaceLoad(
         'Comments Sheet',
         result: SurfaceLoadResult.success,
-        metrics: const {
+        metrics: {
           AnalyticsParam.itemCount: 10,
           AnalyticsParam.hasMore: true,
+          'sort_mode': DateTime(2026),
         },
       );
       await tracker.completeSurfaceLoad(
@@ -85,7 +87,8 @@ void main() {
         AnalyticsParam.entryPoint: 'feed_button',
         AnalyticsParam.initialCount: 12,
         AnalyticsParam.itemCount: 10,
-        AnalyticsParam.hasMore: true,
+        AnalyticsParam.hasMore: 1,
+        AnalyticsParam.featureFlag: 0,
       });
       expect(tracker.activeSessionCount, 0);
     });
@@ -106,6 +109,48 @@ void main() {
         expect(
           sink.events.single.parameters[AnalyticsParam.result],
           SurfaceLoadResult.dismissed,
+        );
+        expect(sink.events.single.parameters[AnalyticsParam.visibleMs], -1);
+        expect(sink.events.single.parameters[AnalyticsParam.dataMs], -1);
+        expect(sink.events.single.parameters[AnalyticsParam.totalMs], 50);
+      },
+    );
+
+    test(
+      'dismissed before data completes records dismissal timing only',
+      () async {
+        tracker.startSurfaceLoad(AnalyticsSurface.commentsSheet);
+        elapse(const Duration(milliseconds: 40));
+
+        tracker.markSurfaceVisible(AnalyticsSurface.commentsSheet);
+        elapse(const Duration(milliseconds: 90));
+
+        await tracker.completeSurfaceLoad(
+          AnalyticsSurface.commentsSheet,
+          result: SurfaceLoadResult.dismissed,
+        );
+
+        expect(sink.events, hasLength(1));
+        expect(
+          sink.events.single.parameters,
+          containsPair(
+            AnalyticsParam.visibleMs,
+            40,
+          ),
+        );
+        expect(
+          sink.events.single.parameters,
+          containsPair(
+            AnalyticsParam.dataMs,
+            -1,
+          ),
+        );
+        expect(
+          sink.events.single.parameters,
+          containsPair(
+            AnalyticsParam.totalMs,
+            130,
+          ),
         );
       },
     );
@@ -137,6 +182,22 @@ void main() {
         elapse(const Duration(seconds: 61));
 
         tracker.markSurfaceVisible(AnalyticsSurface.commentsSheet);
+        await tracker.completeSurfaceLoad(
+          AnalyticsSurface.commentsSheet,
+          result: SurfaceLoadResult.success,
+        );
+
+        expect(tracker.activeSessionCount, 0);
+        expect(sink.events, isEmpty);
+      },
+    );
+
+    test(
+      'completeSurfaceLoad discards stale sessions without visible mark',
+      () async {
+        tracker.startSurfaceLoad(AnalyticsSurface.commentsSheet);
+        elapse(const Duration(seconds: 61));
+
         await tracker.completeSurfaceLoad(
           AnalyticsSurface.commentsSheet,
           result: SurfaceLoadResult.success,


### PR DESCRIPTION
Closes #5126

## Summary
- Add the mobile analytics observability plan and live contract for semantic screen/surface performance metrics.
- Disable Firebase automatic native screen reporting and replace generic screen views with semantic route screen names.
- Add reusable surface load tracking, wire it into the comments sheet through the comments BLoC layer, and show slow surface records in Developer Options.
- Document the first GA dashboard query shape and the Divine Brain ingestion/search workflow.

## Test Plan
- [x] mise exec -C mobile -- flutter test test/services/analytics_event_sink_test.dart test/services/firebase_analytics_event_sink_test.dart test/services/analytics_surface_test.dart test/services/analytics_native_config_test.dart test/services/screen_analytics_service_test.dart test/services/page_load_observer_test.dart test/services/surface_performance_tracker_test.dart test/services/page_load_history_test.dart test/screens/comments/comments_screen_test.dart
- [x] mise exec -C mobile -- dart analyze lib/blocs/comments/comments_surface_performance_telemetry.dart lib/services/analytics_event_sink.dart lib/services/firebase_analytics_event_sink.dart lib/services/analytics_surface.dart lib/services/screen_analytics_service.dart lib/services/page_load_observer.dart lib/services/surface_performance_tracker.dart lib/services/page_load_history.dart lib/router/app_router.dart lib/screens/comments/comments_screen.dart lib/screens/explore_screen.dart lib/screens/developer_options_screen.dart lib/widgets/app_lifecycle_handler.dart test/services/analytics_event_sink_test.dart test/services/firebase_analytics_event_sink_test.dart test/services/analytics_surface_test.dart test/services/analytics_native_config_test.dart test/services/screen_analytics_service_test.dart test/services/page_load_observer_test.dart test/services/surface_performance_tracker_test.dart test/services/page_load_history_test.dart test/screens/comments/comments_screen_test.dart
- [x] bash mobile/scripts/check_ui_service_boundary.sh
- [x] bash mobile/scripts/check_untested_services_floor.sh
- [x] git diff --check origin/main..HEAD
- [x] pre-push hook analyzer and changed-file tests passed: 90/90
- [x] GitHub checks passed: Analyze, Format, Generated Files, Tests, Build Flutter Web Preview, VGV Tag Gate, semantic PR, mergeability, CLA
- [x] Codex final pass: mise exec -- dart analyze targeted analytics/comments files
- [x] Codex final pass: mise exec -- flutter test targeted analytics/comments suite, 80 tests
- [x] Codex final pass: git diff --check

## Divine Brain
- Current Brain search for matching analytics observability context returned no existing docs. This PR adds docs that Brain can ingest from GitHub after merge: docs/ANALYTICS_OBSERVABILITY.md and docs/superpowers/plans/2026-06-12-surface-analytics-observability.md.