### PR TITLE
test(video-events): untag video_event_service_deletion (#3137)

### DIFF
--- a/mobile/test/services/video_event_service_deletion_test.dart
+++ b/mobile/test/services/video_event_service_deletion_test.dart
@@ -2,7 +2,6 @@
 // the removedVideoIds broadcast stream so subscribers (FullscreenFeedBloc,
 // profileFeedProvider) can drop the id without waiting for a route change.
 
-@Tags(['skip_very_good_optimization'])
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';


### PR DESCRIPTION
Part of #3137 (unwind `skip_very_good_optimization` tags).

## What

`video_event_service_deletion_test.dart` constructs `VideoEventService` with a
mocked `NostrClient` / `SubscriptionManager` and **disposes it in `tearDown`**.
It never calls a subscribe path, so it arms no feed-loading timer and leaks no
process-wide state across the merged isolate. The `skip_very_good_optimization`
tag was conservative bundling. Strip it.

## Verification

Ran the exact CI command
(`very_good test --optimization --concurrency=2 --exclude-tags integration`)
on the merged suite at three randomize-ordering seeds (42, 11111, 98765):
**all green, ~9,825 tests each, zero failures** — no contamination, no cascade.

## Scope
- Does not touch `vgv_tag_baseline.txt` (gate permits `current < baseline`).
- One file, test-only, no production change.