### PR TITLE
fix(video-editor): keep selected cover and overlay fonts on saved drafts (#5181)

### DIFF
--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -43,6 +43,11 @@ class VideoEditorConstants {
   /// Default time offset for extracting video thumbnails.
   static const defaultThumbnailExtractTime = Duration(milliseconds: 200);
 
+  /// Maximum time to wait for the text-overlay Google Fonts to load when
+  /// restoring a draft. Already-cached fonts resolve instantly, so this only
+  /// guards the first, uncached load before the canvas imports the overlays.
+  static const textFontLoadTimeout = Duration(seconds: 3);
+
   /// Primary accent color used in the video editor UI.
   static const primaryColor = Color(0xFFFFF140);
 

--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -11,6 +11,7 @@ import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_reply_context.dart';
 import 'package:openvine/utils/path_resolver.dart';
+import 'package:path/path.dart' as p;
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -44,6 +45,7 @@ class DivineVideoDraft {
     this.videoReplyContext,
     this.shareReplyToFeed = false,
     this.thumbnailTimestamp,
+    this.customThumbnailPath,
   });
 
   factory DivineVideoDraft.create({
@@ -67,6 +69,7 @@ class DivineVideoDraft {
     VideoReplyContext? videoReplyContext,
     bool shareReplyToFeed = false,
     Duration? thumbnailTimestamp,
+    String? customThumbnailPath,
   }) {
     final now = DateTime.now();
     return DivineVideoDraft(
@@ -94,6 +97,7 @@ class DivineVideoDraft {
       videoReplyContext: videoReplyContext,
       shareReplyToFeed: shareReplyToFeed,
       thumbnailTimestamp: thumbnailTimestamp,
+      customThumbnailPath: customThumbnailPath,
     );
   }
 
@@ -197,6 +201,11 @@ class DivineVideoDraft {
       thumbnailTimestamp: json['thumbnailTimestamp'] != null
           ? Duration(milliseconds: json['thumbnailTimestamp'] as int)
           : null,
+      customThumbnailPath: resolvePath(
+        json['customThumbnailPath'] as String?,
+        documentsPath,
+        useOriginalPath: useOriginalPath,
+      ),
     );
   }
 
@@ -264,6 +273,14 @@ class DivineVideoDraft {
   /// Position in the video used to generate the thumbnail.
   final Duration? thumbnailTimestamp;
 
+  /// Absolute path to the user-selected cover image.
+  ///
+  /// Persisted independently of [finalRenderedClip] so the chosen cover
+  /// survives the rendered clip being invalidated or cleared (e.g. reopening
+  /// a draft and editing it). Stored as a basename in JSON and resolved back
+  /// to an absolute path on load, matching the clip path handling (#5181).
+  final String? customThumbnailPath;
+
   /// Check if this draft has ProofMode data
   bool get hasProofMode => proofManifestJson != null;
 
@@ -316,6 +333,8 @@ class DivineVideoDraft {
     bool? shareReplyToFeed,
     Duration? thumbnailTimestamp,
     bool clearThumbnailTimestamp = false,
+    String? customThumbnailPath,
+    bool clearCustomThumbnailPath = false,
     bool skipUpdateLastModified = false,
   }) => DivineVideoDraft(
     id: id ?? this.id,
@@ -358,6 +377,9 @@ class DivineVideoDraft {
     thumbnailTimestamp: clearThumbnailTimestamp
         ? null
         : (thumbnailTimestamp ?? this.thumbnailTimestamp),
+    customThumbnailPath: clearCustomThumbnailPath
+        ? null
+        : (customThumbnailPath ?? this.customThumbnailPath),
   );
 
   static const _sentinel = Object();
@@ -393,6 +415,8 @@ class DivineVideoDraft {
     if (shareReplyToFeed) 'shareReplyToFeed': shareReplyToFeed,
     if (thumbnailTimestamp != null)
       'thumbnailTimestamp': thumbnailTimestamp!.inMilliseconds,
+    if (customThumbnailPath != null)
+      'customThumbnailPath': p.basename(customThumbnailPath!),
   };
 
   Set<ContentLabel> get contentWarnings => ContentLabel.fromCsv(contentWarning);
@@ -414,6 +438,15 @@ class DivineVideoDraft {
       return 'Just now';
     }
   }
+
+  /// Path to the thumbnail to display as this draft's cover.
+  ///
+  /// Prefers the durable user-selected cover, then the rendered clip's cover,
+  /// and finally the first source clip's thumbnail.
+  String? get coverThumbnailPath =>
+      customThumbnailPath ??
+      finalRenderedClip?.thumbnailPath ??
+      (clips.isNotEmpty ? clips.first.thumbnailPath : null);
 
   bool get hasTitle => title.trim().isNotEmpty;
   bool get hasDescription => description.trim().isNotEmpty;

--- a/mobile/lib/models/video_editor/video_editor_provider_state.dart
+++ b/mobile/lib/models/video_editor/video_editor_provider_state.dart
@@ -37,6 +37,8 @@ class VideoEditorProviderState {
     this.selectedSound,
     this.contentWarnings = const {},
     this.proofManifestJson,
+    this.thumbnailTimestamp,
+    this.customThumbnailPath,
     GlobalKey? deleteButtonKey,
   }) : deleteButtonKey = deleteButtonKey ?? GlobalKey();
 
@@ -108,6 +110,20 @@ class VideoEditorProviderState {
   /// ProofMode attestation manifest JSON for the final rendered clip.
   final String? proofManifestJson;
 
+  /// User-selected cover position in the rendered video timeline.
+  ///
+  /// Persisted independently of [finalRenderedClip] so the chosen cover
+  /// survives a re-render — when the clip is invalidated and rebuilt (e.g.
+  /// reopening a draft and pressing Done), the rendered clip is recreated at
+  /// its default frame, but this timestamp re-applies the selected cover.
+  final Duration? thumbnailTimestamp;
+
+  /// Absolute path to the user-selected cover image.
+  ///
+  /// Kept separate from [finalRenderedClip] so cover displays (drafts list,
+  /// profile grid) survive the rendered clip being cleared on invalidation.
+  final String? customThumbnailPath;
+
   /// Whether the video is valid and ready to be posted.
   ///
   /// Returns true if:
@@ -156,6 +172,10 @@ class VideoEditorProviderState {
     AudioEvent? selectedSound,
     bool clearSelectedSound = false,
     Set<ContentLabel>? contentWarnings,
+    Duration? thumbnailTimestamp,
+    bool clearThumbnailTimestamp = false,
+    String? customThumbnailPath,
+    bool clearCustomThumbnailPath = false,
   }) {
     return VideoEditorProviderState(
       isProcessing: isProcessing ?? this.isProcessing,
@@ -191,6 +211,12 @@ class VideoEditorProviderState {
       proofManifestJson: clearProofManifestJson || clearFinalRenderedClip
           ? null
           : proofManifestJson ?? this.proofManifestJson,
+      thumbnailTimestamp: clearThumbnailTimestamp
+          ? null
+          : (thumbnailTimestamp ?? this.thumbnailTimestamp),
+      customThumbnailPath: clearCustomThumbnailPath
+          ? null
+          : (customThumbnailPath ?? this.customThumbnailPath),
     );
   }
 }

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -490,7 +490,13 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       contentWarning: ContentLabel.toCsv(state.contentWarnings),
       finalRenderedClip: state.finalRenderedClip,
       proofManifestJson: state.proofManifestJson,
-      thumbnailTimestamp: state.finalRenderedClip?.thumbnailTimestamp,
+      // Prefer the persisted cover so the selection survives a re-render that
+      // resets finalRenderedClip's thumbnail to its default frame (see #5181).
+      thumbnailTimestamp:
+          state.thumbnailTimestamp ??
+          state.finalRenderedClip?.thumbnailTimestamp,
+      customThumbnailPath:
+          state.customThumbnailPath ?? state.finalRenderedClip?.thumbnailPath,
       videoReplyContext: ref.read(videoReplyContextProvider),
       shareReplyToFeed: state.shareReplyToFeed,
     );
