### PR TITLE
feat(video-editor): capture pro_video_editor native logs in UnifiedLogger

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -91,6 +91,7 @@ import 'package:openvine/services/notification_service.dart'
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
+import 'package:openvine/services/pro_video_editor_log_forwarder.dart';
 import 'package:openvine/services/quick_actions_coordinator.dart';
 import 'package:openvine/services/seed_data_preload_service.dart';
 import 'package:openvine/services/seed_media_preload_service.dart';
@@ -949,6 +950,11 @@ Future<void> _startOpenVineApp() async {
       UnifiedLogger.enableCategories({LogCategory.system, LogCategory.auth});
     }
   }
+
+  // Forward pro_video_editor native diagnostics (renderer, thumbnail, audio)
+  // into the unified log so video-editor/render problems land in bug reports
+  // (#4801). Gated per call by the nativeLogLevel passed to each operation.
+  ProVideoEditorLogForwarder.start();
 
   // Store original debugPrint to avoid recursion
   final originalDebugPrint = debugPrint;

--- a/mobile/lib/services/pro_video_editor_log_forwarder.dart
+++ b/mobile/lib/services/pro_video_editor_log_forwarder.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Forwards native diagnostics emitted by `pro_video_editor` (the renderer,
+/// thumbnail, metadata and audio operations) into the app's [UnifiedLogger],
+/// so video-editor problems — e.g. a render that fails after many short clips
+/// (#4801) — are captured for bug reports.
+///
+/// Native forwarding is gated per call by the `nativeLogLevel` argument passed
+/// to each operation; this forwarder just pipes whatever the plugin emits into
+/// the unified log under [LogCategory.video]. The plugin's stream stays empty
+/// on Web, Windows, and Linux.
+class ProVideoEditorLogForwarder {
+  ProVideoEditorLogForwarder._();
+
+  static StreamSubscription<NativeLogEntry>? _subscription;
+
+  /// Starts forwarding `pro_video_editor` native logs into [UnifiedLogger].
+  ///
+  /// Idempotent — a second call while a subscription is active is a no-op.
+  /// [proVideoEditor] is injectable for tests.
+  static void start({ProVideoEditor? proVideoEditor}) {
+    if (_subscription != null) return;
+    final editor = proVideoEditor ?? ProVideoEditor.instance;
+    _subscription = editor.logStream.listen(forwardEntry);
+  }
+
+  /// Stops forwarding and releases the subscription. Mainly for tests.
+  static Future<void> stop() async {
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+
+  /// Maps a single [NativeLogEntry] onto the [UnifiedLogger].
+  @visibleForTesting
+  static void forwardEntry(NativeLogEntry entry) {
+    if (entry.message.isEmpty) return;
+    final name = (entry.tag?.isNotEmpty ?? false)
+        ? entry.tag!
+        : 'ProVideoEditorNative';
+    switch (entry.level) {
+      case NativeLogLevel.error:
+        Log.error(
+          entry.message,
+          name: name,
+          category: LogCategory.video,
+          stackTrace: entry.stackTrace == null
+              ? null
+              : StackTrace.fromString(entry.stackTrace!),
+        );
+      case NativeLogLevel.warning:
+        Log.warning(entry.message, name: name, category: LogCategory.video);
+      case NativeLogLevel.debug:
+        Log.debug(entry.message, name: name, category: LogCategory.video);
+      case NativeLogLevel.verbose:
+        Log.verbose(entry.message, name: name, category: LogCategory.video);
+      case NativeLogLevel.info:
+      case NativeLogLevel.none:
+        Log.info(entry.message, name: name, category: LogCategory.video);
+    }
+  }
+}

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -1021,7 +1021,15 @@ class VideoEditorRenderService {
     VideoRenderData task,
   ) async {
     await cancelTask(task.id);
-    await ProVideoEditor.instance.renderVideoToFile(outputPath, task);
+    // Surface native renderer diagnostics (encoder fallbacks, bitrate clamps,
+    // OOM guards, render errors) into the unified log via
+    // ProVideoEditorLogForwarder — the signal set behind #4801. A clean render
+    // stays quiet at this level, so it does not flood the capture buffer.
+    await ProVideoEditor.instance.renderVideoToFile(
+      outputPath,
+      task,
+      nativeLogLevel: NativeLogLevel.warning,
+    );
   }
 
   static Future<void> cancelTask(String id) async {

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1832,10 +1832,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "4e83988955909810791938b611a3dd6a02f15623cd98f73da976ae98eb917f7f"
+      sha256: "5e1f4dd68dd80a353f945706b0c6d30c5aaf0f7fb226691c0d3b2e8ef083c27b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -298,7 +298,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.18.0
+  pro_video_editor: ^1.19.0
   pro_image_editor: ^12.4.8
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7

--- a/mobile/test/services/pro_video_editor_log_forwarder_test.dart
+++ b/mobile/test/services/pro_video_editor_log_forwarder_test.dart
@@ -1,0 +1,156 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/pro_video_editor_log_forwarder.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+class _MockProVideoEditor extends Mock implements ProVideoEditor {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  LogEntry? latestWithMessage(String message) {
+    final matches = LogCaptureService().getRecentLogs().where(
+      (entry) => entry.message == message,
+    );
+    return matches.isEmpty ? null : matches.last;
+  }
+
+  NativeLogEntry entry(
+    NativeLogLevel level,
+    String message, {
+    String? tag,
+    String? stackTrace,
+  }) => NativeLogEntry(
+    level: level,
+    message: message,
+    tag: tag,
+    stackTrace: stackTrace,
+    timestamp: DateTime.now(),
+  );
+
+  tearDown(() async {
+    await ProVideoEditorLogForwarder.stop();
+  });
+
+  group('ProVideoEditorLogForwarder.forwardEntry', () {
+    test('forwards an error with stack trace under the video category', () {
+      const message = 'pve-fwd-error-unique';
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(
+          NativeLogLevel.error,
+          message,
+          tag: 'ProVideoEditor-Renderer',
+          stackTrace: 'at foo\nat bar',
+        ),
+      );
+
+      final logged = latestWithMessage(message);
+      expect(logged, isNotNull);
+      expect(logged!.level, LogLevel.error);
+      expect(logged.name, 'ProVideoEditor-Renderer');
+      expect(logged.category, LogCategory.video);
+      expect(logged.stackTrace, isNotNull);
+    });
+
+    test('maps the warning level', () {
+      const message = 'pve-fwd-warning-unique';
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(NativeLogLevel.warning, message),
+      );
+      expect(latestWithMessage(message)?.level, LogLevel.warning);
+    });
+
+    test('maps the info level', () {
+      const message = 'pve-fwd-info-unique';
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(NativeLogLevel.info, message),
+      );
+      expect(latestWithMessage(message)?.level, LogLevel.info);
+    });
+
+    test('maps the debug level', () {
+      const message = 'pve-fwd-debug-unique';
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(NativeLogLevel.debug, message),
+      );
+      expect(latestWithMessage(message)?.level, LogLevel.debug);
+    });
+
+    test('maps the verbose level', () {
+      const message = 'pve-fwd-verbose-unique';
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(NativeLogLevel.verbose, message),
+      );
+      expect(latestWithMessage(message)?.level, LogLevel.verbose);
+    });
+
+    test('maps the none level to info', () {
+      const message = 'pve-fwd-none-unique';
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(NativeLogLevel.none, message),
+      );
+      expect(latestWithMessage(message)?.level, LogLevel.info);
+    });
+
+    test('falls back to a default name when tag is missing', () {
+      const message = 'pve-fwd-default-name-unique';
+      ProVideoEditorLogForwarder.forwardEntry(
+        entry(NativeLogLevel.info, message),
+      );
+      expect(latestWithMessage(message)?.name, 'ProVideoEditorNative');
+    });
+
+    test('ignores an entry with an empty message', () {
+      final before = LogCaptureService().bufferSize;
+      ProVideoEditorLogForwarder.forwardEntry(entry(NativeLogLevel.error, ''));
+      expect(LogCaptureService().bufferSize, before);
+    });
+  });
+
+  group('ProVideoEditorLogForwarder start/stop', () {
+    test('forwards stream entries while subscribed, stops on cancel', () async {
+      final mock = _MockProVideoEditor();
+      final controller = StreamController<NativeLogEntry>.broadcast();
+      when(() => mock.logStream).thenAnswer((_) => controller.stream);
+
+      ProVideoEditorLogForwarder.start(proVideoEditor: mock);
+
+      const live = 'pve-stream-live-unique';
+      controller.add(entry(NativeLogLevel.warning, live));
+      await Future<void>.delayed(Duration.zero);
+      expect(latestWithMessage(live), isNotNull);
+
+      await ProVideoEditorLogForwarder.stop();
+
+      const afterStop = 'pve-stream-afterstop-unique';
+      controller.add(entry(NativeLogLevel.warning, afterStop));
+      await Future<void>.delayed(Duration.zero);
+      expect(latestWithMessage(afterStop), isNull);
+
+      await controller.close();
+    });
+
+    test(
+      'start is idempotent — a second call does not double-subscribe',
+      () async {
+        final mock = _MockProVideoEditor();
+        final controller = StreamController<NativeLogEntry>.broadcast();
+        var listenCount = 0;
+        when(() => mock.logStream).thenAnswer((_) {
+          listenCount++;
+          return controller.stream;
+        });
+
+        ProVideoEditorLogForwarder.start(proVideoEditor: mock);
+        ProVideoEditorLogForwarder.start(proVideoEditor: mock);
+
+        expect(listenCount, 1);
+        await ProVideoEditorLogForwarder.stop();
+        await controller.close();
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Final surface of the native-diagnostics initiative: capture **`pro_video_editor`**
native logs in Dart. This is where the video-**editor render** lives (#4801 —
"rendering fails after many short clips"), which is a third-party package, not
one of our own plugins — so the approach differs from the camera / video-player
bridges.

`pro_video_editor` **1.19.0** streams its native diagnostics (renderer,
thumbnail, metadata, audio) back to Dart via
`ProVideoEditor.instance.logStream` (a `Stream<NativeLogEntry>`), gated per call
by the `nativeLogLevel` argument. This PR:

- **Bumps** `pro_video_editor` `^1.18.0 → ^1.19.0`.
- Adds **`ProVideoEditorLogForwarder`** — started once at app init
  ([main.dart]) — which subscribes to `logStream` and pipes each
  `NativeLogEntry` into the app's `UnifiedLogger` under `LogCategory.video`
  (mapping level, carrying `tag` as the log name and the native `stackTrace`
  on errors). The plugin's stream is empty on Web/Windows/Linux, so this is a
  no-op there.
- Sets **`nativeLogLevel: NativeLogLevel.warning`** on the editor render call
  (`video_editor_render_service`) so the #4801 signal set — encoder fallbacks,
  bitrate clamps, OOM guards, and the final render error — actually emits. A
  clean render stays quiet at this level, so it does **not** flood the 50k
  capture buffer on every successful export.

**Related Issue:** Relates to #4801. Independent of the camera (#5110) and
video-player (#5115) native-log PRs — shipped on its own branch from `main`.

## Out of Scope

- Raising the render level to `debug` for the *rich* per-clip renderer trace.
  `warning` is the production-safe default (captures the failure path without
  flooding); `debug` can be enabled per call when actively debugging #4801.
- Adding `nativeLogLevel` to the other `pro_video_editor` calls (thumbnails
  already pass `warning`; metadata/audio/upload-watermark renders left as-is to
  keep the buffer focused on the editor render).

## Verification

- `flutter analyze` (changed files + `main.dart`) → **No issues found**.
- `flutter test` (new suite) → **10/10 pass**: every `NativeLogLevel` arm maps
  to the right `UnifiedLogger` level + category, `tag`→name and error
  `stackTrace` are carried, empty messages are dropped, and `start`/`stop` /
  idempotency are covered via a mocktail-stubbed `logStream`.
- `pubspec.lock` change is the single `pro_video_editor 1.18.0 → 1.19.0` bump
  (no unrelated resolver churn).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
