### PR TITLE
feat(video-player): forward native DivineVideoPlayer diagnostics to UnifiedLogger

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -171,7 +171,8 @@ internal class DivineVideoPlayerInstance(
     private val setClipsTimeoutRunnable = Runnable {
         if (pendingSetClipsResult != null) {
             DivineVideoPlayerLog.warning(
-                "Player $playerId load froze: never reached ready within 10s",
+                "Player $playerId load froze: never reached ready within " +
+                    "${SET_CLIPS_TIMEOUT_MS}ms",
                 name = "DivineVideoPlayer.Freeze",
             )
         }
@@ -491,7 +492,7 @@ internal class DivineVideoPlayerInstance(
         pendingSetClipsResult = result
         // 10 s safety net — if STATE_READY never fires (e.g. corrupt file),
         // Dart is unblocked rather than hanging forever.
-        mainHandler.postDelayed(setClipsTimeoutRunnable, 10_000L)
+        mainHandler.postDelayed(setClipsTimeoutRunnable, SET_CLIPS_TIMEOUT_MS)
     }
 
     private fun handleSeekTo(call: MethodCall, result: MethodChannel.Result) {
@@ -1113,6 +1114,7 @@ internal class DivineVideoPlayerInstance(
 
     companion object {
         private const val POSITION_UPDATE_INTERVAL_MS = 200L
+        private const val SET_CLIPS_TIMEOUT_MS = 10_000L
 
         /**
          * How long the player may stay in `STATE_BUFFERING` before it is

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -352,7 +352,14 @@ internal class DivineVideoPlayerInstance(
         var accumulated = 0L
 
         for (map in clipsRaw) {
-            val uri = map["uri"] as? String ?: continue
+            val uri = map["uri"] as? String
+            if (uri == null) {
+                DivineVideoPlayerLog.warning(
+                    "Player $playerId skipped a clip: missing uri",
+                    name = "DivineVideoPlayer.Load",
+                )
+                continue
+            }
             val startMs = (map["startMs"] as? Number)?.toLong() ?: 0L
             val endMs = (map["endMs"] as? Number)?.toLong()
             val clipVol = (map["volume"] as? Number)?.toFloat() ?: 1.0f
@@ -434,6 +441,10 @@ internal class DivineVideoPlayerInstance(
         exoPlayer.setMediaItems(mediaItems, startIndex, startLocalMs)
         exoPlayer.prepare()
         isResettingPlayer = false
+        DivineVideoPlayerLog.info(
+            "Player $playerId prepared $clipCount clip(s)",
+            name = "DivineVideoPlayer.Load",
+        )
         // Apply the starting clip's per-clip volume immediately so the correct
         // level is audible as soon as the decoder is ready. Use startIndex
         // (not 0) so a resume mid-playlist doesn't play clip 0's volume
@@ -607,6 +618,10 @@ internal class DivineVideoPlayerInstance(
             return
         }
         audioOverlayManager.setTracks(tracksRaw, speed.toFloat())
+        DivineVideoPlayerLog.info(
+            "Player $playerId set ${tracksRaw.size} audio overlay track(s)",
+            name = "DivineVideoPlayer.Audio",
+        )
         syncAudioOverlays()
         result.success(null)
     }
@@ -909,6 +924,11 @@ internal class DivineVideoPlayerInstance(
         }
 
         override fun onPlayerError(error: PlaybackException) {
+            DivineVideoPlayerLog.error(
+                "Player $playerId playback error [${error.errorCodeName}]: " +
+                    (error.message ?: "unknown"),
+                name = "DivineVideoPlayer.Playback",
+            )
             // Unblock a pending setClips with an error so Dart can react
             // rather than waiting for the 10 s safety timeout.
             mainHandler.removeCallbacks(setClipsTimeoutRunnable)

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -169,8 +169,30 @@ internal class DivineVideoPlayerInstance(
 
     /** Safety timeout so Dart is never left hanging if STATE_READY is lost. */
     private val setClipsTimeoutRunnable = Runnable {
+        if (pendingSetClipsResult != null) {
+            DivineVideoPlayerLog.warning(
+                "Player $playerId load froze: never reached ready within 10s",
+                name = "DivineVideoPlayer.Freeze",
+            )
+        }
         pendingSetClipsResult?.success(null)
         pendingSetClipsResult = null
+    }
+
+    /**
+     * Fires when the player stays in `STATE_BUFFERING` past
+     * [BUFFERING_STALL_MS] — the spinner is stuck and the video appears
+     * frozen to the user. Reset whenever the player leaves the buffering
+     * state so each stall episode is reported at most once.
+     */
+    private var bufferingStallReported = false
+    private val bufferingWatchdogRunnable = Runnable {
+        bufferingStallReported = true
+        DivineVideoPlayerLog.warning(
+            "Player $playerId appears frozen: still buffering after " +
+                "${BUFFERING_STALL_MS}ms",
+            name = "DivineVideoPlayer.Freeze",
+        )
     }
 
     private val positionUpdater = object : Runnable {
@@ -825,6 +847,19 @@ internal class DivineVideoPlayerInstance(
 
     private val playerListener = object : Player.Listener {
         override fun onPlaybackStateChanged(playbackState: Int) {
+            if (playbackState == Player.STATE_BUFFERING) {
+                // Arm the freeze watchdog once per stall episode.
+                if (!bufferingStallReported) {
+                    mainHandler.removeCallbacks(bufferingWatchdogRunnable)
+                    mainHandler.postDelayed(
+                        bufferingWatchdogRunnable,
+                        BUFFERING_STALL_MS,
+                    )
+                }
+            } else {
+                mainHandler.removeCallbacks(bufferingWatchdogRunnable)
+                bufferingStallReported = false
+            }
             if (playbackState == Player.STATE_ENDED && isLooping) {
                 syncAudioOverlays()
             }
@@ -1049,6 +1084,7 @@ internal class DivineVideoPlayerInstance(
         mainHandler.removeCallbacks(positionUpdater)
         mainHandler.removeCallbacks(seekTimeoutRunnable)
         mainHandler.removeCallbacks(setClipsTimeoutRunnable)
+        mainHandler.removeCallbacks(bufferingWatchdogRunnable)
         seekCompletionResult?.success(null)
         seekCompletionResult = null
         pendingSetClipsResult?.success(null)
@@ -1077,6 +1113,14 @@ internal class DivineVideoPlayerInstance(
 
     companion object {
         private const val POSITION_UPDATE_INTERVAL_MS = 200L
+
+        /**
+         * How long the player may stay in `STATE_BUFFERING` before it is
+         * treated as frozen and a diagnostic is emitted. Long enough to not
+         * trip on routine rebuffering, short enough that a real freeze is
+         * captured while the user is still on the screen.
+         */
+        private const val BUFFERING_STALL_MS = 8_000L
 
         /**
          * Floor for clip playback speed. Prevents division by zero when

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerLog.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerLog.kt
@@ -1,0 +1,46 @@
+// ABOUTME: Forwards curated native video-player diagnostics to Dart's
+// ABOUTME: UnifiedLogger so playback issues appear in user bug reports
+
+package com.divinevideo.divine_video_player
+
+import android.util.Log
+
+/**
+ * Bridges relevant native diagnostics to the Dart side so they are captured by
+ * the app's `UnifiedLogger` and included in bug-report log dumps.
+ *
+ * Native playback code calls these methods for the handful of events worth
+ * surfacing to support: player lifecycle, clip-composition skips, asset /
+ * playback errors, and audio-track setup. Per-frame / verbose logging must stay
+ * on [Log] so it does not flood the captured buffer.
+ *
+ * `DivineVideoPlayerPlugin` installs [sink] (only for the main FlutterEngine)
+ * to forward each entry over the global method channel. Before that is wired
+ * (or in unit-test contexts) entries fall back to logcat only.
+ */
+object DivineVideoPlayerLog {
+    /**
+     * Forwards `(level, message, name)` to Dart. `level` is one of `debug`,
+     * `info`, `warning`, `error`. Set by the plugin; `null` until then.
+     */
+    @Volatile
+    var sink: ((String, String, String) -> Unit)? = null
+
+    fun debug(message: String, name: String = "DivineVideoPlayer") = emit("debug", message, name)
+
+    fun info(message: String, name: String = "DivineVideoPlayer") = emit("info", message, name)
+
+    fun warning(message: String, name: String = "DivineVideoPlayer") = emit("warning", message, name)
+
+    fun error(message: String, name: String = "DivineVideoPlayer") = emit("error", message, name)
+
+    private fun emit(level: String, message: String, name: String) {
+        // Keep the logcat fallback so on-device debugging is unchanged.
+        when (level) {
+            "error" -> Log.e(name, message)
+            "warning" -> Log.w(name, message)
+            else -> Log.d(name, message)
+        }
+        sink?.invoke(level, message, name)
+    }
+}

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
@@ -25,6 +25,7 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
 
     private lateinit var globalChannel: MethodChannel
     private lateinit var binding: FlutterPlugin.FlutterPluginBinding
+    private val mainHandler = android.os.Handler(android.os.Looper.getMainLooper())
 
     companion object {
         // Tracks the plugin instance attached to the main FlutterEngine.
@@ -65,6 +66,19 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
         )
         globalChannel.setMethodCallHandler(this)
 
+        // Forward curated native diagnostics to Dart's UnifiedLogger so video
+        // playback problems land in user bug reports. Only the main engine
+        // reaches here (background isolates returned early above), so the
+        // process-wide sink always points at the UI engine's channel.
+        DivineVideoPlayerLog.sink = { level, message, name ->
+            mainHandler.post {
+                globalChannel.invokeMethod(
+                    "onNativeLog",
+                    mapOf("level" to level, "message" to message, "name" to name),
+                )
+            }
+        }
+
         flutterPluginBinding.platformViewRegistry.registerViewFactory(
             "divine_video_player_view",
             DivineVideoPlayerViewFactory(flutterPluginBinding),
@@ -78,6 +92,7 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
         }
         mainPluginInstance = null
         globalChannel.setMethodCallHandler(null)
+        DivineVideoPlayerLog.sink = null
         PlayerRegistry.disposeAll()
         VideoCache.release()
     }
@@ -130,6 +145,10 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
                 PlayerRegistry.put(id, instance)
 
                 val useTexture = call.argument<Boolean>("useTexture") ?: false
+                DivineVideoPlayerLog.info(
+                    "Player $id created (useTexture=$useTexture)",
+                    name = "DivineVideoPlayer.Lifecycle",
+                )
                 if (useTexture) {
                     val useLegacySurface =
                         call.argument<Boolean>("useLegacySurface") ?: false
@@ -144,6 +163,10 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
             }
             "dispose" -> {
                 val id = call.argument<Int>("id")!!
+                DivineVideoPlayerLog.info(
+                    "Player $id disposed",
+                    name = "DivineVideoPlayer.Lifecycle",
+                )
                 PlayerRegistry.remove(id)?.dispose()
                 result.success(null)
             }

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -18,9 +18,17 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var timeObserver: Any?
     private var currentItemObservation: NSKeyValueObservation?
     private var statusObservation: NSKeyValueObservation?
+    private var bufferingObservation: NSKeyValueObservation?
+    private var likelyToKeepUpObservation: NSKeyValueObservation?
     /// One-shot KVO that defers `preroll(atRate:)` until `player.status`
     /// is `.readyToPlay`; calling earlier throws `NSInvalidArgumentException`.
     private var pendingPrerollObservation: NSKeyValueObservation?
+    private var setClipsTimeoutWorkItem: DispatchWorkItem?
+    private var bufferingWatchdogWorkItem: DispatchWorkItem?
+    private var bufferingStallReported = false
+
+    private static let setClipsTimeoutMs = 10_000
+    private static let bufferingStallMs = 8_000
 
     // MARK: - Texture rendering
 
@@ -152,6 +160,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             return
         }
 
+        armSetClipsTimeout()
+
         // Build the composition asynchronously.
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -231,6 +241,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.safePreroll(at: startTime)
 
                 self.currentStatus = "ready"
+                self.clearSetClipsTimeout()
                 DivineVideoPlayerLog.shared.info(
                     "Player \(self.playerId) ready: \(self.clipCount) clip(s), "
                         + "totalMs=\(Int(self.totalDuration * 1000))",
@@ -241,6 +252,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             } catch {
                 self.currentStatus = "error"
                 self.errorMessage = error.localizedDescription
+                self.clearSetClipsTimeout()
+                self.clearBufferingWatchdog(resetReported: true)
                 DivineVideoPlayerLog.shared.error(
                     "Player \(self.playerId) composition failed: "
                         + "\(error.localizedDescription)",
@@ -538,6 +551,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
     private func handleStop(result: @escaping FlutterResult) {
         audioOverlayManager.pauseAndDeactivateAll()
+        clearSetClipsTimeout()
+        clearBufferingWatchdog(resetReported: true)
         // Pause and clear media so the surface goes blank.
         player?.pause()
         playerLooper = nil
@@ -758,6 +773,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         guard let item = player?.currentItem else { return }
         textureOutput?.attach(to: item)
         observeStatus(for: item)
+        observeBuffering(for: item)
         observeEnd(for: item)
     }
 
@@ -767,24 +783,114 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             \.status,
             options: [.new]
         ) { [weak self] item, _ in
-            switch item.status {
-            case .readyToPlay:
-                self?.currentStatus = "ready"
-                self?.updateVideoSize(from: item)
-            case .failed:
-                self?.currentStatus = "error"
-                self?.errorMessage = item.error?.localizedDescription
-                if let self {
+            DispatchQueue.main.async { [weak self] in
+                guard let self, item === self.player?.currentItem else { return }
+                switch item.status {
+                case .readyToPlay:
+                    self.clearSetClipsTimeout()
+                    self.currentStatus = "ready"
+                    self.updateVideoSize(from: item)
+                case .failed:
+                    self.clearSetClipsTimeout()
+                    self.clearBufferingWatchdog(resetReported: true)
+                    self.currentStatus = "error"
+                    self.errorMessage = item.error?.localizedDescription
                     DivineVideoPlayerLog.shared.error(
                         "Player \(self.playerId) item failed: "
                             + "\(item.error?.localizedDescription ?? "unknown")",
                         name: "DivineVideoPlayer.Playback"
                     )
+                default:
+                    break
                 }
-            default:
-                break
+                self.sendStateUpdate()
             }
-            self?.sendStateUpdate()
+        }
+    }
+
+    private func observeBuffering(for item: AVPlayerItem) {
+        bufferingObservation?.invalidate()
+        likelyToKeepUpObservation?.invalidate()
+        bufferingObservation = nil
+        likelyToKeepUpObservation = nil
+        clearBufferingWatchdog(resetReported: true)
+
+        bufferingObservation = item.observe(
+            \.isPlaybackBufferEmpty,
+            options: [.initial, .new]
+        ) { [weak self] observedItem, _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let self, observedItem === self.player?.currentItem else { return }
+                if observedItem.isPlaybackBufferEmpty && observedItem.status != .failed {
+                    self.armBufferingWatchdog()
+                } else {
+                    self.clearBufferingWatchdog(resetReported: true)
+                }
+                self.sendStateUpdate()
+            }
+        }
+
+        likelyToKeepUpObservation = item.observe(
+            \.isPlaybackLikelyToKeepUp,
+            options: [.new]
+        ) { [weak self] observedItem, _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let self, observedItem === self.player?.currentItem else { return }
+                if observedItem.isPlaybackLikelyToKeepUp {
+                    self.clearBufferingWatchdog(resetReported: true)
+                }
+                self.sendStateUpdate()
+            }
+        }
+    }
+
+    private func armSetClipsTimeout() {
+        clearSetClipsTimeout()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            DivineVideoPlayerLog.shared.warning(
+                "Player \(self.playerId) load froze: never reached ready within "
+                    + "\(Self.setClipsTimeoutMs)ms",
+                name: "DivineVideoPlayer.Freeze"
+            )
+            self.setClipsTimeoutWorkItem = nil
+        }
+        setClipsTimeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(Self.setClipsTimeoutMs),
+            execute: workItem
+        )
+    }
+
+    private func clearSetClipsTimeout() {
+        setClipsTimeoutWorkItem?.cancel()
+        setClipsTimeoutWorkItem = nil
+    }
+
+    private func armBufferingWatchdog() {
+        guard !bufferingStallReported, bufferingWatchdogWorkItem == nil else { return }
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.bufferingStallReported = true
+            self.bufferingWatchdogWorkItem = nil
+            DivineVideoPlayerLog.shared.warning(
+                "Player \(self.playerId) appears frozen: still buffering after "
+                    + "\(Self.bufferingStallMs)ms",
+                name: "DivineVideoPlayer.Freeze"
+            )
+        }
+        bufferingWatchdogWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(Self.bufferingStallMs),
+            execute: workItem
+        )
+    }
+
+    private func clearBufferingWatchdog(resetReported: Bool) {
+        bufferingWatchdogWorkItem?.cancel()
+        bufferingWatchdogWorkItem = nil
+        if resetReported {
+            bufferingStallReported = false
         }
     }
 
@@ -1025,10 +1131,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         statusObservation?.invalidate()
         statusObservation = nil
+        bufferingObservation?.invalidate()
+        bufferingObservation = nil
+        likelyToKeepUpObservation?.invalidate()
+        likelyToKeepUpObservation = nil
         currentItemObservation?.invalidate()
         currentItemObservation = nil
         pendingPrerollObservation?.invalidate()
         pendingPrerollObservation = nil
+        clearSetClipsTimeout()
+        clearBufferingWatchdog(resetReported: true)
         NotificationCenter.default.removeObserver(self)
         textureOutput?.dispose()
         textureOutput = nil

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerInstance.swift
@@ -231,11 +231,21 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.safePreroll(at: startTime)
 
                 self.currentStatus = "ready"
+                DivineVideoPlayerLog.shared.info(
+                    "Player \(self.playerId) ready: \(self.clipCount) clip(s), "
+                        + "totalMs=\(Int(self.totalDuration * 1000))",
+                    name: "DivineVideoPlayer.Load"
+                )
                 self.sendStateUpdate()
                 result(nil)
             } catch {
                 self.currentStatus = "error"
                 self.errorMessage = error.localizedDescription
+                DivineVideoPlayerLog.shared.error(
+                    "Player \(self.playerId) composition failed: "
+                        + "\(error.localizedDescription)",
+                    name: "DivineVideoPlayer.Load"
+                )
                 self.sendStateUpdate()
                 result(
                     FlutterError(
@@ -275,7 +285,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         var clipVolumes: [Float] = []
 
         for clipMap in clipsRaw {
-            guard let uri = clipMap["uri"] as? String else { continue }
+            guard let uri = clipMap["uri"] as? String else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: missing uri",
+                    name: "DivineVideoPlayer.Load"
+                )
+                continue
+            }
             let startMs = (clipMap["startMs"] as? NSNumber)?.int64Value ?? 0
             let endMs = clipMap["endMs"] as? NSNumber
             let clipVol = (clipMap["volume"] as? NSNumber)?.floatValue ?? 1.0
@@ -288,6 +304,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             } else if let parsed = URL(string: uri) {
                 url = parsed
             } else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: unparseable uri",
+                    name: "DivineVideoPlayer.Load"
+                )
                 continue
             }
 
@@ -301,12 +321,24 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let assetVideoTracks = try await asset.loadTracks(withMediaType: .video)
             let assetAudioTracks = try await asset.loadTracks(withMediaType: .audio)
 
-            guard let sourceVideoTrack = assetVideoTracks.first else { continue }
+            guard let sourceVideoTrack = assetVideoTracks.first else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: no video track",
+                    name: "DivineVideoPlayer.Load"
+                )
+                continue
+            }
             let (naturalSize, transform) = try await sourceVideoTrack.load(
                 .naturalSize, .preferredTransform
             )
             let displaySize = naturalSize.applying(transform).absoluteSize
-            guard displaySize.isPositive else { continue }
+            guard displaySize.isPositive else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: non-positive display size",
+                    name: "DivineVideoPlayer.Load"
+                )
+                continue
+            }
             let standardizedTransform = transform.standardized(for: naturalSize)
 
             let startTime = CMTime(value: startMs, timescale: 1000)