@@ -808,6 +814,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       contentWarnings: draft.contentWarnings,
       finalRenderedClip: validFinalRenderedClip,
       clearFinalRenderedClip: validFinalRenderedClip == null,
+      thumbnailTimestamp: draft.thumbnailTimestamp,
+      clearThumbnailTimestamp: draft.thumbnailTimestamp == null,
+      customThumbnailPath: draft.customThumbnailPath,
+      clearCustomThumbnailPath: draft.customThumbnailPath == null,
     );
 
     _clipManager.replaceClips(clipsWithThumbnails);
@@ -855,7 +865,11 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
   // === RENDERING & PUBLISHING ===
 
-  /// Update thumbnail path for a clip.
+  /// Update the selected cover for the rendered clip.
+  ///
+  /// Records [thumbnailTimestamp] on the state as well as the clip so the
+  /// chosen cover survives a later re-render (which rebuilds the clip with its
+  /// default thumbnail) and reaches publishing via [getActiveDraft].
   void updateCover({
     required String thumbnailPath,
     required Duration thumbnailTimestamp,
@@ -870,6 +884,8 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       return;
     }
     state = state.copyWith(
+      thumbnailTimestamp: thumbnailTimestamp,
+      customThumbnailPath: thumbnailPath,
       finalRenderedClip: finalRenderedClip.copyWith(
         thumbnailPath: thumbnailPath,
         thumbnailTimestamp: thumbnailTimestamp,

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -491,7 +491,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       finalRenderedClip: state.finalRenderedClip,
       proofManifestJson: state.proofManifestJson,
       // Prefer the persisted cover so the selection survives a re-render that
-      // resets finalRenderedClip's thumbnail to its default frame (see #5181).
+      // resets finalRenderedClip's thumbnail to its default frame. When no
+      // cover was picked, fall back to the rendered clip's own cover so the
+      // drafts-list / profile-grid thumbnail keeps showing after the clip is
+      // later invalidated and cleared (see #5181).
       thumbnailTimestamp:
           state.thumbnailTimestamp ??
           state.finalRenderedClip?.thumbnailTimestamp,

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -215,7 +215,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
       font();
     }
     await GoogleFonts.pendingFonts().timeout(
-      const Duration(seconds: 3),
+      VideoEditorConstants.textFontLoadTimeout,
       onTimeout: () => const [],
     );
   }

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -8,6 +8,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/draw_editor/video_editor_draw_bloc.dart';
@@ -166,6 +167,15 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
         category: LogCategory.video,
       );
 
+      // A restored draft's text layers carry only the serialized Google Font
+      // family name. Re-register the editor fonts before the canvas imports
+      // the state history, otherwise the imported overlays fall back to the
+      // default font (see #5181).
+      if (mounted &&
+          ref.read(videoEditorProvider).editorStateHistory.isNotEmpty) {
+        await _preloadEditorTextFonts();
+      }
+
       if (mounted) {
         // Clips are now loaded — initialize the clip editor BLoC.
         final clips = ref.read(clipManagerProvider).clips;
@@ -190,6 +200,24 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
     _bodySizeNotifier.dispose();
     _zoomMatrixNotifier.dispose();
     super.dispose();
+  }
+
+  /// Registers every text-overlay Google Font so a restored draft resolves
+  /// the font family stored on its text layers.
+  ///
+  /// Calling a `GoogleFonts.*` getter registers its [FontLoader] as a side
+  /// effect; the serialized [TextLayer] only keeps the family string, so the
+  /// loader must be re-registered each session before the overlays render.
+  /// Already-loaded fonts resolve instantly, so the timeout only guards the
+  /// first, uncached load.
+  Future<void> _preloadEditorTextFonts() async {
+    for (final font in VideoEditorConstants.textFonts) {
+      font();
+    }
+    await GoogleFonts.pendingFonts().timeout(
+      const Duration(seconds: 3),
+      onTimeout: () => const [],
+    );
   }
 
   /// Precaches stickers for faster display.

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -159,6 +159,7 @@ class DraftStorageService {
         ],
         draft.finalRenderedClip?.video.file?.path,
         draft.finalRenderedClip?.thumbnailPath,
+        draft.customThumbnailPath,
       };
 
       final orphanedFiles = <String?>[
@@ -177,6 +178,8 @@ class DraftStorageService {
           ))
             existingDraft.finalRenderedClip?.thumbnailPath,
         ],
+        if (!newFilePaths.contains(existingDraft.customThumbnailPath))
+          existingDraft.customThumbnailPath,
       ];
 
       // Delete orphaned files (only if not referenced by clip library)
@@ -452,6 +455,13 @@ class DraftStorageService {
         clipsDao: _clipsDao,
       );
     }
+
+    // Delete the user-selected cover, which lives outside the clips.
+    await FileCleanupService.deleteFileIfUnreferenced(
+      draft.customThumbnailPath,
+      draftsDao: _draftsDao,
+      clipsDao: _clipsDao,
+    );
   }
 
   /// Clear all drafts from storage and delete associated files

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -106,6 +106,9 @@ class DraftStorageService {
           renderedThumbnailPath: draft.finalRenderedClip?.thumbnailPath != null
               ? p.basename(draft.finalRenderedClip!.thumbnailPath!)
               : null,
+          customThumbnailPath: draft.customThumbnailPath != null
+              ? p.basename(draft.customThumbnailPath!)
+              : null,
           clipDataList: clipDataList,
           ownerPubkey: ownerPubkey,
         );
@@ -149,8 +152,11 @@ class DraftStorageService {
       category: LogCategory.video,
     );
 
-    // Check for orphaned files before overwriting
+    // Check for orphaned files before overwriting. Delete them only after the
+    // new row is committed, so this draft's old indexed file references no
+    // longer protect files it just stopped using.
     final existingDraft = await getDraftById(draft.id);
