### PR TITLE
fix(grid): center load-more indicator below grid with branded spinner

### DIFF
--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/utils/delete_failure_localization.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
 import 'package:openvine/widgets/user_name.dart';
@@ -138,18 +139,12 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
         ? 3
         : widget.crossAxisCount;
 
-    // Calculate total item count (videos + optional loading indicator)
+    // Whether to render the load-more footer below the grid.
     final showLoadingIndicator =
         widget.isLoadingMore ||
         (widget.hasMoreContent && widget.onLoadMore != null);
-    final totalItemCount = videosToShow.length + (showLoadingIndicator ? 1 : 0);
 
     Widget buildItem(BuildContext context, int index) {
-      // If this is the last item and we're loading more, show loading indicator
-      if (index == videosToShow.length) {
-        return _LoadingMoreIndicator(isLoading: widget.isLoadingMore);
-      }
-
       final video = videosToShow[index];
       final listIds = subscribedListCache?.getListsForVideo(video.id);
       final isInSubscribedList = listIds != null && listIds.isNotEmpty;
@@ -165,30 +160,44 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
       );
     }
 
-    final gridView = widget.useMasonryLayout
-        ? MasonryGridView.count(
-            controller: _scrollController,
-            padding: widget.padding ?? const EdgeInsets.all(4),
+    final gridPadding =
+        widget.padding ??
+        (widget.useMasonryLayout
+            ? const EdgeInsets.all(4)
+            : const EdgeInsets.all(12));
+
+    final gridSliver = widget.useMasonryLayout
+        ? SliverMasonryGrid.count(
             crossAxisCount: responsiveCrossAxisCount,
             mainAxisSpacing: 4,
             crossAxisSpacing: 4,
-            itemCount: totalItemCount,
+            childCount: videosToShow.length,
             itemBuilder: buildItem,
           )
-        : GridView.builder(
-            controller: _scrollController,
-            padding: widget.padding ?? const EdgeInsets.all(12),
+        : SliverGrid.builder(
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: responsiveCrossAxisCount,
               childAspectRatio: widget.thumbnailAspectRatio,
               crossAxisSpacing: 12,
               mainAxisSpacing: 12,
             ),
-            itemCount: totalItemCount,
+            itemCount: videosToShow.length,
             itemBuilder: buildItem,
           );
 
-    return _wrapWithRefreshIndicator(context, gridView);
+    final scrollView = CustomScrollView(
+      controller: _scrollController,
+      physics: const AlwaysScrollableScrollPhysics(),
+      slivers: [
+        SliverPadding(padding: gridPadding, sliver: gridSliver),
+        if (showLoadingIndicator)
+          SliverToBoxAdapter(
+            child: _LoadingMoreIndicator(isLoading: widget.isLoadingMore),
+          ),
+      ],
+    );
+
+    return _wrapWithRefreshIndicator(context, scrollView);
   }
 
   Widget _buildEmptyState(BuildContext context) {
@@ -639,7 +648,7 @@ class _VideoThumbnail extends StatelessWidget {
   }
 }
 
-/// Loading indicator shown at the bottom of the grid during pagination
+/// Loading indicator shown centered below the grid during pagination.
 class _LoadingMoreIndicator extends StatelessWidget {
   const _LoadingMoreIndicator({required this.isLoading});
 
@@ -647,19 +656,13 @@ class _LoadingMoreIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 60,
-      alignment: Alignment.center,
-      child: isLoading
-          ? const SizedBox(
-              width: 24,
-              height: 24,
-              child: CircularProgressIndicator(
-                strokeWidth: 2,
-                color: VineTheme.vineGreen,
-              ),
-            )
-          : const SizedBox.shrink(),
+    if (!isLoading) {
+      return const SizedBox.shrink();
+    }
+
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 16),
+      child: Center(child: BrandedLoadingIndicator(size: 48)),
     );
   }
 }

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -28,6 +28,7 @@ import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/broken_video_tracker.dart' as broken_tracker;
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
 
 void main() {
@@ -346,5 +347,90 @@ void main() {
       expect(find.text('5s'), findsOneWidget); // duration badge
       // TODO(any): Fix and re-enable these tests
     }, skip: true);
