### PR TITLE
fix(feed): ignore stale source load results

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -154,6 +154,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         status: VideoFeedStatus.loading,
         source: source,
         subscribedLists: subscribedLists,
+        isLoadingMore: false,
+        clearPaginationCursor: true,
       ),
     );
 
@@ -164,12 +166,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     );
 
     await _loadVideos(source, emit);
-    if (!_canEmitForSource(source, emit)) return;
+    if (emit.isDone) return;
 
     // After the initial load, check for the "no follows" CTA. Needed for
     // BLoC re-creation (e.g. navigating back to home) when the follow repo
     // is already initialized — .skip(1) would skip the only replay.
-    if (source.type == VideoFeedSourceType.following) {
+    if (state.source == source &&
+        source.type == VideoFeedSourceType.following) {
       final currentFollowing = _followRepository.followingPubkeys;
       if (currentFollowing.isEmpty && state.videos.isEmpty) {
         emit(
@@ -358,7 +361,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         source: source,
         videos: [],
         hasMore: true,
+        isLoadingMore: false,
         clearError: true,
+        videoListSources: const {},
+        listOnlyVideoIds: const {},
+        clearPaginationCursor: true,
       ),
     );
 
@@ -493,7 +500,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         status: VideoFeedStatus.loading,
         videos: [],
         hasMore: true,
+        isLoadingMore: false,
         clearError: true,
+        videoListSources: const {},
+        listOnlyVideoIds: const {},
+        clearPaginationCursor: true,
       ),
     );
 
@@ -523,7 +534,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         status: VideoFeedStatus.loading,
         videos: [],
         hasMore: true,
+        isLoadingMore: false,
         clearError: true,
+        videoListSources: const {},
+        listOnlyVideoIds: const {},
+        clearPaginationCursor: true,
       ),
     );
 
@@ -606,8 +621,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         source: nextSource,
         videos: [],
         hasMore: true,
+        isLoadingMore: false,
         clearError: true,
         subscribedLists: subscribedLists,
+        videoListSources: const {},
+        listOnlyVideoIds: const {},
+        clearPaginationCursor: true,
       ),
     );
 

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -115,6 +115,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   bool _usesHomeFeedCache(VideoFeedSource source) =>
       source.type == VideoFeedSourceType.following;
 
+  bool _canEmitForSource(
+    VideoFeedSource source,
+    Emitter<VideoFeedBlocState> emit,
+  ) => !emit.isDone && state.source == source;
+
   /// Handle feed started event.
   ///
   /// Fires [_loadVideos] immediately without waiting for the follow list to
@@ -159,7 +164,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     );
 
     await _loadVideos(source, emit);
-    if (emit.isDone) return;
+    if (!_canEmitForSource(source, emit)) return;
 
     // After the initial load, check for the "no follows" CTA. Needed for
     // BLoC re-creation (e.g. navigating back to home) when the follow repo
@@ -389,6 +394,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       return;
     }
 
