### PR TITLE
test(nip98): let the #3052 acceptance test do real HTTP

### DIFF
--- a/local_stack/docker-compose.yml
+++ b/local_stack/docker-compose.yml
@@ -141,6 +141,7 @@ services:
       CLICKHOUSE_USER: default
       CLICKHOUSE_PASSWORD: clickhouse
       BIND_ADDR: 0.0.0.0:3001
+      RELAY_URL: ws://funnelcake-relay:7777
 
   # Reverse proxy that unifies relay (WebSocket) and API (REST) on one port,
   # matching production where both live behind the same domain.

--- a/local_stack/funnelcake-proxy/nginx.conf
+++ b/local_stack/funnelcake-proxy/nginx.conf
@@ -5,6 +5,8 @@ server {
     location /api/ {
         proxy_pass http://funnelcake-api:3001;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # Everything else (WebSocket relay) — proxy to funnelcake-relay

--- a/mobile/test/manual/nip98_relay_acceptance_test.dart
+++ b/mobile/test/manual/nip98_relay_acceptance_test.dart
@@ -31,6 +31,11 @@ void main() {
   late bool stackAvailable;
 
   setUpAll(() async {
+    // flutter_test's binding stubs every HttpClient request to status 400 (to
+    // catch accidental network use in unit tests). This is an intentional
+    // real-network acceptance test, so opt out and let HttpClient do real I/O.
+    HttpOverrides.global = null;
+
     stackAvailable = await _isPortOpen(_localHost, _localRelayPort);
   });
 

--- a/mobile/test/manual/nip98_relay_acceptance_test.dart
+++ b/mobile/test/manual/nip98_relay_acceptance_test.dart
@@ -11,6 +11,7 @@
 //   - Query parameters must be included in the u tag
 //   - Expired created_at, wrong signature, mismatched method/url → 401
 
+@Tags(['skip_very_good_optimization', 'integration'])
 import 'dart:convert';
 import 'dart:io';
 
@@ -29,14 +30,20 @@ const _localStackUnavailableMessage =
 
 void main() {
   late bool stackAvailable;
+  late final HttpOverrides? previousHttpOverrides;
 
   setUpAll(() async {
+    previousHttpOverrides = HttpOverrides.current;
     // flutter_test's binding stubs every HttpClient request to status 400 (to
     // catch accidental network use in unit tests). This is an intentional
     // real-network acceptance test, so opt out and let HttpClient do real I/O.
     HttpOverrides.global = null;
 
     stackAvailable = await _isPortOpen(_localHost, _localRelayPort);
+  });
+
+  tearDownAll(() {
+    HttpOverrides.global = previousHttpOverrides;
   });
 
   group(


### PR DESCRIPTION
## Description

Completes the NIP-98 relay acceptance path for #3052 instead of leaving the manual test red against the default local stack.

Root cause and fix:
- `flutter_test` installs a global `HttpClient` override that returns 400s. The manual acceptance test now opts out for real HTTP and restores the previous override in `tearDownAll`, so it cannot leak global network behavior into other tests.
- Very Good CLI optimization does not honor `mobile/dart_test.yaml` excludes. The real-network manual test is tagged `skip_very_good_optimization` and `integration`, so it is not bundled into the shared optimized CI isolate and is excluded by CI's `--exclude-tags integration`.
- The local `funnelcake-api` service did not receive `RELAY_URL`, so NIP-98 routes were not mounted and the documented acceptance run returned 404.
- The local nginx API proxy did not forward the original host with port or scheme, so NIP-98 `u` tag reconstruction could not match requests that go through `localhost:47777`.

Closes #3052

## Verification

- `mise exec -- flutter test test/manual/nip98_relay_acceptance_test.dart` — 9/9 passing against `mise run local_up` stack after recreating `funnelcake-api` and `funnelcake-proxy`
- `mise exec -- flutter analyze`
- pre-push analyzer and changed-file test hook passed

## Type of Change

- [x] Test
- [x] Local stack / developer tooling
