### PR TITLE
feat(video-editor): multi-select clips to merge or delete

### DIFF
--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -292,14 +292,15 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     final selected = state.selectedClipIds;
     if (selected.isEmpty) return;
 
-    final remaining = state.clips
+    final previousClips = state.clips;
+    final remaining = previousClips
         .where((c) => !selected.contains(c.id))
         .toList();
     // At least one clip must always remain in the timeline.
     if (remaining.isEmpty) return;
 
     Log.info(
-      '🗑️ Removed ${state.clips.length - remaining.length} selected clip(s)',
+      '🗑️ Removed ${previousClips.length - remaining.length} selected clip(s)',
       name: 'ClipEditorBloc',
       category: LogCategory.video,
     );
@@ -310,6 +311,9 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         currentClipIndex: state.currentClipIndex.clamp(0, remaining.length - 1),
         isMultiSelectMode: false,
         selectedClipIds: const {},
+        lastClipsRemovedResult: ClipsRemovedResult(
+          previousClips: previousClips,
+        ),
       ),
     );
   }

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -6,6 +6,7 @@ import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
+import 'package:openvine/services/video_editor/video_editor_merge_service.dart';
 import 'package:openvine/services/video_editor/video_editor_reverse_service.dart';
 import 'package:openvine/services/video_editor/video_editor_split_service.dart';
 import 'package:openvine/services/video_editor/video_editor_transform_service.dart';
@@ -51,6 +52,15 @@ typedef TransformClipFn =
       required String renderId,
     });
 
+/// Function signature matching [VideoEditorMergeService.mergeClips], used as an
+/// injectable seam so tests can swap in a pure-Dart fake that does not touch
+/// the render pipeline.
+typedef MergeClipsFn =
+    Future<DivineVideoClip?> Function({
+      required List<DivineVideoClip> clips,
+      required String renderId,
+    });
+
 /// BLoC for managing video clip editor state.
 ///
 /// Owns a local copy of the clip list so that all mutations (add, remove,
@@ -70,12 +80,14 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
     SplitClipFn? splitClip,
     ReverseClipFn? reverseClip,
     TransformClipFn? transformClip,
+    MergeClipsFn? mergeClips,
   }) : _audioExtractionService =
            audioExtractionService ?? AudioExtractionService(),
        _splitClip = splitClip ?? VideoEditorSplitService.splitClip,
        _reverseClip = reverseClip ?? VideoEditorReverseService.reverseClip,
        _transformClip =
            transformClip ?? VideoEditorTransformService.transformClip,
+       _mergeClips = mergeClips ?? VideoEditorMergeService.mergeClips,
        super(const ClipEditorState()) {
     // Clip data
     on<ClipEditorInitialized>(_onInitialized);
@@ -85,6 +97,16 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
 
     // Clip selection
     on<ClipEditorClipSelected>(_onClipSelected);
+
+    // Multi-select
+    on<ClipEditorMultiSelectStarted>(_onMultiSelectStarted);
+    on<ClipEditorMultiSelectClipToggled>(_onMultiSelectClipToggled);
+    on<ClipEditorMultiSelectCancelled>(_onMultiSelectCancelled);
+    on<ClipEditorSelectedClipsRemoved>(_onSelectedClipsRemoved);
+    on<ClipEditorSelectedClipsMergeRequested>(
+      _onSelectedClipsMergeRequested,
+      transformer: droppable(),
+    );
 
     // Editing mode
     on<ClipEditorEditingStarted>(_onEditingStarted);
@@ -135,6 +157,7 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
   final SplitClipFn _splitClip;
   final ReverseClipFn _reverseClip;
   final TransformClipFn _transformClip;
+  final MergeClipsFn _mergeClips;
 
   // === CLIP DATA ===
 
@@ -217,6 +240,190 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
         splitPosition: Duration.zero,
       ),
     );
+  }
+
+  // === MULTI-SELECT ===
+
+  void _onMultiSelectStarted(
+    ClipEditorMultiSelectStarted event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    final initialId = event.initialClipId;
+    final selected = <String>{
+      if (initialId != null && state.clips.any((c) => c.id == initialId))
+        initialId,
+    };
+    emit(
+      state.copyWith(
+        isMultiSelectMode: true,
+        isEditing: false,
+        selectedClipIds: selected,
+      ),
+    );
+  }
+
+  void _onMultiSelectClipToggled(
+    ClipEditorMultiSelectClipToggled event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    if (!state.isMultiSelectMode) return;
+    if (!state.clips.any((c) => c.id == event.clipId)) return;
+
+    final selected = Set<String>.of(state.selectedClipIds);
+    if (!selected.remove(event.clipId)) {
+      selected.add(event.clipId);
+    }
+    emit(state.copyWith(selectedClipIds: selected));
+  }
+
+  void _onMultiSelectCancelled(
+    ClipEditorMultiSelectCancelled event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    emit(
+      state.copyWith(isMultiSelectMode: false, selectedClipIds: const {}),
+    );
+  }
+
+  void _onSelectedClipsRemoved(
+    ClipEditorSelectedClipsRemoved event,
+    Emitter<ClipEditorState> emit,
+  ) {
+    final selected = state.selectedClipIds;
+    if (selected.isEmpty) return;
+
+    final remaining = state.clips
+        .where((c) => !selected.contains(c.id))
+        .toList();
+    // At least one clip must always remain in the timeline.
+    if (remaining.isEmpty) return;
+
+    Log.info(
+      '🗑️ Removed ${state.clips.length - remaining.length} selected clip(s)',
+      name: 'ClipEditorBloc',
+      category: LogCategory.video,
+    );
+
+    emit(
+      state.copyWith(
+        clips: List.unmodifiable(remaining),
+        currentClipIndex: state.currentClipIndex.clamp(0, remaining.length - 1),
+        isMultiSelectMode: false,
+        selectedClipIds: const {},
+      ),
+    );
+  }
+
+  Future<void> _onSelectedClipsMergeRequested(
+    ClipEditorSelectedClipsMergeRequested event,
+    Emitter<ClipEditorState> emit,
+  ) async {
+    final selectedIds = state.selectedClipIds;
+    final selectedClips = state.clips
+        .where((c) => selectedIds.contains(c.id))
+        .toList();
+    if (selectedClips.length < 2) return;
+
+    final renderId = 'merge_${DateTime.now().microsecondsSinceEpoch}';
+
+    Log.info(
+      '🧬 Merging ${selectedClips.length} selected clip(s)',
+      name: 'ClipEditorBloc',
+      category: LogCategory.video,
+    );
+
+    emit(state.copyWith(isMerging: true, mergingRenderId: renderId));
+
+    try {
+      final merged = await _mergeClips(
+        clips: selectedClips,
+        renderId: renderId,
+      );
+
+      if (merged == null) {
+        // Matrix-NO: render cancel/failure is surfaced as a null output by
+        // VideoEditorRenderService.renderVideo (Network/IO).
+        emit(
+          state.copyWith(
+            isMerging: false,
+            clearMergingRenderId: true,
+            lastMergeResult: ClipMergeFailure(),
+          ),
+        );
+        return;
+      }
+
+      // Reconcile against current state after the async gap. The full-screen
+      // progress overlay blocks competing edits, but guard anyway so a stale
+      // result never resurrects removed clips.
+      final currentClips = state.clips;
+      final stillPresent = selectedIds.every(
+        (id) => currentClips.any((c) => c.id == id),
+      );
+      if (!stillPresent) {
+        Log.warning(
+          '⚠️ Merge result discarded: a selected clip no longer exists',
+          name: 'ClipEditorBloc',
+          category: LogCategory.video,
+        );
+        emit(
+          state.copyWith(
+            isMerging: false,
+            clearMergingRenderId: true,
+            isMultiSelectMode: false,
+            selectedClipIds: const {},
+            lastMergeResult: ClipMergeDiscarded(),
+          ),
+        );
+        return;
+      }
+
+      final earliestIndex = currentClips.indexWhere(
+        (c) => selectedIds.contains(c.id),
+      );
+      final newClips =
+          currentClips.where((c) => !selectedIds.contains(c.id)).toList()
+            ..insert(earliestIndex, merged);
+
+      emit(
+        state.copyWith(
+          clips: List.unmodifiable(newClips),
+          currentClipIndex: earliestIndex,
+          isMerging: false,
+          clearMergingRenderId: true,
+          isMultiSelectMode: false,
+          selectedClipIds: const {},
+          lastMergeResult: ClipMergeSuccess(previousClips: currentClips),
+        ),
+      );
+
+      Log.info(
+        '✅ Merged into clip ${merged.id}',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
+      );
+    } catch (e, stackTrace) {
+      final error = switch (e) {
+        StateError() || TypeError() || RangeError() => Reportable(
+          e,
+          context: '_onSelectedClipsMergeRequested',
+        ),
+        _ => e,
+      };
+      addError(error, stackTrace);
+      Log.error(
+        '❌ Failed to merge clips: $e',
+        name: 'ClipEditorBloc',
+        category: LogCategory.video,
+      );
+      emit(
+        state.copyWith(
+          isMerging: false,
+          clearMergingRenderId: true,
+          lastMergeResult: ClipMergeFailure(),
+        ),
+      );
+    }
   }
 
   // === EDITING MODE ===

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_event.dart
@@ -70,6 +70,50 @@ class ClipEditorClipSelected extends ClipEditorEvent {
   List<Object?> get props => [index];
 }
 
+// === MULTI-SELECT ===
+
+/// Enter multi-select mode, optionally pre-selecting [initialClipId].
+///
+/// Exits single-clip editing mode. While multi-select is active, tapping a
+/// clip toggles its membership in the selection.
+class ClipEditorMultiSelectStarted extends ClipEditorEvent {
+  const ClipEditorMultiSelectStarted([this.initialClipId]);
+
+  final String? initialClipId;
+
+  @override
+  List<Object?> get props => [initialClipId];
+}
+
+/// Toggle a clip's membership in the multi-select selection.
+class ClipEditorMultiSelectClipToggled extends ClipEditorEvent {
+  const ClipEditorMultiSelectClipToggled(this.clipId);
+
+  final String clipId;
+
+  @override
+  List<Object?> get props => [clipId];
+}
+
+/// Exit multi-select mode and clear the selection.
+class ClipEditorMultiSelectCancelled extends ClipEditorEvent {
+  const ClipEditorMultiSelectCancelled();
+}
+
+/// Remove every clip currently in the multi-select selection.
+///
+/// No-op when the selection would empty the timeline — at least one clip must
+/// always remain.
+class ClipEditorSelectedClipsRemoved extends ClipEditorEvent {
+  const ClipEditorSelectedClipsRemoved();
+}
+
+/// Merge every clip currently in the multi-select selection into a single
+/// rendered clip placed at the earliest selected position.
+class ClipEditorSelectedClipsMergeRequested extends ClipEditorEvent {
+  const ClipEditorSelectedClipsMergeRequested();
+}
+
 // === EDITING MODE ===
 
 /// Enter editing mode for the currently selected clip.

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -33,6 +33,7 @@ class ClipEditorState extends Equatable {
     this.isMerging = false,
     this.mergingRenderId,
     this.lastMergeResult,
+    this.lastClipsRemovedResult,
   });
 
   /// Local copy of clips managed by this editor session.
@@ -148,6 +149,12 @@ class ClipEditorState extends Equatable {
   /// history (on success) or surface a failure snackbar.
   final ClipMergeResult? lastMergeResult;
 
+  /// One-shot signal emitted after a multi-select removal.
+  ///
+  /// The BLoC owns the clip-list mutation; the widget layer consumes this to
+  /// rebase timeline markers and commit the new clip list to editor history.
+  final ClipsRemovedResult? lastClipsRemovedResult;
+
   /// Total wall-clock duration of all clips (respecting trim and playback speed).
   Duration get totalDuration =>
       clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);
@@ -184,6 +191,7 @@ class ClipEditorState extends Equatable {
     String? mergingRenderId,
     bool clearMergingRenderId = false,
     ClipMergeResult? lastMergeResult,
+    ClipsRemovedResult? lastClipsRemovedResult,
   }) {
     return ClipEditorState(
       clips: clips ?? this.clips,
@@ -220,6 +228,8 @@ class ClipEditorState extends Equatable {
           ? null
           : (mergingRenderId ?? this.mergingRenderId),
       lastMergeResult: lastMergeResult ?? this.lastMergeResult,
+      lastClipsRemovedResult:
+          lastClipsRemovedResult ?? this.lastClipsRemovedResult,
     );
   }
 
@@ -253,6 +263,8 @@ class ClipEditorState extends Equatable {
     mergingRenderId,
     // Identity-only: each ClipMergeResult is a fresh instance per merge.
     identityHashCode(lastMergeResult),
+    // Identity-only: each ClipsRemovedResult is a fresh instance per removal.
+    identityHashCode(lastClipsRemovedResult),
   ];
 }
 
@@ -379,3 +391,18 @@ final class ClipMergeFailure extends ClipMergeResult {}
 /// Merge completed but one or more selected clips were removed from the
 /// timeline while the async render was in flight, so the result was discarded.
 final class ClipMergeDiscarded extends ClipMergeResult {}
+
+// === CLIPS-REMOVED RESULT ===
+
+/// One-shot signal emitted after a multi-select removal succeeds.
+///
+/// The BLoC has already dropped the selected clips from [ClipEditorState.clips]
+/// by the time this fires; [previousClips] is the clip list as it was before the
+/// removal, so the widget layer can rebase timeline markers from the old
+/// composition to the new one. Identity-compared so the scaffold [BlocListener]
+/// fires exactly once per removal.
+final class ClipsRemovedResult {
+  ClipsRemovedResult({required this.previousClips});
+
+  final List<DivineVideoClip> previousClips;
+}

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_state.dart
@@ -28,6 +28,11 @@ class ClipEditorState extends Equatable {
     this.isTransforming = false,
     this.transformingClipId,
     this.lastTransformResult,
+    this.isMultiSelectMode = false,
+    this.selectedClipIds = const {},
+    this.isMerging = false,
+    this.mergingRenderId,
+    this.lastMergeResult,
   });
 
   /// Local copy of clips managed by this editor session.
