### PR TITLE
fix(auth): bound Keycast requests and refresh single-flight so re-login recovers without restart

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -188,6 +188,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     String? primaryRelayUrl,
     RelayDiscoveryService? relayDiscoveryService,
     Nip07Service? nip07ServiceForTest,
+    Duration oauthRefreshTimeout = rpcRefreshTimeout,
+    Duration expiredSessionRefreshTimeout = defaultExpiredSessionRefreshTimeout,
   }) : _keyStorage = keyStorage ?? SecureKeyStorage(),
        _nostrKeyManager = nostrKeyManager,
        _userDataCleanupService = userDataCleanupService,
@@ -202,7 +204,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
        _oauthConfig =
            oauthConfig ??
            const OAuthConfig(serverUrl: '', clientId: '', redirectUri: ''),
-       _injectedNip07ServiceForTest = nip07ServiceForTest;
+       _injectedNip07ServiceForTest = nip07ServiceForTest,
+       _oauthRefreshTimeout = oauthRefreshTimeout,
+       _expiredSessionRefreshTimeout = expiredSessionRefreshTimeout;
   final SecureKeyStorage _keyStorage;
   final NostrKeyManager? _nostrKeyManager;
   final UserDataCleanupService _userDataCleanupService;
@@ -210,6 +214,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   final FlutterSecureStorage? _flutterSecureStorage;
   final PreFetchFollowingCallback? _preFetchFollowing;
   final String? _profileCheckIndexerUrl;
+
+  /// Bound applied to the single-flight OAuth token refresh stored in
+  /// [_pendingOAuthRefresh]. Injectable so tests can use a short bound.
+  final Duration _oauthRefreshTimeout;
+
+  /// Bound applied to the full expired-session refresh flow stored in
+  /// [_pendingRefresh]. Injectable so tests can use a short bound.
+  final Duration _expiredSessionRefreshTimeout;
 
   /// Test seam: when supplied, bypasses the [Nip07Service] singleton and the
   /// [kIsWeb] guard so unit tests can exercise the full NIP-07 flow on the VM
@@ -409,9 +421,18 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// UI does not prompt re-login before the silent refresh has definitively failed.
   bool get isRpcUpgradeInProgress => _isRpcUpgradeInProgress;
 
-  /// Timeout for background RPC refresh during local-first startup.
+  /// Default bound for the single-flight OAuth token refresh. Applied
+  /// inside the future stored in [_pendingOAuthRefresh] so a hung request
+  /// can never occupy the slot forever (#4942).
   @visibleForTesting
   static const rpcRefreshTimeout = Duration(seconds: 10);
+
+  /// Default bound for the full expired-session refresh flow (token refresh
+  /// plus session re-integration). The underlying network calls carry their
+  /// own shorter timeouts; this bound guarantees the single-flight slot in
+  /// [tryRefreshExpiredSession] always clears (#4942).
+  @visibleForTesting
+  static const defaultExpiredSessionRefreshTimeout = Duration(seconds: 30);
 
   /// Local-first Divine OAuth initialization.
   ///
@@ -602,9 +623,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         return;
       }
 