+    final source = state.source;
     emit(state.copyWith(isLoadingMore: true));
 
     try {
@@ -402,12 +408,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       final until = oldestCreatedAt - 1;
 
       final result = await _fetchVideosForSource(
-        state.source,
-        until: state.source.type == VideoFeedSourceType.forYou ? null : until,
-        paginationCursor: state.source.type == VideoFeedSourceType.forYou
+        source,
+        until: source.type == VideoFeedSourceType.forYou ? null : until,
+        paginationCursor: source.type == VideoFeedSourceType.forYou
             ? state.paginationCursor
             : null,
       );
+      if (!_canEmitForSource(source, emit)) return;
 
       // Filter out videos without valid URLs
       final validNewVideos = result.videos
@@ -429,7 +436,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       // For You pages arrive in server-ranked recommendation order;
       // re-sorting by createdAt would shuffle new videos around the
       // current play index and resurface already-seen ones.
-      if (state.source.type != VideoFeedSourceType.forYou) {
+      if (source.type != VideoFeedSourceType.forYou) {
         updatedVideos.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       }
 
@@ -450,7 +457,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           // Only stop pagination when the server returns nothing.
           // Fewer than _pageSize can happen due to server-side filtering.
           hasMore: _hasMoreForSource(
-            state.source,
+            source,
             result,
             fallbackHasMore: result.videos.isNotEmpty,
           ),
@@ -463,8 +470,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       );
 
       // Batch-fetch profiles for new creators only.
-      await _fetchCreatorProfiles(validNewVideos, emit);
+      await _fetchCreatorProfiles(validNewVideos, source, emit);
     } catch (e) {
+      if (!_canEmitForSource(source, emit)) return;
+
       Log.error(
         'VideoFeedBloc: Failed to load more videos - $e',
         name: 'VideoFeedBloc',
@@ -665,6 +674,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         );
         final cachedValid = filtered.where((v) => v.videoUrl != null).toList();
         if (cachedValid.isNotEmpty) {
+          if (!_canEmitForSource(source, emit)) return;
+
           _feedTracker?.markFirstVideosReceived(
             source.mode.name,
             cachedValid.length,
@@ -687,6 +698,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
     try {
       final result = await _fetchVideosForSource(source, skipCache: skipCache);
+      if (!_canEmitForSource(source, emit)) return;
 
       // Filter out videos without valid URLs
       final validVideos = result.videos
@@ -724,7 +736,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       _feedTracker?.markFeedDisplayed(source.mode.name, validVideos.length);
 
       // Batch-fetch creator profiles to warm the Drift cache.
-      await _fetchCreatorProfiles(validVideos, emit);
+      await _fetchCreatorProfiles(validVideos, source, emit);
 
       // Cache the raw response for next cold start (fire-and-forget).
       if (_usesHomeFeedCache(source) &&
@@ -735,6 +747,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         );
       }
     } catch (e) {
+      if (!_canEmitForSource(source, emit)) return;
+
       Log.error(
         'VideoFeedBloc: Failed to load videos - $e',
         name: 'VideoFeedBloc',
@@ -825,6 +839,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   /// after videos are already emitted.
   Future<void> _fetchCreatorProfiles(
     List<VideoEvent> videos,
+    VideoFeedSource source,
     Emitter<VideoFeedBlocState> emit,
   ) async {
     if (_profileRepository == null || videos.isEmpty) return;
@@ -841,6 +856,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       final profiles = await _profileRepository.fetchBatchProfiles(
         pubkeys: newPubkeys,
       );
+
+      if (!_canEmitForSource(source, emit)) return;
 
       if (profiles.isNotEmpty) {
         emit(

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -1031,6 +1031,56 @@ void main() {
           ).called(1);
         },
       );
+
+      test(
+        'keeps startup subscriptions when initial source load becomes stale',
+        () async {
+          final followingVideos = createTestVideos(2, idPrefix: 'following');
+          final newVideos = createTestVideos(2, idPrefix: 'new');
+          final followingResult = Completer<HomeFeedResult>();
+          final newVideosResult = Completer<List<VideoEvent>>();
+
+          when(() => mockFollowRepository.followingPubkeys).thenReturn([
+            'pubkey',
+          ]);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) => followingResult.future);
+          when(
+            () => mockVideosRepository.getNewVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) => newVideosResult.future);
+
+          final bloc = createBloc();
+          addTearDown(bloc.close);
+
+          bloc.add(const VideoFeedStarted(mode: FeedMode.following));
+          await pumpEventQueue();
+
+          bloc.add(const VideoFeedSourceChanged(VideoFeedSource.newVideos()));
+          await pumpEventQueue();
+
+          newVideosResult.complete(newVideos);
+          await pumpEventQueue();
+
+          followingResult.complete(HomeFeedResult(videos: followingVideos));
+          await pumpEventQueue();
+
+          expect(bloc.state.source, const VideoFeedSource.newVideos());
+          expect(followingController.hasListener, isTrue);
+          expect(curatedListsController.hasListener, isTrue);
+        },
+      );
     });
 
     group('VideoFeedModeChanged', () {
@@ -1229,6 +1279,99 @@ void main() {
     });
 
     group('VideoFeedLoadMoreRequested', () {
+      late Completer<HomeFeedResult> loadMoreResult;
+      late Completer<List<VideoEvent>> sourceChangeResult;
+      late List<VideoEvent> moreVideos;
+      late List<VideoEvent> newVideos;
+
+      setUp(() {
+        loadMoreResult = Completer<HomeFeedResult>();
+        sourceChangeResult = Completer<List<VideoEvent>>();
+        moreVideos = createTestVideos(2, idPrefix: 'more');
+        newVideos = createTestVideos(2, idPrefix: 'new');
+
+        addTearDown(() {
+          if (!loadMoreResult.isCompleted) {
+            loadMoreResult.complete(HomeFeedResult(videos: moreVideos));
+          }
+          if (!sourceChangeResult.isCompleted) {
+            sourceChangeResult.complete(newVideos);
+          }
+        });
+      });
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'clears stale pagination loading flag when source changes',
+        setUp: () {
+          when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) => loadMoreResult.future);
+          when(
+            () => mockVideosRepository.getNewVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) => sourceChangeResult.future);
+        },
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          source: const VideoFeedSource.following(),
+          videos: createTestVideos(3),
+        ),
+        act: (bloc) async {
+          bloc.add(const VideoFeedLoadMoreRequested());
+          await pumpEventQueue();
+
+          bloc.add(const VideoFeedSourceChanged(VideoFeedSource.newVideos()));
+          await pumpEventQueue();
+
+          sourceChangeResult.complete(newVideos);
+          await pumpEventQueue();
+
+          loadMoreResult.complete(HomeFeedResult(videos: moreVideos));
+          await pumpEventQueue();
+        },
+        expect: () => [
+          isA<VideoFeedBlocState>()
+              .having(
+                (s) => s.source,
+                'source',
+                const VideoFeedSource.following(),
+              )
+              .having((s) => s.isLoadingMore, 'isLoadingMore', isTrue),
+          isA<VideoFeedBlocState>()
+              .having(
+                (s) => s.source,
+                'source',
+                const VideoFeedSource.newVideos(),
+              )
+              .having((s) => s.status, 'status', VideoFeedStatus.loading)
+              .having((s) => s.isLoadingMore, 'isLoadingMore', isFalse),
+          isA<VideoFeedBlocState>()
+              .having(
+                (s) => s.source,
+                'source',
+                const VideoFeedSource.newVideos(),
+              )
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.isLoadingMore, 'isLoadingMore', isFalse)
+              .having((s) => s.videos.map((video) => video.id), 'video ids', [
+                'new-0',
+                'new-1',
+              ]),
+        ],
+      );
+
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'uses recommendations pagination path for forYou mode',
         setUp: () {

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -1165,6 +1165,67 @@ void main() {
           );
         },
       );
