### PR TITLE
fix(explore): localize async error state, drop raw exception text

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "am",
+    "commonSomethingWentWrong": "የሆነ ችግር ተፈጥሯል",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ar",
+    "commonSomethingWentWrong": "حدث خطأ ما",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "bg",
+    "commonSomethingWentWrong": "Нещо се обърка",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "de",
+    "commonSomethingWentWrong": "Etwas ist schiefgelaufen",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3284,6 +3284,10 @@
   "peopleListsDeleteConfirmBody": "This removes the list for everyone. The people in it will not be unfollowed.",
   "peopleListsDeleteFailed": "Couldn't delete list",
   "commonRetry": "Retry",
+  "commonSomethingWentWrong": "Something went wrong",
+  "@commonSomethingWentWrong": {
+    "description": "Generic error message shown when an async load fails and no more specific message applies. Must not embed raw exception text."
+  },
   "commonNext": "Next",
   "commonDelete": "Delete",
   "commonCancel": "Cancel",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "es",
+    "commonSomethingWentWrong": "Algo salió mal",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fil",
+    "commonSomethingWentWrong": "May nangyaring problema",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fr",
+    "commonSomethingWentWrong": "Un problème est survenu",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "id",
+    "commonSomethingWentWrong": "Terjadi kesalahan",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "it",
+    "commonSomethingWentWrong": "Qualcosa è andato storto",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ja",
+    "commonSomethingWentWrong": "問題が発生しました",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ko",
+    "commonSomethingWentWrong": "문제가 생겼어요",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "nl",
+    "commonSomethingWentWrong": "Er ging iets mis",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "pl",
+    "commonSomethingWentWrong": "Coś poszło nie tak",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "pt",
+    "commonSomethingWentWrong": "Algo deu errado",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ro",
+    "commonSomethingWentWrong": "Ceva nu a mers bine",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "sv",
+    "commonSomethingWentWrong": "Något gick fel",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "tr",
+    "commonSomethingWentWrong": "Bir hata oluştu",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",
     "appTitle": "Divine",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10100,6 +10100,12 @@ abstract class AppLocalizations {
   /// **'Retry'**
   String get commonRetry;
 
+  /// Generic error message shown when an async load fails and no more specific message applies. Must not embed raw exception text.
+  ///
+  /// In en, this message translates to:
+  /// **'Something went wrong'**
+  String get commonSomethingWentWrong;
+
   /// No description provided for @commonNext.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5636,7 +5636,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get commonRetry => 'እንደገና ይሞክሩ';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'የሆነ ችግር ተፈጥሯል';
 
   @override
   String get commonNext => 'ቀጥሎ';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5636,6 +5636,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get commonRetry => 'እንደገና ይሞክሩ';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'ቀጥሎ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5698,6 +5698,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get commonRetry => 'إعادة المحاولة';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'التالي';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5698,7 +5698,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get commonRetry => 'إعادة المحاولة';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'حدث خطأ ما';
 
   @override
   String get commonNext => 'التالي';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5801,6 +5801,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get commonRetry => 'Опитай пак';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Следваща';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5801,7 +5801,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get commonRetry => 'Опитай пак';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Нещо се обърка';
 
   @override
   String get commonNext => 'Следваща';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5816,7 +5816,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get commonRetry => 'Erneut versuchen';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Etwas ist schiefgelaufen';
 
   @override
   String get commonNext => 'Weiter';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5816,6 +5816,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get commonRetry => 'Erneut versuchen';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Weiter';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5748,6 +5748,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get commonRetry => 'Retry';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Next';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5796,6 +5796,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get commonRetry => 'Reintentar';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Siguiente';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5796,7 +5796,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get commonRetry => 'Reintentar';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Algo salió mal';
 
   @override
   String get commonNext => 'Siguiente';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5818,6 +5818,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get commonRetry => 'Subukan ulit';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Susunod';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5818,7 +5818,7 @@ class AppLocalizationsFil extends AppLocalizations {
   String get commonRetry => 'Subukan ulit';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'May nangyaring problema';
 
   @override
   String get commonNext => 'Susunod';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5819,6 +5819,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get commonRetry => 'Réessayer';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Suivant';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5819,7 +5819,7 @@ class AppLocalizationsFr extends AppLocalizations {
   String get commonRetry => 'Réessayer';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Un problème est survenu';
 
   @override
   String get commonNext => 'Suivant';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5725,6 +5725,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get commonRetry => 'Coba lagi';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Berikutnya';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5725,7 +5725,7 @@ class AppLocalizationsId extends AppLocalizations {
   String get commonRetry => 'Coba lagi';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Terjadi kesalahan';
 
   @override
   String get commonNext => 'Berikutnya';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5797,7 +5797,7 @@ class AppLocalizationsIt extends AppLocalizations {
   String get commonRetry => 'Riprova';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Qualcosa è andato storto';
 
   @override
   String get commonNext => 'Avanti';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5797,6 +5797,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get commonRetry => 'Riprova';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Avanti';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5523,6 +5523,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get commonRetry => 'もう一回';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => '次へ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5523,7 +5523,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get commonRetry => 'もう一回';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => '問題が発生しました';
 
   @override
   String get commonNext => '次へ';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5539,7 +5539,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get commonRetry => '다시 시도';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => '문제가 생겼어요';
 
   @override
   String get commonNext => '다음';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5539,6 +5539,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get commonRetry => '다시 시도';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => '다음';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5773,7 +5773,7 @@ class AppLocalizationsNl extends AppLocalizations {
   String get commonRetry => 'Opnieuw proberen';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Er ging iets mis';
 
   @override
   String get commonNext => 'Volgende';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5773,6 +5773,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get commonRetry => 'Opnieuw proberen';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Volgende';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5882,6 +5882,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get commonRetry => 'Ponów';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Dalej';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5882,7 +5882,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get commonRetry => 'Ponów';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Coś poszło nie tak';
 
   @override
   String get commonNext => 'Dalej';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5783,7 +5783,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get commonRetry => 'Tentar novamente';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Algo deu errado';
 
   @override
   String get commonNext => 'Próximo';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5783,6 +5783,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get commonRetry => 'Tentar novamente';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Próximo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5897,6 +5897,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get commonRetry => 'Reîncearcă';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Următorul';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5897,7 +5897,7 @@ class AppLocalizationsRo extends AppLocalizations {
   String get commonRetry => 'Reîncearcă';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Ceva nu a mers bine';
 
   @override
   String get commonNext => 'Următorul';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5750,6 +5750,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get commonRetry => 'Försök igen';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'Nästa';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5750,7 +5750,7 @@ class AppLocalizationsSv extends AppLocalizations {
   String get commonRetry => 'Försök igen';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Något gick fel';
 
   @override
   String get commonNext => 'Nästa';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5730,7 +5730,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get commonRetry => 'Tekrar dene';
 
   @override
-  String get commonSomethingWentWrong => 'Something went wrong';
+  String get commonSomethingWentWrong => 'Bir hata oluştu';
 
   @override
   String get commonNext => 'İleri';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5730,6 +5730,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get commonRetry => 'Tekrar dene';
 
   @override
+  String get commonSomethingWentWrong => 'Something went wrong';
+
+  @override
   String get commonNext => 'İleri';
 
   @override

--- a/mobile/lib/mixins/async_value_ui_helpers_mixin.dart
+++ b/mobile/lib/mixins/async_value_ui_helpers_mixin.dart
@@ -4,6 +4,7 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/l10n/l10n.dart';
 
 /// Mixin that provides consistent AsyncValue UI handling with default loading/error widgets.
 ///
@@ -60,27 +61,36 @@ mixin AsyncValueUIHelpersMixin {
     );
   }
 
-  /// Default error widget - centered error icon with message
+  /// Default error widget - centered error icon with an intentional,
+  /// localized message.
+  ///
+  /// The raw [error] is deliberately not shown to the user (see the
+  /// per-layer failure contract in `rules/error_handling.md`); it stays in
+  /// the [AsyncValue] for logging at the provider layer. Wrapped in a
+  /// [Builder] so the message can resolve `context.l10n` without changing
+  /// this mixin's public API.
   Widget _buildDefaultError(Object error, StackTrace stack) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          const DivineIcon(
-            icon: DivineIconName.warningCircle,
-            color: VineTheme.error,
-            size: 48,
-          ),
-          const SizedBox(height: 16),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 24),
-            child: Text(
-              'Error: $error',
-              style: const TextStyle(color: VineTheme.whiteText),
-              textAlign: TextAlign.center,
+    return Builder(
+      builder: (context) => Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const DivineIcon(
+              icon: DivineIconName.warningCircle,
+              color: VineTheme.error,
+              size: 48,
             ),
-          ),
-        ],
+            const SizedBox(height: 16),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Text(
+                context.l10n.commonSomethingWentWrong,
+                style: const TextStyle(color: VineTheme.whiteText),
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/mobile/lib/mixins/async_value_ui_helpers_mixin.dart
+++ b/mobile/lib/mixins/async_value_ui_helpers_mixin.dart
@@ -46,13 +46,19 @@ mixin AsyncValueUIHelpersMixin {
   }) {
     return asyncValue.when(
       data: onData,
-      loading: onLoading ?? _buildDefaultLoading,
-      error: onError ?? _buildDefaultError,
+      loading: onLoading ?? () => const _DefaultAsyncLoading(),
+      error: onError ?? (_, _) => const _DefaultAsyncError(),
     );
   }
+}
 
-  /// Default loading widget - centered spinner with vine green color on dark background
-  Widget _buildDefaultLoading() {
+/// Default loading widget — centered spinner with vine green color on a dark
+/// background.
+class _DefaultAsyncLoading extends StatelessWidget {
+  const _DefaultAsyncLoading();
+
+  @override
+  Widget build(BuildContext context) {
     return const ColoredBox(
       color: VineTheme.backgroundColor,
       child: Center(
@@ -60,37 +66,38 @@ mixin AsyncValueUIHelpersMixin {
       ),
     );
   }
+}
 
-  /// Default error widget - centered error icon with an intentional,
-  /// localized message.
-  ///
-  /// The raw [error] is deliberately not shown to the user (see the
-  /// per-layer failure contract in `rules/error_handling.md`); it stays in
-  /// the [AsyncValue] for logging at the provider layer. Wrapped in a
-  /// [Builder] so the message can resolve `context.l10n` without changing
-  /// this mixin's public API.
-  Widget _buildDefaultError(Object error, StackTrace stack) {
-    return Builder(
-      builder: (context) => Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const DivineIcon(
-              icon: DivineIconName.warningCircle,
-              color: VineTheme.error,
-              size: 48,
+/// Default error widget — centered error icon with an intentional, localized
+/// message.
+///
+/// The raw error is deliberately not shown to the user (see the per-layer
+/// failure contract in `rules/error_handling.md`); it stays in the
+/// [AsyncValue] for logging at the provider layer.
+class _DefaultAsyncError extends StatelessWidget {
+  const _DefaultAsyncError();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        spacing: 16,
+        children: [
+          const DivineIcon(
+            icon: DivineIconName.warningCircle,
+            color: VineTheme.error,
+            size: 48,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text(
+              context.l10n.commonSomethingWentWrong,
+              style: const TextStyle(color: VineTheme.whiteText),
+              textAlign: TextAlign.center,
             ),
-            const SizedBox(height: 16),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 24),
-              child: Text(
-                context.l10n.commonSomethingWentWrong,
-                style: const TextStyle(color: VineTheme.whiteText),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/test/mixins/async_value_ui_helpers_mixin_test.dart
+++ b/mobile/test/mixins/async_value_ui_helpers_mixin_test.dart
@@ -106,8 +106,12 @@ void main() {
           ),
         );
 
+        final l10n = lookupAppLocalizations(const Locale('en'));
         expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
-        expect(find.textContaining('Test error'), findsOneWidget);
+        // Shows an intentional, localized message...
+        expect(find.text(l10n.commonSomethingWentWrong), findsOneWidget);
+        // ...and never leaks the raw exception text to the user (#3589).
+        expect(find.textContaining('Test error'), findsNothing);
       },
     );
 
@@ -192,8 +196,10 @@ void main() {
         // Should have error icon
         expect(_divineIcon(DivineIconName.warningCircle), findsOneWidget);
 
-        // Should have error message
-        expect(find.textContaining('Network timeout'), findsOneWidget);
+        // Should show the intentional localized message, not the raw error
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.commonSomethingWentWrong), findsOneWidget);
+        expect(find.textContaining('Network timeout'), findsNothing);
 
         // Should be centered
         final center = tester.widget<Center>(


### PR DESCRIPTION
## What

The shared `AsyncValueUIHelpersMixin` default error widget rendered `Text('Error: $error')`, leaking raw exception text into the UI on the Explore router's loading/error states. This replaces it with an intentional, localized message.

- Adds `commonSomethingWentWrong` ("Something went wrong") to `app_en.arb` and translates it into all 17 non-English locales, so the generated getters no longer fall back to English (l10n regenerated and committed).
- Renders it from a private `_DefaultAsyncError` widget that resolves `context.l10n` from its own build context; the raw exception is no longer shown to users (it stays in the `AsyncValue` for logging at the provider layer, per the per-layer failure contract in `rules/error_handling.md`).
- Tests now assert the localized message **and** that the raw exception text is not present.

## Why

Part of #3589 ("Replace raw exception text in user-facing messages"), scoped to the Explore surface. The mixin's only production consumer is `explore_screen_router.dart`.

## Out of scope (left to #3589)

The separate `exploreErrorPrefix` / `exploreErrorLoadingLists` keys still embed a raw `{error}` placeholder. Removing `{error}` from that user-facing copy is a **product/copy decision across all locales** (per the ARB copy-alignment policy), not an l10n-migration side effect — so it stays with #3589.

## Verification

- `flutter analyze lib test integration_test` clean.
- `flutter test test/l10n/arb_consistency_test.dart test/mixins/async_value_ui_helpers_mixin_test.dart test/screens/explore_screen_router_test.dart` → all pass.
- l10n regenerated via `flutter gen-l10n` (generated files committed).

## Scope

One new generic `common*` string (translated in every locale) + the mixin + its test. Relates to the search epic #3801 closeout; does not close it.
