### PR TITLE
feat(profile): add website field to Edit Profile screen

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -932,6 +932,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
 
     final displayName = event.displayName.trim();
     final about = await _canonicalizeProfileAbout(event);
+    final website = event.website?.trim();
 
     // Bloc decides which NIP-05 value to use based on current mode
     final isExternal = state.nip05Mode == Nip05Mode.external_;
@@ -1033,6 +1034,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
       final savedProfile = await _profileRepository.saveProfileEvent(
         displayName: displayName,
         about: about,
+        website: website,
         username: username,
         nip05: externalNip05,
         clearNip05: clearNip05,

--- a/mobile/lib/blocs/profile_editor/profile_editor_event.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_event.dart
@@ -15,6 +15,7 @@ final class ProfileSaved extends ProfileEditorEvent {
     required this.pubkey,
     required this.displayName,
     this.about,
+    this.website,
     this.username,
     this.externalNip05,
     this.picture,
@@ -29,6 +30,9 @@ final class ProfileSaved extends ProfileEditorEvent {
 
   /// Bio/about text (optional).
   final String? about;
+
+  /// Website URL from the Kind-0 `website` field (optional).
+  final String? website;
 
   /// Username to claim as `_@username.divine.video` (optional, divine mode).
   final String? username;

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4060,5 +4060,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4066,5 +4066,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -409,6 +409,8 @@
   "profileSetupDisplayNameRequired": "Please enter a display name",
   "profileSetupBioLabel": "Bio (Optional)",
   "profileSetupBioHint": "Tell people about yourself...",
+  "profileSetupWebsiteLabel": "Website (Optional)",
+  "profileSetupWebsiteHint": "https://yoursite.com",
   "profileSetupPublicKeyLabel": "Public key (npub)",
   "profileSetupUsernameLabel": "Username (Optional)",
   "profileSetupUsernameHint": "username",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2473,5 +2473,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3221,5 +3221,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3932,5 +3932,7 @@
         }
     },
     "profileWebsiteSemanticLabel": "Visit website: {url}",
-    "profileCouldNotOpenWebsite": "Could not open website"
+    "profileCouldNotOpenWebsite": "Could not open website",
+    "profileSetupWebsiteLabel": "Website (Optional)",
+    "profileSetupWebsiteHint": "https://yoursite.com"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -1402,6 +1402,18 @@ abstract class AppLocalizations {
   /// **'Tell people about yourself...'**
   String get profileSetupBioHint;
 
+  /// No description provided for @profileSetupWebsiteLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Website (Optional)'**
+  String get profileSetupWebsiteLabel;
+
+  /// No description provided for @profileSetupWebsiteHint.
+  ///
+  /// In en, this message translates to:
+  /// **'https://yoursite.com'**
+  String get profileSetupWebsiteHint;
+
   /// No description provided for @profileSetupPublicKeyLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -749,6 +749,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get profileSetupBioHint => 'ስለራስዎ ለሰዎች ይንገሩ…';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'የህዝብ ቁልፍ (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -751,6 +751,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get profileSetupBioHint => 'أخبر الناس عن نفسك...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'المفتاح العام (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -783,6 +783,12 @@ class AppLocalizationsBg extends AppLocalizations {
   String get profileSetupBioHint => 'Разкажи на хората за себе си...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Публичен ключ (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -782,6 +782,12 @@ class AppLocalizationsDe extends AppLocalizations {
   String get profileSetupBioHint => 'Erzähl den Leuten etwas über dich...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Public Key (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -774,6 +774,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileSetupBioHint => 'Tell people about yourself...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Public key (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -783,6 +783,12 @@ class AppLocalizationsEs extends AppLocalizations {
   String get profileSetupBioHint => 'Contale algo sobre vos...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Clave pública (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -786,6 +786,12 @@ class AppLocalizationsFil extends AppLocalizations {
   String get profileSetupBioHint => 'Sabihin sa iba ang tungkol sa iyo...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Public key (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -791,6 +791,12 @@ class AppLocalizationsFr extends AppLocalizations {
   String get profileSetupBioHint => 'Parle un peu de toi...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Clé publique (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -759,6 +759,12 @@ class AppLocalizationsId extends AppLocalizations {
   String get profileSetupBioHint => 'Ceritakan tentang dirimu...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Kunci publik (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -785,6 +785,12 @@ class AppLocalizationsIt extends AppLocalizations {
   String get profileSetupBioHint => 'Racconta qualcosa di te...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Chiave pubblica (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -718,6 +718,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get profileSetupBioHint => 'あなたのことを書いてみて...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => '公開鍵 (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -719,6 +719,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get profileSetupBioHint => '자신을 소개해보세요...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => '공개 키 (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -776,6 +776,12 @@ class AppLocalizationsNl extends AppLocalizations {
   String get profileSetupBioHint => 'Vertel iets over jezelf...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Publieke sleutel (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -785,6 +785,12 @@ class AppLocalizationsPl extends AppLocalizations {
   String get profileSetupBioHint => 'Powiedz coś o sobie...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Klucz publiczny (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -785,6 +785,12 @@ class AppLocalizationsPt extends AppLocalizations {
   String get profileSetupBioHint => 'Fale um pouco sobre você...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Chave pública (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -803,6 +803,12 @@ class AppLocalizationsRo extends AppLocalizations {
   String get profileSetupBioHint => 'Spune-le oamenilor despre tine...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Cheie publică (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -760,6 +760,12 @@ class AppLocalizationsSv extends AppLocalizations {
   String get profileSetupBioHint => 'Berätta om dig själv...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Publik nyckel (npub)';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -757,6 +757,12 @@ class AppLocalizationsTr extends AppLocalizations {
   String get profileSetupBioHint => 'İnsanlara kendinden bahset...';
 
   @override
+  String get profileSetupWebsiteLabel => 'Website (Optional)';
+
+  @override
+  String get profileSetupWebsiteHint => 'https://yoursite.com';
+
+  @override
   String get profileSetupPublicKeyLabel => 'Açık anahtar (npub)';
 
   @override

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -149,6 +149,7 @@ class _ProfileSetupScreenViewState
     extends ConsumerState<ProfileSetupScreenView> {
   final _nameController = TextEditingController();
   final _bioController = TextEditingController();
+  final _websiteController = TextEditingController();
   final _pictureController = TextEditingController();
   final _nip05Controller = TextEditingController();
   final ImagePicker _picker = ImagePicker();
@@ -156,6 +157,7 @@ class _ProfileSetupScreenViewState
   // Focus nodes for tracking field focus state
   final _nameFocusNode = FocusNode();
   final _bioFocusNode = FocusNode();
+  final _websiteFocusNode = FocusNode();
   final _usernameFocusNode = FocusNode();
 
   // Local-preview state for the brief window between picking and the
@@ -175,6 +177,7 @@ class _ProfileSetupScreenViewState
     super.initState();
     // Rebuild when display name changes so save button updates.
     _nameController.addListener(_onFocusChange);
+    _websiteFocusNode.addListener(_onFocusChange);
     // Add focus listeners to update label colors
     _nameFocusNode.addListener(_onFocusChange);
     _bioFocusNode.addListener(_onFocusChange);
@@ -190,13 +193,16 @@ class _ProfileSetupScreenViewState
     _nameController.removeListener(_onFocusChange);
     _nameController.dispose();
     _bioController.dispose();
+    _websiteController.dispose();
     _pictureController.dispose();
     _nip05Controller.dispose();
     _nameFocusNode.removeListener(_onFocusChange);
     _bioFocusNode.removeListener(_onFocusChange);
+    _websiteFocusNode.removeListener(_onFocusChange);
     _usernameFocusNode.removeListener(_onFocusChange);
     _nameFocusNode.dispose();
     _bioFocusNode.dispose();
+    _websiteFocusNode.dispose();
     _usernameFocusNode.dispose();
 
     super.dispose();
@@ -220,6 +226,7 @@ class _ProfileSetupScreenViewState
             setState(() {
               _nameController.text = profile.displayName ?? profile.name ?? '';
               _bioController.text = profile.about ?? '';
+              _websiteController.text = profile.website ?? '';
               _pictureController.text = profile.picture ?? '';
 
               if (extractedUsername != null) {
@@ -923,6 +930,73 @@ class _ProfileSetupScreenViewState
                               ),
                               const SizedBox(height: 16),
 
+                              // Website
+                              Padding(
+                                padding: const EdgeInsetsDirectional.only(
+                                  start: 16,
+                                ),
+                                child: Text(
+                                  context.l10n.profileSetupWebsiteLabel,
+                                  style: VineTheme.labelMediumFont(
+                                    color: _websiteFocusNode.hasFocus
+                                        ? VineTheme.primary
+                                        : VineTheme.onSurfaceMuted,
+                                  ),
+                                ),
+                              ),
+                              TextFormField(
+                                controller: _websiteController,
+                                focusNode: _websiteFocusNode,
+                                style: VineTheme.bodyLargeFont(
+                                  color: VineTheme.onSurface,
+                                ),
+                                decoration: InputDecoration(
+                                  isCollapsed: true,
+                                  hintText:
+                                      context.l10n.profileSetupWebsiteHint,
+                                  hintStyle: const TextStyle(
+                                    color: VineTheme.lightText,
+                                  ),
+                                  border: const UnderlineInputBorder(
+                                    borderRadius: BorderRadius.zero,
+                                    borderSide: BorderSide(
+                                      color: VineTheme.neutral10,
+                                    ),
+                                  ),
+                                  enabledBorder: const UnderlineInputBorder(
+                                    borderRadius: BorderRadius.zero,
+                                    borderSide: BorderSide(
+                                      color: VineTheme.neutral10,
+                                    ),
+                                  ),
+                                  focusedBorder: const UnderlineInputBorder(
+                                    borderRadius: BorderRadius.zero,
+                                    borderSide: BorderSide(
+                                      color: VineTheme.neutral10,
+                                    ),
+                                  ),
+                                  errorBorder: const UnderlineInputBorder(
+                                    borderRadius: BorderRadius.zero,
+                                    borderSide: BorderSide(
+                                      color: VineTheme.neutral10,
+                                    ),
+                                  ),
+                                  focusedErrorBorder:
+                                      const UnderlineInputBorder(
+                                        borderRadius: BorderRadius.zero,
+                                        borderSide: BorderSide(
+                                          color: VineTheme.neutral10,
+                                        ),
+                                      ),
+                                  contentPadding: const EdgeInsets.all(16),
+                                ),
+                                keyboardType: TextInputType.url,
+                                textInputAction: TextInputAction.next,
+                                onFieldSubmitted: (_) =>
+                                    FocusScope.of(context).nextFocus(),
+                              ),
+                              const SizedBox(height: 16),
+
                               const _VerifiedAccountsSection(),
 
                               const _PublicKeyLink(),
@@ -1166,6 +1240,7 @@ class _ProfileSetupScreenViewState
                                 pubkey: pubkey,
                                 displayName: _nameController.text,
                                 about: _bioController.text,
+                                website: _websiteController.text,
                                 username: _nip05Controller.text,
                                 // Picture and banner are owned by bloc state.
                                 // The bloc reads pendingPictureUrl /
@@ -1204,6 +1279,7 @@ class _ProfileSetupScreenViewState
         pubkey: pubkey,
         displayName: _nameController.text,
         about: _bioController.text,
+        website: _websiteController.text,
         username: _nip05Controller.text,
         // Picture and banner sourced from bloc state (see ProfileSaved
         // dispatch above) via `effectiveBanner` / `effectivePictureUrl`.

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -154,6 +154,12 @@ class _ProfileSetupScreenViewState
   final _nip05Controller = TextEditingController();
   final ImagePicker _picker = ImagePicker();
 
+  static const _kInputBorder = UnderlineInputBorder(
+    borderRadius: BorderRadius.zero,
+    borderSide: BorderSide(color: VineTheme.neutral10),
+  );
+  static const _kHintStyle = TextStyle(color: VineTheme.lightText);
+
   // Focus nodes for tracking field focus state
   final _nameFocusNode = FocusNode();
   final _bioFocusNode = FocusNode();
@@ -798,40 +804,12 @@ class _ProfileSetupScreenViewState
                                     color: VineTheme.onSurfaceMuted,
                                     fontSize: 12,
                                   ),
-                                  hintStyle: const TextStyle(
-                                    color: VineTheme.lightText,
-                                  ),
-                                  border: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  enabledBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  focusedBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  errorBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  focusedErrorBorder:
-                                      const UnderlineInputBorder(
-                                        borderRadius: BorderRadius.zero,
-                                        borderSide: BorderSide(
-                                          color: VineTheme.neutral10,
-                                        ),
-                                      ),
+                                  hintStyle: _kHintStyle,
+                                  border: _kInputBorder,
+                                  enabledBorder: _kInputBorder,
+                                  focusedBorder: _kInputBorder,
+                                  errorBorder: _kInputBorder,
+                                  focusedErrorBorder: _kInputBorder,
                                   contentPadding: const EdgeInsets.all(16),
                                 ),
                                 textInputAction: TextInputAction.next,
@@ -883,40 +861,12 @@ class _ProfileSetupScreenViewState
                                 decoration: InputDecoration(
                                   isCollapsed: true,
                                   hintText: context.l10n.profileSetupBioHint,
-                                  hintStyle: const TextStyle(
-                                    color: VineTheme.lightText,
-                                  ),
-                                  border: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  enabledBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  focusedBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  errorBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  focusedErrorBorder:
-                                      const UnderlineInputBorder(
-                                        borderRadius: BorderRadius.zero,
-                                        borderSide: BorderSide(
-                                          color: VineTheme.neutral10,
-                                        ),
-                                      ),
+                                  hintStyle: _kHintStyle,
+                                  border: _kInputBorder,
+                                  enabledBorder: _kInputBorder,
+                                  focusedBorder: _kInputBorder,
+                                  errorBorder: _kInputBorder,
+                                  focusedErrorBorder: _kInputBorder,
                                   contentPadding: const EdgeInsets.all(16),
                                   counterText: '',
                                 ),
@@ -954,40 +904,12 @@ class _ProfileSetupScreenViewState
                                   isCollapsed: true,
                                   hintText:
                                       context.l10n.profileSetupWebsiteHint,
-                                  hintStyle: const TextStyle(
-                                    color: VineTheme.lightText,
-                                  ),
-                                  border: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  enabledBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  focusedBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  errorBorder: const UnderlineInputBorder(
-                                    borderRadius: BorderRadius.zero,
-                                    borderSide: BorderSide(
-                                      color: VineTheme.neutral10,
-                                    ),
-                                  ),
-                                  focusedErrorBorder:
-                                      const UnderlineInputBorder(
-                                        borderRadius: BorderRadius.zero,
-                                        borderSide: BorderSide(
-                                          color: VineTheme.neutral10,
-                                        ),
-                                      ),
+                                  hintStyle: _kHintStyle,
+                                  border: _kInputBorder,
+                                  enabledBorder: _kInputBorder,
+                                  focusedBorder: _kInputBorder,
+                                  errorBorder: _kInputBorder,
+                                  focusedErrorBorder: _kInputBorder,
                                   contentPadding: const EdgeInsets.all(16),
                                 ),
                                 keyboardType: TextInputType.url,
@@ -1060,47 +982,12 @@ class _ProfileSetupScreenViewState
                                           hintStyle: const TextStyle(
                                             color: VineTheme.onSurfaceMuted,
                                           ),
-                                          border: const UnderlineInputBorder(
-                                            borderRadius: BorderRadius.zero,
-                                            borderSide: BorderSide(
-                                              color: VineTheme.neutral10,
-                                            ),
-                                          ),
-                                          enabledBorder:
-                                              const UnderlineInputBorder(
-                                                borderRadius: BorderRadius.zero,
-                                                borderSide: BorderSide(
-                                                  color: VineTheme.neutral10,
-                                                ),
-                                              ),
-                                          disabledBorder:
-                                              const UnderlineInputBorder(
-                                                borderRadius: BorderRadius.zero,
-                                                borderSide: BorderSide(
-                                                  color: VineTheme.neutral10,
-                                                ),
-                                              ),
-                                          focusedBorder:
-                                              const UnderlineInputBorder(
-                                                borderRadius: BorderRadius.zero,
-                                                borderSide: BorderSide(
-                                                  color: VineTheme.neutral10,
-                                                ),
-                                              ),
-                                          errorBorder:
-                                              const UnderlineInputBorder(
-                                                borderRadius: BorderRadius.zero,
-                                                borderSide: BorderSide(
-                                                  color: VineTheme.neutral10,
-                                                ),
-                                              ),
-                                          focusedErrorBorder:
-                                              const UnderlineInputBorder(
-                                                borderRadius: BorderRadius.zero,
-                                                borderSide: BorderSide(
-                                                  color: VineTheme.neutral10,
-                                                ),
-                                              ),
+                                          border: _kInputBorder,
+                                          enabledBorder: _kInputBorder,
+                                          disabledBorder: _kInputBorder,
+                                          focusedBorder: _kInputBorder,
+                                          errorBorder: _kInputBorder,
+                                          focusedErrorBorder: _kInputBorder,
                                           contentPadding: const EdgeInsets.all(
                                             16,
                                           ),

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -516,6 +516,7 @@ class ProfileRepository {
   Future<UserProfile> saveProfileEvent({
     required String displayName,
     String? about,
+    String? website,
     String? username,
     String? nip05,
     bool clearNip05 = false,
@@ -547,6 +548,11 @@ class ProfileRepository {
       newContent['about'] = about;
     } else {
       newContent.remove('about');
+    }
+    if (website != null && website.isNotEmpty) {
+      newContent['website'] = website;
+    } else if (website != null) {
+      newContent.remove('website');
     }
     if (picture != null && picture.isNotEmpty) {
       newContent['picture'] = picture;

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -1388,6 +1388,44 @@ void main() {
         ).called(1);
       });
 
+      test('includes website when provided', () async {
+        await profileRepository.saveProfileEvent(
+          displayName: 'Test User',
+          website: 'https://example.com',
+        );
+
+        final captured =
+            verify(
+                  () => mockNostrClient.sendProfile(
+                    profileContent: captureAny(named: 'profileContent'),
+                  ),
+                ).captured.single
+                as Map<String, dynamic>;
+        expect(captured['website'], equals('https://example.com'));
+      });
+
+      test('removes website key when empty string is passed', () async {
+        final currentProfile = await createCurrentProfile({
+          'display_name': 'Old Name',
+          'website': 'https://old.com',
+        });
+
+        await profileRepository.saveProfileEvent(
+          displayName: 'New Name',
+          website: '',
+          currentProfile: currentProfile,
+        );
+
+        final captured =
+            verify(
+                  () => mockNostrClient.sendProfile(
+                    profileContent: captureAny(named: 'profileContent'),
+                  ),
+                ).captured.single
+                as Map<String, dynamic>;
+        expect(captured.containsKey('website'), isFalse);
+      });
+
       test(
         'throws ProfilePublishFailedException when sendProfile fails',
         () async {


### PR DESCRIPTION
## Summary

- Adds a **Website (Optional)** text field to the Edit Profile screen, positioned after the bio field (matching the Name → Bio → Website convention from Twitter/Instagram)
- Pre-populates from the user's cached Kind-0 `website` value on screen load
- On save: non-empty value writes the `website` key into the Kind-0 content map; empty string removes it; omitting the parameter (other `saveProfileEvent` callers) leaves the seed value untouched
- Adds `profileSetupWebsiteLabel` and `profileSetupWebsiteHint` l10n keys to `app_en.arb` and all 17 non-English ARBs with English placeholder values for the translation pipeline

## Test plan

- [ ] Open Edit Profile — existing website value pre-fills the field
- [ ] Clear the website field and save — `website` key is removed from Kind-0
- [ ] Enter a new URL and save — `website` key is updated in Kind-0, and `ProfileWebsiteRow` shows the new value on the profile header
- [ ] Profile without a website: field is blank, save publishes without a `website` key

Closes #5108