@@ -318,7 +350,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             }
             let timeRange = CMTimeRange(start: startTime, end: endTime)
             let clipDuration = CMTimeSubtract(endTime, startTime)
-            guard CMTimeCompare(clipDuration, .zero) > 0 else { continue }
+            guard CMTimeCompare(clipDuration, .zero) > 0 else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: non-positive duration",
+                    name: "DivineVideoPlayer.Load"
+                )
+                continue
+            }
 
             if offsets.isEmpty {
                 composition.naturalSize = displaySize
@@ -529,6 +567,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             return
         }
         audioOverlayManager.setTracks(from: tracksRaw)
+        DivineVideoPlayerLog.shared.info(
+            "Player \(playerId) set \(tracksRaw.count) audio overlay track(s)",
+            name: "DivineVideoPlayer.Audio"
+        )
         syncAudioOverlays()
         result(nil)
     }
@@ -732,6 +774,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             case .failed:
                 self?.currentStatus = "error"
                 self?.errorMessage = item.error?.localizedDescription
+                if let self {
+                    DivineVideoPlayerLog.shared.error(
+                        "Player \(self.playerId) item failed: "
+                            + "\(item.error?.localizedDescription ?? "unknown")",
+                        name: "DivineVideoPlayer.Playback"
+                    )
+                }
             default:
                 break
             }

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerLog.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerLog.swift
@@ -1,0 +1,47 @@
+// ABOUTME: Forwards curated native video-player diagnostics to Dart's
+// ABOUTME: UnifiedLogger so playback issues appear in user bug reports
+
+import Foundation
+
+/// Bridges relevant native diagnostics to the Dart side so they are captured
+/// by the app's `UnifiedLogger` and included in bug-report log dumps.
+///
+/// Native playback code calls these methods for the handful of events worth
+/// surfacing to support: player lifecycle, clip-composition skips, asset /
+/// playback errors, and audio-track setup. Per-frame / verbose logging must
+/// stay on `print` so it does not flood the captured buffer.
+///
+/// `DivineVideoPlayerPlugin` installs `sink` to forward each entry over the
+/// global method channel. Before that is wired (or in unit/host contexts)
+/// entries fall back to the console only.
+final class DivineVideoPlayerLog {
+    static let shared = DivineVideoPlayerLog()
+
+    private init() {}
+
+    /// Forwards `(level, message, name)` to Dart. `level` is one of
+    /// `debug`, `info`, `warning`, `error`. Set by the plugin; `nil` until then.
+    var sink: ((String, String, String) -> Void)?
+
+    func debug(_ message: String, name: String = "DivineVideoPlayer") {
+        emit("debug", message, name)
+    }
+
+    func info(_ message: String, name: String = "DivineVideoPlayer") {
+        emit("info", message, name)
+    }
+
+    func warning(_ message: String, name: String = "DivineVideoPlayer") {
+        emit("warning", message, name)
+    }
+
+    func error(_ message: String, name: String = "DivineVideoPlayer") {
+        emit("error", message, name)
+    }
+
+    private func emit(_ level: String, _ message: String, _ name: String) {
+        // Keep the console fallback so on-device debugging is unchanged.
+        print("[\(name)] \(message)")
+        sink?(level, message, name)
+    }
+}

