### PR TITLE
fix(blocklist): refilter curated/liked grids on broad blocklist changes

### DIFF
--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -4,6 +4,8 @@
 
 import 'dart:async';
 
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -37,21 +39,37 @@ class ProfileLikedVideosBloc
   ProfileLikedVideosBloc({
     required LikesRepository likesRepository,
     required VideosRepository videosRepository,
+    required ContentBlocklistRepository contentBlocklistRepository,
     required String currentUserPubkey,
     String? targetUserPubkey,
   }) : _likesRepository = likesRepository,
        _videosRepository = videosRepository,
+       _blocklistRepository = contentBlocklistRepository,
        _currentUserPubkey = currentUserPubkey,
        _targetUserPubkey = targetUserPubkey,
        super(const ProfileLikedVideosState()) {
     on<ProfileLikedVideosSyncRequested>(_onSyncRequested);
     on<ProfileLikedVideosSubscriptionRequested>(_onSubscriptionRequested);
     on<ProfileLikedVideosLoadMoreRequested>(_onLoadMoreRequested);
+    on<ProfileLikedVideosBlocklistChanged>(_onBlocklistChanged);
+
+    // Re-filter the loaded grid whenever the blocklist changes. Broad changes
+    // (account switch / identity adoption, relay-synced blocked-by-others,
+    // mute-list recovery) bump the version but emit no granular removed-id
+    // signal, so the held list must be re-filtered here (#5104).
+    _blocklistSubscription = _blocklistRepository.stateStream.listen((_) {
+      if (isClosed) return;
+      add(const ProfileLikedVideosBlocklistChanged());
+    });
   }
 
   final LikesRepository _likesRepository;
   final VideosRepository _videosRepository;
+  final ContentBlocklistRepository _blocklistRepository;
   final String _currentUserPubkey;
+
+  /// Subscription to broad blocklist changes; cancelled in [close].
+  late final StreamSubscription<ContentPolicyState> _blocklistSubscription;
 
   /// The pubkey of the user whose likes to display.
   /// If null or same as current user, uses LikesRepository sync.
@@ -474,6 +492,26 @@ class ProfileLikedVideosBloc
     }
   }
 
+  /// Re-filter the loaded videos against the current blocklist.
+  ///
+  /// Removes any now-blocked authors from [ProfileLikedVideosState.videos].
+  /// [likedEventIds] and [ProfileLikedVideosState.nextPageOffset] are left
+  /// untouched: the offset indexes into [likedEventIds] for pagination, and
+  /// the next page fetch re-applies the blocklist filter via
+  /// [VideosRepository], so no offset adjustment is needed here.
+  void _onBlocklistChanged(
+    ProfileLikedVideosBlocklistChanged event,
+    Emitter<ProfileLikedVideosState> emit,
+  ) {
+    final filtered = _blocklistRepository.filterContent(
+      state.videos,
+      (video) => video.pubkey,
+    );
+    if (filtered.length != state.videos.length) {
+      emit(state.copyWith(videos: filtered));
+    }
+  }
+
   /// Fetch videos for the given event IDs.
   ///
   /// Uses [VideosRepository.getVideosByIds] which implements cache-first:
@@ -509,5 +547,11 @@ class ProfileLikedVideosBloc
 
     // Filter unsupported formats
     return videos.where((v) => v.isSupportedOnCurrentPlatform).toList();
+  }
+
+  @override
+  Future<void> close() {
+    _blocklistSubscription.cancel();
+    return super.close();
   }
 }

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
@@ -34,3 +34,14 @@ final class ProfileLikedVideosLoadMoreRequested
     extends ProfileLikedVideosEvent {
   const ProfileLikedVideosLoadMoreRequested();
 }
+
+/// Request to re-filter the loaded videos against the current blocklist.
+///
+/// Dispatched from a [ContentBlocklistRepository.stateStream] subscription so
+/// the grid drops a newly-blocked author after a *broad* blocklist change
+/// (account switch / identity adoption, relay-synced blocked-by-others,
+/// mute-list recovery) — broad changes bump the version but emit no granular
+/// removed-id signal, so the bloc must re-filter its held list itself (#5104).
+final class ProfileLikedVideosBlocklistChanged extends ProfileLikedVideosEvent {
+  const ProfileLikedVideosBlocklistChanged();
+}

