### PR TITLE
fix(video-editor): reflect audio start-trim on the timeline waveform

### DIFF
--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -78,28 +78,11 @@ class TimelineOverlayBloc
 
     final sounds = <TimelineOverlayItem>[
       for (final track in event.audioTracks)
-        TimelineOverlayItem(
-          id: track.id,
-          type: .sound,
-          startTime: track.startTime,
-          endTime: _clampEnd(track.endTime ?? .zero, total),
-          label: track.title ?? track.pubkey,
-          maxDuration: track.duration != null
-              ? Duration(
-                  milliseconds:
-                      (track.duration! * 1000).round() -
-                      track.startOffset.inMilliseconds,
-                )
-              : VideoEditorConstants.maxDuration,
-          sourceDuration: track.duration != null
-              ? Duration(milliseconds: (track.duration! * 1000).round())
-              : null,
-          startOffset: track.startOffset,
-          waveformLeftChannel: leftCache[track.id],
-          waveformRightChannel: rightCache[track.id],
-          audioSource: track.isOriginalSound
-              ? AudioSource.original
-              : AudioSource.custom,
+        _soundItem(
+          track,
+          total: total,
+          leftChannel: leftCache[track.id],
+          rightChannel: rightCache[track.id],
         ),
     ];
 
@@ -167,6 +150,42 @@ class TimelineOverlayBloc
             : state.audioTracksPlayerRevision,
         timelineMarkers: _clampMarkers(event.timelineMarkers, total),
       ),
+    );
+  }
+
+  /// Builds the timeline item for one audio [track].
+  ///
+  /// [maxDuration] (remaining audio after [TimelineOverlayItem.startOffset])
+  /// is derived from the same full-source basis as
+  /// [TimelineOverlayItem.sourceDuration] so the two never drift — the same
+  /// `sourceDuration - startOffset` relationship [_onItemTrimmed] applies
+  /// live during a trim drag.
+  static TimelineOverlayItem _soundItem(
+    AudioEvent track, {
+    required Duration total,
+    Float32List? leftChannel,
+    Float32List? rightChannel,
+  }) {
+    final sourceDuration = track.duration != null
+        ? Duration(milliseconds: (track.duration! * 1000).round())
+        : null;
+
+    return TimelineOverlayItem(
+      id: track.id,
+      type: .sound,
+      startTime: track.startTime,
+      endTime: _clampEnd(track.endTime ?? .zero, total),
+      label: track.title ?? track.pubkey,
+      maxDuration: sourceDuration != null
+          ? sourceDuration - track.startOffset
+          : VideoEditorConstants.maxDuration,
+      sourceDuration: sourceDuration,
+      startOffset: track.startOffset,
+      waveformLeftChannel: leftChannel,
+      waveformRightChannel: rightChannel,
+      audioSource: track.isOriginalSound
+          ? AudioSource.original
+          : AudioSource.custom,
     );
   }
 

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -91,6 +91,10 @@ class TimelineOverlayBloc
                       track.startOffset.inMilliseconds,
                 )
               : VideoEditorConstants.maxDuration,
+          sourceDuration: track.duration != null
+              ? Duration(milliseconds: (track.duration! * 1000).round())
+              : null,
+          startOffset: track.startOffset,
           waveformLeftChannel: leftCache[track.id],
           waveformRightChannel: rightCache[track.id],
           audioSource: track.isOriginalSound
@@ -352,8 +356,23 @@ class TimelineOverlayBloc
 
     final newStart = event.startTime ?? item.startTime;
     final newEnd = event.endTime ?? item.endTime;
+    final newStartOffset = event.startOffset ?? item.startOffset;
 