--- a/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/ios/Classes/DivineVideoPlayerPlugin.swift
@@ -10,6 +10,28 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
 
     private static var registrar: FlutterPluginRegistrar?
 
+    private var globalChannel: FlutterMethodChannel?
+
+    /// Per-instance forwarder pushing native diagnostics over THIS engine's
+    /// global channel. `DivineVideoPlayerLog.shared.sink` is a process-wide
+    /// singleton, so a second FlutterEngine (e.g. the FCM background isolate
+    /// that also runs the plugin registrant) would otherwise overwrite it and
+    /// route video logs to the wrong isolate. We re-assert it in `handle` —
+    /// player operations only ever reach the UI engine.
+    private lazy var logSink: (String, String, String) -> Void = {
+        [weak self] level, message, name in
+        DispatchQueue.main.async {
+            self?.globalChannel?.invokeMethod(
+                "onNativeLog",
+                arguments: ["level": level, "message": message, "name": name]
+            )
+        }
+    }
+
+    private func installLogSink() {
+        DivineVideoPlayerLog.shared.sink = logSink
+    }
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         // Hot restart re-calls register(with:) without disposing the
         // previous engine's players. Clean up zombie players so timers
@@ -23,6 +45,8 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             binaryMessenger: registrar.messenger()
         )
         let plugin = DivineVideoPlayerPlugin()
