### PR TITLE
fix(feed): use inclusive timestamp pagination cursor

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -399,7 +399,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       final oldestCreatedAt = state.videos
           .map((v) => v.createdAt)
           .reduce((a, b) => a < b ? a : b);
-      final until = oldestCreatedAt - 1;
+      final until = oldestCreatedAt;
 
       final result = await _fetchVideosForSource(
         state.source,

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -432,6 +432,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       if (state.source.type != VideoFeedSourceType.forYou) {
         updatedVideos.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       }
+      final addedUniqueVideos = updatedVideos.length > state.videos.length;
 
       // Merge attribution metadata from pagination with existing state.
       final mergedSources = Map.of(state.videoListSources);
@@ -452,7 +453,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           hasMore: _hasMoreForSource(
             state.source,
             result,
-            fallbackHasMore: result.videos.isNotEmpty,
+            fallbackHasMore: addedUniqueVideos,
           ),
           isLoadingMore: false,
           videoListSources: mergedSources,

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -1436,6 +1436,48 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'stops following pagination when load more returns only duplicates',
+        setUp: () {
+          when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: [createTestVideo('old-b', createdAt: 1999)],
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          mode: FeedMode.following,
+          videos: [
+            createTestVideo('old-a', createdAt: 2000),
+            createTestVideo('old-b', createdAt: 1999),
+          ],
+        ),
+        act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
+              .having((s) => s.hasMore, 'hasMore', false)
+              .having((s) => s.videos.length, 'videos count', 2),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'stops forYou pagination when the current page has no cursor',
         build: createBloc,
         seed: () => VideoFeedBlocState(

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -1381,6 +1381,61 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'uses inclusive oldest timestamp when loading more following videos',
+        setUp: () {
+          when(() => mockFollowRepository.followingPubkeys).thenReturn(['a']);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: [createTestVideo('same-second-c', createdAt: 1999)],
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          mode: FeedMode.following,
+          videos: [
+            createTestVideo('old-a', createdAt: 2000),
+            createTestVideo('old-b', createdAt: 1999),
+          ],
+        ),
+        act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<VideoFeedBlocState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            false,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: 1999,
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'stops forYou pagination when the current page has no cursor',
         build: createBloc,
         seed: () => VideoFeedBlocState(


### PR DESCRIPTION
Closes #5086

## Summary
- Fixes COR-07 from AUDIT.md.
- Changes following-feed load-more pagination to request until equal to the oldest loaded createdAt timestamp instead of oldestCreatedAt - 1.
- Relies on the existing event-id deduplication to handle overlap while preserving same-second videos that would otherwise be skipped.

## Test plan
- RED confirmed first: mise exec -- flutter test test/blocs/video_feed/video_feed_bloc_test.dart --plain-name "uses inclusive oldest timestamp when loading more following videos" --timeout 90s failed because getHomeFeedVideos was called with until: 1998 instead of 1999.
- mise exec -- dart format lib/blocs/video_feed/video_feed_bloc.dart test/blocs/video_feed/video_feed_bloc_test.dart
- mise exec -- flutter test test/blocs/video_feed/video_feed_bloc_test.dart --timeout 90s (89 tests passed)
- mise exec -- flutter analyze lib/blocs/video_feed/video_feed_bloc.dart test/blocs/video_feed/video_feed_bloc_test.dart (No issues found)
- Pre-push hook reran analyzer and test/blocs/video_feed/video_feed_bloc_test.dart successfully.