### PR TITLE
fix(auth): retry destructive OAuth cleanup

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -978,11 +978,33 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   }
 
   /// Report a secure storage error to Crashlytics with auth context.
-  void _reportStorageError(dynamic error, StackTrace stack, String reason) {
+  void _reportStorageError(Object error, StackTrace stack, String reason) {
+    _reportAuthError(
+      error,
+      stack,
+      reason: reason,
+      logMessage: 'Storage error during auth: $reason',
+    );
+  }
+
+  void _reportAuthError(
+    Object error,
+    StackTrace stack, {
+    required String reason,
+    required String logMessage,
+  }) {
     final crashlytics = CrashReportingService.instance;
-    crashlytics.log('Storage error during auth: $reason');
+    crashlytics.log(logMessage);
     unawaited(crashlytics.setCustomKey('auth_source', _authSource.code));
     unawaited(crashlytics.recordError(error, stack, reason: reason));
+  }
+
+  void _reportNonFatalAuthCleanupError(
+    Object error,
+    StackTrace stack,
+    String reason,
+  ) {
+    _reportAuthError(error, stack, reason: reason, logMessage: reason);
   }
 
   /// Clears any persisted Divine OAuth session that was created before an
@@ -2220,9 +2242,79 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Used when a stale or ambiguous OAuth session must be discarded
   /// (e.g., during initialization tiebreaker branches).
   Future<void> _clearKeycastSessionAndTokens() async {
-    await KeycastSession.clear(_flutterSecureStorage);
-    await _flutterSecureStorage?.delete(key: _kKeycastRefreshTokenKey);
-    await _flutterSecureStorage?.delete(key: _kKeycastAuthHandleKey);
+    Object? firstError;
+    StackTrace? firstStack;
+
+    Future<void> deleteKey(Future<void> Function() delete) async {
+      try {
+        await delete();
+      } catch (e, stack) {
+        firstError ??= e;
+        firstStack ??= stack;
+      }
+    }
+
+    await deleteKey(() => KeycastSession.clear(_flutterSecureStorage));
+    await deleteKey(() async {
+      await _flutterSecureStorage?.delete(key: _kKeycastRefreshTokenKey);
+    });
+    await deleteKey(() async {
+      await _flutterSecureStorage?.delete(key: _kKeycastAuthHandleKey);
+    });
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStack!);
+    }
+  }
+
+  Future<void> _runSignOutCleanupWithRetry(
+    String operation,
+    Future<void> Function() cleanup,
+  ) async {
+    try {
+      await cleanup();
+      return;
+    } catch (e, stack) {
+      Log.warning(
+        'signOut: $operation failed; retrying once: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      _reportNonFatalAuthCleanupError(
+        e,
+        stack,
+        'signOut $operation failed before retry',
+      );
+    }
+
+    try {
+      await cleanup();
+    } catch (e, stack) {
+      Log.error(
+        'signOut: $operation failed after retry: $e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      _reportNonFatalAuthCleanupError(
+        e,
+        stack,
+        'signOut $operation failed after retry',
+      );
+    }
+  }
+
+  Future<void> _clearOAuthSessionForSignOut() async {
+    if (_oauthClient != null) {
+      await _runSignOutCleanupWithRetry(
+        'OAuth logout',
+        _oauthClient.logout,
+      );
+    }
+
+    await _runSignOutCleanupWithRetry(
+      'Keycast OAuth token cleanup',
+      _clearKeycastSessionAndTokens,
+    );
   }
 
   /// Sets up the auth URL callback for bunker operations that require user
@@ -3628,13 +3720,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _keycastSigner = null;
       _setRpcCapability(AuthRpcCapability.unavailable);
 
-      try {
-        if (_oauthClient != null) {
-          await _oauthClient.logout();
-        } else {
-          await KeycastSession.clear(_flutterSecureStorage);
-        }
-      } catch (_) {}
+      await _clearOAuthSessionForSignOut();
 
       // Reset recovery prefs AFTER all signer cleanup so removed accounts
       // cannot silently recover. Any remaining restorable accounts stay in the
@@ -3797,13 +3883,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _setRpcCapability(AuthRpcCapability.unavailable);
     _keyStorage.clearCache();
 
