### PR TITLE
fix(feed): add per-session seed and stable jitter to For You ordering

### DIFF
--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 part 'for_you_provider.g.dart';
 
@@ -25,6 +26,14 @@ part 'for_you_provider.g.dart';
 @Riverpod(keepAlive: true)
 class ForYouFeed extends _$ForYouFeed {
   int _currentLimit = 50;
+
+  /// Per-session seed for recommendation ordering (#5027).
+  ///
+  /// Forwarded to the recommendations endpoint and used for the
+  /// deterministic windowed jitter. Regenerated only in [refresh] so
+  /// the limit-growth [loadMore] re-fetch keeps a stable ordering
+  /// within the session (jitter prefix stability).
+  String _sessionSeed = generateRecommendationSessionSeed();
 
   @override
   Future<VideoFeedState> build() async {
@@ -113,10 +122,14 @@ class ForYouFeed extends _$ForYouFeed {
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
         limit: limit,
+        seed: _sessionSeed,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
-      final resultVideos = response.videos.toVideoEvents();
+      final resultVideos = applyRecommendationSessionJitter(
+        response.videos.toVideoEvents(),
+        _sessionSeed,
+      );
 
       Log.info(
         '✅ ForYouFeed: Got ${resultVideos.length} recommendations, source: ${response.source}',
@@ -185,10 +198,16 @@ class ForYouFeed extends _$ForYouFeed {
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
         limit: newLimit,
+        seed: _sessionSeed,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
-      final resultVideos = response.videos.toVideoEvents();
+      // Same seed as the initial fetch: jitter prefix stability keeps the
+      // already-displayed prefix in the same order for the larger limit.
+      final resultVideos = applyRecommendationSessionJitter(
+        response.videos.toVideoEvents(),
+        _sessionSeed,
+      );
 
       if (!ref.mounted) return;
 
@@ -243,6 +262,9 @@ class ForYouFeed extends _$ForYouFeed {
     );
 
     _currentLimit = 50; // Reset limit on refresh
+    // New session: rotate the seed so the refreshed feed gets a fresh
+    // ordering instead of replaying the previous session's order.
+    _sessionSeed = generateRecommendationSessionSeed();
 
     await staleWhileRevalidate(
       getCurrentState: () => state,

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'12746d77ebf27e31e6b9678f5301528d3d6b5438';
+String _$forYouFeedHash() => r'49d73c34c9bb7550e15a0dcbc81f179cd8490de2';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1975,6 +1975,10 @@ class FunnelcakeApiClient {
   /// (`'popular'` or `'recent'`, defaults to `'popular'`).
   /// [category] is an optional hashtag/category filter.
   /// [cursor] is the opaque cursor returned by a previous response.
+  /// [seed] is an optional opaque per-session value forwarded so the
+  /// backend can vary ordering between sessions while keeping pages of
+  /// the same session coherent. The backend may ignore it until it
+  /// supports the parameter.
   ///
   /// Returns a [RecommendationsResponse] with videos and source.
   ///
@@ -1993,6 +1997,7 @@ class FunnelcakeApiClient {
     String fallback = 'popular',
     String? category,
     String? cursor,
+    String? seed,
     List<String> preferredLanguages = const [],
     String? viewerCountry,
   }) async {
@@ -2013,6 +2018,9 @@ class FunnelcakeApiClient {
     }
     if (cursor != null && cursor.isNotEmpty) {
       queryParams['cursor'] = cursor;
+    }
+    if (seed != null && seed.isNotEmpty) {
+      queryParams['seed'] = seed;
     }
     _addViewerPreferenceQueryParameters(
       queryParams,

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -4198,6 +4198,54 @@ void main() {
         expect(uri.queryParameters['cursor'], equals('rec-page-2'));
       });
 
+      test('sends session seed when provided', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async =>
+              http.Response('{"videos": [], "source": "popular"}', 200),
+        );
+
+        await client.getRecommendations(
+          pubkey: testPubkey,
+          cursor: 'rec-page-2',
+          seed: 'session-seed-1',
+        );
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.single
+                as Uri;
+        expect(uri.path, equals('/api/users/$testPubkey/recommendations'));
+        expect(uri.queryParameters['seed'], equals('session-seed-1'));
+        expect(uri.queryParameters['cursor'], equals('rec-page-2'));
+      });
+
+      test('omits seed query param when seed is not provided', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async =>
+              http.Response('{"videos": [], "source": "popular"}', 200),
+        );
+
+        await client.getRecommendations(pubkey: testPubkey);
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.single
+                as Uri;
+        expect(uri.queryParameters.containsKey('seed'), isFalse);
+      });
+
       test('sends viewer language and country hints', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),

--- a/mobile/packages/videos_repository/lib/src/recommendation_session_jitter.dart
+++ b/mobile/packages/videos_repository/lib/src/recommendation_session_jitter.dart
@@ -1,0 +1,75 @@
+// ABOUTME: Deterministic seeded windowed jitter for For You ordering.
+// ABOUTME: Adds per-session variety to recommendation feeds while
+// ABOUTME: keeping ordering stable within a pagination session (#5027).
+
+import 'dart:math';
+
+final Random _sessionSeedRandom = Random();
+
+/// Generates an opaque seed string for a recommendation session.
+///
+/// Intentionally non-cryptographic: the seed only diversifies feed
+/// ordering between sessions and protects nothing sensitive, so a
+/// plain [Random] is sufficient (and avoids platform-secure-RNG cost
+/// on the feed hot path).
+String generateRecommendationSessionSeed() =>
+    _sessionSeedRandom.nextInt(1 << 31).toRadixString(16);
+
+/// Reorders [items] by shuffling WITHIN consecutive rank windows of
+/// [windowSize], deterministically derived from [seed].
+///
+/// Properties:
+/// - **Deterministic**: the same [items], [seed], and [windowSize]
+///   always produce the same ordering, so cache replays and feed-mode
+///   switches reproduce the identical jittered order.
+/// - **Window containment**: an item in rank window `k` (server ranks
+///   `k*windowSize ..< (k+1)*windowSize`) stays in window `k`, so a
+///   top-[windowSize] recommendation stays in the top [windowSize].
+/// - **Prefix stability**: each window's shuffle is seeded from
+///   `'$seed:$windowIndex'`, independent of list length, so jittering
+///   a longer list with the same seed yields the identical ordering
+///   for every complete window shared with a shorter list. This keeps
+///   limit-growth pagination (re-fetching with a larger limit) stable.
+///
+/// A trailing partial window is shuffled within itself; it only matches
+/// a longer list's ordering once it becomes a complete window there.
+///
+/// Pure function: [items] is not mutated and a new list is returned.
+/// Empty and single-item lists are returned as (shallow) copies.
+List<T> applyRecommendationSessionJitter<T>(
+  List<T> items,
+  String seed, {
+  int windowSize = 5,
+}) {
+  assert(windowSize >= 1, 'windowSize must be at least 1');
+  final result = List<T>.of(items);
+  if (result.length < 2 || windowSize < 2) return result;
+
+  for (
+    var start = 0, windowIndex = 0;
+    start < result.length;
+    start += windowSize, windowIndex++
+  ) {
+    final end = min(start + windowSize, result.length);
+    final window = result.sublist(start, end)
+      ..shuffle(Random(_stableStringHash('$seed:$windowIndex')));
+    result.setRange(start, end, window);
+  }
+
+  return result;
+}
+
+/// 32-bit FNV-1a hash over the string's code units.
+///
+/// Used instead of [String.hashCode] because Dart's built-in string
+/// hash is not guaranteed stable across platforms or SDK versions,
+/// and the jitter must be reproducible for a given seed.
+int _stableStringHash(String input) {
+  const fnvPrime = 0x01000193;
+  const fnvOffsetBasis = 0x811c9dc5;
+  var hash = fnvOffsetBasis;
+  for (final codeUnit in input.codeUnits) {
+    hash = ((hash ^ codeUnit) * fnvPrime) & 0xFFFFFFFF;
+  }
+  return hash;
+}

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -15,6 +15,7 @@ import 'package:videos_repository/src/home_feed_result.dart';
 import 'package:videos_repository/src/in_memory_feed_cache.dart';
 import 'package:videos_repository/src/popular_videos_page.dart';
 import 'package:videos_repository/src/profile_video_merge.dart';
+import 'package:videos_repository/src/recommendation_session_jitter.dart';
 import 'package:videos_repository/src/video_content_filter.dart';
 import 'package:videos_repository/src/video_event_filter.dart';
 import 'package:videos_repository/src/video_local_storage.dart';
@@ -135,7 +136,7 @@ String _popularPreferenceCacheSuffix({
 /// {@endtemplate}
 class VideosRepository {
   /// {@macro videos_repository}
-  const VideosRepository({
+  VideosRepository({
     required NostrClient nostrClient,
     VideoLocalStorage? localStorage,
     BlockedVideoFilter? blockFilter,
@@ -158,6 +159,16 @@ class VideosRepository {
   final VideoWarningLabelsResolver? _warningLabelsResolver;
   final FunnelcakeApiClient? _funnelcakeApiClient;
   final InMemoryFeedCache? _inMemoryFeedCache;
+
+  /// Per-session seed for For You recommendation ordering (#5027).
+  ///
+  /// A new repository instance (cold start) gets a fresh seed, and the
+  /// seed rotates on explicit fresh sessions (pull-to-refresh / resume
+  /// auto-refresh) in [getRecommendedVideos]. The seed is forwarded to
+  /// the recommendations endpoint and drives the deterministic windowed
+  /// jitter, so ordering stays stable within a pagination session while
+  /// varying between sessions.
+  String _recommendationSessionSeed = generateRecommendationSessionSeed();
 
   /// Clears the in-memory feed cache.
   ///
@@ -2411,9 +2422,18 @@ class VideosRepository {
     final cacheKey =
         'recommended:${effectiveUserPubkey ?? 'anonymous'}'
         '$preferenceCacheSuffix';
-    if (!skipCache && until == null && cursor == null) {
+    final isFirstPage = until == null && cursor == null;
+    if (!skipCache && isFirstPage) {
       final cached = _inMemoryFeedCache?.get(cacheKey);
       if (cached != null) return cached;
+    }
+
+    // An explicit fresh session (pull-to-refresh / resume auto-refresh)
+    // starts a new ordering session. Cursor-bearing pagination calls and
+    // cache-served calls keep the current seed so ordering stays stable
+    // within the session.
+    if (skipCache && isFirstPage) {
+      _recommendationSessionSeed = generateRecommendationSessionSeed();
     }
 
     if (effectiveUserPubkey == null ||
@@ -2435,6 +2455,7 @@ class VideosRepository {
         ? await _funnelcakeApiClient.getRecommendations(
             pubkey: effectiveUserPubkey,
             limit: limit,
+            seed: _recommendationSessionSeed,
             preferredLanguages: preferredLanguages,
             viewerCountry: viewerCountry,
           )
@@ -2442,6 +2463,7 @@ class VideosRepository {
             pubkey: effectiveUserPubkey,
             limit: limit,
             cursor: recommendationCursor,
+            seed: _recommendationSessionSeed,
             preferredLanguages: preferredLanguages,
             viewerCountry: viewerCountry,
           );
@@ -2458,13 +2480,21 @@ class VideosRepository {
       );
     }
 
+    // Jitter the first page only: cursor pages are appended after
+    // already-watched content and must preserve server order. Applying
+    // the jitter before the cache write means cache replays and feed
+    // mode switches reproduce the identical jittered order.
+    final orderedVideos = isFirstPage
+        ? applyRecommendationSessionJitter(videos, _recommendationSessionSeed)
+        : videos;
+
     final result = HomeFeedResult(
-      videos: videos,
+      videos: orderedVideos,
       paginationCursor: response.nextCursor,
       hasMore: response.hasMore,
       rawResponseBody: response.rawBody,
     );
-    if (until == null && cursor == null) {
+    if (isFirstPage) {
       _inMemoryFeedCache?.set(cacheKey, result);
     }
     return result;

--- a/mobile/packages/videos_repository/lib/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/videos_repository.dart
@@ -12,6 +12,7 @@ export 'src/home_feed_result.dart';
 export 'src/in_memory_feed_cache.dart';
 export 'src/popular_videos_page.dart';
 export 'src/profile_video_merge.dart';
+export 'src/recommendation_session_jitter.dart';
 export 'src/video_content_filter.dart';
 export 'src/video_event_filter.dart';
 export 'src/video_local_storage.dart';

--- a/mobile/packages/videos_repository/test/src/recommendation_session_jitter_test.dart
+++ b/mobile/packages/videos_repository/test/src/recommendation_session_jitter_test.dart
@@ -1,0 +1,139 @@
+// ABOUTME: Tests for the deterministic seeded windowed jitter used to
+// ABOUTME: add per-session freshness to For You ordering (#5027).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+void main() {
+  group('applyRecommendationSessionJitter', () {
+    List<String> items(int count) =>
+        List.generate(count, (index) => 'video-$index');
+
+    test('is deterministic: same seed produces the same order', () {
+      final input = items(23);
+
+      final first = applyRecommendationSessionJitter(input, 'seed-a');
+      final second = applyRecommendationSessionJitter(input, 'seed-a');
+
+      expect(first, equals(second));
+    });
+
+    test('different seeds produce different orders', () {
+      // Fixed seeds chosen so the orderings differ — no randomness in
+      // the assertion itself (both calls are deterministic).
+      final input = items(25);
+
+      final orderA = applyRecommendationSessionJitter(input, 'seed-a');
+      final orderB = applyRecommendationSessionJitter(input, 'seed-b');
+
+      expect(orderA, isNot(equals(orderB)));
+    });
+
+    test('keeps every item within its original rank window', () {
+      const windowSize = 4;
+      final input = items(23);
+
+      final jittered = applyRecommendationSessionJitter(
+        input,
+        'seed-a',
+        windowSize: windowSize,
+      );
+
+      expect(jittered, hasLength(input.length));
+      for (var start = 0; start < input.length; start += windowSize) {
+        final end = start + windowSize > input.length
+            ? input.length
+            : start + windowSize;
+        expect(
+          jittered.sublist(start, end),
+          unorderedEquals(input.sublist(start, end)),
+          reason: 'window [$start, $end) must contain its original items',
+        );
+      }
+    });
+
+    test('a top-window item stays in the top window', () {
+      final input = items(50);
+
+      final jittered = applyRecommendationSessionJitter(input, 'seed-a');
+
+      expect(
+        jittered.take(5),
+        unorderedEquals(input.take(5)),
+        reason: 'a top-5 video must stay in the top 5',
+      );
+    });
+
+    test(
+      'prefix stability: longer list reproduces the shorter ordering for '
+      'shared complete windows',
+      () {
+        final shorter = items(50);
+        final longer = items(80);
+
+        final jitteredShorter = applyRecommendationSessionJitter(
+          shorter,
+          'seed-a',
+        );
+        final jitteredLonger = applyRecommendationSessionJitter(
+          longer,
+          'seed-a',
+        );
+
+        expect(
+          jitteredLonger.sublist(0, shorter.length),
+          equals(jitteredShorter),
+          reason:
+              'limit-growth loadMore must keep the already-displayed '
+              'prefix in the same order',
+        );
+      },
+    );
+
+    test('returns an empty list for empty input', () {
+      expect(
+        applyRecommendationSessionJitter(<String>[], 'seed-a'),
+        isEmpty,
+      );
+    });
+
+    test('handles a list shorter than the window', () {
+      final input = items(3);
+
+      final jittered = applyRecommendationSessionJitter(input, 'seed-a');
+
+      expect(jittered, unorderedEquals(input));
+    });
+
+    test('returns a single-item list unchanged', () {
+      expect(
+        applyRecommendationSessionJitter(['only'], 'seed-a'),
+        equals(['only']),
+      );
+    });
+
+    test('does not mutate the input list', () {
+      final input = items(12);
+      final snapshot = List<String>.of(input);
+
+      applyRecommendationSessionJitter(input, 'seed-a');
+
+      expect(input, equals(snapshot));
+    });
+
+    test('windowSize of 1 is the identity ordering', () {
+      final input = items(10);
+
+      expect(
+        applyRecommendationSessionJitter(input, 'seed-a', windowSize: 1),
+        equals(input),
+      );
+    });
+  });
+
+  group('generateRecommendationSessionSeed', () {
+    test('returns a non-empty seed', () {
+      expect(generateRecommendationSessionSeed(), isNotEmpty);
+    });
+  });
+}

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -9749,6 +9749,7 @@ void main() {
         );
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -9784,6 +9785,7 @@ void main() {
         );
         verify(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: 10,
           ),
@@ -9794,6 +9796,7 @@ void main() {
         var callCount = 0;
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             cursor: any(named: 'cursor'),
@@ -9855,6 +9858,7 @@ void main() {
         expect(cachedAfterSecondRefresh.hasMore, isTrue);
         verify(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: any(named: 'limit'),
           ),
@@ -9870,6 +9874,7 @@ void main() {
         );
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -9899,6 +9904,7 @@ void main() {
         expect(result.videos.single.id, equals('country-recommended-video'));
         verify(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: 10,
             viewerCountry: 'BR',
@@ -9939,6 +9945,7 @@ void main() {
           ).called(1);
           verifyNever(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -9959,6 +9966,7 @@ void main() {
           );
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10011,6 +10019,7 @@ void main() {
           var recommendationCallCount = 0;
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10057,6 +10066,7 @@ void main() {
           expect(recovered.videos.single.id, equals('recommended-video'));
           verify(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: 'user-pubkey',
               limit: 10,
             ),
@@ -10092,6 +10102,7 @@ void main() {
           expect(result.videos.single.id, equals('popular-video'));
           verifyNever(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10128,6 +10139,7 @@ void main() {
           ).thenAnswer((_) async => [popular]);
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10162,6 +10174,7 @@ void main() {
           expect(recovered.videos.single.id, equals('recommended-video'));
           verify(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: 'user-pubkey',
               limit: 10,
             ),
@@ -10224,6 +10237,7 @@ void main() {
           expect(result.videos.single.id, equals('popular-video'));
           verifyNever(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10247,6 +10261,7 @@ void main() {
           );
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10281,6 +10296,7 @@ void main() {
           expect(result.hasMore, isTrue);
           verify(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: 'user-pubkey',
               limit: 10,
               cursor: 'rec-page-2',
@@ -10306,6 +10322,7 @@ void main() {
           );
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10340,6 +10357,7 @@ void main() {
           expect(result.hasMore, isTrue);
           verify(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: 'user-pubkey',
               limit: 10,
               cursor: '1700000000',
@@ -10359,6 +10377,7 @@ void main() {
         () async {
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10383,6 +10402,189 @@ void main() {
           );
         },
       );
+
+      group('session seed and jitter (#5027)', () {
+        /// Recommended stats with strictly decreasing createdAt so the
+        /// stats transform (which sorts by createdAt descending) keeps
+        /// the server order, making jitter assertions deterministic.
+        List<VideoStats> recommendedStats(int count) => List.generate(
+          count,
+          (index) => _createVideoStats(
+            id: 'recommended-video-$index',
+            pubkey: 'recommended-pubkey-$index',
+            dTag: 'recommended-dtag-$index',
+            videoUrl: 'https://example.com/recommended-$index.mp4',
+            createdAt: 1704067200 - index,
+          ),
+        );
+
+        void stubRecommendations(List<VideoStats> videos) {
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              cursor: any(named: 'cursor'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => RecommendationsResponse(
+              videos: videos,
+              source: 'personalized',
+              nextCursor: 'rec-page-2',
+              hasMore: true,
+            ),
+          );
+        }
+
+        List<String> capturedSeeds() => verify(
+          () => mockFunnelcakeClient.getRecommendations(
+            seed: captureAny(named: 'seed'),
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).captured.cast<String>();
+
+        test(
+          'forwards a session seed to the recommendations endpoint',
+          () async {
+            stubRecommendations(recommendedStats(1));
+            final repo = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            await repo.getRecommendedVideos(userPubkey: 'user-pubkey');
+
+            final seeds = capturedSeeds();
+            expect(seeds, hasLength(1));
+            expect(seeds.single, isNotEmpty);
+          },
+        );
+
+        test('keeps the same seed across cursor pagination', () async {
+          stubRecommendations(recommendedStats(1));
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          await repo.getRecommendedVideos(userPubkey: 'user-pubkey');
+          await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            cursor: 'rec-page-2',
+          );
+
+          final seeds = capturedSeeds();
+          expect(seeds, hasLength(2));
+          expect(seeds[1], equals(seeds[0]));
+        });
+
+        test('rotates the seed on skipCache refresh', () async {
+          stubRecommendations(recommendedStats(1));
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          await repo.getRecommendedVideos(userPubkey: 'user-pubkey');
+          await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            skipCache: true,
+          );
+
+          final seeds = capturedSeeds();
+          expect(seeds, hasLength(2));
+          expect(seeds[1], isNot(equals(seeds[0])));
+        });
+
+        test(
+          'does not rotate the seed on skipCache cursor pagination',
+          () async {
+            stubRecommendations(recommendedStats(1));
+            final repo = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+            );
+
+            await repo.getRecommendedVideos(userPubkey: 'user-pubkey');
+            await repo.getRecommendedVideos(
+              userPubkey: 'user-pubkey',
+              skipCache: true,
+              cursor: 'rec-page-2',
+            );
+
+            final seeds = capturedSeeds();
+            expect(seeds, hasLength(2));
+            expect(seeds[1], equals(seeds[0]));
+          },
+        );
+
+        test(
+          'jitters the first page and replays the identical order from cache',
+          () async {
+            final stats = recommendedStats(12);
+            stubRecommendations(stats);
+            final repo = VideosRepository(
+              nostrClient: mockNostrClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+              inMemoryFeedCache: InMemoryFeedCache(),
+            );
+
+            final firstPage = await repo.getRecommendedVideos(
+              userPubkey: 'user-pubkey',
+            );
+            final cachedReplay = await repo.getRecommendedVideos(
+              userPubkey: 'user-pubkey',
+            );
+
+            final seeds = capturedSeeds();
+            expect(seeds, hasLength(1));
+
+            final serverOrderIds = stats.map((s) => s.id).toList();
+            final expectedIds = applyRecommendationSessionJitter(
+              serverOrderIds,
+              seeds.single,
+            );
+            final firstPageIds = firstPage.videos
+                .map((video) => video.id)
+                .toList();
+            expect(firstPageIds, equals(expectedIds));
+            expect(firstPageIds, unorderedEquals(serverOrderIds));
+            expect(
+              cachedReplay.videos.map((video) => video.id).toList(),
+              equals(firstPageIds),
+            );
+          },
+        );
+
+        test('does not jitter cursor pages', () async {
+          final stats = recommendedStats(12);
+          stubRecommendations(stats);
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final cursorPage = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            cursor: 'rec-page-2',
+          );
+
+          expect(
+            cursorPage.videos.map((video) => video.id).toList(),
+            equals(stats.map((s) => s.id).toList()),
+          );
+        });
+      });
     });
 
     group('getRecommendations', () {
@@ -10407,6 +10609,7 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10451,6 +10654,7 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10473,6 +10677,7 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10501,6 +10706,7 @@ void main() {
 
         verify(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: 50,
             fallback: 'recent',

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -588,6 +588,7 @@ void main() {
 
         when(
           () => mockFunnelcakeApiClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             preferredLanguages: any(named: 'preferredLanguages'),


### PR DESCRIPTION
This also requires changes on the server side – so it’s a draft for now.

Related: #5027