### PR TITLE
fix(feed): auto-refresh For You on app resume when stale

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -515,7 +515,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   /// Handle auto-refresh request (dispatched by UI on app resume).
   ///
   /// Only refreshes when:
-  /// - The current feed mode is [FeedMode.following] or [FeedMode.forYou]
+  /// - The current feed source type is [VideoFeedSourceType.following] or
+  ///   [VideoFeedSourceType.forYou]
   /// - The data is stale (last refresh was longer ago than
   ///   [_autoRefreshMinInterval])
   ///

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -515,14 +515,21 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   /// Handle auto-refresh request (dispatched by UI on app resume).
   ///
   /// Only refreshes when:
-  /// - The current feed mode is [FeedMode.following]
+  /// - The current feed mode is [FeedMode.following] or [FeedMode.forYou]
   /// - The data is stale (last refresh was longer ago than
   ///   [_autoRefreshMinInterval])
+  ///
+  /// For You is included so the feed picks up fresh recommendations on
+  /// resume, addressing the "feed stays the same after reopening the app"
+  /// report (issue #3861).
   Future<void> _onAutoRefreshRequested(
     VideoFeedAutoRefreshRequested event,
     Emitter<VideoFeedBlocState> emit,
   ) async {
-    if (state.source.type != VideoFeedSourceType.following) return;
+    if (state.source.type != VideoFeedSourceType.following &&
+        state.source.type != VideoFeedSourceType.forYou) {
+      return;
+    }
 
     final lastRefresh = _lastRefreshedAt;
     if (lastRefresh != null &&

--- a/mobile/lib/blocs/video_feed/video_feed_event.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_event.dart
@@ -78,7 +78,8 @@ final class VideoFeedRefreshRequested extends VideoFeedEvent {
 ///
 /// Dispatched by the UI on app resume (background → foreground).
 /// The bloc will only perform the refresh if:
-/// - The current feed mode is [FeedMode.following] or [FeedMode.forYou]
+/// - The current feed source type is [VideoFeedSourceType.following] or
+///   [VideoFeedSourceType.forYou]
 /// - Enough time has passed since the last successful load
 ///
 /// Refreshing For You on resume addresses the "feed stays the same after

--- a/mobile/lib/blocs/video_feed/video_feed_event.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_event.dart
@@ -78,8 +78,11 @@ final class VideoFeedRefreshRequested extends VideoFeedEvent {
 ///
 /// Dispatched by the UI on app resume (background → foreground).
 /// The bloc will only perform the refresh if:
-/// - The current feed mode is [FeedMode.following]
+/// - The current feed mode is [FeedMode.following] or [FeedMode.forYou]
 /// - Enough time has passed since the last successful load
+///
+/// Refreshing For You on resume addresses the "feed stays the same after
+/// reopening the app" report (issue #3861).
 final class VideoFeedAutoRefreshRequested extends VideoFeedEvent {
   const VideoFeedAutoRefreshRequested();
 

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -2150,13 +2150,83 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'does nothing when mode is forYou',
-        build: createBloc,
+        'refreshes forYou when data is stale',
+        setUp: () {
+          final videos = createTestVideos(pageSize);
+
+          when(
+            () => mockVideosRepository.getRecommendedVideos(
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+        },
+        build: () => VideoFeedBloc(
+          videosRepository: mockVideosRepository,
+          followRepository: mockFollowRepository,
+          curatedListRepository: mockCuratedListRepository,
+          autoRefreshMinInterval: Duration.zero,
+        ),
         seed: () => VideoFeedBlocState(
           status: VideoFeedStatus.success,
-          videos: createTestVideos(5),
+          videos: createTestVideos(3),
         ),
         act: (bloc) => bloc.add(const VideoFeedAutoRefreshRequested()),
+        expect: () => [
+          const VideoFeedBlocState(),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'videos count', pageSize),
+        ],
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.getRecommendedVideos(
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: true,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'does nothing for forYou when data is fresh '
+        '(last refresh within auto-refresh interval)',
+        setUp: () {
+          final videos = createTestVideos(pageSize);
+
+          when(
+            () => mockVideosRepository.getRecommendedVideos(
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+        },
+        build: () => VideoFeedBloc(
+          videosRepository: mockVideosRepository,
+          followRepository: mockFollowRepository,
+          curatedListRepository: mockCuratedListRepository,
+          // Large interval so data is always considered fresh
+          autoRefreshMinInterval: const Duration(hours: 1),
+        ),
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: createTestVideos(pageSize),
+        ),
+        act: (bloc) async {
+          // First, trigger a load so _lastRefreshedAt gets set
+          bloc.add(const VideoFeedStarted());
+          await Future<void>.delayed(Duration.zero);
+
+          // Now the auto-refresh should be skipped (data is fresh)
+          bloc.add(const VideoFeedAutoRefreshRequested());
+        },
+        skip: 2, // Skip the loading + success from VideoFeedStarted
         expect: () => <VideoFeedBlocState>[],
       );
 

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -266,6 +266,12 @@ void main() {
 
       final feedVideos = tester.widget<FeedVideos>(find.byType(FeedVideos));
       expect(feedVideos.currentIndex, 2);
+
+      // Drain the player-window preload grace timer before the tree is
+      // disposed so no timer is pending at test teardown.
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
     });
 
     testWidgets('clamps restored home index to loaded videos', (tester) async {
@@ -303,6 +309,12 @@ void main() {
 
       final feedVideos = tester.widget<FeedVideos>(find.byType(FeedVideos));
       expect(feedVideos.currentIndex, 2);
+
+      // Drain the player-window preload grace timer before the tree is
+      // disposed so no timer is pending at test teardown.
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
     });
 
     testWidgets('records active video index for home tab restoration', (
@@ -349,6 +361,12 @@ void main() {
         container.read(lastTabPositionProvider)[RouteType.home],
         equals(1),
       );
+
+      // Drain the player-window preload grace timer before the tree is
+      // disposed so no timer is pending at test teardown.
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
     });
 
     testWidgets('home route emissions do not clobber recorded home index', (

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -231,6 +231,47 @@ void main() {
       await tester.pump();
     });
 
+    testWidgets('requests auto-refresh when app resumes', (tester) async {
+      final video = createTestVideoEvent();
+      final state = VideoFeedBlocState(
+        status: VideoFeedStatus.success,
+        videos: [video],
+      );
+      when(() => videoFeedBloc.state).thenReturn(state);
+      whenListen(
+        videoFeedBloc,
+        const Stream<VideoFeedBlocState>.empty(),
+        initialState: state,
+      );
+
+      await tester.pumpWidget(
+        testMaterialApp(
+          home: MultiBlocProvider(
+            providers: [
+              BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+              BlocProvider<VideoPlaybackStatusCubit>(
+                create: (_) => VideoPlaybackStatusCubit(),
+              ),
+              BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+            ],
+            child: const VideoFeedView(),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+      await tester.pump();
+
+      verify(
+        () => videoFeedBloc.add(const VideoFeedAutoRefreshRequested()),
+      ).called(1);
+
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpWidget(const SizedBox());
+      await tester.pump();
+    });
+
     testWidgets('passes restored home index to FeedVideos', (tester) async {
       final videos = [
         createTestVideoEvent(id: 'video-0'),


### PR DESCRIPTION
## Description

The For You home feed was never refreshed when the app resumed from background. On iOS the app commonly survives in the background for days, so "reopening the app" is a resume, not a cold start — users saw the exact same videos in the same order every time.

`VideoFeedPage` already dispatches `VideoFeedAutoRefreshRequested` on `AppLifecycleState.resumed`, but the bloc handler bailed out for every source except `following`. This PR widens that gate to also cover `forYou`:

- The existing staleness gate (`_autoRefreshMinInterval`, default 10 min) still applies, so quick app switches don't disrupt active sessions.
- The refresh uses the existing `skipCache: true` load path (same as pull-to-refresh), bypassing the session-scoped `InMemoryFeedCache` so genuinely fresh recommendations are fetched.
- Doc comments on the handler and event now describe the source-type gate precisely.
- Widget coverage now verifies that app resume dispatches `VideoFeedAutoRefreshRequested` from `VideoFeedView`.

Complements #5021 (which stopped stale cross-restart cache replay on cold start) by covering the resume path.

**Related Issue:** Closes #3861

## Out of Scope

- Per-session seed/jitter in recommendation ordering — tracked in #5027 (separate PR).
- Other feed sources (`subscribedList`, `newVideos`) keep their current no-auto-refresh behavior.

## Verification

- `flutter test test/blocs/video_feed/` — 103 passed
- `flutter test test/screens/feed/video_feed_page_test.dart` — 12 passed
- `flutter analyze` — no issues
- `dart format` — clean
- Push hook changed-file analyzer/tests — passed
- Replaced the test that encoded the old behavior (`does nothing when mode is forYou`) with stale-refresh and fresh-skip forYou cases.
- Added widget coverage for resume → `VideoFeedAutoRefreshRequested`.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