-    items[idx] = item.copyWith(startTime: newStart, endTime: newEnd);
+    // A left-trim advances the source offset. The full item refresh from
+    // editor history (which recomputes maxDuration) does not run mid-drag, so
+    // keep maxDuration in step here too — otherwise the live waveform window
+    // (and the trim move-conversion) would read a stale remaining-audio value.
+    final newMaxDuration =
+        event.startOffset != null && item.sourceDuration != null
+        ? item.sourceDuration! - newStartOffset
+        : item.maxDuration;
+
+    items[idx] = item.copyWith(
+      startTime: newStart,
+      endTime: newEnd,
+      startOffset: newStartOffset,
+      maxDuration: newMaxDuration,
+    );
 
     // Only re-assign rows for the changed type; other types are unaffected.
     final changedType = item.type;

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_event.dart
@@ -68,6 +68,7 @@ class TimelineOverlayItemTrimmed extends TimelineOverlayEvent {
     required this.isStart,
     this.startTime,
     this.endTime,
+    this.startOffset,
   });
 
   final String itemId;
@@ -75,8 +76,16 @@ class TimelineOverlayItemTrimmed extends TimelineOverlayEvent {
   final Duration? startTime;
   final Duration? endTime;
 
+  /// New source offset for sound items after a left-trim.
+  ///
+  /// Carries the authoritative offset computed alongside the timeline
+  /// move so the live waveform scrolls the trimmed-away head out of view
+  /// during the drag. `null` for non-sound items and right-trims (offset
+  /// unchanged).
+  final Duration? startOffset;
+
   @override
-  List<Object?> get props => [itemId, isStart, startTime, endTime];
+  List<Object?> get props => [itemId, isStart, startTime, endTime, startOffset];
 }
 
 /// Select an overlay item (shows trim handles).