@@ -123,6 +128,26 @@ class ClipEditorState extends Equatable {
   /// the canvas player-sync listener that reacts to the swapped clip file.
   final ClipTransformResult? lastTransformResult;
 
+  /// Whether the timeline is in multi-select mode — tapping a clip toggles its
+  /// membership in [selectedClipIds] instead of entering single-clip editing.
+  final bool isMultiSelectMode;
+
+  /// IDs of the clips currently selected in multi-select mode. Keyed by id so
+  /// the selection survives reorder and re-render.
+  final Set<String> selectedClipIds;
+
+  /// Whether a merge (concat) render operation is currently running.
+  final bool isMerging;
+
+  /// Render id used as the render-progress stream key while merging.
+  final String? mergingRenderId;
+
+  /// Last completed merge-render result.
+  ///
+  /// Consumed by the widget layer to commit the merged clip list to editor
+  /// history (on success) or surface a failure snackbar.
+  final ClipMergeResult? lastMergeResult;
+
   /// Total wall-clock duration of all clips (respecting trim and playback speed).
   Duration get totalDuration =>
       clips.fold(Duration.zero, (sum, clip) => sum + clip.playbackDuration);
@@ -153,6 +178,12 @@ class ClipEditorState extends Equatable {
     String? transformingClipId,
     bool clearTransformingClipId = false,
     ClipTransformResult? lastTransformResult,
+    bool? isMultiSelectMode,
+    Set<String>? selectedClipIds,
+    bool? isMerging,
+    String? mergingRenderId,
+    bool clearMergingRenderId = false,
+    ClipMergeResult? lastMergeResult,
   }) {
     return ClipEditorState(
       clips: clips ?? this.clips,
@@ -182,6 +213,13 @@ class ClipEditorState extends Equatable {
           ? null
           : (transformingClipId ?? this.transformingClipId),
       lastTransformResult: lastTransformResult ?? this.lastTransformResult,
+      isMultiSelectMode: isMultiSelectMode ?? this.isMultiSelectMode,
+      selectedClipIds: selectedClipIds ?? this.selectedClipIds,
+      isMerging: isMerging ?? this.isMerging,
+      mergingRenderId: clearMergingRenderId
+          ? null
+          : (mergingRenderId ?? this.mergingRenderId),
+      lastMergeResult: lastMergeResult ?? this.lastMergeResult,
     );
   }
 
@@ -209,6 +247,12 @@ class ClipEditorState extends Equatable {
     isTransforming,
     transformingClipId,
     identityHashCode(lastTransformResult),
+    isMultiSelectMode,
+    selectedClipIds,
+    isMerging,
+    mergingRenderId,
+    // Identity-only: each ClipMergeResult is a fresh instance per merge.
+    identityHashCode(lastMergeResult),
   ];
 }
 
@@ -309,3 +353,29 @@ final class ClipTransformDiscarded extends ClipTransformResult {}
 
 /// Transform render failed.
 final class ClipTransformFailure extends ClipTransformResult {}
+
+// === MERGE RESULT ===
+
+/// One-shot signal describing the outcome of a merge-render operation.
+///
+/// Emitted into [ClipEditorState.lastMergeResult] after each merge attempt.
+/// Identity-compared so the scaffold [BlocListener] fires exactly once per
+/// attempt even when the same outcome repeats.
+sealed class ClipMergeResult {}
+
+/// Merge render succeeded; [ClipEditorState.clips] already holds the merged
+/// clip in place of the selected ones. [previousClips] is the clip list as it
+/// was immediately before the merge, so the widget layer can rebase timeline
+/// markers from the old composition to the new one.
+final class ClipMergeSuccess extends ClipMergeResult {
+  ClipMergeSuccess({required this.previousClips});
+
+  final List<DivineVideoClip> previousClips;
+}
+
+/// Merge render was attempted but cancelled or failed.
+final class ClipMergeFailure extends ClipMergeResult {}
+
+/// Merge completed but one or more selected clips were removed from the
+/// timeline while the async render was in flight, so the result was discarded.
+final class ClipMergeDiscarded extends ClipMergeResult {}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4079,5 +4079,33 @@
     "videoEditorTransformApplySemanticLabel": "ለውጥን ተግብር",
     "videoEditorTransformCancelSemanticLabel": "ለውጥን ሰርዝ",
     "videoEditorTransformPlayLabel": "አጫውት",
-    "videoEditorTransformPauseLabel": "ለአፍታ አቁም"
+    "videoEditorTransformPauseLabel": "ለአፍታ አቁም",
+    "videoEditorTimelineClipSelectedSemanticLabel": "ቅንጥብ {index} ከ {total}፣ ተመርጧል",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "ቅንጥብ {index} ከ {total}፣ አልተመረጠም",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "ምረጥ",
+    "videoEditorMultiSelectSemanticLabel": "ብዙ ቅንጥቦችን ምረጥ",
+    "videoEditorMultiSelectDoneSemanticLabel": "ምርጫን ጨርስ",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{ምንም ቅንጥብ አልተመረጠም} =1{1 ቅንጥብ ተመርጧል} other{{count} ቅንጥቦች ተመርጠዋል}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "አዋህድ",
+    "videoEditorMergeSelectedClipsSemanticLabel": "የተመረጡ ቅንጥቦችን አዋህድ",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "የተመረጡ ቅንጥቦችን ሰርዝ",
+    "videoEditorMergeProgressLabel": "ትንሽ ይቆዩ፣ ቅንጥቦችዎን እያዋሃድን ነው",
+    "videoEditorMergeFailed": "ቅንጥቦችን ማዋሃድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "تطبيق التحويل",
     "videoEditorTransformCancelSemanticLabel": "إلغاء التحويل",
     "videoEditorTransformPlayLabel": "تشغيل",
-    "videoEditorTransformPauseLabel": "إيقاف مؤقت"
+    "videoEditorTransformPauseLabel": "إيقاف مؤقت",
+    "videoEditorTimelineClipSelectedSemanticLabel": "المقطع {index} من {total}، محدد",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "المقطع {index} من {total}، غير محدد",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "تحديد",
+    "videoEditorMultiSelectSemanticLabel": "تحديد عدة مقاطع",
+    "videoEditorMultiSelectDoneSemanticLabel": "إنهاء التحديد",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{لم يتم تحديد مقاطع} =1{تم تحديد مقطع واحد} other{تم تحديد {count} مقاطع}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "دمج",
+    "videoEditorMergeSelectedClipsSemanticLabel": "دمج المقاطع المحددة",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "حذف المقاطع المحددة",
+    "videoEditorMergeProgressLabel": "لحظة من فضلك، نقوم بدمج مقاطعك",
+    "videoEditorMergeFailed": "تعذّر دمج المقاطع. يُرجى المحاولة مرة أخرى."
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4085,5 +4085,33 @@
     "videoEditorTransformApplySemanticLabel": "Прилагане на преобразуването",
     "videoEditorTransformCancelSemanticLabel": "Отказ на преобразуването",
     "videoEditorTransformPlayLabel": "Възпроизвеждане",
-    "videoEditorTransformPauseLabel": "Пауза"
+    "videoEditorTransformPauseLabel": "Пауза",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Клип {index} от {total}, избран",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Клип {index} от {total}, неизбран",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Избор",
+    "videoEditorMultiSelectSemanticLabel": "Избор на няколко клипа",
+    "videoEditorMultiSelectDoneSemanticLabel": "Завърши избора",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Няма избрани клипове} =1{1 избран клип} other{{count} избрани клипа}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Обедини",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Обединяване на избраните клипове",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Изтриване на избраните клипове",
+    "videoEditorMergeProgressLabel": "Един момент, обединяваме клиповете ти",
+    "videoEditorMergeFailed": "Клиповете не могат да бъдат обединени. Опитай отново."
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Transformation anwenden",
     "videoEditorTransformCancelSemanticLabel": "Transformation abbrechen",
     "videoEditorTransformPlayLabel": "Abspielen",
-    "videoEditorTransformPauseLabel": "Pause"
+    "videoEditorTransformPauseLabel": "Pause",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Clip {index} von {total}, ausgewählt",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Clip {index} von {total}, nicht ausgewählt",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Auswählen",
+    "videoEditorMultiSelectSemanticLabel": "Mehrere Clips auswählen",
+    "videoEditorMultiSelectDoneSemanticLabel": "Auswahl abschließen",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Keine Clips ausgewählt} =1{1 Clip ausgewählt} other{{count} Clips ausgewählt}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Zusammenführen",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Ausgewählte Clips zusammenführen",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Ausgewählte Clips löschen",
+    "videoEditorMergeProgressLabel": "Einen Moment, wir führen deine Clips zusammen",
+    "videoEditorMergeFailed": "Clips konnten nicht zusammengeführt werden. Bitte versuche es erneut."
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4642,6 +4642,71 @@
   "videoEditorClipGalleryInstruction": "Tap to edit. Hold and drag to reorder.",
   "videoEditorTimelineClipMoveLeft": "Move left",
   "videoEditorTimelineClipMoveRight": "Move right",
+  "videoEditorTimelineClipSelectedSemanticLabel": "Clip {index} of {total}, selected",
+  "@videoEditorTimelineClipSelectedSemanticLabel": {
+    "description": "Accessibility label for a timeline clip that is selected in multi-select mode.",
+    "placeholders": {
+      "index": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "videoEditorTimelineClipUnselectedSemanticLabel": "Clip {index} of {total}, not selected",
+  "@videoEditorTimelineClipUnselectedSemanticLabel": {
+    "description": "Accessibility label for a timeline clip that is not selected in multi-select mode.",
+    "placeholders": {
+      "index": {
+        "type": "int"
+      },
+      "total": {
+        "type": "int"
+      }
+    }
+  },
+  "videoEditorMultiSelectLabel": "Select",
+  "@videoEditorMultiSelectLabel": {
+    "description": "Label for the button that starts multi-select mode on the timeline."
+  },
+  "videoEditorMultiSelectSemanticLabel": "Select multiple clips",
+  "@videoEditorMultiSelectSemanticLabel": {
+    "description": "Accessibility label for the button that starts multi-select mode on the timeline."
+  },
+  "videoEditorMultiSelectDoneSemanticLabel": "Done selecting clips",
+  "@videoEditorMultiSelectDoneSemanticLabel": {
+    "description": "Accessibility label for the button that exits multi-select mode."
+  },
+  "videoEditorMultiSelectCountLabel": "{count, plural, =0{No clips selected} =1{1 clip selected} other{{count} clips selected}}",
+  "@videoEditorMultiSelectCountLabel": {
+    "description": "Header shown in the multi-select action bar reporting how many clips are selected.",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "videoEditorMergeLabel": "Merge",
+  "@videoEditorMergeLabel": {
+    "description": "Label for the button that merges the selected clips into one."
+  },
+  "videoEditorMergeSelectedClipsSemanticLabel": "Merge selected clips",
+  "@videoEditorMergeSelectedClipsSemanticLabel": {
+    "description": "Accessibility label for the button that merges the selected clips into one."
+  },
+  "videoEditorDeleteSelectedClipsSemanticLabel": "Delete selected clips",
+  "@videoEditorDeleteSelectedClipsSemanticLabel": {
+    "description": "Accessibility label for the button that deletes the selected clips."
+  },
+  "videoEditorMergeProgressLabel": "One moment, we're merging your clips",
+  "@videoEditorMergeProgressLabel": {
+    "description": "Status text shown while the selected clips are being concatenated into a single clip."
+  },
+  "videoEditorMergeFailed": "Could not merge clips. Please try again.",
+  "@videoEditorMergeFailed": {
+    "description": "Snackbar message shown when merging the selected clips fails during rendering."
+  },
   "videoEditorTimelineLongPressToDragHint": "Long press to drag",
   "videoEditorVideoTimelineSemanticLabel": "Video timeline",
   "videoEditorTimelinePositionFormat": "{minutes}m {seconds}s",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Aplicar transformación",
     "videoEditorTransformCancelSemanticLabel": "Cancelar transformación",
     "videoEditorTransformPlayLabel": "Reproducir",
-    "videoEditorTransformPauseLabel": "Pausar"
+    "videoEditorTransformPauseLabel": "Pausar",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Clip {index} de {total}, seleccionado",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Clip {index} de {total}, no seleccionado",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Seleccionar",
+    "videoEditorMultiSelectSemanticLabel": "Seleccionar varios clips",
+    "videoEditorMultiSelectDoneSemanticLabel": "Finalizar selección",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Ningún clip seleccionado} =1{1 clip seleccionado} other{{count} clips seleccionados}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Combinar",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Combinar clips seleccionados",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Eliminar clips seleccionados",
+    "videoEditorMergeProgressLabel": "Un momento, estamos combinando tus clips",
+    "videoEditorMergeFailed": "No se pudieron combinar los clips. Inténtalo de nuevo."
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2495,5 +2495,33 @@
     "videoEditorTransformApplySemanticLabel": "Ilapat ang transform",
     "videoEditorTransformCancelSemanticLabel": "Kanselahin ang transform",
     "videoEditorTransformPlayLabel": "I-play",
-    "videoEditorTransformPauseLabel": "I-pause"
+    "videoEditorTransformPauseLabel": "I-pause",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Clip {index} ng {total}, napili",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Clip {index} ng {total}, hindi napili",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Pumili",
+    "videoEditorMultiSelectSemanticLabel": "Pumili ng maraming clip",
+    "videoEditorMultiSelectDoneSemanticLabel": "Tapusin ang pagpili",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Walang napiling clip} =1{1 clip ang napili} other{{count} clip ang napili}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Pagsamahin",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Pagsamahin ang mga napiling clip",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Tanggalin ang mga napiling clip",
+    "videoEditorMergeProgressLabel": "Sandali lang, pinagsasama namin ang iyong mga clip",
+    "videoEditorMergeFailed": "Hindi mapagsama ang mga clip. Pakisubukang muli."
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Appliquer la transformation",
     "videoEditorTransformCancelSemanticLabel": "Annuler la transformation",
     "videoEditorTransformPlayLabel": "Lire",
-    "videoEditorTransformPauseLabel": "Pause"
+    "videoEditorTransformPauseLabel": "Pause",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Clip {index} sur {total}, sélectionné",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Clip {index} sur {total}, non sélectionné",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Sélectionner",
+    "videoEditorMultiSelectSemanticLabel": "Sélectionner plusieurs clips",
+    "videoEditorMultiSelectDoneSemanticLabel": "Terminer la sélection",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Aucun clip sélectionné} =1{1 clip sélectionné} other{{count} clips sélectionnés}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Fusionner",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Fusionner les clips sélectionnés",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Supprimer les clips sélectionnés",
+    "videoEditorMergeProgressLabel": "Un instant, nous fusionnons vos clips",
+    "videoEditorMergeFailed": "Impossible de fusionner les clips. Veuillez réessayer."
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Terapkan transformasi",
     "videoEditorTransformCancelSemanticLabel": "Batalkan transformasi",
     "videoEditorTransformPlayLabel": "Putar",
