### PR TITLE
test(upload): untag video_publish_flow + drop dead file IO (#3137)

### DIFF
--- a/mobile/test/models/video_publish_flow_test.dart
+++ b/mobile/test/models/video_publish_flow_test.dart
@@ -1,32 +1,18 @@
-@Tags(['skip_very_good_optimization', 'integration'])
-// ABOUTME: Integration test verifying video upload completes before Nostr event publishing
+// ABOUTME: Unit test verifying video upload completes before Nostr event publishing
 // ABOUTME: Tests TDD failing case: publish should wait for upload to complete and populate videoId/cdnUrl
-import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/pending_upload.dart';
 
 void main() {
   group('Video Upload → Publish Flow', () {
-    late File testVideoFile;
-
-    setUp(() async {
-      // Create a test video file
-      testVideoFile = File('test_video.mp4');
-      await testVideoFile.writeAsBytes([0, 1, 2, 3, 4]); // Minimal test data
-    });
-
-    tearDown(() async {
-      if (testVideoFile.existsSync()) {
-        await testVideoFile.delete();
-      }
-    });
+    const testVideoPath = 'test_video.mp4';
 
     test(
       'publishing should fail when upload has not completed (videoId is null)',
       () async {
         // ARRANGE: Create an upload that hasn't completed yet
         final upload = PendingUpload.create(
-          localVideoPath: testVideoFile.path,
+          localVideoPath: testVideoPath,
           nostrPubkey: 'test_pubkey_123',
           title: 'Test Video',
         );
@@ -63,7 +49,7 @@ void main() {
       () async {
         // ARRANGE: Create an upload and simulate completion
         final upload = PendingUpload.create(
-          localVideoPath: testVideoFile.path,
+          localVideoPath: testVideoPath,
           nostrPubkey: 'test_pubkey_123',
           title: 'Test Video',
         );


### PR DESCRIPTION
Part of #3137 (unwind `skip_very_good_optimization` tags).

## What

`mobile/test/models/video_publish_flow_test.dart` was tagged
`@Tags(['skip_very_good_optimization', 'integration'])`. Its `setUp` wrote a
**relative-path** file (`test_video.mp4`) into the shared CWD and `tearDown`
deleted it — a real cross-test / parallel-isolate hazard under the VGV merge
(and the reason the file was opted out).

That I/O is **dead weight**: the bytes are never read. `PendingUpload.create`
only stores `localVideoPath` as a string, and the assertions only check
`videoId` / `cdnUrl` / `status`. So this PR:

- removes the `dart:io` file write/delete (uses a plain path constant), making
  it a true unit test with no real I/O;
- strips both tags (`skip_very_good_optimization` is unnecessary once the I/O is
  gone; `integration` was incorrect — it's a unit test).

Satisfies the Bucket A acceptance criterion ("rewritten to not depend on real
I/O") for this file.

## Verification

Ran the exact CI command
(`very_good test --optimization --concurrency=2 --exclude-tags integration`)
on the merged suite at three randomize-ordering seeds (42, 11111, 98765):
**all green, ~9,825 tests each, zero failures** — no contamination, no cascade.

## Scope

- Does not touch `vgv_tag_baseline.txt` (gate permits `current < baseline`;
  stays conflict-free with #5150 and other untag PRs).
- One file, test-only, no production change.