### PR TITLE
test(bug-report): untag bug_report_service_upload_logs (#3137)

### DIFF
--- a/mobile/test/unit/services/bug_report_service_upload_logs_test.dart
+++ b/mobile/test/unit/services/bug_report_service_upload_logs_test.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Tests for BugReportService.uploadFullLogs()
 // ABOUTME: Verifies Blossom upload success, failure fallback, and null service handling
 
-@Tags(['skip_very_good_optimization'])
 import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';


### PR DESCRIPTION
Part of #3137 (unwind `skip_very_good_optimization` tags).

## What

`mobile/test/unit/services/bug_report_service_upload_logs_test.dart` is a pure
mocktail test of `BugReportService.uploadFullLogs()` against a mocked
`BlossomUploadService`. `File('')` appears only as a `registerFallbackValue`
(a mocktail matcher fallback, not real I/O). No global state, no platform
channels, no shared singletons — so it merges cleanly under the VGV optimizer.
Strip the tag.

## Verification

Ran the exact CI command
(`very_good test --optimization --concurrency=2 --exclude-tags integration`)
on the merged suite at three randomize-ordering seeds (42, 11111, 98765):
**all green, ~9,825 tests each, zero failures** — no contamination, no cascade.

## Scope

- Does not touch `vgv_tag_baseline.txt` (the gate permits `current < baseline`).
- One file, test-only, no production change.