+        plugin.globalChannel = globalChannel
+        plugin.installLogSink()
         registrar.addMethodCallDelegate(plugin, channel: globalChannel)
 
         registrar.register(
@@ -54,9 +78,15 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // Re-claim the shared sink in case another FlutterEngine overwrote it.
+        installLogSink()
         // Methods that require no arguments are handled before the
         // args guard to avoid returning FlutterMethodNotImplemented.
         if call.method == "disposeAll" {
+            DivineVideoPlayerLog.shared.info(
+                "disposeAll — releasing all players",
+                name: "DivineVideoPlayer.Lifecycle"
+            )
             PlayerRegistry.shared.disposeAll()
             result(nil)
             return
@@ -91,6 +121,10 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             PlayerRegistry.shared.set(instance, for: id)
 
             let useTexture = args["useTexture"] as? Bool ?? false
+            DivineVideoPlayerLog.shared.info(
+                "Player \(id) created (useTexture=\(useTexture))",
+                name: "DivineVideoPlayer.Lifecycle"
+            )
             if useTexture {
                 let textureId = instance.enableTextureOutput(
                     registry: registrar.textures()
@@ -105,6 +139,10 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
                 result(nil)
                 return
             }
+            DivineVideoPlayerLog.shared.info(
+                "Player \(id) disposed",
+                name: "DivineVideoPlayer.Lifecycle"
+            )
             PlayerRegistry.shared.remove(id)?.dispose()
             result(nil)
 

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -9,6 +9,7 @@ import 'package:divine_video_player/src/web/web_video_player_backend_factory.dar
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// Default maximum cache size on disk (500 MB).
 const int kDefaultCacheMaxSizeBytes = 500 * 1024 * 1024;
@@ -48,7 +49,58 @@ class DivineVideoPlayerController {
   DivineVideoPlayerController({
     this.useTexture = false,
     this.useLegacySurface = false,
-  });
+  }) {
+    _ensureNativeLogHandler();
+  }
+
+  /// Guards one-time installation of the global-channel handler that
+  /// receives native diagnostics (`onNativeLog`).
+  static bool _nativeLogHandlerInstalled = false;
+
+  /// Installs the handler that receives curated native diagnostics from the
+  /// platform side and forwards them into the app's [UnifiedLogger], so video
+  /// playback problems show up in bug reports. Idempotent.
+  static void _ensureNativeLogHandler() {
+    if (_nativeLogHandlerInstalled) return;
+    _nativeLogHandlerInstalled = true;
+    _globalChannel.setMethodCallHandler(_handleGlobalChannelCall);
+  }
+
+  static Future<dynamic> _handleGlobalChannelCall(MethodCall call) async {
+    if (call.method == 'onNativeLog') {
+      final args = call.arguments;
+      if (args is Map) {
+        _forwardNativeLog(args);
+      }
+    }
+    return null;
+  }
+
+  /// Forwards a curated native diagnostic into the app's [UnifiedLogger].
+  ///
+  /// The native side only sends events worth surfacing for diagnosing
+  /// playback problems (player lifecycle, clip-composition skips, asset /
+  /// playback errors, audio-track setup) — see `DivineVideoPlayerLog` on each
+  /// platform. Per-frame and verbose native logs stay on the device console.
+  static void _forwardNativeLog(Map<dynamic, dynamic> args) {
+    final message = args['message'] as String?;
+    if (message == null || message.isEmpty) return;
+    final level = args['level'] as String? ?? 'info';
+    final name = args['name'] as String? ?? 'DivineVideoPlayerNative';
+    switch (level) {
+      case 'error':
+        Log.error(message, name: name, category: LogCategory.video);
+      case 'warning':
+        Log.warning(message, name: name, category: LogCategory.video);
+      case 'debug':
+        Log.debug(message, name: name, category: LogCategory.video);
+      case 'verbose':
+        Log.verbose(message, name: name, category: LogCategory.video);
+      case 'info':
+      default:
+        Log.info(message, name: name, category: LogCategory.video);
+    }
+  }
 
   /// Whether this player renders via a Flutter texture instead of a
   /// platform view. When `true` the widget should use the [Texture]

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -18,9 +18,17 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var timeObserver: Any?
     private var currentItemObservation: NSKeyValueObservation?
     private var statusObservation: NSKeyValueObservation?
+    private var bufferingObservation: NSKeyValueObservation?
+    private var likelyToKeepUpObservation: NSKeyValueObservation?
     /// One-shot KVO that defers `preroll(atRate:)` until `player.status`
     /// is `.readyToPlay`; calling earlier throws `NSInvalidArgumentException`.
     private var pendingPrerollObservation: NSKeyValueObservation?
+    private var setClipsTimeoutWorkItem: DispatchWorkItem?
+    private var bufferingWatchdogWorkItem: DispatchWorkItem?
+    private var bufferingStallReported = false
+
+    private static let setClipsTimeoutMs = 10_000
+    private static let bufferingStallMs = 8_000
 
     // MARK: - Texture rendering
 
@@ -151,6 +159,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             return
         }
 
+        armSetClipsTimeout()
+
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
@@ -206,6 +216,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.safePreroll(at: startTime)
 
                 self.currentStatus = "ready"
+                self.clearSetClipsTimeout()
                 DivineVideoPlayerLog.shared.info(
                     "Player \(self.playerId) ready: \(self.clipCount) clip(s), "
                         + "totalMs=\(Int(self.totalDuration * 1000))",
@@ -216,6 +227,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             } catch {
                 self.currentStatus = "error"
                 self.errorMessage = error.localizedDescription
+                self.clearSetClipsTimeout()
+                self.clearBufferingWatchdog(resetReported: true)
                 DivineVideoPlayerLog.shared.error(
                     "Player \(self.playerId) composition failed: "
                         + "\(error.localizedDescription)",
@@ -498,6 +511,8 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
     private func handleStop(result: @escaping FlutterResult) {
         audioOverlayManager.pauseAndDeactivateAll()
+        clearSetClipsTimeout()
+        clearBufferingWatchdog(resetReported: true)
         // Pause and clear media so the surface goes blank.
         player?.pause()
         playerLooper = nil
@@ -702,6 +717,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         guard let item = player?.currentItem else { return }
         textureOutput?.attach(to: item)
         observeStatus(for: item)
+        observeBuffering(for: item)
         observeEnd(for: item)
     }
 
@@ -711,24 +727,114 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             \.status,
             options: [.new]
         ) { [weak self] item, _ in
-            switch item.status {
-            case .readyToPlay:
-                self?.currentStatus = "ready"
-                self?.updateVideoSize(from: item)
-            case .failed:
-                self?.currentStatus = "error"
-                self?.errorMessage = item.error?.localizedDescription
-                if let self {
+            DispatchQueue.main.async { [weak self] in
+                guard let self, item === self.player?.currentItem else { return }
+                switch item.status {
+                case .readyToPlay:
+                    self.clearSetClipsTimeout()
+                    self.currentStatus = "ready"
+                    self.updateVideoSize(from: item)
+                case .failed:
+                    self.clearSetClipsTimeout()
+                    self.clearBufferingWatchdog(resetReported: true)
+                    self.currentStatus = "error"
+                    self.errorMessage = item.error?.localizedDescription
                     DivineVideoPlayerLog.shared.error(
                         "Player \(self.playerId) item failed: "
                             + "\(item.error?.localizedDescription ?? "unknown")",
                         name: "DivineVideoPlayer.Playback"
                     )
+                default:
+                    break
                 }
-            default:
-                break
+                self.sendStateUpdate()
             }
-            self?.sendStateUpdate()
+        }
+    }
+
+    private func observeBuffering(for item: AVPlayerItem) {
+        bufferingObservation?.invalidate()
+        likelyToKeepUpObservation?.invalidate()
+        bufferingObservation = nil
+        likelyToKeepUpObservation = nil
+        clearBufferingWatchdog(resetReported: true)
+
+        bufferingObservation = item.observe(
+            \.isPlaybackBufferEmpty,
+            options: [.initial, .new]
+        ) { [weak self] observedItem, _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let self, observedItem === self.player?.currentItem else { return }
+                if observedItem.isPlaybackBufferEmpty && observedItem.status != .failed {
+                    self.armBufferingWatchdog()
+                } else {
+                    self.clearBufferingWatchdog(resetReported: true)
+                }
+                self.sendStateUpdate()
+            }
+        }
+
+        likelyToKeepUpObservation = item.observe(
+            \.isPlaybackLikelyToKeepUp,
+            options: [.new]
+        ) { [weak self] observedItem, _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let self, observedItem === self.player?.currentItem else { return }
+                if observedItem.isPlaybackLikelyToKeepUp {
+                    self.clearBufferingWatchdog(resetReported: true)
+                }
+                self.sendStateUpdate()
+            }
+        }
+    }
+
+    private func armSetClipsTimeout() {
+        clearSetClipsTimeout()
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            DivineVideoPlayerLog.shared.warning(
+                "Player \(self.playerId) load froze: never reached ready within "
+                    + "\(Self.setClipsTimeoutMs)ms",
+                name: "DivineVideoPlayer.Freeze"
+            )
+            self.setClipsTimeoutWorkItem = nil
+        }
+        setClipsTimeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(Self.setClipsTimeoutMs),
+            execute: workItem
+        )
+    }
+
+    private func clearSetClipsTimeout() {
+        setClipsTimeoutWorkItem?.cancel()
+        setClipsTimeoutWorkItem = nil
+    }
+
+    private func armBufferingWatchdog() {
+        guard !bufferingStallReported, bufferingWatchdogWorkItem == nil else { return }
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.bufferingStallReported = true
+            self.bufferingWatchdogWorkItem = nil
+            DivineVideoPlayerLog.shared.warning(
+                "Player \(self.playerId) appears frozen: still buffering after "
+                    + "\(Self.bufferingStallMs)ms",
+                name: "DivineVideoPlayer.Freeze"
+            )
+        }
+        bufferingWatchdogWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(Self.bufferingStallMs),
+            execute: workItem
+        )
+    }
+
+    private func clearBufferingWatchdog(resetReported: Bool) {
+        bufferingWatchdogWorkItem?.cancel()
+        bufferingWatchdogWorkItem = nil
+        if resetReported {
+            bufferingStallReported = false
         }
     }
 
