### PR TITLE
fix(notifications): mark notifications seen on inbox open (#4708)

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -98,6 +98,14 @@ class NotificationFeedBloc
   /// translated into state by `_onSnapshotChanged`. Status transitions
   /// (loading -> loaded / failure) are emitted here so the UI can render
   /// the initial spinner and error states.
+  ///
+  /// After a successful refresh, advances the server "seen" watermark via
+  /// [_markSeenOnOpen] so opening the notifications surface clears the unread
+  /// badge and the badge thereafter reflects "new since last seen" rather than
+  /// the accumulated untapped total (#4708). `_onStarted` fires once per open
+  /// (it is dispatched from the keyed `BlocProvider.create` on every mount of
+  /// the notifications surface) and is NOT dispatched on app resume or
+  /// pull-to-refresh, so the watermark only advances on a deliberate open.
   Future<void> _onStarted(
     NotificationFeedStarted event,
     Emitter<NotificationFeedState> emit,
@@ -107,6 +115,7 @@ class NotificationFeedBloc
     try {
       await _notificationRepository.refresh();
       emit(state.copyWith(status: NotificationFeedStatus.loaded));
+      await _markSeenOnOpen();
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
       // `FunnelcakeException` (4xx/5xx/timeout; transient-retry
@@ -155,6 +164,40 @@ class NotificationFeedBloc
         ),
       );
       return;
+    }
+  }
+
+  /// Advances the server "seen" watermark when the notifications surface opens.
+  ///
+  /// Reuses [NotificationRepository.markAllAsRead] — the single source of truth
+  /// that posts `read_until = now()` to FunnelCake, optimistically flips the
+  /// snapshot (so the badge clears immediately), and rolls back on failure.
+  /// Going through the repository (not a widget lifecycle hook) is what keeps
+  /// the badge convergent; the previous `MarkAllReadOnDispose` widget that
+  /// marked-on-*leave* fought the snapshot and was removed in #4758. This marks
+  /// on *open* instead.
+  ///
+  /// A seen-advance failure must never blacken the feed, so every error is
+  /// caught here and never rethrown — the repository has already restored the
+  /// snapshot on failure, so the list stays usable.
+  Future<void> _markSeenOnOpen() async {
+    try {
+      await _notificationRepository.markAllAsRead();
+    } on Exception catch (e, s) {
+      // Typed `FunnelcakeException` (4xx/5xx/timeout) + Drift DAO failures the
+      // repository rethrows after rolling the optimistic flip back. Per
+      // .claude/rules/error_handling.md these are expected domain failures,
+      // NOT Reportable.
+      addError(e, s);
+    } catch (e, s) {
+      // Errors (StateError, TypeError) — matrix-YES invariant violation.
+      addError(
+        Reportable(
+          e,
+          context: NotificationFeedBlocReportableSites.markSeenOnOpen,
+        ),
+        s,
+      );
     }
   }
 

--- a/mobile/lib/notifications/bloc/reportable_sites.dart
+++ b/mobile/lib/notifications/bloc/reportable_sites.dart
@@ -17,6 +17,12 @@ abstract class NotificationFeedBlocReportableSites {
   /// `_fetchWithRetry` if the analyzer's loop invariant ever breaks.
   static const String onStarted = '_onStarted';
 
+  /// `_markSeenOnOpen` generic-catch arm — `Error` types that escape
+  /// `NotificationRepository.markAllAsRead`'s rollback `catch (_)` rethrow
+  /// when the notifications surface advances the seen watermark on open.
+  /// Realistically a Drift DAO `TypeError` from a row-shape mismatch.
+  static const String markSeenOnOpen = '_markSeenOnOpen';
+
   /// `_onLoadMore` generic-catch arm — `Error` types that escape
   /// `NotificationRepository.getNotifications`'s `on Exception`
   /// propagation. Single-attempt paginate has no retry, so the

--- a/mobile/lib/notifications/view/notifications_page.dart
+++ b/mobile/lib/notifications/view/notifications_page.dart
@@ -16,8 +16,8 @@ import 'package:openvine/providers/app_providers.dart';
 /// provides it to [NotificationsView]. The bloc dispatches
 /// `NotificationFeedStarted` on mount, which triggers `repository.refresh()`.
 /// The resulting snapshot flows through the repository's snapshot stream and
-/// propagates to the badge cubit automatically. Read state changes only on
-/// explicit per-item taps here; bulk mark-all lives in notification settings.
+/// propagates to the badge cubit automatically. Opening the page advances the
+/// seen watermark; per-item taps still mark individual rows read when needed.
 class NotificationsPage extends ConsumerWidget {
   /// Creates a [NotificationsPage].
   const NotificationsPage({super.key});

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -64,8 +64,7 @@ for core in "${GLOBALS[@]}"; do
     # A real ASSIGNMENT (install or restore): (<prefix>.)?CORE = , where `=` is
     # not `==` / `=>`. `=` may sit at end-of-line (dart format keeps the LHS
     # token on its own line for a multi-line RHS).
-    if ! printf '%s\n' "$body" \
-      | grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)"; then
+    if ! grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)" <<<"$body"; then
       continue
     fi
 
