### PR TITLE
fix(follow): follow button no longer reverts after tapping (#5144)

### DIFF
--- a/mobile/lib/blocs/my_following/my_following_bloc.dart
+++ b/mobile/lib/blocs/my_following/my_following_bloc.dart
@@ -37,7 +37,10 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
                .toList(),
          ),
        ) {
-    on<MyFollowingListLoadRequested>(_onLoadRequested);
+    on<MyFollowingListLoadRequested>(
+      _onLoadRequested,
+      transformer: restartable(),
+    );
     on<MyFollowingToggleRequested>(
       _onToggleRequested,
       transformer: droppable(),
@@ -106,13 +109,16 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
 
   /// Handle follow toggle request.
   ///
-  /// Delegates to repository which handles the toggle logic internally,
-  /// then re-dispatches [MyFollowingListLoadRequested] so the cache layer
-  /// and UI re-observe the new follow set. The previous implementation
-  /// relied on a [BehaviorSubject] replay flowing through
-  /// `CacheSync.watchStream`, which mis-tagged stale in-memory snapshots
-  /// as live; [FollowRepository.watchMyFollowingCached] is now one-shot,
-  /// so explicit re-load here owns the post-toggle refresh.
+  /// Delegates to the repository, which updates the in-memory follow set and
+  /// emits on [FollowRepository.followingStream]. That stream drives
+  /// [_onRepositoryUpdated] — the single source of post-toggle reactivity — so
+  /// the button reflects the new state immediately and optimistically.
+  ///
+  /// We deliberately do NOT re-dispatch [MyFollowingListLoadRequested] here.
+  /// That re-load re-read [FollowRepository.watchMyFollowingCached], whose
+  /// stale-while-revalidate cache served a pre-toggle disk snapshot first and
+  /// reverted the button (#5144). The repository invalidates that cache on
+  /// mutation, so the next load (on the next mount) is fresh.
   ///
   /// Uses [droppable] transformer to prevent concurrent toggles from
   /// racing each other (e.g. rapid taps toggling follow/unfollow/follow).
@@ -127,7 +133,6 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
 
     try {
       await _followRepository.toggleFollow(event.pubkey);
-      add(const MyFollowingListLoadRequested());
     } catch (e) {
       Log.error(
         'Failed to toggle follow for user: $e',

--- a/mobile/lib/blocs/my_following/my_following_bloc.dart
+++ b/mobile/lib/blocs/my_following/my_following_bloc.dart
@@ -67,10 +67,19 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
       await emit.forEach<CacheResult<FollowingSnapshot>>(
         _followRepository.watchMyFollowingCached(),
         onData: (result) {
+          // Once the user has toggled locally, the repository's in-memory list
+          // is the authority. The mount-time load can still be in flight when
+          // the user taps Follow; its revalidation read resolves with the
+          // relay-lagged pre-toggle snapshot and would otherwise revert the
+          // button (#5144). Defer to the repository instead of the stale
+          // emission; let the emission only drive the refreshing indicator.
+          final pubkeys = state.hasLocalFollowEdit
+              ? _followRepository.followingPubkeys
+              : result.data.pubkeys;
           return state.copyWith(
             status: MyFollowingStatus.success,
-            rawFollowingPubkeys: result.data.pubkeys,
-            followingPubkeys: _filterPubkeys(result.data.pubkeys),
+            rawFollowingPubkeys: pubkeys,
+            followingPubkeys: _filterPubkeys(pubkeys),
             isRefreshing: result.isStale,
           );
         },
@@ -120,6 +129,11 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
   /// reverted the button (#5144). The repository invalidates that cache on
   /// mutation, so the next load (on the next mount) is fresh.
   ///
+  /// On success we set [MyFollowingState.hasLocalFollowEdit] so that an
+  /// already-in-flight mount-time load (its revalidation read can still
+  /// resolve with the relay-lagged pre-toggle list) defers to the repository
+  /// instead of reverting the button — see [_onLoadRequested].
+  ///
   /// Uses [droppable] transformer to prevent concurrent toggles from
   /// racing each other (e.g. rapid taps toggling follow/unfollow/follow).
   Future<void> _onToggleRequested(
@@ -133,6 +147,9 @@ class MyFollowingBloc extends Bloc<MyFollowingEvent, MyFollowingState> {
 
     try {
       await _followRepository.toggleFollow(event.pubkey);
+      if (!state.hasLocalFollowEdit) {
+        emit(state.copyWith(hasLocalFollowEdit: true));
+      }
     } catch (e) {
       Log.error(
         'Failed to toggle follow for user: $e',

--- a/mobile/lib/blocs/my_following/my_following_state.dart
+++ b/mobile/lib/blocs/my_following/my_following_state.dart
@@ -25,6 +25,7 @@ final class MyFollowingState extends Equatable {
     this.followingPubkeys = const [],
     this.rawFollowingPubkeys = const [],
     this.isRefreshing = false,
+    this.hasLocalFollowEdit = false,
   });
 
   /// The current status of the following list.
@@ -42,6 +43,15 @@ final class MyFollowingState extends Equatable {
   /// True while stale cache data is shown and a fresh fetch is in progress.
   final bool isRefreshing;
 
+  /// True once the user has toggled follow/unfollow in this bloc's lifetime.
+  ///
+  /// After a local toggle the repository's in-memory list is the authority.
+  /// An in-flight `watchMyFollowingCached` revalidation can still resolve with
+  /// the relay-lagged pre-toggle snapshot; this flag tells the load handler to
+  /// defer to the repository instead of letting that stale emission revert the
+  /// button (#5144).
+  final bool hasLocalFollowEdit;
+
   /// Check if the current user is following a specific pubkey.
   bool isFollowing(String pubkey) => followingPubkeys.contains(pubkey);
 
@@ -51,12 +61,14 @@ final class MyFollowingState extends Equatable {
     List<String>? followingPubkeys,
     List<String>? rawFollowingPubkeys,
     bool? isRefreshing,
+    bool? hasLocalFollowEdit,
   }) {
     return MyFollowingState(
       status: status ?? this.status,
       followingPubkeys: followingPubkeys ?? this.followingPubkeys,
       rawFollowingPubkeys: rawFollowingPubkeys ?? this.rawFollowingPubkeys,
       isRefreshing: isRefreshing ?? this.isRefreshing,
+      hasLocalFollowEdit: hasLocalFollowEdit ?? this.hasLocalFollowEdit,
     );
   }
 
@@ -66,5 +78,6 @@ final class MyFollowingState extends Equatable {
     followingPubkeys,
     rawFollowingPubkeys,
     isRefreshing,
+    hasLocalFollowEdit,
   ];
 }

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -346,9 +346,11 @@ class FollowRepository {
   /// has actually run, breaking the new `isRefreshing` / [CacheResult.isLive]
   /// contract.
   ///
-  /// Ongoing follow/unfollow reactivity is handled by [MyFollowingBloc],
-  /// which re-dispatches [MyFollowingListLoadRequested] after a successful
-  /// toggle so the cache + UI both observe the new state.
+  /// Ongoing follow/unfollow reactivity is handled by [followingStream]
+  /// (the in-memory single source of truth). Local toggles and cross-device
+  /// kind 3 updates invalidate the [_myFollowingCacheKey] entry via
+  /// [_invalidateMyFollowingCache], so the next [watchMyFollowingCached] read
+  /// (on a later mount) never serves a pre-mutation snapshot (#5144).
   Stream<CacheResult<FollowingSnapshot>> watchMyFollowingCached() {
     return CacheSync.watchOne<FollowingSnapshot>(
       key: _myFollowingCacheKey(_nostrClient.publicKey),
@@ -2035,6 +2037,7 @@ class FollowRepository {
         _followingPubkeys = merged.toList();
         _emitFollowingList();
         _saveToLocalStorage();
+        _invalidateMyFollowingCache();
 
         // Re-broadcast the merged list so relays have the correct state.
         _broadcastContactList().catchError((e) {
@@ -2059,6 +2062,7 @@ class FollowRepository {
       );
 
       _saveToLocalStorage();
+      _invalidateMyFollowingCache();
     }
   }
 }

--- a/mobile/packages/follow_repository/lib/src/follow_repository.dart
+++ b/mobile/packages/follow_repository/lib/src/follow_repository.dart
@@ -279,6 +279,27 @@ class FollowRepository {
   static String _othersFollowingCacheKey(String pubkey) =>
       '$pubkey:others_following';
 
+  /// Best-effort invalidation of the cached following-list snapshot.
+  ///
+  /// `follow`/`unfollow` and the offline-sync/merge paths mutate the in-memory
+  /// list and SharedPreferences but never the CacheSync disk entry. Without
+  /// this, the next [watchMyFollowingCached] read serves a pre-mutation
+  /// snapshot and the follow-button state reverts (#5144). Invalidation is
+  /// non-fatal: a cache failure must not fail an otherwise-successful follow.
+  Future<void> _invalidateMyFollowingCache() async {
+    final pubkey = _nostrClient.publicKey;
+    if (pubkey.isEmpty) return;
+    try {
+      await CacheSync.invalidate(_myFollowingCacheKey(pubkey));
+    } on Exception catch (e) {
+      Log.warning(
+        'Failed to invalidate my_following cache: $e',
+        name: 'FollowRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
   /// Cache-backed stream of the current user's followers.
   ///
   /// Emits a [CacheResult.cached] if disk-cached data exists, then a single
@@ -1254,6 +1275,7 @@ class FollowRepository {
     // 1. Update in-memory cache immediately
     _followingPubkeys = [..._followingPubkeys, pubkey];
     _emitFollowingList();
+    await _invalidateMyFollowingCache();
 
     // Check if offline and queue if needed
     if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
@@ -1311,6 +1333,7 @@ class FollowRepository {
       _followingPubkeys = [..._followingPubkeys, pubkey];
       _emitFollowingList();
     }
+    await _invalidateMyFollowingCache();
 
     // Broadcast to network
     await _broadcastContactList();
@@ -1367,6 +1390,7 @@ class FollowRepository {
     // 1. Update in-memory cache immediately
     _followingPubkeys = _followingPubkeys.where((p) => p != pubkey).toList();
     _emitFollowingList();
+    await _invalidateMyFollowingCache();
 
     // Check if offline and queue if needed
     if (_isOnline != null && !_isOnline() && _queueOfflineAction != null) {
@@ -1424,6 +1448,7 @@ class FollowRepository {
       _followingPubkeys = _followingPubkeys.where((p) => p != pubkey).toList();
       _emitFollowingList();
     }
+    await _invalidateMyFollowingCache();
 
     // Broadcast to network
     await _broadcastContactList();
@@ -1452,6 +1477,7 @@ class FollowRepository {
         !merged.every(_followingPubkeys.contains)) {
       _followingPubkeys = merged.toList();
       _emitFollowingList();
+      await _invalidateMyFollowingCache();
 
       // Broadcast the merged list
       await _broadcastContactList();

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -82,6 +82,13 @@ class _FakeRelay extends RelayBase {
 
 class _FakeContactList extends Fake implements ContactList {}
 
+/// A [FakeCacheDao] whose [delete] always throws, to exercise the non-fatal
+/// cache-invalidation failure path in `_invalidateMyFollowingCache`.
+class _ThrowingDeleteCacheDao extends FakeCacheDao {
+  @override
+  Future<void> delete(String key) async => throw Exception('delete failed');
+}
+
 void main() {
   group('FollowRepository', () {
     late FollowRepository repository;
@@ -671,6 +678,70 @@ void main() {
           await cacheDao.read(myFollowingKey(testCurrentUserPubkey)),
           isNull,
         );
+      });
+
+      test(
+        'cross-device Kind 3 update invalidates the my_following cache entry',
+        () async {
+          final realTimeStreamController = StreamController<Event>.broadcast();
+          addTearDown(() async {
+            await repository.dispose();
+            await realTimeStreamController.close();
+          });
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              onEose: any(named: 'onEose'),
+            ),
+          ).thenAnswer((_) => realTimeStreamController.stream);
+
+          await repository.initialize();
+          await cacheDao.write(
+            key: myFollowingKey(testCurrentUserPubkey),
+            payload: const FollowingSnapshot(
+              pubkeys: [testTargetPubkey2],
+              count: 1,
+            ).toJson(),
+          );
+          expect(
+            await cacheDao.read(myFollowingKey(testCurrentUserPubkey)),
+            isNotNull,
+          );
+
+          // A newer Kind 3 event arrives from another device.
+          realTimeStreamController.add(
+            Event(
+              testCurrentUserPubkey,
+              3,
+              [
+                ['p', testTargetPubkey],
+              ],
+              '',
+              createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000 + 100,
+            ),
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          expect(repository.followingPubkeys, contains(testTargetPubkey));
+          expect(
+            await cacheDao.read(myFollowingKey(testCurrentUserPubkey)),
+            isNull,
+          );
+        },
+      );
+
+      test('follow() succeeds even when cache invalidation throws', () async {
+        await CacheSync.init(dao: _ThrowingDeleteCacheDao());
+        stubBroadcastSuccess();
+
+        await repository.follow(testTargetPubkey);
+
+        expect(repository.followingPubkeys, contains(testTargetPubkey));
       });
     });
 

--- a/mobile/packages/follow_repository/test/src/follow_repository_test.dart
+++ b/mobile/packages/follow_repository/test/src/follow_repository_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:cache_sync/cache_sync.dart';
 import 'package:db_client/db_client.dart' hide Filter;
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -13,6 +14,8 @@ import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../cache_sync/test/fake_cache_dao.dart';
 
 class _MockNostrClient extends Mock implements NostrClient {}
 
@@ -83,6 +86,7 @@ void main() {
   group('FollowRepository', () {
     late FollowRepository repository;
     late _MockNostrClient mockNostrClient;
+    late FakeCacheDao cacheDao;
     late bool cacheIsInitialized;
     late List<Event> Function(int kind) getCachedEventsByKind;
     late List<Event> cachedUserEvents;
@@ -103,6 +107,9 @@ void main() {
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
+
+      cacheDao = FakeCacheDao();
+      await CacheSync.init(dao: cacheDao);
 
       mockNostrClient = _MockNostrClient();
       cacheIsInitialized = false;
@@ -594,6 +601,75 @@ void main() {
               contains('Failed to broadcast'),
             ),
           ),
+        );
+      });
+    });
+
+    group('CacheSync invalidation on mutation (#5144)', () {
+      String myFollowingKey(String pubkey) => '$pubkey:my_following';
+
+      void stubBroadcastSuccess() {
+        final mockEvent = _MockEvent();
+        when(() => mockEvent.id).thenReturn(testCurrentUserPubkey);
+        when(() => mockEvent.content).thenReturn('');
+        when(
+          () => mockNostrClient.sendContactList(
+            any(),
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => mockEvent);
+      }
+
+      test('follow() invalidates the my_following cache entry', () async {
+        stubBroadcastSuccess();
+        await cacheDao.write(
+          key: myFollowingKey(testCurrentUserPubkey),
+          payload: const FollowingSnapshot(
+            pubkeys: [testTargetPubkey2],
+            count: 1,
+          ).toJson(),
+        );
+        expect(
+          await cacheDao.read(myFollowingKey(testCurrentUserPubkey)),
+          isNotNull,
+        );
+
+        await repository.follow(testTargetPubkey);
+
+        expect(
+          await cacheDao.read(myFollowingKey(testCurrentUserPubkey)),
+          isNull,
+        );
+      });
+
+      test('unfollow() invalidates the my_following cache entry', () async {
+        SharedPreferences.setMockInitialValues({
+          'following_list_$testCurrentUserPubkey': '["$testTargetPubkey"]',
+        });
+        repository = FollowRepository(
+          nostrClient: mockNostrClient,
+          isCacheInitialized: () => cacheIsInitialized,
+          getCachedEventsByKind: (kind) => getCachedEventsByKind(kind),
+          cacheUserEvent: cachedUserEvents.add,
+          indexerRelayUrls: const [],
+        );
+        await repository.initialize();
+        stubBroadcastSuccess();
+        await cacheDao.write(
+          key: myFollowingKey(testCurrentUserPubkey),
+          payload: const FollowingSnapshot(
+            pubkeys: [testTargetPubkey],
+            count: 1,
+          ).toJson(),
+        );
+
+        await repository.unfollow(testTargetPubkey);
+
+        expect(
+          await cacheDao.read(myFollowingKey(testCurrentUserPubkey)),
+          isNull,
         );
       });
     });

--- a/mobile/test/blocs/my_following/my_following_bloc_test.dart
+++ b/mobile/test/blocs/my_following/my_following_bloc_test.dart
@@ -234,30 +234,87 @@ void main() {
       );
 
       blocTest<MyFollowingBloc, MyFollowingState>(
-        're-dispatches load after successful toggle so cache layer '
-        're-observes new follow set',
+        'does not re-dispatch a load after a successful toggle (#5144)',
         setUp: () {
           when(
             () => mockFollowRepository.toggleFollow(any()),
           ).thenAnswer((_) async {});
-          when(() => mockFollowRepository.watchMyFollowingCached()).thenAnswer(
-            (_) => Stream.value(
-              CacheResult.live(
-                FollowingSnapshot(pubkeys: [validPubkey('user')], count: 1),
-              ),
-            ),
-          );
+          when(
+            () => mockFollowRepository.watchMyFollowingCached(),
+          ).thenAnswer((_) => const Stream.empty());
         },
         build: createBloc,
         act: (bloc) =>
             bloc.add(MyFollowingToggleRequested(validPubkey('user'))),
         verify: (_) {
-          // Toggle issues the relay write and the BLoC re-fetches via
-          // watchMyFollowingCached so the disk cache layer + UI both
-          // observe the new state (replaces the old BehaviorSubject-replay
-          // reactivity that broke the stale/live contract).
           verify(() => mockFollowRepository.toggleFollow(any())).called(1);
-          verify(() => mockFollowRepository.watchMyFollowingCached()).called(1);
+          // The post-toggle re-load that surfaced a stale cached snapshot and
+          // reverted the button (#5144) is gone — reactivity comes from
+          // followingStream/_onRepositoryUpdated, not a watchMyFollowingCached
+          // re-read.
+          verifyNever(() => mockFollowRepository.watchMyFollowingCached());
+        },
+      );
+
+      test(
+        'does not revert follow state after a successful toggle (#5144)',
+        () async {
+          final pubkey = validPubkey('target');
+          final following = <String>[];
+          final followingController =
+              StreamController<List<String>>.broadcast();
+          addTearDown(followingController.close);
+
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn(following);
+          when(
+            () => mockFollowRepository.followingStream,
+          ).thenAnswer((_) => followingController.stream);
+          // If the (now-removed) re-load ran, watchMyFollowingCached would
+          // serve a STALE cached snapshot that does NOT contain pubkey —
+          // exactly what reverted the button before the fix.
+          when(() => mockFollowRepository.watchMyFollowingCached()).thenAnswer(
+            (_) => Stream.value(
+              const CacheResult.cached(
+                FollowingSnapshot(pubkeys: [], count: 0),
+              ),
+            ),
+          );
+          when(() => mockFollowRepository.toggleFollow(pubkey)).thenAnswer((
+            _,
+          ) async {
+            following.add(pubkey);
+            followingController.add(List.of(following));
+          });
+
+          final bloc = createBloc();
+          final isFollowingStates = <bool>[];
+          final sub = bloc.stream.listen(
+            (state) => isFollowingStates.add(state.isFollowing(pubkey)),
+          );
+
+          bloc.add(const MyFollowingListLoadRequested());
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(MyFollowingToggleRequested(pubkey));
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          final firstFollowed = isFollowingStates.indexOf(true);
+          expect(
+            firstFollowed,
+            isNonNegative,
+            reason: 'the follow should register as Following',
+          );
+          expect(
+            isFollowingStates.sublist(firstFollowed),
+            everyElement(isTrue),
+            reason:
+                'follow state must never revert to not-following after a '
+                'successful toggle (#5144)',
+          );
+
+          await sub.cancel();
+          await bloc.close();
         },
       );
 

--- a/mobile/test/blocs/my_following/my_following_bloc_test.dart
+++ b/mobile/test/blocs/my_following/my_following_bloc_test.dart
@@ -318,6 +318,74 @@ void main() {
         },
       );
 
+      test(
+        'does not revert when an in-flight load emits stale data after a '
+        'toggle (#5144)',
+        () async {
+          final pubkey = validPubkey('target');
+          final following = <String>[];
+          final followingController =
+              StreamController<List<String>>.broadcast();
+          final loadController =
+              StreamController<CacheResult<FollowingSnapshot>>();
+          addTearDown(followingController.close);
+          addTearDown(loadController.close);
+
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn(following);
+          when(
+            () => mockFollowRepository.followingStream,
+          ).thenAnswer((_) => followingController.stream);
+          // The mount-time load is still in flight (no emission yet) when the
+          // user taps Follow.
+          when(
+            () => mockFollowRepository.watchMyFollowingCached(),
+          ).thenAnswer((_) => loadController.stream);
+          when(() => mockFollowRepository.toggleFollow(pubkey)).thenAnswer((
+            _,
+          ) async {
+            following.add(pubkey);
+            followingController.add(List.of(following));
+          });
+
+          final bloc = createBloc();
+          final isFollowingStates = <bool>[];
+          final sub = bloc.stream.listen(
+            (state) => isFollowingStates.add(state.isFollowing(pubkey)),
+          );
+
+          bloc.add(const MyFollowingListLoadRequested());
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(MyFollowingToggleRequested(pubkey));
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          // The in-flight load's network revalidation now resolves with the
+          // relay-lagged pre-follow (stale) list — the surviving #5144 race.
+          loadController.add(
+            const CacheResult.live(FollowingSnapshot(pubkeys: [], count: 0)),
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+
+          final firstFollowed = isFollowingStates.indexOf(true);
+          expect(
+            firstFollowed,
+            isNonNegative,
+            reason: 'the follow should register as Following',
+          );
+          expect(
+            isFollowingStates.sublist(firstFollowed),
+            everyElement(isTrue),
+            reason:
+                'a stale in-flight load emission must not revert the button '
+                'after a successful toggle (#5144)',
+          );
+
+          await sub.cancel();
+          await bloc.close();
+        },
+      );
+
       blocTest<MyFollowingBloc, MyFollowingState>(
         'emits toggleFailure when toggleFollow throws',
         setUp: () {


### PR DESCRIPTION
Fixes #5144.

Tapping Follow flipped the button straight back to Follow. The bloc re-loaded the following list after every toggle, and that reload served the cache's pre-follow snapshot first — so the button reverted. I dropped the reload (followingStream already updates the UI optimistically) and the repo now clears the my_following cache on follow/unfollow so the next load is fresh. Added restartable() on the load handler too.

New bloc test reproduces it: fails `[true, false]` with the old reload in place, passes without. I also ran a probe against the real funnelcake relay + ClickHouse — an immediate read-back returns the stale list for ~120–175ms after publish (the relay OKs on enqueue, the read-back beats the batch flush), so that reload was never a reliable refresh anyway.