+    var orphanedFiles = const <String?>[];
     if (existingDraft != null) {
       final newFilePaths = <String?>{
         for (final clip in draft.clips) ...[
@@ -162,7 +168,7 @@ class DraftStorageService {
         draft.customThumbnailPath,
       };
 
-      final orphanedFiles = <String?>[
+      orphanedFiles = <String?>[
         for (final clip in existingDraft.clips) ...[
           if (!newFilePaths.contains(clip.video.file?.path))
             clip.video.file?.path,
@@ -181,13 +187,6 @@ class DraftStorageService {
         if (!newFilePaths.contains(existingDraft.customThumbnailPath))
           existingDraft.customThumbnailPath,
       ];
-
-      // Delete orphaned files (only if not referenced by clip library)
-      await FileCleanupService.deleteFilesIfUnreferenced(
-        orphanedFiles,
-        draftsDao: _draftsDao,
-        clipsDao: _clipsDao,
-      );
     }
 
     // Upsert draft and clips atomically in a single transaction
@@ -231,8 +230,18 @@ class DraftStorageService {
       renderedThumbnailPath: draft.finalRenderedClip?.thumbnailPath != null
           ? p.basename(draft.finalRenderedClip!.thumbnailPath!)
           : null,
+      customThumbnailPath: draft.customThumbnailPath != null
+          ? p.basename(draft.customThumbnailPath!)
+          : null,
       clipDataList: clipDataList,
       ownerPubkey: ownerPubkey,
+    );
+
+    // Delete orphaned files only after the new draft/clip rows are committed.
+    await FileCleanupService.deleteFilesIfUnreferenced(
+      orphanedFiles,
+      draftsDao: _draftsDao,
+      clipsDao: _clipsDao,
     );
   }
 
@@ -477,6 +486,9 @@ class DraftStorageService {
         .map((draft) => draft.finalRenderedClip)
         .whereType<DivineVideoClip>()
         .toList();
+    final allCustomThumbnailPaths = drafts
+        .map((draft) => draft.customThumbnailPath)
+        .toList();
 
     // Clear DB first (clips cascade via FK), then delete files
     await _draftsDao.clearAll();
@@ -489,6 +501,11 @@ class DraftStorageService {
     );
     await FileCleanupService.deleteRecordingClipsFiles(
       allFinalRenderedClips,
+      draftsDao: _draftsDao,
+      clipsDao: _clipsDao,
+    );
+    await FileCleanupService.deleteFilesIfUnreferenced(
+      allCustomThumbnailPaths,
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
     );

--- a/mobile/lib/services/file_cleanup_service.dart
+++ b/mobile/lib/services/file_cleanup_service.dart
@@ -15,8 +15,8 @@ import 'package:unified_logger/unified_logger.dart';
 /// checks both storage locations before deleting to prevent data loss.
 ///
 /// Uses indexed `file_path` / `thumbnail_path` columns on the clips table
-/// and `rendered_file_path` / `rendered_thumbnail_path` on the drafts table
-/// for efficient lookups without loading all rows.
+/// and draft-owned file reference columns on the drafts table for efficient
+/// lookups without loading all rows.
 class FileCleanupService {
   /// Checks if a file is referenced by any clip or draft.
   ///
@@ -29,7 +29,7 @@ class FileCleanupService {
   }) async {
     final filename = p.basename(filePath);
     if (await clipsDao.isFileReferenced(filename)) return true;
-    if (await draftsDao.isRenderedFileReferenced(filename)) return true;
+    if (await draftsDao.isDraftFileReferenced(filename)) return true;
     return false;
   }
 

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -299,7 +299,7 @@ class DraftListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final thumbnailPath = draft.clips.firstOrNull?.thumbnailPath;
+    final thumbnailPath = draft.coverThumbnailPath;
     final thumbnailExists =
         thumbnailPath != null && File(thumbnailPath).existsSync();
 

--- a/mobile/lib/widgets/profile/profile_videos_grid.dart
+++ b/mobile/lib/widgets/profile/profile_videos_grid.dart
@@ -81,7 +81,7 @@ class ActiveUploadsView extends Equatable {
           (
             draftId: upload.draft.id,
             title: upload.draft.title,
-            thumbnailPath: upload.draft.clips.firstOrNull?.thumbnailPath,
+            thumbnailPath: upload.draft.coverThumbnailPath,
           ),
     ]);
   }

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -256,9 +256,10 @@ class AppDatabase extends _$AppDatabase {
       ON clips (thumbnail_path)
     ''');
 
-    // Add rendered_file_path / rendered_thumbnail_path to drafts (if missing)
+    // Add indexed draft-owned file reference columns (if missing)
     await _addColumnIfMissing('drafts', 'rendered_file_path', 'TEXT');
     await _addColumnIfMissing('drafts', 'rendered_thumbnail_path', 'TEXT');
+    await _addColumnIfMissing('drafts', 'custom_thumbnail_path', 'TEXT');
     await customStatement('''
       CREATE INDEX IF NOT EXISTS idx_draft_rendered_file_path
       ON drafts (rendered_file_path)
@@ -266,6 +267,10 @@ class AppDatabase extends _$AppDatabase {
     await customStatement('''
       CREATE INDEX IF NOT EXISTS idx_draft_rendered_thumbnail_path
       ON drafts (rendered_thumbnail_path)
+    ''');
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_draft_custom_thumbnail_path
+      ON drafts (custom_thumbnail_path)
     ''');
 
     // Add owner_pubkey columns for multi-account isolation
@@ -650,6 +655,13 @@ class AppDatabase extends _$AppDatabase {
             data, '$.finalRenderedClip.thumbnailPath'
           )
       WHERE rendered_thumbnail_path IS NULL
+    ''');
+
+    // Drafts: backfill custom_thumbnail_path where missing
+    await customStatement(r'''
+      UPDATE drafts
+      SET custom_thumbnail_path = json_extract(data, '$.customThumbnailPath')
+      WHERE custom_thumbnail_path IS NULL
     ''');
   }
 

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -6847,6 +6847,17 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, DraftRow> {
         type: DriftSqlType.string,
         requiredDuringInsert: false,
       );
+  static const VerificationMeta _customThumbnailPathMeta =
+      const VerificationMeta('customThumbnailPath');
+  @override
+  late final GeneratedColumn<String> customThumbnailPath =
+      GeneratedColumn<String>(
+        'custom_thumbnail_path',
+        aliasedName,
+        true,
+        type: DriftSqlType.string,
+        requiredDuringInsert: false,
+      );
   static const VerificationMeta _ownerPubkeyMeta = const VerificationMeta(
     'ownerPubkey',
   );
@@ -6871,6 +6882,7 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, DraftRow> {
     data,
     renderedFilePath,
     renderedThumbnailPath,
+    customThumbnailPath,
     ownerPubkey,
   ];
   @override
@@ -6977,6 +6989,15 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, DraftRow> {
         ),
       );
     }
+    if (data.containsKey('custom_thumbnail_path')) {
+      context.handle(
+        _customThumbnailPathMeta,
+        customThumbnailPath.isAcceptableOrUnknown(
+          data['custom_thumbnail_path']!,
+          _customThumbnailPathMeta,
+        ),
+      );
+    }
     if (data.containsKey('owner_pubkey')) {
       context.handle(
         _ownerPubkeyMeta,
@@ -7039,6 +7060,10 @@ class $DraftsTable extends Drafts with TableInfo<$DraftsTable, DraftRow> {
         DriftSqlType.string,
         data['${effectivePrefix}rendered_thumbnail_path'],
       ),
+      customThumbnailPath: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}custom_thumbnail_path'],
+      ),
       ownerPubkey: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}owner_pubkey'],
