### PR TITLE
fix(deep-link): hashtag and search links use push/go/skip parity

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -330,6 +330,113 @@ ProfileDeepLinkNavAction resolveProfileDeepLinkNavAction({
   return ProfileDeepLinkNavAction.push;
 }
 
+/// Describes the router action to take when navigating to a hashtag deep link.
+///
+/// Mirrors [VideoDeepLinkNavAction] and [ProfileDeepLinkNavAction] so hashtag
+/// links get the same nav-stack parity: `push` keeps the previous route (e.g.
+/// home) underneath so back returns there, `go` replaces an existing hashtag
+/// route in-place, and `skip` dedupes a navigation to the route already shown.
+@visibleForTesting
+enum HashtagDeepLinkNavAction {
+  /// Navigate to the route, keeping the current route in the back stack.
+  push,
+
+  /// Replace the current route in-place (already on a hashtag route).
+  go,
+
+  /// The router is already on the target route with nothing new to do.
+  skip,
+}
+
+/// Determines which router action to take for a hashtag deep-link navigation
+/// given the current router location and the incoming target path.
+///
+/// Mirrors [resolveProfileDeepLinkNavAction]: extracted for testability — the
+/// caller executes the action; this function only decides what it should be.
+///
+/// Before this existed, the hashtag case always called `router.go()`, which
+/// replaces the entire navigation stack and stranded the user wherever they
+/// were (mid-settings, camera, DMs, …) with no back button to return.
+@visibleForTesting
+HashtagDeepLinkNavAction resolveHashtagDeepLinkNavAction({
+  required String currentLocation,
+  required String targetPath,
+}) {
+  if (currentLocation == targetPath) {
+    // Already on the exact target route. Duplicate navigation with nothing new
+    // to do (e.g. GoRouter's universal-link redirect already navigated here, or
+    // getInitialLink + uriLinkStream both fire for the same URL). Safe to skip.
+    return HashtagDeepLinkNavAction.skip;
+  }
+  if (currentLocation.startsWith('${HashtagScreenRouter.basePath}/')) {
+    // A different hashtag is already showing — replace it in-place, matching
+    // the video-replaces-video behaviour.
+    return HashtagDeepLinkNavAction.go;
+  }
+  // Coming from a non-hashtag route — push so back returns to where the user
+  // was instead of obliterating the navigation stack.
+  return HashtagDeepLinkNavAction.push;
+}
+
+/// Describes the router action to take when navigating to a search deep link.
+///
+/// Mirrors [VideoDeepLinkNavAction] and [ProfileDeepLinkNavAction] so search
+/// links get the same nav-stack parity: `push` keeps the previous route (e.g.
+/// home) underneath so back returns there, `go` replaces an existing search
+/// route in-place, and `skip` dedupes a navigation to the route already shown.
+@visibleForTesting
+enum SearchDeepLinkNavAction {
+  /// Navigate to the route, keeping the current route in the back stack.
+  push,
+
+  /// Replace the current route in-place (already on a search route).
+  go,
+
+  /// The router is already on the target route with nothing new to do.
+  skip,
+}
+
+/// Determines which router action to take for a search deep-link navigation
+/// given the current router location and the incoming target path.
+///
+/// Mirrors [resolveProfileDeepLinkNavAction]: extracted for testability — the
+/// caller executes the action; this function only decides what it should be.
+///
+/// Before this existed, the search case always called `router.go()`, which
+/// replaces the entire navigation stack and stranded the user wherever they
+/// were (mid-settings, camera, DMs, …) with no back button to return.
+///
+/// The "already in the search family" check covers three location shapes:
+/// a prefilled query (`/search-results/<query>`), the empty search screen
+/// (`/search-results`, [SearchResultsPage.emptyPath]), and the empty search
+/// screen with a query string (`/search-results?focus=1`, produced by
+/// [SearchResultsPage.pathForEmptyQuery] when mount focus is requested). All
+/// three are the same search surface, so a deep link replaces them in-place
+/// rather than stacking search on top of search.
+@visibleForTesting
+SearchDeepLinkNavAction resolveSearchDeepLinkNavAction({
+  required String currentLocation,
+  required String targetPath,
+}) {
+  if (currentLocation == targetPath) {
+    // Already on the exact target route. Duplicate navigation with nothing new
+    // to do (e.g. GoRouter's universal-link redirect already navigated here, or
+    // getInitialLink + uriLinkStream both fire for the same URL). Safe to skip.
+    return SearchDeepLinkNavAction.skip;
+  }
+  if (currentLocation == SearchResultsPage.emptyPath ||
+      currentLocation.startsWith('${SearchResultsPage.pathPrefix}/') ||
+      currentLocation.startsWith('${SearchResultsPage.emptyPath}?')) {
+    // Already somewhere on the search surface (empty search, a different
+    // query, or empty search with ?focus=1) — replace it in-place, matching
+    // the video-replaces-video behaviour.
+    return SearchDeepLinkNavAction.go;
+  }
+  // Coming from a non-search route — push so back returns to where the user
+  // was instead of obliterating the navigation stack.
+  return SearchDeepLinkNavAction.push;
+}
+
 /// Resolves a push/local payload to a [NotificationTapTarget], the event id to
 /// navigate to, and the authoritative video coordinate, via the shared
 /// [resolveNotificationTapTarget] contract.
@@ -1811,11 +1918,25 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
                 try {
-                  // GoRouter's universal-link redirect may have already
-                  // navigated here; skip the duplicate go() to avoid a
-                  // second navigation frame on the same target.
-                  if (currentLocation == targetPath) break;
-                  router.go(targetPath);
+                  final action = resolveHashtagDeepLinkNavAction(
+                    currentLocation: currentLocation,
+                    targetPath: targetPath,
+                  );
+                  switch (action) {
+                    case HashtagDeepLinkNavAction.skip:
+                      // GoRouter's universal-link redirect may have already
+                      // navigated here; skip the duplicate navigation to avoid
+                      // a second navigation frame on the same target.
+                      break;
+                    case HashtagDeepLinkNavAction.go:
+                      // Another hashtag is already showing — replace it
+                      // in-place instead of stacking it.
+                      router.go(targetPath);
+                    case HashtagDeepLinkNavAction.push:
+                      // Keep the current route underneath so back returns to
+                      // wherever the user was instead of wiping the stack.
+                      router.push(targetPath);
+                  }
                   Log.info(
                     '✅ Navigation completed to: $targetPath',
                     name: 'DeepLinkHandler',
@@ -1847,11 +1968,26 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                   category: LogCategory.ui,
                 );
                 try {
-                  // GoRouter's universal-link redirect may have already
-                  // navigated here; skip the duplicate go() to avoid a
-                  // second navigation frame on the same target.
-                  if (currentLocation == targetPath) break;
-                  router.go(targetPath);
+                  final action = resolveSearchDeepLinkNavAction(
+                    currentLocation: currentLocation,
+                    targetPath: targetPath,
+                  );
+                  switch (action) {
+                    case SearchDeepLinkNavAction.skip:
+                      // GoRouter's universal-link redirect may have already
+                      // navigated here; skip the duplicate navigation to avoid
+                      // a second navigation frame on the same target.
+                      break;
+                    case SearchDeepLinkNavAction.go:
+                      // Already on the search surface (empty search, another
+                      // query, or ?focus=1) — replace it in-place instead of
+                      // stacking search on top of search.
+                      router.go(targetPath);
+                    case SearchDeepLinkNavAction.push:
+                      // Keep the current route underneath so back returns to
+                      // wherever the user was instead of wiping the stack.
+                      router.push(targetPath);
+                  }
                   Log.info(
                     '✅ Navigation completed to: $targetPath',
                     name: 'DeepLinkHandler',

--- a/mobile/test/main_hashtag_deep_link_nav_action_test.dart
+++ b/mobile/test/main_hashtag_deep_link_nav_action_test.dart
@@ -1,0 +1,107 @@
+// ABOUTME: Regression tests for resolveHashtagDeepLinkNavAction routing decision
+// ABOUTME: Verifies hashtag deep links push (keeping the stack), go (replacing
+// ABOUTME: an existing hashtag route), or skip (dedup) instead of always
+// ABOUTME: calling router.go() which obliterated the navigation stack.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/screens/hashtag_screen_router.dart';
+
+void main() {
+  final targetPath = HashtagScreenRouter.pathForTag('cats');
+
+  group('resolveHashtagDeepLinkNavAction', () {
+    group('same route (currentLocation == targetPath)', () {
+      test(
+        'returns skip when already on the hashtag — duplicate link event, '
+        'nothing new to do',
+        () {
+          final action = app.resolveHashtagDeepLinkNavAction(
+            currentLocation: targetPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.HashtagDeepLinkNavAction.skip));
+        },
+      );
+
+      test(
+        'returns skip when already on a percent-encoded hashtag route',
+        () {
+          // pathForTag percent-encodes, so both sides carry the encoded form.
+          final encodedPath = HashtagScreenRouter.pathForTag('çay keyfi');
+          final action = app.resolveHashtagDeepLinkNavAction(
+            currentLocation: encodedPath,
+            targetPath: encodedPath,
+          );
+          expect(action, equals(app.HashtagDeepLinkNavAction.skip));
+        },
+      );
+    });
+
+    group('a different hashtag is already showing (replacing in-place)', () {
+      test(
+        'returns go when another hashtag is currently visible',
+        () {
+          final otherPath = HashtagScreenRouter.pathForTag('dogs');
+
+          final action = app.resolveHashtagDeepLinkNavAction(
+            currentLocation: otherPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.HashtagDeepLinkNavAction.go));
+        },
+      );
+
+      test(
+        'returns go when a percent-encoded hashtag is currently visible',
+        () {
+          final otherPath = HashtagScreenRouter.pathForTag('çay keyfi');
+
+          final action = app.resolveHashtagDeepLinkNavAction(
+            currentLocation: otherPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.HashtagDeepLinkNavAction.go));
+        },
+      );
+    });
+
+    group('coming from a non-hashtag route', () {
+      // Regression: a hashtag deep link from the home feed used to call
+      // router.go(), wiping the navigation stack and leaving no way back.
+      test(
+        'returns push from the home feed so back returns to the main screen',
+        () {
+          final action = app.resolveHashtagDeepLinkNavAction(
+            currentLocation: '/home/0',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.HashtagDeepLinkNavAction.push));
+        },
+      );
+
+      test(
+        'returns push from a settings / mid-flow route so back returns there',
+        () {
+          final action = app.resolveHashtagDeepLinkNavAction(
+            currentLocation: '/settings',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.HashtagDeepLinkNavAction.push));
+        },
+      );
+
+      test(
+        'returns push from a video route (cross-type navigation)',
+        () {
+          final action = app.resolveHashtagDeepLinkNavAction(
+            currentLocation:
+                '/video/abc123def456abc123def456abc123def456abc123def456abc123def456ab',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.HashtagDeepLinkNavAction.push));
+        },
+      );
+    });
+  });
+}

