### PR TITLE
fix(blocklist): refilter fullscreen snapshot feeds on blocklist version changes

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -27,6 +27,14 @@ part 'fullscreen_feed_state.dart';
 /// services (matches the existing [FullscreenFeedBloc.onLoadMore] pattern).
 typedef OnRemoveVideo = void Function(String videoId);
 
+/// Returns `true` when [pubkey]'s content must be hidden (blocked / muted /
+/// blocked-us / muted-us). Injected so the BLoC stays free of Riverpod and
+/// repository dependencies — the launching `ConsumerWidget` resolves it from
+/// `contentBlocklistRepository.shouldFilterFromFeeds`. The bound method reads
+/// live blocklist state on every call, so a captured reference stays correct
+/// across mutations.
+typedef BlockAuthorFilter = bool Function(String pubkey);
+
 /// Maximum number of concurrent background cache downloads.
 ///
 /// Limiting to 1 prevents background caching from competing with the
@@ -68,6 +76,7 @@ class FullscreenFeedBloc
     BlossomAuthService? blossomAuthService,
     OnRemoveVideo? onRemoveVideo,
     MediaAvailabilityChecker? availabilityChecker,
+    BlockAuthorFilter? blockFilter,
   }) : _videosStream = videosStream,
        _initialVideoId = initialVideoId,
        _initialStableId = initialStableId,
@@ -79,6 +88,7 @@ class FullscreenFeedBloc
        _onRemoveVideo = onRemoveVideo,
        _availabilityChecker =
            availabilityChecker ?? const MediaAvailabilityChecker(),
+       _blockFilter = blockFilter,
        super(FullscreenFeedState(currentIndex: initialIndex)) {
     on<FullscreenFeedStarted>(_onStarted);
     on<FullscreenFeedHasMoreChanged>(_onHasMoreChanged);
@@ -96,6 +106,12 @@ class FullscreenFeedBloc
     // together; concurrent emits for different ids must not interleave.
     on<FullscreenFeedVideoRemoved>(_onVideoRemoved, transformer: sequential());
     on<FullscreenFeedSkipAcknowledged>(_onSkipAcknowledged);
+    // Sequential: a blocklist sweep mutates videos + currentIndex together and
+    // must not interleave with a concurrent removal that does the same.
+    on<FullscreenFeedBlocklistChanged>(
+      _onBlocklistChanged,
+      transformer: sequential(),
+    );
   }
 
   final Stream<List<VideoEvent>> _videosStream;
@@ -108,6 +124,7 @@ class FullscreenFeedBloc
   final BlossomAuthService? _blossomAuthService;
   final OnRemoveVideo? _onRemoveVideo;
   final MediaAvailabilityChecker _availabilityChecker;
+  final BlockAuthorFilter? _blockFilter;
   StreamSubscription<bool>? _hasMoreSubscription;
   StreamSubscription<String>? _removedIdsSubscription;
 