@@ -7086,6 +7111,9 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
   /// Basename of the final rendered thumbnail (for indexed lookups)
   final String? renderedThumbnailPath;
 
+  /// Basename of the selected custom cover thumbnail (for indexed lookups)
+  final String? customThumbnailPath;
+
   /// Hex public key of the account that owns this draft.
   /// NULL for legacy drafts created before multi-account support.
   final String? ownerPubkey;
@@ -7101,6 +7129,7 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
     required this.data,
     this.renderedFilePath,
     this.renderedThumbnailPath,
+    this.customThumbnailPath,
     this.ownerPubkey,
   });
   @override
@@ -7122,6 +7151,9 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
     }
     if (!nullToAbsent || renderedThumbnailPath != null) {
       map['rendered_thumbnail_path'] = Variable<String>(renderedThumbnailPath);
+    }
+    if (!nullToAbsent || customThumbnailPath != null) {
+      map['custom_thumbnail_path'] = Variable<String>(customThumbnailPath);
     }
     if (!nullToAbsent || ownerPubkey != null) {
       map['owner_pubkey'] = Variable<String>(ownerPubkey);
@@ -7148,6 +7180,9 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
       renderedThumbnailPath: renderedThumbnailPath == null && nullToAbsent
           ? const Value.absent()
           : Value(renderedThumbnailPath),
+      customThumbnailPath: customThumbnailPath == null && nullToAbsent
+          ? const Value.absent()
+          : Value(customThumbnailPath),
       ownerPubkey: ownerPubkey == null && nullToAbsent
           ? const Value.absent()
           : Value(ownerPubkey),
@@ -7173,6 +7208,9 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
       renderedThumbnailPath: serializer.fromJson<String?>(
         json['renderedThumbnailPath'],
       ),
+      customThumbnailPath: serializer.fromJson<String?>(
+        json['customThumbnailPath'],
+      ),
       ownerPubkey: serializer.fromJson<String?>(json['ownerPubkey']),
     );
   }
@@ -7193,6 +7231,7 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
       'renderedThumbnailPath': serializer.toJson<String?>(
         renderedThumbnailPath,
       ),
+      'customThumbnailPath': serializer.toJson<String?>(customThumbnailPath),
       'ownerPubkey': serializer.toJson<String?>(ownerPubkey),
     };
   }
@@ -7209,6 +7248,7 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
     String? data,
     Value<String?> renderedFilePath = const Value.absent(),
     Value<String?> renderedThumbnailPath = const Value.absent(),
+    Value<String?> customThumbnailPath = const Value.absent(),
     Value<String?> ownerPubkey = const Value.absent(),
   }) => DraftRow(
     id: id ?? this.id,
@@ -7226,6 +7266,9 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
     renderedThumbnailPath: renderedThumbnailPath.present
         ? renderedThumbnailPath.value
         : this.renderedThumbnailPath,
+    customThumbnailPath: customThumbnailPath.present
+        ? customThumbnailPath.value
+        : this.customThumbnailPath,
     ownerPubkey: ownerPubkey.present ? ownerPubkey.value : this.ownerPubkey,
   );
   DraftRow copyWithCompanion(DraftsCompanion data) {
@@ -7255,6 +7298,9 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
       renderedThumbnailPath: data.renderedThumbnailPath.present
           ? data.renderedThumbnailPath.value
           : this.renderedThumbnailPath,
+      customThumbnailPath: data.customThumbnailPath.present
+          ? data.customThumbnailPath.value
+          : this.customThumbnailPath,
       ownerPubkey: data.ownerPubkey.present
           ? data.ownerPubkey.value
           : this.ownerPubkey,
@@ -7275,6 +7321,7 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
           ..write('data: $data, ')
           ..write('renderedFilePath: $renderedFilePath, ')
           ..write('renderedThumbnailPath: $renderedThumbnailPath, ')
+          ..write('customThumbnailPath: $customThumbnailPath, ')
           ..write('ownerPubkey: $ownerPubkey')
           ..write(')'))
         .toString();
@@ -7293,6 +7340,7 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
     data,
     renderedFilePath,
     renderedThumbnailPath,
+    customThumbnailPath,
     ownerPubkey,
   );
   @override
@@ -7310,6 +7358,7 @@ class DraftRow extends DataClass implements Insertable<DraftRow> {
           other.data == this.data &&
           other.renderedFilePath == this.renderedFilePath &&
           other.renderedThumbnailPath == this.renderedThumbnailPath &&
+          other.customThumbnailPath == this.customThumbnailPath &&
           other.ownerPubkey == this.ownerPubkey);
 }
 
@@ -7325,6 +7374,7 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
   final Value<String> data;
   final Value<String?> renderedFilePath;
   final Value<String?> renderedThumbnailPath;
+  final Value<String?> customThumbnailPath;
   final Value<String?> ownerPubkey;
   final Value<int> rowid;
   const DraftsCompanion({
@@ -7339,6 +7389,7 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
     this.data = const Value.absent(),
     this.renderedFilePath = const Value.absent(),
     this.renderedThumbnailPath = const Value.absent(),
+    this.customThumbnailPath = const Value.absent(),
     this.ownerPubkey = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -7354,6 +7405,7 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
     required String data,
     this.renderedFilePath = const Value.absent(),
     this.renderedThumbnailPath = const Value.absent(),
+    this.customThumbnailPath = const Value.absent(),
     this.ownerPubkey = const Value.absent(),
     this.rowid = const Value.absent(),
   }) : id = Value(id),
@@ -7372,6 +7424,7 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
     Expression<String>? data,
     Expression<String>? renderedFilePath,
     Expression<String>? renderedThumbnailPath,
+    Expression<String>? customThumbnailPath,
     Expression<String>? ownerPubkey,
     Expression<int>? rowid,
   }) {
@@ -7388,6 +7441,8 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
       if (renderedFilePath != null) 'rendered_file_path': renderedFilePath,
       if (renderedThumbnailPath != null)
         'rendered_thumbnail_path': renderedThumbnailPath,
+      if (customThumbnailPath != null)
+        'custom_thumbnail_path': customThumbnailPath,
       if (ownerPubkey != null) 'owner_pubkey': ownerPubkey,
       if (rowid != null) 'rowid': rowid,
     });
@@ -7405,6 +7460,7 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
     Value<String>? data,
     Value<String?>? renderedFilePath,
     Value<String?>? renderedThumbnailPath,
+    Value<String?>? customThumbnailPath,
     Value<String?>? ownerPubkey,
     Value<int>? rowid,
   }) {
@@ -7421,6 +7477,7 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
       renderedFilePath: renderedFilePath ?? this.renderedFilePath,
       renderedThumbnailPath:
           renderedThumbnailPath ?? this.renderedThumbnailPath,
+      customThumbnailPath: customThumbnailPath ?? this.customThumbnailPath,
       ownerPubkey: ownerPubkey ?? this.ownerPubkey,
       rowid: rowid ?? this.rowid,
     );
@@ -7464,6 +7521,11 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
         renderedThumbnailPath.value,
       );
     }
+    if (customThumbnailPath.present) {
+      map['custom_thumbnail_path'] = Variable<String>(
+        customThumbnailPath.value,
+      );
+    }
     if (ownerPubkey.present) {
       map['owner_pubkey'] = Variable<String>(ownerPubkey.value);
     }
