### PR TITLE
fix(profile): persist deleted video tombstones

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -371,11 +371,13 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         if (isClosed) return;
         final after = _videoEventService.authorVideos(_authorPubkey).length;
 
-        _unfilteredVideos = _applyMetadataCache(
-          _videoEventService
-              .authorVideos(_authorPubkey)
-              .where((v) => !v.isRepost)
-              .toList(),
+        _unfilteredVideos = _withoutTombstones(
+          _applyMetadataCache(
+            _videoEventService
+                .authorVideos(_authorPubkey)
+                .where((v) => !v.isRepost)
+                .toList(),
+          ),
         );
         // C5 fix: copyWith over the live state preserves totalVideoCount,
         // isInitialLoad, isFetchingTotalCount and nextOffset that the legacy

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -22,6 +22,7 @@ import 'package:openvine/providers/upload_media_providers.dart';
 import 'package:openvine/services/auth_service.dart' show AuthState;
 import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
+import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/event_router.dart';
 import 'package:openvine/services/nsfw_content_filter.dart';
 import 'package:openvine/services/pending_action_service.dart';
@@ -104,6 +105,7 @@ VideoEventService videoEventService(Ref ref) {
   final likesRepository = ref.watch(likesRepositoryProvider);
   final moderationLabelService = ref.watch(moderationLabelServiceProvider);
   final divineHostFilterService = ref.read(divineHostFilterServiceProvider);
+  final prefs = ref.watch(sharedPreferencesProvider);
 
   final service = VideoEventService(
     nostrService,
@@ -111,6 +113,26 @@ VideoEventService videoEventService(Ref ref) {
     profileRepository: profileRepository,
     eventRouter: eventRouter,
     videoFilterBuilder: videoFilterBuilder,
+  );
+  var persistedDeletions = const <ContentDeletion>[];
+  try {
+    persistedDeletions = ContentDeletionService.parseDeletionHistory(
+      prefs.getString(ContentDeletionService.deletionsStorageKey),
+    );
+  } on Object catch (error, stackTrace) {
+    Log.error(
+      'Failed to hydrate video deletion tombstones: $error',
+      name: 'VideoEventService',
+      category: LogCategory.system,
+      error: error,
+      stackTrace: stackTrace,
+    );
+  }
+  service.seedLocalDeletionTombstones(
+    eventIds: persistedDeletions.map((deletion) => deletion.originalEventId),
+    addressableIds: persistedDeletions
+        .map((deletion) => deletion.addressableId)
+        .whereType<String>(),
   );
   service.setBlocklistRepository(blocklistRepository);
   service.setLikesRepository(likesRepository);

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -322,7 +322,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'5a204c44e3372e78a32beaa8121f28df4121f54a';
+String _$videoEventServiceHash() => r'85ef90976750b306638eca4df08291e7c5e2cb54';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -133,6 +133,15 @@ class ContentDeletionService {
       List.unmodifiable(_deletionHistory);
   bool get isInitialized => _isInitialized;
 
+  static List<ContentDeletion> parseDeletionHistory(String? historyJson) {
+    if (historyJson == null) return const [];
+
+    final List<dynamic> deletionsJson = jsonDecode(historyJson);
+    return deletionsJson
+        .map((json) => ContentDeletion.fromJson(json as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
   /// Initialize deletion service
   Future<void> initialize() async {
     try {
@@ -447,11 +456,19 @@ class ContentDeletionService {
   }
 
   String? _addressableDeletionTarget(VideoEvent video) {
-    final vineId = video.vineId;
-    if (vineId == null || vineId.isEmpty || vineId == video.id) {
+    final dTag = video.rawTags['d'];
+    final stableDTag = dTag != null && dTag.isNotEmpty
+        ? dTag
+        : video.vineId != null &&
+              video.vineId!.isNotEmpty &&
+              video.vineId != video.id
+        ? video.vineId
+        : null;
+    if (stableDTag == null || stableDTag.isEmpty) {
       return null;
     }
-    return video.addressableId;
+    return '${NIP71VideoKinds.getPreferredAddressableKind()}'
+        ':${video.pubkey}:$stableDTag';
   }
 
   /// Get delete reason text for common cases
@@ -477,13 +494,8 @@ class ContentDeletionService {
     final historyJson = _prefs.getString(deletionsStorageKey);
     if (historyJson != null) {
       try {
-        final List<dynamic> deletionsJson = jsonDecode(historyJson);
         _deletionHistory.clear();
-        _deletionHistory.addAll(
-          deletionsJson.map(
-            (json) => ContentDeletion.fromJson(json as Map<String, dynamic>),
-          ),
-        );
+        _deletionHistory.addAll(parseDeletionHistory(historyJson));
         Log.debug(
           '📱 Loaded ${_deletionHistory.length} deletions from history',
           name: 'ContentDeletionService',

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -27,6 +27,7 @@ import 'package:flutter/widgets.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/aid.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/constants/app_constants.dart';
@@ -1155,6 +1156,34 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     return _locallyDeletedVideoIds.contains(videoId);
   }
 
+  /// Hydrate local deletion tombstones from persisted delete history.
+  ///
+  /// [addressableIds] must use the NIP-33 `kind:pubkey:d-tag` format. The
+  /// service keeps its own compact lookup key private so callers do not couple
+  /// to the in-memory implementation.
+  void seedLocalDeletionTombstones({
+    Iterable<String> eventIds = const [],
+    Iterable<String> addressableIds = const [],
+  }) {
+    _locallyDeletedVideoIds.addAll(eventIds.where((id) => id.isNotEmpty));
+
+    for (final addressableId in addressableIds) {
+      final parsed = AId.fromString(addressableId);
+      if (parsed == null ||
+          parsed.kind != NIP71VideoKinds.addressableShortVideo ||
+          parsed.pubkey.isEmpty ||
+          parsed.dTag.isEmpty) {
+        continue;
+      }
+      _locallyDeletedVideoCoordinateKeys.add(
+        _localDeletionCoordinateKeyFromParts(
+          pubkey: parsed.pubkey,
+          stableId: parsed.dTag,
+        ),
+      );
+    }
+  }
+
   /// Check whether this concrete video or its addressable identity has been
   /// locally deleted.
   bool isVideoEventLocallyDeleted(VideoEvent video) {
@@ -1165,7 +1194,15 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   }
 
   String _localDeletionCoordinateKey(VideoEvent video) =>
-      '${video.pubkey.toLowerCase()}:${video.stableId}';
+      _localDeletionCoordinateKeyFromParts(
+        pubkey: video.pubkey,
+        stableId: video.stableId,
+      );
+
+  String _localDeletionCoordinateKeyFromParts({
+    required String pubkey,
+    required String stableId,
+  }) => '${pubkey.toLowerCase()}:$stableId';
 
   /// Emits a video id whenever the service has marked it removed —
   /// today this is user-initiated deletion via [removeVideoCompletely];

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -29,6 +29,7 @@ VideoEvent _video(
   String pubkey = _author,
   int createdAt = 1000,
   int? originalLikes,
+  String? vineId,
 }) {
   return VideoEvent(
     id: id,
@@ -38,6 +39,7 @@ VideoEvent _video(
     timestamp: DateTime.fromMillisecondsSinceEpoch(createdAt * 1000),
     videoUrl: 'https://example.com/$id.mp4',
     originalLikes: originalLikes,
+    vineId: vineId,
   );
 }
 
@@ -248,44 +250,36 @@ void main() {
       },
     );
 
-    test(
-      'cold load: backfill skips empty advancing REST pages',
-      () async {
-        h.stubAuthorFeedSequence([
-          _result(
-            [_video('a', createdAt: 5000), _video('b', createdAt: 4000)],
-            totalCount: 4,
-            nextOffset: 2,
-            hasMore: true,
-          ),
-          _result(const [], totalCount: 4, nextOffset: 3, hasMore: true),
-          _result(
-            [_video('c', createdAt: 3000), _video('d', createdAt: 2000)],
-            totalCount: 4,
-            hasMore: false,
-          ),
-        ]);
+    test('cold load: backfill skips empty advancing REST pages', () async {
+      h.stubAuthorFeedSequence([
+        _result(
+          [_video('a', createdAt: 5000), _video('b', createdAt: 4000)],
+          totalCount: 4,
+          nextOffset: 2,
+          hasMore: true,
+        ),
+        _result(const [], totalCount: 4, nextOffset: 3, hasMore: true),
+        _result(
+          [_video('c', createdAt: 3000), _video('d', createdAt: 2000)],
+          totalCount: 4,
+          hasMore: false,
+        ),
+      ]);
 
-        final cubit = h.build();
-        addTearDown(cubit.close);
-        await pumpEventQueue(times: 8);
+      final cubit = h.build();
+      addTearDown(cubit.close);
+      await pumpEventQueue(times: 8);
 
-        expect(cubit.state.videos.map((video) => video.id), [
-          'a',
-          'b',
-          'c',
-          'd',
-        ]);
-        expect(cubit.state.hasMoreContent, isFalse);
-        expect(cubit.state.nextOffset, isNull);
-        verify(
-          () => h.repo.getAuthorFeed(authorPubkey: _author, offset: 2),
-        ).called(1);
-        verify(
-          () => h.repo.getAuthorFeed(authorPubkey: _author, offset: 3),
-        ).called(1);
-      },
-    );
+      expect(cubit.state.videos.map((video) => video.id), ['a', 'b', 'c', 'd']);
+      expect(cubit.state.hasMoreContent, isFalse);
+      expect(cubit.state.nextOffset, isNull);
+      verify(
+        () => h.repo.getAuthorFeed(authorPubkey: _author, offset: 2),
+      ).called(1);
+      verify(
+        () => h.repo.getAuthorFeed(authorPubkey: _author, offset: 3),
+      ).called(1);
+    });
 
     test('cold load: REST failure, no relay -> failure + addError', () async {
       h.stubAuthorFeedThrows(Exception('boom'));
@@ -354,9 +348,7 @@ void main() {
         addTearDown(cubit.close);
         clearInteractions(h.repo);
 
-        h.stubAuthorFeed(
-          _result(const [], nextOffset: 100, hasMore: true),
-        );
+        h.stubAuthorFeed(_result(const [], nextOffset: 100, hasMore: true));
         cubit.add(const ProfileFeedLoadMoreRequested());
         await pumpEventQueue();
 
@@ -490,6 +482,29 @@ void main() {
       expect(cubit.state.isFetchingTotalCount, isFalse);
     });
 
+    test('Nostr-fallback loadMore excludes tombstoned videos', () async {
+      final cubit = await buildReady(
+        _result([_video('a', createdAt: 3000)], hasMore: true),
+      );
+      addTearDown(cubit.close);
+      expect(cubit.state.nextOffset, isNull);
+
+      when(() => h.ves.authorVideos(_author)).thenReturn([
+        _video('a', createdAt: 3000),
+        _video('b', createdAt: 2000),
+      ]);
+      when(
+        () => h.ves.isVideoEventLocallyDeleted(
+          any(that: isA<VideoEvent>().having((v) => v.id, 'id', 'b')),
+        ),
+      ).thenReturn(true);
+
+      cubit.add(const ProfileFeedLoadMoreRequested());
+      await pumpEventQueue();
+
+      expect(cubit.state.videos.map((v) => v.id), ['a']);
+    });
+
     test(
       'loadMore is droppable: two rapid requests cause one repo call',
       () async {
@@ -585,6 +600,37 @@ void main() {
 
       expect(cubit.state.videos.map((v) => v.id), ['b']);
     });
+
+    test(
+      'cold load excludes tombstoned replacement videos from REST',
+      () async {
+        final replacement = _video(
+          'new-event-id-from-rest',
+          vineId: 'deleted-addressable-d-tag',
+          createdAt: 5000,
+        );
+        when(
+          () => h.ves.isVideoEventLocallyDeleted(
+            any(
+              that: isA<VideoEvent>()
+                  .having((v) => v.id, 'id', 'new-event-id-from-rest')
+                  .having(
+                    (v) => v.stableId,
+                    'stableId',
+                    'deleted-addressable-d-tag',
+                  ),
+            ),
+          ),
+        ).thenReturn(true);
+
+        final cubit = await buildReady(
+          _result([replacement, _video('visible-event-id')]),
+        );
+        addTearDown(cubit.close);
+
+        expect(cubit.state.videos.map((v) => v.id), ['visible-event-id']);
+      },
+    );
 
     test('blocklist is applied on the cold-load emit (#4782)', () async {
       when(() => h.blocklist.shouldFilterFromFeeds('blocked')).thenReturn(true);

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Verifies kind 5 event creation, relay OK confirmation, and
 // ABOUTME: local history bookkeeping.
 
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -78,6 +80,32 @@ void main() {
       noResponseFrom: const ['wss://backup-relay.test'],
     );
 
+    test('parseDeletionHistory reads persisted deletion records', () {
+      final deletedAt = DateTime.utc(2026);
+      final historyJson = jsonEncode([
+        {
+          'deleteEventId': 'delete-event-id',
+          'originalEventId': 'original-event-id',
+          'addressableId': '34236:$testPublicKey:shared-vine-id',
+          'reason': 'Personal choice',
+          'deletedAt': deletedAt.toIso8601String(),
+          'additionalContext': 'Quick delete: personalChoice',
+        },
+      ]);
+
+      final history = ContentDeletionService.parseDeletionHistory(historyJson);
+
+      expect(history, hasLength(1));
+      expect(history.single.deleteEventId, 'delete-event-id');
+      expect(history.single.originalEventId, 'original-event-id');
+      expect(
+        history.single.addressableId,
+        '34236:$testPublicKey:shared-vine-id',
+      );
+      expect(history.single.deletedAt, deletedAt);
+      expect(history.single.additionalContext, 'Quick delete: personalChoice');
+    });
+
     setUp(() async {
       final testPrivateKey = generatePrivateKey();
       testPublicKey = getPublicKey(testPrivateKey);
@@ -130,6 +158,18 @@ void main() {
         timestamp: DateTime.now(),
         videoUrl: 'https://example.com/video.mp4',
         vineId: 'rest-vine-id',
+      );
+    }
+
+    VideoEvent createRawDTagVideoEvent(String pubkey) {
+      return VideoEvent(
+        id: 'raw_d_tag_event_id',
+        pubkey: pubkey,
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        content: 'Test video content',
+        timestamp: DateTime.now(),
+        videoUrl: 'https://example.com/video.mp4',
+        rawTags: const {'d': 'raw-d-tag'},
       );
     }
 
@@ -461,6 +501,60 @@ void main() {
           expect(tags, contains(equals(['e', video.id])));
           expect(tags, contains(equals(['a', video.addressableId])));
           expect(tags, contains(equals(['k', '34236'])));
+        },
+      );
+
+      test(
+        'includes a tag when the raw d tag is present but vineId is null',
+        () async {
+          final video = createRawDTagVideoEvent(testPublicKey);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+              ['a', '34236:$testPublicKey:raw-d-tag'],
+              ['k', '34236'],
+            ],
+            content: 'CONTENT DELETION',
+          );
+
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          await service.deleteContent(video: video, reason: 'Personal choice');
+
+          final captured = verify(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: captureAny(named: 'tags'),
+            ),
+          ).captured;
+
+          final tags = captured.first as List<List<String>>;
+          expect(tags, contains(equals(['e', video.id])));
+          expect(
+            tags,
+            contains(equals(['a', '34236:$testPublicKey:raw-d-tag'])),
+          );
+          expect(tags, contains(equals(['k', '34236'])));
+          expect(
+            service.deletionHistory.single.addressableId,
+            '34236:$testPublicKey:raw-d-tag',
+          );
         },
       );
 

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -161,7 +161,10 @@ void main() {
       );
     }
 
-    VideoEvent createRawDTagVideoEvent(String pubkey) {
+    VideoEvent createRawDTagVideoEvent(
+      String pubkey, {
+      String dTag = 'raw-d-tag',
+    }) {
       return VideoEvent(
         id: 'raw_d_tag_event_id',
         pubkey: pubkey,
@@ -169,7 +172,7 @@ void main() {
         content: 'Test video content',
         timestamp: DateTime.now(),
         videoUrl: 'https://example.com/video.mp4',
-        rawTags: const {'d': 'raw-d-tag'},
+        rawTags: {'d': dTag},
       );
     }
 
@@ -507,13 +510,14 @@ void main() {
       test(
         'includes a tag when the raw d tag is present but vineId is null',
         () async {
-          final video = createRawDTagVideoEvent(testPublicKey);
+          const dTag = 'raw:d:tag';
+          final video = createRawDTagVideoEvent(testPublicKey, dTag: dTag);
           final deleteEvent = createTestEvent(
             pubkey: testPublicKey,
             kind: 5,
             tags: [
               ['e', video.id],
-              ['a', '34236:$testPublicKey:raw-d-tag'],
+              ['a', '34236:$testPublicKey:$dTag'],
               ['k', '34236'],
             ],
             content: 'CONTENT DELETION',
@@ -546,14 +550,11 @@ void main() {
 
           final tags = captured.first as List<List<String>>;
           expect(tags, contains(equals(['e', video.id])));
-          expect(
-            tags,
-            contains(equals(['a', '34236:$testPublicKey:raw-d-tag'])),
-          );
+          expect(tags, contains(equals(['a', '34236:$testPublicKey:$dTag'])));
           expect(tags, contains(equals(['k', '34236'])));
           expect(
             service.deletionHistory.single.addressableId,
-            '34236:$testPublicKey:raw-d-tag',
+            '34236:$testPublicKey:$dTag',
           );
         },
       );

--- a/mobile/test/unit/services/video_event_service_deletion_test.dart
+++ b/mobile/test/unit/services/video_event_service_deletion_test.dart
@@ -187,5 +187,64 @@ void main() {
         isFalse,
       );
     });
+
+    test('seedLocalDeletionTombstones hydrates event id tombstones', () {
+      videoEventService.seedLocalDeletionTombstones(
+        eventIds: const ['deleted-event-id'],
+      );
+
+      expect(videoEventService.isVideoLocallyDeleted('deleted-event-id'), true);
+      expect(videoEventService.isVideoLocallyDeleted('other-event-id'), false);
+    });
+
+    test('seedLocalDeletionTombstones converts persisted addressable ids to '
+        'local coordinate keys', () {
+      const pubkey =
+          'C3DD74D68E414F0305DB9F7DC96EC32E616502E6CCF5BBF5739DE19A96B67F3E';
+      const dTag = 'shared:vine:id';
+      final replacementVersion = _videoEvent(
+        id: 'event-id-after-restart',
+        pubkey: pubkey.toLowerCase(),
+        dTag: dTag,
+        createdAt: 1001,
+      );
+      final unrelatedVideo = _videoEvent(
+        id: 'unrelated-event-id',
+        pubkey: pubkey.toLowerCase(),
+        dTag: 'different-vine-id',
+      );
+
+      videoEventService.seedLocalDeletionTombstones(
+        addressableIds: const ['34236:$pubkey:$dTag'],
+      );
+
+      expect(
+        videoEventService.isVideoEventLocallyDeleted(replacementVersion),
+        isTrue,
+      );
+      expect(
+        videoEventService.isVideoEventLocallyDeleted(unrelatedVideo),
+        isFalse,
+      );
+    });
+
+    test(
+      'seedLocalDeletionTombstones ignores unsupported addressable kinds',
+      () {
+        const pubkey =
+            'c3dd74d68e414f0305db9f7dc96ec32e616502e6ccf5bbf5739de19a96b67f3e';
+        final video = _videoEvent(
+          id: 'not-deleted',
+          pubkey: pubkey,
+          dTag: 'shared-vine-id',
+        );
+
+        videoEventService.seedLocalDeletionTombstones(
+          addressableIds: const ['30023:$pubkey:shared-vine-id'],
+        );
+
+        expect(videoEventService.isVideoEventLocallyDeleted(video), isFalse);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Closes #5113.

Deleted videos could reappear on profile grids after an app restart because the durable NIP-09 deletion history lived in `ContentDeletionService`, while profile feed filtering only checked `VideoEventService`'s in-memory tombstone sets. On restart those in-memory sets were empty, so REST author feed results could reintroduce previously deleted videos.

This PR:

- hydrates `VideoEventService` local tombstones from persisted `ContentDeletionService` history during provider creation
- persists addressable tombstones from a video's raw `d` tag even when `vineId` is null, so replacement REST events with a different event id still filter after restart
- keeps synthetic event-id-as-d-tag cases out of NIP-09 `a` tags
- keeps `VideoEventService`'s local coordinate-key format private by accepting persisted NIP-33 addressable IDs and translating them internally
- reuses one parser for deletion-history persistence so provider hydration and `ContentDeletionService` do not drift
- applies tombstone filtering to the profile feed's Nostr fallback pagination path too
- covers raw `d` tags that contain colons, so persisted addressable IDs keep the full NIP-33 coordinate
- commits the generated Riverpod provider hash update

## Validation

- `cd mobile && mise exec -- dart run build_runner build --delete-conflicting-outputs`
- `cd mobile && mise exec -- dart format --set-exit-if-changed lib/services/content_deletion_service.dart lib/providers/video_providers.dart lib/services/video_event_service.dart test/services/content_deletion_service_test.dart test/unit/services/video_event_service_deletion_test.dart test/blocs/profile_feed/profile_feed_cubit_test.dart`
- `cd mobile && mise exec -- flutter analyze`
- `cd mobile && mise exec -- flutter test test/blocs/profile_feed/profile_feed_cubit_test.dart test/services/content_deletion_service_test.dart test/unit/services/video_event_service_deletion_test.dart`
- `cd mobile && mise exec -- flutter test`
- Pre-push hook: merge-conflict check, analyzer, generated-file verification, and changed-file tests all passed

## Notes

This is a mobile client fix for relay-confirmed deletes surviving app restart and for filtering replacement addressable events while local deletion history exists.

hm21's reinstall repro is a separate backend durability issue: reinstall clears local tombstones, so mobile cannot hide deleted videos if the relay/Funnelcake still serves them to a fresh install or new device. Tracked in #5139.