@@ -79,8 +78,7 @@ for core in "${GLOBALS[@]}"; do
     # SNAPSHOT (capture-read): the global appears on the RHS of an assignment
     # (`<id> = <Global>`), i.e. the original was captured into a local.
     has_capture=0
-    if printf '%s\n' "$body" \
-      | grep -qE "=[[:space:]]*([A-Za-z_][A-Za-z0-9_]*\.)?${core}([^A-Za-z0-9_]|$)"; then
+    if grep -qE "=[[:space:]]*([A-Za-z_][A-Za-z0-9_]*\.)?${core}([^A-Za-z0-9_]|$)" <<<"$body"; then
       has_capture=1
     fi
 
@@ -88,8 +86,7 @@ for core in "${GLOBALS[@]}"; do
     # (`<Global> = original;` block form, or `=> <Global> = original)` arrow
     # form), which distinguishes a restore from a `<Global> = SomeFake()` install.
     has_restore=0
-    if printf '%s\n' "$body" \
-      | grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[;)]"; then
+    if grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[;)]" <<<"$body"; then
       has_restore=1
     fi
 

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -97,6 +97,9 @@ void main() {
       when(
         () => mockNotificationRepo.markAsRead(any()),
       ).thenAnswer((_) async {});
+      when(
+        () => mockNotificationRepo.markAllAsRead(),
+      ).thenAnswer((_) async {});
       when(() => mockNotificationRepo.resetPaginationDepth()).thenReturn(null);
     });
 
