### PR TITLE
feat(profile): render website field in profile header

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4051,5 +4051,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4057,5 +4057,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4931,6 +4931,20 @@
   "@profileEditGetVerifiedSubtitle": {
     "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
   },
+  "profileWebsiteSemanticLabel": "Visit website: {url}",
+  "@profileWebsiteSemanticLabel": {
+    "description": "Screen reader label for the website link row on a user's profile.",
+    "placeholders": {
+      "url": {
+        "type": "String",
+        "description": "The website URL."
+      }
+    }
+  },
+  "profileCouldNotOpenWebsite": "Could not open website",
+  "@profileCouldNotOpenWebsite": {
+    "description": "Snackbar message shown when url_launcher fails to open the profile website link."
+  },
   "videoMetadataEditCoverTitle": "Edit cover",
   "videoMetadataEditCoverCloseSemanticLabel": "Close cover editor",
   "videoMetadataEditCoverConfirmSemanticLabel": "Confirm cover selection",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2464,5 +2464,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3212,5 +3212,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3923,5 +3923,14 @@
     "notificationSettingsSound": "Sound",
     "notificationSettingsSoundSubtitle": "Play sound for notifications",
     "notificationSettingsVibration": "Vibration",
-    "notificationSettingsVibrationSubtitle": "Vibrate for notifications"
+    "notificationSettingsVibrationSubtitle": "Vibrate for notifications",
+    "@profileWebsiteSemanticLabel": {
+        "placeholders": {
+            "url": {
+                "type": "String"
+            }
+        }
+    },
+    "profileWebsiteSemanticLabel": "Visit website: {url}",
+    "profileCouldNotOpenWebsite": "Could not open website"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -15408,6 +15408,18 @@ abstract class AppLocalizations {
   /// **'Link your social media accounts so people know it\'s really you.'**
   String get profileEditGetVerifiedSubtitle;
 
+  /// Screen reader label for the website link row on a user's profile.
+  ///
+  /// In en, this message translates to:
+  /// **'Visit website: {url}'**
+  String profileWebsiteSemanticLabel(String url);
+
+  /// Snackbar message shown when url_launcher fails to open the profile website link.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open website'**
+  String get profileCouldNotOpenWebsite;
+
   /// No description provided for @videoMetadataEditCoverTitle.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -8715,6 +8715,14 @@ class AppLocalizationsAm extends AppLocalizations {
       'ሰዎች በእርግጥ አንተ መሆንህን እንዲያውቁ የማህበራዊ ሚዲያ መለያዎችህን አገናኝ።';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Edit cover';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8801,6 +8801,14 @@ class AppLocalizationsAr extends AppLocalizations {
       'اربط حساباتك على وسائل التواصل ليعرف الناس أنّك أنت فعلًا.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'تعديل الغلاف';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8960,6 +8960,14 @@ class AppLocalizationsBg extends AppLocalizations {
       'Свържи социалните си мрежи, за да знаят хората, че това си наистина ти.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Edit cover';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8969,6 +8969,14 @@ class AppLocalizationsDe extends AppLocalizations {
       'Verknüpfe deine Social-Media-Konten, damit alle wissen, dass du es bist.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Cover bearbeiten';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -8864,6 +8864,14 @@ class AppLocalizationsEn extends AppLocalizations {
       'Link your social media accounts so people know it\'s really you.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Edit cover';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8958,6 +8958,14 @@ class AppLocalizationsEs extends AppLocalizations {
       'Conecta tus redes sociales para que sepan que eres tú.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Editar portada';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8968,6 +8968,14 @@ class AppLocalizationsFil extends AppLocalizations {
       'I-link ang iyong mga social media account para malaman ng mga tao na ikaw talaga ito.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Edit cover';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8989,6 +8989,14 @@ class AppLocalizationsFr extends AppLocalizations {
       'Connecte tes réseaux sociaux pour que les gens sachent que c\'est vraiment toi.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Modifier la couverture';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8852,6 +8852,14 @@ class AppLocalizationsId extends AppLocalizations {
       'Hubungkan akun media sosialmu biar orang tahu ini memang kamu.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Edit sampul';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8954,6 +8954,14 @@ class AppLocalizationsIt extends AppLocalizations {
       'Collega i tuoi profili social così tutti sanno che sei davvero tu.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Modifica copertina';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -8569,6 +8569,14 @@ class AppLocalizationsJa extends AppLocalizations {
       'ソーシャルメディアのアカウントをつないで、本物のあなただと伝えよう。';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'カバーを編集';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -8592,6 +8592,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileEditGetVerifiedSubtitle => '소셜 미디어 계정을 연결해서 진짜 너인 걸 알려줘.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => '커버 편집';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8916,6 +8916,14 @@ class AppLocalizationsNl extends AppLocalizations {
       'Koppel je social-media-accounts zodat mensen weten dat jij het bent.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Omslag bewerken';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9032,6 +9032,14 @@ class AppLocalizationsPl extends AppLocalizations {
       'Połącz swoje konta w mediach społecznościowych, żeby ludzie wiedzieli, że to naprawdę ty.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Edytuj okładkę';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8926,6 +8926,14 @@ class AppLocalizationsPt extends AppLocalizations {
       'Conecte suas redes sociais para que as pessoas saibam que é você mesmo.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Editar capa';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9056,6 +9056,14 @@ class AppLocalizationsRo extends AppLocalizations {
       'Conectează-ți conturile de social media ca lumea să știe că ești tu.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Editează coperta';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -8882,6 +8882,14 @@ class AppLocalizationsSv extends AppLocalizations {
       'Koppla dina sociala medier-konton så folk vet att det är du.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Redigera omslag';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8850,6 +8850,14 @@ class AppLocalizationsTr extends AppLocalizations {
       'Sosyal medya hesaplarını bağla ki insanlar gerçekten sen olduğunu bilsin.';
 
   @override
+  String profileWebsiteSemanticLabel(String url) {
+    return 'Visit website: $url';
+  }
+
+  @override
+  String get profileCouldNotOpenWebsite => 'Could not open website';
+
+  @override
   String get videoMetadataEditCoverTitle => 'Kapağı düzenle';
 
   @override

--- a/mobile/lib/widgets/profile/profile_header_widget.dart
+++ b/mobile/lib/widgets/profile/profile_header_widget.dart
@@ -31,6 +31,7 @@ import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/profile/profile_action_buttons_widget.dart';
 import 'package:openvine/widgets/profile/profile_actions_sheet/profile_actions_sheet.dart';
 import 'package:openvine/widgets/profile/profile_stats_row_widget.dart';
+import 'package:openvine/widgets/profile/profile_website_row.dart';
 import 'package:openvine/widgets/profile/verified_accounts_row.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
@@ -465,6 +466,12 @@ class _ProfileNameAndBio extends StatelessWidget {
         if (about != null && about!.isNotEmpty) ...[
           const SizedBox(height: 16),
           Skeleton.keep(child: _AboutText(about: about!)),
+        ],
+        if (profile?.website?.isNotEmpty == true) ...[
+          const SizedBox(height: 8),
+          Skeleton.keep(
+            child: ProfileWebsiteRow(url: profile!.website!),
+          ),
         ],
         _VerifiedAccountsBlock(isOwnProfile: isOwnProfile),
       ],

--- a/mobile/lib/widgets/profile/profile_website_row.dart
+++ b/mobile/lib/widgets/profile/profile_website_row.dart
@@ -44,13 +44,13 @@ class ProfileWebsiteRow extends StatelessWidget {
           padding: const EdgeInsets.symmetric(vertical: 4),
           child: Row(
             mainAxisSize: MainAxisSize.min,
+            spacing: 6,
             children: [
               const DivineIcon(
                 icon: DivineIconName.globe,
                 size: 14,
                 color: VineTheme.vineGreen,
               ),
-              const SizedBox(width: 6),
               Flexible(
                 child: Text(
                   displayUrl,

--- a/mobile/lib/widgets/profile/profile_website_row.dart
+++ b/mobile/lib/widgets/profile/profile_website_row.dart
@@ -1,0 +1,103 @@
+// ABOUTME: ProfileWebsiteRow — tappable website link row for profile headers.
+// ABOUTME: Renders the Kind-0 `website` field with a globe icon.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Pluggable URL launcher for tests.
+typedef WebsiteUrlLauncher = Future<bool> Function(Uri uri);
+
+Future<bool> _defaultLauncher(Uri uri) =>
+    launchUrl(uri, mode: LaunchMode.externalApplication);
+
+/// A single-line tappable row showing the `website` field from a Kind-0 profile.
+///
+/// Strips the URL scheme for display. Shows a snackbar when the system cannot
+/// open the URL. Override [launcher] in tests.
+class ProfileWebsiteRow extends StatelessWidget {
+  /// Creates a [ProfileWebsiteRow] for [url].
+  const ProfileWebsiteRow({
+    required this.url,
+    super.key,
+    this.launcher = _defaultLauncher,
+  });
+
+  /// The raw website URL from the Kind-0 `website` field.
+  final String url;
+
+  /// URL launcher hook for tests.
+  final WebsiteUrlLauncher launcher;
+
+  @override
+  Widget build(BuildContext context) {
+    final displayUrl = _displayUrl(url);
+    final launchUri = _launchUri(url);
+    return Semantics(
+      button: true,
+      label: context.l10n.profileWebsiteSemanticLabel(url),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(4),
+        onTap: launchUri == null ? null : () => _onTap(context, launchUri),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const DivineIcon(
+                icon: DivineIconName.globe,
+                size: 14,
+                color: VineTheme.vineGreen,
+              ),
+              const SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  displayUrl,
+                  style: VineTheme.bodySmallFont(color: VineTheme.vineGreen),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _onTap(BuildContext context, Uri uri) async {
+    final launched = await launcher(uri);
+    if (!launched && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          context.l10n.profileCouldNotOpenWebsite,
+        ),
+      );
+    }
+  }
+}
+
+/// Strips the URL scheme (and optionally `www.`) for display.
+String _displayUrl(String raw) {
+  var display = raw.trim();
+  display = display.replaceFirst(
+    RegExp('^https?://', caseSensitive: false),
+    '',
+  );
+  if (display.startsWith('www.')) display = display.substring(4);
+  if (display.endsWith('/')) display = display.substring(0, display.length - 1);
+  return display;
+}
+
+/// Returns the [Uri] to launch, adding `https://` when the raw value has no
+/// scheme. Returns `null` for unparseable values.
+Uri? _launchUri(String raw) {
+  final trimmed = raw.trim();
+  if (trimmed.isEmpty) return null;
+  final withScheme =
+      trimmed.startsWith(RegExp('https?://', caseSensitive: false))
+      ? trimmed
+      : 'https://$trimmed';
+  return Uri.tryParse(withScheme);
+}

--- a/mobile/test/widgets/profile/profile_website_row_test.dart
+++ b/mobile/test/widgets/profile/profile_website_row_test.dart
@@ -1,0 +1,110 @@
+// ABOUTME: Widget tests for ProfileWebsiteRow — render, tap, snackbar on failure.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/profile/profile_website_row.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  home: Scaffold(body: Center(child: child)),
+);
+
+void main() {
+  group(ProfileWebsiteRow, () {
+    testWidgets('displays URL with scheme stripped', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ProfileWebsiteRow(
+            url: 'https://example.com',
+            launcher: (_) async => true,
+          ),
+        ),
+      );
+      expect(find.text('example.com'), findsOneWidget);
+    });
+
+    testWidgets('strips www prefix from display URL', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ProfileWebsiteRow(
+            url: 'https://www.example.com',
+            launcher: (_) async => true,
+          ),
+        ),
+      );
+      expect(find.text('example.com'), findsOneWidget);
+    });
+
+    testWidgets('adds https scheme when missing before launching', (
+      tester,
+    ) async {
+      Uri? launched;
+      await tester.pumpWidget(
+        _wrap(
+          ProfileWebsiteRow(
+            url: 'example.com/path',
+            launcher: (uri) async {
+              launched = uri;
+              return true;
+            },
+          ),
+        ),
+      );
+      await tester.tap(find.byType(InkWell));
+      await tester.pumpAndSettle();
+      expect(launched?.scheme, equals('https'));
+      expect(launched?.host, equals('example.com'));
+      expect(launched?.path, equals('/path'));
+    });
+
+    testWidgets('launches the URL on tap', (tester) async {
+      Uri? launched;
+      await tester.pumpWidget(
+        _wrap(
+          ProfileWebsiteRow(
+            url: 'https://example.com',
+            launcher: (uri) async {
+              launched = uri;
+              return true;
+            },
+          ),
+        ),
+      );
+      await tester.tap(find.byType(InkWell));
+      await tester.pumpAndSettle();
+      expect(launched, equals(Uri.parse('https://example.com')));
+    });
+
+    testWidgets('shows snackbar when launcher returns false', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ProfileWebsiteRow(
+            url: 'https://example.com',
+            launcher: (_) async => false,
+          ),
+        ),
+      );
+      await tester.tap(find.byType(InkWell));
+      await tester.pump();
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(find.text(l10n.profileCouldNotOpenWebsite), findsOneWidget);
+    });
+
+    testWidgets('has semantic button label containing the URL', (tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          ProfileWebsiteRow(
+            url: 'https://example.com',
+            launcher: (_) async => true,
+          ),
+        ),
+      );
+      expect(
+        find.bySemanticsLabel(RegExp('example.com')),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `ProfileWebsiteRow` — a tappable globe-icon row that renders the Kind-0 `website` field between the bio and the verified-identity chip row
- Strips the URL scheme (`https://`) and `www.` prefix for clean display; normalises scheme-less values before launching
- Shows a snackbar when `url_launcher` fails to open the link
- Wires the row into `_ProfileNameAndBio` in `ProfileHeaderWidget` (only shown when `profile.website` is non-empty)
- 6 unit tests covering display normalisation, URL launch, scheme injection, and snackbar on failure

Closes the last missing acceptance criterion for #3935.

## What's left in #3935 after this PR

- **Platform-specific icons** in `VerifiedAccountChip` — no social-media SVG assets exist in `divine_ui` yet; globe is the current placeholder. Requires design asset delivery before implementation.

## Related issues

- Closes part of #3935
- #3937 is already fully implemented (`_VerifiedAccountsSection` + `_GetVerifiedTile` in `profile_setup_screen.dart`) — can be closed
- #3936 (Hive session cache) is a separate follow-up
- #4778 (Bluesky blocked, TikTok blank) is a `divine-identify-verification-service` issue — Bluesky/TikTok block OAuth inside WebViews; not fixable from mobile alone

## Test plan

- [ ] Profile with a `website` field set shows the globe-icon row below the bio
- [ ] Profile without a `website` field shows no row
- [ ] Tapping the row opens the URL in the system browser
- [ ] `www.` and `https://` are stripped from the display text
- [ ] `profile_website_row_test.dart` — all 6 tests pass