### PR TITLE
test(search): pin Explore→Search transition + focus contract

### DIFF
--- a/mobile/test/screens/explore_search_transition_test.dart
+++ b/mobile/test/screens/explore_search_transition_test.dart
@@ -1,0 +1,172 @@
+// ABOUTME: Regression test for the Explore→Search transition contract (#3801).
+// ABOUTME: Pins that the Explore search bar is read-only (no typed-input
+// ABOUTME: auto-navigation) and that tapping it opens the empty search route
+// ABOUTME: with mount-focus requested (the contract established by #4901/#4413).
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/classic_vines_provider.dart';
+import 'package:openvine/providers/for_you_provider.dart';
+import 'package:openvine/providers/list_providers.dart';
+import 'package:openvine/providers/route_feed_providers.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/explore_screen.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/services/curated_list_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _FakeAppForeground extends AppForeground {
+  @override
+  bool build() => true;
+}
+
+class _FakeCuratedListsState extends CuratedListsState {
+  @override
+  CuratedListService? get service => null;
+
+  @override
+  Future<List<CuratedList>> build() async => const [];
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(SubscriptionType.discovery);
+    registerFallbackValue(() {});
+  });
+
+  group('Explore → Search transition contract (#3801)', () {
+    late _MockVideoEventService videoEventService;
+
+    setUp(() {
+      videoEventService = _MockVideoEventService();
+
+      when(
+        () => videoEventService.addVideoUpdateListener(any()),
+      ).thenReturn(() {});
+      when(() => videoEventService.filterVideoList(any())).thenAnswer(
+        (invocation) =>
+            invocation.positionalArguments.first as List<VideoEvent>,
+      );
+      when(() => videoEventService.discoveryVideos).thenReturn([]);
+      when(() => videoEventService.popularNowVideos).thenReturn([]);
+      when(() => videoEventService.isSubscribed(any())).thenReturn(false);
+      // ignore: invalid_use_of_protected_member
+      when(() => videoEventService.hasListeners).thenReturn(false);
+    });
+
+    List<dynamic> exploreOverrides() => [
+      appForegroundProvider.overrideWith(_FakeAppForeground.new),
+      videoEventServiceProvider.overrideWithValue(videoEventService),
+      routerLocationStreamProvider.overrideWith(
+        (ref) => Stream.value(ExploreScreen.path),
+      ),
+      exploreTabVideosProvider.overrideWith((ref) => null),
+      classicVinesAvailableProvider.overrideWith((ref) async => false),
+      forYouAvailableProvider.overrideWithValue(false),
+      allListsProvider.overrideWith(
+        (ref) async => (userLists: <UserList>[], curatedLists: <CuratedList>[]),
+      ),
+      curatedListsStateProvider.overrideWith(_FakeCuratedListsState.new),
+      isFeatureEnabledProvider(
+        FeatureFlag.integratedApps,
+      ).overrideWithValue(false),
+    ];
+
+    testWidgets(
+      'Explore search bar is read-only so typed input cannot auto-navigate',
+      (tester) async {
+        await tester.pumpWidget(
+          testProviderScope(
+            additionalOverrides: exploreOverrides(),
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(body: ExploreScreen()),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final searchBar = tester.widget<DivineSearchBar>(
+          find.byType(DivineSearchBar).first,
+        );
+        expect(
+          searchBar.readOnly,
+          isTrue,
+          reason:
+              'A typeable Explore search bar would reintroduce the '
+              'partial-input auto-navigation regression (#3020/#3802).',
+        );
+        expect(
+          searchBar.onTap,
+          isNotNull,
+          reason: 'The read-only bar must route via onTap.',
+        );
+      },
+    );
+
+    testWidgets(
+      'tapping the Explore search bar opens the empty search route with '
+      'mount focus requested',
+      (tester) async {
+        final router = GoRouter(
+          initialLocation: '/',
+          routes: [
+            GoRoute(
+              path: '/',
+              builder: (context, state) =>
+                  const Scaffold(body: ExploreScreen()),
+            ),
+            GoRoute(
+              path: SearchResultsPage.emptyPath,
+              builder: (context, state) => Scaffold(
+                body: Text(
+                  'search-probe '
+                  'focus=${state.uri.queryParameters['focus'] ?? 'none'} '
+                  'query=${state.uri.queryParameters['query'] ?? 'none'}',
+                ),
+              ),
+            ),
+          ],
+        );
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          testProviderScope(
+            additionalOverrides: exploreOverrides(),
+            child: MaterialApp.router(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerConfig: router,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(DivineSearchBar).first);
+        await tester.pumpAndSettle();
+
+        // The probe route reflects the pushed location: the empty search
+        // route (no prefilled query) with the mount-focus flag set — i.e.
+        // pathForEmptyQuery(requestFocusOnMount: true). This is the exact
+        // contract #4901 shipped and #5131 could silently regress. (The probe
+        // reads its query params from the routed GoRouterState.uri, so a
+        // match here proves the pushed URI was '/search-results?focus=1'.)
+        expect(find.text('search-probe focus=1 query=none'), findsOneWidget);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

Adds `mobile/test/screens/explore_search_transition_test.dart` — a regression test for the Explore→Search transition that nothing currently covers end to end.

Two cases, both pumping the **real** `ExploreScreen` via the standard test harness (`testProviderScope`):

1. **The Explore search bar is read-only** — so partial typed input cannot auto-navigate (the #3020/#3802 regression class), and it routes via `onTap`.
2. **Tapping it opens the empty search route with mount focus requested** — `pathForEmptyQuery(requestFocusOnMount: true)`, verified through a `GoRouter` probe route that echoes the routed query params (`focus=1`, no `query`).

## Why

The Explore→Search transition model was reworked twice in June — #4901 removed the debounced auto-navigation in favour of a read-only search bar that opens the unified search route, and #5131 reworked deep-link stack behaviour. The contract (read-only entry → empty focused route) had unit coverage on the destination app bar but no test bridging the actual Explore tap to the navigation. This closes that gap so a third rework can't silently regress it.

## Verification

- `flutter test test/screens/explore_search_transition_test.dart` → **2 passed**.
- Passes under `--test-randomize-ordering-seed random`.
- `flutter analyze` clean.

## Scope

Test-only — no production change. Relates to the search epic #3801; does not close it.