@@ -956,10 +1062,16 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         }
         statusObservation?.invalidate()
         statusObservation = nil
+        bufferingObservation?.invalidate()
+        bufferingObservation = nil
+        likelyToKeepUpObservation?.invalidate()
+        likelyToKeepUpObservation = nil
         currentItemObservation?.invalidate()
         currentItemObservation = nil
         pendingPrerollObservation?.invalidate()
         pendingPrerollObservation = nil
+        clearSetClipsTimeout()
+        clearBufferingWatchdog(resetReported: true)
         NotificationCenter.default.removeObserver(self)
         textureOutput?.dispose()
         textureOutput = nil

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerInstance.swift
@@ -206,11 +206,21 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.safePreroll(at: startTime)
 
                 self.currentStatus = "ready"
+                DivineVideoPlayerLog.shared.info(
+                    "Player \(self.playerId) ready: \(self.clipCount) clip(s), "
+                        + "totalMs=\(Int(self.totalDuration * 1000))",
+                    name: "DivineVideoPlayer.Load"
+                )
                 self.sendStateUpdate()
                 result(nil)
             } catch {
                 self.currentStatus = "error"
                 self.errorMessage = error.localizedDescription
+                DivineVideoPlayerLog.shared.error(
+                    "Player \(self.playerId) composition failed: "
+                        + "\(error.localizedDescription)",
+                    name: "DivineVideoPlayer.Load"
+                )
                 self.sendStateUpdate()
                 result(
                     FlutterError(
@@ -246,7 +256,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
         var clipVolumes: [Float] = []
 
         for clipMap in clipsRaw {
-            guard let uri = clipMap["uri"] as? String else { continue }
+            guard let uri = clipMap["uri"] as? String else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: missing uri",
+                    name: "DivineVideoPlayer.Load"
+                )
+                continue
+            }
             let startMs = (clipMap["startMs"] as? NSNumber)?.int64Value ?? 0
             let endMs = clipMap["endMs"] as? NSNumber
             let clipVol = (clipMap["volume"] as? NSNumber)?.floatValue ?? 1.0
@@ -259,6 +275,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             } else if let parsed = URL(string: uri) {
                 url = parsed
             } else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: unparseable uri",
+                    name: "DivineVideoPlayer.Load"
+                )
                 continue
             }
 
