### PR TITLE
fix(db): preserve the durable database dir when clearing caches (#4968)

### DIFF
--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -4,6 +4,8 @@
 import 'dart:io';
 
 import 'package:hive_ce/hive.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -116,35 +118,86 @@ class CacheRecoveryService {
     return cleared;
   }
 
-  /// Clear app support directory (NOT Documents - that's sandboxed on macOS)
-  static Future<int> _clearAppSupportDirectory() async {
-    int cleared = 0;
+  /// Durable database directory under Application Support that must NEVER be
+  /// deleted by cache clearing. It holds the live SQLite database
+  /// ({appSupport}/openvine/database/divine_db.db) — local-only user data
+  /// (drafts, DMs, pending uploads/actions, reactions, reposts) that cannot be
+  /// re-fetched. Segments mirror db_client's `buildSharedDatabasePath`.
+  ///
+  /// Deleting this directory while the Drift connection is open unlinks the
+  /// file's inode, so every later write returns SqliteException(1032 DBMOVED)
+  /// and is silently swallowed until the app restarts (#4968), on top of
+  /// destroying the durable data.
+  static const List<String> _durableDatabaseDirSegments = [
+    'openvine',
+    'database',
+  ];
 
+  /// Clear app support directory (NOT Documents - that's sandboxed on macOS),
+  /// preserving the durable database directory (see [_durableDatabaseDirSegments]).
+  static Future<int> _clearAppSupportDirectory() async {
     try {
       final appSupportDir = await getApplicationSupportDirectory();
-      if (appSupportDir.existsSync()) {
-        final files = appSupportDir.listSync();
-        for (final file in files) {
-          try {
-            await file.delete(recursive: true);
-            cleared++;
-          } catch (e) {
-            Log.debug(
-              'Could not delete ${file.path}: $e',
-              name: _logName,
-              category: LogCategory.system,
-            );
-          }
-        }
-      }
+      if (!appSupportDir.existsSync()) return 0;
+      final protectedPath = p.joinAll([
+        appSupportDir.path,
+        ..._durableDatabaseDirSegments,
+      ]);
+      return await deleteDirectoryContentsExcept(
+        appSupportDir,
+        protectedPath: protectedPath,
+      );
     } catch (e) {
       Log.warning(
         'Error clearing app support directory: $e',
         name: _logName,
         category: LogCategory.system,
       );
+      return 0;
     }
+  }
 
+  /// Recursively deletes the contents of [dir], preserving [protectedPath] and
+  /// its subtree wherever it sits beneath [dir]. Directories that are ancestors
+  /// of [protectedPath] are recursed into (so their other children are still
+  /// cleared) rather than deleted wholesale; everything else is removed.
+  ///
+  /// This is how cache clearing avoids unlinking the open database file (#4968):
+  /// the live `openvine/database` directory is skipped while the rest of
+  /// Application Support — including the disposable cache_sync database under
+  /// `openvine/cache` — is cleared.
+  @visibleForTesting
+  static Future<int> deleteDirectoryContentsExcept(
+    Directory dir, {
+    required String protectedPath,
+  }) async {
+    // Only apply protection when the path actually exists; otherwise there is
+    // nothing to preserve and ancestors should be cleared like anything else.
+    final protect = Directory(protectedPath).existsSync();
+    var cleared = 0;
+    for (final entity in dir.listSync()) {
+      final path = entity.path;
+      if (protect && p.equals(path, protectedPath)) {
+        continue;
+      }
+      if (protect && entity is Directory && p.isWithin(path, protectedPath)) {
+        cleared += await deleteDirectoryContentsExcept(
+          entity,
+          protectedPath: protectedPath,
+        );
+        continue;
+      }
+      try {
+        await entity.delete(recursive: true);
+        cleared++;
+      } catch (e) {
+        Log.debug(
+          'Could not delete $path: $e',
+          name: _logName,
+          category: LogCategory.system,
+        );
+      }
+    }
     return cleared;
   }
 

--- a/mobile/lib/services/cache_recovery_service.dart
+++ b/mobile/lib/services/cache_recovery_service.dart
@@ -174,6 +174,9 @@ class CacheRecoveryService {
     // Only apply protection when the path actually exists; otherwise there is
     // nothing to preserve and ancestors should be cleared like anything else.
     final protect = Directory(protectedPath).existsSync();
+    if (protect && p.equals(dir.path, protectedPath)) {
+      return 0;
+    }
     var cleared = 0;
     for (final entity in dir.listSync()) {
       final path = entity.path;

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -11,7 +11,6 @@ bookmark_service
 broken_video_tracker
 bug_report_service_stub # noise: stub
 c2pa_signing_service
-cache_recovery_service
 camera_base_service
 camera_mobile_service
 collaborator_invite_local_state_adapter # noise: local-state adapter

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -1,0 +1,111 @@
+// ABOUTME: Tests for CacheRecoveryService's directory clearing
+// ABOUTME: Pins #4968 — the durable database dir is preserved while caches are cleared
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/cache_recovery_service.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group(CacheRecoveryService, () {
+    group('deleteDirectoryContentsExcept', () {
+      late Directory tmp;
+
+      setUp(() {
+        tmp = Directory.systemTemp.createTempSync('cache_recovery_test');
+      });
+
+      tearDown(() {
+        if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+      });
+
+      File write(String relative, String contents) {
+        final file = File(p.join(tmp.path, relative))
+          ..parent.createSync(recursive: true)
+          ..writeAsStringSync(contents);
+        return file;
+      }
+
+      test(
+        'preserves the protected database dir and clears everything else',
+        () async {
+          // Mirror the real Application Support layout.
+          final db = write('openvine/database/divine_db.db', 'data');
+          final dbWal = write('openvine/database/divine_db.db-wal', 'wal');
+          final dbVersion = write('openvine/database/divine_db.version', '2');
+          final cacheSync = write('openvine/cache/cache_sync.db', 'cache');
+          final other = write('other/scratch.txt', 'scratch');
+          final top = write('top_level.txt', 'top');
+
+          final protectedPath = p.join(tmp.path, 'openvine', 'database');
+          final cleared =
+              await CacheRecoveryService.deleteDirectoryContentsExcept(
+                tmp,
+                protectedPath: protectedPath,
+              );
+
+          // Durable DB subtree survives entirely.
+          expect(
+            db.existsSync(),
+            isTrue,
+            reason: 'durable DB file must survive',
+          );
+          expect(dbWal.existsSync(), isTrue);
+          expect(dbVersion.existsSync(), isTrue);
+          expect(Directory(protectedPath).existsSync(), isTrue);
+
+          // Disposable caches and unrelated entries are gone.
+          expect(cacheSync.existsSync(), isFalse);
+          expect(
+            Directory(p.join(tmp.path, 'openvine', 'cache')).existsSync(),
+            isFalse,
+          );
+          expect(other.existsSync(), isFalse);
+          expect(top.existsSync(), isFalse);
+
+          // The ancestor dir of the protected subtree is kept (it holds it).
+          expect(
+            Directory(p.join(tmp.path, 'openvine')).existsSync(),
+            isTrue,
+          );
+          expect(cleared, greaterThan(0));
+        },
+      );
+
+      test('clears everything when the protected dir is absent', () async {
+        write('openvine/cache/cache_sync.db', 'cache');
+        write('top_level.txt', 'top');
+
+        final protectedPath = p.join(tmp.path, 'openvine', 'database');
+        await CacheRecoveryService.deleteDirectoryContentsExcept(
+          tmp,
+          protectedPath: protectedPath,
+        );
+
+        expect(tmp.listSync(), isEmpty);
+      });
+
+      test('preserves the protected dir even at the top level', () async {
+        final db = write('divine_db.db', 'data');
+        write('scratch.txt', 'scratch');
+
+        // Protect the file's own directory (the temp root would be too broad);
+        // use a top-level protected directory instead.
+        final protectedDir = Directory(p.join(tmp.path, 'db'))
+          ..createSync(recursive: true);
+        final keep = File(p.join(protectedDir.path, 'divine_db.db'))
+          ..writeAsStringSync('keep');
+        db.deleteSync();
+
+        await CacheRecoveryService.deleteDirectoryContentsExcept(
+          tmp,
+          protectedPath: protectedDir.path,
+        );
+
+        expect(keep.existsSync(), isTrue);
+        expect(File(p.join(tmp.path, 'scratch.txt')).existsSync(), isFalse);
+      });
+    });
+  });
+}

--- a/mobile/test/services/cache_recovery_service_test.dart
+++ b/mobile/test/services/cache_recovery_service_test.dart
@@ -106,6 +106,22 @@ void main() {
         expect(keep.existsSync(), isTrue);
         expect(File(p.join(tmp.path, 'scratch.txt')).existsSync(), isFalse);
       });
+
+      test('does not clear contents when dir is the protected dir', () async {
+        final protectedDir = Directory(p.join(tmp.path, 'openvine', 'database'))
+          ..createSync(recursive: true);
+        final keep = File(p.join(protectedDir.path, 'divine_db.db'))
+          ..writeAsStringSync('keep');
+
+        final cleared =
+            await CacheRecoveryService.deleteDirectoryContentsExcept(
+              protectedDir,
+              protectedPath: protectedDir.path,
+            );
+
+        expect(cleared, 0);
+        expect(keep.existsSync(), isTrue);
+      });
     });
   });
 }

