### PR TITLE
feat(camera): forward native DivineCamera diagnostics to UnifiedLogger

### DIFF
--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -17,7 +17,6 @@ import android.hardware.camera2.CaptureResult
 import android.hardware.camera2.TotalCaptureResult
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
 import android.view.Surface
 import android.view.WindowManager
 import androidx.camera.camera2.interop.Camera2CameraInfo
@@ -67,7 +66,12 @@ class CameraController(
     private var isTorchEnabled: Boolean = false
     private var isRecording: Boolean = false
     private var recordingTrulyStarted: Boolean = false
-    
+
+    // Last observed CameraX audio-source state for the active recording, so we
+    // only forward a diagnostic when it transitions (the Status event fires
+    // continuously). Reset to the sentinel on each recording Start.
+    private var lastAudioState: Int = Int.MIN_VALUE
+
     // Callback for startRecording - called when recording truly starts or is aborted
     private var startRecordingCallback: ((String?) -> Unit)? = null
     private var isPaused: Boolean = false
@@ -207,7 +211,7 @@ class CameraController(
         enableAutoLensSwitch: Boolean = true,
         callback: (Map<String, Any?>?, String?) -> Unit
     ) {
-        Log.d(TAG, "Initializing camera with lens: $lens, quality: $quality, enableScreenFlash: $enableScreenFlash, mirrorFrontCameraOutput: $mirrorFrontCameraOutput, autoLensSwitch: $enableAutoLensSwitch (portrait mode 1080x1920)")
+        DivineCameraLog.d(TAG, "Initializing camera with lens: $lens, quality: $quality, enableScreenFlash: $enableScreenFlash, mirrorFrontCameraOutput: $mirrorFrontCameraOutput, autoLensSwitch: $enableAutoLensSwitch (portrait mode 1080x1920)")
 
         screenFlashFeatureEnabled = enableScreenFlash
         this.mirrorFrontCameraOutput = mirrorFrontCameraOutput
@@ -234,11 +238,11 @@ class CameraController(
         if (requestedCameraId == null) {
             // Fallback: try back camera first, then front
             if (hasBackCamera) {
-                Log.w(TAG, "Requested lens $lens not available, falling back to back camera")
+                DivineCameraLog.w(TAG, "Requested lens $lens not available, falling back to back camera")
                 currentLensType = "back"
                 currentLens = CameraSelector.LENS_FACING_BACK
             } else if (hasFrontCamera) {
-                Log.w(TAG, "Requested lens $lens not available, falling back to front camera")
+                DivineCameraLog.w(TAG, "Requested lens $lens not available, falling back to front camera")
                 currentLensType = "front"
                 currentLens = CameraSelector.LENS_FACING_FRONT
             }
@@ -248,10 +252,10 @@ class CameraController(
         cameraProviderFuture.addListener({
             try {
                 cameraProvider = cameraProviderFuture.get()
-                Log.d(TAG, "Camera provider obtained")
+                DivineCameraLog.d(TAG, "Camera provider obtained")
                 startCamera(callback)
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to get camera provider", e)
+                DivineCameraLog.e(TAG, "Failed to get camera provider", e)
                 mainHandler.post {
                     callback(null, "Failed to get camera provider: ${e.message}")
                 }
@@ -286,13 +290,13 @@ class CameraController(
                     CameraCharacteristics.LENS_FACING_FRONT -> {
                         val primaryFocalLength = focalLengths?.firstOrNull() ?: 0f
                         frontCameraFocalLengths[cameraId] = primaryFocalLength
-                        Log.d(TAG, "Front camera $cameraId: focalLength=$primaryFocalLength, logical=$isLogicalCamera")
+                        DivineCameraLog.d(TAG, "Front camera $cameraId: focalLength=$primaryFocalLength, logical=$isLogicalCamera")
                     }
                     CameraCharacteristics.LENS_FACING_BACK -> {
                         // Get the primary focal length for this camera
                         val primaryFocalLength = focalLengths?.firstOrNull() ?: 0f
                         backCameraFocalLengths[cameraId] = primaryFocalLength
-                        Log.d(TAG, "Back camera $cameraId: focalLength=$primaryFocalLength, logical=$isLogicalCamera")
+                        DivineCameraLog.d(TAG, "Back camera $cameraId: focalLength=$primaryFocalLength, logical=$isLogicalCamera")
                     }
                 }
             }
@@ -311,7 +315,7 @@ class CameraController(
                     val ultraWideCandidate = sorted.last()
                     if (ultraWideCandidate.value < sorted.first().value - 0.3f) {
                         frontUltraWideCameraId = ultraWideCandidate.key
-                        Log.d(TAG, "Front ultra-wide camera detected: ${ultraWideCandidate.key}")
+                        DivineCameraLog.d(TAG, "Front ultra-wide camera detected: ${ultraWideCandidate.key}")
                     }
                 }
             }
@@ -340,7 +344,7 @@ class CameraController(
                                 .SCALER_AVAILABLE_MAX_DIGITAL_ZOOM
                         ) ?: 10.0f
                     } catch (e: Exception) {
-                        Log.w(TAG, "Could not read main camera max zoom", e)
+                        DivineCameraLog.w(TAG, "Could not read main camera max zoom", e)
                     }
                     
                     // Cameras with shorter focal length are ultra-wide
@@ -348,7 +352,7 @@ class CameraController(
                         .maxByOrNull { it.value }?.let {
                             ultraWideCameraId = it.key
                             ultraWideCameraFocalLength = it.value
-                            Log.d(TAG, "Ultra-wide camera detected: ${it.key} (focal=${it.value}mm)")
+                            DivineCameraLog.d(TAG, "Ultra-wide camera detected: ${it.key} (focal=${it.value}mm)")
                             try {
                                 val uwChars = cameraManager
                                     .getCameraCharacteristics(it.key)
@@ -357,7 +361,7 @@ class CameraController(
                                         .SCALER_AVAILABLE_MAX_DIGITAL_ZOOM
                                 ) ?: 8.0f
                             } catch (e: Exception) {
-                                Log.w(TAG, "Could not read ultra-wide max zoom", e)
+                                DivineCameraLog.w(TAG, "Could not read ultra-wide max zoom", e)
                             }
                         }
                     
@@ -366,7 +370,7 @@ class CameraController(
                         .minByOrNull { it.value }?.let {
                             telephotoCameraId = it.key
                             telephotoCameraFocalLength = it.value
-                            Log.d(TAG, "Telephoto camera detected: ${it.key} (focal=${it.value}mm)")
+                            DivineCameraLog.d(TAG, "Telephoto camera detected: ${it.key} (focal=${it.value}mm)")
                             try {
                                 val teleChars = cameraManager
                                     .getCameraCharacteristics(it.key)
@@ -375,7 +379,7 @@ class CameraController(
                                         .SCALER_AVAILABLE_MAX_DIGITAL_ZOOM
                                 ) ?: 10.0f
                             } catch (e: Exception) {
-                                Log.w(TAG, "Could not read telephoto max zoom", e)
+                                DivineCameraLog.w(TAG, "Could not read telephoto max zoom", e)
                             }
                         }
                 } else if (sorted.isNotEmpty()) {
@@ -392,18 +396,18 @@ class CameraController(
                     // Macro cameras typically have minimum focus distance > 10 diopters (< 10cm focus)
                     if (minFocusDistance != null && minFocusDistance > 10.0f && cameraId != backCameraId) {
                         macroCameraId = cameraId
-                        Log.d(TAG, "Macro camera detected: $cameraId (minFocusDist=$minFocusDistance)")
+                        DivineCameraLog.d(TAG, "Macro camera detected: $cameraId (minFocusDist=$minFocusDistance)")
                         break
                     }
                 }
             }
             
-            Log.d(TAG, "Camera availability: front=$hasFrontCamera, " +
+            DivineCameraLog.d(TAG, "Camera availability: front=$hasFrontCamera, " +
                 "frontUltraWide=${frontUltraWideCameraId != null}, back=$hasBackCamera, " +
                 "ultraWide=${ultraWideCameraId != null}, telephoto=${telephotoCameraId != null}, " +
                 "macro=${macroCameraId != null}")
         } catch (e: Exception) {
-            Log.e(TAG, "Error checking camera availability", e)
+            DivineCameraLog.e(TAG, "Error checking camera availability", e)
         }
     }
     
@@ -431,7 +435,7 @@ class CameraController(
             val chars = cameraManager.getCameraCharacteristics(cameraId)
             extractCameraMetadata(chars, currentLensType, cameraId)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to get metadata for current lens $currentLensType", e)
+            DivineCameraLog.e(TAG, "Failed to get metadata for current lens $currentLensType", e)
             null
         }
     }
@@ -584,7 +588,7 @@ class CameraController(
                         val camera2Info = Camera2CameraInfo.from(cameraInfo)
                         camera2Info.cameraId == cameraId
                     } catch (e: Exception) {
-                        Log.w(TAG, "Failed to get Camera2CameraInfo: ${e.message}")
+                        DivineCameraLog.w(TAG, "Failed to get Camera2CameraInfo: ${e.message}")
                         false
                     }
                 }
@@ -612,14 +616,14 @@ class CameraController(
      */
     private fun startCamera(callback: (Map<String, Any?>?, String?) -> Unit) {
         val provider = cameraProvider ?: run {
-            Log.e(TAG, "Camera provider not available")
+            DivineCameraLog.e(TAG, "Camera provider not available")
             callback(null, "Camera provider not available")
             return
         }
 
         // Check if activity is a LifecycleOwner
         if (activity !is LifecycleOwner) {
-            Log.e(TAG, "Activity is not a LifecycleOwner: ${activity.javaClass.name}")
+            DivineCameraLog.e(TAG, "Activity is not a LifecycleOwner: ${activity.javaClass.name}")
             callback(null, "Activity must be a LifecycleOwner (use FlutterFragmentActivity)")
             return
         }
@@ -627,7 +631,7 @@ class CameraController(
         try {
             // Unbind all use cases before rebinding
             provider.unbindAll()
-            Log.d(TAG, "Unbound all previous use cases")
+            DivineCameraLog.d(TAG, "Unbound all previous use cases")
 
             // Release previous resources only if not already handled (e.g., by switchCamera)
             if (textureEntry != null) {
@@ -643,12 +647,12 @@ class CameraController(
             flutterSurfaceTexture = textureEntry?.surfaceTexture()
 
             val textureId = textureEntry?.id() ?: run {
-                Log.e(TAG, "Failed to create texture entry")
+                DivineCameraLog.e(TAG, "Failed to create texture entry")
                 callback(null, "Failed to create texture")
                 return
             }
 
-            Log.d(TAG, "Created Flutter texture with id: $textureId")
+            DivineCameraLog.d(TAG, "Created Flutter texture with id: $textureId")
 
             // Build camera selector for the current lens type
             val cameraSelector = buildCameraSelectorForLens(currentLensType, provider)
@@ -667,14 +671,14 @@ class CameraController(
                 val resolution = request.resolution
                 videoWidth = resolution.width
                 videoHeight = resolution.height
-                Log.d(
+                DivineCameraLog.d(
                     TAG,
                     "Surface provider called with resolution: ${videoWidth}x${videoHeight}"
                 )
 
                 // Update aspect ratio for portrait mode (height/width gives 9:16 ratio)
                 aspectRatio = videoHeight.toFloat() / videoWidth.toFloat()
-                Log.d(TAG, "Aspect ratio set to: $aspectRatio (portrait), video dimensions: ${videoWidth}x${videoHeight}")
+                DivineCameraLog.d(TAG, "Aspect ratio set to: $aspectRatio (portrait), video dimensions: ${videoWidth}x${videoHeight}")
 
                 // Set the buffer size to match camera resolution
                 flutterSurfaceTexture?.setDefaultBufferSize(videoWidth, videoHeight)
@@ -688,7 +692,7 @@ class CameraController(
                         previewSurface!!,
                         ContextCompat.getMainExecutor(context)
                     ) { result ->
-                        Log.d(TAG, "Surface result code: ${result.resultCode}")
+                        DivineCameraLog.d(TAG, "Surface result code: ${result.resultCode}")
                     }
 
                     // Call the callback NOW after we have the correct resolution
@@ -696,11 +700,11 @@ class CameraController(
                         callbackCalled = true
                         val state = getCameraState().toMutableMap()
                         state["textureId"] = textureId
-                        Log.d(TAG, "Camera initialized successfully: $state")
+                        DivineCameraLog.d(TAG, "Camera initialized successfully: $state")
                         callback(state, null)
                     }
                 } else {
-                    Log.e(TAG, "Preview surface is null or invalid!")
+                    DivineCameraLog.e(TAG, "Preview surface is null or invalid!")
                     if (!callbackCalled) {
                         callbackCalled = true
                         callback(null, "Failed to create preview surface")
@@ -731,7 +735,7 @@ class CameraController(
                 )
                 .build()
 
-            Log.d(TAG, "Binding use cases to lifecycle...")
+            DivineCameraLog.d(TAG, "Binding use cases to lifecycle...")
 
             // Bind use cases to camera
             camera = provider.bindToLifecycle(
@@ -741,7 +745,7 @@ class CameraController(
                 videoCapture
             )
 
-            Log.d(TAG, "Camera bound successfully")
+            DivineCameraLog.d(TAG, "Camera bound successfully")
 
             // Get camera info
             camera?.let { cam ->
@@ -755,14 +759,14 @@ class CameraController(
                     (screenFlashFeatureEnabled && currentLens == CameraSelector.LENS_FACING_FRONT)
                 isFocusPointSupported = true
                 isExposurePointSupported = true
-                Log.d(TAG, "Camera info: zoom=$minZoom-$maxZoom, flash=$hasFlash")
+                DivineCameraLog.d(TAG, "Camera info: zoom=$minZoom-$maxZoom, flash=$hasFlash")
             }
 
             // Compute virtual zoom ranges for auto lens switching
             computeVirtualZoomRanges()
 
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to start camera", e)
+            DivineCameraLog.e(TAG, "Failed to start camera", e)
             mainHandler.post {
                 callback(null, "Failed to start camera: ${e.message}")
             }
@@ -777,7 +781,7 @@ class CameraController(
         lens: String,
         callback: (Map<String, Any?>?, String?) -> Unit
     ) {
-        Log.d(TAG, "Switching camera to: $lens")
+        DivineCameraLog.d(TAG, "Switching camera to: $lens")
         
         // Disable screen flash when switching cameras
         disableScreenFlash()
@@ -789,19 +793,19 @@ class CameraController(
         // Check if the requested lens is available
         val requestedCameraId = getCameraIdForLens(currentLensType)
         if (requestedCameraId == null) {
-            Log.e(TAG, "Requested lens $lens is not available")
+            DivineCameraLog.e(TAG, "Requested lens $lens is not available")
             callback(null, "Lens $lens is not available on this device")
             return
         }
 
         val provider = cameraProvider ?: run {
-            Log.e(TAG, "Camera provider not available")
+            DivineCameraLog.e(TAG, "Camera provider not available")
             callback(null, "Camera provider not available")
             return
         }
 
         if (activity !is LifecycleOwner) {
-            Log.e(TAG, "Activity is not a LifecycleOwner")
+            DivineCameraLog.e(TAG, "Activity is not a LifecycleOwner")
             callback(null, "Activity must be a LifecycleOwner")
             return
         }
@@ -825,7 +829,7 @@ class CameraController(
                 val resolution = request.resolution
                 videoWidth = resolution.width
                 videoHeight = resolution.height
-                Log.d(
+                DivineCameraLog.d(
                     TAG,
                     "Switch: Surface provider called with resolution: ${videoWidth}x${videoHeight}"
                 )
@@ -842,7 +846,7 @@ class CameraController(
                         previewSurface!!,
                         ContextCompat.getMainExecutor(context)
                     ) { result ->
-                        Log.d(TAG, "Switch: Surface result code: ${result.resultCode}")
+                        DivineCameraLog.d(TAG, "Switch: Surface result code: ${result.resultCode}")
                     }
                 } else {
                     // Surface was released, create new one
@@ -852,7 +856,7 @@ class CameraController(
                             previewSurface!!,
                             ContextCompat.getMainExecutor(context)
                         ) { result ->
-                            Log.d(TAG, "Switch: New surface result code: ${result.resultCode}")
+                            DivineCameraLog.d(TAG, "Switch: New surface result code: ${result.resultCode}")
                         }
                     }
                 }
@@ -905,14 +909,14 @@ class CameraController(
             // Compute virtual zoom ranges for auto lens switching
             computeVirtualZoomRanges()
 
-            Log.d(TAG, "Camera switched successfully")
+            DivineCameraLog.d(TAG, "Camera switched successfully")
 
             mainHandler.post {
                 callback(getCameraState(), null)
             }
 
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to switch camera", e)
+            DivineCameraLog.e(TAG, "Failed to switch camera", e)
             mainHandler.post {
                 callback(null, "Failed to switch camera: ${e.message}")
             }
@@ -927,7 +931,7 @@ class CameraController(
     fun setFlashMode(mode: String): Boolean {
         val cam = camera ?: return false
 
-        Log.d(TAG, "Setting flash mode: $mode (currentLens: ${if (currentLens == CameraSelector.LENS_FACING_FRONT) "front" else "back"})")
+        DivineCameraLog.d(TAG, "Setting flash mode: $mode (currentLens: ${if (currentLens == CameraSelector.LENS_FACING_FRONT) "front" else "back"})")
 
         return try {
             // Handle screen brightness for front camera "torch" mode
@@ -943,7 +947,7 @@ class CameraController(
                     isTorchEnabled = false
                     isAutoFlashMode = true
                     currentFlashMode = ImageCapture.FLASH_MODE_AUTO
-                    Log.d(TAG, "Auto flash mode enabled for front camera")
+                    DivineCameraLog.d(TAG, "Auto flash mode enabled for front camera")
                     return true
                 } else {
                     disableScreenFlash()
@@ -967,7 +971,7 @@ class CameraController(
                     isAutoFlashMode = true
                     autoFlashTorchEnabled = false
                     currentFlashMode = ImageCapture.FLASH_MODE_AUTO
-                    Log.d(TAG, "Auto flash mode enabled - will check brightness when recording starts")
+                    DivineCameraLog.d(TAG, "Auto flash mode enabled - will check brightness when recording starts")
                 }
 
                 "on" -> {
@@ -985,7 +989,7 @@ class CameraController(
             }
             true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to set flash mode", e)
+            DivineCameraLog.e(TAG, "Failed to set flash mode", e)
             false
         }
     }
@@ -1006,9 +1010,9 @@ class CameraController(
                 window.attributes = layoutParams
                 isScreenFlashEnabled = true
                 
-                Log.d(TAG, "Screen flash enabled (brightness set to 100%)")
+                DivineCameraLog.d(TAG, "Screen flash enabled (brightness set to 100%)")
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to enable screen flash", e)
+                DivineCameraLog.e(TAG, "Failed to enable screen flash", e)
             }
         }
     }
@@ -1036,9 +1040,9 @@ class CameraController(
                 
                 isScreenFlashEnabled = false
                 
-                Log.d(TAG, "Screen flash disabled (brightness restored to system control)")
+                DivineCameraLog.d(TAG, "Screen flash disabled (brightness restored to system control)")
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to disable screen flash", e)
+                DivineCameraLog.e(TAG, "Failed to disable screen flash", e)
             }
         }
     }
@@ -1056,7 +1060,7 @@ class CameraController(
         
         // If ISO is high or exposure time is long, it's dark
         val isDark = currentIso >= isoThreshold || currentExposureTime >= exposureThreshold
-        Log.d(TAG, "Auto flash: ISO=$currentIso (threshold=$isoThreshold), " +
+        DivineCameraLog.d(TAG, "Auto flash: ISO=$currentIso (threshold=$isoThreshold), " +
                    "ExposureTime=${currentExposureTime/1_000_000}ms (threshold=${exposureThreshold/1_000_000}ms) -> isDark=$isDark")
         return isDark
     }
@@ -1069,10 +1073,10 @@ class CameraController(
         if (!isAutoFlashMode) return
         
         if (isEnvironmentDark()) {
-            Log.d(TAG, "Auto flash: Dark environment detected - enabling flash")
+            DivineCameraLog.d(TAG, "Auto flash: Dark environment detected - enabling flash")
             enableAutoFlashTorch()
         } else {
-            Log.d(TAG, "Auto flash: Bright environment - flash not needed")
+            DivineCameraLog.d(TAG, "Auto flash: Bright environment - flash not needed")
         }
     }
 
@@ -1085,13 +1089,13 @@ class CameraController(
         try {
             if (currentLens == CameraSelector.LENS_FACING_FRONT) {
                 enableScreenFlash()
-                Log.d(TAG, "Auto flash: Screen flash enabled for front camera")
+                DivineCameraLog.d(TAG, "Auto flash: Screen flash enabled for front camera")
             } else {
                 camera?.cameraControl?.enableTorch(true)
-                Log.d(TAG, "Auto flash: Torch enabled for back camera")
+                DivineCameraLog.d(TAG, "Auto flash: Torch enabled for back camera")
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Auto flash: Failed to enable torch", e)
+            DivineCameraLog.e(TAG, "Auto flash: Failed to enable torch", e)
         }
     }
     
@@ -1107,13 +1111,13 @@ class CameraController(
         try {
             if (currentLens == CameraSelector.LENS_FACING_FRONT) {
                 disableScreenFlash()
-                Log.d(TAG, "Auto flash: Screen flash disabled for front camera")
+                DivineCameraLog.d(TAG, "Auto flash: Screen flash disabled for front camera")
             } else {
                 camera?.cameraControl?.enableTorch(false)
-                Log.d(TAG, "Auto flash: Torch disabled for back camera")
+                DivineCameraLog.d(TAG, "Auto flash: Torch disabled for back camera")
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Auto flash: Failed to disable torch", e)
+            DivineCameraLog.e(TAG, "Auto flash: Failed to disable torch", e)
         }
     }
 
@@ -1149,16 +1153,16 @@ class CameraController(
             future.addListener({
                 try {
                     val result = future.get()
-                    Log.d(TAG, "Focus+AE ${if (result.isFocusSuccessful) "successful" else "adjusting"} at: ($x, $y)")
+                    DivineCameraLog.d(TAG, "Focus+AE ${if (result.isFocusSuccessful) "successful" else "adjusting"} at: ($x, $y)")
                 } catch (e: Exception) {
-                    Log.d(TAG, "Focus check: ${e.message}")
+                    DivineCameraLog.d(TAG, "Focus check: ${e.message}")
                 }
             }, ContextCompat.getMainExecutor(context))
             
-            Log.d(TAG, "Focus point set: ($x, $y) with FLAG_AF|FLAG_AE, 10% spot metering")
+            DivineCameraLog.d(TAG, "Focus point set: ($x, $y) with FLAG_AF|FLAG_AE, 10% spot metering")
             true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to set focus point", e)
+            DivineCameraLog.e(TAG, "Failed to set focus point", e)
             false
         }
     }
@@ -1180,10 +1184,10 @@ class CameraController(
                 .setAutoCancelDuration(5, java.util.concurrent.TimeUnit.SECONDS)
                 .build()
             cam.cameraControl.startFocusAndMetering(action)
-            Log.d(TAG, "Exposure point set: ($x, $y)")
+            DivineCameraLog.d(TAG, "Exposure point set: ($x, $y)")
             true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to set exposure point", e)
+            DivineCameraLog.e(TAG, "Failed to set exposure point", e)
             false
         }
     }
@@ -1197,10 +1201,10 @@ class CameraController(
         
         return try {
             cam.cameraControl.cancelFocusAndMetering()
-            Log.d(TAG, "Focus and metering cancelled - returning to continuous auto-focus")
+            DivineCameraLog.d(TAG, "Focus and metering cancelled - returning to continuous auto-focus")
             true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to cancel focus and metering", e)
+            DivineCameraLog.e(TAG, "Failed to cancel focus and metering", e)
             false
         }
     }
@@ -1234,7 +1238,7 @@ class CameraController(
             virtualMinZoom = minZoom
             virtualMaxZoom = maxZoom
             virtualCurrentZoom = currentZoom
-            Log.d(
+            DivineCameraLog.d(
                 TAG,
                 "Logical multi-camera detected " +
                     "(native minZoom=$minZoom, maxZoom=$maxZoom), " +
@@ -1292,7 +1296,7 @@ class CameraController(
         autoLensSwitchEnabled = autoLensSwitchRequested &&
             (ultraWideCameraId != null || telephotoCameraId != null)
 
-        Log.d(
+        DivineCameraLog.d(
             TAG,
             "Virtual zoom: min=$virtualMinZoom, max=$virtualMaxZoom, " +
                 "current=$virtualCurrentZoom, uwRatio=$ultraWideZoomRatio, " +
@@ -1357,7 +1361,7 @@ class CameraController(
         if (activity !is LifecycleOwner) return
 
         isAutoSwitching = true
-        Log.d(
+        DivineCameraLog.d(
             TAG,
             "Auto-switching $currentLensType -> $targetLensType " +
                 "(nativeZoom=$targetNativeZoom)"
@@ -1412,7 +1416,7 @@ class CameraController(
                                 context
                             )
                         ) { result ->
-                            Log.d(
+                            DivineCameraLog.d(
                                 TAG,
                                 "AutoSwitch surface: " +
                                     "${result.resultCode}"
@@ -1420,7 +1424,7 @@ class CameraController(
                         }
                     }
                     isAutoSwitching = false
-                    Log.d(
+                    DivineCameraLog.d(
                         TAG,
                         "AutoSwitch surface provided " +
                             "(delayed)"
@@ -1479,13 +1483,13 @@ class CameraController(
 
             computeVirtualZoomRanges()
 
-            Log.d(
+            DivineCameraLog.d(
                 TAG,
                 "Auto-switch done: $targetLensType " +
                     "native=$currentZoom virtual=$virtualCurrentZoom"
             )
         } catch (e: Exception) {
-            Log.e(
+            DivineCameraLog.e(
                 TAG,
                 "Failed to auto-switch to $targetLensType",
                 e
@@ -1513,10 +1517,10 @@ class CameraController(
                     level.coerceIn(effectiveMin, maxZoom)
                 cam.cameraControl.setZoomRatio(clampedLevel)
                 currentZoom = clampedLevel
-                Log.d(TAG, "Zoom level set: $clampedLevel")
+                DivineCameraLog.d(TAG, "Zoom level set: $clampedLevel")
                 true
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to set zoom level", e)
+                DivineCameraLog.e(TAG, "Failed to set zoom level", e)
                 false
             }
         }
@@ -1544,9 +1548,42 @@ class CameraController(
             currentZoom = clampedNative
             true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to set zoom level", e)
+            DivineCameraLog.e(TAG, "Failed to set zoom level", e)
             false
         }
+    }
+
+    /**
+     * Forwards a diagnostic when the CameraX audio-source state changes during
+     * recording. Only transitions are reported (Status fires continuously):
+     * [AudioStats.AUDIO_STATE_ACTIVE] is info, anything else is a warning
+     * because it means the saved clip loses (or never gets) sound.
+     */
+    private fun logAudioStateTransition(audioStats: AudioStats) {
+        val state = audioStats.audioState
+        if (state == lastAudioState) return
+        lastAudioState = state
+        val stateName = audioStateName(state)
+        if (state == AudioStats.AUDIO_STATE_ACTIVE) {
+            DivineCameraLog.info(
+                "Audio source state: $stateName",
+                name = "DivineCamera.Audio"
+            )
+        } else {
+            DivineCameraLog.warning(
+                "Audio source state: $stateName — clip may have no sound",
+                name = "DivineCamera.Audio"
+            )
+        }
+    }
+
+    private fun audioStateName(state: Int): String = when (state) {
+        AudioStats.AUDIO_STATE_ACTIVE -> "ACTIVE"
+        AudioStats.AUDIO_STATE_DISABLED -> "DISABLED"
+        AudioStats.AUDIO_STATE_SOURCE_SILENCED -> "SOURCE_SILENCED"
+        AudioStats.AUDIO_STATE_ENCODER_ERROR -> "ENCODER_ERROR"
+        AudioStats.AUDIO_STATE_SOURCE_ERROR -> "SOURCE_ERROR"
+        else -> "UNKNOWN($state)"
     }
 
     /**
@@ -1577,6 +1614,10 @@ class CameraController(
                 Manifest.permission.RECORD_AUDIO
             ) != PackageManager.PERMISSION_GRANTED
         ) {
+            DivineCameraLog.warning(
+                "RECORD_AUDIO permission not granted — recording blocked",
+                name = "DivineCamera.Recording"
+            )
             callback("Audio permission not granted")
             return
         }
@@ -1613,7 +1654,7 @@ class CameraController(
             val outputFile = File(outputDir, "VID_$timestamp.mp4")
             currentRecordingFile = outputFile
 
-            Log.d(
+            DivineCameraLog.d(
                 TAG, "Starting recording to: ${outputFile.absolutePath}" +
                         " (useCache: $useCache)" +
                         if (maxDurationMs != null) " (max duration: ${maxDurationMs}ms)" else ""
@@ -1631,13 +1672,19 @@ class CameraController(
                     when (event) {
                         is VideoRecordEvent.Start -> {
                             isRecording = true
-                            Log.d(
+                            lastAudioState = Int.MIN_VALUE
+                            DivineCameraLog.d(
                                 TAG,
                                 "VideoRecordEvent.Start received - waiting for first frame..."
                             )
                         }
 
                         is VideoRecordEvent.Status -> {
+                            // Forward audio-source state transitions: a mid-
+                            // recording switch to SILENCED / SOURCE_ERROR is the
+                            // direct cause of clips saved without sound (#4779).
+                            logAudioStateTransition(event.recordingStats.audioStats)
+
                             // Status events are sent continuously during recording
                             // When recordedDurationNanos > 0, the encoder is truly recording frames
                             val durationNanos = event.recordingStats.recordedDurationNanos
@@ -1647,7 +1694,7 @@ class CameraController(
                                 // Encoder succeeded — clear retry state
                                 encoderRetryCount = 0
                                 pendingRecordingParams = null
-                                Log.d(
+                                DivineCameraLog.d(
                                     TAG,
                                     "Recording truly started - first frame recorded (duration: ${durationNanos / 1_000_000}ms)"
                                 )
@@ -1655,7 +1702,7 @@ class CameraController(
                                 // Schedule auto-stop if maxDuration is set
                                 if (maxDurationMs != null && maxDurationMs > 0) {
                                     maxDurationRunnable = Runnable {
-                                        Log.d(
+                                        DivineCameraLog.d(
                                             TAG,
                                             "Max duration reached (${maxDurationMs}ms) - auto-stopping recording"
                                         )
@@ -1681,9 +1728,18 @@ class CameraController(
                             maxDurationRunnable = null
 
                             if (event.hasError()) {
-                                Log.e(TAG, "Recording error: ${event.error}")
+                                DivineCameraLog.error(
+                                    "Recording finalized with error code ${event.error}",
+                                    name = "DivineCamera.Recording"
+                                )
                             } else {
-                                Log.d(TAG, "Recording finalized")
+                                val hadAudio =
+                                    event.recordingStats.audioStats.audioState ==
+                                        AudioStats.AUDIO_STATE_ACTIVE
+                                DivineCameraLog.info(
+                                    "Recording finalized (audioActive=$hadAudio)",
+                                    name = "DivineCamera.Recording"
+                                )
                             }
 
                             // If startRecordingCallback is still set, recording was stopped before first keyframe.
@@ -1693,7 +1749,11 @@ class CameraController(
                                 val lower = lowerQuality(videoQuality)
                                 if (lower != null && encoderRetryCount < MAX_ENCODER_RETRIES) {
                                     encoderRetryCount++
-                                    Log.w(TAG, "Encoder failed at $videoQuality, retrying with $lower (attempt $encoderRetryCount/$MAX_ENCODER_RETRIES)")
+                                    DivineCameraLog.warning(
+                                        "Encoder failed at $videoQuality, retrying with $lower " +
+                                            "(attempt $encoderRetryCount/$MAX_ENCODER_RETRIES)",
+                                        name = "DivineCamera.Recording"
+                                    )
                                     videoQuality = lower
 
                                     // Clean up failed recording file
@@ -1711,10 +1771,10 @@ class CameraController(
                                     val params = pendingRecordingParams
                                     startCamera { _, error ->
                                         if (error != null) {
-                                            Log.e(TAG, "Failed to reinitialize camera at $lower: $error")
+                                            DivineCameraLog.e(TAG, "Failed to reinitialize camera at $lower: $error")
                                             savedCallback("Recording failed: encoder not supported")
                                         } else {
-                                            Log.d(TAG, "Camera reinitialized at $lower, retrying recording")
+                                            DivineCameraLog.d(TAG, "Camera reinitialized at $lower, retrying recording")
                                             startRecordingInternal(
                                                 params?.maxDurationMs,
                                                 params?.useCache ?: true,
@@ -1728,14 +1788,14 @@ class CameraController(
 
                                 // No more fallback options — report failure
                                 startRecordingCallback?.let { startCallback ->
-                                    Log.w(TAG, "Recording stopped before first keyframe - no more quality fallbacks")
+                                    DivineCameraLog.w(TAG, "Recording stopped before first keyframe - no more quality fallbacks")
                                     startCallback("Recording stopped before first keyframe")
                                     startRecordingCallback = null
                                 }
                             } else {
                                 // Normal finalize — either successful or user-stopped
                                 startRecordingCallback?.let { startCallback ->
-                                    Log.w(TAG, "Recording stopped before first keyframe - notifying Flutter")
+                                    DivineCameraLog.w(TAG, "Recording stopped before first keyframe - notifying Flutter")
                                     startCallback("Recording stopped before first keyframe")
                                     startRecordingCallback = null
                                 }
@@ -1756,10 +1816,10 @@ class CameraController(
                             // Handle manual stop callback (from stopRecording)
                             manualStopCallback?.let { manualCallback ->
                                 if (result != null) {
-                                    Log.d(TAG, "Manual stop recording result: $result")
+                                    DivineCameraLog.d(TAG, "Manual stop recording result: $result")
                                     manualCallback(result, null)
                                 } else {
-                                    Log.w(TAG, "Manual stop: Recording file not found or empty")
+                                    DivineCameraLog.w(TAG, "Manual stop: Recording file not found or empty")
                                     manualCallback(null, "Recording file not found or empty")
                                 }
                                 manualStopCallback = null
@@ -1768,7 +1828,7 @@ class CameraController(
                             // Handle auto-stop callback (from max duration)
                             autoStopCallback?.let { autoCallback ->
                                 if (result != null) {
-                                    Log.d(TAG, "Auto-stop recording result: $result")
+                                    DivineCameraLog.d(TAG, "Auto-stop recording result: $result")
                                     autoCallback(result, null)
                                 } else {
                                     autoCallback(null, "Recording file not found")
@@ -1784,7 +1844,7 @@ class CameraController(
             // Callback is now called in Status event when recording truly starts
 
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to start recording", e)
+            DivineCameraLog.e(TAG, "Failed to start recording", e)
             startRecordingCallback = null
             callback("Failed to start recording: ${e.message}")
         }
@@ -1801,7 +1861,7 @@ class CameraController(
             return
         }
 
-        Log.d(TAG, "Auto-stopping recording...")
+        DivineCameraLog.d(TAG, "Auto-stopping recording...")
         
         // Disable auto-flash torch if it was enabled
         disableAutoFlashTorch()
@@ -1809,7 +1869,7 @@ class CameraController(
         // Set the callback that will be invoked when Finalize event fires
         autoStopCallback = { result, error ->
             if (result != null) {
-                Log.d(TAG, "Auto-stop completed, notifying listener: $result")
+                DivineCameraLog.d(TAG, "Auto-stop completed, notifying listener: $result")
                 onAutoStopListener?.invoke(result)
             }
         }
@@ -1835,13 +1895,13 @@ class CameraController(
 
         // If recording hasn't truly started yet (no keyframe), we need to handle this
         if (!recordingTrulyStarted) {
-            Log.w(TAG, "Stopping recording before first keyframe - will return empty result")
+            DivineCameraLog.w(TAG, "Stopping recording before first keyframe - will return empty result")
             // The startRecordingCallback will be notified via Finalize event
             // We still need to call manualStopCallback, but it will get null result
         }
 
         try {
-            Log.d(TAG, "Stopping recording...")
+            DivineCameraLog.d(TAG, "Stopping recording...")
             
             // Disable auto-flash torch if it was enabled
             disableAutoFlashTorch()
@@ -1852,7 +1912,7 @@ class CameraController(
             // The Finalize event handler will call the callback when file is ready
 
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to stop recording", e)
+            DivineCameraLog.e(TAG, "Failed to stop recording", e)
             manualStopCallback = null
             callback(null, "Failed to stop recording: ${e.message}")
         }
@@ -1862,7 +1922,7 @@ class CameraController(
      * Pauses the camera preview.
      */
     fun pausePreview() {
-        Log.d(TAG, "Pausing preview")
+        DivineCameraLog.d(TAG, "Pausing preview")
         forceDisableScreenFlash()
         isPaused = true
     }
@@ -1871,7 +1931,7 @@ class CameraController(
      * Resumes the camera preview.
      */
     fun resumePreview(callback: (Map<String, Any?>?, String?) -> Unit) {
-        Log.d(TAG, "Resuming preview")
+        DivineCameraLog.d(TAG, "Resuming preview")
         isPaused = false
         
         // Re-enable screen flash if front camera torch mode was active
@@ -1930,7 +1990,7 @@ class CameraController(
      * Releases all camera resources.
      */
     fun release() {
-        Log.d(TAG, "Releasing camera resources")
+        DivineCameraLog.d(TAG, "Releasing camera resources")
         
         // Always restore screen brightness
         forceDisableScreenFlash()
@@ -1962,12 +2022,12 @@ class CameraController(
                             cameraExecutor.shutdown()
                         }
                     } catch (e: Exception) {
-                        Log.w(TAG, "Error shutting down executor: ${e.message}")
+                        DivineCameraLog.w(TAG, "Error shutting down executor: ${e.message}")
                     }
                 }, 500)
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Error releasing camera", e)
+            DivineCameraLog.e(TAG, "Error releasing camera", e)
         }
     }
 }

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraLog.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraLog.kt
@@ -37,26 +37,28 @@ object DivineCameraLog {
 
     // android.util.Log-shaped overloads so existing `Log.x(TAG, ...)` call
     // sites forward to the bridge with a mechanical rename. The tag becomes
-    // the entry name; a throwable is appended to the message.
+    // the entry name. Logcat keeps the full throwable stack trace; Dart gets a
+    // concise throwable summary because MethodChannel payloads stay structured.
     fun d(tag: String, message: String, tr: Throwable? = null) =
-        debug(tr?.let { "$message: $it" } ?: message, name = tag)
+        emit("debug", message, tag, tr)
 
     fun i(tag: String, message: String, tr: Throwable? = null) =
-        info(tr?.let { "$message: $it" } ?: message, name = tag)
+        emit("info", message, tag, tr)
 
     fun w(tag: String, message: String, tr: Throwable? = null) =
-        warning(tr?.let { "$message: $it" } ?: message, name = tag)
+        emit("warning", message, tag, tr)
 
     fun e(tag: String, message: String, tr: Throwable? = null) =
-        error(tr?.let { "$message: $it" } ?: message, name = tag)
+        emit("error", message, tag, tr)
 
-    private fun emit(level: String, message: String, name: String) {
+    private fun emit(level: String, message: String, name: String, tr: Throwable? = null) {
         // Keep the logcat fallback so on-device debugging is unchanged.
         when (level) {
-            "error" -> Log.e(name, message)
-            "warning" -> Log.w(name, message)
-            else -> Log.d(name, message)
+            "error" -> if (tr != null) Log.e(name, message, tr) else Log.e(name, message)
+            "warning" -> if (tr != null) Log.w(name, message, tr) else Log.w(name, message)
+            "info" -> if (tr != null) Log.i(name, message, tr) else Log.i(name, message)
+            else -> if (tr != null) Log.d(name, message, tr) else Log.d(name, message)
         }
-        sink?.invoke(level, message, name)
+        sink?.invoke(level, tr?.let { "$message: $it" } ?: message, name)
     }
 }

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraLog.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraLog.kt
@@ -1,0 +1,62 @@
+// ABOUTME: Forwards curated native camera diagnostics to Dart's UnifiedLogger
+// ABOUTME: so recording issues (e.g. missing audio) appear in user bug reports
+
+package co.openvine.divine_camera
+
+import android.util.Log
+
+/**
+ * Bridges relevant native diagnostics to the Dart side so they are captured by
+ * the app's `UnifiedLogger` and included in bug-report log dumps.
+ *
+ * Native recording code calls these methods (instead of bare [Log]) for the
+ * handful of events worth surfacing to support: audio-permission denial,
+ * recording finalize errors, encoder-fallback retries, and audio-source state
+ * transitions. Per-frame / verbose logging must stay on [Log] so it does not
+ * flood the captured buffer.
+ *
+ * `DivineCameraPlugin` installs [sink] when attached to the engine to forward
+ * each entry over the method channel. Before that is wired (or in unit-test
+ * contexts) entries fall back to logcat only.
+ */
+object DivineCameraLog {
+    /**
+     * Forwards `(level, message, name)` to Dart. `level` is one of `debug`,
+     * `info`, `warning`, `error`. Set by the plugin; `null` until then.
+     */
+    @Volatile
+    var sink: ((String, String, String) -> Unit)? = null
+
+    fun debug(message: String, name: String = "DivineCamera") = emit("debug", message, name)
+
+    fun info(message: String, name: String = "DivineCamera") = emit("info", message, name)
+
+    fun warning(message: String, name: String = "DivineCamera") = emit("warning", message, name)
+
+    fun error(message: String, name: String = "DivineCamera") = emit("error", message, name)
+
+    // android.util.Log-shaped overloads so existing `Log.x(TAG, ...)` call
+    // sites forward to the bridge with a mechanical rename. The tag becomes
+    // the entry name; a throwable is appended to the message.
+    fun d(tag: String, message: String, tr: Throwable? = null) =
+        debug(tr?.let { "$message: $it" } ?: message, name = tag)
+
+    fun i(tag: String, message: String, tr: Throwable? = null) =
+        info(tr?.let { "$message: $it" } ?: message, name = tag)
+
+    fun w(tag: String, message: String, tr: Throwable? = null) =
+        warning(tr?.let { "$message: $it" } ?: message, name = tag)
+
+    fun e(tag: String, message: String, tr: Throwable? = null) =
+        error(tr?.let { "$message: $it" } ?: message, name = tag)
+
+    private fun emit(level: String, message: String, name: String) {
+        // Keep the logcat fallback so on-device debugging is unchanged.
+        when (level) {
+            "error" -> Log.e(name, message)
+            "warning" -> Log.w(name, message)
+            else -> Log.d(name, message)
+        }
+        sink?.invoke(level, message, name)
+    }
+}

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
@@ -30,14 +30,53 @@ class DivineCameraPlugin :
     private var cameraController: CameraController? = null
     private var volumeKeyHandler: VolumeKeyHandler? = null
 
+    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
+
+    // Per-instance forwarder that pushes native diagnostics over THIS engine's
+    // channel. `DivineCameraLog.sink` is a process-wide singleton, so a second
+    // FlutterEngine (e.g. the FCM background isolate that also runs
+    // GeneratedPluginRegistrant) would otherwise overwrite it and route camera
+    // logs to the wrong isolate. We re-assert this in onMethodCall — camera
+    // calls only ever reach the UI engine — so the sink always points back here.
+    private val logSink: (String, String, String) -> Unit = { level, message, name ->
+        mainHandler.post {
+            channel.invokeMethod(
+                "onNativeLog",
+                mapOf("level" to level, "message" to message, "name" to name)
+            )
+        }
+    }
+
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "divine_camera")
         channel.setMethodCallHandler(this)
         context = flutterPluginBinding.applicationContext
         textureRegistry = flutterPluginBinding.textureRegistry
+        DivineCameraLog.sink = logSink
+    }
+
+    // Session-lifecycle operations worth leaving a breadcrumb for. High-
+    // frequency calls (zoom / focus / exposure / getCameraState) are excluded
+    // on purpose so they don't flood the captured log buffer.
+    private val lifecycleMethods = setOf(
+        "initializeCamera", "disposeCamera", "switchCamera",
+        "startRecording", "stopRecording", "pausePreview", "resumePreview",
+        "setFlashMode", "setRemoteRecordControlEnabled"
+    )
+
+    private fun logLifecycleCall(call: MethodCall) {
+        if (call.method !in lifecycleMethods) return
+        val args = call.arguments
+        DivineCameraLog.debug(
+            "→ ${call.method}${if (args != null) " $args" else ""}",
+            name = "DivineCamera.Lifecycle"
+        )
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
+        // Re-claim the shared sink in case another FlutterEngine overwrote it.
+        DivineCameraLog.sink = logSink
+        logLifecycleCall(call)
         val oneShotResult = OneShotMethodResult(result)
         when (call.method) {
             "getPlatformVersion" -> {
@@ -155,6 +194,14 @@ class DivineCameraPlugin :
                 if (error != null) {
                     result.error("INIT_ERROR", error, null)
                 } else {
+                    val dict = state as? Map<*, *>
+                    DivineCameraLog.info(
+                        "Camera initialized (lens=${dict?.get("lens")}, " +
+                            "aspectRatio=${dict?.get("aspectRatio")}, " +
+                            "hasFlash=${dict?.get("hasFlash")}, " +
+                            "lenses=${dict?.get("availableLenses")})",
+                        name = "DivineCamera.Lifecycle"
+                    )
                     result.success(state)
                 }
             }
@@ -261,6 +308,11 @@ class DivineCameraPlugin :
                 if (error != null) {
                     result.error("SWITCH_ERROR", error, null)
                 } else {
+                    val dict = state as? Map<*, *>
+                    DivineCameraLog.info(
+                        "Camera switched (lens=${dict?.get("lens")})",
+                        name = "DivineCamera.Lifecycle"
+                    )
                     result.success(state)
                 }
             }
@@ -393,6 +445,11 @@ class DivineCameraPlugin :
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+        // Only relinquish the shared sink if it still points at this instance,
+        // so a background-engine teardown can't silence the UI engine's logs.
+        if (DivineCameraLog.sink === logSink) {
+            DivineCameraLog.sink = null
+        }
         volumeKeyHandler?.release()
         volumeKeyHandler = null
         cameraController?.release()
@@ -429,6 +486,13 @@ internal class OneShotMethodResult(
 
     override fun error(errorCode: String, errorMessage: String?, errorDetails: Any?) {
         if (markReplied()) {
+            // Choke point for every error returned to Dart — forward it to the
+            // UnifiedLogger so the failure shows up in user bug reports. Fatal
+            // native crashes are captured separately by Crashlytics.
+            DivineCameraLog.error(
+                "$errorCode: ${errorMessage ?: ""}",
+                name = "DivineCamera.Plugin"
+            )
             delegate.error(errorCode, errorMessage, errorDetails)
         }
     }

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/VolumeKeyHandler.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/VolumeKeyHandler.kt
@@ -10,7 +10,6 @@ import android.content.Intent
 import android.os.Build
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
-import android.util.Log
 import android.view.KeyEvent
 import android.view.Window
 
@@ -54,21 +53,21 @@ class VolumeKeyHandler(
      */
     fun enable(): Boolean {
         if (isEnabled) {
-            Log.d(TAG, "Volume key handler already enabled")
+            DivineCameraLog.d(TAG, "Volume key handler already enabled")
             return true
         }
         
         try {
-            Log.d(TAG, "Enabling volume key handler...")
+            DivineCameraLog.d(TAG, "Enabling volume key handler...")
             setupWindowCallback()
             setupMediaSession()
             isEnabled = true
             volumeKeysEnabled = true
             enabledTimestamp = System.currentTimeMillis()
-            Log.i(TAG, "Volume key handler enabled successfully")
+            DivineCameraLog.i(TAG, "Volume key handler enabled successfully")
             return true
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to enable volume key handler: ${e.message}", e)
+            DivineCameraLog.e(TAG, "Failed to enable volume key handler: ${e.message}", e)
             return false
         }
     }
@@ -84,7 +83,7 @@ class VolumeKeyHandler(
             activity?.window?.let { window ->
                 originalCallback?.let { original ->
                     window.callback = original
-                    Log.d(TAG, "Restored original window callback")
+                    DivineCameraLog.d(TAG, "Restored original window callback")
                 }
             }
             originalCallback = null
@@ -94,9 +93,9 @@ class VolumeKeyHandler(
             mediaSession = null
             isEnabled = false
             volumeKeysEnabled = true
-            Log.d(TAG, "Volume key handler disabled")
+            DivineCameraLog.d(TAG, "Volume key handler disabled")
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to disable volume key handler: ${e.message}")
+            DivineCameraLog.e(TAG, "Failed to disable volume key handler: ${e.message}")
         }
     }
 
@@ -107,7 +106,7 @@ class VolumeKeyHandler(
      */
     fun setVolumeKeysEnabled(enabled: Boolean) {
         volumeKeysEnabled = enabled
-        Log.d(TAG, "Volume keys interception ${if (enabled) "enabled" else "disabled"}")
+        DivineCameraLog.d(TAG, "Volume keys interception ${if (enabled) "enabled" else "disabled"}")
     }
     
     /**
@@ -115,12 +114,12 @@ class VolumeKeyHandler(
      */
     private fun setupWindowCallback() {
         val currentActivity = activity ?: run {
-            Log.w(TAG, "No activity available, cannot intercept key events")
+            DivineCameraLog.w(TAG, "No activity available, cannot intercept key events")
             return
         }
         
         val window = currentActivity.window ?: run {
-            Log.w(TAG, "No window available, cannot intercept key events")
+            DivineCameraLog.w(TAG, "No window available, cannot intercept key events")
             return
         }
         
@@ -130,7 +129,7 @@ class VolumeKeyHandler(
         }
         window.callback = callbackWrapper
         
-        Log.i(TAG, "Window.Callback wrapper installed for key event interception")
+        DivineCameraLog.i(TAG, "Window.Callback wrapper installed for key event interception")
     }
 
     /**
@@ -148,28 +147,28 @@ class VolumeKeyHandler(
             KeyEvent.KEYCODE_VOLUME_UP -> {
                 // Only intercept volume keys if enabled and not suppressed
                 if (!volumeKeysEnabled) {
-                    Log.d(TAG, "Volume up pressed but volume keys disabled - passing through")
+                    DivineCameraLog.d(TAG, "Volume up pressed but volume keys disabled - passing through")
                     return false
                 }
                 if (isSuppressed) {
-                    Log.d(TAG, "Volume up pressed but suppressed (camera switch) - consuming")
+                    DivineCameraLog.d(TAG, "Volume up pressed but suppressed (camera switch) - consuming")
                     return true  // Consume to prevent volume change, but don't trigger
                 }
-                Log.d(TAG, "Volume up button pressed")
+                DivineCameraLog.d(TAG, "Volume up button pressed")
                 onTrigger("volumeUp")
                 true
             }
             KeyEvent.KEYCODE_VOLUME_DOWN -> {
                 // Only intercept volume keys if enabled and not suppressed
                 if (!volumeKeysEnabled) {
-                    Log.d(TAG, "Volume down pressed but volume keys disabled - passing through")
+                    DivineCameraLog.d(TAG, "Volume down pressed but volume keys disabled - passing through")
                     return false
                 }
                 if (isSuppressed) {
-                    Log.d(TAG, "Volume down pressed but suppressed (camera switch) - consuming")
+                    DivineCameraLog.d(TAG, "Volume down pressed but suppressed (camera switch) - consuming")
                     return true  // Consume to prevent volume change, but don't trigger
                 }
-                Log.d(TAG, "Volume down button pressed")
+                DivineCameraLog.d(TAG, "Volume down button pressed")
                 onTrigger("volumeDown")
                 true
             }
@@ -200,26 +199,26 @@ class VolumeKeyHandler(
         }
         
         if (!isMediaControlButton) {
-            Log.d(TAG, "Media button not a control button (keyCode=${event.keyCode}) - passing through")
+            DivineCameraLog.d(TAG, "Media button not a control button (keyCode=${event.keyCode}) - passing through")
             return false  // Let system handle volume and other buttons
         }
         
         // Consume repeat events but don't trigger (long-press handling)
         if (event.repeatCount != 0) {
-            Log.d(TAG, "Media button repeat ignored: ${event.keyCode}, repeatCount: ${event.repeatCount}")
+            DivineCameraLog.d(TAG, "Media button repeat ignored: ${event.keyCode}, repeatCount: ${event.repeatCount}")
             return true
         }
         
         // Check suppression (camera switch in progress)
         if (isSuppressed) {
-            Log.d(TAG, "Media button ignored - suppressed (camera switch in progress)")
+            DivineCameraLog.d(TAG, "Media button ignored - suppressed (camera switch in progress)")
             return true
         }
 
         // Check cooldown after activation
         val timeSinceEnabled = System.currentTimeMillis() - enabledTimestamp
         if (timeSinceEnabled < activationCooldownMs) {
-            Log.d(TAG, "Media button ignored - within ${activationCooldownMs}ms cooldown (${timeSinceEnabled}ms since enabled)")
+            DivineCameraLog.d(TAG, "Media button ignored - within ${activationCooldownMs}ms cooldown (${timeSinceEnabled}ms since enabled)")
             return true
         }
 
@@ -227,12 +226,12 @@ class VolumeKeyHandler(
         val now = System.currentTimeMillis()
         val timeSinceLastTrigger = now - lastBluetoothTriggerTimestamp
         if (timeSinceLastTrigger < bluetoothDebounceMs) {
-            Log.d(TAG, "Media button ignored - debounce (${timeSinceLastTrigger}ms since last)")
+            DivineCameraLog.d(TAG, "Media button ignored - debounce (${timeSinceLastTrigger}ms since last)")
             return true
         }
 
         lastBluetoothTriggerTimestamp = now
-        Log.d(TAG, "Media button triggered: ${event.keyCode}")
+        DivineCameraLog.d(TAG, "Media button triggered: ${event.keyCode}")
         onTrigger("bluetooth")
         return true
     }
@@ -246,13 +245,13 @@ class VolumeKeyHandler(
      */
     fun suppressTemporarily(durationMs: Long = 3000) {
         isSuppressed = true
-        Log.d(TAG, "Suppressed for ${durationMs}ms")
+        DivineCameraLog.d(TAG, "Suppressed for ${durationMs}ms")
 
         // Cancel any pending unsuppress
         suppressRunnable?.let { suppressHandler.removeCallbacks(it) }
         suppressRunnable = Runnable {
             isSuppressed = false
-            Log.d(TAG, "Suppression ended")
+            DivineCameraLog.d(TAG, "Suppression ended")
         }
         suppressHandler.postDelayed(suppressRunnable!!, durationMs)
     }
@@ -315,19 +314,19 @@ class VolumeKeyHandler(
 
                 override fun onPlay() {
                     super.onPlay()
-                    Log.d(TAG, "MediaSession onPlay callback")
+                    DivineCameraLog.d(TAG, "MediaSession onPlay callback")
                     triggerWithCooldownCheck()
                 }
 
                 override fun onPause() {
                     super.onPause()
-                    Log.d(TAG, "MediaSession onPause callback")
+                    DivineCameraLog.d(TAG, "MediaSession onPause callback")
                     triggerWithCooldownCheck()
                 }
                 
                 override fun onStop() {
                     super.onStop()
-                    Log.d(TAG, "MediaSession onStop callback")
+                    DivineCameraLog.d(TAG, "MediaSession onStop callback")
                     triggerWithCooldownCheck()
                 }
             })
@@ -335,7 +334,7 @@ class VolumeKeyHandler(
             isActive = true
         }
         
-        Log.i(TAG, "MediaSession created and active for Bluetooth remote control")
+        DivineCameraLog.i(TAG, "MediaSession created and active for Bluetooth remote control")
     }
     
     /**
@@ -344,18 +343,18 @@ class VolumeKeyHandler(
      */
     private fun triggerWithCooldownCheck() {
         if (isSuppressed) {
-            Log.d(TAG, "MediaSession callback ignored - suppressed")
+            DivineCameraLog.d(TAG, "MediaSession callback ignored - suppressed")
             return
         }
         val timeSinceEnabled = System.currentTimeMillis() - enabledTimestamp
         if (timeSinceEnabled < activationCooldownMs) {
-            Log.d(TAG, "MediaSession callback ignored - within cooldown")
+            DivineCameraLog.d(TAG, "MediaSession callback ignored - within cooldown")
             return
         }
         val now = System.currentTimeMillis()
         val timeSinceLastTrigger = now - lastBluetoothTriggerTimestamp
         if (timeSinceLastTrigger < bluetoothDebounceMs) {
-            Log.d(TAG, "MediaSession callback ignored - debounce")
+            DivineCameraLog.d(TAG, "MediaSession callback ignored - debounce")
             return
         }
         lastBluetoothTriggerTimestamp = now
@@ -387,7 +386,7 @@ private class KeyInterceptingCallback(
                           event.keyCode == KeyEvent.KEYCODE_VOLUME_DOWN
         
         if (isVolumeKey && onKeyEvent(event)) {
-            Log.d(TAG, "Volume key event consumed: ${event.keyCode}")
+            DivineCameraLog.d(TAG, "Volume key event consumed: ${event.keyCode}")
             return true  // Event consumed, don't pass to system
         }
         // Pass unhandled events to the original callback

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -213,7 +213,7 @@ class CameraController: NSObject {
             }
         }
         
-        print("[DivineCameraController] Camera availability: front=\(hasFrontCamera), " +
+        DivineCameraLog.shared.debug("[DivineCameraController] Camera availability: front=\(hasFrontCamera), " +
               "frontUltraWide=\(hasFrontUltraWideCamera), back=\(hasBackCamera), " +
               "ultraWide=\(hasUltraWideCamera), telephoto=\(hasTelephotoCamera), macro=\(hasMacroCamera)")
         
@@ -228,7 +228,7 @@ class CameraController: NSObject {
             let hasDual = AVCaptureDevice.default(
                 .builtInDualCamera, for: .video, position: .back
             ) != nil
-            print("[DivineCameraController] Virtual devices: " +
+            DivineCameraLog.shared.debug("[DivineCameraController] Virtual devices: " +
                   "triple=\(hasTriple), dualWide=\(hasDualWide), dual=\(hasDual)")
         }
     }
@@ -278,10 +278,16 @@ class CameraController: NSObject {
                 options: [.defaultToSpeaker, .allowBluetoothA2DP]
             )
             try audioSession.setActive(true)
-            print("[DivineCameraController] Audio session configured: A2DP for playback, built-in mic for recording")
+            DivineCameraLog.shared.info(
+                "Audio session configured: A2DP playback, built-in mic for recording",
+                name: "DivineCamera.AudioSession"
+            )
             return true
         } catch {
-            print("[DivineCameraController] Failed to configure audio session: \(error.localizedDescription)")
+            DivineCameraLog.shared.error(
+                "Failed to configure audio session: \(error.localizedDescription)",
+                name: "DivineCamera.AudioSession"
+            )
             return false
         }
     }
@@ -314,7 +320,10 @@ class CameraController: NSObject {
             // accessor so cross-queue reads from `videoOutputQueue`
             // (captureOutput) see a consistent value.
             self.audioInterrupted = true
-            print("[DivineCameraController] AVAudioSession interruption began")
+            DivineCameraLog.shared.warning(
+                "AVAudioSession interruption began — audio capture paused",
+                name: "DivineCamera.AudioSession"
+            )
         case .ended:
             let shouldResume: Bool = {
                 guard let raw = info[AVAudioSessionInterruptionOptionKey] as? UInt else {
@@ -322,7 +331,10 @@ class CameraController: NSObject {
                 }
                 return AVAudioSession.InterruptionOptions(rawValue: raw).contains(.shouldResume)
             }()
-            print("[DivineCameraController] AVAudioSession interruption ended (shouldResume=\(shouldResume))")
+            DivineCameraLog.shared.info(
+                "AVAudioSession interruption ended (shouldResume=\(shouldResume))",
+                name: "DivineCamera.AudioSession"
+            )
             // Always try to recover — even when shouldResume is false the
             // user can still press record again and we want a working session.
             // attachAudioToSessionIfNeeded() must run on sessionQueue (it
@@ -338,7 +350,10 @@ class CameraController: NSObject {
                 if self.attachAudioToSessionIfNeeded() {
                     self.audioInterrupted = false
                 } else {
-                    print("[DivineCameraController] Audio recovery failed; keeping audioInterrupted=true")
+                    DivineCameraLog.shared.error(
+                        "Audio recovery failed; next recording continues without audio",
+                        name: "DivineCamera.AudioSession"
+                    )
                 }
             }
         @unknown default:
@@ -536,11 +551,17 @@ class CameraController: NSObject {
         if getDeviceForLensType(currentLensType) == nil {
             // Try back camera first, then front
             if hasBackCamera {
-                print("[DivineCameraController] Requested lens \(lens) not available, falling back to back camera")
+                DivineCameraLog.shared.warning(
+                    "Requested lens \(lens) not available, falling back to back camera",
+                    name: "DivineCamera.Lifecycle"
+                )
                 currentLensType = "back"
                 currentLens = .back
             } else if hasFrontCamera {
-                print("[DivineCameraController] Requested lens \(lens) not available, falling back to front camera")
+                DivineCameraLog.shared.warning(
+                    "Requested lens \(lens) not available, falling back to front camera",
+                    name: "DivineCamera.Lifecycle"
+                )
                 currentLensType = "front"
                 currentLens = .front
             }
@@ -630,7 +651,10 @@ class CameraController: NSObject {
                 if session.canSetSessionPreset(preset) {
                     session.sessionPreset = preset
                     if preset != videoQualityPreset {
-                        print("[DivineCameraController] Requested preset not supported, falling back to: \(preset.rawValue)")
+                        DivineCameraLog.shared.warning(
+                            "Requested capture preset not supported, falling back to: \(preset.rawValue)",
+                            name: "DivineCamera.Lifecycle"
+                        )
                     }
                     presetSet = true
                     break
@@ -638,7 +662,10 @@ class CameraController: NSObject {
             }
             
             if !presetSet {
-                print("[DivineCameraController] Warning: Could not set any preferred preset")
+                DivineCameraLog.shared.warning(
+                    "Could not set any preferred capture preset",
+                    name: "DivineCamera.Lifecycle"
+                )
             }
         } catch {
             completion(nil, "Failed to create video input: \(error.localizedDescription)")
@@ -667,11 +694,11 @@ class CameraController: NSObject {
         if session.canAddOutput(videoOutput) {
             session.addOutput(videoOutput)
             self.videoOutput = videoOutput
-            print("DivineCamera: Video output added successfully")
+            DivineCameraLog.shared.debug("DivineCamera: Video output added successfully")
             
             // Set video orientation to portrait
             if let connection = videoOutput.connection(with: .video) {
-                print("DivineCamera: Video connection established")
+                DivineCameraLog.shared.debug("DivineCamera: Video connection established")
                 if connection.isVideoOrientationSupported {
                     connection.videoOrientation = .portrait
                 }
@@ -684,7 +711,7 @@ class CameraController: NSObject {
                 }
             }
         } else {
-            print("DivineCamera: ERROR - Cannot add video output to session!")
+            DivineCameraLog.shared.error("DivineCamera: Cannot add video output to session", name: "DivineCamera.Setup")
         }
         
         // NOTE: AVCaptureAudioDataOutput is also added lazily in startRecording().
@@ -709,7 +736,7 @@ class CameraController: NSObject {
                 videoDevice.unlockForConfiguration()
                 currentZoom = 1.0
             } catch {
-                print("DivineCamera: Failed to set initial zoom to 1.0x: \(error.localizedDescription)")
+                DivineCameraLog.shared.warning("DivineCamera: Failed to set initial zoom to 1.0x: \(error.localizedDescription)", name: "DivineCamera.Setup")
             }
         }
         
@@ -718,11 +745,11 @@ class CameraController: NSObject {
         self.captureSession = session
         
         // Debug: Check session and connection status
-        print("DivineCamera: Session running: \(session.isRunning)")
+        DivineCameraLog.shared.debug("DivineCamera: Session running: \(session.isRunning)")
         if let connection = self.videoOutput?.connection(with: .video) {
-            print("DivineCamera: Video connection active: \(connection.isActive), enabled: \(connection.isEnabled)")
+            DivineCameraLog.shared.debug("DivineCamera: Video connection active: \(connection.isActive), enabled: \(connection.isEnabled)")
         } else {
-            print("DivineCamera: ERROR - No video connection available!")
+            DivineCameraLog.shared.error("DivineCamera: No video connection available", name: "DivineCamera.Setup")
         }
         
         // Watchdog: Check if frames are flowing after 1 second
@@ -736,7 +763,7 @@ class CameraController: NSObject {
             self.pixelBufferLock.unlock()
             
             if !hasReceivedFrames {
-                print("DivineCamera: ⚠️ WATCHDOG: No frames received after 1s - restarting session")
+                DivineCameraLog.shared.warning("DivineCamera: WATCHDOG - no frames received after 1s, restarting session", name: "DivineCamera.Setup")
                 self.sessionQueue.async { [weak self] in
                     guard let self = self, let session = self.captureSession else { return }
                     
@@ -747,17 +774,17 @@ class CameraController: NSObject {
                     self.sessionQueue.asyncAfter(deadline: .now() + 0.1) { [weak self] in
                         guard let self = self, let session = self.captureSession else { return }
                         session.startRunning()
-                        print("DivineCamera: ✅ Session restarted by watchdog")
+                        DivineCameraLog.shared.debug("DivineCamera: ✅ Session restarted by watchdog")
                     }
                 }
             } else {
-                print("DivineCamera: ✅ Watchdog: Frames are flowing normally")
+                DivineCameraLog.shared.debug("DivineCamera: ✅ Watchdog: Frames are flowing normally")
             }
         }
         
         // Register texture after session is running
         textureId = textureRegistry.register(self)
-        print("DivineCamera: Registered texture with ID: \(textureId)")
+        DivineCameraLog.shared.debug("DivineCamera: Registered texture with ID: \(textureId)")
         
         // NOTE: AVAssetWriter (VideoToolbox) and audio stack (AudioToolbox)
         // pre-warming used to live here, but doing dlopen() on a background
@@ -854,7 +881,11 @@ class CameraController: NSObject {
                 do {
                     try session.setActive(true)
                 } catch {
-                    print("[DivineCameraController] setActive(true) on existing session failed: \(error.localizedDescription)")
+                    DivineCameraLog.shared.error(
+                        "setActive(true) on existing audio session failed: "
+                            + "\(error.localizedDescription)",
+                        name: "DivineCamera.AudioSession"
+                    )
                     return false
                 }
                 if !existing.isRunning {
@@ -886,7 +917,10 @@ class CameraController: NSObject {
         if self.audioInput == nil {
             let device = self.audioDevice ?? AVCaptureDevice.default(for: .audio)
             guard let audioDevice = device else {
-                print("DivineCamera: No audio device available, recording without audio")
+                DivineCameraLog.shared.warning(
+                    "No audio device available — recording without audio",
+                    name: "DivineCamera.Audio"
+                )
                 session.commitConfiguration()
                 return false
             }
@@ -897,12 +931,18 @@ class CameraController: NSObject {
                     session.addInput(input)
                     self.audioInput = input
                 } else {
-                    print("DivineCamera: Cannot add audio input to audio session")
+                    DivineCameraLog.shared.error(
+                        "Cannot add audio input to audio session",
+                        name: "DivineCamera.Audio"
+                    )
                     session.commitConfiguration()
                     return false
                 }
             } catch {
-                print("DivineCamera: Failed to create audio input: \(error.localizedDescription)")
+                DivineCameraLog.shared.error(
+                    "Failed to create audio input: \(error.localizedDescription)",
+                    name: "DivineCamera.Audio"
+                )
                 session.commitConfiguration()
                 return false
             }
@@ -916,7 +956,10 @@ class CameraController: NSObject {
                 session.addOutput(output)
                 self.audioOutput = output
             } else {
-                print("DivineCamera: Cannot add audio output to audio session")
+                DivineCameraLog.shared.error(
+                    "Cannot add audio output to audio session",
+                    name: "DivineCamera.Audio"
+                )
                 session.commitConfiguration()
                 return false
             }
@@ -946,16 +989,16 @@ class CameraController: NSObject {
         initializationCompletion = nil
         
         if timedOut {
-            print("DivineCamera: ⚠️ Initialization completed via timeout (frames may not be flowing)")
+            DivineCameraLog.shared.debug("DivineCamera: ⚠️ Initialization completed via timeout (frames may not be flowing)")
         } else {
-            print("DivineCamera: ✅ Initialization completed - first frame received")
+            DivineCameraLog.shared.debug("DivineCamera: ✅ Initialization completed - first frame received")
         }
         
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             var state = self.getCameraState()
             state["textureId"] = self.textureId
-            print("DivineCamera: Returning state with textureId: \(self.textureId)")
+            DivineCameraLog.shared.debug("DivineCamera: Returning state with textureId: \(self.textureId)")
             completion(state, nil)
         }
         
@@ -1022,7 +1065,7 @@ class CameraController: NSObject {
         // dimensions.width is the longer side (landscape), height is shorter
         // For portrait mode, we swap to get 9:16 ratio
         aspectRatio = CGFloat(dimensions.height) / CGFloat(dimensions.width)
-        print("Camera aspect ratio (portrait): \(aspectRatio) from dimensions: \(dimensions.height)x\(dimensions.width)")
+        DivineCameraLog.shared.debug("Camera aspect ratio (portrait): \(aspectRatio) from dimensions: \(dimensions.height)x\(dimensions.width)")
     }
     
     /// Switches to a different camera lens.
@@ -1085,7 +1128,7 @@ class CameraController: NSObject {
                                 self.videoInput = newInput
                                 self.videoDevice = newDevice
                                 self.updateCameraProperties(device: newDevice)
-                                print("[DivineCameraController] Camera switch: preset fallback to \(preset.rawValue)")
+                                DivineCameraLog.shared.debug("[DivineCameraController] Camera switch: preset fallback to \(preset.rawValue)")
                                 success = true
                                 break
                             }
@@ -1136,7 +1179,7 @@ class CameraController: NSObject {
                     newDevice.unlockForConfiguration()
                     self.currentZoom = 1.0
                 } catch {
-                    print("DivineCamera: Failed to set zoom after camera switch: \(error.localizedDescription)")
+                    DivineCameraLog.shared.warning("DivineCamera: Failed to set zoom after camera switch: \(error.localizedDescription)", name: "DivineCamera.Setup")
                 }
             }
             
@@ -1158,7 +1201,7 @@ class CameraController: NSObject {
     func setFlashMode(mode: String) -> Bool {
         guard let device = videoDevice else { return false }
         
-        print("DivineCamera: Setting flash mode: \(mode) (currentLens: \(currentLens == .front ? "front" : "back"))")
+        DivineCameraLog.shared.debug("DivineCamera: Setting flash mode: \(mode) (currentLens: \(currentLens == .front ? "front" : "back"))")
         
         // Handle screen brightness for front camera "torch" mode
         if currentLens == .front {
@@ -1173,7 +1216,7 @@ class CameraController: NSObject {
                 currentTorchMode = .off
                 isAutoFlashMode = true
                 currentFlashMode = .auto
-                print("DivineCamera: Auto flash mode enabled for front camera")
+                DivineCameraLog.shared.debug("DivineCamera: Auto flash mode enabled for front camera")
                 return true
             } else {
                 disableScreenFlash()
@@ -1203,7 +1246,7 @@ class CameraController: NSObject {
                 isAutoFlashMode = true
                 autoFlashTorchEnabled = false
                 currentFlashMode = .auto
-                print("DivineCamera: Auto flash mode enabled - will check brightness when recording starts")
+                DivineCameraLog.shared.debug("DivineCamera: Auto flash mode enabled - will check brightness when recording starts")
                 
             case "on":
                 currentFlashMode = .on
@@ -1223,7 +1266,7 @@ class CameraController: NSObject {
             device.unlockForConfiguration()
             return true
         } catch {
-            print("DivineCamera: Failed to set flash mode: \(error.localizedDescription)")
+            DivineCameraLog.shared.warning("DivineCamera: Failed to set flash mode: \(error.localizedDescription)", name: "DivineCamera.Flash")
             return false
         }
     }
@@ -1250,7 +1293,7 @@ class CameraController: NSObject {
             if let brightness = self.originalBrightness {
                 UIScreen.main.brightness = brightness
                 self.originalBrightness = nil
-                print("DivineCamera: Screen flash disabled (brightness restored)")
+                DivineCameraLog.shared.debug("DivineCamera: Screen flash disabled (brightness restored)")
             }
         }
     }
@@ -1270,7 +1313,7 @@ class CameraController: NSObject {
         // If ISO is high OR exposure time is long, it's dark (same as Android)
         let isDark = currentISO >= isoThreshold || currentExposure >= exposureThreshold
         
-        print("DivineCamera: Auto flash: ISO=\(currentISO) (threshold=\(isoThreshold)), " +
+        DivineCameraLog.shared.debug("DivineCamera: Auto flash: ISO=\(currentISO) (threshold=\(isoThreshold)), " +
               "ExposureTime=\(currentExposure * 1000)ms (threshold=\(exposureThreshold * 1000)ms) -> isDark=\(isDark)")
         return isDark
     }
@@ -1281,10 +1324,10 @@ class CameraController: NSObject {
         guard isAutoFlashMode else { return }
         
         if isEnvironmentDark() {
-            print("DivineCamera: Auto flash: Dark environment detected - enabling flash")
+            DivineCameraLog.shared.debug("DivineCamera: Auto flash: Dark environment detected - enabling flash")
             enableAutoFlashTorch()
         } else {
-            print("DivineCamera: Auto flash: Bright environment - flash not needed")
+            DivineCameraLog.shared.debug("DivineCamera: Auto flash: Bright environment - flash not needed")
         }
     }
     
@@ -1293,14 +1336,14 @@ class CameraController: NSObject {
         if currentLens == .front {
             autoFlashTorchEnabled = true
             enableScreenFlash()
-            print("DivineCamera: Auto flash: Screen flash enabled for front camera")
+            DivineCameraLog.shared.debug("DivineCamera: Auto flash: Screen flash enabled for front camera")
         } else {
             guard let device = videoDevice else {
-                print("DivineCamera: Auto flash: No video device")
+                DivineCameraLog.shared.debug("DivineCamera: Auto flash: No video device")
                 return
             }
             guard device.hasTorch else {
-                print("DivineCamera: Auto flash: Device has no torch")
+                DivineCameraLog.shared.debug("DivineCamera: Auto flash: Device has no torch")
                 return
             }
             do {
@@ -1308,13 +1351,13 @@ class CameraController: NSObject {
                 if device.isTorchModeSupported(.on) {
                     device.torchMode = .on
                     autoFlashTorchEnabled = true
-                    print("DivineCamera: Auto flash: Torch enabled for back camera")
+                    DivineCameraLog.shared.debug("DivineCamera: Auto flash: Torch enabled for back camera")
                 } else {
-                    print("DivineCamera: Auto flash: Torch mode .on not supported")
+                    DivineCameraLog.shared.debug("DivineCamera: Auto flash: Torch mode .on not supported")
                 }
                 device.unlockForConfiguration()
             } catch {
-                print("DivineCamera: Auto flash: Failed to enable torch: \(error.localizedDescription)")
+                DivineCameraLog.shared.warning("DivineCamera: Auto flash failed to enable torch: \(error.localizedDescription)", name: "DivineCamera.Flash")
             }
         }
     }
@@ -1330,11 +1373,11 @@ class CameraController: NSObject {
                     try device.lockForConfiguration()
                     if device.torchMode != .off && device.isTorchModeSupported(.off) {
                         device.torchMode = .off
-                        print("DivineCamera: Auto flash: Torch disabled for back camera")
+                        DivineCameraLog.shared.debug("DivineCamera: Auto flash: Torch disabled for back camera")
                     }
                     device.unlockForConfiguration()
                 } catch {
-                    print("DivineCamera: Auto flash: Failed to disable torch: \(error.localizedDescription)")
+                    DivineCameraLog.shared.warning("DivineCamera: Auto flash failed to disable torch: \(error.localizedDescription)", name: "DivineCamera.Flash")
                 }
             }
         } else if autoFlashTorchEnabled {
@@ -1544,7 +1587,11 @@ class CameraController: NSObject {
             // that is not worth the added complexity here.
             let audioReady = self.attachAudioToSessionIfNeeded() && !self.audioInterrupted
             if !audioReady {
-                print("[DivineCameraController] Audio not ready — recording WITHOUT audio track")
+                DivineCameraLog.shared.warning(
+                    "Audio not ready (attach failed or interrupted) — recording "
+                        + "WITHOUT audio track",
+                    name: "DivineCamera.Recording"
+                )
             }
 
             self.videoOutputQueue.async { [weak self] in
@@ -1655,7 +1702,10 @@ class CameraController: NSObject {
                     writer.add(audioInput)
                     addedAudioInput = audioInput
                 } else {
-                    print("[DivineCameraController] writer.canAdd(audioInput)=false — recording without audio")
+                    DivineCameraLog.shared.warning(
+                        "writer.canAdd(audioInput)=false — recording without audio",
+                        name: "DivineCamera.Recording"
+                    )
                 }
             }
 
@@ -1674,7 +1724,10 @@ class CameraController: NSObject {
             // Check and enable auto-flash if needed
             self.checkAndEnableAutoFlash()
 
-            print("DivineCamera: Recording started to \(outputURL.path)")
+            DivineCameraLog.shared.info(
+                "Recording started (audioTrack=\(addedAudioInput != nil))",
+                name: "DivineCamera.Recording"
+            )
 
             // Schedule max duration timer if specified
             if let maxMs = self.maxDurationMs, maxMs > 0 {
@@ -1771,17 +1824,37 @@ class CameraController: NSObject {
                             width = Int(abs(size.width))
                             height = Int(abs(size.height))
                         }
-                        
+
+                        // Definitive signal for the "clip saved without sound"
+                        // reports (#4779): inspect the finished file rather than
+                        // trusting the in-flight audioReady flag.
+                        let hasAudioTrack = !asset.tracks(withMediaType: .audio).isEmpty
+                        if hasAudioTrack {
+                            DivineCameraLog.shared.info(
+                                "Recording completed with audio track (durationMs=\(duration))",
+                                name: "DivineCamera.Recording"
+                            )
+                        } else {
+                            DivineCameraLog.shared.warning(
+                                "Recording completed WITHOUT audio track (durationMs=\(duration))",
+                                name: "DivineCamera.Recording"
+                            )
+                        }
+
                         let result: [String: Any] = [
                             "filePath": outputURL.path,
                             "durationMs": duration,
                             "width": width,
                             "height": height
                         ]
-                        
-                        print("DivineCamera: Recording completed - \(outputURL.path)")
+
                         completion(result, nil)
                     } else {
+                        DivineCameraLog.shared.error(
+                            "Recording failed: "
+                                + "\(writer.error?.localizedDescription ?? "Unknown error")",
+                            name: "DivineCamera.Recording"
+                        )
                         completion(nil, "Recording failed: \(writer.error?.localizedDescription ?? "Unknown error")")
                     }
                     
@@ -1927,6 +2000,7 @@ extension CameraController: FlutterTexture {
         defer { pixelBufferLock.unlock() }
         
         guard let pixelBuffer = pixelBufferRef else {
+            // Per-frame on cold start; console only to avoid flooding the log buffer.
             print("DivineCamera: copyPixelBuffer called but pixelBufferRef is nil")
             return nil
         }
@@ -1944,6 +2018,7 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
         if output == videoOutput {
             // Get pixel buffer from sample buffer
             guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else {
+                // Per-frame on failure; console only to avoid flooding the log buffer.
                 print("DivineCamera: Could not get pixel buffer from sample buffer")
                 return
             }
@@ -1956,7 +2031,7 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
             pixelBufferLock.unlock()
             
             if isFirstFrame {
-                print("DivineCamera: First frame received! Pixel buffer dimensions: \(CVPixelBufferGetWidth(pixelBuffer))x\(CVPixelBufferGetHeight(pixelBuffer))")
+                DivineCameraLog.shared.debug("DivineCamera: First frame received! Pixel buffer dimensions: \(CVPixelBufferGetWidth(pixelBuffer))x\(CVPixelBufferGetHeight(pixelBuffer))")
                 
                 // Complete initialization now that we know frames are flowing
                 DispatchQueue.main.async { [weak self] in
@@ -1987,7 +2062,7 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                 if !isWriterSessionStarted && writer.status == .writing {
                     writer.startSession(atSourceTime: timestamp)
                     isWriterSessionStarted = true
-                    print("DivineCamera: Writer session started at \(timestamp.seconds)")
+                    DivineCameraLog.shared.debug("DivineCamera: Writer session started at \(timestamp.seconds)")
                 }
                 
                 if writer.status == .writing && videoInput.isReadyForMoreMediaData {

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraLog.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraLog.swift
@@ -1,0 +1,48 @@
+// ABOUTME: Forwards curated native camera diagnostics to Dart's UnifiedLogger
+// ABOUTME: so recording issues (e.g. missing audio) appear in user bug reports
+
+import Foundation
+
+/// Bridges relevant native diagnostics to the Dart side so they are captured
+/// by the app's `UnifiedLogger` and included in bug-report log dumps.
+///
+/// Native recording code calls these methods (instead of bare `print`) for the
+/// handful of events worth surfacing to support: audio-session configuration,
+/// interruptions and recovery, recording start/stop, and asset-writer
+/// failures. Per-frame / verbose logging must stay on `print` so it does not
+/// flood the captured buffer.
+///
+/// `DivineCameraPlugin` installs `sink` at registration to forward each entry
+/// over the method channel. Before that is wired (or in unit/host contexts)
+/// entries fall back to the console only.
+final class DivineCameraLog {
+    static let shared = DivineCameraLog()
+
+    private init() {}
+
+    /// Forwards `(level, message, name)` to Dart. `level` is one of
+    /// `debug`, `info`, `warning`, `error`. Set by the plugin; `nil` until then.
+    var sink: ((String, String, String) -> Void)?
+
+    func debug(_ message: String, name: String = "DivineCamera") {
+        emit("debug", message, name)
+    }
+
+    func info(_ message: String, name: String = "DivineCamera") {
+        emit("info", message, name)
+    }
+
+    func warning(_ message: String, name: String = "DivineCamera") {
+        emit("warning", message, name)
+    }
+
+    func error(_ message: String, name: String = "DivineCamera") {
+        emit("error", message, name)
+    }
+
+    private func emit(_ level: String, _ message: String, _ name: String) {
+        // Keep the console fallback so on-device debugging is unchanged.
+        print("[\(name)] \(message)")
+        sink?(level, message, name)
+    }
+}

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -19,7 +19,11 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         instance.messenger = registrar.messenger()
         instance.methodChannel = channel
         registrar.addMethodCallDelegate(instance, channel: channel)
-        
+
+        // Forward curated native diagnostics to Dart's UnifiedLogger so
+        // recording issues (e.g. missing audio) land in user bug reports.
+        instance.installLogSink()
+
         // Listen for auto-stop events from CameraController
         NotificationCenter.default.addObserver(
             instance,
@@ -67,9 +71,9 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
                 // Do NOT call setActive(true) — that would steal audio focus
                 // from anything currently playing. setCategory alone triggers
                 // the dlopen.
-                print("DivineCamera: AVAudioSession category configured")
+                DivineCameraLog.shared.debug("AVAudioSession category configured (pre-warm)", name: "DivineCamera.Prewarm")
             } catch {
-                print("DivineCamera: AVAudioSession config failed: \(error.localizedDescription)")
+                DivineCameraLog.shared.warning("AVAudioSession pre-warm config failed: \(error.localizedDescription)", name: "DivineCamera.Prewarm")
             }
             _ = AVCaptureDevice.default(for: .audio)
 
@@ -94,9 +98,9 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
                 writer.startWriting()
                 writer.cancelWriting()
                 try? FileManager.default.removeItem(at: tempURL)
-                print("DivineCamera: VideoToolbox pre-warmed via AVAssetWriter")
+                DivineCameraLog.shared.debug("VideoToolbox pre-warmed via AVAssetWriter", name: "DivineCamera.Prewarm")
             } catch {
-                print("DivineCamera: VideoToolbox pre-warm failed: \(error.localizedDescription)")
+                DivineCameraLog.shared.warning("VideoToolbox pre-warm failed: \(error.localizedDescription)", name: "DivineCamera.Prewarm")
             }
         }
     }
@@ -110,7 +114,46 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         }
     }
     
+    /// Session-lifecycle operations worth leaving a breadcrumb for. High-
+    /// frequency calls (zoom / focus / exposure / getCameraState) are excluded
+    /// on purpose so they don't flood the captured log buffer.
+    private static let lifecycleMethods: Set<String> = [
+        "initializeCamera", "disposeCamera", "switchCamera",
+        "startRecording", "stopRecording", "pausePreview", "resumePreview",
+        "setFlashMode", "setRemoteRecordControlEnabled",
+    ]
+
+    private static func logLifecycleCall(_ call: FlutterMethodCall) {
+        guard lifecycleMethods.contains(call.method) else { return }
+        let args = call.arguments as? [String: Any]
+        DivineCameraLog.shared.debug(
+            "→ \(call.method)\(args.map { " \($0)" } ?? "")",
+            name: "DivineCamera.Lifecycle"
+        )
+    }
+
+    /// Per-instance forwarder pushing native diagnostics over THIS engine's
+    /// channel. `DivineCameraLog.shared.sink` is a process-wide singleton, so a
+    /// second FlutterEngine that registers the plugin would otherwise overwrite
+    /// it and route camera logs to the wrong isolate. We re-assert it in
+    /// `handle` — camera calls only ever reach the UI engine.
+    private lazy var logSink: (String, String, String) -> Void = {
+        [weak self] level, message, name in
+        DispatchQueue.main.async {
+            self?.methodChannel?.invokeMethod(
+                "onNativeLog",
+                arguments: ["level": level, "message": message, "name": name]
+            )
+        }
+    }
+
+    private func installLogSink() {
+        DivineCameraLog.shared.sink = logSink
+    }
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        installLogSink()
+        DivineCameraPlugin.logLifecycleCall(call)
         switch call.method {
         case "getPlatformVersion":
             result("iOS " + UIDevice.current.systemVersion)
@@ -193,10 +236,22 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             result(FlutterMethodNotImplemented)
         }
     }
-    
+
+    /// Builds a `FlutterError` and forwards it to Dart's UnifiedLogger so the
+    /// failure shows up in user bug reports. Fatal native crashes are captured
+    /// separately by Crashlytics. Static so it can be called from `@escaping`
+    /// completion closures without capturing `self`.
+    private static func cameraError(_ code: String, _ message: String?) -> FlutterError {
+        DivineCameraLog.shared.error(
+            "\(code): \(message ?? "")",
+            name: "DivineCamera.Plugin"
+        )
+        return FlutterError(code: code, message: message, details: nil)
+    }
+
     private func initializeCamera(lens: String, videoQuality: String, enableScreenFlash: Bool, mirrorFrontCameraOutput: Bool, enableAutoLensSwitch: Bool, result: @escaping FlutterResult) {
         guard let registry = textureRegistry else {
-            result(FlutterError(code: "NO_REGISTRY", message: "Texture registry not available", details: nil))
+            result(Self.cameraError("NO_REGISTRY", "Texture registry not available"))
             return
         }
         
@@ -206,8 +261,17 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         cameraController?.initialize(lens: lens, videoQuality: videoQuality, enableScreenFlash: enableScreenFlash, mirrorFrontCameraOutput: mirrorFrontCameraOutput, enableAutoLensSwitch: enableAutoLensSwitch) { [weak self] state, error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(FlutterError(code: "INIT_ERROR", message: error, details: nil))
+                    result(Self.cameraError("INIT_ERROR", error))
                 } else {
+                    if let dict = state as? [String: Any] {
+                        DivineCameraLog.shared.info(
+                            "Camera initialized (lens=\(dict["lens"] ?? "?"), "
+                                + "aspectRatio=\(dict["aspectRatio"] ?? "?"), "
+                                + "hasFlash=\(dict["hasFlash"] ?? "?"), "
+                                + "lenses=\(dict["availableLenses"] ?? "?"))",
+                            name: "DivineCamera.Lifecycle"
+                        )
+                    }
                     result(state)
                 }
             }
@@ -247,7 +311,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func setFlashMode(mode: String, result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.setFlashMode(mode: mode)
@@ -256,7 +320,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func setFocusPoint(x: Double, y: Double, result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.setFocusPoint(x: CGFloat(x), y: CGFloat(y))
@@ -265,7 +329,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func setExposurePoint(x: Double, y: Double, result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.setExposurePoint(x: CGFloat(x), y: CGFloat(y))
@@ -274,7 +338,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func cancelFocusAndMetering(result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.cancelFocusAndMetering()
@@ -283,7 +347,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func setZoomLevel(level: Double, result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.setZoomLevel(level: CGFloat(level))
@@ -292,7 +356,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func switchCamera(lens: String, result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         
@@ -305,8 +369,14 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         controller.switchCamera(lens: lens) { state, error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(FlutterError(code: "SWITCH_ERROR", message: error, details: nil))
+                    result(Self.cameraError("SWITCH_ERROR", error))
                 } else {
+                    if let dict = state as? [String: Any] {
+                        DivineCameraLog.shared.info(
+                            "Camera switched (lens=\(dict["lens"] ?? "?"))",
+                            name: "DivineCamera.Lifecycle"
+                        )
+                    }
                     result(state)
                 }
             }
@@ -315,14 +385,14 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func startRecording(maxDurationMs: Int?, useCache: Bool, outputDirectory: String?, result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         
         controller.startRecording(maxDurationMs: maxDurationMs, useCache: useCache, outputDirectory: outputDirectory) { error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(FlutterError(code: "RECORD_START_ERROR", message: error, details: nil))
+                    result(Self.cameraError("RECORD_START_ERROR", error))
                 } else {
                     result(nil)
                 }
@@ -332,14 +402,14 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func stopRecording(result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         
         controller.stopRecording { recordingResult, error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(FlutterError(code: "RECORD_STOP_ERROR", message: error, details: nil))
+                    result(Self.cameraError("RECORD_STOP_ERROR", error))
                 } else {
                     result(recordingResult)
                 }
@@ -356,7 +426,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         cameraController?.resumePreview { state, error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(FlutterError(code: "RESUME_ERROR", message: error, details: nil))
+                    result(Self.cameraError("RESUME_ERROR", error))
                 } else {
                     result(state)
                 }
@@ -366,7 +436,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     
     private func getCameraState(result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(FlutterError(code: "NOT_INITIALIZED", message: "Camera not initialized", details: nil))
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         result(controller.getCameraState())

--- a/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
+++ b/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
@@ -68,9 +68,9 @@ class VolumeKeyHandler: NSObject {
         isSuppressed = true
         DispatchQueue.main.asyncAfter(deadline: .now() + activationCooldownSeconds) { [weak self] in
             self?.isSuppressed = false
-            NSLog("DivineCameraVolumeKeyHandler: Initial suppression ended")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Initial suppression ended")
         }
-        NSLog("DivineCameraVolumeKeyHandler: Enabled (suppressed for \(activationCooldownSeconds)s)")
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Enabled (suppressed for \(activationCooldownSeconds)s)")
         return true
     }
     
@@ -85,7 +85,7 @@ class VolumeKeyHandler: NSObject {
         
         isEnabled = false
         volumeKeysEnabled = true
-        NSLog("DivineCameraVolumeKeyHandler: Disabled")
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Disabled")
     }
     
     /// Enable or disable volume key interception.
@@ -93,7 +93,7 @@ class VolumeKeyHandler: NSObject {
     /// Bluetooth media buttons are NOT affected by this setting.
     func setVolumeKeysEnabled(_ enabled: Bool) {
         volumeKeysEnabled = enabled
-        NSLog("DivineCameraVolumeKeyHandler: Volume keys \(enabled ? "enabled" : "disabled")")
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume keys \(enabled ? "enabled" : "disabled")")
     }
     
     /// Whether volume key handling is currently enabled.
@@ -108,10 +108,10 @@ class VolumeKeyHandler: NSObject {
     /// play/pause events from connected devices (e.g. Apple Watch).
     func suppressTemporarily(forSeconds duration: TimeInterval = 1.0) {
         isSuppressed = true
-        NSLog("DivineCameraVolumeKeyHandler: Suppressed for \(duration)s")
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Suppressed for \(duration)s")
         DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak self] in
             self?.isSuppressed = false
-            NSLog("DivineCameraVolumeKeyHandler: Suppression ended")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Suppression ended")
         }
     }
     
@@ -128,21 +128,21 @@ class VolumeKeyHandler: NSObject {
         
         // Play/Pause toggle (most common on Bluetooth headphones)
         commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
-            NSLog("DivineCameraVolumeKeyHandler: Bluetooth toggle play/pause")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth toggle play/pause")
             self?.handleBluetoothTrigger()
             return .success
         }
         
         // Play command
         commandCenter.playCommand.addTarget { [weak self] _ in
-            NSLog("DivineCameraVolumeKeyHandler: Bluetooth play")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth play")
             self?.handleBluetoothTrigger()
             return .success
         }
         
         // Pause command
         commandCenter.pauseCommand.addTarget { [weak self] _ in
-            NSLog("DivineCameraVolumeKeyHandler: Bluetooth pause")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth pause")
             self?.handleBluetoothTrigger()
             return .success
         }
@@ -158,7 +158,7 @@ class VolumeKeyHandler: NSObject {
         nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = 1.0
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
         
-        NSLog("DivineCameraVolumeKeyHandler: Remote command center configured")
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Remote command center configured")
     }
     
     private func teardownRemoteCommandCenter() {
@@ -183,26 +183,26 @@ class VolumeKeyHandler: NSObject {
         
         // Check suppression (camera switch in progress)
         if isSuppressed {
-            NSLog("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - suppressed")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - suppressed")
             return
         }
         
         // Check activation cooldown
         let timeSinceEnabled = now - enabledTimestamp
         if timeSinceEnabled < activationCooldownSeconds {
-            NSLog("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - within \(String(format: "%.0f", activationCooldownSeconds * 1000))ms activation cooldown (\(String(format: "%.0f", timeSinceEnabled * 1000))ms since enabled)")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - within \(String(format: "%.0f", activationCooldownSeconds * 1000))ms activation cooldown (\(String(format: "%.0f", timeSinceEnabled * 1000))ms since enabled)")
             return
         }
         
         // Check debounce between triggers
         let timeSinceLastTrigger = now - lastBluetoothTriggerTimestamp
         if timeSinceLastTrigger < bluetoothDebounceSeconds {
-            NSLog("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - debounce (\(String(format: "%.0f", timeSinceLastTrigger * 1000))ms since last)")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth trigger ignored - debounce (\(String(format: "%.0f", timeSinceLastTrigger * 1000))ms since last)")
             return
         }
         
         lastBluetoothTriggerTimestamp = now
-        NSLog("DivineCameraVolumeKeyHandler: Bluetooth trigger accepted")
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth trigger accepted")
         
         // Refresh now playing info so iOS keeps routing remote events to us.
         // Without this, audio session changes during recording start/stop can
@@ -258,7 +258,7 @@ class VolumeKeyHandler: NSObject {
         )
         isObservingVolume = true
         
-        NSLog("DivineCameraVolumeKeyHandler: Volume observer configured")
+        DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume observer configured")
     }
     
     private func teardownVolumeObserver() {
@@ -290,20 +290,20 @@ class VolumeKeyHandler: NSObject {
         // switch from being misinterpreted as volume button presses.
         if !isInternalVolumeChange && isEnabled && volumeKeysEnabled && !isSuppressed {
             if newValue > oldValue {
-                NSLog("DivineCameraVolumeKeyHandler: Volume up button pressed")
+                DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume up button pressed")
                 onTrigger?("volumeUp")
                 
                 // Restore volume to prevent actual volume change
                 restoreVolume(to: oldValue)
             } else if newValue < oldValue {
-                NSLog("DivineCameraVolumeKeyHandler: Volume down button pressed")
+                DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume down button pressed")
                 onTrigger?("volumeDown")
                 
                 // Restore volume to prevent actual volume change
                 restoreVolume(to: oldValue)
             }
         } else if isSuppressed && !isInternalVolumeChange && newValue != oldValue {
-            NSLog("DivineCameraVolumeKeyHandler: Volume change ignored - suppressed (camera switch in progress)")
+            DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Volume change ignored - suppressed (camera switch in progress)")
             // Still restore volume during suppression to prevent drift
             restoreVolume(to: oldValue)
         }

--- a/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
@@ -69,8 +69,41 @@ class MethodChannelDivineCamera extends DivineCameraPlatform {
           _onRemoteRecordTrigger!(trigger);
         }
         return null;
+      case 'onNativeLog':
+        final args = call.arguments as Map<dynamic, dynamic>?;
+        if (args != null) {
+          _forwardNativeLog(args);
+        }
+        return null;
       default:
         return null;
+    }
+  }
+
+  /// Forwards a curated diagnostic emitted by the native recording path into
+  /// the app's [UnifiedLogger] so it is captured for bug reports.
+  ///
+  /// The native side only sends events that matter for diagnosing recording
+  /// problems (audio-session setup, interruptions, recovery, recording
+  /// start/stop, asset-writer failures) — see `DivineCameraLog` on each
+  /// platform. Per-frame and verbose native logs stay on the device console.
+  void _forwardNativeLog(Map<dynamic, dynamic> args) {
+    final message = args['message'] as String?;
+    if (message == null || message.isEmpty) return;
+    final level = args['level'] as String? ?? 'info';
+    final name = args['name'] as String? ?? 'DivineCameraNative';
+    switch (level) {
+      case 'error':
+        Log.error(message, name: name, category: LogCategory.video);
+      case 'warning':
+        Log.warning(message, name: name, category: LogCategory.video);
+      case 'debug':
+        Log.debug(message, name: name, category: LogCategory.video);
+      case 'verbose':
+        Log.verbose(message, name: name, category: LogCategory.video);
+      case 'info':
+      default:
+        Log.info(message, name: name, category: LogCategory.video);
     }
   }
 
@@ -201,7 +234,14 @@ class MethodChannelDivineCamera extends DivineCameraPlatform {
         'outputDirectory': ?outputDirectory,
       });
       return true;
-    } on PlatformException {
+    } on PlatformException catch (e, stackTrace) {
+      Log.error(
+        'startRecording failed: ${e.code} ${e.message ?? ''}',
+        name: 'DivineCameraMethodChannel',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
       return false;
     }
   }

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
@@ -133,9 +133,10 @@ extension CameraController {
                     addedAudioInput = audioInput
                 } else {
                     addedAudioInput = nil
-                    print(
-                        "DivineCamera macOS: Cannot add audio input "
-                            + "to asset writer"
+                    DivineCameraLog.shared.warning(
+                        "Cannot add audio input to asset writer — "
+                            + "recording without audio",
+                        name: "DivineCamera.Recording"
                     )
                 }
 
@@ -149,6 +150,10 @@ extension CameraController {
                         writer.error?.localizedDescription ?? "Unknown error"
                     writer.cancelWriting()
                     self.cleanupRecordingState(deleteOutputFile: true)
+                    DivineCameraLog.shared.error(
+                        "Failed to start asset writer: \(message)",
+                        name: "DivineCamera.Recording"
+                    )
                     DispatchQueue.main.async {
                         completion(
                             "Failed to start asset writer: \(message)"
@@ -168,8 +173,9 @@ extension CameraController {
                 self.isWriterSessionStarted = false
                 self.recordingStartTime = Date()
 
-                print(
-                    "DivineCamera macOS: Recording started to \(outputURL.path)"
+                DivineCameraLog.shared.info(
+                    "Recording started (audioTrack=\(addedAudioInput != nil))",
+                    name: "DivineCamera.Recording"
                 )
 
                 // Schedule max duration timer if specified
@@ -254,6 +260,12 @@ extension CameraController {
             writer.finishWriting { [weak self] in
                 guard let self = self else { return }
 
+                // Whether an audio track was written, captured before the
+                // cleanup below nils out the input. The macOS path avoids
+                // loading the finished AVAsset, so this writer-input proxy
+                // stands in for the iOS file-level check.
+                let hadAudioTrack = self.audioWriterInput != nil
+
                 DispatchQueue.main.async {
                     if writer.status == .completed {
                         let duration: Int
@@ -291,12 +303,26 @@ extension CameraController {
                             "height": height,
                         ]
 
-                        print(
-                            "DivineCamera macOS: Recording completed - "
-                                + "\(outputURL.path)"
-                        )
+                        if hadAudioTrack {
+                            DivineCameraLog.shared.info(
+                                "Recording completed with audio track "
+                                    + "(durationMs=\(duration))",
+                                name: "DivineCamera.Recording"
+                            )
+                        } else {
+                            DivineCameraLog.shared.warning(
+                                "Recording completed WITHOUT audio track "
+                                    + "(durationMs=\(duration))",
+                                name: "DivineCamera.Recording"
+                            )
+                        }
                         completion(result, nil)
                     } else {
+                        DivineCameraLog.shared.error(
+                            "Recording failed: "
+                                + "\(writer.error?.localizedDescription ?? "Unknown error")",
+                            name: "DivineCamera.Recording"
+                        )
                         completion(
                             nil,
                             "Recording failed: "

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+ScreenFlash.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+ScreenFlash.swift
@@ -48,7 +48,7 @@ extension CameraController {
                 self.screenFlashWindows.append(window)
             }
 
-            print("DivineCamera macOS: Screen flash enabled")
+            DivineCameraLog.shared.debug("DivineCamera macOS: Screen flash enabled")
         }
     }
 
@@ -62,7 +62,7 @@ extension CameraController {
             }
             self.screenFlashWindows.removeAll()
             if hadWindows {
-                print("DivineCamera macOS: Screen flash disabled")
+                DivineCameraLog.shared.debug("DivineCamera macOS: Screen flash disabled")
             }
         }
     }
@@ -80,14 +80,14 @@ extension CameraController {
         guard isAutoFlashMode else { return }
 
         if isEnvironmentDark() {
-            print(
+            DivineCameraLog.shared.debug(
                 "DivineCamera macOS: Auto flash: "
                     + "Dark environment detected - enabling screen flash"
             )
             autoFlashEnabled = true
             enableScreenFlash()
         } else {
-            print(
+            DivineCameraLog.shared.debug(
                 "DivineCamera macOS: Auto flash: "
                     + "Bright environment - flash not needed"
             )
@@ -105,7 +105,7 @@ extension CameraController {
     /// Sets the flash mode.
     /// On macOS the only flash mechanism is the screen flash (warm overlay).
     func setFlashMode(mode: String) -> Bool {
-        print("DivineCamera macOS: Setting flash mode: \(mode)")
+        DivineCameraLog.shared.debug("DivineCamera macOS: Setting flash mode: \(mode)")
 
         switch mode {
         case "off":

--- a/mobile/packages/divine_camera/macos/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController.swift
@@ -116,7 +116,7 @@ class CameraController: NSObject {
             }
         }
 
-        print(
+        DivineCameraLog.shared.debug(
             "[DivineCameraController] macOS cameras: "
                 + "front=\(hasFrontCamera), back=\(hasBackCamera)"
         )
@@ -318,7 +318,7 @@ class CameraController: NSObject {
                     self.audioInput = audioInput
                 }
             } catch {
-                print(
+                DivineCameraLog.shared.debug(
                     "Failed to add audio input: "
                         + "\(error.localizedDescription)"
                 )
@@ -350,7 +350,7 @@ class CameraController: NSObject {
             session.addOutput(audioOutput)
             self.audioOutput = audioOutput
         } else {
-            print("DivineCamera macOS: Cannot add audio output")
+            DivineCameraLog.shared.warning("Cannot add audio output to session", name: "DivineCamera.Audio")
         }
 
         session.commitConfiguration()
@@ -370,7 +370,7 @@ class CameraController: NSObject {
 
         // Register texture
         textureId = textureRegistry.register(self)
-        print(
+        DivineCameraLog.shared.debug(
             "DivineCamera macOS: Registered texture with ID: \(textureId)"
         )
 
@@ -397,11 +397,11 @@ class CameraController: NSObject {
         initializationCompletion = nil
 
         if timedOut {
-            print(
+            DivineCameraLog.shared.debug(
                 "DivineCamera macOS: Initialization completed via timeout"
             )
         } else {
-            print(
+            DivineCameraLog.shared.debug(
                 "DivineCamera macOS: Initialization completed - first frame"
             )
         }
@@ -669,13 +669,13 @@ class CameraController: NSObject {
                 session.addInput(newInput)
                 self.audioInput = newInput
                 self.audioDevice = newDevice
-                print(
+                DivineCameraLog.shared.debug(
                     "DivineCamera macOS: Switched audio device to "
                         + "\(newDevice.localizedName)"
                 )
             }
         } catch {
-            print(
+            DivineCameraLog.shared.debug(
                 "Failed to switch audio device: "
                     + "\(error.localizedDescription)"
             )

--- a/mobile/packages/divine_camera/macos/Classes/DivineCameraLog.swift
+++ b/mobile/packages/divine_camera/macos/Classes/DivineCameraLog.swift
@@ -1,0 +1,47 @@
+// ABOUTME: Forwards curated native camera diagnostics to Dart's UnifiedLogger
+// ABOUTME: so recording issues (e.g. missing audio) appear in user bug reports
+
+import Foundation
+
+/// Bridges relevant native diagnostics to the Dart side so they are captured
+/// by the app's `UnifiedLogger` and included in bug-report log dumps.
+///
+/// Native recording code calls these methods (instead of bare `print`) for the
+/// handful of events worth surfacing to support: audio-session configuration,
+/// recording start/stop, and asset-writer failures. Per-frame / verbose
+/// logging must stay on `print` so it does not flood the captured buffer.
+///
+/// `DivineCameraPlugin` installs `sink` at registration to forward each entry
+/// over the method channel. Before that is wired (or in unit/host contexts)
+/// entries fall back to the console only.
+final class DivineCameraLog {
+    static let shared = DivineCameraLog()
+
+    private init() {}
+
+    /// Forwards `(level, message, name)` to Dart. `level` is one of
+    /// `debug`, `info`, `warning`, `error`. Set by the plugin; `nil` until then.
+    var sink: ((String, String, String) -> Void)?
+
+    func debug(_ message: String, name: String = "DivineCamera") {
+        emit("debug", message, name)
+    }
+
+    func info(_ message: String, name: String = "DivineCamera") {
+        emit("info", message, name)
+    }
+
+    func warning(_ message: String, name: String = "DivineCamera") {
+        emit("warning", message, name)
+    }
+
+    func error(_ message: String, name: String = "DivineCamera") {
+        emit("error", message, name)
+    }
+
+    private func emit(_ level: String, _ message: String, _ name: String) {
+        // Keep the console fallback so on-device debugging is unchanged.
+        print("[\(name)] \(message)")
+        sink?(level, message, name)
+    }
+}

--- a/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
@@ -22,6 +22,10 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         instance.methodChannel = channel
         registrar.addMethodCallDelegate(instance, channel: channel)
 
+        // Forward curated native diagnostics to Dart's UnifiedLogger so
+        // recording issues (e.g. missing audio) land in user bug reports.
+        instance.installLogSink()
+
         // Listen for auto-stop events from CameraController
         NotificationCenter.default.addObserver(
             instance,
@@ -42,10 +46,49 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         }
     }
 
+    /// Session-lifecycle operations worth leaving a breadcrumb for. High-
+    /// frequency calls (zoom / focus / exposure / getCameraState) are excluded
+    /// on purpose so they don't flood the captured log buffer.
+    private static let lifecycleMethods: Set<String> = [
+        "initializeCamera", "disposeCamera", "switchCamera",
+        "startRecording", "stopRecording", "pausePreview", "resumePreview",
+        "setFlashMode",
+    ]
+
+    private static func logLifecycleCall(_ call: FlutterMethodCall) {
+        guard lifecycleMethods.contains(call.method) else { return }
+        let args = call.arguments as? [String: Any]
+        DivineCameraLog.shared.debug(
+            "→ \(call.method)\(args.map { " \($0)" } ?? "")",
+            name: "DivineCamera.Lifecycle"
+        )
+    }
+
+    /// Per-instance forwarder pushing native diagnostics over THIS engine's
+    /// channel. `DivineCameraLog.shared.sink` is a process-wide singleton, so a
+    /// second FlutterEngine that registers the plugin would otherwise overwrite
+    /// it and route camera logs to the wrong isolate. We re-assert it in
+    /// `handle` — camera calls only ever reach the UI engine.
+    private lazy var logSink: (String, String, String) -> Void = {
+        [weak self] level, message, name in
+        DispatchQueue.main.async {
+            self?.methodChannel?.invokeMethod(
+                "onNativeLog",
+                arguments: ["level": level, "message": message, "name": name]
+            )
+        }
+    }
+
+    private func installLogSink() {
+        DivineCameraLog.shared.sink = logSink
+    }
+
     public func handle(
         _ call: FlutterMethodCall,
         result: @escaping FlutterResult
     ) {
+        installLogSink()
+        DivineCameraPlugin.logLifecycleCall(call)
         switch call.method {
         case "getPlatformVersion":
             result(
@@ -143,6 +186,18 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
 
     // MARK: - Camera Operations
 
+    /// Builds a `FlutterError` and forwards it to Dart's UnifiedLogger so the
+    /// failure shows up in user bug reports. Fatal native crashes are captured
+    /// separately by Crashlytics. Static so it can be called from `@escaping`
+    /// completion closures without capturing `self`.
+    private static func cameraError(_ code: String, _ message: String?) -> FlutterError {
+        DivineCameraLog.shared.error(
+            "\(code): \(message ?? "")",
+            name: "DivineCamera.Plugin"
+        )
+        return FlutterError(code: code, message: message, details: nil)
+    }
+
     private func initializeCamera(
         lens: String,
         videoQuality: String,
@@ -150,13 +205,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         result: @escaping FlutterResult
     ) {
         guard let registry = textureRegistry else {
-            result(
-                FlutterError(
-                    code: "NO_REGISTRY",
-                    message: "Texture registry not available",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NO_REGISTRY", "Texture registry not available"))
             return
         }
 
@@ -170,14 +219,17 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         ) { state, error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(
-                        FlutterError(
-                            code: "INIT_ERROR",
-                            message: error,
-                            details: nil
-                        )
-                    )
+                    result(Self.cameraError("INIT_ERROR", error))
                 } else {
+                    if let dict = state as? [String: Any] {
+                        DivineCameraLog.shared.info(
+                            "Camera initialized (lens=\(dict["lens"] ?? "?"), "
+                                + "aspectRatio=\(dict["aspectRatio"] ?? "?"), "
+                                + "hasFlash=\(dict["hasFlash"] ?? "?"), "
+                                + "lenses=\(dict["availableLenses"] ?? "?"))",
+                            name: "DivineCamera.Lifecycle"
+                        )
+                    }
                     result(state)
                 }
             }
@@ -195,13 +247,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         result: @escaping FlutterResult
     ) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.setFlashMode(mode: mode)
@@ -214,13 +260,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         result: @escaping FlutterResult
     ) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.setFocusPoint(x: CGFloat(x), y: CGFloat(y))
@@ -233,13 +273,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         result: @escaping FlutterResult
     ) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.setExposurePoint(
@@ -251,13 +285,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
 
     private func cancelFocusAndMetering(result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.cancelFocusAndMetering()
@@ -266,13 +294,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
 
     private func setZoomLevel(level: Double, result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         let success = controller.setZoomLevel(level: CGFloat(level))
@@ -281,27 +303,21 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
 
     private func switchCamera(lens: String, result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
 
         controller.switchCamera(lens: lens) { state, error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(
-                        FlutterError(
-                            code: "SWITCH_ERROR",
-                            message: error,
-                            details: nil
-                        )
-                    )
+                    result(Self.cameraError("SWITCH_ERROR", error))
                 } else {
+                    if let dict = state as? [String: Any] {
+                        DivineCameraLog.shared.info(
+                            "Camera switched (lens=\(dict["lens"] ?? "?"))",
+                            name: "DivineCamera.Lifecycle"
+                        )
+                    }
                     result(state)
                 }
             }
@@ -316,13 +332,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         result: @escaping FlutterResult
     ) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
 
@@ -334,13 +344,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         ) { error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(
-                        FlutterError(
-                            code: "RECORD_START_ERROR",
-                            message: error,
-                            details: nil
-                        )
-                    )
+                    result(Self.cameraError("RECORD_START_ERROR", error))
                 } else {
                     result(nil)
                 }
@@ -350,26 +354,14 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
 
     private func stopRecording(result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
 
         controller.stopRecording { recordingResult, error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(
-                        FlutterError(
-                            code: "RECORD_STOP_ERROR",
-                            message: error,
-                            details: nil
-                        )
-                    )
+                    result(Self.cameraError("RECORD_STOP_ERROR", error))
                 } else {
                     result(recordingResult)
                 }
@@ -386,13 +378,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         cameraController?.resumePreview { state, error in
             DispatchQueue.main.async {
                 if let error = error {
-                    result(
-                        FlutterError(
-                            code: "RESUME_ERROR",
-                            message: error,
-                            details: nil
-                        )
-                    )
+                    result(Self.cameraError("RESUME_ERROR", error))
                 } else {
                     result(state)
                 }
@@ -402,13 +388,7 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
 
     private func getCameraState(result: @escaping FlutterResult) {
         guard let controller = cameraController else {
-            result(
-                FlutterError(
-                    code: "NOT_INITIALIZED",
-                    message: "Camera not initialized",
-                    details: nil
-                )
-            )
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
         result(controller.getCameraState())

--- a/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
@@ -3,6 +3,7 @@ import 'package:divine_camera/divine_camera_method_channel.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -324,6 +325,13 @@ void main() {
 
       final result = await platform.startRecording();
       expect(result, isFalse);
+
+      final logged = LogCaptureService().getRecentLogs().any(
+        (entry) =>
+            entry.level == LogLevel.error &&
+            entry.message.contains('RECORD_START_ERROR'),
+      );
+      expect(logged, isTrue);
     });
 
     test('stopRecording returns VideoRecordingResult', () async {
@@ -573,6 +581,95 @@ void main() {
             ),
         completes,
       );
+    });
+  });
+
+  group('MethodChannelDivineCamera onNativeLog forwarding', () {
+    Future<void> dispatchNativeLog(Object? arguments) {
+      const codec = StandardMethodCodec();
+      final envelope = codec.encodeMethodCall(
+        MethodCall('onNativeLog', arguments),
+      );
+      return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .handlePlatformMessage('divine_camera', envelope, (data) {});
+    }
+
+    LogEntry? latestEntryWithMessage(String message) {
+      final matches = LogCaptureService().getRecentLogs().where(
+        (entry) => entry.message == message,
+      );
+      return matches.isEmpty ? null : matches.last;
+    }
+
+    test(
+      'forwards a warning into UnifiedLogger under the video category',
+      () async {
+        const message = 'onNativeLog-test-warning-unique';
+        await dispatchNativeLog({
+          'level': 'warning',
+          'message': message,
+          'name': 'DivineCamera.Recording',
+        });
+
+        final entry = latestEntryWithMessage(message);
+        expect(entry, isNotNull);
+        expect(entry!.level, LogLevel.warning);
+        expect(entry.name, 'DivineCamera.Recording');
+        expect(entry.category, LogCategory.video);
+      },
+    );
+
+    test('maps the error level', () async {
+      const message = 'onNativeLog-test-error-unique';
+      await dispatchNativeLog({
+        'level': 'error',
+        'message': message,
+        'name': 'DivineCamera.AudioSession',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.error);
+    });
+
+    test('falls back to info for an unknown level', () async {
+      const message = 'onNativeLog-test-unknown-level-unique';
+      await dispatchNativeLog({
+        'level': 'something-unexpected',
+        'message': message,
+        'name': 'DivineCamera',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.info);
+    });
+
+    test('falls back to the native name when none is provided', () async {
+      const message = 'onNativeLog-test-default-name-unique';
+      await dispatchNativeLog({
+        'level': 'info',
+        'message': message,
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.name, 'DivineCameraNative');
+    });
+
+    test('ignores an entry with an empty message', () async {
+      final before = LogCaptureService().bufferSize;
+      await dispatchNativeLog({
+        'level': 'warning',
+        'message': '',
+        'name': 'DivineCamera',
+      });
+
+      expect(LogCaptureService().bufferSize, before);
+    });
+
+    test('ignores a call with null arguments without throwing', () async {
+      await expectLater(dispatchNativeLog(null), completes);
     });
   });
 }

--- a/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
@@ -632,6 +632,32 @@ void main() {
       expect(entry!.level, LogLevel.error);
     });
 
+    test('maps the debug level', () async {
+      const message = 'onNativeLog-test-debug-unique';
+      await dispatchNativeLog({
+        'level': 'debug',
+        'message': message,
+        'name': 'DivineCamera.Lifecycle',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.debug);
+    });
+
+    test('maps the verbose level', () async {
+      const message = 'onNativeLog-test-verbose-unique';
+      await dispatchNativeLog({
+        'level': 'verbose',
+        'message': message,
+        'name': 'DivineCamera',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.verbose);
+    });
+
     test('falls back to info for an unknown level', () async {
       const message = 'onNativeLog-test-unknown-level-unique';
       await dispatchNativeLog({


### PR DESCRIPTION
## Description

Native camera/audio diagnostics in `divine_camera` were previously stranded in platform consoles (`print`, `NSLog`, and `android.util.Log`). Those lines never reached the Dart `UnifiedLogger` buffer that `bug_report_service.dart` exports into support logs, which left bug reports for audio-loss cases without the native recording timeline.

This PR adds a native -> Dart diagnostics bridge for DivineCamera so support can reconstruct recording behavior from a user bug report without changing recording control flow.

Closes #5127.
Supports investigation of #4779.

## Mechanism

- Adds a per-platform `DivineCameraLog` helper on Android, iOS, and macOS with `debug`, `info`, `warning`, and `error` methods.
- Installs a per-plugin-instance sink that forwards native diagnostics over the existing `divine_camera` method channel via `onNativeLog`.
- Maps `onNativeLog` in `MethodChannelDivineCamera` to `UnifiedLogger` with `LogCategory.video`, so the entries land in `LogCaptureService` and bug-report exports.
- Keeps console/logcat fallback behavior for local device debugging.
- Preserves Android throwable stack traces in logcat while forwarding a concise throwable summary to Dart.

## What Gets Forwarded

- Audio and recording diagnostics: audio-session setup, interruptions and recovery, recording start/stop, asset-writer failures, and missing-audio-track signals.
- Android CameraX `AudioStats.audioState` transitions, including `SOURCE_SILENCED` and `SOURCE_ERROR`.
- Errors returned to Dart through the native plugin error path.
- Session lifecycle breadcrumbs for camera initialization, switching, recording, pause/resume, disposal, flash mode, and remote record control.
- Existing native controller diagnostics that are useful for support triage.

Per-frame logs remain console-only where they would flood the captured log buffer.

## Multi-Engine Handling

`DivineCameraLog.sink` is process-global on the native side. The app can also run a background Flutter engine for Firebase Messaging, and that engine may register the plugin too.

This PR binds each plugin instance to its own `logSink` and re-asserts the active sink at the top of each camera method call. Normal camera calls hit the UI engine, so camera-operation diagnostics are routed back to the UI isolate. Android detach also clears the singleton only when the current plugin instance still owns it.

The remaining native-only edge is tracked in #5128.

## Out Of Scope

- `pro_video_editor` render diagnostics for #4801. That is a different native surface and should wire the package's existing `nativeLogLevel` and render callbacks separately.
- Binding the native diagnostics sink to activity/UI lifecycle attachment for the rare native-only sink ownership window. Tracked by #5128.

## Verification

- `mise exec -- flutter analyze lib test` from `mobile/packages/divine_camera` -> no issues found.
- `mise exec -- flutter test` from `mobile/packages/divine_camera` -> 314 tests passed.
- Push hook analyze and targeted `packages/divine_camera/test/divine_camera_method_channel_test.dart` -> passed.
- Android device verification from the original PR author: `onNativeLog` arrived in Dart after the multi-engine fix.
- CI is expected to rerun on the rebased branch and pushed cleanup commit.

## Type of Change

- [x] New feature (non-breaking change which adds diagnostics)
- [x] Bug fix (non-breaking diagnostics fix for missing support logs)
- [ ] Breaking change
- [ ] Build configuration change
- [ ] Documentation