@@ -270,12 +290,24 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             let assetVideoTracks = try await asset.loadTracks(withMediaType: .video)
             let assetAudioTracks = try await asset.loadTracks(withMediaType: .audio)
 
-            guard let sourceVideoTrack = assetVideoTracks.first else { continue }
+            guard let sourceVideoTrack = assetVideoTracks.first else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: no video track",
+                    name: "DivineVideoPlayer.Load"
+                )
+                continue
+            }
             let (naturalSize, transform) = try await sourceVideoTrack.load(
                 .naturalSize, .preferredTransform
             )
             let displaySize = naturalSize.applying(transform).absoluteSize
-            guard displaySize.isPositive else { continue }
+            guard displaySize.isPositive else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: non-positive display size",
+                    name: "DivineVideoPlayer.Load"
+                )
+                continue
+            }
             let standardizedTransform = transform.standardized(for: naturalSize)
 
             let startTime = CMTime(value: startMs, timescale: 1000)
@@ -287,7 +319,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             }
             let timeRange = CMTimeRange(start: startTime, end: endTime)
             let clipDuration = CMTimeSubtract(endTime, startTime)
-            guard CMTimeCompare(clipDuration, .zero) > 0 else { continue }
+            guard CMTimeCompare(clipDuration, .zero) > 0 else {
+                DivineVideoPlayerLog.shared.warning(
+                    "Player \(playerId) skipped a clip: non-positive duration",
+                    name: "DivineVideoPlayer.Load"
+                )
+                continue
+            }
 
             if offsets.isEmpty {
                 composition.naturalSize = displaySize
@@ -487,6 +525,10 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             return
         }
         audioOverlayManager.setTracks(from: tracksRaw)
+        DivineVideoPlayerLog.shared.info(
+            "Player \(playerId) set \(tracksRaw.count) audio overlay track(s)",
+            name: "DivineVideoPlayer.Audio"
+        )
         syncAudioOverlays()
         result(nil)
     }
@@ -676,6 +718,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
             case .failed:
                 self?.currentStatus = "error"
                 self?.errorMessage = item.error?.localizedDescription
