### PR TITLE
feat(video-recorder): auto lens switch with pinch zoom ruler

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -203,6 +203,7 @@ class VideoRecorderBloc
     on<_VideoRecorderRemoteRecordTriggered>(_onRemoteRecordTriggered);
     on<_VideoRecorderAutoStopped>(_onAutoStopped);
     on<_VideoRecorderFocusPointTimerFired>(_onFocusPointTimerFired);
+    on<_VideoRecorderZoomIndicatorTimerFired>(_onZoomIndicatorTimerFired);
   }
 
   final ReadClipManager _readClipManager;
@@ -217,7 +218,12 @@ class VideoRecorderBloc
   AudioPlaybackService? _audioPlaybackService;
   CountdownSoundService? _countdownSoundService;
   Timer? _focusPointTimer;
+  Timer? _zoomIndicatorTimer;
   bool _remoteRecordControlEnabled = false;
+
+  /// How long the zoom ruler stays visible after the last pinch activity
+  /// before the auto-hide timer clears it.
+  static const _zoomIndicatorHideDelay = Duration(milliseconds: 1000);
 
   /// The current active camera lens. Delegates to the camera service.
   DivineCameraLens get currentLens => _cameraService.currentLens;
@@ -264,6 +270,7 @@ class VideoRecorderBloc
       await _cameraService.initialize(
         videoQuality: event.videoQuality,
         initialLens: initialLens,
+        enableAutoLensSwitch: true,
       );
     } catch (e) {
       Log.error(
@@ -475,7 +482,8 @@ class VideoRecorderBloc
       );
       return;
     }
-    emit(state.copyWith(zoomLevel: event.value));
+    emit(state.copyWith(zoomLevel: event.value, showZoomIndicator: true));
+    _armZoomIndicatorHideTimer();
   }
 
   Future<void> _onFocusPointSet(
@@ -923,23 +931,23 @@ class VideoRecorderBloc
         baseZoomLevel: state.zoomLevel,
         snappedTo1x: false,
         lastRawZoom: state.zoomLevel,
+        showZoomIndicator: true,
       ),
     );
+    _armZoomIndicatorHideTimer();
   }
 
   Future<void> _onScaleUpdated(
     VideoRecorderScaleUpdated event,
     Emitter<VideoRecorderBlocState> emit,
   ) async {
-    final scaleChange = event.details.scale - 1.0;
-    final normalizedChange = scaleChange.clamp(-1.0, 2.0);
-
-    final zoomRangeDown = state.baseZoomLevel - _cameraService.minZoomLevel;
-    final zoomRangeUp = _cameraService.maxZoomLevel - state.baseZoomLevel;
-
-    final newZoom = normalizedChange >= 0
-        ? state.baseZoomLevel + (normalizedChange / 2.0) * zoomRangeUp
-        : state.baseZoomLevel + normalizedChange * zoomRangeDown;
+    // Multiplicative mapping: the cumulative pinch scale multiplies the zoom
+    // captured at gesture start, so the perceived sensitivity is uniform
+    // across the whole range (1×→2× feels like 2×→4×). The previous
+    // range-proportional mapping made the gain depend on the starting zoom —
+    // fast far from a bound, sluggish near max — and differed between
+    // zoom-in and zoom-out.
+    final newZoom = state.baseZoomLevel * event.details.scale;
 
     var clampedZoom = newZoom.clamp(
       _cameraService.minZoomLevel,
@@ -972,6 +980,8 @@ class VideoRecorderBloc
         snapped = true;
         snapTime = DateTime.now();
         clampedZoom = 1.0;
+        // Confirm the 1× detent engagement with a light tick.
+        unawaited(HapticService.snapFeedback());
       }
 
       if (snapped) {
@@ -989,12 +999,33 @@ class VideoRecorderBloc
         lastRawZoom: clampedZoom,
         snappedTo1x: snapped,
         snapTime: snapTime,
+        showZoomIndicator: true,
       ),
     );
+    _armZoomIndicatorHideTimer();
 
     if ((state.zoomLevel - clampedZoom).abs() > 0.01) {
       add(VideoRecorderZoomLevelSet(clampedZoom));
     }
+  }
+
+  /// (Re)starts the zoom-ruler auto-hide countdown. Called on every pinch
+  /// activity so the ruler stays up while the user is zooming and fades a
+  /// short while after the gesture settles.
+  void _armZoomIndicatorHideTimer() {
+    _zoomIndicatorTimer?.cancel();
+    _zoomIndicatorTimer = Timer(_zoomIndicatorHideDelay, () {
+      if (isClosed) return;
+      add(const _VideoRecorderZoomIndicatorTimerFired());
+    });
+  }
+
+  void _onZoomIndicatorTimerFired(
+    _VideoRecorderZoomIndicatorTimerFired event,
+    Emitter<VideoRecorderBlocState> emit,
+  ) {
+    _zoomIndicatorTimer = null;
+    emit(state.copyWith(showZoomIndicator: false));
   }
 
   Future<void> _onCameraPausedForNavigation(
@@ -1126,6 +1157,8 @@ class VideoRecorderBloc
         cameraRebuildCount: cameraRebuildCount ?? state.cameraRebuildCount,
         aspectRatio: aspectRatio ?? state.aspectRatio,
         flashMode: DivineFlashMode.off,
+        minZoomLevel: _cameraService.minZoomLevel,
+        maxZoomLevel: _cameraService.maxZoomLevel,
         cameraSensorAspectRatio: _cameraService.cameraAspectRatio,
         canRecord: _cameraService.canRecord,
         isCameraInitialized: _cameraService.isInitialized,
@@ -1318,6 +1351,8 @@ class VideoRecorderBloc
     );
     _focusPointTimer?.cancel();
     _focusPointTimer = null;