+      // The shared refresh future is internally bounded by
+      // [_oauthRefreshTimeout] (see _refreshOAuthSession), so this await
+      // cannot block startup indefinitely.
       final refreshed = await _refreshOAuthSession(
         expectedOwnerPubkey: expectedOwnerPubkey ?? session?.userPubkey,
-      ).timeout(rpcRefreshTimeout);
+      );
 
       if (!upgradeContextStillCurrent()) {
         Log.warning(
@@ -632,13 +656,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         _setRpcCapability(AuthRpcCapability.rpcReady);
         return;
       }
-    } on TimeoutException {
-      Log.warning(
-        'initialize: background RPC refresh timed out '
-        '(${rpcRefreshTimeout.inSeconds}s)',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
     } catch (e) {
       Log.error(
         'initialize: background RPC refresh failed: $e',
@@ -783,14 +800,40 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// the refresh fails (caller should navigate to login).
   ///
   /// Concurrent callers share a single in-flight refresh to avoid
-  /// consuming one-time-use refresh tokens in a race.
+  /// consuming one-time-use refresh tokens in a race. The shared future is
+  /// bounded by [_expiredSessionRefreshTimeout] so a hung attempt always
+  /// releases the slot and the next call starts a fresh refresh (#4942).
   Future<bool> tryRefreshExpiredSession() {
     if (!_hasExpiredOAuthSession || _oauthClient == null) {
       return Future.value(false);
     }
-    return _pendingRefresh ??= _doRefreshExpiredSession().whenComplete(() {
-      _pendingRefresh = null;
-    });
+    final pending = _pendingRefresh;
+    if (pending != null) return pending;
+
+    late final Future<bool> refresh;
+    refresh = _doRefreshExpiredSession()
+        .timeout(
+          _expiredSessionRefreshTimeout,
+          onTimeout: () {
+            Log.warning(
+              'tryRefreshExpiredSession: timed out after '
+              '${_expiredSessionRefreshTimeout.inMilliseconds}ms — '
+              'treating as failed',
+              name: 'AuthService',
+              category: LogCategory.auth,
+            );
+            return false;
+          },
+        )
+        .whenComplete(() {
+          // Only release the slot if it still holds this attempt — signOut
+          // may have detached it and a fresh attempt may already be in
+          // flight.
+          if (identical(_pendingRefresh, refresh)) {
+            _pendingRefresh = null;
+          }
+        });
+    return _pendingRefresh = refresh;
   }
 
   Future<bool> _doRefreshExpiredSession() async {
@@ -845,6 +888,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Guarantees:
   /// - Only one `refreshSession()` call in flight at a time (concurrent
   ///   callers share the same [Future]).
+  /// - The shared future is bounded by [_oauthRefreshTimeout] and ALWAYS
+  ///   releases the single-flight slot, even if the underlying request
+  ///   hangs on a dead socket — so the next attempt gets a fresh refresh
+  ///   instead of joining a poisoned one (#4942).
   /// - `userPubkey` is bound before the session is persisted, so
   ///   ownership checks on restore stay valid.
   /// - `_hasExpiredOAuthSession` is cleared on success.
@@ -856,12 +903,34 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   ///
   /// Returns the refreshed session on success, or `null` on failure.
   Future<KeycastSession?> _refreshOAuthSession({String? expectedOwnerPubkey}) {
-    return _pendingOAuthRefresh ??=
-        _doRefreshOAuthSession(
-          expectedOwnerPubkey: expectedOwnerPubkey,
-        ).whenComplete(() {
-          _pendingOAuthRefresh = null;
-        });
+    final pending = _pendingOAuthRefresh;
+    if (pending != null) return pending;
+
+    late final Future<KeycastSession?> refresh;
+    refresh =
+        _doRefreshOAuthSession(expectedOwnerPubkey: expectedOwnerPubkey)
+            .timeout(
+              _oauthRefreshTimeout,
+              onTimeout: () {
+                Log.warning(
+                  '_refreshOAuthSession: timed out after '
+                  '${_oauthRefreshTimeout.inMilliseconds}ms — '
+                  'treating as failed',
+                  name: 'AuthService',
+                  category: LogCategory.auth,
+                );
+                return null;
+              },
+            )
+            .whenComplete(() {
+              // Only release the slot if it still holds this attempt —
+              // signOut may have detached it and a fresh attempt may
+              // already be in flight.
+              if (identical(_pendingOAuthRefresh, refresh)) {
+                _pendingOAuthRefresh = null;
+              }
+            });
+    return _pendingOAuthRefresh = refresh;
   }
 
   Future<KeycastSession?> _doRefreshOAuthSession({
@@ -3719,6 +3788,14 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Clean up Keycast RPC signer if active
       _keycastSigner = null;
       _setRpcCapability(AuthRpcCapability.unavailable);
+
+      // Detach any in-flight token refresh so post-signout logins start a
+      // fresh attempt instead of joining one issued for the outgoing
+      // session. The futures cannot be cancelled, but their completion
+      // handlers only release the slot they still own (identical check),
+      // so a late completion cannot clobber a newer attempt.
+      _pendingOAuthRefresh = null;
+      _pendingRefresh = null;
 
       await _clearOAuthSessionForSignOut();
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -188,7 +188,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     String? primaryRelayUrl,
     RelayDiscoveryService? relayDiscoveryService,
     Nip07Service? nip07ServiceForTest,
-    Duration oauthRefreshTimeout = rpcRefreshTimeout,
+    Duration oauthRefreshTimeout = defaultOAuthRefreshTimeout,
     Duration expiredSessionRefreshTimeout = defaultExpiredSessionRefreshTimeout,
   }) : _keyStorage = keyStorage ?? SecureKeyStorage(),
        _nostrKeyManager = nostrKeyManager,
@@ -421,18 +421,21 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// UI does not prompt re-login before the silent refresh has definitively failed.
   bool get isRpcUpgradeInProgress => _isRpcUpgradeInProgress;
 
-  /// Default bound for the single-flight OAuth token refresh. Applied
-  /// inside the future stored in [_pendingOAuthRefresh] so a hung request
-  /// can never occupy the slot forever (#4942).
+  /// Legacy test-friendly short bound for background RPC refresh.
   @visibleForTesting
   static const rpcRefreshTimeout = Duration(seconds: 10);
 
-  /// Default bound for the full expired-session refresh flow (token refresh
-  /// plus session re-integration). The underlying network calls carry their
-  /// own shorter timeouts; this bound guarantees the single-flight slot in
-  /// [tryRefreshExpiredSession] always clears (#4942).
+  /// Default bound for the single-flight OAuth token refresh. It is longer
+  /// than KeycastOAuth's own HTTP bound so production code does not abandon
+  /// a slow-but-still-live request before the client has resolved it.
   @visibleForTesting
-  static const defaultExpiredSessionRefreshTimeout = Duration(seconds: 30);
+  static const defaultOAuthRefreshTimeout = Duration(seconds: 35);
+
+  /// Default bound for the full expired-session refresh flow (token refresh
+  /// plus session re-integration). This stays longer than the OAuth refresh
+  /// bound so the outer flow does not detach from a live refresh.
+  @visibleForTesting
+  static const defaultExpiredSessionRefreshTimeout = Duration(seconds: 40);
 
   /// Local-first Divine OAuth initialization.
   ///

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -907,29 +907,28 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     if (pending != null) return pending;
 
     late final Future<KeycastSession?> refresh;
-    refresh =
-        _doRefreshOAuthSession(expectedOwnerPubkey: expectedOwnerPubkey)
-            .timeout(
-              _oauthRefreshTimeout,
-              onTimeout: () {
-                Log.warning(
-                  '_refreshOAuthSession: timed out after '
-                  '${_oauthRefreshTimeout.inMilliseconds}ms — '
-                  'treating as failed',
-                  name: 'AuthService',
-                  category: LogCategory.auth,
-                );
-                return null;
-              },
-            )
-            .whenComplete(() {
-              // Only release the slot if it still holds this attempt —
-              // signOut may have detached it and a fresh attempt may
-              // already be in flight.
-              if (identical(_pendingOAuthRefresh, refresh)) {
-                _pendingOAuthRefresh = null;
-              }
-            });
+    refresh = _doRefreshOAuthSession(expectedOwnerPubkey: expectedOwnerPubkey)
+        .timeout(
+          _oauthRefreshTimeout,
+          onTimeout: () {
+            Log.warning(
+              '_refreshOAuthSession: timed out after '
+              '${_oauthRefreshTimeout.inMilliseconds}ms — '
+              'treating as failed',
+              name: 'AuthService',
+              category: LogCategory.auth,
+            );
+            return null;
+          },
+        )
+        .whenComplete(() {
+          // Only release the slot if it still holds this attempt —
+          // signOut may have detached it and a fresh attempt may
+          // already be in flight.
+          if (identical(_pendingOAuthRefresh, refresh)) {
+            _pendingOAuthRefresh = null;
+          }
+        });
     return _pendingOAuthRefresh = refresh;
   }
 

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -28,14 +28,26 @@ const _storageKeyHandle = 'keycast_auth_handle';
 const _storageKeyRefreshToken = 'keycast_refresh_token';
 
 class KeycastOAuth {
+  /// Default timeout applied to every Keycast HTTP request.
+  ///
+  /// Without a bound, a dead socket (e.g. Android Doze killing the
+  /// connection while backgrounded) hangs the request forever and wedges
+  /// every caller awaiting it.
+  static const Duration defaultRequestTimeout = Duration(seconds: 30);
+
   final OAuthConfig config;
   final http.Client _client;
   final KeycastStorage _storage;
+
+  /// Maximum time to wait for any single HTTP request before failing
+  /// with a [TimeoutException].
+  final Duration requestTimeout;
 
   KeycastOAuth({
     required this.config,
     http.Client? httpClient,
     KeycastStorage? storage,
+    this.requestTimeout = defaultRequestTimeout,
   }) : _client = httpClient ?? http.Client(),
        _storage = storage ?? MemoryKeycastStorage();
 
@@ -103,22 +115,24 @@ class KeycastOAuth {
   /// the saved session is always owner-bound.
   ///
   /// On HTTP error the consumed refresh token is cleared (server may have
-  /// rotated it). On network error the token is preserved since the server
-  /// may not have consumed it.
+  /// rotated it). On network error or timeout the token is preserved since
+  /// the server may not have consumed it.
   Future<KeycastSession?> refreshSession({String? userPubkey}) async {
     final refreshToken = await _storage.read(_storageKeyRefreshToken);
     if (refreshToken == null) return null;
 
     try {
-      final response = await _client.post(
-        Uri.parse(config.tokenUrl),
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({
-          'grant_type': 'refresh_token',
-          'refresh_token': refreshToken,
-          'client_id': config.clientId,
-        }),
-      );
+      final response = await _client
+          .post(
+            Uri.parse(config.tokenUrl),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({
+              'grant_type': 'refresh_token',
+              'refresh_token': refreshToken,
+              'client_id': config.clientId,
+            }),
+          )
+          .timeout(requestTimeout);
 
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -135,7 +149,8 @@ class KeycastOAuth {
       await _storage.delete(_storageKeyRefreshToken);
       return null;
     } catch (_) {
-      // Network error — server may not have consumed the token, keep it
+      // Network error or timeout — server may not have consumed the
+      // token, keep it so the next attempt can retry the refresh
       return null;
     }
   }
@@ -230,21 +245,26 @@ class KeycastOAuth {
 
   /// Exchange authorization code for tokens
   /// Automatically saves session to storage after successful exchange
+  ///
+  /// Throws [TimeoutException] if the server does not respond within
+  /// [requestTimeout].
   Future<TokenResponse> exchangeCode({
     required String code,
     required String verifier,
   }) async {
-    final response = await _client.post(
-      Uri.parse(config.tokenUrl),
-      headers: {'Content-Type': 'application/json'},
-      body: jsonEncode({
-        'grant_type': 'authorization_code',
-        'code': code,
-        'client_id': config.clientId,
-        'redirect_uri': config.redirectUri,
-        'code_verifier': verifier,
-      }),
-    );
+    final response = await _client
+        .post(
+          Uri.parse(config.tokenUrl),
+          headers: {'Content-Type': 'application/json'},
+          body: jsonEncode({
+            'grant_type': 'authorization_code',
+            'code': code,
+            'client_id': config.clientId,
+            'redirect_uri': config.redirectUri,
+            'code_verifier': verifier,
+          }),
+        )
+        .timeout(requestTimeout);
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
 
@@ -313,11 +333,13 @@ class KeycastOAuth {
         body['state'] = state;
       }
 
-      final response = await _client.post(
-        Uri.parse('${config.serverUrl}/api/headless/register'),
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode(body),
-      );
+      final response = await _client
+          .post(
+            Uri.parse('${config.serverUrl}/api/headless/register'),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode(body),
+          )
+          .timeout(requestTimeout);
 
       // Check for non-success status codes first
       if (response.statusCode == 404) {
@@ -365,6 +387,14 @@ class KeycastOAuth {
 
       return (
         HeadlessRegisterResult.error(description, code: errorCode),
+        verifier,
+      );
+    } on TimeoutException {
+      return (
+        HeadlessRegisterResult.error(
+          'Request timed out. Check your internet connection and try again.',
+          code: 'timeout',
+        ),
         verifier,
       );
     } catch (e) {
@@ -416,11 +446,13 @@ class KeycastOAuth {
         body['state'] = state;
       }
 
-      final response = await _client.post(
-        Uri.parse('${config.serverUrl}/api/headless/login'),
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode(body),
-      );
+      final response = await _client
+          .post(
+            Uri.parse('${config.serverUrl}/api/headless/login'),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode(body),
+          )
+          .timeout(requestTimeout);
 
       // Check for non-success status codes first
       if (response.statusCode == 404) {
@@ -469,6 +501,14 @@ class KeycastOAuth {
           'Login failed';
 
       return (HeadlessLoginResult.error(description, code: error), verifier);
+    } on TimeoutException {
+      return (
+        HeadlessLoginResult.error(
+          'Request timed out. Check your internet connection and try again.',
+          code: 'timeout',
+        ),
+        verifier,
+      );
     } catch (e) {
       if (e.toString().contains('SocketException') ||
           e.toString().contains('Connection refused')) {
@@ -492,11 +532,13 @@ class KeycastOAuth {
   /// Returns [PollResult.error] if something went wrong.
   Future<PollResult> pollForCode(String deviceCode) async {
     try {
-      final response = await _client.get(
-        Uri.parse(
-          '${config.serverUrl}/api/oauth/poll',
-        ).replace(queryParameters: {'device_code': deviceCode}),
-      );
+      final response = await _client
+          .get(
+            Uri.parse(
+              '${config.serverUrl}/api/oauth/poll',
+            ).replace(queryParameters: {'device_code': deviceCode}),
+          )
+          .timeout(requestTimeout);
 
       if (response.statusCode == 200) {
         final json = jsonDecode(response.body) as Map<String, dynamic>;

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -43,6 +43,9 @@ class KeycastOAuth {
   /// with a [TimeoutException].
   final Duration requestTimeout;
 
+  // Invalidates in-flight refresh saves after logout clears credential storage.
+  int _storageEpoch = 0;
+
   KeycastOAuth({
     required this.config,
     http.Client? httpClient,
@@ -80,6 +83,7 @@ class KeycastOAuth {
   /// we still complete the local logout. The server will eventually expire
   /// the token anyway.
   Future<void> logout() async {
+    _storageEpoch++;
     await _storage.delete(_storageKeySession);
     await _storage.delete(_storageKeyHandle);
     await _storage.delete(_storageKeyRefreshToken);
@@ -118,6 +122,7 @@ class KeycastOAuth {
   /// rotated it). On network error or timeout the token is preserved since
   /// the server may not have consumed it.
   Future<KeycastSession?> refreshSession({String? userPubkey}) async {
+    final refreshEpoch = _storageEpoch;
     final refreshToken = await _storage.read(_storageKeyRefreshToken);
     if (refreshToken == null) return null;
 
@@ -140,6 +145,9 @@ class KeycastOAuth {
         var session = KeycastSession.fromTokenResponse(tokenResponse);
         if (userPubkey != null && userPubkey.isNotEmpty) {
           session = session.copyWith(userPubkey: userPubkey);
+        }
+        if (refreshEpoch != _storageEpoch) {
+          return null;
         }
         await _saveSession(session);
         return session;
@@ -572,11 +580,13 @@ class KeycastOAuth {
   /// Send a password reset link to the provided email address
   Future<ForgotPasswordResult> sendPasswordResetEmail(String email) async {
     try {
-      final response = await _client.post(
-        Uri.parse('${config.serverUrl}/api/auth/forgot-password'),
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'email': email}),
-      );
+      final response = await _client
+          .post(
+            Uri.parse('${config.serverUrl}/api/auth/forgot-password'),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'email': email}),
+          )
+          .timeout(requestTimeout);
 
       final json = jsonDecode(response.body) as Map<String, dynamic>;
 
@@ -602,11 +612,13 @@ class KeycastOAuth {
     required String newPassword,
   }) async {
     try {
-      final response = await _client.post(
-        Uri.parse('${config.serverUrl}/api/auth/reset-password'),
-        headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'token': token, 'new_password': newPassword}),
-      );
+      final response = await _client
+          .post(
+            Uri.parse('${config.serverUrl}/api/auth/reset-password'),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'token': token, 'new_password': newPassword}),
+          )
+          .timeout(requestTimeout);
 
       final json = jsonDecode(response.body) as Map<String, dynamic>;
 

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Keycast RPC client implementing NostrSigner interface
 // ABOUTME: Provides remote signing via Keycast server for Nostr events
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -17,16 +18,28 @@ import 'package:unified_logger/unified_logger.dart';
 typedef TokenRefreshCallback = Future<String?> Function();
 
 class KeycastRpc implements NostrSigner {
+  /// Default timeout applied to every RPC HTTP request.
+  ///
+  /// Without a bound, a dead socket (e.g. Android Doze killing the
+  /// connection while backgrounded) hangs the request forever and wedges
+  /// every caller awaiting it.
+  static const Duration defaultRequestTimeout = Duration(seconds: 30);
+
   final String nostrApi;
   String _accessToken;
   final http.Client _client;
   final TokenRefreshCallback? _onTokenRefresh;
+
+  /// Maximum time to wait for any single RPC request before failing
+  /// with a [TimeoutException].
+  final Duration requestTimeout;
 
   KeycastRpc({
     required this.nostrApi,
     required String accessToken,
     http.Client? httpClient,
     TokenRefreshCallback? onTokenRefresh,
+    this.requestTimeout = defaultRequestTimeout,
   }) : _accessToken = accessToken,
        _client = httpClient ?? http.Client(),
        _onTokenRefresh = onTokenRefresh;
@@ -35,6 +48,7 @@ class KeycastRpc implements NostrSigner {
     OAuthConfig config,
     KeycastSession session, {
     TokenRefreshCallback? onTokenRefresh,
+    Duration requestTimeout = defaultRequestTimeout,
   }) {
     if (!session.hasRpcAccess) {
       throw SessionExpiredException();
@@ -43,6 +57,7 @@ class KeycastRpc implements NostrSigner {
       nostrApi: config.nostrApiUrl,
       accessToken: session.accessToken!,
       onTokenRefresh: onTokenRefresh,
+      requestTimeout: requestTimeout,
     );
   }
 
@@ -101,14 +116,16 @@ class KeycastRpc implements NostrSigner {
       category: LogCategory.auth,
     );
     final stopwatch = Stopwatch()..start();
-    final response = await _client.post(
-      Uri.parse(nostrApi),
-      headers: {
-        'Authorization': 'Bearer $_accessToken',
-        'Content-Type': 'application/json',
-      },
-      body: jsonEncode({'method': method, 'params': params}),
-    );
+    final response = await _client
+        .post(
+          Uri.parse(nostrApi),
+          headers: {
+            'Authorization': 'Bearer $_accessToken',
+            'Content-Type': 'application/json',
+          },
+          body: jsonEncode({'method': method, 'params': params}),
+        )
+        .timeout(requestTimeout);
     stopwatch.stop();
     Log.debug(
       '[Keycast RPC] $method completed in '

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -1136,6 +1136,58 @@ void main() {
         );
         expect(saved.userPubkey, 'abc123pubkey');
       });
+
+      test(
+        'does not save a refresh response that completes after logout',
+        () async {
+          final storage = MemoryKeycastStorage();
+          await storage.write('keycast_refresh_token', 'old_refresh_token');
+
+          final refreshResponse = Completer<http.Response>();
+          var refreshRequestStarted = false;
+          final mockClient = MockClient((request) async {
+            if (request.url.path == '/api/oauth/token') {
+              refreshRequestStarted = true;
+              return refreshResponse.future;
+            }
+            if (request.url.path == '/api/auth/logout') {
+              return http.Response('', 204);
+            }
+            fail('Unexpected request to ${request.url}');
+          });
+
+          final oauth = KeycastOAuth(
+            config: config,
+            httpClient: mockClient,
+            storage: storage,
+          );
+
+          final refresh = oauth.refreshSession();
+          while (!refreshRequestStarted) {
+            await Future<void>.delayed(Duration.zero);
+          }
+
+          await oauth.logout();
+          refreshResponse.complete(
+            http.Response(
+              jsonEncode({
+                'bunker_url': 'bunker://refreshed',
+                'access_token': 'new_access_token',
+                'token_type': 'Bearer',
+                'expires_in': 86400,
+                'refresh_token': 'new_refresh_token',
+                'authorization_handle': 'new_handle',
+              }),
+              200,
+            ),
+          );
+
+          expect(await refresh, isNull);
+          expect(await storage.read('keycast_session'), isNull);
+          expect(await storage.read('keycast_refresh_token'), isNull);
+          expect(await storage.read('keycast_auth_handle'), isNull);
+        },
+      );
     });
 
     group('getSessionOrRefresh', () {
@@ -1325,6 +1377,38 @@ void main() {
 
         expect(result.status, PollStatus.error);
         expect(result.error, contains('TimeoutException'));
+      });
+
+      test(
+        'sendPasswordResetEmail returns error result on hung request',
+        () async {
+          final oauth = KeycastOAuth(
+            config: config,
+            httpClient: hangingClient(),
+            requestTimeout: shortTimeout,
+          );
+
+          final result = await oauth.sendPasswordResetEmail('test@example.com');
+
+          expect(result.success, isFalse);
+          expect(result.error, contains('TimeoutException'));
+        },
+      );
+
+      test('resetPassword returns error result on hung request', () async {
+        final oauth = KeycastOAuth(
+          config: config,
+          httpClient: hangingClient(),
+          requestTimeout: shortTimeout,
+        );
+
+        final result = await oauth.resetPassword(
+          token: 'reset-token',
+          newPassword: 'new-password',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.message, contains('TimeoutException'));
       });
     });
 

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for KeycastOAuth client - OAuth flow handling
 // ABOUTME: Verifies URL building, callback parsing, token exchange (mocked HTTP)
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -1222,6 +1223,108 @@ void main() {
         final result = await oauth.getSessionOrRefresh();
 
         expect(result, isNull);
+      });
+    });
+
+    group('request timeouts', () {
+      /// HTTP client whose requests never complete — simulates a dead
+      /// socket (e.g. Android Doze killing the connection).
+      MockClient hangingClient() =>
+          MockClient((request) => Completer<http.Response>().future);
+
+      const shortTimeout = Duration(milliseconds: 50);
+
+      test(
+        'refreshSession fails within the timeout and preserves the '
+        'refresh token',
+        () async {
+          final storage = MemoryKeycastStorage();
+          await storage.write('keycast_refresh_token', 'my_refresh_token');
+
+          final oauth = KeycastOAuth(
+            config: config,
+            httpClient: hangingClient(),
+            storage: storage,
+            requestTimeout: shortTimeout,
+          );
+
+          final result = await oauth.refreshSession();
+
+          expect(result, isNull);
+          // CRITICAL: a timeout is a network failure, not an auth
+          // rejection — the refresh token must survive so the next
+          // attempt can retry.
+          expect(
+            await storage.read('keycast_refresh_token'),
+            'my_refresh_token',
+          );
+        },
+      );
+
+      test('exchangeCode throws TimeoutException on hung request', () async {
+        final oauth = KeycastOAuth(
+          config: config,
+          httpClient: hangingClient(),
+          requestTimeout: shortTimeout,
+        );
+
+        await expectLater(
+          oauth.exchangeCode(code: 'code', verifier: 'verifier'),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+
+      test(
+        'headlessLogin returns timeout error result on hung request',
+        () async {
+          final oauth = KeycastOAuth(
+            config: config,
+            httpClient: hangingClient(),
+            requestTimeout: shortTimeout,
+          );
+
+          final (result, verifier) = await oauth.headlessLogin(
+            email: 'test@example.com',
+            password: 'password123',
+          );
+
+          expect(result.success, isFalse);
+          expect(result.error, 'timeout');
+          expect(verifier, isNotEmpty);
+        },
+      );
+
+      test(
+        'headlessRegister returns timeout error result on hung request',
+        () async {
+          final oauth = KeycastOAuth(
+            config: config,
+            httpClient: hangingClient(),
+            requestTimeout: shortTimeout,
+          );
+
+          final (result, verifier) = await oauth.headlessRegister(
+            email: 'test@example.com',
+            password: 'password123',
+          );
+
+          expect(result.success, isFalse);
+          expect(result.errorCode, 'timeout');
+          expect(verifier, isNotEmpty);
+        },
+      );
+
+      test('pollForCode returns error result on hung request', () async {
+        final oauth = KeycastOAuth(
+          config: config,
+          httpClient: hangingClient(),
+          requestTimeout: shortTimeout,
+        );
+
+        final result = await oauth.pollForCode('device123');
+
+        expect(result.status, PollStatus.error);
+        expect(result.error, contains('TimeoutException'));
       });
     });
 

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Tests for KeycastRpc client - Nostr signing via RPC
 // ABOUTME: Verifies all RPC methods with mocked HTTP, error handling, auth headers
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -398,6 +399,28 @@ void main() {
           onTokenRefresh: () async => 'refreshed',
         );
         expect(rpc, isNotNull);
+      });
+    });
+
+    group('request timeout', () {
+      test('throws TimeoutException when the request hangs', () async {
+        // Simulates a dead socket (e.g. Android Doze killing the
+        // connection) — the request future never completes.
+        mockClient = MockClient(
+          (request) => Completer<http.Response>().future,
+        );
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+          requestTimeout: const Duration(milliseconds: 50),
+        );
+
+        await expectLater(
+          rpc.getPublicKey(),
+          throwsA(isA<TimeoutException>()),
+        );
       });
     });
 

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -119,7 +119,7 @@ void main() {
     }
 
     /// Helper: creates an AuthService wired to the mocks
-    AuthService createAuthService() {
+    AuthService createAuthService({Duration? oauthRefreshTimeout}) {
       final keyStorage = SecureKeyStorage(
         securityConfig: const SecurityConfig(requireHardwareBacked: false),
       );
@@ -127,6 +127,7 @@ void main() {
         userDataCleanupService: mockCleanupService,
         keyStorage: keyStorage,
         oauthClient: mockOAuthClient,
+        oauthRefreshTimeout: oauthRefreshTimeout ?? AuthService.rpcRefreshTimeout,
       );
     }
 
@@ -416,6 +417,92 @@ void main() {
                 userPubkey: any(named: 'userPubkey'),
               ),
             ).called(1);
+          },
+          (error, stack) {
+            // Ignore background errors
+          },
+        );
+      },
+    );
+
+    test(
+      'hung refresh fails within the bounded time and clears the pending '
+      'slot so a later tryRefreshExpiredSession starts a fresh attempt',
+      () async {
+        // Regression for #4942: a Keycast refresh request hanging on a dead
+        // socket must not poison the process-lifetime single-flight slot.
+        // Before the fix, the never-completing future stayed in
+        // _pendingOAuthRefresh forever and EVERY re-login surface joined it,
+        // so the user could not log back in until the app was killed.
+        SharedPreferences.setMockInitialValues({
+          'authentication_source': 'divineOAuth',
+          'tos_accepted': true,
+        });
+
+        arrangeExpiredSessionWithLocalKeys();
+
+        // Init-phase refresh fails fast so initialize() settles quickly.
+        when(
+          () => mockOAuthClient.refreshSession(
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        // Short injected bound so the test does not wait the production 10s.
+        final authService = createAuthService(
+          oauthRefreshTimeout: const Duration(milliseconds: 300),
+        );
+
+        await runZonedGuarded(
+          () async {
+            await authService.initialize();
+
+            // Wait for the background upgrade to release the single-flight
+            // slot before exercising tryRefreshExpiredSession in isolation.
+            final deadline = DateTime.now().add(const Duration(seconds: 5));
+            while (authService.isRpcUpgradeInProgress &&
+                DateTime.now().isBefore(deadline)) {
+              await Future<void>.delayed(const Duration(milliseconds: 10));
+            }
+            expect(authService.hasExpiredOAuthSession, isTrue);
+            clearInteractions(mockOAuthClient);
+
+            // First call hangs forever (dead socket); later calls fail fast.
+            var refreshCalls = 0;
+            final hung = Completer<KeycastSession?>();
+            when(
+              () => mockOAuthClient.refreshSession(
+                userPubkey: any(named: 'userPubkey'),
+              ),
+            ).thenAnswer((_) {
+              refreshCalls++;
+              return refreshCalls == 1
+                  ? hung.future
+                  : Future<KeycastSession?>.value();
+            });
+
+            // (a) The hung attempt must fail within the bounded time
+            // instead of wedging forever.
+            final first = await authService
+                .tryRefreshExpiredSession()
+                .timeout(const Duration(seconds: 5));
+            expect(first, isFalse);
+
+            // (b) The pending slot must be released so this triggers a
+            // FRESH refresh attempt rather than joining the hung one.
+            final second = await authService
+                .tryRefreshExpiredSession()
+                .timeout(const Duration(seconds: 5));
+            expect(second, isFalse);
+
+            expect(
+              refreshCalls,
+              2,
+              reason:
+                  'Second tryRefreshExpiredSession must start a fresh '
+                  'refresh attempt — the hung first attempt must not '
+                  'occupy the single-flight slot after its timeout',
+            );
           },
           (error, stack) {
             // Ignore background errors

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -127,7 +127,8 @@ void main() {
         userDataCleanupService: mockCleanupService,
         keyStorage: keyStorage,
         oauthClient: mockOAuthClient,
-        oauthRefreshTimeout: oauthRefreshTimeout ?? AuthService.rpcRefreshTimeout,
+        oauthRefreshTimeout:
+            oauthRefreshTimeout ?? AuthService.rpcRefreshTimeout,
       );
     }
 
@@ -483,16 +484,16 @@ void main() {
 
             // (a) The hung attempt must fail within the bounded time
             // instead of wedging forever.
-            final first = await authService
-                .tryRefreshExpiredSession()
-                .timeout(const Duration(seconds: 5));
+            final first = await authService.tryRefreshExpiredSession().timeout(
+              const Duration(seconds: 5),
+            );
             expect(first, isFalse);
 
             // (b) The pending slot must be released so this triggers a
             // FRESH refresh attempt rather than joining the hung one.
-            final second = await authService
-                .tryRefreshExpiredSession()
-                .timeout(const Duration(seconds: 5));
+            final second = await authService.tryRefreshExpiredSession().timeout(
+              const Duration(seconds: 5),
+            );
             expect(second, isFalse);
 
             expect(


### PR DESCRIPTION
## Description

"The app kicks me out and tells me to log back in but then won't let me log back in until I have closed out completely."

Root cause: Keycast auth/RPC HTTP calls had no hard request bound, so a hung request - for example a dead Android socket after Doze/backgrounding - could permanently poison the process-lifetime single-flight refresh future in `AuthService`. Every re-login surface then awaited the same never-completing future, while UI guards disabled the escape hatches. Only killing the process recovered.

**Related Issue:** Closes #4942

## Changes

- **`keycast_flutter` request timeouts:** adds a `requestTimeout` constructor param (default 30s) on `KeycastOAuth` and `KeycastRpc`.
- **All Keycast OAuth/RPC HTTP calls are bounded:** `refreshSession`, `exchangeCode`, `headlessRegister`, `headlessLogin`, `pollForCode`, password reset email, password reset submit, and RPC `_sendRequest` now time out instead of hanging forever.
- **Refresh token preservation remains conservative:** `refreshSession` preserves the refresh token on network error/timeout and only deletes it on definitive HTTP rejection.
- **Stale refresh writes are fenced:** `KeycastOAuth.logout()` invalidates in-flight refresh saves, so a refresh response that completes after logout cannot rewrite the cleared session, refresh token, or authorization handle.
- **Self-terminating single-flight in `AuthService`:** the timeout is part of the future stored in `_pendingOAuthRefresh` / `_pendingRefresh`, so a hung attempt clears its slot and the next attempt starts fresh.
- **No early production detach:** AuthService's default OAuth/full expired-session bounds are longer than Keycast's own HTTP bound, so production code does not abandon a slow-but-still-live refresh before the Keycast client has resolved it.
- **`signOut` detaches pending futures:** post-signout logins start fresh, while late completions cannot clobber newer attempts.

## Out of Scope

- `signInWithDivineOAuth` swallowing sign-in failures while the cubit emits success.
- `FlutterSecureStorage.resetOnError` secure-storage wipe behavior on Android keystore errors.

## Verification

- `mise exec -- flutter test packages/keycast_flutter/test/oauth_client_test.dart packages/keycast_flutter/test/rpc_client_test.dart test/services/auth_service_expired_session_downgrade_test.dart`
- `mise exec -- flutter analyze`
- Pre-push hook reran changed-file analyze and the targeted changed-file tests successfully.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
