### PR TITLE
fix(comments): stop blocking thread load on relay

### DIFF
--- a/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
@@ -419,9 +419,9 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
 
   /// Starts the real-time comment subscription.
   ///
-  /// Called from [_onLoadRequested] after the initial load so the `since`
-  /// timestamp aligns with that load. Routes incoming comments through
-  /// [NewCommentReceived].
+  /// Called from [_onLoadRequested] after the initial load so the REST-backed
+  /// first paint is not blocked by relay backfill. Routes incoming comments
+  /// through [NewCommentReceived].
   void _startWatchingComments() {
     _commentStreamSubscription?.cancel();
 

--- a/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
+++ b/mobile/lib/blocs/comments/comments_list/comments_list_bloc.dart
@@ -112,7 +112,6 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
         isBackfillComplete: false,
       ),
     );
-    _startWatchingComments();
 
     try {
       final thread = await _commentsRepository.loadComments(
@@ -142,6 +141,7 @@ class CommentsListBloc extends Bloc<CommentsListEvent, CommentsListState> {
           replyCountsByCommentId: computeReplyCounts(commentsById),
         ),
       );
+      _startWatchingComments();
     } on CommentsRepositoryException catch (e, stackTrace) {
       // *FailedException + relay timeouts are matrix-NO (API/domain +
       // Network/IO). addError logs without flagging Reportable so they stay

--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -4,7 +4,6 @@
 // chronologically.
 
 import 'dart:async';
-import 'dart:math';
 
 import 'package:comments_repository/src/blocked_comment_filter.dart';
 import 'package:comments_repository/src/exceptions.dart';
@@ -160,17 +159,7 @@ class CommentsRepository {
               rootEventKind,
               rootAddressableId: rootAddressableId,
             );
-            final thread = includeVideoReplies
-                ? _mergeRestThreadWithRelayVideoReplies(
-                    restThread: restThread,
-                    relayVideoReplyThread: await _loadRelayVideoReplies(
-                      rootEventId: rootEventId,
-                      rootEventKind: rootEventKind,
-                      rootAddressableId: rootAddressableId,
-                      limit: limit,
-                    ),
-                  )
-                : restThread;
+            final thread = restThread;
             if (thread.hasExactTotal) {
               // Auto-update the count cache with the authoritative REST total.
               // Zero is written too so a previously cached positive value
@@ -936,75 +925,6 @@ class CommentsRepository {
       totalCount: response.total,
       hasMore: response.hasMore,
       hasExactTotal: response.hasExactTotal,
-    );
-  }
-
-  Future<CommentThread> _loadRelayVideoReplies({
-    required String rootEventId,
-    required int rootEventKind,
-    required String? rootAddressableId,
-    required int limit,
-  }) async {
-    final filterByE = Filter(
-      kinds: const [EventKind.videoVertical],
-      uppercaseE: [rootEventId],
-      limit: limit,
-    );
-
-    final events = <String, Event>{};
-    if (rootAddressableId != null && rootAddressableId.isNotEmpty) {
-      final filterByA = Filter(
-        kinds: const [EventKind.videoVertical],
-        uppercaseA: [rootAddressableId],
-        limit: limit,
-      );
-      final results = await Future.wait([
-        _nostrClient.queryEvents([filterByE]),
-        _nostrClient.queryEvents([filterByA]),
-      ]);
-      for (final event in results.expand((result) => result)) {
-        events[event.id] = event;
-      }
-    } else {
-      final results = await _nostrClient.queryEvents([filterByE]);
-      for (final event in results) {
-        events[event.id] = event;
-      }
-    }
-
-    return _buildThreadFromEvents(
-      events.values.toList(),
-      rootEventId,
-      rootEventKind,
-      rootAddressableId: rootAddressableId,
-    );
-  }
-
-  CommentThread _mergeRestThreadWithRelayVideoReplies({
-    required CommentThread restThread,
-    required CommentThread relayVideoReplyThread,
-  }) {
-    if (relayVideoReplyThread.comments.isEmpty) return restThread;
-
-    final commentMap = <String, Comment>{
-      for (final comment in restThread.comments) comment.id: comment,
-    };
-    var addedRelayVideoReplyCount = 0;
-    for (final comment in relayVideoReplyThread.comments) {
-      if (!comment.hasVideo || commentMap.containsKey(comment.id)) continue;
-      commentMap[comment.id] = comment;
-      addedRelayVideoReplyCount++;
-    }
-
-    final merged = _buildThreadFromComments(commentMap, restThread.rootEventId);
-    final restTotal = max(restThread.totalCount, restThread.comments.length);
-    return merged.copyWith(
-      totalCount: max(
-        merged.comments.length,
-        restTotal + addedRelayVideoReplyCount,
-      ),
-      hasMore: restThread.hasMore,
-      hasExactTotal: restThread.hasExactTotal,
     );
   }
 

--- a/mobile/packages/comments_repository/test/src/comments_repository_test.dart
+++ b/mobile/packages/comments_repository/test/src/comments_repository_test.dart
@@ -175,82 +175,63 @@ void main() {
         },
       );
 