-    try {
-      if (_oauthClient != null) {
-        await _oauthClient.logout();
-      } else {
-        await KeycastSession.clear(_flutterSecureStorage);
-      }
-    } catch (_) {}
+    await _clearOAuthSessionForSignOut();
 
     await prefs.remove(_kSessionRecoveryAnchorKey);
     await prefs.remove('age_verified_16_plus');

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -64,6 +64,7 @@ void main() {
   late _MockNostrKeyManager mockNostrKeyManager;
   late _MockUserDataCleanupService mockCleanupService;
   late _MockFlutterSecureStorage mockSecureStorage;
+  late _MockKeycastOAuth mockOAuthClient;
   late AuthService authService;
   late SecureKeyContainer testKeyContainer;
 
@@ -77,6 +78,7 @@ void main() {
     mockNostrKeyManager = _MockNostrKeyManager();
     mockCleanupService = _MockUserDataCleanupService();
     mockSecureStorage = _MockFlutterSecureStorage();
+    mockOAuthClient = _MockKeycastOAuth();
     testKeyContainer = SecureKeyContainer.fromNsec(_testNsec);
 
     // Default stubs
@@ -143,6 +145,7 @@ void main() {
     when(
       () => mockSecureStorage.delete(key: any(named: 'key')),
     ).thenAnswer((_) async {});
+    when(() => mockOAuthClient.logout()).thenAnswer((_) async {});
 
     authService = AuthService(
       userDataCleanupService: mockCleanupService,
@@ -1889,6 +1892,126 @@ void main() {
           ),
         ).called(1);
         verify(() => mockKeyStorage.deleteKeys()).called(1);
+      },
+    );
+
+    test(
+      'remove keys retries Keycast cleanup and clears OAuth tokens',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'last_used_npub': testKeyContainer.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+
+        final deletedKeys = <String>[];
+        when(
+          () => mockSecureStorage.delete(key: any(named: 'key')),
+        ).thenAnswer((invocation) async {
+          final key = invocation.namedArguments[#key] as String;
+          deletedKeys.add(key);
+
+          final keycastSessionAttempts = deletedKeys
+              .where((deletedKey) => deletedKey == 'keycast_session')
+              .length;
+          if (key == 'keycast_session' && keycastSessionAttempts == 1) {
+            throw StateError('transient secure storage delete failure');
+          }
+        });
+
+        await authService.signOut(deleteKeys: true);
+
+        expect(
+          deletedKeys,
+          containsAllInOrder([
+            'keycast_session',
+            'keycast_session',
+            'keycast_refresh_token',
+            'keycast_auth_handle',
+          ]),
+        );
+      },
+    );
+
+    test(
+      'remove keys still attempts all Keycast token deletes when session delete keeps failing',
+      () async {
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'last_used_npub': testKeyContainer.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+
+        final deletedKeys = <String>[];
+        when(
+          () => mockSecureStorage.delete(key: any(named: 'key')),
+        ).thenAnswer((invocation) async {
+          final key = invocation.namedArguments[#key] as String;
+          deletedKeys.add(key);
+
+          if (key == 'keycast_session') {
+            throw StateError('persistent secure storage delete failure');
+          }
+        });
+
+        await authService.signOut(deleteKeys: true);
+
+        expect(authService.authState, equals(AuthState.unauthenticated));
+        expect(
+          deletedKeys,
+          containsAllInOrder([
+            'keycast_session',
+            'keycast_refresh_token',
+            'keycast_auth_handle',
+            'keycast_session',
+            'keycast_refresh_token',
+            'keycast_auth_handle',
+          ]),
+        );
+      },
+    );
+
+    test(
+      'remove keys logs out OAuth client and clears local Keycast tokens',
+      () async {
+        await authService.dispose();
+        authService = AuthService(
+          userDataCleanupService: mockCleanupService,
+          keyStorage: mockKeyStorage,
+          nostrKeyManager: mockNostrKeyManager,
+          oauthClient: mockOAuthClient,
+          flutterSecureStorage: mockSecureStorage,
+        );
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'automatic',
+          'last_used_npub': testKeyContainer.npub,
+          kKnownAccountsKey: '[]',
+        });
+
+        await _ignoringDiscoveryErrors(authService.createNewIdentity);
+
+        final deletedKeys = <String>[];
+        when(
+          () => mockSecureStorage.delete(key: any(named: 'key')),
+        ).thenAnswer((invocation) async {
+          deletedKeys.add(invocation.namedArguments[#key] as String);
+        });
+
+        await authService.signOut(deleteKeys: true);
+
+        verify(() => mockOAuthClient.logout()).called(1);
+        expect(
+          deletedKeys,
+          containsAllInOrder([
+            'keycast_session',
+            'keycast_refresh_token',
+            'keycast_auth_handle',
+          ]),
+        );
       },
     );
 


### PR DESCRIPTION
Closes #5089

## Summary
- Fixes COR-10 from AUDIT.md.
- Retries OAuth logout and Keycast token cleanup once during sign-out, with log and non-fatal crash reporting when cleanup fails.
- Clears the Keycast session, refresh token, and auth handle through the same retry path so remove keys does not silently leave OAuth credentials after a transient storage failure.
- Hardens the Keycast key-set cleanup so every local OAuth key is attempted even if an earlier key delete throws, then rethrows the first failure to the retry/reporting wrapper.
- Reuses shared auth Crashlytics reporting plumbing instead of duplicating the storage-error reporter.

## Root cause
The old sign-out cleanup swallowed all OAuth cleanup errors and, when no `KeycastOAuth` client was present, only deleted `keycast_session`. That left `keycast_refresh_token` and `keycast_auth_handle` behind on the common automatic/imported-key destructive sign-out path. A failure deleting the first Keycast key could also prevent later token deletes from being attempted.

## User impact
Removing keys now makes a best-effort pass over all local OAuth credentials, retries transient cleanup failures once, and still lets destructive sign-out complete if storage cleanup ultimately fails.

## Test plan
- RED confirmed first: `mise exec -- flutter test test/services/auth_service_multi_account_test.dart --plain-name "remove keys retries Keycast cleanup and clears OAuth tokens" --timeout 90s` failed because the first `keycast_session` delete error was swallowed and `keycast_refresh_token`/`keycast_auth_handle` were never deleted.
- `dart format lib/services/auth_service.dart test/services/auth_service_multi_account_test.dart`
- `mise exec flutter@3.44.0 -- flutter test test/services/auth_service_multi_account_test.dart`
- `mise exec flutter@3.44.0 -- flutter analyze lib/services/auth_service.dart test/services/auth_service_multi_account_test.dart`
- Pre-push hook reran analyzer and `test/services/auth_service_multi_account_test.dart` successfully.
