### PR TITLE
feat(image): add @visibleForTesting cache seam to VineCachedImage (#3137)

### DIFF
--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -14,6 +14,23 @@ final openVineImageCache = MediaCacheManager(
   config: const MediaCacheConfig.image(cacheKey: 'openvine_image_cache'),
 );
 
+/// Test-only override for the cache used by every [VineCachedImage].
+///
+/// When non-null, images resolve through this manager instead of
+/// [openVineImageCache], letting widget tests inject a stubbed
+/// `MockMediaCacheManager` so the eager image resolve avoids the real
+/// on-disk cache. The real cache performs async `path_provider` work that
+/// can settle *after* a test completes, polluting the shared VGV merge
+/// isolate; the override keeps that work out of tests. Reset to `null` in
+/// `tearDown`.
+@visibleForTesting
+MediaCacheManager? debugImageCacheOverride;
+
+/// The cache [VineCachedImage] resolves through — the test override if set,
+/// otherwise the global [openVineImageCache].
+MediaCacheManager get _activeImageCache =>
+    debugImageCacheOverride ?? openVineImageCache;
+
 /// A wrapper around [Image] that always uses [openVineImageCache].
 class VineCachedImage extends StatefulWidget {
   const VineCachedImage({
@@ -56,7 +73,7 @@ class _VineCachedImageState extends State<VineCachedImage> {
   ImageProvider<Object> get _imageProvider => ResizeImage.resizeIfNeeded(
     widget.memCacheWidth,
     widget.memCacheHeight,
-    MediaCacheImageProvider(widget.imageUrl, cacheManager: openVineImageCache),
+    MediaCacheImageProvider(widget.imageUrl, cacheManager: _activeImageCache),
   );
 
   @override

--- a/mobile/test/widgets/vine_cached_image_test.dart
+++ b/mobile/test/widgets/vine_cached_image_test.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:media_cache/media_cache.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
+
+class _FakeImageCache extends Mock implements MediaCacheManager {}
 
 void main() {
   group('openVineImageCache', () {
@@ -169,6 +172,43 @@ void main() {
       );
       expect(image.fadeInDuration, equals(Duration.zero));
       expect(image.fadeOutDuration, equals(const Duration(milliseconds: 200)));
+    });
+  });
+
+  group('debugImageCacheOverride', () {
+    tearDown(() => debugImageCacheOverride = null);
+
+    testWidgets('resolves through openVineImageCache when override is null', (
+      tester,
+    ) async {
+      debugImageCacheOverride = null;
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(imageUrl: 'https://example.com/a.jpg'),
+        ),
+      );
+
+      final provider =
+          tester.widget<Image>(find.byType(Image)).image
+              as MediaCacheImageProvider;
+      expect(provider.cacheManager, same(openVineImageCache));
+    });
+
+    testWidgets('resolves through the override when set', (tester) async {
+      final override = _FakeImageCache();
+      debugImageCacheOverride = override;
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: VineCachedImage(imageUrl: 'https://example.com/a.jpg'),
+        ),
+      );
+
+      final provider =
+          tester.widget<Image>(find.byType(Image)).image
+              as MediaCacheImageProvider;
+      expect(provider.cacheManager, same(override));
     });
   });
 }


### PR DESCRIPTION
Part of #3137. Infrastructure for unwinding the **image-cache cluster** of
`skip_very_good_optimization` tags (the profile grids, notification avatar,
ios_network_image — ~7 tagged files plus 3 already-merged order-fragile
widget tests).

## Root cause

`VineCachedImage` hard-codes the global `openVineImageCache`. Pumping it with a
non-empty URL kicks off an eager `MediaCacheImageProvider` resolve whose
`_loadAsync` awaits `getFileFromCache()` → `getApplicationSupportDirectory()`
(path_provider) and **settles after the test completes**, polluting the merged
VGV test isolate — the image analogue of a leaked timer. That late async is why
those widget tests were tagged out of the optimizer.

## The seam (Option B — minimal, behaviour-neutral)

- Add a `@visibleForTesting MediaCacheManager? debugImageCacheOverride;` and an
  `_activeImageCache` getter; `_imageProvider` resolves through it.
- **Production behaviour is unchanged** — the override defaults to `null`, which
  resolves to `openVineImageCache`. The `const VineCachedImage(...)` constructor
  and all 21 call sites are untouched.
- Widget tests can now set `debugImageCacheOverride = createMockMediaCacheManager()`
  in `setUp` / clear it in `tearDown`, so the eager resolve hits a stubbed cache
  and never touches the real on-disk/path_provider path.

Includes a unit test covering both override paths (null → `openVineImageCache`,
set → the injected manager).

## Why seam-only (no untags in this PR)

The seam neutralises the image-cache leak (verified: the previously-tagged
`profile_liked_grid` passes at seed 42 with the override). However, untagging
those files still trips a **separate, unrelated** ordering fragility in
already-merged `path_provider`/`ProVideoEditor` tests
(e.g. `video_clip_import_service_test`), which is outside the image-cache scope.
So this lands the seam as behaviour-neutral infrastructure; the per-file untags
follow once those cascade victims are de-flaked.

## Verification

`very_good test --optimization --concurrency=2 --exclude-tags integration` on the
merged suite at seeds 42, 11111, 98765: **all green** (behaviour-neutral change).