+    _zoomIndicatorTimer?.cancel();
+    _zoomIndicatorTimer = null;
     try {
       await _audioPlaybackService?.dispose();
       _audioPlaybackService = null;

--- a/mobile/lib/blocs/video_recorder/video_recorder_event.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_event.dart
@@ -270,3 +270,9 @@ final class _VideoRecorderAutoStopped extends VideoRecorderEvent {
 final class _VideoRecorderFocusPointTimerFired extends VideoRecorderEvent {
   const _VideoRecorderFocusPointTimerFired();
 }
+
+/// Internal event: the zoom-indicator auto-hide timer fired. Clears
+/// [VideoRecorderBlocState.showZoomIndicator] once the pinch settles.
+final class _VideoRecorderZoomIndicatorTimerFired extends VideoRecorderEvent {
+  const _VideoRecorderZoomIndicatorTimerFired();
+}

--- a/mobile/lib/blocs/video_recorder/video_recorder_state.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_state.dart
@@ -11,6 +11,8 @@ class VideoRecorderBlocState extends Equatable {
     this.recorderMode = VideoRecorderMode.capture,
     this.recordingState = VideoRecorderState.idle,
     this.zoomLevel = 1.0,
+    this.minZoomLevel = 1.0,
+    this.maxZoomLevel = 1.0,
     this.cameraSensorAspectRatio = 1.0,
     this.focusPoint = Offset.zero,
     this.canRecord = false,
@@ -35,6 +37,7 @@ class VideoRecorderBlocState extends Equatable {
     this.snappedTo1x = false,
     this.lastRawZoom = 1.0,
     this.snapTime,
+    this.showZoomIndicator = false,
   });
 
   /// Recorder mode from the camera.
@@ -55,8 +58,17 @@ class VideoRecorderBlocState extends Equatable {
   /// Whether the camera has flash capability.
   final bool hasFlash;
 
-  /// Current zoom level.
+  /// Current zoom level (user-facing, e.g. 0.5× ultra-wide, 1.0× wide).
   final double zoomLevel;
+
+  /// Minimum zoom level supported by the active camera.
+  ///
+  /// With auto lens switching this is < 1.0 on devices with an ultra-wide
+  /// lens (e.g. 0.5×); otherwise it equals 1.0.
+  final double minZoomLevel;
+
+  /// Maximum zoom level supported by the active camera.
+  final double maxZoomLevel;
 
   /// Aspect ratio of the camera sensor.
   final double cameraSensorAspectRatio;
@@ -126,6 +138,13 @@ class VideoRecorderBlocState extends Equatable {
   /// hold duration before releasing back to free-scrubbing.
   final DateTime? snapTime;
 
+  /// Whether the Android-style zoom ruler should be visible.
+  ///
+  /// Driven by pinch activity: set true while zooming and for a short
+  /// hold afterwards, then cleared by the auto-hide timer so the ruler
+  /// only shows up while the user is actively changing the zoom.
+  final bool showZoomIndicator;
+
   /// Whether currently recording.
   bool get isRecording => recordingState == VideoRecorderState.recording;
 
@@ -146,6 +165,8 @@ class VideoRecorderBlocState extends Equatable {
     VideoRecorderMode? recorderMode,
     VideoRecorderState? recordingState,
     double? zoomLevel,
+    double? minZoomLevel,
+    double? maxZoomLevel,
     double? cameraSensorAspectRatio,
     Offset? focusPoint,
     bool? canRecord,
@@ -167,11 +188,14 @@ class VideoRecorderBlocState extends Equatable {
     bool? snappedTo1x,
     double? lastRawZoom,
     DateTime? snapTime,
+    bool? showZoomIndicator,
   }) {
     return VideoRecorderBlocState(
       recorderMode: recorderMode ?? this.recorderMode,
       recordingState: recordingState ?? this.recordingState,
       zoomLevel: zoomLevel ?? this.zoomLevel,
+      minZoomLevel: minZoomLevel ?? this.minZoomLevel,
+      maxZoomLevel: maxZoomLevel ?? this.maxZoomLevel,
       cameraSensorAspectRatio:
           cameraSensorAspectRatio ?? this.cameraSensorAspectRatio,
       focusPoint: focusPoint ?? this.focusPoint,
@@ -196,6 +220,7 @@ class VideoRecorderBlocState extends Equatable {
       snappedTo1x: snappedTo1x ?? this.snappedTo1x,
       lastRawZoom: lastRawZoom ?? this.lastRawZoom,
       snapTime: snapTime ?? this.snapTime,
+      showZoomIndicator: showZoomIndicator ?? this.showZoomIndicator,
     );
   }
 
@@ -204,6 +229,8 @@ class VideoRecorderBlocState extends Equatable {
     recorderMode,
     recordingState,
     zoomLevel,
+    minZoomLevel,
+    maxZoomLevel,
     cameraSensorAspectRatio,
     focusPoint,
     canRecord,
@@ -225,5 +252,6 @@ class VideoRecorderBlocState extends Equatable {
     snappedTo1x,
     lastRawZoom,
     snapTime,
+    showZoomIndicator,
   ];
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3306,6 +3306,7 @@
     "videoRecorderTapToStartLabel": "መቅዳት ለመጀመር የትኛውም ቦታ ላይ መታ ያድርጉ",
     "videoRecorderDeleteLastClipLabel": "የመጨረሻውን ቅንጥብ ሰርዝ",
     "videoRecorderSwitchCameraLabel": "ካሜራ ቀይር",
+    "videoRecorderZoomLevelLabel": "ወደ {zoom}× አጉላ",
     "videoRecorderToggleGridLabel": "ፍርግርግ ቀያይር",
     "videoRecorderToggleGhostFrameLabel": "የGhost ፍሬም ሁኔታ ቀይር",
     "videoRecorderGhostFrameEnabled": "Ghost ፍሬም በርቷል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3027,6 +3027,7 @@
     "videoRecorderStartRecordingTooltip": "بدء التسجيل",
     "videoRecorderStopRecordingTooltip": "إيقاف التسجيل",
     "videoRecorderSwitchCameraLabel": "تبديل الكاميرا",
+    "videoRecorderZoomLevelLabel": "تكبير إلى {zoom}×",
     "videoRecorderTapToStartLabel": "اضغط في أي مكان لبدء التسجيل",
     "videoRecorderToggleAspectRatioLabel": "تبديل نسبة العرض إلى الارتفاع",
     "videoRecorderToggleFlashLabel": "تبديل الفلاش",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2996,6 +2996,7 @@
     "videoRecorderTapToStartLabel": "Докосни произволно място, за да започнете да записвате",
     "videoRecorderDeleteLastClipLabel": "Изтрий последния клип",
     "videoRecorderSwitchCameraLabel": "Смени камерата",
+    "videoRecorderZoomLevelLabel": "Мащабиране до {zoom}×",
     "videoRecorderToggleGridLabel": "Превключване на мрежата",
     "videoRecorderToggleGhostFrameLabel": "Превключване на призрачна рамка",
     "videoRecorderGhostFrameEnabled": "Рамката призрак е активирана",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2746,6 +2746,7 @@
     "videoRecorderTapToStartLabel": "Tippe irgendwo, um die Aufnahme zu starten",
     "videoRecorderDeleteLastClipLabel": "Letzten Clip löschen",
     "videoRecorderSwitchCameraLabel": "Kamera wechseln",
+    "videoRecorderZoomLevelLabel": "Auf {zoom}× zoomen",
     "videoRecorderToggleGridLabel": "Raster ein-/ausblenden",
     "videoRecorderToggleGhostFrameLabel": "Geisterbild ein-/ausblenden",
     "videoRecorderGhostFrameEnabled": "Geisterbild aktiviert",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4315,7 +4315,7 @@
   "videoRecorderSwitchCameraLabel": "Switch camera",
   "videoRecorderZoomLevelLabel": "Zoom to {zoom}×",
   "@videoRecorderZoomLevelLabel": {
-    "description": "Accessibility label for a camera zoom quick-stop button in the lens picker. {zoom} is a zoom factor like 0.5, 1, or 2.",
+    "description": "Accessibility label for the transient camera zoom ruler shown while pinch-zooming. {zoom} is a zoom factor like 0.5, 1, or 2.",
     "placeholders": {
       "zoom": {
         "type": "String"

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4313,6 +4313,15 @@
   "videoRecorderTapToStartLabel": "Tap anywhere to start recording",
   "videoRecorderDeleteLastClipLabel": "Delete last clip",
   "videoRecorderSwitchCameraLabel": "Switch camera",
+  "videoRecorderZoomLevelLabel": "Zoom to {zoom}×",
+  "@videoRecorderZoomLevelLabel": {
+    "description": "Accessibility label for a camera zoom quick-stop button in the lens picker. {zoom} is a zoom factor like 0.5, 1, or 2.",
+    "placeholders": {
+      "zoom": {
+        "type": "String"
+      }
+    }
+  },
   "videoRecorderToggleGridLabel": "Toggle grid",
   "videoRecorderToggleGhostFrameLabel": "Toggle ghost frame",
   "videoRecorderGhostFrameEnabled": "Ghost frame enabled",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2754,6 +2754,7 @@
     "videoRecorderTapToStartLabel": "Toca en cualquier lugar para iniciar la grabación",
     "videoRecorderDeleteLastClipLabel": "Eliminar último clip",
     "videoRecorderSwitchCameraLabel": "Cambiar cámara",
+    "videoRecorderZoomLevelLabel": "Zoom a {zoom}×",
     "videoRecorderToggleGridLabel": "Mostrar u ocultar cuadrícula",
     "videoRecorderToggleGhostFrameLabel": "Mostrar u ocultar fotograma fantasma",
     "videoRecorderGhostFrameEnabled": "Fotograma fantasma activado",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1663,6 +1663,7 @@
     "videoRecorderTapToStartLabel": "I-tap kahit saan para magsimulang mag-record",
     "videoRecorderDeleteLastClipLabel": "Burahin ang huling clip",
     "videoRecorderSwitchCameraLabel": "Magpalit ng camera",
+    "videoRecorderZoomLevelLabel": "I-zoom sa {zoom}×",
     "videoRecorderToggleGridLabel": "I-toggle ang grid",
     "videoRecorderToggleGhostFrameLabel": "I-toggle ang ghost frame",
     "videoRecorderGhostFrameEnabled": "Naka-enable ang ghost frame",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2746,6 +2746,7 @@
     "videoRecorderTapToStartLabel": "Appuyez n'importe où pour démarrer l'enregistrement",
     "videoRecorderDeleteLastClipLabel": "Supprimer le dernier clip",
     "videoRecorderSwitchCameraLabel": "Changer de caméra",
+    "videoRecorderZoomLevelLabel": "Zoomer à {zoom}×",
     "videoRecorderToggleGridLabel": "Afficher/masquer la grille",
     "videoRecorderToggleGhostFrameLabel": "Afficher/masquer le cadre fantôme",
     "videoRecorderGhostFrameEnabled": "Cadre fantôme activé",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3034,6 +3034,7 @@
     "videoRecorderStartRecordingTooltip": "Mulai merekam",
     "videoRecorderStopRecordingTooltip": "Hentikan perekaman",
     "videoRecorderSwitchCameraLabel": "Ganti kamera",
+    "videoRecorderZoomLevelLabel": "Zoom ke {zoom}×",
     "videoRecorderTapToStartLabel": "Ketuk di mana saja untuk mulai merekam",
     "videoRecorderToggleAspectRatioLabel": "Ganti rasio aspek",
     "videoRecorderToggleFlashLabel": "Ganti flash",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2746,6 +2746,7 @@
     "videoRecorderTapToStartLabel": "Tocca ovunque per avviare la registrazione",
     "videoRecorderDeleteLastClipLabel": "Elimina ultimo clip",
     "videoRecorderSwitchCameraLabel": "Cambia fotocamera",
+    "videoRecorderZoomLevelLabel": "Zoom a {zoom}×",
     "videoRecorderToggleGridLabel": "Mostra/nascondi griglia",
     "videoRecorderToggleGhostFrameLabel": "Mostra/nascondi fotogramma fantasma",
     "videoRecorderGhostFrameEnabled": "Fotogramma fantasma attivato",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3027,6 +3027,7 @@
     "videoRecorderStartRecordingTooltip": "録画を開始",
     "videoRecorderStopRecordingTooltip": "録画を停止",
     "videoRecorderSwitchCameraLabel": "カメラを切り替え",
+    "videoRecorderZoomLevelLabel": "{zoom}× にズーム",
     "videoRecorderTapToStartLabel": "どこかタップして録画を開始",
     "videoRecorderToggleAspectRatioLabel": "アスペクト比を切り替え",
     "videoRecorderToggleFlashLabel": "フラッシュを切り替え",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2323,6 +2323,7 @@
     "videoRecorderStartRecordingTooltip": "녹화 시작",
     "videoRecorderStopRecordingTooltip": "녹화 중지",
     "videoRecorderSwitchCameraLabel": "카메라 전환",
+    "videoRecorderZoomLevelLabel": "{zoom}×로 확대",
     "videoRecorderTapToStartLabel": "아무 곳이나 탭하여 녹화 시작",
     "videoRecorderToggleAspectRatioLabel": "화면 비율 전환",
     "videoRecorderToggleFlashLabel": "플래시 전환",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2746,6 +2746,7 @@
     "videoRecorderTapToStartLabel": "Tik ergens om de opname te starten",
     "videoRecorderDeleteLastClipLabel": "Laatste clip verwijderen",
     "videoRecorderSwitchCameraLabel": "Camera wisselen",
+    "videoRecorderZoomLevelLabel": "Zoomen naar {zoom}×",
     "videoRecorderToggleGridLabel": "Raster in-/uitschakelen",
     "videoRecorderToggleGhostFrameLabel": "Spookframe in-/uitschakelen",
     "videoRecorderGhostFrameEnabled": "Spookframe ingeschakeld",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2746,6 +2746,7 @@
     "videoRecorderTapToStartLabel": "Dotknij dowolnego miejsca, aby rozpocząć nagrywanie",
     "videoRecorderDeleteLastClipLabel": "Usuń ostatni klip",
     "videoRecorderSwitchCameraLabel": "Przełącz aparat",
+    "videoRecorderZoomLevelLabel": "Powiększ do {zoom}×",
     "videoRecorderToggleGridLabel": "Przełącz siatkę",
     "videoRecorderToggleGhostFrameLabel": "Przełącz klatkę odniesienia",
     "videoRecorderGhostFrameEnabled": "Klatka odniesienia włączona",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2746,6 +2746,7 @@
     "videoRecorderTapToStartLabel": "Toque em qualquer lugar para iniciar a gravação",
     "videoRecorderDeleteLastClipLabel": "Excluir último clipe",
     "videoRecorderSwitchCameraLabel": "Trocar câmera",
+    "videoRecorderZoomLevelLabel": "Zoom para {zoom}×",
     "videoRecorderToggleGridLabel": "Alternar grade",
     "videoRecorderToggleGhostFrameLabel": "Alternar quadro fantasma",
     "videoRecorderGhostFrameEnabled": "Quadro fantasma ativado",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2746,6 +2746,7 @@
     "videoRecorderTapToStartLabel": "Atinge oriunde pentru a începe înregistrarea",
     "videoRecorderDeleteLastClipLabel": "Șterge ultimul clip",
     "videoRecorderSwitchCameraLabel": "Schimbă camera",
+    "videoRecorderZoomLevelLabel": "Zoom la {zoom}×",
     "videoRecorderToggleGridLabel": "Activează/dezactivează grila",
     "videoRecorderToggleGhostFrameLabel": "Activează/dezactivează cadrul fantomă",
     "videoRecorderGhostFrameEnabled": "Cadru fantomă activat",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2746,6 +2746,7 @@
     "videoRecorderTapToStartLabel": "Tryck var som helst för att starta inspelningen",
     "videoRecorderDeleteLastClipLabel": "Ta bort senaste klippet",
     "videoRecorderSwitchCameraLabel": "Byt kamera",
+    "videoRecorderZoomLevelLabel": "Zooma till {zoom}×",
     "videoRecorderToggleGridLabel": "Växla rutnät",
     "videoRecorderToggleGhostFrameLabel": "Växla spökram",
     "videoRecorderGhostFrameEnabled": "Spökram aktiverad",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3034,6 +3034,7 @@
     "videoRecorderStartRecordingTooltip": "Kaydı başlat",
     "videoRecorderStopRecordingTooltip": "Kaydı durdur",
     "videoRecorderSwitchCameraLabel": "Kamerayı değiştir",
+    "videoRecorderZoomLevelLabel": "{zoom}× yakınlaştır",
     "videoRecorderTapToStartLabel": "Kaydı başlatmak için herhangi bir yere dokunun",
     "videoRecorderToggleAspectRatioLabel": "En-boy oranını değiştir",
     "videoRecorderToggleFlashLabel": "Flaşı değiştir",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13286,6 +13286,12 @@ abstract class AppLocalizations {
   /// **'Switch camera'**
   String get videoRecorderSwitchCameraLabel;
 
+  /// Accessibility label for a camera zoom quick-stop button in the lens picker. {zoom} is a zoom factor like 0.5, 1, or 2.
+  ///
+  /// In en, this message translates to:
+  /// **'Zoom to {zoom}×'**
+  String videoRecorderZoomLevelLabel(String zoom);
+
   /// No description provided for @videoRecorderToggleGridLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13286,7 +13286,7 @@ abstract class AppLocalizations {
   /// **'Switch camera'**
   String get videoRecorderSwitchCameraLabel;
 
-  /// Accessibility label for a camera zoom quick-stop button in the lens picker. {zoom} is a zoom factor like 0.5, 1, or 2.
+  /// Accessibility label for the transient camera zoom ruler shown while pinch-zooming. {zoom} is a zoom factor like 0.5, 1, or 2.
   ///
   /// In en, this message translates to:
   /// **'Zoom to {zoom}×'**

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7505,6 +7505,11 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'ካሜራ ቀይር';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'ወደ $zoom× አጉላ';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'ፍርግርግ ቀያይር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7580,6 +7580,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'تبديل الكاميرا';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'تكبير إلى $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'تبديل الشبكة';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7707,6 +7707,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Смени камерата';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Мащабиране до $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Превключване на мрежата';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7721,6 +7721,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Kamera wechseln';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Auf $zoom× zoomen';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Raster ein-/ausblenden';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7638,6 +7638,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Switch camera';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zoom to $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Toggle grid';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7706,6 +7706,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Cambiar cámara';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zoom a $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Mostrar u ocultar cuadrícula';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7725,6 +7725,11 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Magpalit ng camera';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'I-zoom sa $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'I-toggle ang grid';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7732,6 +7732,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Changer de caméra';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zoomer à $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Afficher/masquer la grille';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7616,6 +7616,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Ganti kamera';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zoom ke $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Ganti grid';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7703,6 +7703,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Cambia fotocamera';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zoom a $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Mostra/nascondi griglia';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7371,6 +7371,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'カメラを切り替え';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return '$zoom× にズーム';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'グリッドを切り替え';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7393,6 +7393,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => '카메라 전환';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return '$zoom×로 확대';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => '그리드 전환';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7674,6 +7674,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Camera wisselen';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zoomen naar $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Raster in-/uitschakelen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7792,6 +7792,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Przełącz aparat';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Powiększ do $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Przełącz siatkę';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7685,6 +7685,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Trocar câmera';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zoom para $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Alternar grade';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7802,6 +7802,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Schimbă camera';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zoom la $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Activează/dezactivează grila';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7645,6 +7645,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Byt kamera';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return 'Zooma till $zoom×';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Växla rutnät';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7618,6 +7618,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoRecorderSwitchCameraLabel => 'Kamerayı değiştir';
 
   @override
+  String videoRecorderZoomLevelLabel(String zoom) {
+    return '$zoom× yakınlaştır';
+  }
+
+  @override
   String get videoRecorderToggleGridLabel => 'Izgarayı değiştir';
 
   @override

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -13,6 +13,11 @@ import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_cap
 import 'package:openvine/widgets/video_recorder/preview/video_recorder_camera_preview.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_countdown_overlay.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_record_button.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_zoom_indicator.dart';
+
+/// Bottom inset that lifts the zoom ruler clear of the record button:
+/// the 96px button plus its 24px bottom padding plus a 12px gap.
+const double _zoomIndicatorBottomInset = 24.0 + 96.0 + 12.0;
 
 /// Capture-mode stack with viewfinder, controls, and top bar.
 class VideoRecorderCaptureStack extends ConsumerWidget {
@@ -49,6 +54,16 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
           const Align(
             alignment: .centerRight,
             child: VideoRecorderCaptureActions(),
+          ),
+
+          // Zoom ruler — floats above the record button and only appears
+          // while the user is pinch-zooming.
+          const Align(
+            alignment: .bottomCenter,
+            child: Padding(
+              padding: .fromLTRB(20, 0, 20, _zoomIndicatorBottomInset),
+              child: VideoRecorderZoomIndicator(),
+            ),
           ),
 
           /// Record button

--- a/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
@@ -43,17 +43,20 @@ class VideoRecorderZoomIndicator extends StatelessWidget {
     }
 
     return IgnorePointer(
-      child: AnimatedOpacity(
-        duration: const Duration(milliseconds: 200),
-        opacity: showZoomIndicator ? 1 : 0,
-        child: Semantics(
-          label: context.l10n.videoRecorderZoomLevelLabel(
-            _accessibilityValue(zoomLevel),
-          ),
-          child: _ZoomRuler(
-            zoom: zoomLevel,
-            minZoom: minZoomLevel,
-            maxZoom: maxZoomLevel,
+      child: ExcludeSemantics(
+        excluding: !showZoomIndicator,
+        child: AnimatedOpacity(
+          duration: const Duration(milliseconds: 200),
+          opacity: showZoomIndicator ? 1 : 0,
+          child: Semantics(
+            label: context.l10n.videoRecorderZoomLevelLabel(
+              _accessibilityValue(zoomLevel),
+            ),
+            child: _ZoomRuler(
+              zoom: zoomLevel,
+              minZoom: minZoomLevel,
+              maxZoom: maxZoomLevel,
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
@@ -1,0 +1,217 @@
+// ABOUTME: Android-style zoom ruler that appears only while pinch-zooming
+// ABOUTME: Fine ticks scroll under a fixed centre marker; value floats above
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Transient zoom indicator modelled on the native Android camera ruler.
+///
+/// A horizontal strip of fine tick marks scrolls under a fixed centre
+/// accent while the user pinch-zooms, with the live zoom factor floating
+/// above it. It is purely a read-out — the pinch gesture on the preview
+/// drives the zoom — so it ignores pointer events and only becomes visible
+/// while [VideoRecorderBlocState.showZoomIndicator] is set (during a pinch
+/// and for a short hold afterwards).
+///
+/// Renders nothing when the active camera exposes no usable zoom range
+/// (single lens / before initialization).
+class VideoRecorderZoomIndicator extends StatelessWidget {
+  const VideoRecorderZoomIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final (
+      :zoomLevel,
+      :minZoomLevel,
+      :maxZoomLevel,
+      :showZoomIndicator,
+    ) = context.select(
+      (VideoRecorderBloc b) => (
+        zoomLevel: b.state.zoomLevel,
+        minZoomLevel: b.state.minZoomLevel,
+        maxZoomLevel: b.state.maxZoomLevel,
+        showZoomIndicator: b.state.showZoomIndicator,
+      ),
+    );
+
+    // Single lens / no usable zoom range: nothing to indicate.
+    if (maxZoomLevel - minZoomLevel <= _zoomRangeEpsilon) {
+      return const SizedBox.shrink();
+    }
+
+    return IgnorePointer(
+      child: AnimatedOpacity(
+        duration: const Duration(milliseconds: 200),
+        opacity: showZoomIndicator ? 1 : 0,
+        child: Semantics(
+          label: context.l10n.videoRecorderZoomLevelLabel(
+            _accessibilityValue(zoomLevel),
+          ),
+          child: _ZoomRuler(
+            zoom: zoomLevel,
+            minZoom: minZoomLevel,
+            maxZoom: maxZoomLevel,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ZoomRuler extends StatelessWidget {
+  const _ZoomRuler({
+    required this.zoom,
+    required this.minZoom,
+    required this.maxZoom,
+  });
+
+  final double zoom;
+  final double minZoom;
+  final double maxZoom;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            _valueLabel(zoom),
+            style: VineTheme.titleMediumFont().copyWith(
+              shadows: const [Shadow(color: VineTheme.scrim70, blurRadius: 6)],
+            ),
+          ),
+          const SizedBox(height: 6),
+          SizedBox(
+            width: double.infinity,
+            height: _rulerHeight,
+            child: RepaintBoundary(
+              child: CustomPaint(
+                painter: _ZoomRulerPainter(
+                  zoom: zoom,
+                  minZoom: minZoom,
+                  maxZoom: maxZoom,
+                  labelStyle: VineTheme.labelSmallFont(
+                    color: VineTheme.whiteText.withValues(alpha: 0.7),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ZoomRulerPainter extends CustomPainter {
+  _ZoomRulerPainter({
+    required this.zoom,
+    required this.minZoom,
+    required this.maxZoom,
+    required this.labelStyle,
+  });
+
+  final double zoom;
+  final double minZoom;
+  final double maxZoom;
+  final TextStyle labelStyle;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final centerX = size.width / 2;
+    final minorPaint = Paint()
+      ..color = VineTheme.whiteText.withValues(alpha: 0.45)
+      ..strokeWidth = 1.5
+      ..strokeCap = StrokeCap.round;
+    final majorPaint = Paint()
+      ..color = VineTheme.whiteText.withValues(alpha: 0.85)
+      ..strokeWidth = 2
+      ..strokeCap = StrokeCap.round;
+
+    // Walk the ruler in integer steps of [_minorStep] to avoid float drift.
+    final first = (minZoom / _minorStep).ceil();
+    final last = (maxZoom / _minorStep).floor();
+    for (var i = first; i <= last; i++) {
+      final value = i * _minorStep;
+      final x = centerX + (value - zoom) * _pxPerZoomUnit;
+      if (x < 0 || x > size.width) continue;
+
+      // Majors: every whole factor, plus the 0.5× ultra-wide stop.
+      final isMajor = i % 10 == 0 || i == 5;
+      canvas.drawLine(
+        Offset(x, 0),
+        Offset(x, isMajor ? _majorTickHeight : _minorTickHeight),
+        isMajor ? majorPaint : minorPaint,
+      );
+
+      if (isMajor) _paintLabel(canvas, x, _majorLabel(value));
+    }
+
+    canvas.drawLine(
+      Offset(centerX, 0),
+      Offset(centerX, _accentHeight),
+      Paint()
+        ..color = VineTheme.primary
+        ..strokeWidth = 3
+        ..strokeCap = StrokeCap.round,
+    );
+  }
+
+  void _paintLabel(Canvas canvas, double x, String text) {
+    final painter = TextPainter(
+      text: TextSpan(text: text, style: labelStyle),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    painter.paint(
+      canvas,
+      Offset(x - painter.width / 2, _majorTickHeight + 4),
+    );
+  }
+
+  @override
+  bool shouldRepaint(_ZoomRulerPainter old) =>
+      old.zoom != zoom ||
+      old.minZoom != minZoom ||
+      old.maxZoom != maxZoom ||
+      old.labelStyle != labelStyle;
+}
+
+/// Pixels of horizontal travel per 1.0× of zoom.
+const _pxPerZoomUnit = 110.0;
+
+/// Spacing between minor tick marks, in zoom units.
+const _minorStep = 0.1;
+
+const _minorTickHeight = 9.0;
+const _majorTickHeight = 16.0;
+const _accentHeight = 20.0;
+const _rulerHeight = 36.0;
+
+/// Below this the camera has effectively a single zoom stop, so the ruler
+/// is never shown.
+const _zoomRangeEpsilon = 0.01;
+
+/// Floating value label, e.g. `0.5×`, `1×`, `2.4×` (drops a trailing `.0`).
+String _valueLabel(double zoom) {
+  final rounded = (zoom * 10).roundToDouble() / 10;
+  if (rounded == rounded.truncateToDouble()) return '${rounded.toInt()}×';
+  return '${rounded.toStringAsFixed(1)}×';
+}
+
+/// Compact tick label, e.g. `0.5` → `.5`, `1.0` → `1`.
+String _majorLabel(double value) {
+  if (value == value.truncateToDouble()) return '${value.toInt()}';
+  return value.toStringAsFixed(1).replaceFirst('0.', '.');
+}
+
+/// Spoken value for screen readers, e.g. `0.5` or `1`.
+String _accessibilityValue(double zoom) {
+  final rounded = (zoom * 10).roundToDouble() / 10;
+  if (rounded == rounded.truncateToDouble()) return '${rounded.toInt()}';
+  return rounded.toStringAsFixed(1);
+}

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -1045,13 +1045,15 @@ class CameraController: NSObject {
             // multi-camera devices (e.g. builtInTripleCamera).
             // Convert native zoom values to user-facing values.
             minZoom = device.minAvailableVideoZoomFactor * nativeToUserZoomScale
-            maxZoom = min(device.maxAvailableVideoZoomFactor * nativeToUserZoomScale, 10.0)
+            // Use the full hardware zoom range (mirrors the stock camera).
+            // Beyond the optical max this is digital zoom and gets soft.
+            maxZoom = device.maxAvailableVideoZoomFactor * nativeToUserZoomScale
         } else {
             // No auto lens switch - clamp to 1.0 to prevent native
             // lens switching on virtual multi-camera devices.
             nativeToUserZoomScale = 1.0
             minZoom = 1.0
-            maxZoom = min(device.activeFormat.videoMaxZoomFactor, 10.0)
+            maxZoom = device.activeFormat.videoMaxZoomFactor
         }
         currentZoom = device.videoZoomFactor * nativeToUserZoomScale
         // Front camera has "flash" via screen brightness when feature is enabled

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -137,6 +137,86 @@ void main() {
       expect(bloc.currentLensMetadata, isNull);
     });
 
+    group('showZoomIndicator', () {
+      test('shows the zoom ruler when a pinch starts', () async {
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails()));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.showZoomIndicator, isTrue);
+      });
+
+      test('shows the zoom ruler when the zoom level is set', () async {
+        when(
+          () => cameraService.setZoomLevel(any()),
+        ).thenAnswer((_) async => true);
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(const VideoRecorderZoomLevelSet(2));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.showZoomIndicator, isTrue);
+      });
+
+      test('auto-hides the zoom ruler after the pinch settles', () async {
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails()));
+        // The auto-hide timer is 1000ms — give it room to fire.
+        await Future<void>.delayed(const Duration(milliseconds: 1100));
+
+        expect(bloc.state.showZoomIndicator, isFalse);
+      });
+    });
+
+    group('pinch-to-zoom snap', () {
+      test('pinching down across the 1× detent snaps zoom to 1.0', () async {
+        when(
+          () => cameraService.setZoomLevel(any()),
+        ).thenAnswer((_) async => true);
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        // Start zoomed in past the detent (base = 1.5), then pinch down so
+        // the multiplicative zoom (base × scale) crosses 1.0 — the gravity
+        // well + detent should lock it to 1×.
+        bloc.emit(const VideoRecorderBlocState(zoomLevel: 1.5));
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails()));
+        await Future<void>.delayed(Duration.zero);
+        // 1.5 × 0.9 = 1.35 (still above the detent).
+        bloc.add(VideoRecorderScaleUpdated(ScaleUpdateDetails(scale: 0.9)));
+        await Future<void>.delayed(Duration.zero);
+        // 1.5 × 0.66 = 0.99 (within the snap tolerance of 1.0).
+        bloc.add(VideoRecorderScaleUpdated(ScaleUpdateDetails(scale: 0.66)));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.snappedTo1x, isTrue);
+        expect(bloc.state.zoomLevel, closeTo(1.0, 0.02));
+      });
+
+      test('maps zoom multiplicatively as base × pinch scale', () async {
+        when(
+          () => cameraService.setZoomLevel(any()),
+        ).thenAnswer((_) async => true);
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        // From 2×, a 1.5× spread reaches 3× (2 × 1.5) regardless of where in
+        // the range the gesture starts — uniform sensitivity.
+        bloc.emit(const VideoRecorderBlocState(zoomLevel: 2));
+        bloc.add(VideoRecorderScaleStarted(ScaleStartDetails()));
+        await Future<void>.delayed(Duration.zero);
+        bloc.add(VideoRecorderScaleUpdated(ScaleUpdateDetails(scale: 1.5)));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(bloc.state.zoomLevel, closeTo(3.0, 0.01));
+      });
+    });
+
     group('VideoRecorderFlashToggled', () {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'cycles off → torch → auto → off and persists each new mode',
@@ -266,7 +346,9 @@ void main() {
         },
         build: buildBloc,
         act: (bloc) => bloc.add(const VideoRecorderZoomLevelSet(2)),
-        expect: () => const [VideoRecorderBlocState(zoomLevel: 2)],
+        expect: () => const [
+          VideoRecorderBlocState(zoomLevel: 2, showZoomIndicator: true),
+        ],
       );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
@@ -651,6 +733,7 @@ void main() {
           () => cameraService.initialize(
             videoQuality: any(named: 'videoQuality'),
             initialLens: any(named: 'initialLens'),
+            enableAutoLensSwitch: any(named: 'enableAutoLensSwitch'),
           ),
         ).thenAnswer((_) async {});
         when(
@@ -659,6 +742,21 @@ void main() {
           ),
         ).thenAnswer((_) async => true);
       });
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'initializes the camera with auto lens switching enabled',
+        build: buildBloc,
+        act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
+        verify: (_) {
+          verify(
+            () => cameraService.initialize(
+              videoQuality: any(named: 'videoQuality'),
+              initialLens: any(named: 'initialLens'),
+              enableAutoLensSwitch: true,
+            ),
+          ).called(1);
+        },
+      );
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'does NOT restore persisted mode when opened from the editor '

--- a/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
@@ -1,0 +1,105 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_zoom_indicator.dart';
+
+class _MockVideoRecorderBloc
+    extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
+    implements VideoRecorderBloc {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(VideoRecorderZoomIndicator, () {
+    late _MockVideoRecorderBloc bloc;
+
+    setUp(() {
+      bloc = _MockVideoRecorderBloc();
+    });
+
+    Widget buildWidget({
+      double zoomLevel = 1.0,
+      double minZoomLevel = 0.5,
+      double maxZoomLevel = 5.0,
+      bool showZoomIndicator = true,
+    }) {
+      when(() => bloc.state).thenReturn(
+        VideoRecorderBlocState(
+          zoomLevel: zoomLevel,
+          minZoomLevel: minZoomLevel,
+          maxZoomLevel: maxZoomLevel,
+          showZoomIndicator: showZoomIndicator,
+          isCameraInitialized: true,
+        ),
+      );
+
+      return BlocProvider<VideoRecorderBloc>.value(
+        value: bloc,
+        child: const MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Center(child: VideoRecorderZoomIndicator()),
+          ),
+        ),
+      );
+    }
+
+    group('renders', () {
+      testWidgets('shows the live zoom value while zooming', (tester) async {
+        await tester.pumpWidget(buildWidget(zoomLevel: 2.4));
+        await tester.pumpAndSettle();
+
+        expect(find.text('2.4×'), findsOneWidget);
+        expect(find.byType(CustomPaint), findsWidgets);
+      });
+
+      testWidgets('drops the trailing .0 on clean zoom factors', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text('1×'), findsOneWidget);
+      });
+    });
+
+    group('visibility', () {
+      testWidgets('is visible while the user is zooming', (tester) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        final opacity = tester.widget<AnimatedOpacity>(
+          find.byType(AnimatedOpacity),
+        );
+        expect(opacity.opacity, equals(1));
+      });
+
+      testWidgets('is hidden when not zooming', (tester) async {
+        await tester.pumpWidget(buildWidget(showZoomIndicator: false));
+        await tester.pumpAndSettle();
+
+        final opacity = tester.widget<AnimatedOpacity>(
+          find.byType(AnimatedOpacity),
+        );
+        expect(opacity.opacity, equals(0));
+      });
+
+      testWidgets('renders nothing when the camera has a single zoom stop', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(minZoomLevel: 1, maxZoomLevel: 1),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AnimatedOpacity), findsNothing);
+        expect(find.text('1×'), findsNothing);
+      });
+    });
+  });
+}

--- a/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
@@ -89,6 +89,20 @@ void main() {
         expect(opacity.opacity, equals(0));
       });
 
+      testWidgets('excludes the zoom semantics label when hidden', (
+        tester,
+      ) async {
+        final semantics = tester.ensureSemantics();
+        try {
+          await tester.pumpWidget(buildWidget(showZoomIndicator: false));
+          await tester.pumpAndSettle();
+
+          expect(find.bySemanticsLabel('Zoom to 1×'), findsNothing);
+        } finally {
+          semantics.dispose();
+        }
+      });
+
       testWidgets('renders nothing when the camera has a single zoom stop', (
         tester,
       ) async {


### PR DESCRIPTION


## Summary

Enables automatic lens switching in the video recorder (so the ultra-wide
`0.5×` and telephoto stops are usable) and reworks the zoom UX around it.

Closes #1607
Closes #5149

## Changes

- **Android-style zoom ruler** — replaces the always-on lens chips. A fine
  tick ruler with the live zoom value appears **only while the user is
  pinch-zooming** and auto-hides ~1s after the gesture settles
  (`showZoomIndicator` + a bloc auto-hide timer mirroring the focus-point
  pattern). Purely a read-out (`IgnorePointer`, semantics-aware).
- **Multiplicative pinch zoom** — `zoom = baseZoom × pinchScale`, so the
  perceived sensitivity is uniform across the range (`1×→2×` feels like
  `2×→4×`). The previous range-proportional mapping made the gain depend on
  the starting zoom (fast far from a bound, sluggish near max) and was
  asymmetric between zoom-in and zoom-out.
- **Haptic detent** — a light tick when the zoom snaps to the `1×` detent.
- **Auto lens switch enabled** at camera init; `minZoomLevel`/`maxZoomLevel`
  now flow through state to drive the ruler.
- **iOS** — drops the artificial `10×` zoom cap and exposes the device's
  full video zoom range, matching the stock camera.
- **l10n** — adds `videoRecorderZoomLevelLabel` (+ translations for all
  locales) for the ruler's accessibility label.

## Verification

- `flutter analyze` (touched Dart areas): clean.
- Tests green: `video_recorder_bloc_test`, `video_recorder_zoom_indicator_test`,
  `video_recorder_capture_stack_test` (incl. new tests for the ruler,
  auto-hide, and multiplicative mapping). Pre-push hook tests passed.

## Notes / open items (why this is a draft)

- **Native changes are unverified on-device by me** (this environment only
  builds Dart). The iOS Swift cap-removal and the Android behaviour should be
  built/tested on a device before marking ready, plus screen recordings of
  the ruler.
- **Android max zoom stays at 10×.** Investigated on a Samsung device: both
  CameraX `maxZoomRatio` and Camera2 `CONTROL_ZOOM_RATIO_RANGE` report
  `[0.6, 10.0]` — i.e. 10× is the ceiling the HAL exposes to third-party
  apps. The stock camera's 30× is Samsung's proprietary super-resolution and
  is **not reachable** via standard CameraX/Camera2 APIs.
- **iOS cap removal** is per request (match the stock camera). On some iPhones
  the hardware max is high (digital → soft); easy to re-cap (e.g. 30×) if
  preferred.

## Test plan

- [x] Pinch-zoom on a multi-lens device: ruler appears, scrolls under the
      centre marker, hides after release.
- [x] Sensitivity feels uniform near `1×` and near max.
- [x] `1×` snap detent fires the haptic.
- [x] iOS reaches the device's full zoom range.