@@ -7487,6 +7549,7 @@ class DraftsCompanion extends UpdateCompanion<DraftRow> {
           ..write('data: $data, ')
           ..write('renderedFilePath: $renderedFilePath, ')
           ..write('renderedThumbnailPath: $renderedThumbnailPath, ')
+          ..write('customThumbnailPath: $customThumbnailPath, ')
           ..write('ownerPubkey: $ownerPubkey, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -16939,6 +17002,7 @@ typedef $$DraftsTableCreateCompanionBuilder =
       required String data,
       Value<String?> renderedFilePath,
       Value<String?> renderedThumbnailPath,
+      Value<String?> customThumbnailPath,
       Value<String?> ownerPubkey,
       Value<int> rowid,
     });
@@ -16955,6 +17019,7 @@ typedef $$DraftsTableUpdateCompanionBuilder =
       Value<String> data,
       Value<String?> renderedFilePath,
       Value<String?> renderedThumbnailPath,
+      Value<String?> customThumbnailPath,
       Value<String?> ownerPubkey,
       Value<int> rowid,
     });
@@ -17020,6 +17085,11 @@ class $$DraftsTableFilterComposer
 
   ColumnFilters<String> get renderedThumbnailPath => $composableBuilder(
     column: $table.renderedThumbnailPath,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get customThumbnailPath => $composableBuilder(
+    column: $table.customThumbnailPath,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -17093,6 +17163,11 @@ class $$DraftsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<String> get customThumbnailPath => $composableBuilder(
+    column: $table.customThumbnailPath,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get ownerPubkey => $composableBuilder(
     column: $table.ownerPubkey,
     builder: (column) => ColumnOrderings(column),
@@ -17155,6 +17230,11 @@ class $$DraftsTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<String> get customThumbnailPath => $composableBuilder(
+    column: $table.customThumbnailPath,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get ownerPubkey => $composableBuilder(
     column: $table.ownerPubkey,
     builder: (column) => column,
@@ -17200,6 +17280,7 @@ class $$DraftsTableTableManager
                 Value<String> data = const Value.absent(),
                 Value<String?> renderedFilePath = const Value.absent(),
                 Value<String?> renderedThumbnailPath = const Value.absent(),
+                Value<String?> customThumbnailPath = const Value.absent(),
                 Value<String?> ownerPubkey = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => DraftsCompanion(
@@ -17214,6 +17295,7 @@ class $$DraftsTableTableManager
                 data: data,
                 renderedFilePath: renderedFilePath,
                 renderedThumbnailPath: renderedThumbnailPath,
+                customThumbnailPath: customThumbnailPath,
                 ownerPubkey: ownerPubkey,
                 rowid: rowid,
               ),
@@ -17230,6 +17312,7 @@ class $$DraftsTableTableManager
                 required String data,
                 Value<String?> renderedFilePath = const Value.absent(),
                 Value<String?> renderedThumbnailPath = const Value.absent(),
+                Value<String?> customThumbnailPath = const Value.absent(),
                 Value<String?> ownerPubkey = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
               }) => DraftsCompanion.insert(
@@ -17244,6 +17327,7 @@ class $$DraftsTableTableManager
                 data: data,
                 renderedFilePath: renderedFilePath,
                 renderedThumbnailPath: renderedThumbnailPath,
+                customThumbnailPath: customThumbnailPath,
                 ownerPubkey: ownerPubkey,
                 rowid: rowid,
               ),

--- a/mobile/packages/db_client/lib/src/database/daos/drafts_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/drafts_dao.dart
@@ -53,6 +53,7 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
     required String data,
     required String? renderedFilePath,
     required String? renderedThumbnailPath,
+    String? customThumbnailPath,
     int publishAttempts = 0,
     String? publishError,
     String? ownerPubkey,
@@ -70,6 +71,7 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
         data: data,
         renderedFilePath: Value(renderedFilePath),
         renderedThumbnailPath: Value(renderedThumbnailPath),
+        customThumbnailPath: Value(customThumbnailPath),
         ownerPubkey: Value(ownerPubkey),
       ),
     );
@@ -258,14 +260,14 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
         .write(DraftsCompanion(ownerPubkey: Value(newOwnerPubkey)));
   }
 
-  /// Check if a filename is referenced by any draft's
-  /// rendered_file_path or rendered_thumbnail_path.
-  Future<bool> isRenderedFileReferenced(String filename) async {
+  /// Check if a filename is referenced by any draft-owned file column.
+  Future<bool> isDraftFileReferenced(String filename) async {
     final query = selectOnly(drafts)
       ..addColumns([drafts.id.count()])
       ..where(
         drafts.renderedFilePath.equals(filename) |
-            drafts.renderedThumbnailPath.equals(filename),
+            drafts.renderedThumbnailPath.equals(filename) |
+            drafts.customThumbnailPath.equals(filename),
       );
     final result = await query.getSingle();
     return (result.read(drafts.id.count()) ?? 0) > 0;
@@ -284,6 +286,7 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
     required String data,
     required String? renderedFilePath,
     required String? renderedThumbnailPath,
+    required String? customThumbnailPath,
     required List<DraftClipData> clipDataList,
     int publishAttempts = 0,
     String? publishError,
@@ -304,6 +307,7 @@ class DraftsDao extends DatabaseAccessor<AppDatabase> with _$DraftsDaoMixin {
           data: data,
           renderedFilePath: Value(renderedFilePath),
           renderedThumbnailPath: Value(renderedThumbnailPath),
+          customThumbnailPath: Value(customThumbnailPath),
           ownerPubkey: Value(ownerPubkey),
         ),
       );

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -518,6 +518,10 @@ class Drafts extends Table {
   TextColumn get renderedThumbnailPath =>
       text().nullable().named('rendered_thumbnail_path')();
 
+  /// Basename of the selected custom cover thumbnail (for indexed lookups)
+  TextColumn get customThumbnailPath =>
+      text().nullable().named('custom_thumbnail_path')();
+
   /// Hex public key of the account that owns this draft.
   /// NULL for legacy drafts created before multi-account support.
   TextColumn get ownerPubkey => text().nullable().named('owner_pubkey')();
@@ -555,6 +559,11 @@ class Drafts extends Table {
       'idx_draft_rendered_thumbnail_path',
       'CREATE INDEX IF NOT EXISTS idx_draft_rendered_thumbnail_path '
           'ON drafts (rendered_thumbnail_path)',
+    ),
+    Index(
+      'idx_draft_custom_thumbnail_path',
+      'CREATE INDEX IF NOT EXISTS idx_draft_custom_thumbnail_path '
+          'ON drafts (custom_thumbnail_path)',
     ),
   ];
 }

--- a/mobile/packages/db_client/test/src/database/daos/drafts_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/drafts_dao_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Unit tests for DraftsDao - focused on isRenderedFileReferenced
+// ABOUTME: Unit tests for DraftsDao - focused on isDraftFileReferenced
 // ABOUTME: and basic CRUD operations.
 
 import 'dart:io';
@@ -33,7 +33,7 @@ void main() {
   });
 
   group(DraftsDao, () {
-    group('isRenderedFileReferenced', () {
+    group('isDraftFileReferenced', () {
       test('returns true when filename matches renderedFilePath', () async {
         await dao.upsertDraft(
           id: 'draft_1',
@@ -47,7 +47,7 @@ void main() {
           data: '{}',
         );
 
-        final result = await dao.isRenderedFileReferenced('rendered_video.mp4');
+        final result = await dao.isDraftFileReferenced('rendered_video.mp4');
         expect(result, isTrue);
       });
 
@@ -66,12 +66,32 @@ void main() {
             data: '{}',
           );
 
-          final result = await dao.isRenderedFileReferenced(
+          final result = await dao.isDraftFileReferenced(
             'rendered_thumb.jpeg',
           );
           expect(result, isTrue);
         },
       );
+
+      test('returns true when filename matches customThumbnailPath', () async {
+        await dao.upsertDraft(
+          id: 'draft_1',
+          title: 'Test',
+          description: '',
+          publishStatus: 'draft',
+          createdAt: DateTime(2023, 11, 14),
+          lastModified: DateTime(2023, 11, 14),
+          renderedFilePath: null,
+          renderedThumbnailPath: null,
+          customThumbnailPath: 'selected_cover.jpeg',
+          data: '{}',
+        );
+
+        final result = await dao.isDraftFileReferenced(
+          'selected_cover.jpeg',
+        );
+        expect(result, isTrue);
+      });
 
       test('returns false when filename is not referenced', () async {
         await dao.upsertDraft(
@@ -86,12 +106,12 @@ void main() {
           data: '{}',
         );
 
-        final result = await dao.isRenderedFileReferenced('nonexistent.mp4');
+        final result = await dao.isDraftFileReferenced('nonexistent.mp4');
         expect(result, isFalse);
       });
 
       test('returns false when no drafts exist', () async {
-        final result = await dao.isRenderedFileReferenced('anything.mp4');
+        final result = await dao.isDraftFileReferenced('anything.mp4');
         expect(result, isFalse);
       });
 
@@ -109,7 +129,7 @@ void main() {
           data: '{}',
         );
 
-        final result = await dao.isRenderedFileReferenced('something.mp4');
+        final result = await dao.isDraftFileReferenced('something.mp4');
         expect(result, isFalse);
       });
 
@@ -138,8 +158,8 @@ void main() {
           data: '{}',
         );
 
-        expect(await dao.isRenderedFileReferenced('video_b.mp4'), isTrue);
-        expect(await dao.isRenderedFileReferenced('video_c.mp4'), isFalse);
+        expect(await dao.isDraftFileReferenced('video_b.mp4'), isTrue);
+        expect(await dao.isDraftFileReferenced('video_c.mp4'), isFalse);
       });
     });
 
@@ -314,6 +334,7 @@ void main() {
           lastModified: DateTime(2023, 11, 14),
           renderedFilePath: null,
           renderedThumbnailPath: null,
+          customThumbnailPath: null,
           data: '{}',
           clipDataList: const [],
           ownerPubkey: pubkeyA,

--- a/mobile/test/models/divine_video_draft_cover_thumbnail_test.dart
+++ b/mobile/test/models/divine_video_draft_cover_thumbnail_test.dart
@@ -1,0 +1,114 @@
+// ABOUTME: Tests for DivineVideoDraft.coverThumbnailPath getter
+// ABOUTME: Validates the selected cover is preferred over the source clip
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+DivineVideoClip _clip({required String id, String? thumbnailPath}) =>
+    DivineVideoClip(
+      id: id,
+      video: EditorVideo.file('/tmp/$id.mp4'),
+      duration: const Duration(seconds: 6),
+      recordedAt: DateTime(2025),
+      originalAspectRatio: 9 / 16,
+      targetAspectRatio: .vertical,
+      thumbnailPath: thumbnailPath,
+    );
+
+DivineVideoDraft _draft({
+  required List<DivineVideoClip> clips,
+  DivineVideoClip? finalRenderedClip,
+  String? customThumbnailPath,
+}) => DivineVideoDraft(
+  id: 'draft_1',
+  clips: clips,
+  title: '',
+  description: '',
+  hashtags: const {},
+  selectedApproach: 'camera',
+  createdAt: DateTime(2025),
+  lastModified: DateTime(2025),
+  publishStatus: PublishStatus.draft,
+  publishAttempts: 0,
+  finalRenderedClip: finalRenderedClip,
+  customThumbnailPath: customThumbnailPath,
+);
+
+void main() {
+  group(DivineVideoDraft, () {
+    group('coverThumbnailPath', () {
+      test('prefers the custom cover over the rendered and source clips', () {
+        final draft = _draft(
+          clips: [_clip(id: 'source', thumbnailPath: '/docs/source.jpg')],
+          finalRenderedClip: _clip(
+            id: 'rendered',
+            thumbnailPath: '/docs/rendered.jpg',
+          ),
+          customThumbnailPath: '/docs/custom.jpg',
+        );
+
+        expect(draft.coverThumbnailPath, '/docs/custom.jpg');
+      });
+
+      test('prefers the rendered clip cover over the source clip', () {
+        final draft = _draft(
+          clips: [_clip(id: 'source', thumbnailPath: '/docs/source.jpg')],
+          finalRenderedClip: _clip(
+            id: 'rendered',
+            thumbnailPath: '/docs/cover.jpg',
+          ),
+        );
+
+        expect(draft.coverThumbnailPath, '/docs/cover.jpg');
+      });
+
+      test('falls back to the first source clip when no rendered clip', () {
+        final draft = _draft(
+          clips: [_clip(id: 'source', thumbnailPath: '/docs/source.jpg')],
+        );
+
+        expect(draft.coverThumbnailPath, '/docs/source.jpg');
+      });
+
+      test('returns null when there is no thumbnail anywhere', () {
+        final draft = _draft(clips: [_clip(id: 'source')]);
+
+        expect(draft.coverThumbnailPath, isNull);
+      });
+
+      test('returns null when there are no clips', () {
+        final draft = _draft(clips: const []);
+
+        expect(draft.coverThumbnailPath, isNull);
+      });
+    });
+
+    group('customThumbnailPath serialization', () {
+      test('round-trips as a basename resolved against the documents '
+          'path', () {
+        final draft = _draft(
+          clips: [_clip(id: 'source')],
+          customThumbnailPath: '/old/container/cover.jpg',
+        );
+
+        final json = draft.toJson();
+        expect(
+          json['customThumbnailPath'],
+          'cover.jpg',
+          reason: 'only the basename is persisted for iOS path stability',
+        );
+
+        final restored = DivineVideoDraft.fromJson(json, '/new/container');
+        expect(restored.customThumbnailPath, '/new/container/cover.jpg');
+      });
+
+      test('omits the key when there is no custom cover', () {
+        final draft = _draft(clips: [_clip(id: 'source')]);
+
+        expect(draft.toJson().containsKey('customThumbnailPath'), isFalse);
+      });
+    });
+  });
+}

--- a/mobile/test/models/video_editor_state_test.dart
+++ b/mobile/test/models/video_editor_state_test.dart
@@ -114,5 +114,79 @@ void main() {
 
       expect(cleared.selectedSound, isNull);
     });
+
+    test('thumbnailTimestamp defaults to null', () {
+      final state = VideoEditorProviderState();
+
+      expect(state.thumbnailTimestamp, isNull);
+    });
+
+    test('copyWith updates thumbnailTimestamp', () {
+      final state = VideoEditorProviderState();
+
+      final updated = state.copyWith(
+        thumbnailTimestamp: const Duration(seconds: 2),
+      );
+
+      expect(updated.thumbnailTimestamp, const Duration(seconds: 2));
+    });
+
+    test('thumbnailTimestamp survives clearFinalRenderedClip', () {
+      final state = VideoEditorProviderState(
+        thumbnailTimestamp: const Duration(seconds: 2),
+      );
+
+      final cleared = state.copyWith(clearFinalRenderedClip: true);
+
+      expect(
+        cleared.thumbnailTimestamp,
+        const Duration(seconds: 2),
+        reason:
+            'invalidating the rendered clip must not discard the selected '
+            'cover position',
+      );
+    });
+
+    test('copyWith with clearThumbnailTimestamp sets it to null', () {
+      final state = VideoEditorProviderState(
+        thumbnailTimestamp: const Duration(seconds: 2),
+      );
+
+      final cleared = state.copyWith(clearThumbnailTimestamp: true);
+
+      expect(cleared.thumbnailTimestamp, isNull);
+    });
+
+    test('customThumbnailPath defaults to null', () {
+      final state = VideoEditorProviderState();
+
+      expect(state.customThumbnailPath, isNull);
+    });
+
+    test('customThumbnailPath survives clearFinalRenderedClip', () {
+      final state = VideoEditorProviderState(
+        customThumbnailPath: '/docs/cover.jpg',
+      );
+
+      final cleared = state.copyWith(clearFinalRenderedClip: true);
+
+      expect(
+        cleared.customThumbnailPath,
+        '/docs/cover.jpg',
+        reason:
+            'invalidating the rendered clip must not discard the selected '
+            'cover image path',
+      );
+    });
+
+    test('copyWith with clearCustomThumbnailPath sets it to null', () {
+      final state = VideoEditorProviderState(
+        customThumbnailPath: '/docs/cover.jpg',
+      );
+
+      final cleared = state.copyWith(clearCustomThumbnailPath: true);
+
+      expect(cleared.customThumbnailPath, isNull);
+    });
   });
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -10,6 +10,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -689,6 +690,43 @@ void main() {
           const Duration(seconds: 2),
         );
       });