--- a/mobile/lib/providers/list_providers.dart
+++ b/mobile/lib/providers/list_providers.dart
@@ -8,6 +8,7 @@ import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/video_events_providers.dart';
@@ -222,6 +223,13 @@ Stream<List<CuratedList>> publicListsContainingVideo(
 /// Streams videos as they are fetched from cache or relays
 @riverpod
 Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
+  // Re-run (and therefore re-filter) when the blocklist changes. Broad changes
+  // (account switch / identity adoption, relay-synced blocked-by-others,
+  // mute-list recovery) bump this version but emit no granular removed-id
+  // signal, so version-reactivity is the only way the grid drops a newly
+  // blocked author without a manual refresh (#5104).
+  ref.watch(blocklistVersionProvider);
+
   Log.info(
     '📋 Fetching videos for curated list: $listId',
     name: 'CuratedListVideoEvents',
@@ -275,13 +283,15 @@ Stream<List<VideoEvent>> curatedListVideoEvents(Ref ref, String listId) async* {
   final missingIds = <String>[];
   final missingCoords = <String>[];
 
-  // Check cache for regular event IDs
+  // Check cache for regular event IDs. Skip blocked authors here too — the
+  // addressable-coord and relay branches already guard, but a plain-event-ID
+  // cache hit would otherwise pass an unfiltered blocked author through (#5104).
   for (final eventId in eventIds) {
     final cached = videoEventService.getVideoById(eventId);
-    if (cached != null) {
-      foundVideos.add(cached);
-    } else {
+    if (cached == null) {
       missingIds.add(eventId);
+    } else if (!videoEventService.shouldHideVideo(cached)) {
+      foundVideos.add(cached);
     }
   }
 
@@ -431,6 +441,10 @@ Stream<List<VideoEvent>> videoEventsByIds(
   Ref ref,
   List<String> videoIds,
 ) async* {
+  // Re-run (and therefore re-filter) when the blocklist changes — broad changes
+  // bump this version but emit no granular removed-id signal (#5104).
+  ref.watch(blocklistVersionProvider);
+
   Log.info(
     '📋 Fetching ${videoIds.length} videos by IDs',
     name: 'VideoEventsByIds',
@@ -470,13 +484,15 @@ Stream<List<VideoEvent>> videoEventsByIds(
   final missingIds = <String>[];
   final missingCoords = <String>[];
 
-  // Check cache for regular event IDs
+  // Check cache for regular event IDs. Skip blocked authors here too — a
+  // plain-event-ID cache hit would otherwise pass an unfiltered blocked author
+  // through, unlike the addressable-coord and relay branches below (#5104).
   for (final eventId in eventIds) {
     final cached = videoEventService.getVideoById(eventId);
-    if (cached != null) {
-      foundVideos.add(cached);
-    } else {
+    if (cached == null) {
       missingIds.add(eventId);
+    } else if (!videoEventService.shouldHideVideo(cached)) {
+      foundVideos.add(cached);
     }
   }
 

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -563,7 +563,7 @@ final class CuratedListVideoEventsProvider
 }
 
 String _$curatedListVideoEventsHash() =>
-    r'c74a136634eea5ad4ec744156164e2a24b9305ef';
+    r'c75af13b98f9f2859e06bb938119bc8187bd9e90';
 
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
@@ -652,7 +652,7 @@ final class VideoEventsByIdsProvider
   }
 }
 
-String _$videoEventsByIdsHash() => r'5e8ecb9a7517462193b7648f9a0fcd9483407741';
+String _$videoEventsByIdsHash() => r'e6a653a18021cfbf8221af6045f7f20a93841622';
 
 /// Provider that fetches VideoEvent objects directly from a list of video IDs
 /// Use this for discovered lists that aren't in local storage

--- a/mobile/lib/screens/curated_list_feed_screen.dart
+++ b/mobile/lib/screens/curated_list_feed_screen.dart
@@ -93,6 +93,10 @@ class _CuratedListFeedScreenState extends ConsumerState<CuratedListFeedScreen> {
             )
           : null,
       body: videosAsync.when(
+        // Keep the current grid on screen while the provider re-runs after a
+        // blocklist version bump, instead of flashing the spinner and resetting
+        // scroll (#5104).
+        skipLoadingOnReload: true,
         data: (videos) {
           if (videos.isEmpty) {
             return Center(

--- a/mobile/lib/screens/liked_videos_screen_router.dart
+++ b/mobile/lib/screens/liked_videos_screen_router.dart
@@ -70,6 +70,9 @@ class _LikedVideosScreenRouterState
     // Get services for ProfileLikedVideosBloc
     final likesRepository = ref.watch(likesRepositoryProvider);
     final videosRepository = ref.watch(videosRepositoryProvider);
+    final contentBlocklistRepository = ref.watch(
+      contentBlocklistRepositoryProvider,
+    );
     final nostrService = ref.watch(nostrServiceProvider);
     final currentUserPubkey = nostrService.publicKey;
     final videoIndex = routeCtx.videoIndex;
@@ -101,6 +104,7 @@ class _LikedVideosScreenRouterState
           create: (_) => ProfileLikedVideosBloc(
             likesRepository: likesRepository,
             videosRepository: videosRepository,
+            contentBlocklistRepository: contentBlocklistRepository,
             currentUserPubkey: currentUserPubkey,
           )..add(const ProfileLikedVideosSyncRequested()),
           child: const ProfileLikedGrid(isOwnProfile: true),
@@ -119,6 +123,7 @@ class _LikedVideosScreenRouterState
       create: (_) => ProfileLikedVideosBloc(
         likesRepository: likesRepository,
         videosRepository: videosRepository,
+        contentBlocklistRepository: contentBlocklistRepository,
         currentUserPubkey: currentUserPubkey,
       )..add(const ProfileLikedVideosSyncRequested()),
       child: _LikedVideosFeedView(videoIndex: videoIndex),

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -284,6 +284,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       _likedVideosBloc = ProfileLikedVideosBloc(
         likesRepository: likesRepository,
         videosRepository: videosRepository,
+        contentBlocklistRepository: contentBlocklistRepository,
         currentUserPubkey: currentUserPubkey,
         targetUserPubkey: widget.userIdHex,
       )..add(const ProfileLikedVideosSubscriptionRequested());

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -4,6 +4,8 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
@@ -15,11 +17,16 @@ class _MockLikesRepository extends Mock implements LikesRepository {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
 void main() {
   group('ProfileLikedVideosBloc', () {
     late _MockLikesRepository mockLikesRepository;
     late _MockVideosRepository mockVideosRepository;
+    late _MockContentBlocklistRepository mockBlocklistRepository;
     late StreamController<List<String>> likedIdsController;
+    late StreamController<ContentPolicyState> blocklistStateController;
 
     // Test pubkeys
     const currentUserPubkey =
@@ -30,7 +37,10 @@ void main() {
     setUp(() {
       mockLikesRepository = _MockLikesRepository();
       mockVideosRepository = _MockVideosRepository();
+      mockBlocklistRepository = _MockContentBlocklistRepository();
       likedIdsController = StreamController<List<String>>.broadcast();
+      blocklistStateController =
+          StreamController<ContentPolicyState>.broadcast();
 
       // Default stub for watchLikedEventIds
       when(
@@ -42,16 +52,23 @@ void main() {
       when(
         () => mockLikesRepository.getOrderedLikedEventIds(),
       ).thenAnswer((_) async => []);
+
+      // The bloc subscribes to stateStream in its constructor.
+      when(
+        () => mockBlocklistRepository.stateStream,
+      ).thenAnswer((_) => blocklistStateController.stream);
     });
 
     tearDown(() {
       likedIdsController.close();
+      blocklistStateController.close();
     });
 
     ProfileLikedVideosBloc createBloc({String? targetUserPubkey}) =>
         ProfileLikedVideosBloc(
           likesRepository: mockLikesRepository,
           videosRepository: mockVideosRepository,
+          contentBlocklistRepository: mockBlocklistRepository,
           currentUserPubkey: currentUserPubkey,
           targetUserPubkey: targetUserPubkey,
         );
@@ -671,6 +688,103 @@ void main() {
               // nextPageOffset shifted forward by 1 (1 new like added)
               .having((s) => s.nextPageOffset, 'nextPageOffset', 3),
         ],
+      );
+    });
+
+    group('ProfileLikedVideosBlocklistChanged', () {
+      const blockedPubkey =
+          'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+      const allowedPubkey =
+          'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+
+      VideoEvent videoBy(String id, String pubkey) {
+        final now = DateTime.now();
+        return VideoEvent(
+          id: id,
+          pubkey: pubkey,
+          createdAt: now.millisecondsSinceEpoch ~/ 1000,
+          content: '',
+          timestamp: now,
+          title: 'Test Video $id',
+          videoUrl: 'https://example.com/video.mp4',
+          thumbnailUrl: 'https://example.com/thumb.jpg',
+        );
+      }
+
+      void stubFilterRemovingBlocked() {
+        when(
+          () => mockBlocklistRepository.filterContent<VideoEvent>(any(), any()),
+        ).thenAnswer(
+          (invocation) =>
+              (invocation.positionalArguments[0] as List<VideoEvent>)
+                  .where((v) => v.pubkey != blockedPubkey)
+                  .toList(),
+        );
+      }
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'removes blocked authors from videos, leaving likedEventIds/offset',
+        setUp: stubFilterRemovingBlocked,
+        build: createBloc,
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          videos: [videoBy('a', blockedPubkey), videoBy('b', allowedPubkey)],
+          likedEventIds: const ['a', 'b'],
+          nextPageOffset: 2,
+        ),
+        act: (bloc) => bloc.add(const ProfileLikedVideosBlocklistChanged()),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'videos',
+                ['b'],
+              )
+              .having((s) => s.likedEventIds, 'likedEventIds', ['a', 'b'])
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 2),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'a stateStream emission triggers the re-filter',
+        setUp: stubFilterRemovingBlocked,
+        build: createBloc,
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          videos: [videoBy('a', blockedPubkey), videoBy('b', allowedPubkey)],
+          likedEventIds: const ['a', 'b'],
+        ),
+        act: (_) => blocklistStateController.add(ContentPolicyState.empty()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'videos',
+            ['b'],
+          ),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'emits nothing when no loaded video is blocked',
+        setUp: () {
+          when(
+            () =>
+                mockBlocklistRepository.filterContent<VideoEvent>(any(), any()),
+          ).thenAnswer(
+            (invocation) => List<VideoEvent>.from(
+              invocation.positionalArguments[0] as List<VideoEvent>,
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          videos: [videoBy('b', allowedPubkey)],
+          likedEventIds: const ['b'],
+        ),
+        act: (bloc) => bloc.add(const ProfileLikedVideosBlocklistChanged()),
+        expect: () => const <ProfileLikedVideosState>[],
       );
     });
   });

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -786,6 +786,19 @@ void main() {
         act: (bloc) => bloc.add(const ProfileLikedVideosBlocklistChanged()),
         expect: () => const <ProfileLikedVideosState>[],
       );
+
+      test('cancels the blocklist subscription on close', () async {
+        final bloc = createBloc();
+        await bloc.close();
+
+        // A stateStream emission after close must not trigger a re-filter.
+        blocklistStateController.add(ContentPolicyState.empty());
+        await Future<void>.delayed(Duration.zero);
+
+        verifyNever(
+          () => mockBlocklistRepository.filterContent<VideoEvent>(any(), any()),
+        );
+      });
     });
   });
 }

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -411,4 +411,87 @@ void main() {
       expect(second, isEmpty);
     });
   });