@@ -167,7 +184,13 @@ class FullscreenFeedBloc
 
     await emit.forEach<List<VideoEvent>>(
       _videosStream,
-      onData: (videos) {
+      onData: (incoming) {
+        // Filter blocked authors at the stream boundary so a source re-push
+        // (e.g. the liked-videos like-change subscription / load-more, which
+        // never re-filter) can't re-introduce an author who is blocked under
+        // the current blocklist. Idempotent for sources that already filter.
+        final videos = _applyBlockFilter(incoming);
+
         Log.debug(
           'FullscreenFeedBloc: Videos updated, count=${videos.length}',
           name: 'FullscreenFeedBloc',
@@ -560,6 +583,61 @@ class FullscreenFeedBloc
         removedVideoIds: updatedRemoved,
       ),
     );
+  }
+
+  /// Returns [videos] with blocked authors removed, or the same list
+  /// unchanged when no [BlockAuthorFilter] was injected.
+  List<VideoEvent> _applyBlockFilter(List<VideoEvent> videos) {
+    final blockFilter = _blockFilter;
+    if (blockFilter == null) return videos;
+    return videos.where((v) => !blockFilter(v.pubkey)).toList();
+  }
+
+  /// Handle a broad blocklist change (`blocklistVersionProvider` bumped).
+  ///
+  /// Re-filters the current [FullscreenFeedState.videos] against the injected
+  /// [BlockAuthorFilter] and drops now-blocked authors. This is the path for
+  /// account switch / identity adoption / external relay sync, which bump the
+  /// version but emit no granular `removedVideoIds` (see #5041). It is a pure
+  /// list filter — never a permanent tombstone — so an unblock re-shows the
+  /// author on the next source emit.
+  ///
+  /// The cursor shifts left by the number of removed videos that preceded it,
+  /// preserving the playing video when it survives and landing on the next
+  /// survivor otherwise — mirrors the single-id shift in [_onVideoRemoved].
+  /// When the list empties, transitions to
+  /// [FullscreenFeedStatus.emptyAfterRemoval] so the screen pops.
+  void _onBlocklistChanged(
+    FullscreenFeedBlocklistChanged event,
+    Emitter<FullscreenFeedState> emit,
+  ) {
+    final blockFilter = _blockFilter;
+    if (blockFilter == null || state.videos.isEmpty) return;
+
+    final kept = _applyBlockFilter(state.videos);
+    if (kept.length == state.videos.length) return; // nothing newly blocked
+
+    if (kept.isEmpty) {
+      emit(
+        state.copyWith(
+          status: FullscreenFeedStatus.emptyAfterRemoval,
+          videos: const [],
+          clearPendingSkipTarget: true,
+        ),
+      );
+      return;
+    }
+
+    final removedBeforeCursor = state.videos
+        .take(state.currentIndex)
+        .where((v) => blockFilter(v.pubkey))
+        .length;
+    final nextIndex = (state.currentIndex - removedBeforeCursor).clamp(
+      0,
+      kept.length - 1,
+    );
+
+    emit(state.copyWith(videos: kept, currentIndex: nextIndex));
   }
 
   /// Extracts the scheme+host origin from [url], e.g.

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
@@ -114,3 +114,21 @@ final class FullscreenFeedVideoRemoved extends FullscreenFeedEvent {
   @override
   List<Object?> get props => [videoId];
 }
+
+/// Dispatched when `blocklistVersionProvider` changes (block / mute / account
+/// switch / identity adoption / external relay sync). The BLoC re-filters its
+/// current [FullscreenFeedState.videos] against the injected
+/// [BlockAuthorFilter], dropping now-blocked authors and shifting the cursor;
+/// an empty result transitions to [FullscreenFeedStatus.emptyAfterRemoval].
+///
+/// This covers BROAD blocklist changes that emit no granular `removedVideoIds`
+/// — account switch / identity adoption bump the version via `onChanged` but
+/// never fire the per-pubkey sweep, and the sweep is cache-scoped anyway, so a
+/// static-snapshot fullscreen feed (curated list / liked videos) would
+/// otherwise keep showing a blocked author until reopened. See #5041.
+final class FullscreenFeedBlocklistChanged extends FullscreenFeedEvent {
+  const FullscreenFeedBlocklistChanged();
+
+  @override
+  List<Object?> get props => [];
+}

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -198,6 +198,16 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final mediaCache = kIsWeb ? null : ref.read(mediaCacheProvider);
     final blossomAuthService = ref.read(blossomAuthServiceProvider);
+    // Viewer-aware block predicate (blocks ∪ mutes ∪ blocked-us ∪ muted-us) —
+    // the same `shouldFilterFromFeeds` every other feed surface filters with.
+    // The bound method reads live blocklist state on each call, so capturing it
+    // once in `create:` is safe: `contentBlocklistRepository` is keepAlive and
+    // doesn't flip identity on a block action. The version listener in
+    // [FullscreenFeedContent] re-runs the filter when the blocklist changes
+    // broadly (account switch / external sync). See #5041.
+    final blockFilter = ref
+        .read(contentBlocklistRepositoryProvider)
+        .shouldFilterFromFeeds;
 
     return MultiBlocProvider(
       providers: [
@@ -212,6 +222,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             onLoadMore: onLoadMore,
             mediaCache: mediaCache,
             blossomAuthService: blossomAuthService,
+            blockFilter: blockFilter,
           )..add(const FullscreenFeedStarted()),
         ),
         BlocProvider(create: (_) => VideoPlaybackStatusCubit()),
@@ -382,6 +393,22 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
 
   @override
   Widget build(BuildContext context) {
+    // Refilter the open feed when the blocklist changes broadly (block / mute
+    // / account switch / identity adoption / external relay sync). This listen
+    // lives in the fullscreen's OWN state — which is mounted whenever the feed
+    // is visible — so it survives the launching widget unmounting on a
+    // shell-route push (the same reason the `removedIdsStream` bus exists).
+    // Broad changes bump `blocklistVersionProvider` but emit no granular
+    // removal, so the static-snapshot routes (curated list / liked videos)
+    // would otherwise keep showing a blocked author until reopened. See #5041.
+    ref.listen<int>(blocklistVersionProvider, (previous, next) {
+      if (previous != null && next > previous) {
+        context.read<FullscreenFeedBloc>().add(
+          const FullscreenFeedBlocklistChanged(),
+        );
+      }
+    });
+
     // Owned at the screen level so the inline comment composer bar at the
     // bottom of the Scaffold has a single cubit shared across page swipes —
     // re-creating it per-item would lose any in-flight publish during a

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -51,12 +51,13 @@ void main() {
       String id, {
       String? sha256,
       String? videoUrl,
+      String? pubkey,
       Map<String, String> rawTags = const {},
     }) {
       final now = DateTime.now();
       return VideoEvent(
         id: id,
-        pubkey: '0' * 64,
+        pubkey: pubkey ?? '0' * 64,
         createdAt: now.millisecondsSinceEpoch ~/ 1000,
         content: '',
         timestamp: now,
@@ -78,6 +79,7 @@ void main() {
       BlossomAuthService? blossomAuthService,
       OnRemoveVideo? onRemoveVideo,
       MediaAvailabilityChecker? availabilityChecker,
+      BlockAuthorFilter? blockFilter,
     }) => FullscreenFeedBloc(
       videosStream: videosController.stream,
       initialIndex: initialIndex,
@@ -89,6 +91,7 @@ void main() {
       blossomAuthService: blossomAuthService,
       onRemoveVideo: onRemoveVideo,
       availabilityChecker: availabilityChecker,
+      blockFilter: blockFilter,
     );
 
     test('initial state has correct values', () {
@@ -481,6 +484,231 @@ void main() {
             1,
           ),
         ],
+      );
+    });
+
+    group('FullscreenFeedBlocklistChanged', () {
+      final authorA = 'a' * 64;
+      final authorB = 'b' * 64;
+      final authorC = 'c' * 64;
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'filters blocked authors from incoming stream lists at the boundary',
+        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorB),
+            createTestVideo('c', pubkey: authorC),
+          ]);
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<FullscreenFeedState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'video ids',
+            ['a', 'c'],
+          ),
+        ],
+      );
+
+      // The boundary filter must hold across a source re-push — the
+      // liked-videos like-change subscription / load-more re-emit unfiltered
+      // lists (finding N1), so a blocked author must not slip back in.
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'keeps blocked authors out across a source re-push',
+        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorB),
+            createTestVideo('c', pubkey: authorC),
+          ]);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          // Source re-emits the same blocked author (plus a new unblocked one)
+          // — 'b' must stay filtered out on the re-push.
+          videosController.add([
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorB),
+            createTestVideo('c', pubkey: authorC),
+            createTestVideo('d', pubkey: authorC),
+          ]);
+        },
+        wait: const Duration(milliseconds: 200),
+        expect: () => [
+          isA<FullscreenFeedState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'first ids',
+            ['a', 'c'],
+          ),
+          isA<FullscreenFeedState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            're-push ids',
+            ['a', 'c', 'd'],
+          ),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'preserves the playing video when an earlier author is blocked',
+        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorB),
+            createTestVideo('c', pubkey: authorC),
+            createTestVideo('d', pubkey: authorA),
+          ],
+          currentIndex: 2,
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                ['a', 'c', 'd'],
+              )
+              .having((s) => s.currentIndex, 'currentIndex', 1)
+              .having((s) => s.currentVideo?.id, 'currentVideo', 'c'),
+        ],
+      );
+
+      // Seeded so the shift result (1) differs from a naive clamp of the old
+      // index (clamp(3, 0, 2) == 2). Removing the cursor shift would land on
+      // 'e', not 'd' — so this test fails loudly if the shift logic regresses.
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'shifts the cursor left by the count of blocked videos before it',
+        build: () => createBloc(blockFilter: (pk) => pk == authorA),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorA),
+            createTestVideo('c', pubkey: authorC),
+            createTestVideo('d', pubkey: authorB),
+            createTestVideo('e', pubkey: authorC),
+          ],
+          currentIndex: 3,
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                ['c', 'd', 'e'],
+              )
+              .having((s) => s.currentIndex, 'currentIndex', 1)
+              .having((s) => s.currentVideo?.id, 'currentVideo', 'd'),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'lands on the next survivor when the current video is blocked',
+        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorB),
+            createTestVideo('c', pubkey: authorC),
+          ],
+          currentIndex: 1,
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                ['a', 'c'],
+              )
+              .having((s) => s.currentIndex, 'currentIndex', 1)
+              .having((s) => s.currentVideo?.id, 'currentVideo', 'c'),
+        ],
+      );
+
+      // Boundary case: cursor at 0 and the index-0 video is itself blocked.
+      // `take(0)` yields 0 removed-before-cursor, so the next survivor must
+      // surface at index 0.
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'lands on the next survivor when the index-0 video is blocked',
+        build: () => createBloc(blockFilter: (pk) => pk == authorA),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorB),
+            createTestVideo('c', pubkey: authorC),
+          ],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'video ids',
+                ['b', 'c'],
+              )
+              .having((s) => s.currentIndex, 'currentIndex', 0)
+              .having((s) => s.currentVideo?.id, 'currentVideo', 'b'),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'transitions to emptyAfterRemoval when every author is blocked',
+        build: () => createBloc(blockFilter: (pk) => pk == authorA),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorA),
+          ],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having(
+                (s) => s.status,
+                'status',
+                FullscreenFeedStatus.emptyAfterRemoval,
+              )
+              .having((s) => s.videos, 'videos', isEmpty),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'emits nothing when no author is blocked',
+        build: () => createBloc(blockFilter: (pk) => pk == authorB),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('c', pubkey: authorC),
+          ],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
+        expect: () => <FullscreenFeedState>[],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'emits nothing when no block filter is injected',
+        build: createBloc,
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [
+            createTestVideo('a', pubkey: authorA),
+            createTestVideo('b', pubkey: authorB),
+          ],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedBlocklistChanged()),
+        expect: () => <FullscreenFeedState>[],
       );
     });
 

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:divine_video_player/divine_video_player.dart'
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart';
@@ -183,6 +184,7 @@ void main() {
       registerFallbackValue(const FullscreenFeedVideoCacheStarted(index: 0));
       registerFallbackValue(const FullscreenFeedVideoUnavailable('fallback'));
       registerFallbackValue(const FullscreenFeedVideoRemoved('fallback'));
+      registerFallbackValue(const FullscreenFeedBlocklistChanged());
       registerFallbackValue(const FullscreenFeedSkipAcknowledged());
       registerFallbackValue(Duration.zero);
       registerFallbackValue(_FakeBuildContext());
@@ -275,6 +277,32 @@ void main() {
     InfiniteVideoFeed nativeFeed(WidgetTester tester) {
       return tester.widget<InfiniteVideoFeed>(find.byType(InfiniteVideoFeed));
     }
+
+    group('blocklist version listener', () {
+      testWidgets(
+        'dispatches FullscreenFeedBlocklistChanged when the version increments',
+        (tester) async {
+          await tester.pumpWidget(buildSubject());
+
+          // The listener registers on first build with previous == null; it
+          // must NOT dispatch until the version actually changes.
+          verifyNever(
+            () => mockBloc.add(const FullscreenFeedBlocklistChanged()),
+          );
+
+          final container = ProviderScope.containerOf(
+            tester.element(find.byType(FullscreenFeedContent)),
+            listen: false,
+          );
+          container.read(blocklistVersionProvider.notifier).increment();
+          await tester.pump();
+
+          verify(
+            () => mockBloc.add(const FullscreenFeedBlocklistChanged()),
+          ).called(1);
+        },
+      );
+    });
 
     group('state rendering', () {
       testWidgets('shows loading indicator when status is initial', (


### PR DESCRIPTION
## Description

Fullscreen feeds opened from a static snapshot (curated list, liked videos) kept showing a now-blocked author when the blocklist changed **broadly** — account switch / identity adoption (#5031) and externally-applied / relay-synced changes bump `blocklistVersionProvider` via `ContentBlocklistRepository.onChanged` but emit no granular `removedVideoIds`, and the `_sweepAuthor` removal bus is cache-scoped (it never covers snapshot videos sourced outside `VideoEventService`). `FullscreenFeedBloc` had no version-driven refilter path, so a blocked author stayed visible until the route was reopened.

This:

- injects the viewer-aware `shouldFilterFromFeeds` predicate into `FullscreenFeedBloc` at its single construction site;
- filters incoming stream lists at the boundary, so a liked-path re-push (the like-change subscription / load-more, which never re-filter) can't reintroduce a blocked author;
- adds a `FullscreenFeedBlocklistChanged` event dispatched by `FullscreenFeedContent`'s own `ConsumerState` on a `blocklistVersionProvider` change — placed in the fullscreen's own state so it survives the launching widget unmounting on a shell-route push (the same reason the `removedIdsStream` bus exists).

The handler drops now-blocked authors, shifts the cursor to preserve sensible playback (mirrors the existing single-id removal in `_onVideoRemoved`), and reuses `emptyAfterRemoval` when the list empties. It is a pure list filter — never a permanent tombstone — so an unblock re-shows the author on the next source emit.

Centralizing at the shared bloc covers the curated-list, liked-videos, and profile fullscreen paths; it is idempotent for callers whose source already filters (hashtag / search / explore / profile).

**Related Issue:** Closes #5041

## Out of Scope

The grid-level freeze: the curated/liked source providers (`curatedListVideoEventsProvider` / `videoEventsByIdsProvider`) filter only at fetch time via `shouldHideVideo` and don't watch `blocklistVersionProvider` (and curated skips the filter on the plain-event-ID cache-hit branch), so the grids are also stale on broad changes. Lower severity (thumbnails, not autoplay); tracked in #5104.

## Verification

- `dart format` — clean
- `flutter analyze lib test` — No issues found
- `flutter test test/blocs/fullscreen_feed/ test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` — 109 passing (9 new `FullscreenFeedBlocklistChanged` / boundary-filter bloc cases incl. cursor-shift, index-0, all-blocked → `emptyAfterRemoval`, and re-push; 1 new screen test proving the version bump reaches the bloc)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)