-    "videoEditorTransformPauseLabel": "Jeda"
+    "videoEditorTransformPauseLabel": "Jeda",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Klip {index} dari {total}, dipilih",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Klip {index} dari {total}, tidak dipilih",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Pilih",
+    "videoEditorMultiSelectSemanticLabel": "Pilih beberapa klip",
+    "videoEditorMultiSelectDoneSemanticLabel": "Selesai memilih",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Tidak ada klip dipilih} =1{1 klip dipilih} other{{count} klip dipilih}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Gabungkan",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Gabungkan klip yang dipilih",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Hapus klip yang dipilih",
+    "videoEditorMergeProgressLabel": "Sebentar, kami sedang menggabungkan klipmu",
+    "videoEditorMergeFailed": "Tidak dapat menggabungkan klip. Silakan coba lagi."
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Applica trasformazione",
     "videoEditorTransformCancelSemanticLabel": "Annulla trasformazione",
     "videoEditorTransformPlayLabel": "Riproduci",
-    "videoEditorTransformPauseLabel": "Pausa"
+    "videoEditorTransformPauseLabel": "Pausa",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Clip {index} di {total}, selezionata",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Clip {index} di {total}, non selezionata",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Seleziona",
+    "videoEditorMultiSelectSemanticLabel": "Seleziona più clip",
+    "videoEditorMultiSelectDoneSemanticLabel": "Termina selezione",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Nessuna clip selezionata} =1{1 clip selezionata} other{{count} clip selezionate}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Unisci",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Unisci le clip selezionate",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Elimina le clip selezionate",
+    "videoEditorMergeProgressLabel": "Un momento, stiamo unendo le tue clip",
+    "videoEditorMergeFailed": "Impossibile unire le clip. Riprova."
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "変形を適用",
     "videoEditorTransformCancelSemanticLabel": "変形をキャンセル",
     "videoEditorTransformPlayLabel": "再生",
-    "videoEditorTransformPauseLabel": "一時停止"
+    "videoEditorTransformPauseLabel": "一時停止",
+    "videoEditorTimelineClipSelectedSemanticLabel": "クリップ {index}/{total}、選択中",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "クリップ {index}/{total}、未選択",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "選択",
+    "videoEditorMultiSelectSemanticLabel": "複数のクリップを選択",
+    "videoEditorMultiSelectDoneSemanticLabel": "選択を完了",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{クリップが選択されていません} =1{1 件のクリップを選択中} other{{count} 件のクリップを選択中}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "結合",
+    "videoEditorMergeSelectedClipsSemanticLabel": "選択したクリップを結合",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "選択したクリップを削除",
+    "videoEditorMergeProgressLabel": "少々お待ちください。クリップを結合しています",
+    "videoEditorMergeFailed": "クリップを結合できませんでした。もう一度お試しください。"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3243,5 +3243,33 @@
     "videoEditorTransformApplySemanticLabel": "변형 적용",
     "videoEditorTransformCancelSemanticLabel": "변형 취소",
     "videoEditorTransformPlayLabel": "재생",
-    "videoEditorTransformPauseLabel": "일시정지"
+    "videoEditorTransformPauseLabel": "일시정지",
+    "videoEditorTimelineClipSelectedSemanticLabel": "클립 {index}/{total}, 선택됨",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "클립 {index}/{total}, 선택 안 됨",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "선택",
+    "videoEditorMultiSelectSemanticLabel": "여러 클립 선택",
+    "videoEditorMultiSelectDoneSemanticLabel": "선택 완료",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{선택된 클립 없음} =1{클립 1개 선택됨} other{클립 {count}개 선택됨}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "병합",
+    "videoEditorMergeSelectedClipsSemanticLabel": "선택한 클립 병합",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "선택한 클립 삭제",
+    "videoEditorMergeProgressLabel": "잠시만요, 클립을 병합하고 있어요",
+    "videoEditorMergeFailed": "클립을 병합할 수 없습니다. 다시 시도해 주세요."
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Transformatie toepassen",
     "videoEditorTransformCancelSemanticLabel": "Transformatie annuleren",
     "videoEditorTransformPlayLabel": "Afspelen",
-    "videoEditorTransformPauseLabel": "Pauze"
+    "videoEditorTransformPauseLabel": "Pauze",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Clip {index} van {total}, geselecteerd",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Clip {index} van {total}, niet geselecteerd",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Selecteren",
+    "videoEditorMultiSelectSemanticLabel": "Meerdere clips selecteren",
+    "videoEditorMultiSelectDoneSemanticLabel": "Selectie voltooien",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Geen clips geselecteerd} =1{1 clip geselecteerd} other{{count} clips geselecteerd}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Samenvoegen",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Geselecteerde clips samenvoegen",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Geselecteerde clips verwijderen",
+    "videoEditorMergeProgressLabel": "Een moment, we voegen je clips samen",
+    "videoEditorMergeFailed": "Kan clips niet samenvoegen. Probeer het opnieuw."
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Zastosuj przekształcenie",
     "videoEditorTransformCancelSemanticLabel": "Anuluj przekształcenie",
     "videoEditorTransformPlayLabel": "Odtwórz",
-    "videoEditorTransformPauseLabel": "Pauza"
+    "videoEditorTransformPauseLabel": "Pauza",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Klip {index} z {total}, zaznaczony",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Klip {index} z {total}, niezaznaczony",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Zaznacz",
+    "videoEditorMultiSelectSemanticLabel": "Zaznacz wiele klipów",
+    "videoEditorMultiSelectDoneSemanticLabel": "Zakończ zaznaczanie",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Nie zaznaczono klipów} =1{Zaznaczono 1 klip} other{Zaznaczono {count} klipów}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Scal",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Scal zaznaczone klipy",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Usuń zaznaczone klipy",
+    "videoEditorMergeProgressLabel": "Chwila, scalamy Twoje klipy",
+    "videoEditorMergeFailed": "Nie udało się scalić klipów. Spróbuj ponownie."
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Aplicar transformação",
     "videoEditorTransformCancelSemanticLabel": "Cancelar transformação",
     "videoEditorTransformPlayLabel": "Reproduzir",
-    "videoEditorTransformPauseLabel": "Pausar"
+    "videoEditorTransformPauseLabel": "Pausar",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Clipe {index} de {total}, selecionado",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Clipe {index} de {total}, não selecionado",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Selecionar",
+    "videoEditorMultiSelectSemanticLabel": "Selecionar vários clipes",
+    "videoEditorMultiSelectDoneSemanticLabel": "Concluir seleção",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Nenhum clipe selecionado} =1{1 clipe selecionado} other{{count} clipes selecionados}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Mesclar",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Mesclar clipes selecionados",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Excluir clipes selecionados",
+    "videoEditorMergeProgressLabel": "Um momento, estamos mesclando seus clipes",
+    "videoEditorMergeFailed": "Não foi possível mesclar os clipes. Tente novamente."
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Aplică transformarea",
     "videoEditorTransformCancelSemanticLabel": "Anulează transformarea",
     "videoEditorTransformPlayLabel": "Redă",
-    "videoEditorTransformPauseLabel": "Pauză"
+    "videoEditorTransformPauseLabel": "Pauză",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Clip {index} din {total}, selectat",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Clip {index} din {total}, neselectat",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Selectează",
+    "videoEditorMultiSelectSemanticLabel": "Selectează mai multe clipuri",
+    "videoEditorMultiSelectDoneSemanticLabel": "Finalizează selecția",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Niciun clip selectat} =1{1 clip selectat} other{{count} clipuri selectate}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Îmbină",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Îmbină clipurile selectate",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Șterge clipurile selectate",
+    "videoEditorMergeProgressLabel": "Un moment, îți îmbinăm clipurile",
+    "videoEditorMergeFailed": "Clipurile nu au putut fi îmbinate. Încearcă din nou."
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Tillämpa transformering",
     "videoEditorTransformCancelSemanticLabel": "Avbryt transformering",
     "videoEditorTransformPlayLabel": "Spela",
-    "videoEditorTransformPauseLabel": "Pausa"
+    "videoEditorTransformPauseLabel": "Pausa",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Klipp {index} av {total}, markerat",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Klipp {index} av {total}, inte markerat",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Markera",
+    "videoEditorMultiSelectSemanticLabel": "Markera flera klipp",
+    "videoEditorMultiSelectDoneSemanticLabel": "Slutför markering",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Inga klipp markerade} =1{1 klipp markerat} other{{count} klipp markerade}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Slå samman",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Slå samman markerade klipp",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Ta bort markerade klipp",
+    "videoEditorMergeProgressLabel": "Ett ögonblick, vi slår samman dina klipp",
+    "videoEditorMergeFailed": "Det gick inte att slå samman klippen. Försök igen."
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3954,5 +3954,33 @@
     "videoEditorTransformApplySemanticLabel": "Dönüşümü uygula",
     "videoEditorTransformCancelSemanticLabel": "Dönüşümü iptal et",
     "videoEditorTransformPlayLabel": "Oynat",
-    "videoEditorTransformPauseLabel": "Duraklat"
+    "videoEditorTransformPauseLabel": "Duraklat",
+    "videoEditorTimelineClipSelectedSemanticLabel": "Klip {index}/{total}, seçili",
+    "@videoEditorTimelineClipSelectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorTimelineClipUnselectedSemanticLabel": "Klip {index}/{total}, seçili değil",
+    "@videoEditorTimelineClipUnselectedSemanticLabel": {
+        "placeholders": {
+            "index": {"type": "int"},
+            "total": {"type": "int"}
+        }
+    },
+    "videoEditorMultiSelectLabel": "Seç",
+    "videoEditorMultiSelectSemanticLabel": "Birden çok klip seç",
+    "videoEditorMultiSelectDoneSemanticLabel": "Seçimi tamamla",
+    "videoEditorMultiSelectCountLabel": "{count, plural, =0{Hiç klip seçilmedi} =1{1 klip seçildi} other{{count} klip seçildi}}",
+    "@videoEditorMultiSelectCountLabel": {
+        "placeholders": {
+            "count": {"type": "int"}
+        }
+    },
+    "videoEditorMergeLabel": "Birleştir",
+    "videoEditorMergeSelectedClipsSemanticLabel": "Seçili klipleri birleştir",
+    "videoEditorDeleteSelectedClipsSemanticLabel": "Seçili klipleri sil",
+    "videoEditorMergeProgressLabel": "Bir saniye, kliplerini birleştiriyoruz",
+    "videoEditorMergeFailed": "Klipler birleştirilemedi. Lütfen tekrar dene."
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -14262,6 +14262,72 @@ abstract class AppLocalizations {
   /// **'Move right'**
   String get videoEditorTimelineClipMoveRight;
 
+  /// Accessibility label for a timeline clip that is selected in multi-select mode.
+  ///
+  /// In en, this message translates to:
+  /// **'Clip {index} of {total}, selected'**
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total);
+
+  /// Accessibility label for a timeline clip that is not selected in multi-select mode.
+  ///
+  /// In en, this message translates to:
+  /// **'Clip {index} of {total}, not selected'**
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total);
+
+  /// Label for the button that starts multi-select mode on the timeline.
+  ///
+  /// In en, this message translates to:
+  /// **'Select'**
+  String get videoEditorMultiSelectLabel;
+
+  /// Accessibility label for the button that starts multi-select mode on the timeline.
+  ///
+  /// In en, this message translates to:
+  /// **'Select multiple clips'**
+  String get videoEditorMultiSelectSemanticLabel;
+
+  /// Accessibility label for the button that exits multi-select mode.
+  ///
+  /// In en, this message translates to:
+  /// **'Done selecting clips'**
+  String get videoEditorMultiSelectDoneSemanticLabel;
+
+  /// Header shown in the multi-select action bar reporting how many clips are selected.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{No clips selected} =1{1 clip selected} other{{count} clips selected}}'**
+  String videoEditorMultiSelectCountLabel(int count);
+
+  /// Label for the button that merges the selected clips into one.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge'**
+  String get videoEditorMergeLabel;
+
+  /// Accessibility label for the button that merges the selected clips into one.
+  ///
+  /// In en, this message translates to:
+  /// **'Merge selected clips'**
+  String get videoEditorMergeSelectedClipsSemanticLabel;
+
+  /// Accessibility label for the button that deletes the selected clips.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete selected clips'**
+  String get videoEditorDeleteSelectedClipsSemanticLabel;
+
+  /// Status text shown while the selected clips are being concatenated into a single clip.
+  ///
+  /// In en, this message translates to:
+  /// **'One moment, we\'re merging your clips'**
+  String get videoEditorMergeProgressLabel;
+
+  /// Snackbar message shown when merging the selected clips fails during rendering.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not merge clips. Please try again.'**
+  String get videoEditorMergeFailed;
+
   /// No description provided for @videoEditorTimelineLongPressToDragHint.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -8042,6 +8042,52 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'ወደ ቀኝ አንቀሳቅስ';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'ቅንጥብ $index ከ $total፣ ተመርጧል';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'ቅንጥብ $index ከ $total፣ አልተመረጠም';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'ምረጥ';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'ብዙ ቅንጥቦችን ምረጥ';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'ምርጫን ጨርስ';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count ቅንጥቦች ተመርጠዋል',