+
+      test(
+        'ignores stale source response after a newer source is selected',
+        () async {
+          final followingVideos = createTestVideos(2, idPrefix: 'following');
+          final newVideos = createTestVideos(2, idPrefix: 'new');
+          final followingResult = Completer<HomeFeedResult>();
+          final newVideosResult = Completer<List<VideoEvent>>();
+
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn(['pubkey']);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) => followingResult.future);
+          when(
+            () => mockVideosRepository.getNewVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) => newVideosResult.future);
+
+          final bloc = createBloc();
+          addTearDown(bloc.close);
+
+          bloc.add(
+            const VideoFeedSourceChanged(VideoFeedSource.following()),
+          );
+          await pumpEventQueue();
+
+          bloc.add(
+            const VideoFeedSourceChanged(VideoFeedSource.newVideos()),
+          );
+          await pumpEventQueue();
+
+          newVideosResult.complete(newVideos);
+          await pumpEventQueue();
+          expect(bloc.state.source, const VideoFeedSource.newVideos());
+          expect(bloc.state.videos.map((video) => video.id), [
+            'new-0',
+            'new-1',
+          ]);
+
+          followingResult.complete(HomeFeedResult(videos: followingVideos));
+          await pumpEventQueue();
+
+          expect(bloc.state.source, const VideoFeedSource.newVideos());
+          expect(bloc.state.videos.map((video) => video.id), [
+            'new-0',
+            'new-1',
+          ]);
+        },
+      );
     });
 
     group('VideoFeedLoadMoreRequested', () {


### PR DESCRIPTION
Closes #5084

## Summary
- Fixes COR-06 from AUDIT.md.
- Adds a regression test for a slow old source response completing after a newer source is selected.
- Guards post-await VideoFeedBloc emits by the captured VideoFeedSource so stale source, refresh, pagination, cache, error, and profile-prefetch continuations cannot overwrite the active feed.
- Keeps startup follow/list subscriptions wired even when the initial source load becomes stale before it finishes.
- Resets primary-load pagination state and stale attribution metadata when starting a new source, refresh, auto-refresh, or subscribed-list fallback load.

## Root cause
- Async feed loads used the live bloc state after awaits, so an older source load could emit over a newer selected source.
- The first source guard also covered `_onStarted` subscription setup, which meant a stale initial load could skip the only startup wiring for following/list change streams.
- Source changes did not reset `isLoadingMore`, so a stale pagination request could leave the newly selected source stuck in a loading-more state after its result was ignored.

## Impact
- Rapid feed-source switches no longer let stale load, pagination, cache, error, or profile-prefetch continuations overwrite the active feed.
- Startup follow/list change subscriptions remain active after a source switch during initial load.
- New primary feed loads start from clean pagination and attribution state.

## Test plan
- RED confirmed first: `mise exec -- flutter test test/blocs/video_feed/video_feed_bloc_test.dart --plain-name "ignores stale source response after a newer source is selected" --timeout 90s` failed because following-* videos overwrote the selected New Videos state.
- RED confirmed locally for the review follow-ups: startup subscriptions were not wired when the initial load became stale, and source changes could preserve `isLoadingMore: true` from stale pagination.
- `mise exec -- dart format lib/blocs/video_feed/video_feed_bloc.dart test/blocs/video_feed/video_feed_bloc_test.dart`
- `mise exec -- flutter test test/blocs/video_feed/video_feed_bloc_test.dart --plain-name "keeps startup subscriptions when initial source load becomes stale"`
- `mise exec -- flutter test test/blocs/video_feed/video_feed_bloc_test.dart --plain-name "clears stale pagination loading flag when source changes"`
- `mise exec -- flutter test test/blocs/video_feed/video_feed_bloc_test.dart` (91 tests passed)
- `mise exec -- flutter analyze lib/blocs/video_feed/video_feed_bloc.dart test/blocs/video_feed/video_feed_bloc_test.dart` (No issues found)
- Pre-push hook reran analyzer and `test/blocs/video_feed/video_feed_bloc_test.dart` successfully.