@@ -191,7 +194,7 @@ void main() {
 
     group('NotificationFeedStarted', () {
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'emits loading then loaded; calls refresh without marking read',
+        'emits loading then loaded; refreshes then marks seen on open (#4708)',
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
@@ -199,8 +202,33 @@ void main() {
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
+          // Seen-on-open advances the server watermark AFTER the refresh so
+          // the badge clears and thereafter shows "new since last seen".
+          verifyInOrder([
+            () => mockNotificationRepo.refresh(),
+            () => mockNotificationRepo.markAllAsRead(),
+          ]);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'stays loaded when the seen-on-open mark-all fails (does not blacken '
+        'the feed)',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenThrow(Exception('mark-all boom'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        expect: () => [
+          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        ],
+        errors: () => [isA<Exception>()],
+        verify: (_) {
           verify(() => mockNotificationRepo.refresh()).called(1);
-          verifyNever(() => mockNotificationRepo.markAllAsRead());
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
         },
       );
 
@@ -413,6 +441,9 @@ void main() {
         ],
         verify: (_) {
           verify(() => mockNotificationRepo.refresh()).called(1);
+          // Pull-to-refresh shows current unread; only opening (Started)
+          // advances the seen watermark (#4708).
+          verifyNever(() => mockNotificationRepo.markAllAsRead());
         },
       );
 

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -14,6 +14,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:notification_repository/notification_repository.dart';
 import 'package:openvine/notifications/bloc/notification_feed_bloc.dart';
+import 'package:openvine/notifications/bloc/reportable_sites.dart';
 import 'package:openvine/observability/reportable_error.dart';
 
 class _MockNotificationRepository extends Mock
@@ -226,6 +227,39 @@ void main() {
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         errors: () => [isA<Exception>()],
+        verify: (_) {
+          verify(() => mockNotificationRepo.refresh()).called(1);
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+        },
+      );
+
+      blocTest<NotificationFeedBloc, NotificationFeedState>(
+        'wraps unexpected Error from seen-on-open mark-all as Reportable '
+        'without blackening the feed',
+        setUp: () {
+          when(
+            () => mockNotificationRepo.markAllAsRead(),
+          ).thenThrow(StateError('invariant'));
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(NotificationFeedStarted()),
+        expect: () => [
+          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>()
+              .having(
+                (r) => r.context,
+                'context',
+                NotificationFeedBlocReportableSites.markSeenOnOpen,
+              )
+              .having(
+                (r) => r.unwrap(),
+                'unwrap',
+                isA<StateError>(),
+              ),
+        ],
         verify: (_) {
           verify(() => mockNotificationRepo.refresh()).called(1);
           verify(() => mockNotificationRepo.markAllAsRead()).called(1);

--- a/mobile/test/notifications/view/inbox_notifications_page_test.dart
+++ b/mobile/test/notifications/view/inbox_notifications_page_test.dart
@@ -1,5 +1,6 @@
 // ABOUTME: Widget tests for InboxNotificationsPage — verifies that opening
-// ABOUTME: the inbox refreshes once without implicitly mutating read state.
+// ABOUTME: the inbox refreshes once and marks notifications seen on open
+// ABOUTME: (advances the read watermark) without fanning out across tabs (#4708).
 
 // ignore_for_file: prefer_const_constructors
 
@@ -73,21 +74,27 @@ void main() {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
+      // Opening the inbox refreshes and marks notifications seen (advances the
+      // server read watermark) so the badge reflects "new since last seen"
+      // (#4708).
       verify(() => mockNotificationRepo.refresh()).called(1);
-      verifyNever(() => mockNotificationRepo.markAllAsRead());
+      verify(() => mockNotificationRepo.markAllAsRead()).called(1);
     });
 
     testWidgets(
-      'does not mark notifications read when the inbox page is unmounted',
+      'marks seen on open but not again when the inbox page is unmounted',
       (tester) async {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
-        verifyNever(() => mockNotificationRepo.markAllAsRead());
+        // Marked seen exactly once on open.
+        verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+        clearInteractions(mockNotificationRepo);
 
         // Leaving the inbox (toggling to the Messages segment so the
         // notifications KeyedSubtree is swapped out, or leaving the inbox tab
-        // so the ShellRoute unmounts the subtree) must NOT auto-zero unread
-        // state. Read transitions are deliberate only. See #4729.
+        // so the ShellRoute unmounts the subtree) must NOT mark read again on
+        // *leave* — the seen advance is on open only. #4758 removed the old
+        // mark-on-dispose; #4708 added mark-on-open.
         await tester.pumpWidget(const SizedBox.shrink());
         await tester.pumpAndSettle();
 
@@ -96,24 +103,25 @@ void main() {
     );
 
     testWidgets(
-      'does not fan out refresh or mark-read across the five filter tabs',
+      'does not fan out refresh or mark-seen across the five filter tabs',
       (tester) async {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 
         // Swipe through the four non-default tabs. Each visit mounts a
-        // fresh NotificationsView; the contract is that none of them
-        // triggers another refresh or implicit mark-all-read.
+        // fresh NotificationsView but they share one NotificationFeedBloc;
+        // the contract is that none of them triggers another refresh or an
+        // additional mark-seen.
         for (var i = 1; i < 5; i++) {
           await tester.tap(find.byType(Tab).at(i));
           await tester.pumpAndSettle();
         }
 
-        // Exactly one refresh and no implicit markAllAsRead across the
-        // whole inbox-open lifecycle, even after all five filter views
-        // have mounted.
+        // Exactly one refresh and one mark-seen across the whole inbox-open
+        // lifecycle, even after all five filter views have mounted — the
+        // shared bloc opens once, not once per tab.
         verify(() => mockNotificationRepo.refresh()).called(1);
-        verifyNever(() => mockNotificationRepo.markAllAsRead());
+        verify(() => mockNotificationRepo.markAllAsRead()).called(1);
         // Confirm all five filter views actually mounted — guards
         // against the test silently passing because TabBarView never
         // built the off-default children.

--- a/mobile/test/notifications/view/notifications_page_test.dart
+++ b/mobile/test/notifications/view/notifications_page_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Tests for NotificationsPage — verifies route constants and that
 // ABOUTME: the page forwards bloc construction + initial refresh to the
-// ABOUTME: repository without implicitly mutating read state.
+// ABOUTME: repository and marks notifications seen on open (#4708).
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -87,26 +87,30 @@ void main() {
         verify(() => mockNotificationRepo.refresh()).called(1);
       });
 
-      testWidgets('does not mark notifications read on open', (
+      testWidgets('marks notifications seen on open', (
         tester,
       ) async {
         await tester.pumpWidget(buildSubject());
         await tester.pumpAndSettle();
 
-        verifyNever(() => mockNotificationRepo.markAllAsRead());
+        // Opening advances the server read watermark so the badge clears and
+        // thereafter shows "new since last seen" (#4708).
+        verify(() => mockNotificationRepo.markAllAsRead()).called(1);
       });
 
       testWidgets(
-        'does not mark notifications read when the page is unmounted',
+        'marks seen on open but not again when the page is unmounted',
         (tester) async {
           await tester.pumpWidget(buildSubject());
           await tester.pumpAndSettle();
-          verifyNever(() => mockNotificationRepo.markAllAsRead());
+          // Marked seen exactly once on open.
+          verify(() => mockNotificationRepo.markAllAsRead()).called(1);
+          clearInteractions(mockNotificationRepo);
 
           // Leaving the notifications route (e.g. switching bottom-nav tabs;
           // the ShellRoute is not stateful, so the page unmounts) must NOT
-          // auto-zero unread state. Read transitions are deliberate only —
-          // a per-item tap or an explicit mark-all action. See #4729.
+          // mark read again on *leave* — #4758 removed mark-on-dispose;
+          // #4708 added mark-on-open only.
           await tester.pumpWidget(const SizedBox.shrink());
           await tester.pumpAndSettle();
 


### PR DESCRIPTION
## Description

The Inbox unread badge showed the **accumulated untapped-unread total** instead of "new since last seen" - reported as "stuck at 50 / never resets" (Zendesk, 2026-05-25) and "yesterday 9, today 11, but only 2 are actually new" (2026-06-11), the latter reproducing after the merged fixes #4758/#4760.

**Root cause.** #4758 deleted `MarkAllReadOnDispose` (the last mark-on-view path) with no replacement, so a notification's `read` flag flipped only on a per-item tap or the settings "mark all read" action. Merely opening the inbox marked nothing, so the badge - `count(!isRead)` over the loaded page - kept accumulating. #5018 ("refresh inbox on app resume", merged the same day as the 2026-06-11 report) re-pulls page-1 server-unread on every resume, which made the accumulated count continuously visible.

The backend was confirmed not to be the cause: read state persists per recipient (`notification_reads`) and FunnelCake already exposes a server-side seen watermark (`notification_read_markers.read_until`, advanced by `mark_all_notifications_read`). No backend change is needed.

**Fix.** On opening the notifications surface, advance the existing server watermark. After a successful refresh, `NotificationFeedBloc._onStarted` calls `NotificationRepository.markAllAsRead()` (posts `notification_ids: null` -> `read_until = now()`). The badge derives from the repository snapshot, so it clears to 0 on open and thereafter shows only notifications created after the last open. Because the watermark is timestamp-based and server-side, this fixes both the accumulation and the "stuck at 50" page-cap symptom.

Design notes:
- Goes through `repository.markAllAsRead` (the single source of truth, already used by the settings screen and covered by rollback semantics), not a widget dispose hook, so it does not reintroduce the snapshot desync #4758 removed.
- Fires only on open (`NotificationFeedStarted`, dispatched once per mount of the notifications surface), not on app resume or pull-to-refresh.
- A seen-advance failure is caught and swallowed so it never blackens the feed; the repository already rolls the optimistic flip back on failure.
- Product decision confirmed: **seen == read**. There is no separate seen-only state; per-row unread styling clears on open.

This PR also hardens `scripts/check_process_global_mutations.sh` after the final rebase exposed a false negative in the generated-files guard: `printf ... | grep -q` under `set -o pipefail` can report failure when `grep -q` exits early and `printf` receives SIGPIPE. The guard now uses here-strings for those probes.

Closes #4708.
Relates to #4200.

## Out of Scope

- De-SUM / relabel the Inbox badge. It is a combined DM + notification count (`vine_bottom_nav.dart`), so a reported "11 vs 2" can still be 2 notifications + 9 unread DMs. Product chose to keep the combined badge for now.
- Mute filtering of notification counts (backend `divine-funnelcake#495` / `#494`).
- Dead-code cleanup of `_consolidateFollows` + the `funnelcake#234` TODO in `notification_feed_state.dart`; cleaning it here would widen the PR beyond the badge/read-state fix.
- Optional unconditional `markSeen()` repository method for the rare "loaded-all-read + unloaded-unread at open" edge.

## Verification

- Rebased onto current `origin/main` (`9bfcf2ab1`).
- `bash scripts/check_process_global_mutations.sh` - pass.
- `mise exec -- flutter test test/notifications/ test/blocs/notifications/` - 184 passed.
- `mise exec -- flutter analyze lib test` - No issues found.
- `mise exec -- dart format --set-exit-if-changed lib test` - 0 changed.
- Pre-push hook re-ran analyzer and changed-file notification tests - all passed.
- GitHub checks green on head `bc6aa0426`: Generated Files, Format, Analyze, Tests, VGV Tag Gate, Mobile CI, Web Preview, Mergeability, semantic PR, and CLA.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI hardening / tech-debt cleanup