+                if let self {
+                    DivineVideoPlayerLog.shared.error(
+                        "Player \(self.playerId) item failed: "
+                            + "\(item.error?.localizedDescription ?? "unknown")",
+                        name: "DivineVideoPlayer.Playback"
+                    )
+                }
             default:
                 break
             }

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerLog.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerLog.swift
@@ -1,0 +1,47 @@
+// ABOUTME: Forwards curated native video-player diagnostics to Dart's
+// ABOUTME: UnifiedLogger so playback issues appear in user bug reports
+
+import Foundation
+
+/// Bridges relevant native diagnostics to the Dart side so they are captured
+/// by the app's `UnifiedLogger` and included in bug-report log dumps.
+///
+/// Native playback code calls these methods for the handful of events worth
+/// surfacing to support: player lifecycle, clip-composition skips, asset /
+/// playback errors, and audio-track setup. Per-frame / verbose logging must
+/// stay on `print` so it does not flood the captured buffer.
+///
+/// `DivineVideoPlayerPlugin` installs `sink` to forward each entry over the
+/// global method channel. Before that is wired (or in unit/host contexts)
+/// entries fall back to the console only.
+final class DivineVideoPlayerLog {
+    static let shared = DivineVideoPlayerLog()
+
+    private init() {}
+
+    /// Forwards `(level, message, name)` to Dart. `level` is one of
+    /// `debug`, `info`, `warning`, `error`. Set by the plugin; `nil` until then.
+    var sink: ((String, String, String) -> Void)?
+
+    func debug(_ message: String, name: String = "DivineVideoPlayer") {
+        emit("debug", message, name)
+    }
+
+    func info(_ message: String, name: String = "DivineVideoPlayer") {
+        emit("info", message, name)
+    }
+
+    func warning(_ message: String, name: String = "DivineVideoPlayer") {
+        emit("warning", message, name)
+    }
+
+    func error(_ message: String, name: String = "DivineVideoPlayer") {
+        emit("error", message, name)
+    }
+
+    private func emit(_ level: String, _ message: String, _ name: String) {
+        // Keep the console fallback so on-device debugging is unchanged.
+        print("[\(name)] \(message)")
+        sink?(level, message, name)
+    }
+}

--- a/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/macos/Classes/DivineVideoPlayerPlugin.swift
@@ -10,6 +10,28 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
 
     private static var registrar: FlutterPluginRegistrar?
 
+    private var globalChannel: FlutterMethodChannel?
+
+    /// Per-instance forwarder pushing native diagnostics over THIS engine's
+    /// global channel. `DivineVideoPlayerLog.shared.sink` is a process-wide
+    /// singleton, so a second FlutterEngine that registers the plugin would
+    /// otherwise overwrite it and route video logs to the wrong isolate. We
+    /// re-assert it in `handle` — player operations only ever reach the UI
+    /// engine.
+    private lazy var logSink: (String, String, String) -> Void = {
+        [weak self] level, message, name in
+        DispatchQueue.main.async {
+            self?.globalChannel?.invokeMethod(
+                "onNativeLog",
+                arguments: ["level": level, "message": message, "name": name]
+            )
+        }
+    }
+
+    private func installLogSink() {
+        DivineVideoPlayerLog.shared.sink = logSink
+    }
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         // Hot restart re-calls register(with:) without disposing the
         // previous engine's players. Clean up zombie players so timers
@@ -23,6 +45,8 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             binaryMessenger: registrar.messenger
         )
         let plugin = DivineVideoPlayerPlugin()
+        plugin.globalChannel = globalChannel
+        plugin.installLogSink()
         registrar.addMethodCallDelegate(plugin, channel: globalChannel)
 
         registrar.register(
@@ -54,9 +78,15 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        // Re-claim the shared sink in case another FlutterEngine overwrote it.
+        installLogSink()
         // Methods that require no arguments are handled before the
         // args guard to avoid returning FlutterMethodNotImplemented.
         if call.method == "disposeAll" {
+            DivineVideoPlayerLog.shared.info(
+                "disposeAll — releasing all players",
+                name: "DivineVideoPlayer.Lifecycle"
+            )
             MacPlayerRegistry.shared.disposeAll()
             result(nil)
             return
@@ -91,6 +121,10 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             MacPlayerRegistry.shared.set(instance, for: id)
 
             let useTexture = args["useTexture"] as? Bool ?? false
+            DivineVideoPlayerLog.shared.info(
+                "Player \(id) created (useTexture=\(useTexture))",
+                name: "DivineVideoPlayer.Lifecycle"
+            )
             if useTexture {
                 let textureId = instance.enableTextureOutput(
                     registry: registrar.textures
@@ -105,6 +139,10 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
                 result(nil)
                 return
             }
+            DivineVideoPlayerLog.shared.info(
+                "Player \(id) disposed",
+                name: "DivineVideoPlayer.Lifecycle"
+            )
             MacPlayerRegistry.shared.remove(id)?.dispose()
             result(nil)
 

--- a/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_threading_contract_test.dart
@@ -66,6 +66,25 @@ void main() {
           expect(source, contains('reportedPositionOverrideMs = nil'));
         },
       );
+
+      test(
+        '$platform emits freeze diagnostics for stalled native playback',
+        () {
+          final source = _appleSourceFile(platform).readAsStringSync();
+
+          expect(source, contains('setClipsTimeoutMs'));
+          expect(source, contains('bufferingStallMs'));
+          expect(source, contains('DivineVideoPlayer.Freeze'));
+          expect(source, contains('observeBuffering(for: item)'));
+          expect(source, contains(r'\.isPlaybackBufferEmpty'));
+          expect(source, contains(r'\.isPlaybackLikelyToKeepUp'));
+          expect(source, contains('clearSetClipsTimeout()'));
+          expect(
+            source,
+            contains('clearBufferingWatchdog(resetReported: true)'),
+          );
+        },
+      );
     }
   });
 }