-      test('merges relay video replies into REST bootstrap comments', () async {
-        when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
-        when(
-          () => mockFunnelcakeApiClient.getVideoComments(
-            videoId: any(named: 'videoId'),
-            sort: any(named: 'sort'),
-            limit: any(named: 'limit'),
-            offset: any(named: 'offset'),
-          ),
-        ).thenAnswer(
-          (_) async => VideoCommentsResponse(
-            comments: [
-              VideoComment(
-                id: 'rest_comment',
-                pubkey: testUserPubkey,
-                createdAt: 1000,
-                kind: _commentKind,
-                content: 'REST comment',
-                sig: 'sig',
-                tags: [
-                  ['E', testRootEventId],
-                  ['K', _testRootEventKind.toString()],
-                  ['P', testRootAuthorPubkey],
-                  ['e', testRootEventId],
-                  ['k', _testRootEventKind.toString()],
-                  ['p', testRootAuthorPubkey],
-                ],
-              ),
-            ],
-            total: 1,
-          ),
-        );
-        final videoReplyEvent = _createCommentEvent(
-          id: 'video_reply',
-          kind: EventKind.videoVertical,
-          content: 'Reply title',
-          pubkey: testUserPubkey,
-          rootEventId: testRootEventId,
-          rootAuthorPubkey: testRootAuthorPubkey,
-          rootEventKind: _testRootEventKind,
-          createdAt: 1001,
-          extraTags: const [
-            ['imeta', 'url https://media.divine.video/video.mp4'],
-            ['title', 'Reply title'],
-          ],
-        );
-        when(
-          () => mockNostrClient.queryEvents(any()),
-        ).thenAnswer((_) async => [videoReplyEvent]);
+      test(
+        'REST bootstrap does not wait for relay video reply lookup',
+        () async {
+          when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeApiClient.getVideoComments(
+              videoId: any(named: 'videoId'),
+              sort: any(named: 'sort'),
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
+            ),
+          ).thenAnswer(
+            (_) async => VideoCommentsResponse(
+              comments: [
+                VideoComment(
+                  id: 'rest_comment',
+                  pubkey: testUserPubkey,
+                  createdAt: 1000,
+                  kind: _commentKind,
+                  content: 'REST comment',
+                  sig: 'sig',
+                  tags: [
+                    ['E', testRootEventId],
+                    ['K', _testRootEventKind.toString()],
+                    ['P', testRootAuthorPubkey],
+                    ['e', testRootEventId],
+                    ['k', _testRootEventKind.toString()],
+                    ['p', testRootAuthorPubkey],
+                  ],
+                ),
+              ],
+              total: 1,
+            ),
+          );
+          final neverCompletes = Completer<List<Event>>();
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) => neverCompletes.future);
 
-        repository = CommentsRepository(
-          nostrClient: mockNostrClient,
-          funnelcakeApiClient: mockFunnelcakeApiClient,
-        );
+          repository = CommentsRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeApiClient,
+          );
 
-        final result = await repository.loadComments(
-          rootEventId: testRootEventId,
-          rootEventKind: _testRootEventKind,
-          includeVideoReplies: true,
-        );
+          final result = await repository.loadComments(
+            rootEventId: testRootEventId,
+            rootEventKind: _testRootEventKind,
+            includeVideoReplies: true,
+          );
 