+
+      test('persists the cover position on state so it survives a '
+          're-render', () {
+        final notifier = container.read(videoEditorProvider.notifier);
+
+        notifier.state = notifier.state.copyWith(
+          finalRenderedClip: DivineVideoClip(
+            id: 'rendered',
+            video: EditorVideo.file('/docs/rendered.mp4'),
+            duration: const Duration(seconds: 5),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+          ),
+        );
+
+        notifier.updateCover(
+          thumbnailPath: '/docs/cover.jpg',
+          thumbnailTimestamp: const Duration(seconds: 2),
+        );
+
+        final state = container.read(videoEditorProvider);
+        expect(
+          state.thumbnailTimestamp,
+          const Duration(seconds: 2),
+          reason:
+              'updateCover must record the cover position on state, not '
+              'only on finalRenderedClip, so it survives invalidation',
+        );
+        expect(
+          state.customThumbnailPath,
+          '/docs/cover.jpg',
+          reason:
+              'updateCover must record the cover image path durably so cover '
+              'displays survive finalRenderedClip being cleared',
+        );
+      });
     });
 
     group('cancelRenderVideo', () {
@@ -1097,6 +1135,133 @@ void main() {
           () => mockDraftStorage.getDraftById(VideoEditorConstants.autoSaveId),
         ).called(1);
       });