--- a/mobile/packages/divine_video_player/test/src/native_log_forwarding_test.dart
+++ b/mobile/packages/divine_video_player/test/src/native_log_forwarding_test.dart
@@ -1,0 +1,151 @@
+import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    // Constructing a controller installs the one-time global-channel handler
+    // that receives `onNativeLog` from the platform side.
+    DivineVideoPlayerController();
+  });
+
+  Future<void> dispatchNativeLog(Object? arguments) {
+    const codec = StandardMethodCodec();
+    final envelope = codec.encodeMethodCall(
+      MethodCall('onNativeLog', arguments),
+    );
+    return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage('divine_video_player', envelope, (_) {});
+  }
+
+  LogEntry? latestEntryWithMessage(String message) {
+    final matches = LogCaptureService().getRecentLogs().where(
+      (entry) => entry.message == message,
+    );
+    return matches.isEmpty ? null : matches.last;
+  }
+
+  group('DivineVideoPlayer onNativeLog forwarding', () {
+    test(
+      'forwards a warning into UnifiedLogger under the video category',
+      () async {
+        const message = 'dvp-onNativeLog-warning-unique';
+        await dispatchNativeLog({
+          'level': 'warning',
+          'message': message,
+          'name': 'DivineVideoPlayer.Load',
+        });
+
+        final entry = latestEntryWithMessage(message);
+        expect(entry, isNotNull);
+        expect(entry!.level, LogLevel.warning);
+        expect(entry.name, 'DivineVideoPlayer.Load');
+        expect(entry.category, LogCategory.video);
+      },
+    );
+
+    test('maps the error level', () async {
+      const message = 'dvp-onNativeLog-error-unique';
+      await dispatchNativeLog({
+        'level': 'error',
+        'message': message,
+        'name': 'DivineVideoPlayer.Playback',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.error);
+    });
+
+    test('maps the info level', () async {
+      const message = 'dvp-onNativeLog-info-unique';
+      await dispatchNativeLog({
+        'level': 'info',
+        'message': message,
+        'name': 'DivineVideoPlayer.Lifecycle',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.info);
+    });
+
+    test('maps the debug level', () async {
+      const message = 'dvp-onNativeLog-debug-unique';
+      await dispatchNativeLog({
+        'level': 'debug',
+        'message': message,
+        'name': 'DivineVideoPlayer',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.debug);
+    });
+
+    test('maps the verbose level', () async {
+      const message = 'dvp-onNativeLog-verbose-unique';
+      await dispatchNativeLog({
+        'level': 'verbose',
+        'message': message,
+        'name': 'DivineVideoPlayer',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.verbose);
+    });
+
+    test('falls back to info for an unknown level', () async {
+      const message = 'dvp-onNativeLog-unknown-level-unique';
+      await dispatchNativeLog({
+        'level': 'something-unexpected',
+        'message': message,
+        'name': 'DivineVideoPlayer',
+      });
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.level, LogLevel.info);
+    });
+
+    test('falls back to the native name when none is provided', () async {
+      const message = 'dvp-onNativeLog-default-name-unique';
+      await dispatchNativeLog({'level': 'info', 'message': message});
+
+      final entry = latestEntryWithMessage(message);
+      expect(entry, isNotNull);
+      expect(entry!.name, 'DivineVideoPlayerNative');
+    });
+
+    test('ignores an entry with an empty message', () async {
+      final before = LogCaptureService().bufferSize;
+      await dispatchNativeLog({
+        'level': 'warning',
+        'message': '',
+        'name': 'DivineVideoPlayer',
+      });
+
+      expect(LogCaptureService().bufferSize, before);
+    });
+
+    test('ignores a call with non-map arguments without throwing', () async {
+      await expectLater(dispatchNativeLog('not-a-map'), completes);
+    });
+
+    test('ignores an unknown global method without throwing', () async {
+      const codec = StandardMethodCodec();
+      final envelope = codec.encodeMethodCall(
+        const MethodCall('unknownMethod'),
+      );
+      await expectLater(
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .handlePlatformMessage('divine_video_player', envelope, (_) {}),
+        completes,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #5116

## Description

Mirrors the `divine_camera` native-log bridge (#5110) for
`divine_video_player`, so video **playback** problems are reconstructable
from a user's bug report.

`divine_video_player` had **zero** native logging before this change. This PR
adds the native -> Dart diagnostics bridge plus a curated set of diagnostics
for iOS, macOS, and Android.

**Mechanism**
- A per-platform `DivineVideoPlayerLog` (`object` on Kotlin, singleton on
  Swift) with `debug/info/warning/error`, a console fallback, and a `sink`.
- The plugin forwards each entry over the **global** method channel
  (`divine_video_player`) via a new `onNativeLog` call.
- `DivineVideoPlayerController` installs a one-time handler on that channel
  and maps the entry to `Log.<level>(..., category: LogCategory.video)` ->
  `LogCaptureService` -> bug-report dump.

**Core diagnostics added**
- **Player lifecycle**: create (with `useTexture`), dispose, disposeAll.
- **Clip composition**: per-clip silent skips that explain "a clip is missing /
  black": missing uri, unparseable uri, no video track, non-positive display
  size, non-positive duration (iOS/macOS); missing uri (Android). Plus a
  "ready: N clips" / load-failure summary.
- **Asset / playback errors**: `AVPlayerItem` `.failed` (iOS/macOS) and
  ExoPlayer `onPlayerError` with the Media3 error code (Android).
- **Freeze diagnostics**: load-never-ready warnings and sustained buffering
  stall warnings on Android, iOS, and macOS. Android's existing set-clips
  timeout now uses a named timeout constant; Apple platforms use matching
  watchdogs that clear on ready, failure, stop, dispose, and item replacement.
- **Audio overlay tracks**: track count on `setAudioTracks`.

Per-frame / verbose paths stay console-only.

**Multi-engine safety**
`DivineVideoPlayerLog.sink` is a process-wide singleton; the app runs a
second `FlutterEngine` for the FCM background isolate. iOS/macOS bind the
sink to the per-instance plugin and re-assert it at the top of every `handle`
(player ops only reach the UI engine). Android already gates background
isolates (`mainPluginInstance`), so the sink is installed only for the main
engine and cleared on its detach.

**Related Issue:** Relates to the native-diagnostics initiative (see #5110 for
the camera half). Independent package, shipped as its own PR.

## Out of Scope

- Comprehensive per-operation breadcrumbs (play/pause/seek/jump/volume/speed/
  loop, cache config, preload, texture setup). This PR ships **core**
  diagnostics: the "why won't this video play / why is it silent / why did it
  freeze" signals. Finer breadcrumbs can follow if needed.

## Verification

- `mise exec -- flutter analyze lib test` from
  `mobile/packages/divine_video_player` -> **No issues found**.
- `mise exec -- flutter test` from `mobile/packages/divine_video_player` ->
  **226/226 pass**, including native-log forwarding tests and Apple freeze
  parity contract coverage.
- Pre-push hook reran analyzer and targeted changed-file tests -> **pass**.
- `mise exec -- flutter build apk --debug` from `mobile/` was attempted but
  this machine has no Java runtime, so Gradle could not start.
- `mise exec -- flutter build ios --simulator --debug` from `mobile/` was
  attempted but Xcode failed during Swift Package Manager dependency
  resolution with an internal `NSMutableArray insertObjects` exception before
  native compilation began.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