+
+  group(curatedListVideoEventsProvider, () {
+    test(
+      'filters hidden videos found by plain event id in the local cache',
+      () async {
+        const listId = 'curated-list-1';
+        final blockedVideo = _video(
+          id: _blockedVideoId,
+          pubkey: _blockedAuthor,
+        );
+        final allowedVideo = _video(id: _allowedVideoId, pubkey: _ownerA);
+        final videoEventService = _MockVideoEventService();
+        when(() => videoEventService.discoveryVideos).thenReturn(const []);
+        when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+        when(() => videoEventService.profileVideos).thenReturn(const []);
+        when(
+          () => videoEventService.getVideoById(_blockedVideoId),
+        ).thenReturn(blockedVideo);
+        when(
+          () => videoEventService.getVideoById(_allowedVideoId),
+        ).thenReturn(allowedVideo);
+        when(
+          () => videoEventService.shouldHideVideo(blockedVideo),
+        ).thenReturn(true);
+        when(
+          () => videoEventService.shouldHideVideo(allowedVideo),
+        ).thenReturn(false);
+
+        final container = ProviderContainer(
+          overrides: [
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+            curatedListVideosProvider(
+              listId,
+            ).overrideWith((ref) => [_blockedVideoId, _allowedVideoId]),
+          ],
+        );
+        addTearDown(container.dispose);
+        final provider = curatedListVideoEventsProvider(listId);
+        final subscription = container.listen(provider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final result = await container.read(provider.future);
+        expect(result.map((v) => v.id), [_allowedVideoId]);
+        verify(() => videoEventService.shouldHideVideo(blockedVideo)).called(1);
+      },
+    );
+
+    test('re-runs and re-filters when the blocklist version changes', () async {
+      const listId = 'curated-list-2';
+      final video = _video(id: _allowedVideoId, pubkey: _ownerA);
+      final videoEventService = _MockVideoEventService();
+      when(() => videoEventService.discoveryVideos).thenReturn(const []);
+      when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+      when(() => videoEventService.profileVideos).thenReturn(const []);
+      when(
+        () => videoEventService.getVideoById(_allowedVideoId),
+      ).thenReturn(video);
+      when(() => videoEventService.shouldHideVideo(video)).thenReturn(false);
+
+      final container = ProviderContainer(
+        overrides: [
+          videoEventServiceProvider.overrideWithValue(videoEventService),
+          curatedListVideosProvider(
+            listId,
+          ).overrideWith((ref) => [_allowedVideoId]),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final provider = curatedListVideoEventsProvider(listId);
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      final first = await container.read(provider.future);
+      expect(first.map((v) => v.id), [_allowedVideoId]);
+
+      when(() => videoEventService.shouldHideVideo(video)).thenReturn(true);
+      container.read(blocklistVersionProvider.notifier).increment();
+
+      final second = await container.read(provider.future);
+      expect(second, isEmpty);
+    });
+  });
 }

--- a/mobile/test/providers/list_providers_test.dart
+++ b/mobile/test/providers/list_providers_test.dart
@@ -29,6 +29,11 @@ const String _ownerB =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 const String _blockedAuthor =
     'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+// Full-length 64-char hex event ids — the plain-event-ID branch requires them.
+const String _blockedVideoId =
+    'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+const String _allowedVideoId =
+    'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
 
 final DateTime _frozenNow = DateTime.utc(2026, 4, 20, 12);
 
@@ -326,5 +331,84 @@ void main() {
         verify(() => videoEventService.shouldHideVideo(blockedVideo)).called(1);
       },
     );
+
+    test(
+      'filters hidden videos found by plain event id in the local cache',
+      () async {
+        final blockedVideo = _video(
+          id: _blockedVideoId,
+          pubkey: _blockedAuthor,
+        );
+        final allowedVideo = _video(id: _allowedVideoId, pubkey: _ownerA);
+        final videoEventService = _MockVideoEventService();
+        when(() => videoEventService.discoveryVideos).thenReturn(const []);
+        when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+        when(() => videoEventService.profileVideos).thenReturn(const []);
+        when(
+          () => videoEventService.getVideoById(_blockedVideoId),
+        ).thenReturn(blockedVideo);
+        when(
+          () => videoEventService.getVideoById(_allowedVideoId),
+        ).thenReturn(allowedVideo);
+        when(
+          () => videoEventService.shouldHideVideo(blockedVideo),
+        ).thenReturn(true);
+        when(
+          () => videoEventService.shouldHideVideo(allowedVideo),
+        ).thenReturn(false);
+
+        final container = ProviderContainer(
+          overrides: [
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+          ],
+        );
+        addTearDown(container.dispose);
+        final provider = videoEventsByIdsProvider([
+          _blockedVideoId,
+          _allowedVideoId,
+        ]);
+        final subscription = container.listen(provider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final result = await container.read(provider.future);
+        expect(result.map((v) => v.id), [_allowedVideoId]);
+        verify(() => videoEventService.shouldHideVideo(blockedVideo)).called(1);
+      },
+    );
+
+    test('re-runs and re-filters when the blocklist version changes', () async {
+      final video = _video(id: _allowedVideoId, pubkey: _ownerA);
+      final videoEventService = _MockVideoEventService();
+      when(() => videoEventService.discoveryVideos).thenReturn(const []);
+      when(() => videoEventService.homeFeedVideos).thenReturn(const []);
+      when(() => videoEventService.profileVideos).thenReturn(const []);
+      when(
+        () => videoEventService.getVideoById(_allowedVideoId),
+      ).thenReturn(video);
+      // Initially the author is visible.
+      when(() => videoEventService.shouldHideVideo(video)).thenReturn(false);
+
+      final container = ProviderContainer(
+        overrides: [
+          videoEventServiceProvider.overrideWithValue(videoEventService),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final provider = videoEventsByIdsProvider([_allowedVideoId]);
+      final subscription = container.listen(provider, (_, _) {});
+      addTearDown(subscription.close);
+
+      final first = await container.read(provider.future);
+      expect(first.map((v) => v.id), [_allowedVideoId]);
+
+      // Block the author and bump the blocklist version (a broad change emits
+      // no removed-id signal — only the version bump).
+      when(() => videoEventService.shouldHideVideo(video)).thenReturn(true);
+      container.read(blocklistVersionProvider.notifier).increment();
+
+      final second = await container.read(provider.future);
+      expect(second, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Description

The curated-list grid (`CuratedListFeedScreen`) and the liked-videos grid (`ProfileLikedGrid`) kept showing a blocked author after a **broad** blocklist change — account switch / identity adoption (#5031), a relay-synced "blocked-by-others", or mute-list recovery — until the screen re-fetched. Broad changes bump the blocklist version but emit **no** granular removed-id signal (the mechanism #5041/#5105 used for the fullscreen feeds), so any surface that doesn't watch the version stays stale. This is the grid-level sibling of #5041, deliberately deferred from PR #5105.

Verified the fix must be client-side: the relay serves these surfaces viewer-blind, the curated grid subscribes directly to the relay, and the liked grid sources video events from relay/SQLite (funnelcake is used only for loop-count stats, with no viewer identity). No backend filters blocked authors per-viewer on either path.

### Liked-videos grid (commit 1)
`ProfileLikedVideosBloc` filtered blocked authors only at fetch time and held a static `state.videos`, reacting only to like add/remove. It now subscribes to `ContentBlocklistRepository.stateStream` (mirroring `SafetySettingsCubit`) and re-filters its held list via `filterContent` on any blocklist change — self-contained, so it covers all three render sites (liked screen grid + feed, profile Liked tab; own and other profiles) with no per-screen wiring. `likedEventIds`/pagination offset are left untouched; the next page fetch re-applies the filter.

### Curated-list grid (commit 2)
`curatedListVideoEvents` and `videoEventsByIds` never watched `blocklistVersionProvider`, so an already-loaded grid stayed stale on a broad change. They also skipped `shouldHideVideo` on the plain-event-ID cache-hit branch, leaking a blocked author's cached video even at fetch time (the addressable-coord and relay branches already guarded). Both providers now watch the version (re-running and re-filtering on a broad change) and guard the cache-hit branch.

**Related Issue:** Closes #5104

## Out of Scope

- Fullscreen snapshot feeds — already fixed in #5041 / PR #5105.
- No backend change: server-side per-viewer block/mute filtering does not apply to these surfaces; the fix is necessarily client-side.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart` — 29 pass (3 new: handler refilter, stateStream-triggered refilter, no-op when nothing blocked).
- `flutter test test/providers/list_providers_test.dart` — 7 pass (2 new: plain-event-ID cache-hit guard, version-bump re-filter).
- `flutter test test/screens/curated_list_feed_screen_test.dart test/widgets/profile/profile_liked_grid_test.dart` — pass, no regressions.
- `dart run build_runner build --delete-conflicting-outputs` — `list_providers.g.dart` regenerated and committed (provider-body hash only).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)