--- a/mobile/lib/models/timeline_overlay_item.dart
+++ b/mobile/lib/models/timeline_overlay_item.dart
@@ -44,6 +44,8 @@ class TimelineOverlayItem extends Equatable {
     this.label = '',
     this.layer,
     this.maxDuration,
+    this.sourceDuration,
+    this.startOffset = Duration.zero,
     this.waveformLeftChannel,
     this.waveformRightChannel,
     this.audioSource,
@@ -77,6 +79,21 @@ class TimelineOverlayItem extends Equatable {
   /// the item beyond this duration — the item moves instead.
   final Duration? maxDuration;
 
+  /// Full duration of the underlying audio source for sound items.
+  ///
+  /// `null` for non-sound items or when the source duration is unknown.
+  /// Distinct from [maxDuration] (which is the remaining audio *after*
+  /// [startOffset]); the waveform painter needs the full-source basis to map
+  /// samples to time when [startOffset] is non-zero.
+  final Duration? sourceDuration;
+
+  /// Offset into the audio source where the visible segment begins.
+  ///
+  /// Advancing this — e.g. by left-trimming a sound item — scrolls the
+  /// waveform so the trimmed-away head leaves the view, rather than the tail
+  /// being clipped. [Duration.zero] for non-sound items.
+  final Duration startOffset;
+
   /// Left audio waveform amplitude samples for sound items.
   final Float32List? waveformLeftChannel;
 
@@ -103,6 +120,8 @@ class TimelineOverlayItem extends Equatable {
     String? label,
     Layer? layer,
     Duration? maxDuration,
+    Duration? sourceDuration,
+    Duration? startOffset,
     Float32List? waveformLeftChannel,
     Float32List? waveformRightChannel,
     AudioSource? audioSource,
@@ -116,6 +135,8 @@ class TimelineOverlayItem extends Equatable {
       label: label ?? this.label,
       layer: layer ?? this.layer,
       maxDuration: maxDuration ?? this.maxDuration,
+      sourceDuration: sourceDuration ?? this.sourceDuration,
+      startOffset: startOffset ?? this.startOffset,
       waveformLeftChannel: waveformLeftChannel ?? this.waveformLeftChannel,
       waveformRightChannel: waveformRightChannel ?? this.waveformRightChannel,
       audioSource: audioSource ?? this.audioSource,
@@ -132,6 +153,8 @@ class TimelineOverlayItem extends Equatable {
     label,
     layer,
     maxDuration,
+    sourceDuration,
+    startOffset,
     waveformLeftChannel,
     waveformRightChannel,
     audioSource,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_item.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_item.dart
@@ -97,7 +97,8 @@ class TimelineOverlayItemTile extends StatelessWidget {
                     label: item.label,
                     color: foregroundColor,
                     currentDuration: item.duration,
-                    maxDuration: item.maxDuration,
+                    sourceDuration: item.sourceDuration,
+                    startOffset: item.startOffset,
                     leftChannel: item.waveformLeftChannel,
                     rightChannel: item.waveformRightChannel,
                   )
@@ -182,28 +183,46 @@ class _StickerPreview extends StatelessWidget {
 
 /// Sound-item content: label text at top, waveform bars at bottom.
 ///
-/// The waveform is always rendered at [maxDuration] width and clipped
-/// by the parent so trimming doesn't re-scale the bars.
+/// The waveform shows the source samples windowed to
+/// `[startOffset, startOffset + currentDuration]`. Left-trimming advances
+/// [startOffset], scrolling the trimmed-away head out of view instead of
+/// clipping the tail — so the visible waveform matches what actually plays.
 class _SoundContent extends StatelessWidget {
   const _SoundContent({
     required this.label,
     required this.color,
     required this.currentDuration,
-    this.maxDuration,
+    this.sourceDuration,
+    this.startOffset = Duration.zero,
     this.leftChannel,
     this.rightChannel,
   });
 
   final String label;
   final Color color;
+
+  /// Visible span of the item on the timeline (`endTime - startTime`).
   final Duration currentDuration;
-  final Duration? maxDuration;
+
+  /// Full duration of the underlying audio source, or `null` if unknown.
+  final Duration? sourceDuration;
+
+  /// Offset into the audio source where the visible segment begins.
+  final Duration startOffset;
+
   final Float32List? leftChannel;
   final Float32List? rightChannel;
 
   @override
   Widget build(BuildContext context) {
-    final effectiveMax = maxDuration ?? currentDuration;
+    // The painter maps samples against the full-source duration, then windows
+    // them to [startOffset, startOffset + currentDuration]. When the source
+    // duration is unknown there's no basis to resolve the offset against, so
+    // fall back to treating the visible span as the whole source.
+    final hasSourceDuration =
+        sourceDuration != null && sourceDuration! > Duration.zero;
+    final audioDuration = hasSourceDuration ? sourceDuration! : currentDuration;
+    final effectiveOffset = hasSourceDuration ? startOffset : Duration.zero;
 
     return Padding(
       padding: const .fromLTRB(0, 8, 0, 4),
@@ -222,39 +241,21 @@ class _SoundContent extends StatelessWidget {
           ),
 
           Expanded(
-            child: LayoutBuilder(
-              builder: (context, constraints) {
-                final currentUs = currentDuration.inMicroseconds;
-                final maxUs = effectiveMax.inMicroseconds;
-                final waveformWidth = currentUs > 0 && maxUs > 0
-                    ? constraints.maxWidth * maxUs / currentUs
-                    : constraints.maxWidth;
-
-                return ClipRect(
-                  child: OverflowBox(
-                    minWidth: 0,
-                    maxWidth: waveformWidth,
-                    alignment: .centerLeft,
-                    child: RepaintBoundary(
-                      child: SizedBox(
-                        width: waveformWidth,
-                        child: CustomPaint(
-                          painter: StereoWaveformPainter(
-                            leftChannel: leftChannel ?? Float32List(0),
-                            rightChannel: rightChannel,
-                            progress: 1,
-                            activeColor: VineTheme.accentPurple,
-                            inactiveColor: VineTheme.accentPurple,
-                            audioDuration: effectiveMax,
-                            maxDuration: effectiveMax,
-                            barWidth: TimelineConstants.soundWaveformBarWidth,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                );
-              },
+            child: RepaintBoundary(
+              child: CustomPaint(
+                size: Size.infinite,
+                painter: StereoWaveformPainter(
+                  leftChannel: leftChannel ?? Float32List(0),
+                  rightChannel: rightChannel,
+                  progress: 1,
+                  activeColor: VineTheme.accentPurple,
+                  inactiveColor: VineTheme.accentPurple,
+                  audioDuration: audioDuration,
+                  maxDuration: currentDuration,
+                  startOffset: effectiveOffset,
+                  barWidth: TimelineConstants.soundWaveformBarWidth,
+                ),
+              ),
             ),
           ),
         ],

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline.dart
@@ -583,6 +583,12 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
   }) {
     final editor = VideoEditorScope.of(context).requireEditor;
 
+    // For sound items, the new source offset computed alongside the timeline
+    // move is forwarded to the BLoC so the live waveform scrolls the
+    // trimmed-away head out of view during the drag — the full item refresh
+    // that would otherwise carry it does not run mid-trim.
+    Duration? newStartOffset;
+
     switch (item.type) {
       case .layer:
         final layers = editor.activeLayers;
@@ -613,6 +619,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
                 newStartTime: startTime,
               )
             : null;
+        newStartOffset = trimResult?.startOffset;
 
         editor.setSoundTimeline(
           index: audioIdx,
@@ -630,6 +637,7 @@ class _VideoEditorTimelineState extends State<VideoEditorTimelineScaffold> {
         isStart: isStart,
         startTime: startTime,
         endTime: endTime,
+        startOffset: newStartOffset,
       ),
     );
   }

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -163,6 +163,73 @@ void main() {
       );
 
       blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'carries full source duration and start offset onto sound items',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: const Duration(seconds: 1),
+                end: const Duration(seconds: 4),
+              ).copyWith(
+                duration: 8.0,
+                startOffset: const Duration(seconds: 2),
+              ),
+            ],
+            totalVideoDuration: const Duration(seconds: 12),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.sourceDuration,
+                'sourceDuration',
+                const Duration(seconds: 8),
+              )
+              .having(
+                (s) => s.items.first.startOffset,
+                'startOffset',
+                const Duration(seconds: 2),
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'leaves source duration null when the track has no duration',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: const Duration(seconds: 1),
+                end: const Duration(seconds: 4),
+              ),
+            ],
+            totalVideoDuration: const Duration(seconds: 12),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.sourceDuration,
+                'sourceDuration',
+                isNull,
+              )
+              .having(
+                (s) => s.items.first.startOffset,
+                'startOffset',
+                Duration.zero,
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
         'clears selection when not trimming',
         build: TimelineOverlayBloc.new,
         seed: () => const TimelineOverlayState(selectedItemId: 'sound-1'),
@@ -606,6 +673,100 @@ void main() {
               ),
             ],
             trimPosition: const Duration(seconds: 4),
+          ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'applies the source offset and remaining-audio max on a left-trim',
+        build: TimelineOverlayBloc.new,
+        seed: () => const TimelineOverlayState(
+          items: [
+            TimelineOverlayItem(
+              id: 'sound-1',
+              type: TimelineOverlayType.sound,
+              startTime: Duration.zero,
+              endTime: Duration(seconds: 8),
+              sourceDuration: Duration(seconds: 20),
+              maxDuration: Duration(seconds: 20),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayItemTrimmed(
+            itemId: 'sound-1',
+            isStart: true,
+            startTime: Duration(seconds: 3),
+            endTime: Duration(seconds: 8),
+            startOffset: Duration(seconds: 3),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>().having(
+            (s) => s.items.single,
+            'item',
+            isA<TimelineOverlayItem>()
+                .having(
+                  (i) => i.startTime,
+                  'startTime',
+                  const Duration(seconds: 3),
+                )
+                .having((i) => i.endTime, 'endTime', const Duration(seconds: 8))
+                .having(
+                  (i) => i.startOffset,
+                  'startOffset',
+                  const Duration(seconds: 3),
+                )
+                // maxDuration tracks the offset: 20s source - 3s consumed head.
+                .having(
+                  (i) => i.maxDuration,
+                  'maxDuration',
+                  const Duration(seconds: 17),
+                ),
+          ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'leaves the source offset untouched on a right-trim',
+        build: TimelineOverlayBloc.new,
+        seed: () => const TimelineOverlayState(
+          items: [
+            TimelineOverlayItem(
+              id: 'sound-1',
+              type: TimelineOverlayType.sound,
+              startTime: Duration(seconds: 2),
+              endTime: Duration(seconds: 8),
+              startOffset: Duration(seconds: 2),
+              sourceDuration: Duration(seconds: 20),
+              maxDuration: Duration(seconds: 18),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(
+          const TimelineOverlayItemTrimmed(
+            itemId: 'sound-1',
+            isStart: false,
+            startTime: Duration(seconds: 2),
+            endTime: Duration(seconds: 6),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>().having(
+            (s) => s.items.single,
+            'item',
+            isA<TimelineOverlayItem>()
+                .having((i) => i.endTime, 'endTime', const Duration(seconds: 6))
+                .having(
+                  (i) => i.startOffset,
+                  'startOffset',
+                  const Duration(seconds: 2),
+                )
+                .having(
+                  (i) => i.maxDuration,
+                  'maxDuration',
+                  const Duration(seconds: 18),
+                ),
           ),
         ],
       );

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/audio_left_trim_gesture_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/audio_left_trim_gesture_test.dart
@@ -1,0 +1,150 @@
+// ABOUTME: Gesture-level test for left-trimming a sound overlay item.
+// ABOUTME: Verifies the start handle moves the start, never the end.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/timeline_overlay_item.dart';
+import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_positioned_item.dart';
+
+typedef _TrimCall = ({Duration start, Duration end, bool isStart});
+
+void main() {
+  group('audio left trim', () {
+    late List<_TrimCall> calls;
+
+    Future<void> pumpSelectedSound(
+      WidgetTester tester, {
+      required TimelineOverlayItem item,
+      double pixelsPerSecond = 100,
+      List<int> clipEdgesMs = const [0, 30000],
+      Duration totalDuration = const Duration(seconds: 30),
+    }) async {
+      calls = [];
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Stack(
+              children: [
+                TimelineOverlayPositionedItem(
+                  item: item,
+                  isDragging: false,
+                  isSelected: true,
+                  snappedStartMs: 0,
+                  dragDeltaY: 0,
+                  rowHeight: 56,
+                  pixelsPerSecond: pixelsPerSecond,
+                  totalDuration: totalDuration,
+                  clipEdgesMs: clipEdgesMs,
+                  color: Colors.blue,
+                  isCollapsed: false,
+                  trimExpansion: 16,
+                  onTap: () {},
+                  onLongPressStart: () {},
+                  onLongPressMoveUpdate: (_) {},
+                  onLongPressEnd: () {},
+                  onTrimDragChanged: (_) {},
+                  onTrimChanged:
+                      ({
+                        required item,
+                        required startTime,
+                        required endTime,
+                        required isStart,
+                      }) {
+                        calls.add((
+                          start: startTime,
+                          end: endTime,
+                          isStart: isStart,
+                        ));
+                      },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Drags the left/start trim handle horizontally by [dx] pixels.
+    Future<void> dragStartHandle(WidgetTester tester, double dx) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      final handle = find.descendant(
+        of: find.bySemanticsLabel(
+          l10n.videoEditorTimelineTrimStartSemanticLabel,
+        ),
+        matching: find.byType(GestureDetector),
+      );
+      expect(handle, findsOneWidget);
+      final center = tester.getCenter(handle);
+      final gesture = await tester.startGesture(center);
+      // Move in small steps so onHorizontalDragUpdate fires repeatedly.
+      const steps = 10;
+      for (var i = 0; i < steps; i++) {
+        await gesture.moveBy(Offset(dx / steps, 0));
+        await tester.pump();
+      }
+      await gesture.up();
+      await tester.pump();
+    }
+
+    testWidgets(
+      'dragging the start handle right moves the start, keeps the end',
+      (tester) async {
+        // 6s-long clip starting 5s into a 30s source, plenty of headroom so
+        // the maxDuration move-conversion cannot fire.
+        await pumpSelectedSound(
+          tester,
+          item: const TimelineOverlayItem(
+            id: 'sound-1',
+            type: TimelineOverlayType.sound,
+            startTime: Duration(seconds: 5),
+            endTime: Duration(seconds: 11),
+            label: 'Beat',
+            maxDuration: Duration(seconds: 25),
+            sourceDuration: Duration(seconds: 30),
+            startOffset: Duration(seconds: 5),
+          ),
+        );
+
+        await dragStartHandle(tester, 100); // +1s
+
+        expect(calls, isNotEmpty);
+        final last = calls.last;
+        expect(last.isStart, isTrue);
+        expect(last.end, const Duration(seconds: 11));
+        expect(last.start.inMilliseconds, greaterThan(5000));
+        expect(last.start, lessThan(const Duration(seconds: 11)));
+      },
+    );
+
+    testWidgets(
+      'start handle keeps the end fixed when span equals maxDuration',
+      (tester) async {
+        // Extracted-audio shape: the visible span equals the remaining
+        // source (span == maxDuration).
+        await pumpSelectedSound(
+          tester,
+          item: const TimelineOverlayItem(
+            id: 'sound-2',
+            type: TimelineOverlayType.sound,
+            startTime: Duration(seconds: 5),
+            endTime: Duration(seconds: 11),
+            label: 'Extracted',
+            maxDuration: Duration(seconds: 6),
+            sourceDuration: Duration(seconds: 6),
+          ),
+        );
+
+        await dragStartHandle(tester, 100); // +1s
+
+        expect(calls, isNotEmpty);
+        final last = calls.last;
+        expect(last.isStart, isTrue);
+        expect(last.end, const Duration(seconds: 11));
+        expect(last.start.inMilliseconds, greaterThan(5000));
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_item_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_item_test.dart
@@ -1,11 +1,14 @@
 // ABOUTME: Widget tests for TimelineOverlayItemTile.
 // ABOUTME: Verifies label rendering and drag visual state.
 
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show StickerData, StickerPackData;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
+import 'package:openvine/widgets/stereo_waveform_painter.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_item.dart';
 import 'package:pro_image_editor/pro_image_editor.dart' show WidgetLayer;
 
@@ -59,6 +62,90 @@ void main() {
         find.byType(AnimatedContainer),
       );
       expect(animated.foregroundDecoration, isNotNull);
+    });
+
+    group('sound waveform', () {
+      StereoWaveformPainter findWaveformPainter(WidgetTester tester) {
+        final painter = tester
+            .widgetList<CustomPaint>(find.byType(CustomPaint))
+            .map((c) => c.painter)
+            .whereType<StereoWaveformPainter>()
+            .single;
+        return painter;
+      }
+
+      Widget buildSound(TimelineOverlayItem item) {
+        return MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: Center(
+              child: TimelineOverlayItemTile(
+                item: item,
+                width: 120,
+                height: 56,
+                color: Colors.blue,
+              ),
+            ),
+          ),
+        );
+      }
+
+      testWidgets(
+        'windows the waveform to the start offset when left-trimmed',
+        (tester) async {
+          final soundItem = TimelineOverlayItem(
+            id: 'sound-1',
+            type: TimelineOverlayType.sound,
+            // A left-trim that consumed 2s of the head: the visible span is
+            // 4s, starting 2s into an 8s source.
+            startTime: const Duration(seconds: 2),
+            endTime: const Duration(seconds: 6),
+            label: 'Beat',
+            sourceDuration: const Duration(seconds: 8),
+            startOffset: const Duration(seconds: 2),
+            waveformLeftChannel: Float32List.fromList(
+              List<double>.generate(64, (i) => (i % 8) / 8),
+            ),
+          );
+
+          await tester.pumpWidget(buildSound(soundItem));
+
+          final painter = findWaveformPainter(tester);
+          // The full source is the mapping basis, the visible span is what's
+          // shown, and the head offset scrolls the bars instead of clipping
+          // the tail.
+          expect(painter.audioDuration, const Duration(seconds: 8));
+          expect(painter.maxDuration, const Duration(seconds: 4));
+          expect(painter.startOffset, const Duration(seconds: 2));
+        },
+      );
+
+      testWidgets(
+        'falls back to zero offset when the source duration is unknown',
+        (tester) async {
+          final soundItem = TimelineOverlayItem(
+            id: 'sound-2',
+            type: TimelineOverlayType.sound,
+            startTime: const Duration(seconds: 2),
+            endTime: const Duration(seconds: 6),
+            label: 'Beat',
+            // No sourceDuration: there's no basis to resolve the offset, so
+            // the painter must not scroll the head out of view.
+            startOffset: const Duration(seconds: 2),
+            waveformLeftChannel: Float32List.fromList(
+              List<double>.generate(64, (i) => (i % 8) / 8),
+            ),
+          );
+
+          await tester.pumpWidget(buildSound(soundItem));
+
+          final painter = findWaveformPainter(tester);
+          expect(painter.startOffset, Duration.zero);
+          expect(painter.audioDuration, const Duration(seconds: 4));
+          expect(painter.maxDuration, const Duration(seconds: 4));
+        },
+      );
     });
 
     group('_StickerPreview', () {


### PR DESCRIPTION
## Description

Left-trimming a sound item on the editor timeline advances its source
offset, but the timeline waveform tile always rendered from source
sample 0 with the wrong duration basis (`maxDuration` instead of the full
source duration, and no `startOffset`). So the bars only ever clipped
from the *end* — a start-trim looked like an end-trim, for both extracted
and imported audio.

The audio output itself was already correct (the preview re-syncs from
`AudioEvent.startOffset` on trim-end and export honors it), so this is a
**visual-fidelity** fix.

Changes:
- Carry `startOffset` + full `sourceDuration` onto `TimelineOverlayItem`
  and feed them to `StereoWaveformPainter`, which windows the waveform to
  `[startOffset, startOffset + span]`.
- The full item refresh that recomputes these (`_onUpdateItems`) does
  **not** run during a trim drag (no history change fires it), so the
  new offset is forwarded through `TimelineOverlayItemTrimmed` and applied
  in `_onItemTrimmed` (along with the remaining-audio `maxDuration`),
  scrolling the trimmed-away head out of view live during the drag.

Closes #5200

## Out of Scope

- Product behavior of the trim itself (gap-on-start vs. ripple) is
  unchanged — only the waveform now matches what plays.

## Verification

- `flutter analyze lib test integration_test` — clean (pinned toolchain).
- New gesture test drives the actual left-handle drag and asserts the
  start moves while the end stays fixed (incl. the `span == maxDuration`
  extracted-audio shape).
- New bloc tests: `_onItemTrimmed` applies `startOffset` + recomputes
  `maxDuration` on a left-trim, leaves them untouched on a right-trim;
  `_onUpdateItems` populates `startOffset`/`sourceDuration`.
- New widget tests: the painter receives the correct window, plus the
  unknown-duration fallback.
- Full `timeline_editor` + `timeline_overlay` suites pass.


## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)