### PR TITLE
docs(moderation): refresh stale architecture docs after Phase 4 cleanup (#5137)

### DIFF
--- a/docs/MODERATION_COMPLETE_ARCHITECTURE.md
+++ b/docs/MODERATION_COMPLETE_ARCHITECTURE.md
@@ -48,8 +48,8 @@ Divine uses a **three-tier moderation architecture**:
 **Consumes Labels (kind 1985):**
 - `ModerationLabelService` - Subscribes to trusted labelers
 - `ReportAggregationService` - Aggregates reports from friends
-- `ContentModerationService` - Personal mute lists (kind 10000)
-- `ModerationFeedService` - Combines all sources into filtering decisions
+- `ContentBlocklistRepository` - Tracks own blocks (kind 30000 `d=block`), own mutes (kind 10000), and mutual block/mute; exposes an immutable `ContentPolicyState` snapshot
+- `ContentPolicyEngine` (`mobile/packages/content_policy`) - Applies ordered rules (SelfReference, PubkeyMute, PubkeyBlock, MutualMute) against that snapshot to make filtering decisions
 
 **User Experience:**
 - Users see content warnings/blurs based on labels
@@ -158,18 +158,24 @@ Divine uses a **three-tier moderation architecture**:
 8. Label provides additional authoritative signal
 ```
 
-### Example 3: User Subscribes to Curator's Mute List
+### Example 3: User Subscribes to Curator's Mute List (not yet shipped)
+
+> Subscribing to an external curator's NIP-51 list is a deferred capability
+> (a future `SubscribedListRule` on the engine). It is **not** implemented
+> today — the engine only consumes the user's own block/mute state. The flow
+> below is the intended shape once that rule lands:
 
 ```
 1. User discovers "Tech Content Curator" moderator
    ↓
 2. User subscribes to curator's NIP-51 mute list
    ↓
-3. ContentModerationService queries curator's kind 10000 events
+3. ContentBlocklistRepository aggregates the curator's kind 10000 entries
+   into its ContentPolicyState snapshot
    ↓
 4. Curator has muted 50 spam accounts
    ↓
-5. All 50 accounts automatically muted in user's feed
+5. ContentPolicyEngine's mute rule hides those 50 accounts from the user's feed
 ```
 
 ## Divine Services (Current State)
@@ -178,15 +184,15 @@ Divine uses a **three-tier moderation architecture**:
 
 1. **ModerationLabelService** - Subscribes to Faro's kind 1985 labels
 2. **ReportAggregationService** - Aggregates community kind 1984 reports
-3. **ContentModerationService** - Personal + external NIP-51 mute lists
-4. **ContentReportingService** - Creates kind 1984 reports → Faro
+3. **ContentBlocklistRepository** - Own blocks (kind 30000 `d=block`), own mutes (kind 10000), and mutual block/mute; exposes `ContentPolicyState`
+4. **ContentPolicyEngine** - Pure-Dart ordered rules (SelfReference, PubkeyMute, PubkeyBlock, MutualMute) gating every feed/search/profile/comment/notification ingress seam
+5. **ContentReportingService** - Creates kind 1984 reports → Faro
 
 ### 🔨 Missing
 
-1. **ModerationFeedService** - Coordinator combining all sources
+1. **`SubscribedListRule`** - Subscribe to external curators' kind 10000 / kind 30000 lists and fold them into `ContentPolicyState`
 2. **ModeratorRegistryService** - Manage trusted moderators/Faro instances
-3. **Integration** - Wire services into ContentModerationService
-4. **UI** - Subscribe to moderators, content warnings, report flows
+3. **UI** - Subscribe to moderators, content warnings, report flows
 
 ## Faro Integration Points
 
@@ -286,8 +292,8 @@ final defaultModerators = [
 | Report Creation | ✅ | ContentReportingService creates kind 1984 |
 | Label Subscription | ✅ | ModerationLabelService subscribes to kind 1985 |
 | Report Aggregation | ✅ | ReportAggregationService aggregates kind 1984 |
-| Mute Lists | ✅ | ContentModerationService handles kind 10000 |
-| Feed Coordinator | 🔨 | ModerationFeedService - combines all sources |
+| Mute Lists | ✅ | ContentBlocklistRepository tracks kind 10000 / kind 30000; ContentPolicyEngine applies the rules |
+| Feed Coordinator | ✅ | ContentPolicyEngine gates every ingress seam directly (no separate coordinator) |
 | Moderator Registry | 🔨 | ModeratorRegistryService - manage Faro subs |
 | UI Components | 🔨 | Content warnings, moderator browse |
 

--- a/mobile/docs/CONTENT_MODERATION_POLICY.md
+++ b/mobile/docs/CONTENT_MODERATION_POLICY.md
@@ -11,14 +11,13 @@ Divine fully complies with Apple's requirements for user-generated content apps 
 ### ✅ Method for Filtering Objectionable Content
 
 **Implementation:**
-- Client-side content filtering via `ContentModerationService`
-- User-managed blocklist via `ContentBlocklistRepository`
-- NIP-51 mute list support for decentralized filtering
-- Multiple filter categories: spam, harassment, violence, sexual content, copyright violations, misinformation, CSAM, and AI-generated content
+- Client-side content filtering via `ContentPolicyEngine` — a pure-Dart rules engine (SelfReference, PubkeyMute, PubkeyBlock, MutualMute) that gates every feed/search/profile/comment/notification ingress seam
+- User-managed block/mute state via `ContentBlocklistRepository`, which exposes an immutable `ContentPolicyState` snapshot to the engine and a `shouldFilterFromFeeds` predicate covering own blocks (kind 30000 `d=block`), own mutes (kind 10000), and mutual block/mute
+- Multiple report categories: spam, harassment, violence, sexual content, copyright violations, misinformation, CSAM, and AI-generated content
 
 **Location:**
-- `lib/services/content_moderation_service.dart`
-- `packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart`
+- `packages/content_policy/` (ContentPolicyEngine and rules)
+- `packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart` (ContentPolicyState + shouldFilterFromFeeds)
 
 ### ✅ Mechanism to Report Offensive Content
 

--- a/mobile/docs/MODERATION_RESPONSE_PROCESS.md
+++ b/mobile/docs/MODERATION_RESPONSE_PROCESS.md
@@ -33,7 +33,7 @@ For reports of illegal content (especially CSAM), our response is **immediate**.
 **Services**:
 - `ContentReportingService` - Handles report submission (lib/services/content_reporting_service.dart)
 - `ReportAggregationService` - Tracks and aggregates reports (lib/services/report_aggregation_service.dart)
-- `ContentModerationService` - Enforces moderation decisions (lib/services/content_moderation_service.dart)
+- `ContentPolicyEngine` - Enforces filtering decisions via ordered rules (mobile/packages/content_policy), fed by `ContentPolicyState` from `ContentBlocklistRepository` (mobile/packages/content_blocklist_repository)
 
 ## Moderation Team Monitoring
 

--- a/mobile/docs/MODERATION_SYSTEM_ARCHITECTURE.md
+++ b/mobile/docs/MODERATION_SYSTEM_ARCHITECTURE.md
@@ -1,5 +1,17 @@
 # Divine Moderation System Architecture
 
+> **Implementation status (2026-06):** This is a forward-looking design
+> proposal. The block/mute filtering it describes shipped as the
+> **`ContentPolicyEngine`** (`mobile/packages/content_policy`) — a pure-Dart
+> ordered-rules engine (SelfReference, PubkeyMute, PubkeyBlock, MutualMute)
+> fed by an immutable `ContentPolicyState` snapshot from
+> **`ContentBlocklistRepository`** (`mobile/packages/content_blocklist_repository`).
+> The engine gates every repository ingress seam directly; there is **no**
+> `ModerationFeedService` coordinator and **no** `ContentModerationService`
+> (both were removed in #5136). The labeler-stack and coordinator sections
+> below are the original proposal, not shipped code — read them as design
+> intent, not as current guidance.
+
 ## Overview
 
 Divine implements a **stackable, user-controlled moderation system** inspired by Bluesky's labeler architecture, using Nostr's NIP-32 (labeling) and NIP-56 (reporting) specifications.
@@ -245,7 +257,7 @@ class ModerationFeedService {
   final ModerationLabelService _labelService;
   final ReportAggregationService _reportService;
   final ModeratorRegistryService _registryService;
-  final ContentModerationService _muteService; // Existing
+  final ContentBlocklistRepository _blocklistRepository; // ships as ContentPolicyState source
 
   // Check content against ALL moderation sources
   Future<ModerationDecision> checkContent(Event event);
@@ -291,7 +303,13 @@ enum ModerationAction {
 }
 ```
 
-### 5. Updated ContentModerationService
+### 5. Feed integration (as shipped: ContentPolicyEngine)
+
+> The proposal below wrapped an existing `ContentModerationService`. As
+> shipped there is no such service — `ContentPolicyEngine.evaluate(...)` is
+> called directly at each repository ingress seam against the current
+> `ContentPolicyState`, with no wrapper or coordinator. The sketch is
+> retained as design context.
 
 **Integration with feed system:**
 
@@ -547,8 +565,7 @@ Labels and reports should be stored in embedded relay for:
 
 ### Phase 2: Core Features
 - 🔨 ReportAggregationService (kind 1984)
-- 🔨 ModerationFeedService coordinator
-- 🔨 Integration with ContentModerationService
+- ✅ Filtering engine — shipped as `ContentPolicyEngine` gating every ingress seam (no coordinator service)
 - 🔨 Basic UI for subscribing to moderators
 
 ### Phase 3: User Experience


### PR DESCRIPTION
Docs follow-up for #5137. PR #5136 deleted `ContentModerationService`, `MuteService`, and the `contentPolicyV2` flag, but the moderation docs still described them as current implementation.

- Updated the four docs that read as current guidance to describe the shipped path — `ContentPolicyEngine` (ordered rules: SelfReference / PubkeyMute / PubkeyBlock / MutualMute) fed by `ContentBlocklistRepository`'s `ContentPolicyState` snapshot: `MODERATION_COMPLETE_ARCHITECTURE.md`, `CONTENT_MODERATION_POLICY.md`, `MODERATION_RESPONSE_PROCESS.md`, and `MODERATION_SYSTEM_ARCHITECTURE.md`.
- For the labeler-stack design doc I added a "this is a proposal, not shipped code" banner rather than rewrite 580 lines of speculative `ModerationFeedService` design, and fixed the lines that asserted the deleted class still exists.
- The curator-mute-list example in the architecture doc is now marked "not yet shipped" — that's the deferred `SubscribedListRule`.
- Left the dated planning docs alone (`docs/plans/2025-*`, `docs/superpowers/2026-04-23-*`, `TRUST_SAFETY_SETTINGS_PLAN.md`) — they already read as historical.

Docs-only, no behavior change.

Closes #5137.
