### PR TITLE
fix(router): relink AppShell transitional TODOs

### DIFF
--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -202,23 +202,23 @@ class _AppShellState extends ConsumerState<AppShell> {
     ref.watch(videoControllerAutoCleanupProvider);
 
     // Transitional scaffold: records relay connection events for analytics.
-    // TODO(#3339): remove when relay management moves to a dedicated cubit/service.
+    // TODO(#4338): remove when relay management moves to a dedicated cubit/service.
     ref.watch(relayStatisticsBridgeProvider);
 
     // Transitional scaffold: refreshes feeds when the relay set changes.
-    // TODO(#3339): remove when feed refresh is driven by a relay event stream in a cubit.
+    // TODO(#4338): remove when feed refresh is driven by a relay event stream in a cubit.
     ref.watch(relaySetChangeBridgeProvider);
 
     // Initialize Zendesk identity sync to keep user identity in sync with auth
     ref.watch(zendeskIdentitySyncProvider);
 
     // Transitional scaffold: syncs notification preferences on auth change.
-    // TODO(#3339): remove when NotificationPreferencesCubit owns this lifecycle.
+    // TODO(#4338): remove when NotificationPreferencesCubit owns this lifecycle.
     ref.watch(notificationPreferencesDirtySyncBridgeProvider);
     ref.watch(pushNotificationSyncProvider);
 
     // Transitional scaffold: syncs block/mute list after login.
-    // TODO(#3339): remove when BlocklistCubit owns post-login sync.
+    // TODO(#4338): remove when BlocklistCubit owns post-login sync.
     ref.watch(blocklistSyncBridgeProvider);
 
     // Watch page context to determine if back button should show and if on search route

--- a/mobile/test/router/app_shell_todo_test.dart
+++ b/mobile/test/router/app_shell_todo_test.dart
@@ -1,0 +1,20 @@
+// ABOUTME: Static-source guard for AppShell transitional TODO hygiene.
+// ABOUTME: Prevents closed tracking issues from remaining as removal plans.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AppShell does not reference closed migration issue #3339', () {
+    final source = File('lib/router/app_shell.dart').readAsStringSync();
+
+    expect(
+      source,
+      isNot(contains('TODO(#3339)')),
+      reason:
+          '#3339 is closed. Transitional TODOs must either be removed '
+          'or point at an open tracking issue.',
+    );
+  });
+}


### PR DESCRIPTION
Closes #5093

## Summary
- Fixes DED-07 from AUDIT.md.
- Relinks the four AppShell transitional TODOs from closed issue #3339 to the open architecture/state-boundary epic #4338.
- Adds a static-source guard so AppShell cannot regress to referencing closed #3339 as the removal plan.

## Test plan
- RED confirmed first: mise exec -- flutter test test/router/app_shell_todo_test.dart --timeout 90s failed because app_shell.dart still contained TODO(#3339).
- mise exec -- dart format lib/router/app_shell.dart test/router/app_shell_todo_test.dart
- mise exec -- flutter test test/router/app_shell_todo_test.dart --timeout 90s
- mise exec -- flutter analyze lib/router/app_shell.dart test/router/app_shell_todo_test.dart (No issues found)
- mise exec -- flutter test test/router/app_shell_todo_test.dart test/router/app_shell_header_test.dart --timeout 90s (all non-skipped tests passed)
- Pre-push hook reran analyzer and test/router/app_shell_todo_test.dart successfully.