--- a/mobile/test/main_search_deep_link_nav_action_test.dart
+++ b/mobile/test/main_search_deep_link_nav_action_test.dart
@@ -1,0 +1,132 @@
+// ABOUTME: Regression tests for resolveSearchDeepLinkNavAction routing decision
+// ABOUTME: Verifies search deep links push (keeping the stack), go (replacing
+// ABOUTME: an existing search route), or skip (dedup) instead of always
+// ABOUTME: calling router.go() which obliterated the navigation stack.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
+
+void main() {
+  final targetPath = SearchResultsPage.pathForQuery(
+    'vine classics',
+    requestFocusOnMount: false,
+  );
+
+  group('resolveSearchDeepLinkNavAction', () {
+    group('same route (currentLocation == targetPath)', () {
+      test(
+        'returns skip when already on the search query — duplicate link '
+        'event, nothing new to do',
+        () {
+          final action = app.resolveSearchDeepLinkNavAction(
+            currentLocation: targetPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.SearchDeepLinkNavAction.skip));
+        },
+      );
+    });
+
+    group('already on the search surface (replacing in-place)', () {
+      test(
+        'returns go when a different search query is currently visible',
+        () {
+          final otherPath = SearchResultsPage.pathForQuery(
+            'dog tricks',
+            requestFocusOnMount: false,
+          );
+
+          final action = app.resolveSearchDeepLinkNavAction(
+            currentLocation: otherPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.SearchDeepLinkNavAction.go));
+        },
+      );
+
+      test(
+        'returns go from the empty search screen (no prefilled query)',
+        () {
+          final action = app.resolveSearchDeepLinkNavAction(
+            currentLocation: SearchResultsPage.emptyPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.SearchDeepLinkNavAction.go));
+        },
+      );
+
+      test(
+        'returns go from the empty search screen with mount focus '
+        '(/search-results?focus=1)',
+        () {
+          final action = app.resolveSearchDeepLinkNavAction(
+            currentLocation: SearchResultsPage.pathForEmptyQuery(
+              requestFocusOnMount: true,
+            ),
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.SearchDeepLinkNavAction.go));
+        },
+      );
+
+      // Same query but the current location carries ?focus=1 while the deep
+      // link target does not. The paths differ, so this is not a skip; both
+      // are the same search surface, so the resolver replaces in-place (go)
+      // rather than stacking a second copy of the same query.
+      test(
+        'returns go from the same query with ?focus=1 — replace, not stack',
+        () {
+          final focusedPath = SearchResultsPage.pathForQuery(
+            'vine classics',
+            requestFocusOnMount: true,
+          );
+
+          final action = app.resolveSearchDeepLinkNavAction(
+            currentLocation: focusedPath,
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.SearchDeepLinkNavAction.go));
+        },
+      );
+    });
+
+    group('coming from a non-search route', () {
+      // Regression: a search deep link from the home feed used to call
+      // router.go(), wiping the navigation stack and leaving no way back.
+      test(
+        'returns push from the home feed so back returns to the main screen',
+        () {
+          final action = app.resolveSearchDeepLinkNavAction(
+            currentLocation: '/home/0',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.SearchDeepLinkNavAction.push));
+        },
+      );
+
+      test(
+        'returns push from the explore screen so back returns there',
+        () {
+          final action = app.resolveSearchDeepLinkNavAction(
+            currentLocation: '/explore',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.SearchDeepLinkNavAction.push));
+        },
+      );
+
+      test(
+        'returns push from a profile route (cross-type navigation)',
+        () {
+          final action = app.resolveSearchDeepLinkNavAction(
+            currentLocation:
+                '/profile/npub1abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwx',
+            targetPath: targetPath,
+          );
+          expect(action, equals(app.SearchDeepLinkNavAction.push));
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Description

Hashtag and search deep links still used the older skip-or-`go()` pattern: skip only when `currentLocation == targetPath`, otherwise always `router.go(targetPath)` — which replaces the navigation stack and strands users with no back navigation when a hashtag/search link is opened from another flow.

This PR aligns both with the push/go/skip resolver pattern established for video links and extended to profile links in #5023:

- New `@visibleForTesting` pure resolvers in `main.dart`: `resolveHashtagDeepLinkNavAction` and `resolveSearchDeepLinkNavAction`.
  - **skip** on exact duplicate (universal-link redirect parity),
  - **go** when already in the same route family (`/hashtag/...`; for search: `/search-results/...`, the empty path `/search-results`, and `/search-results?focus=1`) to avoid unbounded stacking,
  - **push** from unrelated routes so back returns to the previous screen.
- Both deep-link listener consumers rewritten to switch over the resolved action; logging preserved.

**Related Issue:** Closes #5026

## Out of Scope

- Consolidating the now-five structurally similar resolvers into one generic resolver — the video variant's `goSameRouteWithComments` breaks full uniformity; kept per-type to match the #5023 pattern and stay reviewable.

## Verification

- `flutter test` on all four nav-action resolver test files — 29 passed (7 new hashtag + 8 new search, video/profile unchanged)
- New tests cover percent-encoded tags, the search empty-path and `?focus=1` family cases, and cross-type navigation with full-length Nostr identifiers
- `flutter analyze` — no issues; `dart format` — clean

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