+      one: '1 ቅንጥብ ተመርጧል',
+      zero: 'ምንም ቅንጥብ አልተመረጠም',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'አዋህድ';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel => 'የተመረጡ ቅንጥቦችን አዋህድ';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel => 'የተመረጡ ቅንጥቦችን ሰርዝ';
+
+  @override
+  String get videoEditorMergeProgressLabel => 'ትንሽ ይቆዩ፣ ቅንጥቦችዎን እያዋሃድን ነው';
+
+  @override
+  String get videoEditorMergeFailed => 'ቅንጥቦችን ማዋሃድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint => 'ለመጎተት በረጅሙ ተጫን';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8125,6 +8125,55 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'تحريك لليمين';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'المقطع $index من $total، محدد';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'المقطع $index من $total، غير محدد';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'تحديد';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'تحديد عدة مقاطع';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'إنهاء التحديد';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'تم تحديد $count مقاطع',
+      one: 'تم تحديد مقطع واحد',
+      zero: 'لم يتم تحديد مقاطع',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'دمج';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'دمج المقاطع المحددة';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'حذف المقاطع المحددة';
+
+  @override
+  String get videoEditorMergeProgressLabel => 'لحظة من فضلك، نقوم بدمج مقاطعك';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'تعذّر دمج المقاطع. يُرجى المحاولة مرة أخرى.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint => 'اضغط مطولاً للسحب';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -8273,6 +8273,56 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Преместете се надясно';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Клип $index от $total, избран';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Клип $index от $total, неизбран';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Избор';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Избор на няколко клипа';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Завърши избора';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count избрани клипа',
+      one: '1 избран клип',
+      zero: 'Няма избрани клипове',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Обедини';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Обединяване на избраните клипове';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Изтриване на избраните клипове';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Един момент, обединяваме клиповете ти';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Клиповете не могат да бъдат обединени. Опитай отново.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Натисни дълго, за да плъзнеш';
 

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -8282,6 +8282,56 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Nach rechts verschieben';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clip $index von $total, ausgewählt';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clip $index von $total, nicht ausgewählt';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Auswählen';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Mehrere Clips auswählen';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Auswahl abschließen';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count Clips ausgewählt',
+      one: '1 Clip ausgewählt',
+      zero: 'Keine Clips ausgewählt',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Zusammenführen';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Ausgewählte Clips zusammenführen';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Ausgewählte Clips löschen';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Einen Moment, wir führen deine Clips zusammen';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Clips konnten nicht zusammengeführt werden. Bitte versuche es erneut.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Lange drücken zum Ziehen';
 

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -8186,6 +8186,56 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Move right';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clip $index of $total, selected';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clip $index of $total, not selected';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Select';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Select multiple clips';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Done selecting clips';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count clips selected',
+      one: '1 clip selected',
+      zero: 'No clips selected',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Merge';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Merge selected clips';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Delete selected clips';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'One moment, we\'re merging your clips';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Could not merge clips. Please try again.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint => 'Long press to drag';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -8268,6 +8268,56 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Mover a la derecha';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clip $index de $total, seleccionado';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clip $index de $total, no seleccionado';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Seleccionar';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Seleccionar varios clips';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Finalizar selección';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count clips seleccionados',
+      one: '1 clip seleccionado',
+      zero: 'Ningún clip seleccionado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Combinar';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Combinar clips seleccionados';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Eliminar clips seleccionados';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Un momento, estamos combinando tus clips';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'No se pudieron combinar los clips. Inténtalo de nuevo.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Mantén presionado para arrastrar';
 

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -8282,6 +8282,56 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Ilipat sa kanan';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clip $index ng $total, napili';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clip $index ng $total, hindi napili';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Pumili';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Pumili ng maraming clip';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Tapusin ang pagpili';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count clip ang napili',
+      one: '1 clip ang napili',
+      zero: 'Walang napiling clip',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Pagsamahin';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Pagsamahin ang mga napiling clip';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Tanggalin ang mga napiling clip';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Sandali lang, pinagsasama namin ang iyong mga clip';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Hindi mapagsama ang mga clip. Pakisubukang muli.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Pindutin nang matagal para i-drag';
 

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -8298,6 +8298,57 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Déplacer vers la droite';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clip $index sur $total, sélectionné';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clip $index sur $total, non sélectionné';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Sélectionner';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel =>
+      'Sélectionner plusieurs clips';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Terminer la sélection';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count clips sélectionnés',
+      one: '1 clip sélectionné',
+      zero: 'Aucun clip sélectionné',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Fusionner';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Fusionner les clips sélectionnés';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Supprimer les clips sélectionnés';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Un instant, nous fusionnons vos clips';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Impossible de fusionner les clips. Veuillez réessayer.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Appui long pour glisser';
 

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -8170,6 +8170,56 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Geser ke kanan';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Klip $index dari $total, dipilih';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Klip $index dari $total, tidak dipilih';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Pilih';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Pilih beberapa klip';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Selesai memilih';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count klip dipilih',
+      one: '1 klip dipilih',
+      zero: 'Tidak ada klip dipilih',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Gabungkan';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Gabungkan klip yang dipilih';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Hapus klip yang dipilih';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Sebentar, kami sedang menggabungkan klipmu';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Tidak dapat menggabungkan klip. Silakan coba lagi.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Tekan lama untuk menyeret';
 

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -8266,6 +8266,55 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Sposta a destra';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clip $index di $total, selezionata';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clip $index di $total, non selezionata';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Seleziona';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Seleziona più clip';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Termina selezione';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count clip selezionate',
+      one: '1 clip selezionata',
+      zero: 'Nessuna clip selezionata',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Unisci';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Unisci le clip selezionate';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Elimina le clip selezionate';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Un momento, stiamo unendo le tue clip';
+
+  @override
+  String get videoEditorMergeFailed => 'Impossibile unire le clip. Riprova.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Tieni premuto per trascinare';
 

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7897,6 +7897,52 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => '右に移動';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'クリップ $index/$total、選択中';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'クリップ $index/$total、未選択';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => '選択';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => '複数のクリップを選択';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => '選択を完了';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count 件のクリップを選択中',
+      one: '1 件のクリップを選択中',
+      zero: 'クリップが選択されていません',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => '結合';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel => '選択したクリップを結合';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel => '選択したクリップを削除';
+
+  @override
+  String get videoEditorMergeProgressLabel => '少々お待ちください。クリップを結合しています';
+
+  @override
+  String get videoEditorMergeFailed => 'クリップを結合できませんでした。もう一度お試しください。';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint => '長押しでドラッグ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7922,6 +7922,52 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => '오른쪽으로 이동';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return '클립 $index/$total, 선택됨';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return '클립 $index/$total, 선택 안 됨';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => '선택';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => '여러 클립 선택';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => '선택 완료';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '클립 $count개 선택됨',
+      one: '클립 1개 선택됨',
+      zero: '선택된 클립 없음',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => '병합';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel => '선택한 클립 병합';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel => '선택한 클립 삭제';
+
+  @override
+  String get videoEditorMergeProgressLabel => '잠시만요, 클립을 병합하고 있어요';
+
+  @override
+  String get videoEditorMergeFailed => '클립을 병합할 수 없습니다. 다시 시도해 주세요.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint => '길게 눌러 드래그';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -8232,6 +8232,56 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Naar rechts verplaatsen';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clip $index van $total, geselecteerd';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clip $index van $total, niet geselecteerd';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Selecteren';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Meerdere clips selecteren';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Selectie voltooien';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count clips geselecteerd',
+      one: '1 clip geselecteerd',
+      zero: 'Geen clips geselecteerd',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Samenvoegen';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Geselecteerde clips samenvoegen';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Geselecteerde clips verwijderen';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Een moment, we voegen je clips samen';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Kan clips niet samenvoegen. Probeer het opnieuw.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Lang indrukken om te slepen';
 

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -8349,6 +8349,55 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Przesuń w prawo';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Klip $index z $total, zaznaczony';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Klip $index z $total, niezaznaczony';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Zaznacz';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Zaznacz wiele klipów';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Zakończ zaznaczanie';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'Zaznaczono $count klipów',
+      one: 'Zaznaczono 1 klip',
+      zero: 'Nie zaznaczono klipów',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Scal';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Scal zaznaczone klipy';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Usuń zaznaczone klipy';
+
+  @override
+  String get videoEditorMergeProgressLabel => 'Chwila, scalamy Twoje klipy';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Nie udało się scalić klipów. Spróbuj ponownie.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Przytrzymaj, aby przeciągnąć';
 

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -8239,6 +8239,56 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Mover para a direita';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clipe $index de $total, selecionado';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clipe $index de $total, não selecionado';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Selecionar';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Selecionar vários clipes';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Concluir seleção';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count clipes selecionados',
+      one: '1 clipe selecionado',
+      zero: 'Nenhum clipe selecionado',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Mesclar';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Mesclar clipes selecionados';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Excluir clipes selecionados';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Um momento, estamos mesclando seus clipes';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Não foi possível mesclar os clipes. Tente novamente.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Pressione e segure para arrastar';
 

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -8366,6 +8366,57 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Mută la dreapta';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Clip $index din $total, selectat';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Clip $index din $total, neselectat';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Selectează';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel =>
+      'Selectează mai multe clipuri';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Finalizează selecția';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count clipuri selectate',
+      one: '1 clip selectat',
+      zero: 'Niciun clip selectat',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Îmbină';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Îmbină clipurile selectate';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Șterge clipurile selectate';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Un moment, îți îmbinăm clipurile';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Clipurile nu au putut fi îmbinate. Încearcă din nou.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Apasă lung pentru a trage';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -8200,6 +8200,56 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Flytta höger';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Klipp $index av $total, markerat';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Klipp $index av $total, inte markerat';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Markera';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Markera flera klipp';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Slutför markering';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count klipp markerade',
+      one: '1 klipp markerat',
+      zero: 'Inga klipp markerade',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Slå samman';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Slå samman markerade klipp';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Ta bort markerade klipp';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Ett ögonblick, vi slår samman dina klipp';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Det gick inte att slå samman klippen. Försök igen.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint => 'Håll ned för att dra';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -8166,6 +8166,56 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoEditorTimelineClipMoveRight => 'Sağa taşı';
 
   @override
+  String videoEditorTimelineClipSelectedSemanticLabel(int index, int total) {
+    return 'Klip $index/$total, seçili';
+  }
+
+  @override
+  String videoEditorTimelineClipUnselectedSemanticLabel(int index, int total) {
+    return 'Klip $index/$total, seçili değil';
+  }
+
+  @override
+  String get videoEditorMultiSelectLabel => 'Seç';
+
+  @override
+  String get videoEditorMultiSelectSemanticLabel => 'Birden çok klip seç';
+
+  @override
+  String get videoEditorMultiSelectDoneSemanticLabel => 'Seçimi tamamla';
+
+  @override
+  String videoEditorMultiSelectCountLabel(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count klip seçildi',
+      one: '1 klip seçildi',
+      zero: 'Hiç klip seçilmedi',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get videoEditorMergeLabel => 'Birleştir';
+
+  @override
+  String get videoEditorMergeSelectedClipsSemanticLabel =>
+      'Seçili klipleri birleştir';
+
+  @override
+  String get videoEditorDeleteSelectedClipsSemanticLabel =>
+      'Seçili klipleri sil';
+
+  @override
+  String get videoEditorMergeProgressLabel =>
+      'Bir saniye, kliplerini birleştiriyoruz';
+
+  @override
+  String get videoEditorMergeFailed =>
+      'Klipler birleştirilemedi. Lütfen tekrar dene.';
+
+  @override
   String get videoEditorTimelineLongPressToDragHint =>
       'Sürüklemek için uzun basın';
 

--- a/mobile/lib/services/video_editor/video_editor_merge_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_merge_service.dart
@@ -1,0 +1,60 @@
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' show EditorVideo;
+import 'package:unified_logger/unified_logger.dart';
+
+/// Service for flattening several timeline clips into a single new clip.
+class VideoEditorMergeService {
+  /// Concatenates [clips] (already in timeline order) into one rendered file
+  /// and returns it as a fresh [DivineVideoClip].
+  ///
+  /// Each clip's trim/speed/volume/reverse is baked into the output by the
+  /// underlying [VideoEditorRenderService.renderVideo] pipeline, so the merged
+  /// clip carries no residual trim or speed. The merged duration is the full
+  /// sum of the inputs' [DivineVideoClip.playbackDuration] — the render is
+  /// uncapped (`maxOutputDuration: null`) because the merged clip is an
+  /// intermediate editor clip the user can still trim, not the final export
+  /// (which applies the duration cap on its own).
+  ///
+  /// Returns `null` when fewer than two clips are supplied, or when the render
+  /// is cancelled / fails (both already surface as a `null` output path from
+  /// [VideoEditorRenderService.renderVideo]).
+  static Future<DivineVideoClip?> mergeClips({
+    required List<DivineVideoClip> clips,
+    required String renderId,
+  }) async {
+    if (clips.length < 2) return null;
+
+    Log.info(
+      '🧬 Merging ${clips.length} clip(s) into one',
+      name: 'VideoEditorMergeService',
+      category: LogCategory.video,
+    );
+
+    final outputPath = await VideoEditorRenderService.renderVideo(
+      clips: clips,
+      usePersistentStorage: true,
+      taskId: renderId,
+      maxOutputDuration: null,
+    );
+
+    if (outputPath == null) return null;
+
+    final mergedDuration = clips.fold(
+      Duration.zero,
+      (sum, clip) => sum + clip.playbackDuration,
+    );
+
+    final first = clips.first;
+    return DivineVideoClip(
+      id: 'merged_${DateTime.now().microsecondsSinceEpoch}',
+      video: EditorVideo.file(outputPath),
+      duration: mergedDuration,
+      recordedAt: first.recordedAt,
+      targetAspectRatio: first.targetAspectRatio,
+      originalAspectRatio: first.originalAspectRatio,
+      thumbnailPath: first.thumbnailPath,
+      lensMetadata: first.lensMetadata,
+    );
+  }
+}

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -483,12 +483,18 @@ class VideoEditorRenderService {
   /// If [usePersistentStorage] is true, the output file will be saved to the
   /// documents directory instead of the temporary directory. Use this when
   /// the rendered video should persist across app restarts.
+  ///
+  /// [maxOutputDuration] caps the rendered output length. It defaults to
+  /// [VideoEditorConstants.maxDuration] for the final-export path; pass `null`
+  /// to render the full concatenation uncapped (e.g. when merging clips into an
+  /// intermediate editor clip that the user can still trim).
   static Future<String?> renderVideo({
     required List<DivineVideoClip> clips,
     bool usePersistentStorage = false,
     model.AspectRatio? aspectRatio,
     CompleteParameters? parameters,
     String? taskId,
+    Duration? maxOutputDuration = VideoEditorConstants.maxDuration,
   }) async {
     final override = renderVideoOverride;
     if (override != null) {
@@ -535,6 +541,7 @@ class VideoEditorRenderService {
         globalTransform: result.globalTransform,
         aspectRatio: aspectRatio ?? clips.first.targetAspectRatio,
         parameters: parameters,
+        maxOutputDuration: maxOutputDuration,
       );
 
       // Fire-and-forget: temp cleanup is non-critical and handles
@@ -866,6 +873,7 @@ class VideoEditorRenderService {
     required Directory outputDir,
     required CompleteParameters? parameters,
     required model.AspectRatio aspectRatio,
+    required Duration? maxOutputDuration,
     _CropParameters? globalTransform,
   }) async {
     final outputPath = path.join(
@@ -907,7 +915,7 @@ class VideoEditorRenderService {
     final task = VideoRenderData(
       id: taskId,
       videoSegments: volumeSegments,
-      endTime: VideoEditorConstants.maxDuration,
+      endTime: maxOutputDuration,
       shouldOptimizeForNetworkUse: true,
       audioTracks: audioTracks,
       imageLayers: parameters?.capturedLayers.isNotEmpty == true

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart
@@ -48,6 +48,7 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       onTransform: () => _transformClip(context),
       onExtractAudio: () => _requestExtractAudio(context),
       onReversed: () => _reverseClip(context),
+      onMultiSelect: isLastClip ? null : () => _startMultiSelect(context),
       isReversed: isReversed,
       isExtractingAudio: isExtractingAudio,
       // Done is gated while extraction is in flight purely as a UX cue —
@@ -149,6 +150,18 @@ class _TimelineClipControlsState extends State<TimelineClipControls> {
       ClipEditorAudioExtractionRequested(
         clipTitle: context.l10n.videoEditorClipAudioTitle,
       ),
+    );
+  }
+
+  void _startMultiSelect(BuildContext context) {
+    final bloc = context.read<ClipEditorBloc>();
+    final state = bloc.state;
+    if (state.currentClipIndex < 0 ||
+        state.currentClipIndex >= state.clips.length) {
+      return;
+    }
+    bloc.add(
+      ClipEditorMultiSelectStarted(state.clips[state.currentClipIndex].id),
     );
   }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_control_bar.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_overlay_controls.dart';
 
 /// Shows context-specific controls at the bottom of the timeline based on
@@ -21,6 +23,9 @@ class TimelineControlsBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isMultiSelectMode = context.select(
+      (ClipEditorBloc b) => b.state.isMultiSelectMode,
+    );
     final selectedOverlayItem = context.select((TimelineOverlayBloc b) {
       final state = b.state;
       final selectedId = state.selectedItemId;
@@ -28,17 +33,25 @@ class TimelineControlsBar extends StatelessWidget {
       return state.items.where((i) => i.id == selectedId).firstOrNull;
     });
 
-    final showControls = isEditing || selectedOverlayItem != null;
-    final controlsChild = switch ((showControls, isEditing)) {
-      (true, true) => TimelineClipControls(
+    final showControls =
+        isMultiSelectMode || isEditing || selectedOverlayItem != null;
+    final controlsChild = switch ((
+      isMultiSelectMode,
+      showControls,
+      isEditing,
+    )) {
+      (true, _, _) => const TimelineMultiSelectControls(
+        key: ValueKey('timeline_controls_multi_select'),
+      ),
+      (false, true, true) => TimelineClipControls(
         key: const ValueKey('timeline_controls_clip'),
         playheadPosition: playheadPosition,
       ),
-      (true, false) => TimelineOverlayControls(
+      (false, true, false) => TimelineOverlayControls(
         key: const ValueKey('timeline_controls_overlay'),
         item: selectedOverlayItem!,
       ),
-      (false, _) => const SizedBox(
+      (false, false, _) => const SizedBox(
         key: ValueKey('timeline_controls_hidden'),
         width: double.infinity,
       ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_controls.dart
@@ -16,6 +16,7 @@ class VideoEditorTimelineControls extends StatelessWidget {
     this.isReversed = false,
     this.onExtractAudio,
     this.isExtractingAudio = false,
+    this.onMultiSelect,
     super.key,
   });
 
@@ -29,6 +30,7 @@ class VideoEditorTimelineControls extends StatelessWidget {
   final bool isReversed;
   final VoidCallback? onExtractAudio;
   final bool isExtractingAudio;
+  final VoidCallback? onMultiSelect;
   final VoidCallback? onDone;
 
   @override
@@ -128,6 +130,14 @@ class VideoEditorTimelineControls extends StatelessWidget {
                           .videoEditorExtractAudioFromClipSemanticLabel,
                       onPressed: isExtractingAudio ? null : onExtractAudio,
                       isLoading: isExtractingAudio,
+                    ),
+                  if (onMultiSelect != null)
+                    _ControlButton(
+                      icon: .checks,
+                      label: context.l10n.videoEditorMultiSelectLabel,
+                      semanticLabel:
+                          context.l10n.videoEditorMultiSelectSemanticLabel,
+                      onPressed: onMultiSelect,
                     ),
                   _ControlButton(
                     icon: .check,

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
@@ -2,11 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
-import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
-import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
-import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 
 /// Action bar shown while the timeline is in multi-select mode.
 ///
@@ -108,30 +104,11 @@ class TimelineMultiSelectControls extends StatelessWidget {
   }
 
   void _delete(BuildContext context) {
-    final bloc = context.read<ClipEditorBloc>();
-    final overlayBloc = context.read<TimelineOverlayBloc>();
-    final editor = VideoEditorScope.of(context).requireEditor;
-    final state = bloc.state;
-    final selected = state.selectedClipIds;
-
-    final newClips = state.clips
-        .where((clip) => !selected.contains(clip.id))
-        .toList();
-    // The bloc applies the same guard, but mirror it here so we never commit an
-    // empty timeline to editor history.
-    if (newClips.isEmpty) return;
-
-    // Markers on removed clips are dropped; markers on later clips shift
-    // earlier — rebase by source position so both rules are honoured.
-    final rebasedMarkers = rebaseTimelineMarkersForClipState(
-      oldClips: state.clips,
-      newClips: newClips,
-      markers: overlayBloc.state.timelineMarkers,
+    // The bloc owns the clip-list mutation; the scaffold's removed-result
+    // listener rebases markers and commits the new list to editor history.
+    context.read<ClipEditorBloc>().add(
+      const ClipEditorSelectedClipsRemoved(),
     );
-
-    bloc.add(const ClipEditorSelectedClipsRemoved());
-    overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
-    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
   }
 }
 

--- a/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart
@@ -1,0 +1,169 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
+import 'package:openvine/extensions/video_editor_extensions.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
+
+/// Action bar shown while the timeline is in multi-select mode.
+///
+/// Surfaces the selection count plus Merge / Delete / Done actions. Merge and
+/// Delete are gated on the selection so the user can never merge a single clip
+/// or delete every clip.
+class TimelineMultiSelectControls extends StatelessWidget {
+  const TimelineMultiSelectControls({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final (selectedCount, clipCount, isMerging) = context.select(
+      (ClipEditorBloc b) => (
+        b.state.selectedClipIds.length,
+        b.state.clips.length,
+        b.state.isMerging,
+      ),
+    );
+
+    final canMerge = selectedCount >= 2 && !isMerging;
+    final canDelete =
+        selectedCount >= 1 && selectedCount < clipCount && !isMerging;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.backgroundCamera,
+        boxShadow: [
+          BoxShadow(
+            color: VineTheme.backgroundColor.withValues(alpha: 0.4),
+            blurRadius: 8,
+            offset: const Offset(0, -4),
+          ),
+        ],
+      ),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.fromLTRB(0, 16, 0, 8),
+        child: SafeArea(
+          top: false,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 8,
+            children: [
+              Text(
+                context.l10n.videoEditorMultiSelectCountLabel(selectedCount),
+                style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+              ),
+              Center(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    spacing: 16,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      _ControlButton(
+                        icon: .stackSimple,
+                        label: context.l10n.videoEditorMergeLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorMergeSelectedClipsSemanticLabel,
+                        onPressed: canMerge ? () => _merge(context) : null,
+                        type: .primary,
+                      ),
+                      _ControlButton(
+                        icon: .trash,
+                        label: context.l10n.videoEditorDeleteLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorDeleteSelectedClipsSemanticLabel,
+                        onPressed: canDelete ? () => _delete(context) : null,
+                        type: .error,
+                      ),
+                      _ControlButton(
+                        icon: .check,
+                        label: context.l10n.videoEditorDoneLabel,
+                        semanticLabel: context
+                            .l10n
+                            .videoEditorMultiSelectDoneSemanticLabel,
+                        onPressed: () => context.read<ClipEditorBloc>().add(
+                          const ClipEditorMultiSelectCancelled(),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _merge(BuildContext context) {
+    context.read<ClipEditorBloc>().add(
+      const ClipEditorSelectedClipsMergeRequested(),
+    );
+  }
+
+  void _delete(BuildContext context) {
+    final bloc = context.read<ClipEditorBloc>();
+    final overlayBloc = context.read<TimelineOverlayBloc>();
+    final editor = VideoEditorScope.of(context).requireEditor;
+    final state = bloc.state;
+    final selected = state.selectedClipIds;
+
+    final newClips = state.clips
+        .where((clip) => !selected.contains(clip.id))
+        .toList();
+    // The bloc applies the same guard, but mirror it here so we never commit an
+    // empty timeline to editor history.
+    if (newClips.isEmpty) return;
+
+    // Markers on removed clips are dropped; markers on later clips shift
+    // earlier — rebase by source position so both rules are honoured.
+    final rebasedMarkers = rebaseTimelineMarkersForClipState(
+      oldClips: state.clips,
+      newClips: newClips,
+      markers: overlayBloc.state.timelineMarkers,
+    );
+
+    bloc.add(const ClipEditorSelectedClipsRemoved());
+    overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
+    editor.setClipState(newClips, timelineMarkers: rebasedMarkers);
+  }
+}
+
+class _ControlButton extends StatelessWidget {
+  const _ControlButton({
+    required this.icon,
+    required this.label,
+    required this.semanticLabel,
+    required this.onPressed,
+    this.type = .secondary,
+  });
+
+  final DivineIconName icon;
+  final String label;
+  final String semanticLabel;
+  final VoidCallback? onPressed;
+  final DivineIconButtonType type;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      spacing: 8,
+      children: [
+        DivineIconButton(
+          icon: icon,
+          semanticLabel: semanticLabel,
+          onPressed: onPressed,
+          type: type,
+          size: .small,
+        ),
+        Text(label, style: VineTheme.bodySmallFont()),
+      ],
+    );
+  }
+}

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -43,6 +43,8 @@ class VideoEditorTimelineClipStrip extends StatefulWidget {
     this.trimmingClipId,
     this.onTrimChanged,
     this.onTrimDragChanged,
+    this.isMultiSelectMode = false,
+    this.selectedClipIds = const {},
     super.key,
   });
 
@@ -52,6 +54,13 @@ class VideoEditorTimelineClipStrip extends StatefulWidget {
   final ScrollController? scrollController;
   final ValueChanged<List<DivineVideoClip>>? onReorder;
   final ValueChanged<bool>? onReorderChanged;
+
+  /// Whether the timeline is in multi-select mode. Disables reorder and shows
+  /// per-clip selection affordances.
+  final bool isMultiSelectMode;
+
+  /// IDs of the clips currently selected in multi-select mode.
+  final Set<String> selectedClipIds;
 
   /// When `true` the user is scrolling or pinch-zooming — long press
   /// must not start a reorder drag.
@@ -548,7 +557,9 @@ class _VideoEditorTimelineClipStripState
         label: context.l10n.videoEditorTimelineLongPressToDragHint,
         button: true,
         child: GestureDetector(
-          onLongPressStart: isVolumeEditMode ? null : _onLongPressStart,
+          onLongPressStart: isVolumeEditMode || widget.isMultiSelectMode
+              ? null
+              : _onLongPressStart,
           onLongPressMoveUpdate: _isReordering ? _onLongPressMoveUpdate : null,
           onLongPressEnd: _isReordering ? _onLongPressEnd : null,
           onLongPressCancel: _isReordering ? _onLongPressCancel : null,
@@ -584,6 +595,8 @@ class _VideoEditorTimelineClipStripState
                   rowOffsetSize: _reorderSize,
                   isVolumeEditMode: isVolumeEditMode,
                   volumeRowStep: volumeRowStep,
+                  isMultiSelectMode: widget.isMultiSelectMode,
+                  selectedClipIds: widget.selectedClipIds,
                 ),
 
                 /// Trimming clip — rendered last so handles stay on top.
@@ -735,6 +748,8 @@ class _NonTrimmingClipPositions extends StatelessWidget {
     required this.rowOffsetSize,
     required this.isVolumeEditMode,
     required this.volumeRowStep,
+    required this.isMultiSelectMode,
+    required this.selectedClipIds,
   });
 
   final List<DivineVideoClip> orderedClips;
@@ -754,6 +769,8 @@ class _NonTrimmingClipPositions extends StatelessWidget {
   final double rowOffsetSize;
   final bool isVolumeEditMode;
   final double volumeRowStep;
+  final bool isMultiSelectMode;
+  final Set<String> selectedClipIds;
 
   @override
   Widget build(BuildContext context) {
@@ -781,6 +798,8 @@ class _NonTrimmingClipPositions extends StatelessWidget {
                 thumbnailNotifier: thumbnails[orderedClips[i].id],
                 onReorder: onReorder,
                 onTap: onClipTapped,
+                isMultiSelectMode: isMultiSelectMode,
+                isSelected: selectedClipIds.contains(orderedClips[i].id),
               ),
             ),
       ],

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -212,6 +212,8 @@ class _AccessibleClipTile extends StatelessWidget {
     required this.thumbnailNotifier,
     required this.onReorder,
     this.onTap,
+    this.isMultiSelectMode = false,
+    this.isSelected = false,
   });
 
   final DivineVideoClip clip;
@@ -222,6 +224,8 @@ class _AccessibleClipTile extends StatelessWidget {
   final ValueNotifier<List<StripThumbnail>> thumbnailNotifier;
   final void Function(int from, int to) onReorder;
   final ValueChanged<int>? onTap;
+  final bool isMultiSelectMode;
+  final bool isSelected;
 
   @override
   Widget build(BuildContext context) {
@@ -230,26 +234,39 @@ class _AccessibleClipTile extends StatelessWidget {
       onTap: onTap != null ? () => onTap!(index) : null,
       behavior: HitTestBehavior.opaque,
       child: Semantics(
-        label: context.l10n.videoEditorTimelineClipSemanticLabel(
-          index + 1,
-          total,
-          durationSec.toStringAsFixed(1),
-        ),
-        hint: total > 1
+        label: isMultiSelectMode
+            ? (isSelected
+                  ? context.l10n.videoEditorTimelineClipSelectedSemanticLabel(
+                      index + 1,
+                      total,
+                    )
+                  : context.l10n.videoEditorTimelineClipUnselectedSemanticLabel(
+                      index + 1,
+                      total,
+                    ))
+            : context.l10n.videoEditorTimelineClipSemanticLabel(
+                index + 1,
+                total,
+                durationSec.toStringAsFixed(1),
+              ),
+        selected: isMultiSelectMode ? isSelected : null,
+        hint: !isMultiSelectMode && total > 1
             ? context.l10n.videoEditorTimelineClipReorderHint
             : null,
-        customSemanticsActions: {
-          if (index > 0)
-            CustomSemanticsAction(
-              label: context.l10n.videoEditorTimelineClipMoveLeft,
-            ): () =>
-                onReorder(index, index - 1),
-          if (index < total - 1)
-            CustomSemanticsAction(
-              label: context.l10n.videoEditorTimelineClipMoveRight,
-            ): () =>
-                onReorder(index, index + 1),
-        },
+        customSemanticsActions: isMultiSelectMode
+            ? null
+            : {
+                if (index > 0)
+                  CustomSemanticsAction(
+                    label: context.l10n.videoEditorTimelineClipMoveLeft,
+                  ): () =>
+                      onReorder(index, index - 1),
+                if (index < total - 1)
+                  CustomSemanticsAction(
+                    label: context.l10n.videoEditorTimelineClipMoveRight,
+                  ): () =>
+                      onReorder(index, index + 1),
+              },
         child: _ClipTile(
           clip: clip,
           fullWidth:
@@ -260,11 +277,19 @@ class _AccessibleClipTile extends StatelessWidget {
               pixelsPerSecond *
               clip._playbackScale,
           thumbnailNotifier: thumbnailNotifier,
+          selectionState: isMultiSelectMode
+              ? (isSelected
+                    ? _ClipSelectionState.selected
+                    : _ClipSelectionState.unselected)
+              : _ClipSelectionState.none,
         ),
       ),
     );
   }
 }
+
+/// Multi-select visual state for a clip tile.
+enum _ClipSelectionState { none, unselected, selected }
 
 class _ClipTile extends StatelessWidget {
   const _ClipTile({
@@ -272,6 +297,7 @@ class _ClipTile extends StatelessWidget {
     required this.fullWidth,
     required this.thumbnailNotifier,
     this.trimStartOffset = 0,
+    this.selectionState = _ClipSelectionState.none,
   });
 
   final DivineVideoClip clip;
@@ -281,9 +307,12 @@ class _ClipTile extends StatelessWidget {
   /// Pixel offset from the left to shift thumbnails for trim-start.
   final double trimStartOffset;
 
+  /// Multi-select visual state — drives the selection border / dim scrim.
+  final _ClipSelectionState selectionState;
+
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
+    final tile = ClipRRect(
       borderRadius: .circular(TimelineConstants.thumbnailRadius),
       child: LayoutBuilder(
         builder: (context, constraints) {
@@ -318,6 +347,75 @@ class _ClipTile extends StatelessWidget {
           );
         },
       ),
+    );
+
+    if (selectionState == _ClipSelectionState.none) return tile;
+
+    return Stack(
+      fit: StackFit.passthrough,
+      children: [
+        tile,
+        Positioned.fill(
+          child: _ClipSelectionOverlay(
+            isSelected: selectionState == _ClipSelectionState.selected,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Foreground overlay drawn on a clip tile while multi-selecting: a primary
+/// border + check badge for selected clips, a translucent dim scrim for
+/// unselected ones.
+class _ClipSelectionOverlay extends StatelessWidget {
+  const _ClipSelectionOverlay({required this.isSelected});
+
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!isSelected) {
+      return DecoratedBox(
+        decoration: BoxDecoration(
+          color: VineTheme.scrim65,
+          borderRadius: BorderRadius.circular(
+            TimelineConstants.thumbnailRadius,
+          ),
+        ),
+      );
+    }
+
+    return Stack(
+      fit: StackFit.passthrough,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            border: Border.all(color: VineTheme.primary, width: 2),
+            borderRadius: BorderRadius.circular(
+              TimelineConstants.thumbnailRadius,
+            ),
+          ),
+        ),
+        const Positioned(
+          top: 4,
+          right: 4,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: VineTheme.primary,
+              shape: BoxShape.circle,
+            ),
+            child: Padding(
+              padding: EdgeInsets.all(2),
+              child: DivineIcon(
+                icon: .check,
+                size: 12,
+                color: VineTheme.onPrimary,
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -98,15 +98,23 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
 
   @override
   Widget build(BuildContext context) {
-    final (:clips, :totalDuration, :isEditing, :currentClipIndex) = context
-        .select(
-          (ClipEditorBloc b) => (
-            clips: b.state.clips,
-            totalDuration: b.state.totalDuration,
-            isEditing: b.state.isEditing,
-            currentClipIndex: b.state.currentClipIndex,
-          ),
-        );
+    final (
+      :clips,
+      :totalDuration,
+      :isEditing,
+      :currentClipIndex,
+      :isMultiSelectMode,
+      :selectedClipIds,
+    ) = context.select(
+      (ClipEditorBloc b) => (
+        clips: b.state.clips,
+        totalDuration: b.state.totalDuration,
+        isEditing: b.state.isEditing,
+        currentClipIndex: b.state.currentClipIndex,
+        isMultiSelectMode: b.state.isMultiSelectMode,
+        selectedClipIds: b.state.selectedClipIds,
+      ),
+    );
     if (clips.isEmpty) return const SizedBox.shrink();
 
     final trimmingClipId =
@@ -267,6 +275,8 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
                       onTrimChanged: _onClipTrimChange,
                       onTrimDragChanged: _onTrimDragChanged,
                       onClipTapped: _onClipTapped,
+                      isMultiSelectMode: isMultiSelectMode,
+                      selectedClipIds: selectedClipIds,
                       onOverlayItemMoved: _onOverlayItemMoved,
                       onOverlayItemMoving: _onOverlayItemMoving,
                       onOverlayItemTrimmed: _onOverlayItemTrimmed,
@@ -417,13 +427,22 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   // -- Clip tap callback ----------------------------------------------------
 
   void _onClipTapped(int index) {
+    final bloc = context.read<ClipEditorBloc>();
+    final state = bloc.state;
+
+    // In multi-select mode a tap toggles the clip's membership instead of
+    // entering single-clip editing.
+    if (state.isMultiSelectMode) {
+      if (index < 0 || index >= state.clips.length) return;
+      bloc.add(ClipEditorMultiSelectClipToggled(state.clips[index].id));
+      return;
+    }
+
     // Deselect any overlay item when a clip is tapped.
     context.read<TimelineOverlayBloc>().add(
       const TimelineOverlayItemSelected(null),
     );
 
-    final bloc = context.read<ClipEditorBloc>();
-    final state = bloc.state;
     if (index == state.currentClipIndex) {
       // Same clip: toggle editing on/off.
       bloc.add(const ClipEditorEditingToggled());
@@ -896,6 +915,8 @@ class _TimelineInteractiveBody extends StatelessWidget {
     required this.onTrimChanged,
     required this.onTrimDragChanged,
     required this.onClipTapped,
+    required this.isMultiSelectMode,
+    required this.selectedClipIds,
     required this.onOverlayItemMoved,
     required this.onOverlayItemMoving,
     required this.onOverlayItemTrimmed,
@@ -930,6 +951,8 @@ class _TimelineInteractiveBody extends StatelessWidget {
   final ClipTrimCallback onTrimChanged;
   final ValueChanged<bool> onTrimDragChanged;
   final ValueChanged<int> onClipTapped;
+  final bool isMultiSelectMode;
+  final Set<String> selectedClipIds;
   final OverlayMoveCallback onOverlayItemMoved;
   final OverlayMovingCallback onOverlayItemMoving;
   final OverlayTrimCallback onOverlayItemTrimmed;
@@ -1047,6 +1070,8 @@ class _TimelineInteractiveBody extends StatelessWidget {
                             onClipTapped: isVolumeEditMode
                                 ? null
                                 : onClipTapped,
+                            isMultiSelectMode: isMultiSelectMode,
+                            selectedClipIds: selectedClipIds,
                             onOverlayItemMoved: onOverlayItemMoved,
                             onOverlayItemMoving: onOverlayItemMoving,
                             onOverlayItemTrimmed: onOverlayItemTrimmed,

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -34,6 +34,8 @@ class VideoEditorTimelineBody extends StatelessWidget {
     this.onTrimChanged,
     this.onTrimDragChanged,
     this.onClipTapped,
+    this.isMultiSelectMode = false,
+    this.selectedClipIds = const {},
     this.onOverlayItemMoved,
     this.onOverlayItemMoving,
     this.onOverlayItemTrimmed,
@@ -59,6 +61,8 @@ class VideoEditorTimelineBody extends StatelessWidget {
   final ClipTrimCallback? onTrimChanged;
   final ValueChanged<bool>? onTrimDragChanged;
   final ValueChanged<int>? onClipTapped;
+  final bool isMultiSelectMode;
+  final Set<String> selectedClipIds;
   final OverlayMoveCallback? onOverlayItemMoved;
   final OverlayMovingCallback? onOverlayItemMoving;
   final OverlayTrimCallback? onOverlayItemTrimmed;
@@ -143,6 +147,8 @@ class VideoEditorTimelineBody extends StatelessWidget {
                   onTrimChanged: onTrimChanged,
                   onTrimDragChanged: onTrimDragChanged,
                   onClipTapped: onClipTapped,
+                  isMultiSelectMode: isMultiSelectMode,
+                  selectedClipIds: selectedClipIds,
                 ),
               ),
 

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -10,6 +10,7 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/video_editor/draw_editor/video_editor_draw_bottom_bar.dart';
 import 'package:openvine/widgets/video_editor/draw_editor/video_editor_draw_overlay_controls.dart';
@@ -20,6 +21,7 @@ import 'package:openvine/widgets/video_editor/main_editor/video_editor_main_acti
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_geometry.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
 /// A scaffold widget that provides the standard layout for the video editor.
@@ -48,8 +50,10 @@ class VideoEditorScaffold extends StatelessWidget {
         body: _SplitFailureListener(
           child: _ClipReverseResultListener(
             child: _ClipTransformResultListener(
-              child: _AudioExtractionResultListener(
-                child: _ScaffoldBody(isLoading: isLoading),
+              child: _ClipMergeResultListener(
+                child: _AudioExtractionResultListener(
+                  child: _ScaffoldBody(isLoading: isLoading),
+                ),
               ),
             ),
           ),
@@ -92,6 +96,7 @@ class _ScaffoldBody extends StatelessWidget {
 
         const _ReverseProgressOverlay(),
         const _TransformProgressOverlay(),
+        const _MergeProgressOverlay(),
       ],
     );
   }
@@ -225,6 +230,68 @@ class _ClipTransformResultListener extends StatelessWidget {
         // Player sync is handled by the canvas listener; nothing to do here.
         break;
     }
+  }
+}
+
+/// Listens to [ClipEditorBloc.state.lastMergeResult] and commits a successful
+/// merge to editor history (replacing the selected clips with the merged clip,
+/// with timeline markers rebased) or surfaces a snackbar on failure.
+///
+/// The bloc has already swapped the clip list by the time this fires; this
+/// listener persists that change plus the rebased markers as one history entry
+/// so undo/redo restores a consistent timeline. Kept at the scaffold level
+/// (always mounted) so it survives the multi-select controls unmounting when
+/// the bloc exits multi-select mode on success.
+class _ClipMergeResultListener extends StatelessWidget {
+  const _ClipMergeResultListener({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ClipEditorBloc, ClipEditorState>(
+      listenWhen: (prev, curr) =>
+          !identical(prev.lastMergeResult, curr.lastMergeResult) &&
+          curr.lastMergeResult != null,
+      listener: _onMergeResult,
+      child: child,
+    );
+  }
+
+  void _onMergeResult(BuildContext context, ClipEditorState state) {
+    final result = state.lastMergeResult;
+    if (result == null) return;
+
+    switch (result) {
+      case ClipMergeSuccess(:final previousClips):
+        _commitMerge(context, state, previousClips);
+      case ClipMergeFailure():
+        ScaffoldMessenger.of(context).showSnackBar(
+          DivineSnackbarContainer.snackBar(context.l10n.videoEditorMergeFailed),
+        );
+      case ClipMergeDiscarded():
+        // A selected clip was removed during the async render — nothing to
+        // commit and no user action that warrants a snackbar.
+        break;
+    }
+  }
+
+  void _commitMerge(
+    BuildContext context,
+    ClipEditorState state,
+    List<DivineVideoClip> previousClips,
+  ) {
+    final editor = VideoEditorScope.of(context).requireEditor;
+    final overlayBloc = context.read<TimelineOverlayBloc>();
+
+    final rebasedMarkers = rebaseTimelineMarkersForClipState(
+      oldClips: previousClips,
+      newClips: state.clips,
+      markers: overlayBloc.state.timelineMarkers,
+    );
+
+    overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
+    editor.setClipState(state.clips, timelineMarkers: rebasedMarkers);
   }
 }
 
@@ -524,6 +591,77 @@ class _TransformProgressContent extends StatelessWidget {
   }
 }
 
+/// Full-screen progress overlay shown while the selected clips are concatenated
+/// into a single new clip file. Absorbs input for the duration so the timeline
+/// controls underneath can't start a competing edit mid-render, and fades
+/// in/out via [AnimatedSwitcher].
+class _MergeProgressOverlay extends StatelessWidget {
+  const _MergeProgressOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocSelector<
+      ClipEditorBloc,
+      ClipEditorState,
+      ({bool isMerging, String? renderId})
+    >(
+      selector: (state) => (
+        isMerging: state.isMerging,
+        renderId: state.mergingRenderId,
+      ),
+      builder: (context, mergeState) {
+        final renderId = mergeState.isMerging ? mergeState.renderId : null;
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          child: renderId == null
+              ? const SizedBox.shrink()
+              : _MergeProgressContent(renderId: renderId),
+        );
+      },
+    );
+  }
+}
+
+class _MergeProgressContent extends StatelessWidget {
+  const _MergeProgressContent({required this.renderId});
+
+  final String renderId;
+
+  @override
+  Widget build(BuildContext context) {
+    return AbsorbPointer(
+      child: ColoredBox(
+        color: VineTheme.backgroundColor.withAlpha(210),
+        child: Center(
+          child: RepaintBoundary(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 24,
+              children: [
+                StreamBuilder<ProgressModel>(
+                  stream: ProVideoEditor.instance.progressStreamById(renderId),
+                  builder: (context, snapshot) {
+                    final progress = snapshot.data?.progress ?? 0;
+                    return PartialCircleSpinner(progress: progress);
+                  },
+                ),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 240),
+                  child: Text(
+                    context.l10n.videoEditorMergeProgressLabel,
+                    textAlign: TextAlign.center,
+                    style: VineTheme.bodyMediumFont(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Bottom section that switches between different toolbars based on context.
 ///
 /// Only visible when a sub-editor is open. When no sub-editor is open the
@@ -575,11 +713,11 @@ class _AddElementFab extends StatelessWidget {
     final hasSelectedOverlay = context.select(
       (TimelineOverlayBloc b) => b.state.selectedItemId != null,
     );
-    final isClipEditing = context.select(
-      (ClipEditorBloc b) => b.state.isEditing,
+    final isClipInteracting = context.select(
+      (ClipEditorBloc b) => b.state.isEditing || b.state.isMultiSelectMode,
     );
 
-    if (shouldHide || hasSelectedOverlay || isClipEditing) {
+    if (shouldHide || hasSelectedOverlay || isClipInteracting) {
       return const SizedBox.shrink();
     }
 

--- a/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
+++ b/mobile/lib/widgets/video_editor/video_editor_scaffold.dart
@@ -51,8 +51,10 @@ class VideoEditorScaffold extends StatelessWidget {
           child: _ClipReverseResultListener(
             child: _ClipTransformResultListener(
               child: _ClipMergeResultListener(
-                child: _AudioExtractionResultListener(
-                  child: _ScaffoldBody(isLoading: isLoading),
+                child: _ClipsRemovedResultListener(
+                  child: _AudioExtractionResultListener(
+                    child: _ScaffoldBody(isLoading: isLoading),
+                  ),
                 ),
               ),
             ),
@@ -286,6 +288,50 @@ class _ClipMergeResultListener extends StatelessWidget {
 
     final rebasedMarkers = rebaseTimelineMarkersForClipState(
       oldClips: previousClips,
+      newClips: state.clips,
+      markers: overlayBloc.state.timelineMarkers,
+    );
+
+    overlayBloc.add(TimelineMarkersRebased(rebasedMarkers));
+    editor.setClipState(state.clips, timelineMarkers: rebasedMarkers);
+  }
+}
+
+/// Listens to [ClipEditorBloc.state.lastClipsRemovedResult] and commits a
+/// multi-select removal to editor history (the new clip list with timeline
+/// markers rebased).
+///
+/// The bloc owns the clip-list mutation; this listener only persists it. Kept
+/// at the scaffold level (always mounted) so it survives the multi-select
+/// controls unmounting when the bloc exits multi-select mode on removal.
+class _ClipsRemovedResultListener extends StatelessWidget {
+  const _ClipsRemovedResultListener({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ClipEditorBloc, ClipEditorState>(
+      listenWhen: (prev, curr) =>
+          !identical(
+            prev.lastClipsRemovedResult,
+            curr.lastClipsRemovedResult,
+          ) &&
+          curr.lastClipsRemovedResult != null,
+      listener: _onClipsRemoved,
+      child: child,
+    );
+  }
+
+  void _onClipsRemoved(BuildContext context, ClipEditorState state) {
+    final result = state.lastClipsRemovedResult;
+    if (result == null) return;
+
+    final editor = VideoEditorScope.of(context).requireEditor;
+    final overlayBloc = context.read<TimelineOverlayBloc>();
+
+    final rebasedMarkers = rebaseTimelineMarkersForClipState(
+      oldClips: result.previousClips,
       newClips: state.clips,
       markers: overlayBloc.state.timelineMarkers,
     );

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -204,6 +204,14 @@ Future<DivineVideoClip?> _fakeMergeClipsFail({
   return null;
 }
 
+/// Fake merge that throws — exercises the BLoC's catch / [Reportable] path.
+Future<DivineVideoClip?> _fakeMergeClipsThrow({
+  required List<DivineVideoClip> clips,
+  required String renderId,
+}) async {
+  throw StateError('merge boom');
+}
+
 void main() {
   group(ClipEditorBloc, () {
     late List<DivineVideoClip> twoClips;
@@ -2219,6 +2227,10 @@ void main() {
     // =========================================================
 
     group('multi-select', () {
+      // Backs the deferred merge fake in the mid-render discard test; assigned
+      // in that test's act before the merge handler reads its future.
+      late Completer<DivineVideoClip?> mergeCompleter;
+
       blocTest<ClipEditorBloc, ClipEditorState>(
         'starts multi-select with the initial clip pre-selected and exits '
         'editing',
@@ -2287,6 +2299,14 @@ void main() {
           expect(bloc.state.clips.map((c) => c.id), equals(['b']));
           expect(bloc.state.isMultiSelectMode, isFalse);
           expect(bloc.state.selectedClipIds, isEmpty);
+          // The widget layer commits the removal via this one-shot signal,
+          // which carries the pre-removal clips for marker rebasing.
+          final result = bloc.state.lastClipsRemovedResult;
+          expect(result, isNotNull);
+          expect(
+            result!.previousClips.map((c) => c.id),
+            equals(['a', 'b', 'c']),
+          );
         },
       );
 
@@ -2362,6 +2382,67 @@ void main() {
           expect(bloc.state.isMerging, isFalse);
           expect(bloc.state.isMultiSelectMode, isTrue);
           expect(bloc.state.lastMergeResult, isA<ClipMergeFailure>());
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'reports the error and emits failure when the merge render throws',
+        build: () => buildBloc(mergeClips: _fakeMergeClipsThrow),
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b'},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorSelectedClipsMergeRequested()),
+        errors: () => [
+          isA<Reportable<Object>>().having(
+            (r) => r.unwrap(),
+            'unwrap',
+            isA<StateError>(),
+          ),
+        ],
+        verify: (bloc) {
+          expect(bloc.state.clips, hasLength(3));
+          expect(bloc.state.isMerging, isFalse);
+          expect(bloc.state.lastMergeResult, isA<ClipMergeFailure>());
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'discards the merge result when a selected clip is removed mid-render',
+        build: () => buildBloc(
+          mergeClips: ({required clips, required renderId}) =>
+              mergeCompleter.future,
+        ),
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'c'},
+        ),
+        act: (bloc) async {
+          mergeCompleter = Completer<DivineVideoClip?>();
+          bloc.add(const ClipEditorSelectedClipsMergeRequested());
+          // Let the merge start (emits isMerging) and suspend on the completer.
+          await Future<void>.delayed(Duration.zero);
+          // A selected clip disappears while the render is in flight.
+          bloc.add(const ClipEditorClipRemoved('a'));
+          await Future<void>.delayed(Duration.zero);
+          mergeCompleter.complete(
+            _createClip(
+              id: 'merged-clip',
+              duration: const Duration(seconds: 2),
+            ),
+          );
+        },
+        verify: (bloc) {
+          expect(bloc.state.lastMergeResult, isA<ClipMergeDiscarded>());
+          // The merged clip must not be inserted.
+          expect(
+            bloc.state.clips.map((c) => c.id),
+            isNot(contains('merged-clip')),
+          );
+          expect(bloc.state.isMerging, isFalse);
+          expect(bloc.state.isMultiSelectMode, isFalse);
         },
       );
     });

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -183,6 +183,27 @@ Future<EditorVideo> _fakeTransformClip({
   return EditorVideo.file('/transformed/${sourceClip.id}_$renderId.mp4');
 }
 
+/// Pure-Dart fake of [VideoEditorMergeService.mergeClips] for tests. Returns a
+/// single clip whose duration is the sum of the inputs' playback durations.
+Future<DivineVideoClip?> _fakeMergeClips({
+  required List<DivineVideoClip> clips,
+  required String renderId,
+}) async {
+  final duration = clips.fold(
+    Duration.zero,
+    (sum, clip) => sum + clip.playbackDuration,
+  );
+  return _createClip(id: 'merged-clip', duration: duration);
+}
+
+/// Fake merge that fails (renders to a null output / cancelled).
+Future<DivineVideoClip?> _fakeMergeClipsFail({
+  required List<DivineVideoClip> clips,
+  required String renderId,
+}) async {
+  return null;
+}
+
 void main() {
   group(ClipEditorBloc, () {
     late List<DivineVideoClip> twoClips;
@@ -216,6 +237,7 @@ void main() {
       SplitClipFn? splitClip,
       ReverseClipFn? reverseClip,
       TransformClipFn? transformClip,
+      MergeClipsFn? mergeClips,
     }) {
       return ClipEditorBloc(
         onFinalClipInvalidated: () {},
@@ -223,6 +245,7 @@ void main() {
         splitClip: splitClip,
         reverseClip: reverseClip,
         transformClip: transformClip,
+        mergeClips: mergeClips,
       );
     }
 
@@ -2189,6 +2212,158 @@ void main() {
 
         await bloc.close();
       });
+    });
+
+    // =========================================================
+    // MULTI-SELECT
+    // =========================================================
+
+    group('multi-select', () {
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'starts multi-select with the initial clip pre-selected and exits '
+        'editing',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: threeClips, isEditing: true),
+        act: (bloc) => bloc.add(const ClipEditorMultiSelectStarted('b')),
+        verify: (bloc) {
+          expect(bloc.state.isMultiSelectMode, isTrue);
+          expect(bloc.state.isEditing, isFalse);
+          expect(bloc.state.selectedClipIds, equals({'b'}));
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'ignores an unknown initial clip id',
+        build: buildBloc,
+        seed: () => ClipEditorState(clips: threeClips),
+        act: (bloc) => bloc.add(const ClipEditorMultiSelectStarted('missing')),
+        verify: (bloc) {
+          expect(bloc.state.isMultiSelectMode, isTrue);
+          expect(bloc.state.selectedClipIds, isEmpty);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'toggles clip membership in the selection',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a'},
+        ),
+        act: (bloc) => bloc
+          ..add(const ClipEditorMultiSelectClipToggled('b'))
+          ..add(const ClipEditorMultiSelectClipToggled('a')),
+        verify: (bloc) {
+          expect(bloc.state.selectedClipIds, equals({'b'}));
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'cancel exits multi-select and clears the selection',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b'},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorMultiSelectCancelled()),
+        verify: (bloc) {
+          expect(bloc.state.isMultiSelectMode, isFalse);
+          expect(bloc.state.selectedClipIds, isEmpty);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'removes the selected clips and exits multi-select',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'c'},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorSelectedClipsRemoved()),
+        verify: (bloc) {
+          expect(bloc.state.clips.map((c) => c.id), equals(['b']));
+          expect(bloc.state.isMultiSelectMode, isFalse);
+          expect(bloc.state.selectedClipIds, isEmpty);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'does not remove clips when the selection covers the whole timeline',
+        build: buildBloc,
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b', 'c'},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorSelectedClipsRemoved()),
+        verify: (bloc) {
+          expect(bloc.state.clips, hasLength(3));
+          expect(bloc.state.isMultiSelectMode, isTrue);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'merges the selected clips into one at the earliest position',
+        build: () => buildBloc(mergeClips: _fakeMergeClips),
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'c'},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorSelectedClipsMergeRequested()),
+        verify: (bloc) {
+          expect(
+            bloc.state.clips.map((c) => c.id),
+            equals(['merged-clip', 'b']),
+          );
+          expect(bloc.state.isMerging, isFalse);
+          expect(bloc.state.isMultiSelectMode, isFalse);
+          expect(bloc.state.selectedClipIds, isEmpty);
+          expect(bloc.state.currentClipIndex, equals(0));
+          final result = bloc.state.lastMergeResult;
+          expect(result, isA<ClipMergeSuccess>());
+          expect(
+            (result! as ClipMergeSuccess).previousClips.map((c) => c.id),
+            equals(['a', 'b', 'c']),
+          );
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'does nothing when fewer than two clips are selected',
+        build: () => buildBloc(mergeClips: _fakeMergeClips),
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a'},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorSelectedClipsMergeRequested()),
+        verify: (bloc) {
+          expect(bloc.state.clips, hasLength(3));
+          expect(bloc.state.isMerging, isFalse);
+          expect(bloc.state.lastMergeResult, isNull);
+        },
+      );
+
+      blocTest<ClipEditorBloc, ClipEditorState>(
+        'emits a failure result and stays in multi-select when merge fails',
+        build: () => buildBloc(mergeClips: _fakeMergeClipsFail),
+        seed: () => ClipEditorState(
+          clips: threeClips,
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b'},
+        ),
+        act: (bloc) => bloc.add(const ClipEditorSelectedClipsMergeRequested()),
+        verify: (bloc) {
+          expect(bloc.state.clips, hasLength(3));
+          expect(bloc.state.isMerging, isFalse);
+          expect(bloc.state.isMultiSelectMode, isTrue);
+          expect(bloc.state.lastMergeResult, isA<ClipMergeFailure>());
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/video_editor/video_editor_merge_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_merge_service_test.dart
@@ -1,0 +1,168 @@
+// ABOUTME: Tests for VideoEditorMergeService - flattening selected clips into
+// ABOUTME: a single rendered clip via the concat render pipeline.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/video_editor_merge_service.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+DivineVideoClip _createClip({
+  required String id,
+  Duration duration = const Duration(seconds: 2),
+  double? playbackSpeed,
+}) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('/path/$id.mp4'),
+    duration: duration,
+    recordedAt: DateTime(2025),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+    playbackSpeed: playbackSpeed,
+  );
+}
+
+void main() {
+  group(VideoEditorMergeService, () {
+    tearDown(() {
+      VideoEditorRenderService.renderVideoOverride = null;
+    });
+
+    test('returns null when fewer than two clips are supplied', () async {
+      var called = false;
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+          }) async {
+            called = true;
+            return '/out.mp4';
+          };
+
+      final result = await VideoEditorMergeService.mergeClips(
+        clips: [_createClip(id: 'a')],
+        renderId: 'merge-1',
+      );
+
+      expect(result, isNull);
+      expect(called, isFalse, reason: 'render should not run for one clip');
+    });
+
+    test(
+      'forwards clips + taskId and returns merged clip on success',
+      () async {
+        List<DivineVideoClip>? forwardedClips;
+        String? forwardedTaskId;
+        bool? forwardedPersistent;
+        VideoEditorRenderService.renderVideoOverride =
+            ({
+              required clips,
+              required usePersistentStorage,
+              aspectRatio,
+              parameters,
+              taskId,
+            }) async {
+              forwardedClips = clips;
+              forwardedTaskId = taskId;
+              forwardedPersistent = usePersistentStorage;
+              return '/documents/merged.mp4';
+            };
+
+        final clips = [
+          _createClip(id: 'a'),
+          _createClip(id: 'b', duration: const Duration(seconds: 3)),
+        ];
+
+        final result = await VideoEditorMergeService.mergeClips(
+          clips: clips,
+          renderId: 'merge-1',
+        );
+
+        expect(forwardedClips, same(clips));
+        expect(forwardedTaskId, equals('merge-1'));
+        expect(forwardedPersistent, isTrue);
+        expect(result, isNotNull);
+        expect(result!.video.file?.path, equals('/documents/merged.mp4'));
+        expect(result.duration, equals(const Duration(seconds: 5)));
+        expect(result.trimStart, equals(Duration.zero));
+        expect(result.trimEnd, equals(Duration.zero));
+        expect(result.targetAspectRatio, equals(model.AspectRatio.vertical));
+      },
+    );
+
+    test('keeps the full merged duration uncapped (no export limit)', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+          }) async => '/documents/merged.mp4';
+
+      // 5s + 5s = 10s, well beyond the ~6.3s final-export cap, which must not
+      // truncate an intermediate merged clip.
+      final result = await VideoEditorMergeService.mergeClips(
+        clips: [
+          _createClip(id: 'a', duration: const Duration(seconds: 5)),
+          _createClip(id: 'b', duration: const Duration(seconds: 5)),
+        ],
+        renderId: 'merge-1',
+      );
+
+      expect(result!.duration, equals(const Duration(seconds: 10)));
+    });
+
+    test('accounts for playback speed when summing duration', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+          }) async => '/documents/merged.mp4';
+
+      // 4s at 2x = 2s playback; 2s at 1x = 2s → 4s total.
+      final result = await VideoEditorMergeService.mergeClips(
+        clips: [
+          _createClip(
+            id: 'a',
+            duration: const Duration(seconds: 4),
+            playbackSpeed: 2,
+          ),
+          _createClip(id: 'b'),
+        ],
+        renderId: 'merge-1',
+      );
+
+      expect(result!.duration, equals(const Duration(seconds: 4)));
+    });
+
+    test('returns null when the render fails or is cancelled', () async {
+      VideoEditorRenderService.renderVideoOverride =
+          ({
+            required clips,
+            required usePersistentStorage,
+            aspectRatio,
+            parameters,
+            taskId,
+          }) async => null;
+
+      final result = await VideoEditorMergeService.mergeClips(
+        clips: [
+          _createClip(id: 'a'),
+          _createClip(id: 'b'),
+        ],
+        renderId: 'merge-1',
+      );
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_clip_controls_test.dart
@@ -142,5 +142,56 @@ void main() {
         expect(controls.onSpeed, isNull);
       },
     );
+
+    testWidgets('Select button is hidden for a single clip', (tester) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [
+            DivineVideoClip(
+              id: 'clip-1',
+              video: EditorVideo.file('/tmp/clip-1.mp4'),
+              duration: const Duration(seconds: 3),
+              recordedAt: DateTime(2025),
+              targetAspectRatio: model.AspectRatio.vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+        ),
+      );
+      await tester.pumpWidget(build());
+
+      final controls = tester.widget<VideoEditorTimelineControls>(
+        find.byType(VideoEditorTimelineControls),
+      );
+      expect(controls.onMultiSelect, isNull);
+    });
+
+    testWidgets('Select button starts multi-select with multiple clips', (
+      tester,
+    ) async {
+      DivineVideoClip clip(String id) => DivineVideoClip(
+        id: id,
+        video: EditorVideo.file('/tmp/$id.mp4'),
+        duration: const Duration(seconds: 3),
+        recordedAt: DateTime(2025),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 9 / 16,
+      );
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(clips: [clip('clip-1'), clip('clip-2')]),
+      );
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await tester.pumpWidget(build());
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorMultiSelectSemanticLabel),
+      );
+      await tester.pump();
+
+      verify(
+        () => bloc.add(const ClipEditorMultiSelectStarted('clip-1')),
+      ).called(1);
+    });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
@@ -192,5 +192,28 @@ void main() {
         () => bloc.add(const ClipEditorMultiSelectCancelled()),
       ).called(1);
     });
+
+    testWidgets('Delete dispatches a remove event when enabled', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_clip('a'), _clip('b'), _clip('c')],
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b'},
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorDeleteSelectedClipsSemanticLabel),
+      );
+      await tester.pump();
+
+      verify(
+        () => bloc.add(const ClipEditorSelectedClipsRemoved()),
+      ).called(1);
+    });
   });
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls_test.dart
@@ -1,0 +1,196 @@
+// ABOUTME: Widget tests for TimelineMultiSelectControls.
+// ABOUTME: Verifies the count label, merge/delete gating, and event dispatch.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_timeline_multi_select_controls.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+class _MockClipEditorBloc extends MockBloc<ClipEditorEvent, ClipEditorState>
+    implements ClipEditorBloc {}
+
+DivineVideoClip _clip(String id) {
+  return DivineVideoClip(
+    id: id,
+    video: EditorVideo.file('/tmp/$id.mp4'),
+    duration: const Duration(seconds: 2),
+    recordedAt: DateTime(2025),
+    targetAspectRatio: model.AspectRatio.vertical,
+    originalAspectRatio: 9 / 16,
+  );
+}
+
+void main() {
+  group(TimelineMultiSelectControls, () {
+    late _MockClipEditorBloc bloc;
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    setUp(() {
+      bloc = _MockClipEditorBloc();
+      when(
+        () => bloc.stream,
+      ).thenAnswer((_) => const Stream<ClipEditorState>.empty());
+    });
+
+    Widget build() {
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: BlocProvider<ClipEditorBloc>.value(
+            value: bloc,
+            child: const TimelineMultiSelectControls(),
+          ),
+        ),
+      );
+    }
+
+    DivineIconButton buttonWithLabel(WidgetTester tester, String label) {
+      return tester
+          .widgetList<DivineIconButton>(find.byType(DivineIconButton))
+          .firstWhere((b) => b.semanticLabel == label);
+    }
+
+    testWidgets('renders the selection count and Merge/Delete/Done', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_clip('a'), _clip('b'), _clip('c')],
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b'},
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      expect(
+        find.text(l10n.videoEditorMultiSelectCountLabel(2)),
+        findsOneWidget,
+      );
+      expect(find.text(l10n.videoEditorMergeLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorDeleteLabel), findsOneWidget);
+      expect(find.text(l10n.videoEditorDoneLabel), findsOneWidget);
+    });
+
+    testWidgets('Merge is disabled with fewer than two clips selected', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_clip('a'), _clip('b')],
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a'},
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      final merge = buttonWithLabel(
+        tester,
+        l10n.videoEditorMergeSelectedClipsSemanticLabel,
+      );
+      expect(merge.onPressed, isNull);
+    });
+
+    testWidgets('Merge dispatches a merge request when enabled', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_clip('a'), _clip('b'), _clip('c')],
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b'},
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorMergeSelectedClipsSemanticLabel),
+      );
+      await tester.pump();
+
+      verify(
+        () => bloc.add(const ClipEditorSelectedClipsMergeRequested()),
+      ).called(1);
+    });
+
+    testWidgets('Delete is disabled when every clip is selected', (
+      tester,
+    ) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_clip('a'), _clip('b')],
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b'},
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      final delete = buttonWithLabel(
+        tester,
+        l10n.videoEditorDeleteSelectedClipsSemanticLabel,
+      );
+      expect(delete.onPressed, isNull);
+    });
+
+    testWidgets('Merge and Delete are disabled while merging', (tester) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_clip('a'), _clip('b'), _clip('c')],
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a', 'b'},
+          isMerging: true,
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      expect(
+        buttonWithLabel(
+          tester,
+          l10n.videoEditorMergeSelectedClipsSemanticLabel,
+        ).onPressed,
+        isNull,
+      );
+      expect(
+        buttonWithLabel(
+          tester,
+          l10n.videoEditorDeleteSelectedClipsSemanticLabel,
+        ).onPressed,
+        isNull,
+      );
+    });
+
+    testWidgets('Done dispatches a cancel event', (tester) async {
+      when(() => bloc.state).thenReturn(
+        ClipEditorState(
+          clips: [_clip('a'), _clip('b')],
+          isMultiSelectMode: true,
+          selectedClipIds: const {'a'},
+        ),
+      );
+
+      await tester.pumpWidget(build());
+
+      await tester.tap(
+        find.bySemanticsLabel(l10n.videoEditorMultiSelectDoneSemanticLabel),
+      );
+      await tester.pump();
+
+      verify(
+        () => bloc.add(const ClipEditorMultiSelectCancelled()),
+      ).called(1);
+    });
+  });
+}


### PR DESCRIPTION


## Description

Adds a **multi-select mode** to the video-editor timeline so users can act on several clips at once.

Flow: tap a clip → the edit bar shows a new **Select** button → tap Select to enter multi-select (the tapped clip is pre-selected) → tap more clips to toggle them → confirm **Merge** (flatten the selection into one re-encoded clip) or **Delete** (remove all selected). **Done** exits.

Details:
- **Merge** concatenates the selected clips in timeline order into a single new clip placed at the earliest selected position, baking in each clip's trim/speed/volume/reverse. Reuses the existing concat render pipeline behind a new `VideoEditorMergeService` (injected via a `MergeClipsFn` seam like Split/Reverse/Transform). Shows a full-screen progress overlay and is undoable via editor history.
- **Merge scope** is any selection (non-contiguous allowed); later clips collapse up.
- Selected clips get a primary border + check badge; unselected dim; reorder is locked during select; the FAB is hidden in select mode.
- **Guards:** Merge needs ≥2 selected; Delete is blocked when every clip is selected (the timeline can't be emptied).
- Multi-select state lives in `ClipEditorBloc`, keyed by clip id. The async merge is bloc-driven + a session-level result listener that commits the new clip list with rebased markers; Delete is synchronous via `setClipState`, mirroring the existing delete path.
- The merge render is **uncapped** (`renderVideo` gained an optional `maxOutputDuration`, defaulting to the existing export cap) — the ~6.3s limit applies to the final export, not to an intermediate merged clip the user can still trim.


https://github.com/user-attachments/assets/070c7fe0-ac99-47c7-9e63-e09001b1e354



Closes: #4754
Closes #5194

## Out of Scope

- Markers anchored to merged clips are dropped — consistent with the existing `rebaseTimelineMarkersForClipState` contract for id-changing ops (split/reorder).
- Anchored extracted audio keeps single-delete semantics (no special handling on merge), to stay in scope.

## Verification

- `flutter analyze lib` — no issues.
- `flutter test` for `clip_editor` bloc, `video_editor` services, and `timeline_editor` controls — all green (pre-push hook ran the full suite, all passing).
- New bloc tests (multi-select start/toggle/cancel, remove, merge success/failure/discarded/<2), merge-service tests (uncapped duration, render failure, forwarding), and multi-select controls widget tests.
- `flutter gen-l10n` regenerated; 11 new keys added and translated into all 17 non-English locales.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
