### PR TITLE
test(ci): gate untagged tests that leak process-global singletons (#5183)

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -38,6 +38,8 @@ jobs:
         run: bash scripts/check_raw_logging.sh
       - name: 🌐 Verify no untagged test mutates HttpOverrides.global
         run: bash scripts/check_http_overrides_isolation.sh
+      - name: 🧬 Verify no untagged test leaks a process-global singleton
+        run: bash scripts/check_process_global_mutations.sh
       - name: 🚧 Verify Riverpod boundary (@riverpod / StateProvider locations)
         run: bash scripts/check_riverpod_boundary.sh
       - name: 🚧 Verify ChangeNotifier boundary (sanctioned-allowlist ratchet)

--- a/mobile/scripts/check_process_global_mutations.sh
+++ b/mobile/scripts/check_process_global_mutations.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Fails CI if a test the very_good optimizer MERGES into the shared isolate
+# installs a process-global platform/package singleton WITHOUT restoring it.
+# An unrestored install persists into every later merged test in the shared
+# isolate, surfacing as an order-dependent failure cross-attributed to an
+# unrelated test. This generalizes the single-global precedent
+# check_http_overrides_isolation.sh (PR #5163) to the class of
+# `<Singleton>.instance` test seams behind the #5159 / #5180 cascades
+# (parent #3137).
+#
+# A file is in the merge UNLESS it is tagged @Tags(['skip_very_good_optimization']).
+# Being under test/manual/ does NOT exclude it — only the tag does (the very_good
+# --optimization globber does not honor dart_test.yaml's exclude: test/manual/**).
+#
+# Policy: HARD-ZERO. Every untagged *_test.dart that installs a candidate global
+# must, within the same file, SNAPSHOT the original (a `<id> = <Global>` read)
+# and RESTORE it (a `<Global> = <id>` write, e.g. in tearDown / tearDownAll).
+# Unlike check_http_overrides_isolation.sh — which rejects even a correct restore
+# because a nulled HttpOverrides 400-mock is itself the hazard while the file
+# runs — a within-file restore PASSES here: for these singletons the tearDown
+# returns the global to its prior value before the next merged file runs.
+# Detection is a grep proxy (it cannot prove the restore is reachable or lives
+# in a tearDown); the snapshot+restore pair is the canonical fix and the tag is
+# the escape hatch for tests that legitimately cannot restore (real plugin /
+# integration tests).
+#
+# Scope: only `<Singleton>.instance` assignments (the class that caused the
+# #5159 cascades). A read of the global, a comment mention, and `==` / `=>` do
+# not match. lib/ is out of scope. Only `*_test.dart` files are scanned, so
+# non-test helpers — e.g. test/test_setup.dart, which installs the suite-wide
+# PathProviderPlatform mock by design — are not flagged. HttpOverrides.global
+# keeps its own dedicated STRICT gate and is intentionally not handled here.
+#
+# Usage:
+#   bash mobile/scripts/check_process_global_mutations.sh
+#   (run from the repository root or from mobile/)
+set -euo pipefail
+export LC_ALL=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MOBILE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Candidate process-global singletons (Tier-2). Extend as new leak classes are
+# found. Each entry is the ERE core, matched after an optional `<prefix>.`.
+GLOBALS=(
+  'PathProviderPlatform\.instance'
+  'ProVideoEditor\.instance'
+  'WebViewPlatform\.instance'
+  'UrlLauncherPlatform\.instance'
+  'VideoPlayerPlatform\.instance'
+  'FirebasePlatform\.instance'
+)
+
+violations=""
+
+for core in "${GLOBALS[@]}"; do
+  # Fast pre-filter: *_test.dart files mentioning the global at all.
+  files=$(grep -rlE --include='*_test.dart' "$core" "$MOBILE_DIR/test" || true)
+  for f in $files; do
+    # Comment-stripped view: drop lines whose first non-blank chars are // or ///
+    # (defends doc-comment install snippets and fully commented-out tests).
+    body=$(grep -vE '^[[:space:]]*//' "$f" || true)
+
+    # A real ASSIGNMENT (install or restore): (<prefix>.)?CORE = , where `=` is
+    # not `==` / `=>`. `=` may sit at end-of-line (dart format keeps the LHS
+    # token on its own line for a multi-line RHS).
+    if ! printf '%s\n' "$body" \
+      | grep -qE "(^|[^A-Za-z0-9_.])([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=([^=>]|$)"; then
+      continue
+    fi
+
+    # Tagged out of the merge? Line-anchored so a commented-out (// @Tags(...))
+    # or doc-mention does NOT satisfy the gate — mirrors how the Dart test
+    # runner reads the library annotation.
+    if grep -qE "^[[:space:]]*@Tags\([^)]*skip_very_good_optimization" "$f"; then
+      continue
+    fi
+
+    # SNAPSHOT (capture-read): the global appears on the RHS of an assignment
+    # (`<id> = <Global>`), i.e. the original was captured into a local.
+    has_capture=0
+    if printf '%s\n' "$body" \
+      | grep -qE "=[[:space:]]*([A-Za-z_][A-Za-z0-9_]*\.)?${core}([^A-Za-z0-9_]|$)"; then
+      has_capture=1
+    fi
+
+    # RESTORE (restore-write): the global is assigned a BARE identifier
+    # (`<Global> = original;` block form, or `=> <Global> = original)` arrow
+    # form), which distinguishes a restore from a `<Global> = SomeFake()` install.
+    has_restore=0
+    if printf '%s\n' "$body" \
+      | grep -qE "([A-Za-z_][A-Za-z0-9_]*\.)?${core}[[:space:]]*=[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[;)]"; then
+      has_restore=1
+    fi
+
+    if [[ "$has_capture" -eq 0 || "$has_restore" -eq 0 ]]; then
+      rel="${f#"$MOBILE_DIR"/}"
+      disp="${core//\\/}"
+      violations="$violations  $rel  ($disp)"$'\n'
+    fi
+  done
+done
+
+if [[ -n "$violations" ]]; then
+  echo "FAIL [process_global_mutations]: untagged test installs a process-global"
+  echo "singleton without a within-file restore:"
+  printf '%s' "$violations" | sed '/^$/d'
+  echo ""
+  echo "Installing <Singleton>.instance in a MERGED (untagged) test without"
+  echo "restoring it leaks the fake into every later test in the shared"
+  echo "very_good --optimization isolate, causing order-dependent flakes"
+  echo "(generalizes PR #5163; cascades #5159 / #5180; parent #3137)."
+  echo ""
+  echo "Remediation — pick one:"
+  echo "  (a) Snapshot the original and restore it within the file:"
+  echo "        late <Type> original;"
+  echo "        setUp(() { original = <Global>.instance; <Global>.instance = <fake>; });"
+  echo "        tearDown(() { <Global>.instance = original; });"
+  echo "      (use setUpAll / tearDownAll for a setUpAll install)."
+  echo "  (b) Real-plugin / integration test that cannot restore: tag it so it"
+  echo "      stays out of the merge (annotation BEFORE the first import):"
+  echo "        @Tags(['skip_very_good_optimization', 'integration'])"
+  echo "      then bump mobile/test/vgv_tag_baseline.txt if the tag count rises."
+  exit 1
+fi
+
+echo "OK: no untagged test leaks a process-global singleton."

--- a/mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart
+++ b/mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart
@@ -47,10 +47,16 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late _MockProVideoEditor mockProVideoEditor;
+  late ProVideoEditor originalProVideoEditor;
 
   setUp(() {
+    originalProVideoEditor = ProVideoEditor.instance;
     mockProVideoEditor = _MockProVideoEditor();
     ProVideoEditor.instance = mockProVideoEditor;
+  });
+
+  tearDown(() {
+    ProVideoEditor.instance = originalProVideoEditor;
   });
 
   group(SoundWaveformBloc, () {

--- a/mobile/test/router/apps_sandbox_route_test.dart
+++ b/mobile/test/router/apps_sandbox_route_test.dart
@@ -18,8 +18,20 @@ class _MockNostrAppDirectoryService extends Mock
     implements NostrAppDirectoryService {}
 
 void main() {
+  WebViewPlatform? originalWebViewPlatform;
+
   setUpAll(() {
+    originalWebViewPlatform = WebViewPlatform.instance;
     WebViewPlatform.instance = _FakeWebViewPlatform();
+  });
+
+  tearDownAll(() {
+    // WebViewPlatform's setter rejects null, so only restore a non-null
+    // original (the local promotes inside the guard, no `!` needed).
+    final original = originalWebViewPlatform;
+    if (original != null) {
+      WebViewPlatform.instance = original;
+    }
   });
 
   testWidgets('${NostrAppSandboxScreen.path} route works', (tester) async {

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -16,6 +16,21 @@ import 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
 
 void main() {
   group('NostrAppSandboxScreen', () {
+    WebViewPlatform? originalWebViewPlatform;
+
+    setUp(() {
+      originalWebViewPlatform = WebViewPlatform.instance;
+    });
+
+    tearDown(() {
+      // WebViewPlatform's setter rejects null, so only restore a non-null
+      // original (the local promotes inside the guard, no `!` needed).
+      final original = originalWebViewPlatform;
+      if (original != null) {
+        WebViewPlatform.instance = original;
+      }
+    });
+
     testWidgets(
       'does not call setBackgroundColor on macOS WebView initialization',
       (tester) async {

--- a/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
+++ b/mobile/test/screens/video_editor/video_audio_editor_timing_screen_test.dart
@@ -151,8 +151,10 @@ void main() {
   group(VideoAudioEditorTimingScreen, () {
     late _MockProVideoEditor mockEditor;
     late _MockAudioClipPlayer mockClipPlayer;
+    late ProVideoEditor originalProVideoEditor;
 
     setUp(() {
+      originalProVideoEditor = ProVideoEditor.instance;
       mockEditor = _MockProVideoEditor();
       ProVideoEditor.instance = mockEditor;
       mockClipPlayer = _MockAudioClipPlayer();
@@ -164,6 +166,10 @@ void main() {
       when(() => mockClipPlayer.pause()).thenAnswer((_) async {});
       when(() => mockClipPlayer.stop()).thenAnswer((_) async {});
       when(() => mockClipPlayer.dispose()).thenAnswer((_) async {});
+    });
+
+    tearDown(() {
+      ProVideoEditor.instance = originalProVideoEditor;
     });
 
     Widget buildWidget({AudioEvent? sound, Locale? locale}) {

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -68,8 +68,11 @@ void _clearHandler(MethodChannel channel) {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  late ProVideoEditor originalProVideoEditor;
+
   setUp(() {
     DivineVideoPlayerController.resetIdCounterForTesting();
+    originalProVideoEditor = ProVideoEditor.instance;
     ProVideoEditor.instance = _NoopInitProVideoEditor();
 
     _setHandler(const MethodChannel('plugins.flutter.io/path_provider'), (
@@ -107,6 +110,7 @@ void main() {
   });
 
   tearDown(() {
+    ProVideoEditor.instance = originalProVideoEditor;
     _clearHandler(const MethodChannel('divine_video_player'));
     _clearHandler(const MethodChannel('pro_video_editor'));
     _clearHandler(const MethodChannel('plugins.flutter.io/path_provider'));

--- a/mobile/test/services/page_load_observer_test.dart
+++ b/mobile/test/services/page_load_observer_test.dart
@@ -78,7 +78,17 @@ class _FakeFirebaseApp extends Fake
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  FirebasePlatform.instance = _FakeFirebaseCore();
+
+  late FirebasePlatform originalFirebasePlatform;
+
+  setUpAll(() {
+    originalFirebasePlatform = FirebasePlatform.instance;
+    FirebasePlatform.instance = _FakeFirebaseCore();
+  });
+
+  tearDownAll(() {
+    FirebasePlatform.instance = originalFirebasePlatform;
+  });
 
   group(PageLoadObserver, () {
     late _RecordingAnalyticsEventSink sink;

--- a/mobile/test/services/video_thumbnail_service_test.dart
+++ b/mobile/test/services/video_thumbnail_service_test.dart
@@ -32,6 +32,7 @@ void main() {
   group('VideoThumbnailService', () {
     late String testVideoPath;
     late Directory tempDir;
+    late ProVideoEditor originalProVideoEditor;
 
     const channel = MethodChannel('pro_video_editor');
 
@@ -52,6 +53,7 @@ void main() {
       // `ProVideoEditor.instance` pointing at a foreign mock that overrides
       // only its own methods, causing our method calls to throw
       // `UnimplementedError` instead of routing through the MethodChannel.
+      originalProVideoEditor = ProVideoEditor.instance;
       ProVideoEditor.instance = _NoopInitProVideoEditor();
 
       testVideoPath = '${tempDir.path}/test_video.mp4';
@@ -68,6 +70,7 @@ void main() {
     });
 
     tearDown(() {
+      ProVideoEditor.instance = originalProVideoEditor;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, null);
     });
@@ -300,6 +303,7 @@ void main() {
     /// can toggle behaviour mid-test.
     late bool getThumbnailsReturnsBytes;
     late bool getMetadataSucceeds;
+    late ProVideoEditor originalProVideoEditor;
 
     /// Dummy JPEG-like bytes produced by the mock.
     final fakeJpegBytes = Uint8List.fromList(List<int>.generate(128, (i) => i));
@@ -321,6 +325,7 @@ void main() {
       // `ProVideoEditor.instance` pointing at a foreign mock that overrides
       // only its own methods, causing our method calls to throw
       // `UnimplementedError` instead of routing through the MethodChannel.
+      originalProVideoEditor = ProVideoEditor.instance;
       ProVideoEditor.instance = _NoopInitProVideoEditor();
 
       getThumbnailsReturnsBytes = false;
@@ -355,6 +360,7 @@ void main() {
     });
 
     tearDown(() {
+      ProVideoEditor.instance = originalProVideoEditor;
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(channel, null);
     });

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_test.dart
@@ -76,8 +76,10 @@ void main() {
     late _MockClipEditorBloc mockClipBloc;
     late _MockTimelineOverlayBloc mockOverlayBloc;
     late _MockVideoEditorFilterBloc mockFilterBloc;
+    late ProVideoEditor originalProVideoEditor;
 
     setUp(() {
+      originalProVideoEditor = ProVideoEditor.instance;
       ProVideoEditor.instance = _MockProVideoEditor();
 
       mockMainBloc = _MockVideoEditorMainBloc();
@@ -105,6 +107,10 @@ void main() {
       when(
         () => mockFilterBloc.stream,
       ).thenAnswer((_) => const Stream<VideoEditorFilterState>.empty());
+    });
+
+    tearDown(() {
+      ProVideoEditor.instance = originalProVideoEditor;
     });
 
     Widget buildWidget({


### PR DESCRIPTION
## Description

Generalizes the single-global guardrail #5163 proved on `HttpOverrides.global` to the class of `<Singleton>.instance` test seams behind the `very_good --optimization` merged-isolate cascades (#5159 / #5180, parent #3137). An untagged test that installs a process-global singleton and never restores it poisons every later test in the shared optimizer isolate, surfacing as an order-dependent failure cross-attributed to an unrelated test.

**Fix the 8 pre-existing leakers** with the snapshot/restore template (capture the original in `setUp`/`setUpAll`, reassign it in `tearDown`/`tearDownAll`):

- `ProVideoEditor.instance` ×5 — `sound_waveform_bloc_test`, `video_audio_editor_timing_screen_test`, `video_metadata_cover_screen_test`, `video_thumbnail_service_test` (both groups; defensive self-install preserved), `video_editor_timeline_test`
- `WebViewPlatform.instance` ×2 — `apps_sandbox_route_test`, `nostr_app_sandbox_screen_test`. Its setter rejects `null` (nullable getter, non-null setter), so the restore is guarded on a non-null original.
- `FirebasePlatform.instance` ×1 — `page_load_observer_test` (moved the top-level `main()` install into `setUpAll`/`tearDownAll`).

**Add the gate** `mobile/scripts/check_process_global_mutations.sh` (hard-zero), wired into the `generated-files` job right after the `check_http_overrides_isolation.sh` step. It fails an untagged `*_test.dart` that installs a candidate global without **both** a capture-read (`x = G.instance`) and a restore-write (`G.instance = x`). It strips `//` and `///` comment lines, ignores `==`/`=>`, allows an optional import prefix, scans only `*_test.dart` (so the shared `test_setup.dart` installer is not flagged), and exempts files tagged `@Tags(['skip_very_good_optimization'])`. `HttpOverrides.global` keeps its own dedicated gate.

Candidate set is the Tier-2 `.instance` platform/package singletons: `PathProviderPlatform`, `ProVideoEditor`, `WebViewPlatform`, `UrlLauncherPlatform`, `VideoPlayerPlatform`, `FirebasePlatform`.

**Related Issue:** Closes #5183

## Out of Scope

- Tier-3 debug-override globals (`debugDefaultTargetPlatformOverride` et al.) — their "restore" is reset-to-default rather than a capture-read, with a `tearDown`-vs-`try/finally` ambiguity; deferred to a follow-up. The unguarded `debugDefaultTargetPlatformOverride` reset in `nostr_app_sandbox_screen_test` is a known Tier-3 item not addressed here.
- Tier-4 app-owned static setters (`Bloc.observer`, `FlutterError.onError`, `FirebaseAnalytics.instance`, `UnifiedLogger.setLogLevel`, `registerFallbackValue`, `openVineImageCache`) — future follow-ups.
- Folding `HttpOverrides.global` into this script — intentionally kept as a separate gate.

## Verification

- The 8 fixed files pass standalone and together (126 tests).
- Merged optimizer green at `+9873 ~316: All tests passed!` across seeds `42`, `11111`, and `random` (`very_good test --optimization --concurrency=4 --exclude-tags integration`), re-run after rebasing onto current `origin/main`.
- `flutter analyze lib test integration_test` — no issues.
- Gate self-tested: catches an unrestored install (names the file), passes a `@Tags(['skip_very_good_optimization'])` file, passes a capture/restore file, ignores `//`/`///`-commented install snippets, and accepts the arrow `addTearDown(() => G.instance = x)` restore form.
- Tag baseline unchanged (these are fixed, not tagged), so no `vgv_tag_baseline.txt` churn.

## Type of Change

- [x] ✅ Build configuration change
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)