### PR TITLE
docs(state): mark #3523 likes/comments/reposts gating as not planned

### DIFF
--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -297,9 +297,10 @@ readiness signal — `profileRepositoryProvider` and
 reads the nullable value and renders a loading / disabled
 affordance until it's non-null; the bloc never gets a chance to
 capture a stale instance, and there's nothing for this rule to
-guard. #3523 tracks the in-flight migration of `likes` / `comments`
-/ `reposts` to the same shape — once it ships, the four canonical
-sites this rule cites won't need this rule at all.
+guard. Migrating `likes` / `comments` / `reposts` to that same
+nullable-gated shape was evaluated in #3523 and closed as not
+planned — they stay under the rule below, where the `ValueKey`
+guard is the shipped defense.
 
 The rule below is the answer when Pattern A isn't available — when
 the provider has no clean "not ready" signal, or when restructuring

--- a/.claude/rules/state_management.md
+++ b/.claude/rules/state_management.md
@@ -380,12 +380,11 @@ class _FeedItem extends ConsumerWidget {
 }
 ```
 
-The canonical implementation lives at four sites — see
-`video_feed_page.dart` (`_PooledVideoFeedItem.build`,
-`_WebVideoFeedItem.build`) and
-`pooled_fullscreen_video_feed_screen.dart`
-(`_PooledFullscreenItem.build`, `_WebFullscreenItem.build`). The
-failure they cure (#3503): a cold-launch race where the warm-up
+The canonical implementation lives in `feed_videos.dart` at the
+`BlocProvider<VideoInteractionsBloc>` created in
+`__OverlayState.build`, using `videoInteractionsBlocKey(...)` from
+`video_interactions_bloc_key.dart`. The failure it cures (#3503): a
+cold-launch race where the warm-up
 chain materialised `likesRepository` before
 `AuthService.initialize()` resolved, the underlying `Nostr` wrapped
 a `LocalKeySigner(null)` placeholder, and every `sendLike` from the
@@ -487,12 +486,11 @@ wraps a `StatefulWidget` child via `BlocProvider`, and have the
 stateful child consume the bloc through `context.read<Bloc>()`.
 The parent then uses the existing rule (record-typed `ValueKey`
 over the captured provider tuple) — no new shape introduced. This
-matches the four canonical existing examples in this codebase:
-`_PooledVideoFeedItem` / `_PooledVideoFeedItemContent` in
-`video_feed_page.dart`, and `_PooledFullscreenItem` /
-`_PooledFullscreenItemContent` in
-`pooled_fullscreen_video_feed_screen.dart`. It also follows the
-Page/View pattern in [`ui_theming.md`](ui_theming.md) and the
+matches the existing feed item host in `feed_videos.dart`, where
+`__OverlayState` watches the repositories and keys the
+`BlocProvider<VideoInteractionsBloc>` with
+`videoInteractionsBlocKey(...)`. It also follows the Page/View
+pattern in [`ui_theming.md`](ui_theming.md) and the
 constructor-injection guidance in
 [`architecture.md`](architecture.md) — the stateful child stops
 reaching into Riverpod for its dependencies.


### PR DESCRIPTION
Closes #5172

## Why

#3523 (`task(providers): gate likes/comments/reposts repos on isNostrReady`) was closed as **not planned** after re-evaluating the cost/benefit on current main:

- The three providers are still ungated and the intent is unshipped.
- All three defense layers from the original deferral are intact, and the point-fix is stronger now — the former four keyed `BlocProvider<VideoInteractionsBloc>` create-sites collapsed into one (`feed_videos.dart` via `videoInteractionsBlocKey`), with the call-site cost down 21→13.

The "Bridging Riverpod-provided dependencies into BlocProvider" rule still described #3523 as an "in-flight migration" that would soon retire the rule. That is no longer true. The same rule body also still pointed at the pre-consolidation four feed/fullscreen classes.

## Change

Docs-only updates in `.claude/rules/state_management.md`:

- Mark the #3523 likes/comments/reposts Pattern A migration as evaluated and closed not planned.
- Repoint the canonical `VideoInteractionsBloc` implementation references to the current `feed_videos.dart` / `videoInteractionsBlocKey` host.

No code, tests, generated files, or build inputs are touched.