--- a/mobile/test/services/upload_manager_from_draft_test.dart
+++ b/mobile/test/services/upload_manager_from_draft_test.dart
@@ -41,6 +41,7 @@ void main() {
         ..setApplicationDocumentsPath('${tempDir.path}/documents')
         ..setApplicationSupportPath('${tempDir.path}/support');
       PathProviderPlatform.instance = mockPathProvider;
+      await TestHelpers.cleanupHiveBox('pending_uploads');
       sourceVideoFile = File('${tempDir.path}/source_video.mp4')
         ..writeAsBytesSync([0, 1, 2, 3]);
 
@@ -81,6 +82,7 @@ void main() {
       if (Hive.isBoxOpen('pending_uploads')) {
         await Hive.box<PendingUpload>('pending_uploads').close();
       }
+      await Hive.deleteBoxFromDisk('pending_uploads');
       PathProviderPlatform.instance = originalPathProviderInstance;
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);


### PR DESCRIPTION
## Description

Tapping **Clear Cache** corrupted the live database session and destroyed durable user data. `CacheRecoveryService._clearAppSupportDirectory()` recursively deleted **every** entry under Application Support — including the live `{appSupport}/openvine/database/divine_db.db`. Deleting the open SQLite file unlinks its inode, so every later write returns `SqliteException(1032 DBMOVED)` and is silently swallowed until the app restarts, and it wipes local-only data (drafts, DMs, pending uploads/actions, reactions, reposts) that `connection_native.dart` explicitly documents must never be wiped ("wipe-and-resync is intentionally rejected").

**Fix:** preserve the `openvine/database` subtree during the wipe, via a new pure, unit-tested `deleteDirectoryContentsExcept` helper. Ancestor directories of the protected path are recursed into (so their *other* children — e.g. the disposable `openvine/cache/cache_sync.db` — are still cleared); only the durable DB subtree is kept. The fix avoids mid-session connection juggling (the caller shows an OK dialog with no restart, so recreating the connection would leave startup-captured consumers pointing at a closed DB).

Also adds `cache_recovery_service_test.dart` — the service previously had **zero** test coverage (#4335 M17).

## Root cause
`1032 = SQLITE_READONLY_DBMOVED` ("file moved/replaced since the connection opened"). Confirmed in #4968 (13-agent investigation) and #4782 logs.

**Related Issue:** Closes #4968

## Out of Scope

- `openvine/cache/cache_sync.db` (the disposable SWR cache) is still deleted while its connection may be open — lower severity (disposable, recoverable) and clearing it safely needs a connection-closing reset path. Separate follow-up.
- A proper "Reset Database" action (close → delete → restart) for genuine DB corruption — this PR intentionally stops Clear Cache from destroying durable data rather than adding a new reset path.

## Verification

- `flutter test test/services/cache_recovery_service_test.dart` — 3/3 pass (durable dir preserved + others cleared; everything cleared when no DB present; protected dir at top level).
- `flutter analyze` — no issues (pre-commit hook green).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)