+
+      test('restores the saved cover position onto state', () async {
+        final draft = DivineVideoDraft.create(
+          id: 'draft-1',
+          clips: [
+            DivineVideoClip(
+              id: 'c1',
+              video: EditorVideo.file('/docs/clip.mp4'),
+              duration: const Duration(seconds: 3),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Title',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+          thumbnailTimestamp: const Duration(milliseconds: 900),
+        );
+        when(
+          () => mockDraftStorage.getDraftById('draft-1'),
+        ).thenAnswer((_) async => draft);
+
+        final result = await container
+            .read(videoEditorProvider.notifier)
+            .restoreDraft('draft-1');
+
+        expect(result, isTrue);
+        expect(
+          container.read(videoEditorProvider).thumbnailTimestamp,
+          const Duration(milliseconds: 900),
+          reason: 'reopening a draft must restore the selected cover position',
+        );
+      });
+
+      test('restores the durable custom cover path onto state', () async {
+        final draft = DivineVideoDraft.create(
+          id: 'draft-1',
+          clips: [
+            DivineVideoClip(
+              id: 'c1',
+              video: EditorVideo.file('/docs/clip.mp4'),
+              duration: const Duration(seconds: 3),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Title',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+          thumbnailTimestamp: const Duration(milliseconds: 900),
+          customThumbnailPath: '/docs/cover.jpg',
+        );
+        when(
+          () => mockDraftStorage.getDraftById('draft-1'),
+        ).thenAnswer((_) async => draft);
+
+        await container
+            .read(videoEditorProvider.notifier)
+            .restoreDraft('draft-1');
+
+        expect(
+          container.read(videoEditorProvider).customThumbnailPath,
+          '/docs/cover.jpg',
+          reason:
+              'the selected cover image path must survive reopening a draft, '
+              'independently of finalRenderedClip (#5181)',
+        );
+      });
+    });
+  });
+
+  group('cover thumbnail persistence', () {
+    late ProviderContainer container;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      container = ProviderContainer(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('getActiveDraft sources thumbnailTimestamp from the persisted '
+        'cover position when finalRenderedClip is absent', () {
+      final notifier = container.read(videoEditorProvider.notifier);
+
+      container
+          .read(clipManagerProvider.notifier)
+          .addClip(
+            limitClipDuration: false,
+            video: EditorVideo.file('/docs/original.mp4'),
+            targetAspectRatio: .vertical,
+            originalAspectRatio: 9 / 16,
+            duration: const Duration(seconds: 2),
+          );
+
+      // The cover lives only on state, mirroring the window after invalidation
+      // clears finalRenderedClip but before a re-render.
+      notifier.state = notifier.state.copyWith(
+        thumbnailTimestamp: const Duration(milliseconds: 1200),
+        customThumbnailPath: '/docs/cover.jpg',
+      );
+
+      final draft = notifier.getActiveDraft();
+
+      expect(
+        draft.thumbnailTimestamp,
+        const Duration(milliseconds: 1200),
+        reason:
+            'the published cover is derived from draft.thumbnailTimestamp, so '
+            'it must reflect the selected position even without a rendered clip',
+      );
+      expect(
+        draft.customThumbnailPath,
+        '/docs/cover.jpg',
+        reason:
+            'the durable cover path must persist so the drafts list keeps '
+            'showing the selected cover after finalRenderedClip is cleared',
+      );
     });
   });
 }

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -1020,6 +1020,43 @@ void main() {
           reason: 'deleting a draft must remove its user-selected cover',
         );
       });
