### PR TITLE
fix(feed): send recommendation session seed

### DIFF
--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -216,6 +216,9 @@ class ForYouFeed extends _$ForYouFeed {
       final resultVideos = response.videos.toVideoEvents();
 
       if (!ref.mounted) return;
+      if (_sessionSeed != seed) {
+        return;
+      }
 
       final videoEventService = ref.read(videoEventServiceProvider);
       final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -101,15 +101,17 @@ class ForYouFeed extends _$ForYouFeed {
       return const VideoFeedState(videos: [], hasMoreContent: false);
     }
 
-    _nextCursor = null;
-    _sessionSeed = generateRecommendationSessionSeed();
-    return _fetchRecommendations();
+    return _fetchRecommendations(
+      sessionSeed: generateRecommendationSessionSeed(),
+    );
   }
 
   Future<VideoFeedState> _fetchRecommendations({
     bool preserveExistingOnError = false,
+    String? sessionSeed,
   }) async {
     try {
+      final requestSeed = sessionSeed ?? _sessionSeed;
       final authService = ref.read(authServiceProvider);
       final currentUserPubkey = authService.currentPublicKeyHex;
       if (currentUserPubkey == null) {
@@ -121,7 +123,7 @@ class ForYouFeed extends _$ForYouFeed {
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
         limit: _pageSize,
-        seed: _sessionSeed,
+        seed: requestSeed,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
@@ -144,6 +146,7 @@ class ForYouFeed extends _$ForYouFeed {
             .toList(),
       );
 
+      _sessionSeed = requestSeed;
       _nextCursor = response.nextCursor;
       final hasMore = response.hasMore && _nextCursor != null;
 
@@ -194,6 +197,7 @@ class ForYouFeed extends _$ForYouFeed {
 
       final client = ref.read(funnelcakeApiClientProvider);
       final cursor = _nextCursor;
+      final seed = _sessionSeed;
       if (cursor == null) {
         state = AsyncData(
           currentState.copyWith(isLoadingMore: false, hasMoreContent: false),
@@ -205,7 +209,7 @@ class ForYouFeed extends _$ForYouFeed {
         pubkey: currentUserPubkey,
         limit: _pageSize,
         cursor: cursor,
-        seed: _sessionSeed,
+        seed: seed,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
@@ -267,14 +271,14 @@ class ForYouFeed extends _$ForYouFeed {
       category: LogCategory.video,
     );
 
-    _nextCursor = null;
-    _sessionSeed = generateRecommendationSessionSeed();
-
     await staleWhileRevalidate(
       getCurrentState: () => state,
       isMounted: () => ref.mounted,
       setState: (s) => state = s,
-      fetchFresh: () => _fetchRecommendations(preserveExistingOnError: true),
+      fetchFresh: () => _fetchRecommendations(
+        preserveExistingOnError: true,
+        sessionSeed: generateRecommendationSessionSeed(),
+      ),
     );
   }
 }

--- a/mobile/lib/providers/for_you_provider.dart
+++ b/mobile/lib/providers/for_you_provider.dart
@@ -14,6 +14,7 @@ import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/state/video_feed_state.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 part 'for_you_provider.g.dart';
 
@@ -27,6 +28,7 @@ class ForYouFeed extends _$ForYouFeed {
   static const int _pageSize = 50;
 
   String? _nextCursor;
+  String _sessionSeed = generateRecommendationSessionSeed();
 
   @override
   Future<VideoFeedState> build() async {
@@ -100,6 +102,7 @@ class ForYouFeed extends _$ForYouFeed {
     }
 
     _nextCursor = null;
+    _sessionSeed = generateRecommendationSessionSeed();
     return _fetchRecommendations();
   }
 
@@ -118,6 +121,7 @@ class ForYouFeed extends _$ForYouFeed {
       final response = await client.getRecommendations(
         pubkey: currentUserPubkey,
         limit: _pageSize,
+        seed: _sessionSeed,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
@@ -201,6 +205,7 @@ class ForYouFeed extends _$ForYouFeed {
         pubkey: currentUserPubkey,
         limit: _pageSize,
         cursor: cursor,
+        seed: _sessionSeed,
         preferredLanguages: hints.preferredLanguages,
         viewerCountry: hints.viewerCountry,
       );
@@ -261,6 +266,9 @@ class ForYouFeed extends _$ForYouFeed {
       name: 'ForYouFeedProvider',
       category: LogCategory.video,
     );
+
+    _nextCursor = null;
+    _sessionSeed = generateRecommendationSessionSeed();
 
     await staleWhileRevalidate(
       getCurrentState: () => state,

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'48c8a6027b0bbc85ffae4a7305c97b8a0b4c5991';
+String _$forYouFeedHash() => r'f57a9a078661c3aa5f10aa1aaf9b7fd41791fc4a';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'15e638990cec37ac7cd5c7fe7470fc6c50b10166';
+String _$forYouFeedHash() => r'99fea132c17a4c236b75cd70e8dcc4d7a06f3dad';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -48,7 +48,7 @@ final class ForYouFeedProvider
   ForYouFeed create() => ForYouFeed();
 }
 
-String _$forYouFeedHash() => r'f57a9a078661c3aa5f10aa1aaf9b7fd41791fc4a';
+String _$forYouFeedHash() => r'15e638990cec37ac7cd5c7fe7470fc6c50b10166';
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///

--- a/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/funnelcake_api_client.dart
@@ -1975,6 +1975,8 @@ class FunnelcakeApiClient {
   /// (`'popular'` or `'recent'`, defaults to `'popular'`).
   /// [category] is an optional hashtag/category filter.
   /// [cursor] is the opaque cursor returned by a previous response.
+  /// [seed] is an optional opaque per-session value used by the backend
+  /// to vary ordering while keeping cursor pagination coherent.
   ///
   /// Returns a [RecommendationsResponse] with videos and source.
   ///
@@ -1993,6 +1995,7 @@ class FunnelcakeApiClient {
     String fallback = 'popular',
     String? category,
     String? cursor,
+    String? seed,
     List<String> preferredLanguages = const [],
     String? viewerCountry,
   }) async {
@@ -2013,6 +2016,9 @@ class FunnelcakeApiClient {
     }
     if (cursor != null && cursor.isNotEmpty) {
       queryParams['cursor'] = cursor;
+    }
+    if (seed != null && seed.isNotEmpty) {
+      queryParams['seed'] = seed;
     }
     _addViewerPreferenceQueryParameters(
       queryParams,

--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -4198,6 +4198,54 @@ void main() {
         expect(uri.queryParameters['cursor'], equals('rec-page-2'));
       });
 
+      test('sends session seed when provided', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async =>
+              http.Response('{"videos": [], "source": "popular"}', 200),
+        );
+
+        await client.getRecommendations(
+          pubkey: testPubkey,
+          cursor: 'rec-page-2',
+          seed: 'session-seed-1',
+        );
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.single
+                as Uri;
+        expect(uri.path, equals('/api/users/$testPubkey/recommendations'));
+        expect(uri.queryParameters['cursor'], equals('rec-page-2'));
+        expect(uri.queryParameters['seed'], equals('session-seed-1'));
+      });
+
+      test('omits session seed when not provided', () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer(
+          (_) async =>
+              http.Response('{"videos": [], "source": "popular"}', 200),
+        );
+
+        await client.getRecommendations(pubkey: testPubkey);
+
+        final uri =
+            verify(
+                  () => mockHttpClient.get(
+                    captureAny(),
+                    headers: any(named: 'headers'),
+                  ),
+                ).captured.single
+                as Uri;
+        expect(uri.queryParameters.containsKey('seed'), isFalse);
+      });
+
       test('sends viewer language and country hints', () async {
         when(
           () => mockHttpClient.get(any(), headers: any(named: 'headers')),

--- a/mobile/packages/videos_repository/lib/src/recommendation_session_seed.dart
+++ b/mobile/packages/videos_repository/lib/src/recommendation_session_seed.dart
@@ -1,0 +1,22 @@
+// ABOUTME: Session seed generation for backend recommendation ordering.
+// ABOUTME: Produces opaque, non-sensitive values for per-session freshness.
+
+import 'dart:math';
+
+final Random _recommendationSessionSeedRandom = Random();
+int _recommendationSessionSeedSequence = 0;
+
+/// Generates an opaque seed for a recommendation session.
+///
+/// The seed is not security-sensitive; it only lets Funnelcake vary For You
+/// ordering between sessions while keeping cursor pagination stable within a
+/// session.
+String generateRecommendationSessionSeed() {
+  final timestamp = DateTime.now().microsecondsSinceEpoch.toRadixString(16);
+  final sequence = (_recommendationSessionSeedSequence++).toRadixString(16);
+  final random = _recommendationSessionSeedRandom
+      .nextInt(0x100000000)
+      .toRadixString(16)
+      .padLeft(8, '0');
+  return '$timestamp-$sequence-$random';
+}

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -15,6 +15,7 @@ import 'package:videos_repository/src/home_feed_result.dart';
 import 'package:videos_repository/src/in_memory_feed_cache.dart';
 import 'package:videos_repository/src/popular_videos_page.dart';
 import 'package:videos_repository/src/profile_video_merge.dart';
+import 'package:videos_repository/src/recommendation_session_seed.dart';
 import 'package:videos_repository/src/video_content_filter.dart';
 import 'package:videos_repository/src/video_event_filter.dart';
 import 'package:videos_repository/src/video_local_storage.dart';
@@ -135,7 +136,7 @@ String _popularPreferenceCacheSuffix({
 /// {@endtemplate}
 class VideosRepository {
   /// {@macro videos_repository}
-  const VideosRepository({
+  VideosRepository({
     required NostrClient nostrClient,
     VideoLocalStorage? localStorage,
     BlockedVideoFilter? blockFilter,
@@ -158,6 +159,7 @@ class VideosRepository {
   final VideoWarningLabelsResolver? _warningLabelsResolver;
   final FunnelcakeApiClient? _funnelcakeApiClient;
   final InMemoryFeedCache? _inMemoryFeedCache;
+  String _recommendationSessionSeed = generateRecommendationSessionSeed();
 
   /// Clears the in-memory feed cache.
   ///
@@ -2416,6 +2418,11 @@ class VideosRepository {
       if (cached != null) return cached;
     }
 
+    final isFirstPage = until == null && cursor == null;
+    if (skipCache && isFirstPage) {
+      _recommendationSessionSeed = generateRecommendationSessionSeed();
+    }
+
     if (effectiveUserPubkey == null ||
         _funnelcakeApiClient == null ||
         !_funnelcakeApiClient.isAvailable) {
@@ -2435,6 +2442,7 @@ class VideosRepository {
         ? await _funnelcakeApiClient.getRecommendations(
             pubkey: effectiveUserPubkey,
             limit: limit,
+            seed: _recommendationSessionSeed,
             preferredLanguages: preferredLanguages,
             viewerCountry: viewerCountry,
           )
@@ -2442,6 +2450,7 @@ class VideosRepository {
             pubkey: effectiveUserPubkey,
             limit: limit,
             cursor: recommendationCursor,
+            seed: _recommendationSessionSeed,
             preferredLanguages: preferredLanguages,
             viewerCountry: viewerCountry,
           );
@@ -2480,6 +2489,7 @@ class VideosRepository {
     int limit = 20,
     String fallback = 'popular',
     String? category,
+    String? seed,
     List<String> preferredLanguages = const [],
     String? viewerCountry,
   }) async {
@@ -2491,6 +2501,7 @@ class VideosRepository {
       limit: limit,
       fallback: fallback,
       category: category,
+      seed: seed,
       preferredLanguages: preferredLanguages,
       viewerCountry: viewerCountry,
     );

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2419,9 +2419,9 @@ class VideosRepository {
     }
 
     final isFirstPage = until == null && cursor == null;
-    if (skipCache && isFirstPage) {
-      _recommendationSessionSeed = generateRecommendationSessionSeed();
-    }
+    final requestSeed = skipCache && isFirstPage
+        ? generateRecommendationSessionSeed()
+        : _recommendationSessionSeed;
 
     if (effectiveUserPubkey == null ||
         _funnelcakeApiClient == null ||
@@ -2442,7 +2442,7 @@ class VideosRepository {
         ? await _funnelcakeApiClient.getRecommendations(
             pubkey: effectiveUserPubkey,
             limit: limit,
-            seed: _recommendationSessionSeed,
+            seed: requestSeed,
             preferredLanguages: preferredLanguages,
             viewerCountry: viewerCountry,
           )
@@ -2450,7 +2450,7 @@ class VideosRepository {
             pubkey: effectiveUserPubkey,
             limit: limit,
             cursor: recommendationCursor,
-            seed: _recommendationSessionSeed,
+            seed: requestSeed,
             preferredLanguages: preferredLanguages,
             viewerCountry: viewerCountry,
           );
@@ -2473,6 +2473,9 @@ class VideosRepository {
       hasMore: response.hasMore,
       rawResponseBody: response.rawBody,
     );
+    if (isFirstPage) {
+      _recommendationSessionSeed = requestSeed;
+    }
     if (until == null && cursor == null) {
       _inMemoryFeedCache?.set(cacheKey, result);
     }
@@ -2489,7 +2492,6 @@ class VideosRepository {
     int limit = 20,
     String fallback = 'popular',
     String? category,
-    String? seed,
     List<String> preferredLanguages = const [],
     String? viewerCountry,
   }) async {
@@ -2501,7 +2503,6 @@ class VideosRepository {
       limit: limit,
       fallback: fallback,
       category: category,
-      seed: seed,
       preferredLanguages: preferredLanguages,
       viewerCountry: viewerCountry,
     );

--- a/mobile/packages/videos_repository/lib/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/videos_repository.dart
@@ -12,6 +12,7 @@ export 'src/home_feed_result.dart';
 export 'src/in_memory_feed_cache.dart';
 export 'src/popular_videos_page.dart';
 export 'src/profile_video_merge.dart';
+export 'src/recommendation_session_seed.dart';
 export 'src/video_content_filter.dart';
 export 'src/video_event_filter.dart';
 export 'src/video_local_storage.dart';

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -9978,8 +9978,8 @@ void main() {
           final firstPage = await repo.getRecommendedVideos(
             userPubkey: 'user-pubkey',
           );
-          expect(
-            () => repo.getRecommendedVideos(
+          await expectLater(
+            repo.getRecommendedVideos(
               userPubkey: 'user-pubkey',
               skipCache: true,
             ),

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -9749,6 +9749,7 @@ void main() {
         );
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -9784,6 +9785,7 @@ void main() {
         );
         verify(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: 10,
           ),
@@ -9791,9 +9793,11 @@ void main() {
       });
 
       test('caches refreshed recommendations for feed remounts', () async {
+        final requestedSeeds = <String?>[];
         var callCount = 0;
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             cursor: any(named: 'cursor'),
@@ -9802,7 +9806,8 @@ void main() {
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
-        ).thenAnswer((_) async {
+        ).thenAnswer((invocation) async {
+          requestedSeeds.add(invocation.namedArguments[#seed] as String?);
           callCount += 1;
           return RecommendationsResponse(
             videos: [
@@ -9853,12 +9858,69 @@ void main() {
         );
         expect(cachedAfterSecondRefresh.paginationCursor, equals('cursor-2'));
         expect(cachedAfterSecondRefresh.hasMore, isTrue);
+        expect(requestedSeeds, hasLength(2));
+        expect(requestedSeeds.first, isNotNull);
+        expect(requestedSeeds.first, isNotEmpty);
+        expect(requestedSeeds.last, isNot(requestedSeeds.first));
         verify(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: any(named: 'limit'),
           ),
         ).called(2);
+      });
+
+      test('keeps the same session seed across cursor pagination', () async {
+        final requestedSeeds = <String?>[];
+        var callCount = 0;
+        when(
+          () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((invocation) async {
+          requestedSeeds.add(invocation.namedArguments[#seed] as String?);
+          callCount += 1;
+          return RecommendationsResponse(
+            videos: [
+              _createVideoStats(
+                id: 'recommended-video-$callCount',
+                pubkey: 'recommended-pubkey-$callCount',
+                dTag: 'recommended-dtag-$callCount',
+                videoUrl: 'https://example.com/recommended-$callCount.mp4',
+              ),
+            ],
+            source: 'personalized',
+            nextCursor: 'cursor-${callCount + 1}',
+            hasMore: true,
+          );
+        });
+
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final firstPage = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+        );
+        final cursorPage = await repo.getRecommendedVideos(
+          userPubkey: 'user-pubkey',
+          cursor: firstPage.paginationCursor,
+        );
+
+        expect(cursorPage.videos.single.id, equals('recommended-video-2'));
+        expect(requestedSeeds, hasLength(2));
+        expect(requestedSeeds.first, isNotNull);
+        expect(requestedSeeds.first, isNotEmpty);
+        expect(requestedSeeds.last, requestedSeeds.first);
       });
 
       test('passes viewer country hint to recommendations endpoint', () async {
@@ -9870,6 +9932,7 @@ void main() {
         );
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -9899,6 +9962,7 @@ void main() {
         expect(result.videos.single.id, equals('country-recommended-video'));
         verify(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: 10,
             viewerCountry: 'BR',
@@ -9939,6 +10003,7 @@ void main() {
           ).called(1);
           verifyNever(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -9959,6 +10024,7 @@ void main() {
           );
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10011,6 +10077,7 @@ void main() {
           var recommendationCallCount = 0;
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10057,6 +10124,7 @@ void main() {
           expect(recovered.videos.single.id, equals('recommended-video'));
           verify(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: 'user-pubkey',
               limit: 10,
             ),
@@ -10092,6 +10160,7 @@ void main() {
           expect(result.videos.single.id, equals('popular-video'));
           verifyNever(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10128,6 +10197,7 @@ void main() {
           ).thenAnswer((_) async => [popular]);
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10162,6 +10232,7 @@ void main() {
           expect(recovered.videos.single.id, equals('recommended-video'));
           verify(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: 'user-pubkey',
               limit: 10,
             ),
@@ -10224,6 +10295,7 @@ void main() {
           expect(result.videos.single.id, equals('popular-video'));
           verifyNever(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10247,6 +10319,7 @@ void main() {
           );
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10281,6 +10354,7 @@ void main() {
           expect(result.hasMore, isTrue);
           verify(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: 'user-pubkey',
               limit: 10,
               cursor: 'rec-page-2',
@@ -10306,6 +10380,7 @@ void main() {
           );
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10340,6 +10415,7 @@ void main() {
           expect(result.hasMore, isTrue);
           verify(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: 'user-pubkey',
               limit: 10,
               cursor: '1700000000',
@@ -10359,6 +10435,7 @@ void main() {
         () async {
           when(
             () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
               pubkey: any(named: 'pubkey'),
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
@@ -10407,6 +10484,7 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10451,6 +10529,7 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10473,6 +10552,7 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10501,6 +10581,7 @@ void main() {
 
         verify(
           () => mockFunnelcakeClient.getRecommendations(
+            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: 50,
             fallback: 'recent',

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -81,6 +81,15 @@ void main() {
       repository = VideosRepository(nostrClient: mockNostrClient);
     });
 
+    test('generates non-empty unique recommendation session seeds', () {
+      final first = generateRecommendationSessionSeed();
+      final second = generateRecommendationSessionSeed();
+
+      expect(first, isNotEmpty);
+      expect(second, isNotEmpty);
+      expect(second, isNot(first));
+    });
+
     setUpAll(() {
       registerFallbackValue(<Filter>[]);
       registerFallbackValue(LeaderboardPeriod.week);
@@ -9923,6 +9932,72 @@ void main() {
         expect(requestedSeeds.last, requestedSeeds.first);
       });
 
+      test(
+        'does not commit refreshed session seed when first page fails',
+        () async {
+          final requestedSeeds = <String?>[];
+          var callCount = 0;
+          when(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: any(named: 'pubkey'),
+              limit: any(named: 'limit'),
+              cursor: any(named: 'cursor'),
+              fallback: any(named: 'fallback'),
+              category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer((invocation) async {
+            requestedSeeds.add(invocation.namedArguments[#seed] as String?);
+            callCount += 1;
+            if (callCount == 2) {
+              throw const FunnelcakeException('refresh failed');
+            }
+            return RecommendationsResponse(
+              videos: [
+                _createVideoStats(
+                  id: 'recommended-video-$callCount',
+                  pubkey: 'recommended-pubkey-$callCount',
+                  dTag: 'recommended-dtag-$callCount',
+                  videoUrl: 'https://example.com/recommended-$callCount.mp4',
+                ),
+              ],
+              source: 'personalized',
+              nextCursor: 'cursor-${callCount + 1}',
+              hasMore: true,
+            );
+          });
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            inMemoryFeedCache: InMemoryFeedCache(),
+          );
+
+          final firstPage = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+          );
+          expect(
+            () => repo.getRecommendedVideos(
+              userPubkey: 'user-pubkey',
+              skipCache: true,
+            ),
+            throwsA(isA<FunnelcakeException>()),
+          );
+          await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            cursor: firstPage.paginationCursor,
+          );
+
+          expect(requestedSeeds, hasLength(3));
+          expect(requestedSeeds[0], isNotNull);
+          expect(requestedSeeds[0], isNotEmpty);
+          expect(requestedSeeds[1], isNot(requestedSeeds[0]));
+          expect(requestedSeeds[2], requestedSeeds[0]);
+        },
+      );
+
       test('passes viewer country hint to recommendations endpoint', () async {
         final recommended = _createVideoStats(
           id: 'country-recommended-video',
@@ -10484,7 +10559,6 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
-            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10529,7 +10603,6 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
-            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10552,7 +10625,6 @@ void main() {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
         when(
           () => mockFunnelcakeClient.getRecommendations(
-            seed: any(named: 'seed'),
             pubkey: any(named: 'pubkey'),
             limit: any(named: 'limit'),
             fallback: any(named: 'fallback'),
@@ -10581,7 +10653,6 @@ void main() {
 
         verify(
           () => mockFunnelcakeClient.getRecommendations(
-            seed: any(named: 'seed'),
             pubkey: 'user-pubkey',
             limit: 50,
             fallback: 'recent',

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/providers/popular_videos_feed_provider.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/geo_blocking_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/services/video_filter_builder.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -38,6 +39,22 @@ class _MockNostrClient extends Mock implements NostrClient {}
 class _AlwaysAvailableFunnelcake extends FunnelcakeAvailable {
   @override
   Future<bool> build() async => true;
+}
+
+class _DelayedSecondGeoBlockingService extends GeoBlockingService {
+  _DelayedSecondGeoBlockingService(this.secondCallCompleter);
+
+  final Completer<GeoBlockResponse> secondCallCompleter;
+  int _callCount = 0;
+
+  @override
+  Future<GeoBlockResponse> getGeoInfo() {
+    _callCount += 1;
+    if (_callCount == 2) {
+      return secondCallCompleter.future;
+    }
+    return Future.value(_geoResponse());
+  }
 }
 
 void main() {
@@ -673,8 +690,10 @@ void main() {
       },
     );
 
-    test('for you preserves existing videos when refresh fails', () async {
+    test('for you preserves existing pagination when refresh fails', () async {
       var requestCount = 0;
+      final requestedCursors = <String?>[];
+      final requestedSeeds = <String?>[];
 
       when(
         () => mockFunnelcakeApiClient.getRecommendations(
@@ -687,7 +706,9 @@ void main() {
           preferredLanguages: any(named: 'preferredLanguages'),
           viewerCountry: any(named: 'viewerCountry'),
         ),
-      ).thenAnswer((_) {
+      ).thenAnswer((invocation) {
+        requestedCursors.add(invocation.namedArguments[#cursor] as String?);
+        requestedSeeds.add(invocation.namedArguments[#seed] as String?);
         requestCount += 1;
         if (requestCount == 1) {
           return Future.value(
@@ -696,7 +717,12 @@ void main() {
             ], nextCursor: 'cursor-2'),
           );
         }
-        throw StateError('recommendations refresh failed');
+        if (requestCount == 2) {
+          throw StateError('recommendations refresh failed');
+        }
+        return Future.value(
+          _recommendationsResponse(['for-you-page-2'], nextCursor: 'cursor-3'),
+        );
       });
 
       final container = ProviderContainer(
@@ -736,6 +762,22 @@ void main() {
       expect(refreshedState.hasMoreContent, isTrue);
       expect(refreshedState.isRefreshing, isFalse);
       expect(refreshedState.error, contains('recommendations refresh failed'));
+
+      await container.read(forYouFeedProvider.notifier).loadMore();
+
+      final loadedState = container.read(forYouFeedProvider).value;
+      expect(loadedState, isNotNull);
+      expect(loadedState!.videos.map((video) => video.id), [
+        'for-you-initial',
+        'for-you-page-2',
+      ]);
+      expect(loadedState.hasMoreContent, isTrue);
+      expect(requestedCursors, [null, null, 'cursor-2']);
+      expect(requestedSeeds, hasLength(3));
+      expect(requestedSeeds[0], isNotNull);
+      expect(requestedSeeds[0], isNotEmpty);
+      expect(requestedSeeds[1], isNot(requestedSeeds[0]));
+      expect(requestedSeeds[2], requestedSeeds[0]);
     });
 
     test(
@@ -821,6 +863,87 @@ void main() {
         expect(requestedSeeds.first, isNotNull);
         expect(requestedSeeds.first, isNotEmpty);
         expect(requestedSeeds.last, requestedSeeds.first);
+      },
+    );
+
+    test(
+      'for you load more keeps cursor and seed paired across rebuilds',
+      () async {
+        final geoCompleter = Completer<GeoBlockResponse>();
+        final requests = <({String? cursor, String? seed})>[];
+
+        when(
+          () => mockFunnelcakeApiClient.getRecommendations(
+            pubkey: any(named: 'pubkey'),
+            limit: any(named: 'limit'),
+            fallback: any(named: 'fallback'),
+            category: any(named: 'category'),
+            cursor: any(named: 'cursor'),
+            seed: any(named: 'seed'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((invocation) {
+          final cursor = invocation.namedArguments[#cursor] as String?;
+          final seed = invocation.namedArguments[#seed] as String?;
+          requests.add((cursor: cursor, seed: seed));
+          return Future.value(
+            _recommendationsResponse(
+              cursor == null ? ['for-you-rebuilt'] : ['for-you-page-2'],
+              nextCursor: cursor == null ? 'cursor-2' : 'cursor-3',
+            ),
+          );
+        });
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            funnelcakeApiClientProvider.overrideWithValue(
+              mockFunnelcakeApiClient,
+            ),
+            authServiceProvider.overrideWithValue(mockAuthService),
+            funnelcakeAvailableProvider.overrideWith(
+              _AlwaysAvailableFunnelcake.new,
+            ),
+            geoBlockingServiceProvider.overrideWithValue(
+              _DelayedSecondGeoBlockingService(geoCompleter),
+            ),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        await container.read(funnelcakeAvailableProvider.future);
+        final subscription = container.listen(forYouFeedProvider, (_, _) {});
+        addTearDown(subscription.close);
+
+        final initialState = await container.read(forYouFeedProvider.future);
+        expect(initialState.hasMoreContent, isTrue);
+        expect(requests, hasLength(1));
+        final firstPageSeed = requests.single.seed;
+        expect(firstPageSeed, isNotNull);
+        expect(firstPageSeed, isNotEmpty);
+
+        final loadMoreFuture = container
+            .read(forYouFeedProvider.notifier)
+            .loadMore();
+        await pumpEventQueue();
+
+        container.read(blocklistVersionProvider.notifier).increment();
+        await pumpEventQueue();
+
+        geoCompleter.complete(_geoResponse());
+        await loadMoreFuture;
+        await pumpEventQueue();
+
+        final cursorPageRequest = requests.singleWhere(
+          (request) => request.cursor == 'cursor-2',
+        );
+        expect(cursorPageRequest.seed, firstPageSeed);
       },
     );
 
@@ -1107,6 +1230,15 @@ RecommendationsResponse _recommendationsResponse(
     source: 'personalized',
     nextCursor: nextCursor,
     hasMore: hasMore,
+  );
+}
+
+GeoBlockResponse _geoResponse() {
+  return GeoBlockResponse(
+    blocked: false,
+    country: 'UNKNOWN',
+    region: 'UNKNOWN',
+    city: 'UNKNOWN',
   );
 }
 

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -584,6 +584,7 @@ void main() {
       'for you keeps existing videos visible while refresh is in flight',
       () async {
         final refreshCompleter = Completer<RecommendationsResponse>();
+        final requestedSeeds = <String?>[];
         var requestCount = 0;
 
         when(
@@ -593,10 +594,12 @@ void main() {
             fallback: any(named: 'fallback'),
             category: any(named: 'category'),
             cursor: any(named: 'cursor'),
+            seed: any(named: 'seed'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
-        ).thenAnswer((_) {
+        ).thenAnswer((invocation) {
+          requestedSeeds.add(invocation.namedArguments[#seed] as String?);
           requestCount += 1;
           if (requestCount == 1) {
             return Future.value(
@@ -663,86 +666,83 @@ void main() {
           'for-you-refreshed',
         ]);
         expect(finalState.isRefreshing, isFalse);
+        expect(requestedSeeds, hasLength(2));
+        expect(requestedSeeds.first, isNotNull);
+        expect(requestedSeeds.first, isNotEmpty);
+        expect(requestedSeeds.last, isNot(requestedSeeds.first));
       },
     );
 
-    test(
-      'for you preserves existing videos when refresh fails',
-      () async {
-        var requestCount = 0;
+    test('for you preserves existing videos when refresh fails', () async {
+      var requestCount = 0;
 
-        when(
-          () => mockFunnelcakeApiClient.getRecommendations(
-            pubkey: any(named: 'pubkey'),
-            limit: any(named: 'limit'),
-            fallback: any(named: 'fallback'),
-            category: any(named: 'category'),
-            cursor: any(named: 'cursor'),
-            preferredLanguages: any(named: 'preferredLanguages'),
-            viewerCountry: any(named: 'viewerCountry'),
+      when(
+        () => mockFunnelcakeApiClient.getRecommendations(
+          pubkey: any(named: 'pubkey'),
+          limit: any(named: 'limit'),
+          fallback: any(named: 'fallback'),
+          category: any(named: 'category'),
+          cursor: any(named: 'cursor'),
+          seed: any(named: 'seed'),
+          preferredLanguages: any(named: 'preferredLanguages'),
+          viewerCountry: any(named: 'viewerCountry'),
+        ),
+      ).thenAnswer((_) {
+        requestCount += 1;
+        if (requestCount == 1) {
+          return Future.value(
+            _recommendationsResponse([
+              'for-you-initial',
+            ], nextCursor: 'cursor-2'),
+          );
+        }
+        throw StateError('recommendations refresh failed');
+      });
+
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+          appReadyProvider.overrideWithValue(true),
+          videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+          contentBlocklistRepositoryProvider.overrideWithValue(
+            mockBlocklistRepository,
           ),
-        ).thenAnswer((_) {
-          requestCount += 1;
-          if (requestCount == 1) {
-            return Future.value(
-              _recommendationsResponse(
-                ['for-you-initial'],
-                nextCursor: 'cursor-2',
-              ),
-            );
-          }
-          throw StateError('recommendations refresh failed');
-        });
+          funnelcakeApiClientProvider.overrideWithValue(
+            mockFunnelcakeApiClient,
+          ),
+          authServiceProvider.overrideWithValue(mockAuthService),
+          funnelcakeAvailableProvider.overrideWith(
+            _AlwaysAvailableFunnelcake.new,
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
 
-        final container = ProviderContainer(
-          overrides: [
-            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
-            appReadyProvider.overrideWithValue(true),
-            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
-            contentBlocklistRepositoryProvider.overrideWithValue(
-              mockBlocklistRepository,
-            ),
-            funnelcakeApiClientProvider.overrideWithValue(
-              mockFunnelcakeApiClient,
-            ),
-            authServiceProvider.overrideWithValue(mockAuthService),
-            funnelcakeAvailableProvider.overrideWith(
-              _AlwaysAvailableFunnelcake.new,
-            ),
-          ],
-        );
-        addTearDown(container.dispose);
+      await container.read(funnelcakeAvailableProvider.future);
+      final subscription = container.listen(forYouFeedProvider, (_, _) {});
+      addTearDown(subscription.close);
 
-        await container.read(funnelcakeAvailableProvider.future);
-        final subscription = container.listen(forYouFeedProvider, (_, _) {});
-        addTearDown(subscription.close);
+      final initialState = await container.read(forYouFeedProvider.future);
+      expect(initialState.videos.map((video) => video.id), ['for-you-initial']);
+      expect(initialState.hasMoreContent, isTrue);
 
-        final initialState = await container.read(forYouFeedProvider.future);
-        expect(initialState.videos.map((video) => video.id), [
-          'for-you-initial',
-        ]);
-        expect(initialState.hasMoreContent, isTrue);
+      await container.read(forYouFeedProvider.notifier).refresh();
 
-        await container.read(forYouFeedProvider.notifier).refresh();
-
-        final refreshedState = container.read(forYouFeedProvider).value;
-        expect(refreshedState, isNotNull);
-        expect(refreshedState!.videos.map((video) => video.id), [
-          'for-you-initial',
-        ]);
-        expect(refreshedState.hasMoreContent, isTrue);
-        expect(refreshedState.isRefreshing, isFalse);
-        expect(
-          refreshedState.error,
-          contains('recommendations refresh failed'),
-        );
-      },
-    );
+      final refreshedState = container.read(forYouFeedProvider).value;
+      expect(refreshedState, isNotNull);
+      expect(refreshedState!.videos.map((video) => video.id), [
+        'for-you-initial',
+      ]);
+      expect(refreshedState.hasMoreContent, isTrue);
+      expect(refreshedState.isRefreshing, isFalse);
+      expect(refreshedState.error, contains('recommendations refresh failed'));
+    });
 
     test(
       'for you load more uses recommendation cursor and appends unseen videos',
       () async {
         final requestedCursors = <String?>[];
+        final requestedSeeds = <String?>[];
         var recommendationsCallCount = 0;
 
         when(
@@ -752,11 +752,13 @@ void main() {
             fallback: any(named: 'fallback'),
             category: any(named: 'category'),
             cursor: any(named: 'cursor'),
+            seed: any(named: 'seed'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) {
           requestedCursors.add(invocation.namedArguments[#cursor] as String?);
+          requestedSeeds.add(invocation.namedArguments[#seed] as String?);
           recommendationsCallCount += 1;
           if (recommendationsCallCount == 1) {
             return Future.value(
@@ -815,6 +817,10 @@ void main() {
         ]);
         expect(loadedState.hasMoreContent, isTrue);
         expect(requestedCursors, [null, 'cursor-2']);
+        expect(requestedSeeds, hasLength(2));
+        expect(requestedSeeds.first, isNotNull);
+        expect(requestedSeeds.first, isNotEmpty);
+        expect(requestedSeeds.last, requestedSeeds.first);
       },
     );
 
@@ -822,6 +828,7 @@ void main() {
       'for you keeps loading when a cursor page adds no visible videos',
       () async {
         final requestedCursors = <String?>[];
+        final requestedSeeds = <String?>[];
         var recommendationsCallCount = 0;
 
         when(
@@ -831,11 +838,13 @@ void main() {
             fallback: any(named: 'fallback'),
             category: any(named: 'category'),
             cursor: any(named: 'cursor'),
+            seed: any(named: 'seed'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((invocation) {
           requestedCursors.add(invocation.namedArguments[#cursor] as String?);
+          requestedSeeds.add(invocation.namedArguments[#seed] as String?);
           recommendationsCallCount += 1;
           if (recommendationsCallCount == 1) {
             return Future.value(
@@ -913,6 +922,9 @@ void main() {
         ]);
         expect(nextPageState.hasMoreContent, isFalse);
         expect(requestedCursors, [null, 'cursor-2', 'cursor-3']);
+        expect(requestedSeeds, hasLength(3));
+        expect(requestedSeeds.toSet(), hasLength(1));
+        expect(requestedSeeds.first, isNotEmpty);
       },
     );
 
@@ -928,14 +940,13 @@ void main() {
             fallback: any(named: 'fallback'),
             category: any(named: 'category'),
             cursor: any(named: 'cursor'),
+            seed: any(named: 'seed'),
             preferredLanguages: any(named: 'preferredLanguages'),
             viewerCountry: any(named: 'viewerCountry'),
           ),
         ).thenAnswer((_) {
           recommendationsCallCount += 1;
-          return Future.value(
-            _recommendationsResponse(['for-you-legacy']),
-          );
+          return Future.value(_recommendationsResponse(['for-you-legacy']));
         });
 
         final container = ProviderContainer(

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -940,10 +940,32 @@ void main() {
         await loadMoreFuture;
         await pumpEventQueue();
 
-        final cursorPageRequest = requests.singleWhere(
+        final rebuiltFirstPageSeed = requests
+            .lastWhere(
+              (request) => request.cursor == null,
+            )
+            .seed;
+        expect(rebuiltFirstPageSeed, isNot(firstPageSeed));
+
+        final staleCursorPageRequest = requests.singleWhere(
           (request) => request.cursor == 'cursor-2',
         );
-        expect(cursorPageRequest.seed, firstPageSeed);
+        expect(staleCursorPageRequest.seed, firstPageSeed);
+
+        await container.read(forYouFeedProvider.notifier).loadMore();
+
+        final cursorPageRequests = requests
+            .where((request) => request.cursor == 'cursor-2')
+            .toList();
+        expect(cursorPageRequests, hasLength(2));
+        expect(cursorPageRequests.last.seed, rebuiltFirstPageSeed);
+
+        final loadedState = container.read(forYouFeedProvider).value;
+        expect(loadedState, isNotNull);
+        expect(loadedState!.videos.map((video) => video.id), [
+          'for-you-rebuilt',
+          'for-you-page-2',
+        ]);
       },
     );
 


### PR DESCRIPTION
## Summary

Closes #5174.

- add an optional recommendation session seed query parameter to the Funnelcake API client
- generate one stable seed per For You session and keep it across cursor pagination
- rotate the seed on explicit For You refresh/new repository refresh, without client-side jitter or shuffling
- cover seed forwarding, refresh rotation, and cursor pagination seed stability in API client, repository, and provider tests

## Verification

- mise exec -- dart run build_runner build --delete-conflicting-outputs
- mise exec -- flutter test packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
- mise exec -- flutter test test/providers/explore_feed_refresh_retention_test.dart
- mise exec -- flutter test packages/videos_repository/test/src/videos_repository_test.dart --plain-name getRecommendedVideos
- mise exec -- flutter test --coverage (from mobile/packages/videos_repository, 100.00% line coverage)
- mise exec -- flutter analyze
- git diff --check
- pre-push analyzer/generated/changed-file tests