### PR TITLE
fix(relay): replay pending messages from a snapshot

### DIFF
--- a/mobile/packages/nostr_sdk/lib/relay/relay.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay.dart
@@ -74,21 +74,28 @@ abstract class Relay {
       );
       return;
     }
-    for (var message in pendingMessages) {
-      // TODO To check result? and how to handle if send fail?
-      var result = await send(message);
-      if (!result) {
-        log("message send fail onConnected");
-      } else {
-        log(
-          '[Relay] onConnected[${source ?? "unknown"}]: sent pending message type=${message.isNotEmpty ? message[0] : "unknown"}',
-        );
+    final messagesToSend = List<List<dynamic>>.from(pendingMessages);
+    pendingMessages.clear();
+
+    for (var message in messagesToSend) {
+      try {
+        final result = await send(message, queueIfFailed: false);
+        if (!result) {
+          pendingMessages.add(message);
+          log("message send fail onConnected");
+        } else {
+          log(
+            '[Relay] onConnected[${source ?? "unknown"}]: sent pending message type=${message.isNotEmpty ? message[0] : "unknown"}',
+          );
+        }
+      } catch (e) {
+        pendingMessages.add(message);
+        log("message send exception onConnected");
+        log('$e');
       }
     }
-
-    pendingMessages.clear();
     log(
-      '[Relay] onConnected[${source ?? "unknown"}]: ${relayStatus.addr} - cleared pending messages',
+      '[Relay] onConnected[${source ?? "unknown"}]: ${relayStatus.addr} - replay complete, remaining pending messages=${pendingMessages.length}',
     );
   }
 

--- a/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pending_messages_test.dart
@@ -1,0 +1,84 @@
+// ABOUTME: Regression tests for Relay pending-message replay on reconnect.
+// ABOUTME: Ensures failed replays are re-queued without corrupting iteration.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+class _RequeueingRelay extends Relay {
+  _RequeueingRelay(String url, {required this.failedMessage})
+    : super(url, RelayStatus(url));
+
+  final List<dynamic> failedMessage;
+  final List<List<dynamic>> sentMessages = [];
+
+  @override
+  Future<bool> doConnect() async => true;
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) async {
+    sentMessages.add(List<dynamic>.from(message));
+
+    if (_messagesEqual(message, failedMessage)) {
+      if (queueIfFailed) {
+        pendingMessages.add(message);
+      }
+      return false;
+    }
+
+    return true;
+  }
+
+  bool _messagesEqual(List<dynamic> a, List<dynamic> b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
+  }
+}
+
+void main() {
+  group('Relay pending-message replay', () {
+    test(
+      're-queues failed sends without mutating the active iteration',
+      () async {
+        final failedMessage = [
+          'EVENT',
+          {'id': 'retry'},
+        ];
+        final relay =
+            _RequeueingRelay(
+                'wss://relay.example',
+                failedMessage: failedMessage,
+              )
+              ..pendingMessages.addAll([
+                [
+                  'EVENT',
+                  {'id': 'sent'},
+                ],
+                failedMessage,
+              ]);
+
+        await expectLater(relay.onConnected(source: 'test'), completes);
+
+        expect(relay.sentMessages, [
+          [
+            'EVENT',
+            {'id': 'sent'},
+          ],
+          failedMessage,
+        ]);
+        expect(relay.pendingMessages, [failedMessage]);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #5096

## Summary
- Fixes COR-08 from AUDIT.md.
- Replays `Relay.pendingMessages` from a snapshot after clearing the active queue, so failed sends cannot mutate the list being iterated.
- Requeues only messages whose replay send fails or throws, preserving genuinely unsent messages for the next reconnect.
- Rebased onto current `origin/main` before final review.

## Root cause
`Relay.onConnected` previously iterated `pendingMessages` directly while awaiting `send(message)`. Failed sends could append to `pendingMessages` through `send()`'s default `queueIfFailed: true`, causing concurrent modification. The method then unconditionally cleared the queue, which could silently drop messages that were still unsent.

## Test plan
- RED confirmed first by the author: `mise exec -- flutter test test/unit/relay_pending_messages_test.dart --timeout 90s` failed with `Concurrent modification during iteration` from `Relay.onConnected`.
- Author verification: `mise exec -- dart format lib/relay/relay.dart test/unit/relay_pending_messages_test.dart`.
- Author verification: `mise exec -- flutter test test/unit/relay_pending_messages_test.dart test/unit/relay_count_test.dart test/unit/relay_pool_concurrency_test.dart --timeout 90s` passed.
- Author verification: `mise exec -- flutter analyze lib/relay/relay.dart test/unit/relay_pending_messages_test.dart` passed.
- Codex final verification after local rebase onto current `origin/main`: `mise exec flutter@3.44.0 -- flutter test test/unit/relay_pending_messages_test.dart test/unit/relay_pool_concurrency_test.dart test/defensive_serialization_test.dart` passed, 24 tests.
- Codex final verification after local rebase onto current `origin/main`: `mise exec flutter@3.44.0 -- flutter analyze lib/relay/relay.dart test/unit/relay_pending_messages_test.dart` passed with no issues.