### PR TITLE
fix(notifications): decide fallback UX for unfetchable coordinate-routed push taps

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -340,6 +340,12 @@ ProfileDeepLinkNavAction resolveProfileDeepLinkNavAction({
 /// executor routes to it directly. Otherwise the video target is
 /// `referencedEventId` (the event acted upon), falling back to `eventId` (the
 /// source event) for follow/mention, which the executor walks to a root video.
+///
+/// At most one of `videoCoordinate` / `targetEventId` is non-null: a usable
+/// coordinate suppresses the event-id walk entirely, encoding the
+/// coordinate-over-walk precedence in the returned value rather than leaving
+/// it to the executor's branch order.
+///
 /// Extracted and `@visibleForTesting` so the push-side per-kind routing can be
 /// asserted without a navigator — mirrors [resolveVideoDeepLinkNavAction].
 @visibleForTesting
@@ -352,8 +358,9 @@ pushNotificationTapTarget({
   required String? senderPubkey,
 }) {
   final videoCoordinate = videoAddressableTarget(referencedAddress);
-  final targetEventId =
-      (referencedEventId != null && referencedEventId.isNotEmpty)
+  final targetEventId = videoCoordinate != null
+      ? null
+      : (referencedEventId != null && referencedEventId.isNotEmpty)
       ? referencedEventId
       : eventId;
   final hasVideoTarget =

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -381,6 +381,19 @@ pushNotificationTapTarget({
 /// mentions, which carry no `referencedEventId`. [senderPubkey] is the actor —
 /// it opens a profile for follows and is the safe fallback when a video target
 /// cannot be resolved.
+///
+/// Failure UX contract (decided in #5079): the profile/inbox fallback applies
+/// only to the event-id walk, where resolution happens *before* a route exists
+/// and can fail. A valid video coordinate is pushed without a pre-fetch; if
+/// the video is then unfetchable (deleted, moderated, offline), the user
+/// intentionally lands on [VideoDetailScreen]'s error state — same
+/// trust-the-coordinate contract as the in-app rows, which push immediately on
+/// an addressable id and surface fetch failure in place. Redirecting a "they
+/// interacted with your video" tap to the actor's profile would be
+/// misdirection, and a pre-push fetch would reintroduce the relay round-trip
+/// this path exists to avoid. Transient failures are already mitigated
+/// downstream: the route lookup tries cache → Funnelcake REST → relays, and
+/// the screen retries once when relays become ready on cold start.
 Future<void> _routeNotificationTap({
   required String? referencedAddress,
   required String? referencedEventId,

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -118,6 +118,8 @@ String? videoAddressableTarget(String? referencedAddress) {
   if (referencedAddress == null || referencedAddress.isEmpty) return null;
   final parsed = parseAddressableId(referencedAddress);
   if (parsed == null) return null;
+  // Push-service also rejects these before sending; keep the app guard as
+  // defense-in-depth for stale local payloads and future non-push callers.
   if (parsed.pubkey.isEmpty || parsed.dTag.isEmpty) return null;
   return NIP71VideoKinds.isVideoKind(parsed.kind) ? referencedAddress : null;
 }

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -28,9 +28,9 @@ sealed class NotificationTapTarget extends Equatable {
 /// video) and the fallback when that resolution fails. That fallback applies
 /// only to the event-id walk: a stable addressable id is routed to directly,
 /// and an unfetchable video then intentionally surfaces its failure at the
-/// destination (the video detail error state for push taps, an in-place
-/// snackbar for in-app row taps) rather than rerouting to profile/inbox —
-/// see #5079.
+/// destination rather than rerouting to profile/inbox — the video detail
+/// error state for push taps; for in-app row taps, which also navigate
+/// first, a snackbar over the empty fullscreen feed. See #5079.
 class OpenVideoTarget extends NotificationTapTarget {
   const OpenVideoTarget({required this.autoOpenComments});
 

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -112,10 +112,13 @@ NotificationKind? notificationKindFromPushType(String? type) {
 /// predicate guarantees a non-null result resolves to a video, so the executor
 /// can push it directly without a relay round-trip; non-video or malformed
 /// coordinates return null and the caller falls back to the event-id walk.
+/// Coordinates with an empty pubkey or d-tag (e.g. `34236::`) parse but cannot
+/// route to a video, so they also return null and fall back the same way.
 String? videoAddressableTarget(String? referencedAddress) {
   if (referencedAddress == null || referencedAddress.isEmpty) return null;
   final parsed = parseAddressableId(referencedAddress);
   if (parsed == null) return null;
+  if (parsed.pubkey.isEmpty || parsed.dTag.isEmpty) return null;
   return NIP71VideoKinds.isVideoKind(parsed.kind) ? referencedAddress : null;
 }
 

--- a/mobile/lib/notifications/routing/notification_tap_target.dart
+++ b/mobile/lib/notifications/routing/notification_tap_target.dart
@@ -25,7 +25,12 @@ sealed class NotificationTapTarget extends Equatable {
 ///
 /// The executor owns resolving the concrete route id (preferring a stable
 /// NIP-33 addressable id, otherwise walking the target event to its root
-/// video) and the fallback when that resolution fails.
+/// video) and the fallback when that resolution fails. That fallback applies
+/// only to the event-id walk: a stable addressable id is routed to directly,
+/// and an unfetchable video then intentionally surfaces its failure at the
+/// destination (the video detail error state for push taps, an in-place
+/// snackbar for in-app row taps) rather than rerouting to profile/inbox —
+/// see #5079.
 class OpenVideoTarget extends NotificationTapTarget {
   const OpenVideoTarget({required this.autoOpenComments});
 

--- a/mobile/test/main_notification_tap_routing_test.dart
+++ b/mobile/test/main_notification_tap_routing_test.dart
@@ -141,6 +141,7 @@ void main() {
 
       expect(result.target, const OpenVideoTarget(autoOpenComments: false));
       expect(result.videoCoordinate, equals(videoCoordinate));
+      expect(result.targetEventId, isNull);
     });
 
     test('a video coordinate alone is a video target (no event id)', () {
@@ -161,12 +162,13 @@ void main() {
         'intentional, #5079)', () {
       // Pin of the #5079 decision: the routing decision is made purely from
       // the payload shape, with no pre-push fetch. When a valid video
-      // coordinate is present the executor pushes it directly, so the
-      // profile/inbox fallback never applies — an unfetchable video is
+      // coordinate is present it suppresses the event-id walk entirely
+      // (targetEventId comes back null even though referencedEventId is set),
+      // so the profile/inbox fallback never applies — an unfetchable video is
       // discovered at, and surfaced by, the video detail screen by design.
       final result = app.pushNotificationTapTarget(
         referencedAddress: videoCoordinate,
-        referencedEventId: null,
+        referencedEventId: commentEvent,
         eventId: null,
         notificationType: 'comment',
         senderPubkey: actor,

--- a/mobile/test/main_notification_tap_routing_test.dart
+++ b/mobile/test/main_notification_tap_routing_test.dart
@@ -220,6 +220,22 @@ void main() {
       expect(result.target, const OpenProfileTarget(actor));
       expect(result.videoCoordinate, isNull);
     });
+
+    test('ignores a coordinate with empty pubkey and d-tag and falls '
+        'back', () {
+      // '34236::' parses to empty pubkey/d-tag components — not a routable
+      // video, so the tap must fall back instead of pushing a dead route.
+      final result = app.pushNotificationTapTarget(
+        referencedAddress: '34236::',
+        referencedEventId: null,
+        eventId: null,
+        notificationType: 'like',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenProfileTarget(actor));
+      expect(result.videoCoordinate, isNull);
+    });
   });
 
   group('videoAddressableTarget', () {
@@ -244,6 +260,11 @@ void main() {
     test('returns null for a malformed coordinate', () {
       expect(videoAddressableTarget('34236:only-two-parts'), isNull);
       expect(videoAddressableTarget('not-a-coordinate'), isNull);
+    });
+
+    test('returns null for a coordinate with empty components', () {
+      expect(videoAddressableTarget('34236::'), isNull);
+      expect(videoAddressableTarget('34236:owner_hex:'), isNull);
     });
 
     test('returns null for empty or null input', () {

--- a/mobile/test/main_notification_tap_routing_test.dart
+++ b/mobile/test/main_notification_tap_routing_test.dart
@@ -156,6 +156,27 @@ void main() {
       expect(result.videoCoordinate, equals(videoCoordinate));
     });
 
+    test('a video coordinate wins over the actor-profile fallback even for '
+        'comment taps (unfetchable videos land on the detail error state — '
+        'intentional, #5079)', () {
+      // Pin of the #5079 decision: the routing decision is made purely from
+      // the payload shape, with no pre-push fetch. When a valid video
+      // coordinate is present the executor pushes it directly, so the
+      // profile/inbox fallback never applies — an unfetchable video is
+      // discovered at, and surfaced by, the video detail screen by design.
+      final result = app.pushNotificationTapTarget(
+        referencedAddress: videoCoordinate,
+        referencedEventId: null,
+        eventId: null,
+        notificationType: 'comment',
+        senderPubkey: actor,
+      );
+
+      expect(result.target, const OpenVideoTarget(autoOpenComments: true));
+      expect(result.videoCoordinate, equals(videoCoordinate));
+      expect(result.targetEventId, isNull);
+    });
+
     test('ignores a non-video addressable coordinate and falls back', () {
       // A coordinate whose kind is not a NIP-71 video kind cannot be resolved
       // as a raw video route, so it must not be treated as a video target.

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -351,6 +351,32 @@ void main() {
       );
 
       testWidgets(
+        'renders the error state with an exit affordance for an unfetchable '
+        'NIP-33 video coordinate route (intended destination for '
+        'coordinate-routed push taps, #5079)',
+        (tester) async {
+          // Push taps carrying an authoritative referencedAddress push the
+          // raw kind:pubkey:d-tag coordinate straight to this route with no
+          // pre-fetch. When the video is deleted or otherwise unfetchable,
+          // this error state — not a profile/inbox fallback — is the decided
+          // destination, matching the in-app rows' trust-the-coordinate
+          // contract.
+          const coordinate = '34236:owner_pubkey_hex:my-vine-id';
+          when(
+            () =>
+                mockVideosRepository.fetchVideoWithStatsForRouteId(coordinate),
+          ).thenAnswer((_) async => null);
+
+          await tester.pumpWidget(buildSubject(videoId: coordinate));
+          await tester.pump();
+
+          expect(find.text('Video not found'), findsOneWidget);
+          expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
+          expect(find.bySemanticsLabel('Close video player'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
         'retries once when relays become ready after cold-start miss',
         (tester) async {
           var connectedRelayCount = 0;


### PR DESCRIPTION
## Description

Issue #5079 asked for a product decision: when a like/comment/repost push tap carries a signed video coordinate and that video can't be fetched, should the user land on the video detail error screen, or be redirected to the actor's profile or the inbox?

This change decides for the error screen and pins that decision with docs and tests. The in-app notification rows already work this way: when they have a stable video address they navigate immediately and surface "Video not found" at the destination, never redirecting to a profile. The push is about the user's own video, so sending them to the liker's profile when the video is deleted would be misleading. The old profile/inbox fallback exists only because the event-id path must walk a comment to its root video before it can route at all; the coordinate path has nothing to resolve before routing, and a pre-route fetch would bring back the relay round-trip that #5054 removed. Transient failures are already covered: the route lookup tries cache, then the REST API, then relays, and the detail screen retries once when relays connect after a cold start.

Review hardening made the contract real in code, not just in docs:

- `pushNotificationTapTarget` now returns at most one of `videoCoordinate` / `targetEventId` — a usable coordinate suppresses the event-id walk in the returned value instead of relying on the executor's branch order, and the pin test passes a non-null `referencedEventId` so its `targetEventId`-is-null assertion actually proves the suppression.
- `videoAddressableTarget` rejects coordinates with an empty pubkey or d-tag (e.g. `34236::`), which parse but cannot route; these now fall back to the event-id walk instead of pushing a dead route. The guard is documented as app-side defense-in-depth because push-service already rejects empty coordinate components before sending.
- `_routeNotificationTap` and `OpenVideoTarget` docs state the failure-UX contract, with the in-app row surface described accurately (snackbar over the empty fullscreen feed after navigating).
- Tests pin the contract at both levels: routing (coordinate wins over the profile fallback, empty-component coordinates fall back) and widget (an unfetchable raw `kind:pubkey:d-tag` route renders the error state with the exit button).

**Related Issue:** Closes #5079

## Follow-Up Issues

- #5124 tracks the pre-existing route lookup gap where Funnelcake REST receives only the bare d-tag for addressable coordinate routes and therefore is not pubkey-authoritative.
- #5125 tracks the pre-existing `VideoDetailScreen` not-found localization gap.

## Out of Scope

- No fallback path was added — that is the decision, not an omission.
- The detail screen's hardcoded "Video not found" string is pre-existing and untouched; tracked in #5125.
- Author-scoped REST resolution for coordinate routes is pre-existing repository debt; tracked in #5124.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `dart format --output=none --set-exit-if-changed` on the four changed files — clean.
- `flutter test` on the routing, video detail screen, notification helpers, and notification service suites — 91 pass.
- Codex final pass:
  - `mise exec -- dart format --output=none --set-exit-if-changed lib/notifications/routing/notification_tap_target.dart`
  - `mise exec -- flutter analyze lib/main.dart lib/notifications/routing/notification_tap_target.dart test/main_notification_tap_routing_test.dart test/screens/video_detail_screen_test.dart`
  - `mise exec -- flutter test test/main_notification_tap_routing_test.dart test/screens/video_detail_screen_test.dart`
  - pre-push hook: analyzer passed and 54 changed-file tests passed, including `test/notifications/routing/notification_tap_target_test.dart`
- Rebased onto latest `origin/main` before handoff.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation
