### PR TITLE
fix(search): restore back navigation from search results screen

### DIFF
--- a/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
+++ b/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
@@ -1,11 +1,13 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/hashtag_search/hashtag_search_bloc.dart';
 import 'package:openvine/blocs/list_search/list_search_bloc.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
 import 'package:openvine/blocs/video_search/video_search_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/search_results/widgets/search_filter_pill.dart';
 
 /// App bar for the search results screen.
@@ -111,6 +113,18 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
     context.read<ListSearchBloc>().add(ListSearchQueryChanged(query));
   }
 
+  // Pop when there's a back stack; otherwise fall back to Explore. The search
+  // screen can be entered via `context.go(...)` (e.g. a username-mention tap)
+  // or a cold-start deep link, both of which leave nothing to pop — a bare
+  // `Navigator.maybePop()` would then silently do nothing and strand the user.
+  void _handleBack() {
+    if (context.canPop()) {
+      context.pop();
+      return;
+    }
+    context.go(ExploreScreen.path);
+  }
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
@@ -124,7 +138,7 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
               icon: DivineIconName.caretLeft,
               type: DivineIconButtonType.secondary,
               size: DivineIconButtonSize.small,
-              onPressed: () => Navigator.of(context).maybePop(),
+              onPressed: _handleBack,
               semanticLabel: context.l10n.commonBack,
             ),
             Expanded(

--- a/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
+++ b/mobile/lib/screens/search_results/widgets/search_results_app_bar.dart
@@ -113,9 +113,8 @@ class _SearchResultsAppBarState extends State<SearchResultsAppBar> {
     context.read<ListSearchBloc>().add(ListSearchQueryChanged(query));
   }
 
-  // Pop when there's a back stack; otherwise fall back to Explore. The search
-  // screen can be entered via `context.go(...)` (e.g. a username-mention tap)
-  // or a cold-start deep link, both of which leave nothing to pop — a bare
+  // Pop when there's a back stack; otherwise fall back to Explore. A cold-start
+  // deep link can enter search with nothing to pop — a bare
   // `Navigator.maybePop()` would then silently do nothing and strand the user.
   void _handleBack() {
     if (context.canPop()) {

--- a/mobile/lib/widgets/linkified_text/linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text.dart
@@ -118,7 +118,7 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
 
   void _navigateToSearch(BuildContext context, String username) {
     widget.onVideoStateChange?.call();
-    context.go(
+    context.push(
       SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
     );
   }

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -110,7 +110,7 @@ class _SelectableLinkifiedTextState
   }
 
   void _navigateToSearch(BuildContext context, String username) {
-    context.go(
+    context.push(
       SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
     );
   }

--- a/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
@@ -1,4 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,9 +9,11 @@ import 'package:openvine/blocs/list_search/list_search_bloc.dart';
 import 'package:openvine/blocs/search_results_filter/search_results_filter.dart';
 import 'package:openvine/blocs/user_search/user_search_bloc.dart';
 import 'package:openvine/blocs/video_search/video_search_bloc.dart';
+import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/search_results/widgets/search_filter_pill.dart';
 import 'package:openvine/screens/search_results/widgets/search_results_app_bar.dart';
 
+import '../../../helpers/go_router.dart';
 import '../../../helpers/test_provider_overrides.dart';
 
 class _MockSearchResultsFilterCubit extends MockCubit<SearchResultsFilter>
@@ -314,6 +317,72 @@ void main() {
         verify(
           () => mockListSearchBloc.add(const ListSearchQueryChanged('')),
         ).called(1);
+      },
+    );
+
+    Widget createBackButtonSubject(MockGoRouter goRouter) {
+      final controller = TextEditingController(text: 'test');
+      addTearDown(controller.dispose);
+      return testMaterialApp(
+        home: MockGoRouterProvider(
+          goRouter: goRouter,
+          child: MultiBlocProvider(
+            providers: [
+              BlocProvider<SearchResultsFilterCubit>.value(
+                value: mockFilterCubit,
+              ),
+              BlocProvider<UserSearchBloc>.value(value: mockUserSearchBloc),
+              BlocProvider<VideoSearchBloc>.value(value: mockVideoSearchBloc),
+              BlocProvider<HashtagSearchBloc>.value(
+                value: mockHashtagSearchBloc,
+              ),
+              BlocProvider<ListSearchBloc>.value(value: mockListSearchBloc),
+            ],
+            child: Scaffold(
+              body: SearchResultsAppBar(
+                controller: controller,
+                initialQuery: 'test',
+              ),
+            ),
+          ),
+        ),
+        mockAuthService: createMockAuthService(),
+      );
+    }
+
+    testWidgets('back button pops when there is a route to pop', (
+      tester,
+    ) async {
+      final goRouter = MockGoRouter();
+      when(goRouter.canPop).thenReturn(true);
+      when(() => goRouter.pop<Object?>()).thenReturn(null);
+
+      await tester.pumpWidget(createBackButtonSubject(goRouter));
+      await tester.pump();
+
+      await tester.tap(find.byType(DivineIconButton));
+      await tester.pump();
+
+      verify(() => goRouter.pop<Object?>()).called(1);
+      verifyNever(() => goRouter.go(any()));
+    });
+
+    testWidgets(
+      'back button falls back to Explore when the back stack is empty '
+      '(reached via context.go or a cold-start deep link)',
+      (tester) async {
+        final goRouter = MockGoRouter();
+        when(goRouter.canPop).thenReturn(false);
+        when(() => goRouter.go(any())).thenReturn(null);
+
+        await tester.pumpWidget(createBackButtonSubject(goRouter));
+        await tester.pump();
+
+        await tester.tap(find.byType(DivineIconButton));
+        await tester.pump();
+
+        verify(() => goRouter.go(ExploreScreen.path)).called(1);
+        verifyNever(() => goRouter.pop<Object?>());
       },
     );
   });

--- a/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_results_app_bar_test.dart
@@ -350,6 +350,13 @@ void main() {
       );
     }
 
+    // Scope to the back button by its icon so the finder stays unambiguous if
+    // a DivineIconButton is later added to DivineSearchBar/SearchFilterPill.
+    final backButtonFinder = find.byWidgetPredicate(
+      (widget) =>
+          widget is DivineIconButton && widget.icon == DivineIconName.caretLeft,
+    );
+
     testWidgets('back button pops when there is a route to pop', (
       tester,
     ) async {
@@ -360,7 +367,7 @@ void main() {
       await tester.pumpWidget(createBackButtonSubject(goRouter));
       await tester.pump();
 
-      await tester.tap(find.byType(DivineIconButton));
+      await tester.tap(backButtonFinder);
       await tester.pump();
 
       verify(() => goRouter.pop<Object?>()).called(1);
@@ -378,7 +385,7 @@ void main() {
         await tester.pumpWidget(createBackButtonSubject(goRouter));
         await tester.pump();
 
-        await tester.tap(find.byType(DivineIconButton));
+        await tester.tap(backButtonFinder);
         await tester.pump();
 
         verify(() => goRouter.go(ExploreScreen.path)).called(1);


### PR DESCRIPTION
Closes #5197

## Description

Users reported on discord [here](https://discord.com/channels/1470168817589158040/1470255950408454164/1515884021521973408) being unable to go back from the search results screen. The back button used `Navigator.of(context).maybePop()`, which is a **silent no-op when the navigation stack is empty** — so whether "back" works depended on *how* the screen was entered:

- From the Explore search button → `context.push()` → stack has an entry → back works (the common path, hence hard to reproduce).
- From a `@username` tap in linkified text (video description, DM, …) → `context.go()` → **replaces** the stack → nothing to pop → back is dead.
- From a cold-start deep link to `/search-results/:query` → empty stack → back is dead.

**Fixes:**

1. **Root cause** — `_navigateToSearch` in `linkified_text.dart` and `selectable_linkified_text.dart` now uses `context.push()` instead of `context.go()`, matching its sibling methods (`_navigateToProfile`/`_navigateToVideo`/`_navigateToHashtagFeed`, all `push`) and preserving the back stack to the originating screen.
2. **Hardened back button** — `SearchResultsAppBar` now uses the repo's canonical `canPop`/fallback pattern (cf. `video_detail_screen.dart`, `back_button_handler.dart`): `context.pop()` when there's a stack, otherwise `context.go(ExploreScreen.path)`. This covers every entry path, including cold-start deep links where there is genuinely nothing to pop.




## Out of Scope

None.

## Verification

- `dart format` (no changes)
- `flutter analyze lib/screens/search_results lib/widgets/linkified_text test/screens/search_results` → No issues found
- `flutter test test/screens/search_results/widgets/search_results_app_bar_test.dart` → 12 passed (incl. 2 new back-button tests covering pop + Explore-fallback)
- `flutter test test/widgets/linkified_text/` → all passed

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)