### PR TITLE
test(upload): untag upload_publish_race_condition (#3137)

### DIFF
--- a/mobile/test/models/upload_publish_race_condition_test.dart
+++ b/mobile/test/models/upload_publish_race_condition_test.dart
@@ -1,4 +1,3 @@
-@Tags(['skip_very_good_optimization', 'integration'])
 // ABOUTME: Test verifying race condition is fixed - upload completes before publishing
 // ABOUTME: Ensures videoId and cdnUrl are populated when publishDirectUpload is called
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Closes #3137.

## What changed

Removed the file-level `@Tags(['skip_very_good_optimization', 'integration'])` annotation from `mobile/test/models/upload_publish_race_condition_test.dart`.

This test imports only `flutter_test` and `PendingUpload`, creates/copies a value object, and asserts on fields. It does not use `IntegrationTestWidgetsFlutterBinding`, platform channels, file or network I/O, shared repositories, or global app state, so neither tag is justified.

## Why

The `integration` tag was incorrect because this is a unit test. The `skip_very_good_optimization` tag was also unnecessary because the test has no cross-file state that would contaminate Very Good Ventures optimized test merging. Removing both tags reduces the VGV skip-tag debt without changing production behavior.

## Validation

- Rebased the PR branch onto current `origin/main` (`08a039dda`).
- Verified the diff is still one test-only deletion.
- Ran `mise exec -- flutter test test/models/upload_publish_race_condition_test.dart` from `mobile/`: all 3 tests passed.
- Push hook ran analyzer for the changed file: no issues found.
- Push hook reran the targeted test: all 3 tests passed.

## Scope

No production code changes. `mobile/test/vgv_tag_baseline.txt` is intentionally unchanged because the tag gate permits decreases; baseline ratcheting can happen separately after the untag batch lands.