### PR TITLE
fix(library): prevent draft posts from dropping editor layers

### DIFF
--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -456,11 +456,12 @@ class DivineVideoDraft {
 
   /// Whether the draft can be posted directly from the library.
   ///
-  /// Requires [finalRenderedClip] so the published video includes all editor
-  /// layers (text, stickers, filters). Without a render, posting falls back to
-  /// the raw recording and silently drops those layers, so the post action
-  /// stays hidden until a render exists.
-  bool get canPost => finalRenderedClip != null;
+  /// Single-clip drafts require [finalRenderedClip] so the published video
+  /// includes all editor layers (text, stickers, filters). Without a render,
+  /// the single-clip publish path falls back to the raw recording and silently
+  /// drops those layers. Multi-clip drafts can still be posted because the
+  /// publish path renders them before upload.
+  bool get canPost => finalRenderedClip != null || clips.length > 1;
 
   bool get hasEditorStateEdits {
     if (editorStateHistory.isEmpty) return false;

--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -454,6 +454,14 @@ class DivineVideoDraft {
   bool get canRetry => publishStatus == PublishStatus.failed;
   bool get isPublishing => publishStatus == PublishStatus.publishing;
 
+  /// Whether the draft can be posted directly from the library.
+  ///
+  /// Requires [finalRenderedClip] so the published video includes all editor
+  /// layers (text, stickers, filters). Without a render, posting falls back to
+  /// the raw recording and silently drops those layers, so the post action
+  /// stays hidden until a render exists.
+  bool get canPost => finalRenderedClip != null;
+
   bool get hasEditorStateEdits {
     if (editorStateHistory.isEmpty) return false;
 

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -356,7 +356,7 @@ class DraftStorageService {
       );
     }
 
-    return draft.copyWith(clips: validClips);
+    return _clearMissingFinalRenderedClip(draft.copyWith(clips: validClips));
   }
 
   /// Get the autosaved draft with validation.
@@ -381,6 +381,21 @@ class DraftStorageService {
     }).toList();
   }
 