+
+      test('keeps a cover referenced by a saved draft when autosave is '
+          'deleted', () async {
+        final cover = writeCover('shared_cover.jpg');
+        final autosave = draftWithCover(cover.path).copyWith(
+          id: 'draft_autosave',
+        );
+        final savedDraft = draftWithCover(cover.path).copyWith(
+          id: 'draft_named',
+        );
+
+        await service.saveDraft(autosave);
+        await service.saveDraft(savedDraft);
+
+        await service.deleteDraft(autosave.id);
+
+        expect(
+          cover.existsSync(),
+          isTrue,
+          reason:
+              'custom cover paths are draft references even when they are not '
+              'mirrored on finalRenderedClip',
+        );
+      });
+
+      test('deletes custom cover files when all drafts are cleared', () async {
+        final cover = writeCover('clear_all_cover.jpg');
+        await service.saveDraft(draftWithCover(cover.path));
+
+        await service.clearAllDrafts();
+
+        expect(
+          cover.existsSync(),
+          isFalse,
+          reason: 'clearing all drafts should not leak custom cover files',
+        );
+      });
     });
   });
 }

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Tests save, load, delete, clear, and migration operations using Drift
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
@@ -10,6 +11,7 @@ import 'package:models/models.dart' show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/services/draft_storage_service.dart';
+import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -930,6 +932,94 @@ void main() {
           expect(drafts.first.clips, hasLength(2));
         },
       );
+    });
+
+    group('custom cover file hygiene', () {
+      late Directory docsDir;
+
+      setUp(() {
+        docsDir = Directory(documentsPath)..createSync(recursive: true);
+      });
+
+      tearDown(() {
+        if (docsDir.existsSync()) docsDir.deleteSync(recursive: true);
+      });
+
+      File writeCover(String name) {
+        final file = File(p.join(documentsPath, name));
+        file.writeAsBytesSync(const [0, 1, 2, 3]);
+        return file;
+      }
+
+      DivineVideoDraft draftWithCover(String coverPath) =>
+          DivineVideoDraft.create(
+            id: 'draft_cover',
+            clips: [
+              DivineVideoClip(
+                id: 'clip_cover',
+                video: EditorVideo.file('/path/to/video.mp4'),
+                duration: const Duration(seconds: 6),
+                recordedAt: DateTime(2025),
+                targetAspectRatio: AspectRatio.square,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Cover draft',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            customThumbnailPath: coverPath,
+          );
+
+      test('preserves the active cover file across a re-save', () async {
+        final cover = writeCover('cover.jpg');
+        await service.saveDraft(draftWithCover(cover.path));
+
+        // An autosave after an unrelated edit re-saves the same draft.
+        await service.saveDraft(
+          draftWithCover(cover.path).copyWith(title: 'Updated'),
+        );
+
+        expect(
+          cover.existsSync(),
+          isTrue,
+          reason:
+              're-saving a draft must keep its still-referenced custom cover',
+        );
+      });
+
+      test('deletes the previous cover when a new one is selected', () async {
+        final oldCover = writeCover('old_cover.jpg');
+        final newCover = writeCover('new_cover.jpg');
+
+        await service.saveDraft(draftWithCover(oldCover.path));
+        await service.saveDraft(draftWithCover(newCover.path));
+
+        expect(
+          oldCover.existsSync(),
+          isFalse,
+          reason: 'the replaced cover is orphaned and must be cleaned up',
+        );
+        expect(
+          newCover.existsSync(),
+          isTrue,
+          reason: 'the newly selected cover must be kept',
+        );
+      });
+
+      test('deletes the cover file when the draft is deleted', () async {
+        final cover = writeCover('cover.jpg');
+        final draft = draftWithCover(cover.path);
+        await service.saveDraft(draft);
+
+        await service.deleteDraft(draft.id);
+
+        expect(
+          cover.existsSync(),
+          isFalse,
+          reason: 'deleting a draft must remove its user-selected cover',
+        );
+      });
     });
   });
 }

--- a/mobile/test/services/file_cleanup_service_test.dart
+++ b/mobile/test/services/file_cleanup_service_test.dart
@@ -29,7 +29,7 @@ void main() {
       );
 
       verifyNever(() => clipsDao.isFileReferenced(any()));
-      verifyNever(() => draftsDao.isRenderedFileReferenced(any()));
+      verifyNever(() => draftsDao.isDraftFileReferenced(any()));
     });
   });
 }


### PR DESCRIPTION
## Description

Saving a video post **for later** did not preserve the selected cover
thumbnail or text-overlay font/size. Reopening the saved post and publishing
could revert both.

Two independent root causes:

1. **Cover loss.** The selected cover image path and position were stored only
   on the ephemeral `finalRenderedClip`, which is cleared when the draft is
   reopened or edited. The drafts list, metadata preview, profile grid, and
   publish path could then fall back to the default source thumbnail.
2. **Font loss.** Text overlays serialize only the Google Fonts family name.
   `GoogleFonts.x()` registers its font loader as a side effect of being
   called; on a fresh restore that had not happened yet, so imported overlays
   rendered with the default font.

### Changes

- Add durable `customThumbnailPath` and `thumbnailTimestamp` state to
  `DivineVideoDraft` and the editor provider, decoupled from
  `finalRenderedClip`.
- Display draft/upload covers through `DivineVideoDraft.coverThumbnailPath`,
  preferring the custom cover before rendered/source thumbnails.
- Restore editor text fonts before importing saved overlay history.
- Add an indexed `custom_thumbnail_path` draft column, migration/backfill, and
  generated Drift output so file cleanup can see custom covers without loading
  JSON blobs.
- Rename the draft reference check to `isDraftFileReferenced` and include
  rendered video, rendered thumbnail, and custom cover columns.
- Fix draft orphan cleanup ordering: old files are deleted only after the new
  draft rows are committed, so the row being updated no longer protects files
  it just stopped using.
- Include custom covers in `deleteDraft` and `clearAllDrafts` cleanup.

### Regression Coverage

- Cover getter priority and JSON basename round-trip.
- Editor state cover fields surviving rendered-clip invalidation.
- Provider restore/getActiveDraft cover persistence.
- DAO custom-cover reference detection.
- Draft storage cleanup for replacing covers, deleting drafts, clearing all
  drafts, and deleting autosave while a named draft still references the same
  custom cover.

**Related Issue:** Closes #5181

## Verification

- `mise exec -- dart run build_runner build --delete-conflicting-outputs`
  from `mobile/packages/db_client`
- `mise exec -- flutter analyze lib test packages/db_client/lib packages/db_client/test`
  from `mobile`
- `mise exec -- flutter test test/services/file_cleanup_service_test.dart test/services/draft_storage_service_test.dart test/models/divine_video_draft_cover_thumbnail_test.dart test/models/video_editor_state_test.dart test/providers/video_editor_provider_test.dart`
  from `mobile`
- `mise exec -- flutter test test/src/database/daos/drafts_dao_test.dart`
  from `mobile/packages/db_client`
- Pre-push hook: merge-conflict check, analyzer, generated-files check, and
  changed-file tests all passed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