-        expect(result.totalCount, equals(2));
-        expect(result.comments.map((comment) => comment.id), [
-          'video_reply',
-          'rest_comment',
-        ]);
-        expect(result.comments.first.hasVideo, isTrue);
-
-        final captured =
-            verify(
-                  () => mockNostrClient.queryEvents(captureAny()),
-                ).captured.single
-                as List<Filter>;
-        expect(captured.single.kinds, equals([EventKind.videoVertical]));
-        expect(captured.single.uppercaseE, equals([testRootEventId]));
-      });
+          expect(result.totalCount, equals(1));
+          expect(result.comments.map((comment) => comment.id), [
+            'rest_comment',
+          ]);
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+        },
+      );
 
       test('falls back to relay query when REST bootstrap throws', () async {
         when(() => mockFunnelcakeApiClient.isAvailable).thenReturn(true);

--- a/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
+++ b/mobile/test/blocs/comments/comments_list/comments_list_bloc_test.dart
@@ -215,6 +215,70 @@ void main() {
           expect(b.state.hasMoreContent, isTrue);
         },
       );
+
+      test('starts live watch after initial load populates comments', () async {
+        final loadCompleter = Completer<CommentThread>();
+        final comment = makeComment(validId('c1'));
+        when(
+          () => mockCommentsRepository.loadComments(
+            rootEventId: any(named: 'rootEventId'),
+            rootEventKind: any(named: 'rootEventKind'),
+            rootAddressableId: any(named: 'rootAddressableId'),
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) => loadCompleter.future);
+
+        final bloc = createBloc();
+        addTearDown(bloc.close);
+        bloc.add(const CommentsLoadRequested());
+
+        await expectLater(
+          bloc.stream,
+          emits(
+            isA<CommentsListState>().having(
+              (s) => s.status,
+              'status',
+              CommentsStatus.loading,
+            ),
+          ),
+        );
+        verifyNever(
+          () => mockCommentsRepository.watchComments(
+            rootEventId: any(named: 'rootEventId'),
+            rootEventKind: any(named: 'rootEventKind'),
+            rootAddressableId: any(named: 'rootAddressableId'),
+            since: any(named: 'since'),
+            onEose: any(named: 'onEose'),
+          ),
+        );
+
+        loadCompleter.complete(
+          CommentThread(
+            rootEventId: validId('root'),
+            comments: [comment],
+            totalCount: 1,
+            commentCache: {comment.id: comment},
+          ),
+        );
+
+        await expectLater(
+          bloc.stream,
+          emits(
+            isA<CommentsListState>()
+                .having((s) => s.status, 'status', CommentsStatus.success)
+                .having((s) => s.commentsById.length, 'comment count', 1),
+          ),
+        );
+        verify(
+          () => mockCommentsRepository.watchComments(
+            rootEventId: any(named: 'rootEventId'),
+            rootEventKind: any(named: 'rootEventKind'),
+            rootAddressableId: any(named: 'rootAddressableId'),
+            since: any(named: 'since'),
+            onEose: any(named: 'onEose'),
+          ),
+        ).called(1);
+      });
     });
 
     group('CommentsLoadMoreRequested', () {


### PR DESCRIPTION
Closes #5100

## Summary
- Stop the REST comment bootstrap from waiting on the relay video-reply lookup.
- Start the live relay subscription only after the initial REST comments are in bloc state.
- Keep video replies available through the post-load relay backfill subscription.
- Update tests to prove an empty/slow relay video-reply path cannot block first paint.
- Clarify the `_startWatchingComments` doc comment so it matches the new backfill timing.

## Motivation
Opening the comments sheet could take several seconds even when a video had no video replies, because the client still awaited the relay query to prove there were none. This keeps the initial thread load on the cached REST path and moves relay work out of the render-critical path.

## Behavior Notes
- Video replies are still loaded when enabled because `watchComments` subscribes with the same `includeVideoReplies` kind filter and no `since`, so the relay path backfills history after REST first paint.
- If the initial REST/relay fallback load fails and the store is empty, the live watch no longer starts in the failure state. Retry starts the load/watch sequence again.
- REST comments re-emitted by relay backfill remain deduped by comment id in `NewCommentReceived`.

## Linked Issues
- Closes #5100.
- Follow-up to #5076.

## Validation
- `mise exec -- flutter test packages/comments_repository/test/src/comments_repository_test.dart test/blocs/comments/comments_list/comments_list_bloc_test.dart`
- `mise exec -- flutter analyze lib/blocs/comments/comments_list/comments_list_bloc.dart packages/comments_repository/lib/src/comments_repository.dart packages/comments_repository/test/src/comments_repository_test.dart test/blocs/comments/comments_list/comments_list_bloc_test.dart`
- Pre-push hook analyzer and changed-file tests passed on the final pushed branch.