+
+    group('load-more footer', () {
+      // Renders the grid path with no tiles (empty list + no emptyBuilder) so
+      // the footer can be exercised without the video-tile Nostr/network chain.
+      Widget buildGrid({
+        required bool isLoadingMore,
+        required bool hasMoreContent,
+        Future<void> Function()? onLoadMore,
+      }) {
+        return ProviderScope(
+          overrides: [
+            brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            subscribedListVideoCacheProvider.overrideWithValue(null),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: ComposableVideoGrid(
+                videos: const [],
+                onVideoTap: (videos, index) {},
+                isLoadingMore: isLoadingMore,
+                hasMoreContent: hasMoreContent,
+                onLoadMore: onLoadMore,
+              ),
+            ),
+          ),
+        );
+      }
+
+      testWidgets(
+        'shows a centered $BrandedLoadingIndicator below the scrolling grid '
+        'while loading more',
+        (tester) async {
+          await tester.pumpWidget(
+            buildGrid(
+              isLoadingMore: true,
+              hasMoreContent: true,
+              onLoadMore: () async {},
+            ),
+          );
+          await tester.pump(); // resolve broken-tracker future
+
+          expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
+          // The footer is no longer a grid cell: the grid is a sliver scroll
+          // view and the legacy box-scrolling GridView is gone.
+          expect(find.byType(CustomScrollView), findsOneWidget);
+          expect(find.byType(GridView), findsNothing);
+
+          // Horizontally centered across the full grid width (800px surface).
+          final indicatorCenter = tester.getCenter(
+            find.byType(BrandedLoadingIndicator),
+          );
+          expect(indicatorCenter.dx, moreOrLessEquals(400, epsilon: 1));
+        },
+      );
+
+      testWidgets('does not show the loading indicator when not loading more', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildGrid(
+            isLoadingMore: false,
+            hasMoreContent: true,
+            onLoadMore: () async {},
+          ),
+        );
+        await tester.pump();
+
+        // Footer slot exists (more content available) but stays empty until
+        // a load actually starts.
+        expect(find.byType(BrandedLoadingIndicator), findsNothing);
+      });
+
+      testWidgets('omits the loading indicator when there is no more content', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildGrid(isLoadingMore: false, hasMoreContent: false),
+        );
+        await tester.pump();
+
+        expect(find.byType(BrandedLoadingIndicator), findsNothing);
+      });
+    });
   });
 }

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -397,11 +397,17 @@ void main() {
           expect(find.byType(CustomScrollView), findsOneWidget);
           expect(find.byType(GridView), findsNothing);
 
-          // Horizontally centered across the full grid width (800px surface).
+          // Horizontally centered across the full scrollable width.
           final indicatorCenter = tester.getCenter(
             find.byType(BrandedLoadingIndicator),
           );
-          expect(indicatorCenter.dx, moreOrLessEquals(400, epsilon: 1));
+          final scrollViewCenter = tester.getCenter(
+            find.byType(CustomScrollView),
+          );
+          expect(
+            indicatorCenter.dx,
+            moreOrLessEquals(scrollViewCenter.dx, epsilon: 1),
+          );
         },
       );
 

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -1,9 +1,10 @@
 // ABOUTME: Tests for ComposableVideoGrid widget
 // ABOUTME: Verifies grid rendering, broken video filtering, and user interactions
 //
-// NOTE: These tests fail because ComposableVideoGrid uses UserName widget which
-// triggers the Nostr provider chain (userProfileReactive -> userProfileService ->
-// nostrService) that attempts real WebSocket connections to relays.
+// NOTE: Tests that render video tiles are skipped because ComposableVideoGrid
+// uses UserName widget, which triggers the Nostr provider chain
+// (userProfileReactive -> userProfileService -> nostrService) that attempts
+// real WebSocket connections to relays.
 //
 // Flutter's TestWidgetsFlutterBinding automatically intercepts and mocks all
 // HTTP/WebSocket connections, returning "Mocked response" errors. This is built
@@ -15,9 +16,9 @@
 // That version uses IntegrationTestWidgetsFlutterBinding which allows real
 // network connections and tests the widget in the context of the running app.
 //
-// These widget tests are kept for reference and potential future refactoring
-// where ComposableVideoGrid could accept profile data as props instead of
-// fetching via providers, which would allow isolated widget testing.
+// The skipped tile tests are kept for reference and potential future
+// refactoring where ComposableVideoGrid could accept profile data as props
+// instead of fetching via providers, which would allow isolated widget testing.
 
 import 'dart:ui' show PointerDeviceKind;
 


### PR DESCRIPTION
Closes #5207

## Description

The pagination load-more indicator in `ComposableVideoGrid` was rendered as the final item inside the `GridView`/`MasonryGridView`. That made the spinner appear inside one grid column instead of centered below the full grid, and it used a raw `CircularProgressIndicator`.

This PR restructures the widget into a `CustomScrollView` so videos render in a `SliverGrid`/`SliverMasonryGrid` and the load-more footer renders in its own full-width `SliverToBoxAdapter` below the grid. Grid padding now wraps only the grid via `SliverPadding`, and the footer uses the animated `BrandedLoadingIndicator`.

The follow-up commit also cleans up stale wording in `composable_video_grid_test.dart` so the file no longer claims every widget test is expected to fail; only the video-tile tests remain skipped because they pull in the UserName/Nostr provider chain.

## Impact

This affects paginated screens that use `ComposableVideoGrid`, including Explore feed tabs, hashtag feeds, category galleries, curated list feeds, and user-list video grids. Pagination still uses the same `_scrollController` through `ScrollPaginationMixin`, so load-more triggering remains tied to the same scrollable.

## Verification

- `dart format test/widgets/composable_video_grid_test.dart`
- `mise exec -- flutter analyze lib/widgets/composable_video_grid.dart test/widgets/composable_video_grid_test.dart`
- `mise exec -- flutter test test/widgets/composable_video_grid_test.dart`
- pre-push hook analyze and changed-file widget tests

## Type of Change

- [x] Bug fix
- [x] Test/documentation cleanup
- [ ] Breaking change