### PR TITLE
test(video-events): untag video_event_service_blocklist_sweep (#3137)

### DIFF
--- a/mobile/test/services/video_event_service_blocklist_sweep_test.dart
+++ b/mobile/test/services/video_event_service_blocklist_sweep_test.dart
@@ -2,7 +2,6 @@
 // ContentBlocklistRepository.changes and emits removedVideoIds for every
 // cached video by the affected author when an "addition" event fires.
 
-@Tags(['skip_very_good_optimization'])
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';


### PR DESCRIPTION
Part of #3137 (unwind `skip_very_good_optimization` tags).

## What

`video_event_service_blocklist_sweep_test.dart` constructs `VideoEventService`
with mocked `NostrClient` / `SubscriptionManager` and disposes each instance in
`tearDown`. It exercises no subscribe path, so it arms no feed-loading timer and
leaks no process-wide state across the merged isolate. Conservative tag. Strip it.

## Verification

Ran the exact CI command
(`very_good test --optimization --concurrency=2 --exclude-tags integration`)
on the merged suite at three randomize-ordering seeds (42, 11111, 98765):
**all green, ~9,825 tests each, zero failures** — no contamination, no cascade.

## Scope
- Does not touch `vgv_tag_baseline.txt` (gate permits `current < baseline`).
- One file, test-only, no production change.