+  DivineVideoDraft _clearMissingFinalRenderedClip(DivineVideoDraft draft) {
+    final finalClip = draft.finalRenderedClip;
+    if (finalClip == null) return draft;
+
+    final videoPath = finalClip.video.file?.path;
+    if (videoPath != null && File(videoPath).existsSync()) return draft;
+
+    Log.info(
+      '📝 Draft ${draft.id}: final rendered clip missing, clearing reference',
+      name: 'DraftStorageService',
+      category: LogCategory.video,
+    );
+    return draft.copyWith(clearFinalRenderedClip: true);
+  }
+
   /// Get all drafts from storage
   Future<List<DivineVideoDraft>> getAllDrafts() async {
     try {
@@ -402,7 +417,7 @@ class DraftStorageService {
           clipRows: clipRows,
           documentsPath: documentsPath,
         );
-        drafts.add(draft);
+        drafts.add(_clearMissingFinalRenderedClip(draft));
       }
 
       // Clean up corrupted drafts (0 clips) in the background

--- a/mobile/lib/widgets/library/drafts_tab.dart
+++ b/mobile/lib/widgets/library/drafts_tab.dart
@@ -135,11 +135,12 @@ class DraftsTab extends ConsumerWidget {
       context: context,
       title: DraftListTile(draft: draft, enableShrink: true),
       options: [
-        VineBottomSheetActionData(
-          iconPath: DivineIconName.paperPlaneTilt.assetPath,
-          label: context.l10n.libraryDraftActionPost,
-          onTap: () => _postDraft(context, ref, draft),
-        ),
+        if (draft.canPost)
+          VineBottomSheetActionData(
+            iconPath: DivineIconName.paperPlaneTilt.assetPath,
+            label: context.l10n.libraryDraftActionPost,
+            onTap: () => _postDraft(context, ref, draft),
+          ),
         VineBottomSheetActionData(
           iconPath: DivineIconName.pencilSimple.assetPath,
           label: context.l10n.libraryDraftActionEdit,

--- a/mobile/test/models/divine_video_draft_can_post_test.dart
+++ b/mobile/test/models/divine_video_draft_can_post_test.dart
@@ -1,0 +1,45 @@
+// ABOUTME: Tests for DivineVideoDraft.canPost getter
+// ABOUTME: Validates the draft is only postable once a final render exists
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+DivineVideoClip _createTestClip() => DivineVideoClip(
+  id: 'clip_1',
+  video: EditorVideo.file('/tmp/test.mp4'),
+  duration: const Duration(seconds: 6),
+  recordedAt: DateTime(2025),
+  originalAspectRatio: 9 / 16,
+  targetAspectRatio: .vertical,
+);
+
+DivineVideoDraft _draft({DivineVideoClip? finalRenderedClip}) =>
+    DivineVideoDraft(
+      id: 'draft_1',
+      clips: [_createTestClip()],
+      title: '',
+      description: '',
+      hashtags: const {},
+      selectedApproach: 'camera',
+      createdAt: DateTime(2025),
+      lastModified: DateTime(2025),
+      publishStatus: PublishStatus.draft,
+      publishAttempts: 0,
+      finalRenderedClip: finalRenderedClip,
+    );
+
+void main() {
+  group(DivineVideoDraft, () {
+    group('canPost', () {
+      test('returns false when finalRenderedClip is null', () {
+        expect(_draft().canPost, isFalse);
+      });
+
+      test('returns true when finalRenderedClip is present', () {
+        expect(_draft(finalRenderedClip: _createTestClip()).canPost, isTrue);
+      });
+    });
+  });
+}

--- a/mobile/test/models/divine_video_draft_can_post_test.dart
+++ b/mobile/test/models/divine_video_draft_can_post_test.dart
@@ -1,13 +1,13 @@
 // ABOUTME: Tests for DivineVideoDraft.canPost getter
-// ABOUTME: Validates the draft is only postable once a final render exists
+// ABOUTME: Validates library draft post eligibility mirrors publish behavior
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
-DivineVideoClip _createTestClip() => DivineVideoClip(
-  id: 'clip_1',
+DivineVideoClip _createTestClip([String id = 'clip_1']) => DivineVideoClip(
+  id: id,
   video: EditorVideo.file('/tmp/test.mp4'),
   duration: const Duration(seconds: 6),
   recordedAt: DateTime(2025),
@@ -15,26 +15,37 @@ DivineVideoClip _createTestClip() => DivineVideoClip(
   targetAspectRatio: .vertical,
 );
 
-DivineVideoDraft _draft({DivineVideoClip? finalRenderedClip}) =>
-    DivineVideoDraft(
-      id: 'draft_1',
-      clips: [_createTestClip()],
-      title: '',
-      description: '',
-      hashtags: const {},
-      selectedApproach: 'camera',
-      createdAt: DateTime(2025),
-      lastModified: DateTime(2025),
-      publishStatus: PublishStatus.draft,
-      publishAttempts: 0,
-      finalRenderedClip: finalRenderedClip,
-    );
+DivineVideoDraft _draft({
+  List<DivineVideoClip>? clips,
+  DivineVideoClip? finalRenderedClip,
+}) => DivineVideoDraft(
+  id: 'draft_1',
+  clips: clips ?? [_createTestClip()],
+  title: '',
+  description: '',
+  hashtags: const {},
+  selectedApproach: 'camera',
+  createdAt: DateTime(2025),
+  lastModified: DateTime(2025),
+  publishStatus: PublishStatus.draft,
+  publishAttempts: 0,
+  finalRenderedClip: finalRenderedClip,
+);
 
 void main() {
   group(DivineVideoDraft, () {
     group('canPost', () {
-      test('returns false when finalRenderedClip is null', () {
+      test('returns false for single-clip draft without final render', () {
         expect(_draft().canPost, isFalse);
+      });
+
+      test('returns true for multi-clip draft without final render', () {
+        expect(
+          _draft(
+            clips: [_createTestClip(), _createTestClip('clip_2')],
+          ).canPost,
+          isTrue,
+        );
       });
 
       test('returns true when finalRenderedClip is present', () {

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -257,6 +257,40 @@ void main() {
         );
         expect(rowAfter, isNull);
       });
+
+      test('clears missing final rendered clip references', () async {
+        final draft = DivineVideoDraft.create(
+          clips: [
+            DivineVideoClip(
+              id: 'clip_1',
+              video: EditorVideo.file('/path/to/video.mp4'),
+              duration: const Duration(seconds: 6),
+              recordedAt: DateTime(2025),
+              targetAspectRatio: AspectRatio.square,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Rendered Draft',
+          description: '',
+          hashtags: {},
+          selectedApproach: 'video',
+          finalRenderedClip: DivineVideoClip(
+            id: 'rendered_clip',
+            video: EditorVideo.file('/path/to/missing-render.mp4'),
+            duration: const Duration(seconds: 6),
+            recordedAt: DateTime(2025),
+            targetAspectRatio: AspectRatio.square,
+            originalAspectRatio: 9 / 16,
+          ),
+        );
+
+        await service.saveDraft(draft);
+
+        final drafts = await service.getAllDrafts();
+        expect(drafts, hasLength(1));
+        expect(drafts.single.finalRenderedClip, isNull);
+        expect(drafts.single.canPost, isFalse);
+      });
     });
 
     group('deleteDraft', () {

--- a/mobile/test/widgets/library/drafts_tab_test.dart
+++ b/mobile/test/widgets/library/drafts_tab_test.dart
@@ -22,8 +22,8 @@ class _MockDraftsLibraryBloc
     extends MockBloc<DraftsLibraryEvent, DraftsLibraryState>
     implements DraftsLibraryBloc {}
 
-DivineVideoClip _createTestClip() => DivineVideoClip(
-  id: 'clip_1',
+DivineVideoClip _createTestClip([String id = 'clip_1']) => DivineVideoClip(
+  id: id,
   video: EditorVideo.file('/tmp/test.mp4'),
   duration: const Duration(seconds: 6),
   recordedAt: DateTime(2025),
@@ -40,11 +40,12 @@ void main() {
     DivineVideoDraft createDraft({
       String? id,
       String title = 'Test Draft',
+      List<DivineVideoClip> clips = const [],
       DivineVideoClip? finalRenderedClip,
     }) {
       return DivineVideoDraft(
         id: id ?? 'draft-${DateTime.now().millisecondsSinceEpoch}',
-        clips: const [],
+        clips: clips,
         title: title,
         description: 'Test Description',
         hashtags: const {},
@@ -203,9 +204,9 @@ void main() {
       testWidgets('hides post action when draft has no final render', (
         tester,
       ) async {
-        when(() => mockBloc.state).thenReturn(
-          DraftsLibraryLoaded(drafts: [createDraft(id: 'draft1')]),
-        );
+        when(
+          () => mockBloc.state,
+        ).thenReturn(DraftsLibraryLoaded(drafts: [createDraft(id: 'draft1')]));
 
         await tester.pumpWidget(buildWidget());
         await tester.tap(find.byType(IconButton));
@@ -233,6 +234,28 @@ void main() {
 
         expect(find.text(en.libraryDraftActionPost), findsOneWidget);
       });
+
+      testWidgets(
+        'shows post action for multi-clip draft without final render',
+        (tester) async {
+          when(() => mockBloc.state).thenReturn(
+            DraftsLibraryLoaded(
+              drafts: [
+                createDraft(
+                  id: 'draft1',
+                  clips: [_createTestClip(), _createTestClip('clip_2')],
+                ),
+              ],
+            ),
+          );
+
+          await tester.pumpWidget(buildWidget());
+          await tester.tap(find.byType(IconButton));
+          await tester.pumpAndSettle();
+
+          expect(find.text(en.libraryDraftActionPost), findsOneWidget);
+        },
+      );
     });
   });
 

--- a/mobile/test/widgets/library/drafts_tab_test.dart
+++ b/mobile/test/widgets/library/drafts_tab_test.dart
@@ -12,13 +12,24 @@ import 'package:openvine/blocs/drafts_library/drafts_library_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/widgets/library/drafts_tab.dart';
 import 'package:openvine/widgets/library/empty_library_state.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _MockDraftsLibraryBloc
     extends MockBloc<DraftsLibraryEvent, DraftsLibraryState>
     implements DraftsLibraryBloc {}
+
+DivineVideoClip _createTestClip() => DivineVideoClip(
+  id: 'clip_1',
+  video: EditorVideo.file('/tmp/test.mp4'),
+  duration: const Duration(seconds: 6),
+  recordedAt: DateTime(2025),
+  originalAspectRatio: 9 / 16,
+  targetAspectRatio: .vertical,
+);
 
 void main() {
   final en = AppLocalizationsEn();
@@ -26,7 +37,11 @@ void main() {
   group(DraftsTab, () {
     late _MockDraftsLibraryBloc mockBloc;
 
-    DivineVideoDraft createDraft({String? id, String title = 'Test Draft'}) {
+    DivineVideoDraft createDraft({
+      String? id,
+      String title = 'Test Draft',
+      DivineVideoClip? finalRenderedClip,
+    }) {
       return DivineVideoDraft(
         id: id ?? 'draft-${DateTime.now().millisecondsSinceEpoch}',
         clips: const [],
@@ -38,6 +53,7 @@ void main() {
         lastModified: DateTime(2026),
         publishStatus: PublishStatus.draft,
         publishAttempts: 0,
+        finalRenderedClip: finalRenderedClip,
       );
     }
 
@@ -180,6 +196,42 @@ void main() {
 
         expect(find.byType(EmptyLibraryState), findsOneWidget);
         expect(find.text('No Drafts Yet'), findsOneWidget);
+      });
+    });
+
+    group('post action', () {
+      testWidgets('hides post action when draft has no final render', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          DraftsLibraryLoaded(drafts: [createDraft(id: 'draft1')]),
+        );
+
+        await tester.pumpWidget(buildWidget());
+        await tester.tap(find.byType(IconButton));
+        await tester.pumpAndSettle();
+
+        expect(find.text(en.libraryDraftActionPost), findsNothing);
+        expect(find.text(en.libraryDraftActionEdit), findsOneWidget);
+        expect(find.text(en.libraryDraftActionDelete), findsOneWidget);
+      });
+
+      testWidgets('shows post action when draft has a final render', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          DraftsLibraryLoaded(
+            drafts: [
+              createDraft(id: 'draft1', finalRenderedClip: _createTestClip()),
+            ],
+          ),
+        );
+
+        await tester.pumpWidget(buildWidget());
+        await tester.tap(find.byType(IconButton));
+        await tester.pumpAndSettle();
+
+        expect(find.text(en.libraryDraftActionPost), findsOneWidget);
       });
     });
   });


### PR DESCRIPTION
Closes #5204

## Description

The draft options sheet offered Post for drafts even when posting could publish a source clip instead of the edited render. For single-clip drafts with no finalRenderedClip, video_publish_provider.dart falls back to draft.clips.first, which can silently drop editor layers such as text, stickers, filters, and other baked edits.

This keeps the Library shortcut aligned with the actual publish boundary:

- Single-clip drafts need a finalRenderedClip before Library shows Post.
- Multi-clip drafts can still show Post without a saved final render because the publish path renders them before upload and preserves editor state.
- Draft loading clears stale finalRenderedClip references when the rendered file is missing, so a broken render reference cannot make an unsafe single-clip draft appear postable.

Edit and Delete remain available for all drafts.

## Verification

- mise exec -- flutter test test/models/divine_video_draft_can_post_test.dart test/widgets/library/drafts_tab_test.dart test/services/draft_storage_service_test.dart
- mise exec -- flutter analyze lib test
- Pre-push hook: merge conflict check, changed-file analyze, changed-file tests

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)