### PR TITLE
fix(verifier): open verifyer in the system browser

### DIFF
--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -21,10 +21,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
-import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
-import 'package:openvine/screens/apps/web_iframe_sandbox_screen.dart';
 import 'package:openvine/screens/key_management_screen.dart';
-import 'package:openvine/utils/nostr_apps_platform_support.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/profile/nostr_info_sheet_content.dart';
 import 'package:openvine/widgets/profile/verified_accounts_row.dart';
@@ -477,36 +474,10 @@ class _ProfileSetupScreenViewState
               prev.verifierStatus != curr.verifierStatus &&
               curr.verifierStatus == VerifierStatus.launchRequested,
           listener: (context, state) async {
-            final editorBloc = context.read<ProfileEditorBloc>();
-            final myProfileBloc = context.read<MyProfileBloc>();
-            final verifyer = preloadedNostrApps.firstWhere(
-              (app) => app.slug == 'verifyer',
+            await launchVerifierFlow(
+              editorBloc: context.read<ProfileEditorBloc>(),
+              myProfileBloc: context.read<MyProfileBloc>(),
             );
-            if (nostrAppsSandboxSupported) {
-              // Native (iOS / Android / macOS): full webview_flutter
-              // sandbox with NIP-07 bridge injection.
-              await context.push(
-                NostrAppSandboxScreen.pathForAppId(verifyer.id),
-                extra: verifyer,
-              );
-            } else if (kIsWeb) {
-              // Flutter web: webview_flutter is unavailable, but we can
-              // host the verifyer in an <iframe> with a postMessage
-              // NIP-07 bridge to Divine's web signer.
-              await context.push(
-                WebIframeSandboxScreen.pathForAppId(verifyer.id),
-                extra: verifyer,
-              );
-            } else {
-              // Last-resort fallback for any future platform without
-              // either capability — open in the system browser.
-              await launchUrl(
-                Uri.parse(verifyer.launchUrl),
-                mode: LaunchMode.externalApplication,
-              );
-            }
-            editorBloc.add(const VerifierWebViewDismissed());
-            myProfileBloc.add(const MyProfileFetchRequested());
           },
         ),
       ],
@@ -1868,6 +1839,30 @@ class _VerifiedAccountsSection extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Opens the Divine verifyer in the system browser and refreshes the
+/// profile when the user returns.
+///
+/// The verifyer authenticates via login.divine.video and runs OAuth
+/// hand-offs to external platforms (bsky, github, x) to prove account
+/// ownership. Those flows need a real browser — new windows
+/// (`target="_blank"`), cross-site cookies, and provider redirects — which
+/// an in-app webview can't provide, so it is launched externally.
+@visibleForTesting
+Future<void> launchVerifierFlow({
+  required ProfileEditorBloc editorBloc,
+  required MyProfileBloc myProfileBloc,
+}) async {
+  final verifyer = preloadedNostrApps.firstWhere(
+    (app) => app.slug == 'verifyer',
+  );
+  await launchUrl(
+    Uri.parse(verifyer.launchUrl),
+    mode: LaunchMode.externalApplication,
+  );
+  editorBloc.add(const VerifierWebViewDismissed());
+  myProfileBloc.add(const MyProfileFetchRequested());
 }
 
 class _GetVerifiedTile extends StatelessWidget {

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -19,7 +19,10 @@ import 'package:openvine/screens/key_management_screen.dart';
 import 'package:openvine/screens/profile_setup_screen.dart';
 import 'package:openvine/widgets/profile_editor/username_status_indicator.dart';
 
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
 import '../helpers/test_provider_overrides.dart';
+import '../helpers/url_launcher_test_double.dart';
 
 class _MockProfileEditorBloc
     extends MockBloc<ProfileEditorEvent, ProfileEditorState>
@@ -860,5 +863,44 @@ void main() {
         },
       );
     });
+  });
+
+  group('launchVerifierFlow', () {
+    late UrlLauncherPlatform originalPlatform;
+    late UrlLauncherTestDouble launcher;
+    late _MockProfileEditorBloc editorBloc;
+    late _MockMyProfileBloc myProfileBloc;
+
+    setUp(() {
+      originalPlatform = UrlLauncherPlatform.instance;
+      launcher = UrlLauncherTestDouble();
+      UrlLauncherPlatform.instance = launcher;
+      editorBloc = _MockProfileEditorBloc();
+      myProfileBloc = _MockMyProfileBloc();
+    });
+
+    tearDown(() {
+      UrlLauncherPlatform.instance = originalPlatform;
+    });
+
+    test(
+      'opens the verifyer in the external browser and refreshes profile',
+      () async {
+        await launchVerifierFlow(
+          editorBloc: editorBloc,
+          myProfileBloc: myProfileBloc,
+        );
+
+        expect(launcher.launched, hasLength(1));
+        expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
+        expect(launcher.launched.single.useExternalApplication, isTrue);
+        verify(
+          () => editorBloc.add(const VerifierWebViewDismissed()),
+        ).called(1);
+        verify(
+          () => myProfileBloc.add(const MyProfileFetchRequested()),
+        ).called(1);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

Fixes the account-verification flow being unusable from the profile
editor (#4861).

The flow regressed in #4179 (`098a382d0`) when "Get verified" moved out
of the system browser and into the in-app `NostrAppSandboxScreen`. That
sandbox injects the NIP-07 signer and therefore **locks the WebView to
the app's own origin** — but the verifyer fundamentally can't run there:

- its **"Open login.divine.video"** button is an `<a target="_blank">`
  link (a *new window*, which an in-app WebView ignores → the tap does
  nothing), and
- it runs **OAuth hand-offs to external platforms** (bsky, github, x)
  with cross-site cookies and provider redirects.

Every step either hit the "Blocked for safety" origin guard or silently
did nothing.

This launches the verifyer in the **system browser** instead — the
pre-#4179 behaviour — where the full `login.divine.video` login + OAuth
round-trip works with real tabs, cookies, and redirects. The launch is
extracted into a `@visibleForTesting launchVerifierFlow()` so the
external-launch + profile-refresh contract is unit-tested.

**Related Issue:** Closes #4861

## Out of Scope

- **In-app `window.nostr` "browser signer" convenience**: not available
  in the system browser, so users sign via the verifyer's other supported
  methods (login.divine.video / bunker / Nostr Connect). Making the full
  OAuth flow work inside the sandbox would require multi-window
  (`target=_blank`) handling plus cross-site cookie/redirect support in
  webview_flutter — out of scope here.
- The verifyer's entry in the bundled Apps directory is unchanged.

## Verification

- `flutter test test/screens/profile_setup_screen_test.dart`: 45 passed,
  incl. new `launchVerifierFlow` test (asserts external launch of
  `https://verifyer.divine.video/` + `VerifierWebViewDismissed` +
  `MyProfileFetchRequested`).
- `flutter analyze` on changed files: no issues.
- Pre-push hook (analyze + changed-file tests): green.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
