### PR TITLE
fix(thumbnails): keep grid thumbnails cached during fast scroll

### DIFF
--- a/mobile/lib/constants/app_constants.dart
+++ b/mobile/lib/constants/app_constants.dart
@@ -117,6 +117,20 @@ class AppConstants {
   static const double gridPrefetchMinBandwidthMbps = 1.5;
 
   // ============================================================================
+  // IMAGE CACHE CONFIGURATION
+  // ============================================================================
+
+  /// Byte budget for Flutter's in-memory [ImageCache] (decoded images).
+  ///
+  /// Flutter's default is 100 MB, which on the thumbnail grids only holds a few
+  /// dozen decoded thumbnails — fast scrolling evicts already-loaded thumbnails,
+  /// so they flash back through their blurhash placeholder when scrolled into
+  /// view again. A larger budget keeps a much bigger working set resident so
+  /// scroll-back is an instant (synchronous) cache hit. Per-thumbnail memory is
+  /// bounded separately by decoding at display size, so this stays bounded.
+  static const int imageCacheMaxBytes = 256 * 1024 * 1024;
+
+  // ============================================================================
   // NETWORK CONFIGURATION
   // ============================================================================
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -38,6 +38,7 @@ import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/config/app_config.dart';
 import 'package:openvine/config/zendesk_config.dart';
+import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/features/app/startup/startup_coordinator.dart';
 import 'package:openvine/features/app/startup/startup_phase.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -959,6 +960,12 @@ Future<void> _startOpenVineApp() async {
 
   // Ensure bindings are initialized first (required for everything)
   final widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+
+  // Give the in-memory image cache a larger byte budget than Flutter's 100 MB
+  // default so thumbnails survive fast scrolling instead of being evicted and
+  // reloaded. Per-thumbnail memory is bounded by decoding at display size.
+  PaintingBinding.instance.imageCache.maximumSizeBytes =
+      AppConstants.imageCacheMaxBytes;
 
   // Keep the native splash visible until startup auth reaches a terminal
   // state. The release watcher is installed after the ProviderContainer exists

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show ScrollCacheExtent;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:go_router/go_router.dart';
@@ -20,6 +21,15 @@ import 'package:openvine/widgets/feed_refresh_control.dart';
 import 'package:openvine/widgets/share_video_menu.dart';
 import 'package:openvine/widgets/user_name.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
+
+/// Extra off-screen distance the grid keeps built, expressed as a multiple of
+/// the viewport height applied on each side of the visible area.
+///
+/// The grid's default cache extent is only 250px, so thumbnails just off-screen
+/// are disposed and have to reload (re-flicker through their blurhash) the
+/// moment they scroll back in during fast scrolling. Keeping a couple of
+/// screens built on either side avoids that churn while still bounding memory.
+const double _gridCacheExtentScreens = 2;
 
 /// Composable video grid that automatically filters broken videos
 /// and provides consistent styling across Explore, Hashtag, and Search screens.
@@ -134,10 +144,11 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
 
     // Responsive column count: 3 for tablets/desktop (width >= 600),
     // 2 for phones
-    final screenWidth = MediaQuery.of(context).size.width;
-    final responsiveCrossAxisCount = screenWidth >= 600
+    final screenSize = MediaQuery.sizeOf(context);
+    final responsiveCrossAxisCount = screenSize.width >= 600
         ? 3
         : widget.crossAxisCount;
+    final cacheExtent = screenSize.height * _gridCacheExtentScreens;
 
     // Whether to render the load-more footer below the grid.
     final showLoadingIndicator =
@@ -187,6 +198,7 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
 
     final scrollView = CustomScrollView(
       controller: _scrollController,
+      scrollCacheExtent: ScrollCacheExtent.pixels(cacheExtent),
       physics: const AlwaysScrollableScrollPhysics(),
       slivers: [
         SliverPadding(padding: gridPadding, sliver: gridSliver),

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -11,14 +11,6 @@ import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-/// Decode width (physical px) used only to probe a thumbnail's intrinsic
-/// aspect ratio when the video metadata omits dimensions.
-///
-/// Resizing preserves the aspect ratio, so a small probe avoids a
-/// full-resolution decode (which would otherwise thrash the in-memory image
-/// cache) while still yielding an accurate ratio.
-const int _aspectRatioProbeWidth = 256;
-
 /// Smart thumbnail widget that displays thumbnails with blurhash fallback
 class VideoThumbnailWidget extends StatefulWidget {
   const VideoThumbnailWidget({
@@ -75,40 +67,27 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
     final url = widget.video.thumbnailUrl;
     if (url != null && url.isNotEmpty) {
       _thumbnailUrl = url;
-      _resolveImageDimensions(url);
     } else {
       _thumbnailUrl = null;
     }
     if (mounted) setState(() {});
   }
 
-  /// Resolves image dimensions from the network image when video dimensions
-  /// are not available from metadata.
-  void _resolveImageDimensions(String url) {
-    // Skip if video already has dimensions
-    if (widget.video.width != null && widget.video.height != null) return;
+  void _handleImageDimensionsResolved(String url, int width, int height) {
+    if (url != _thumbnailUrl ||
+        !mounted ||
+        widget.video.width != null ||
+        widget.video.height != null ||
+        width <= 0 ||
+        height <= 0) {
+      return;
+    }
 
-    final imageStream = ResizeImage(
-      NetworkImage(url),
-      width: _aspectRatioProbeWidth,
-    ).resolve(ImageConfiguration.empty);
-    late ImageStreamListener listener;
-    listener = ImageStreamListener(
-      (ImageInfo info, bool _) {
-        final imageWidth = info.image.width;
-        final imageHeight = info.image.height;
-        if (mounted && imageHeight > 0) {
-          setState(() {
-            _resolvedAspectRatio = imageWidth / imageHeight;
-          });
-        }
-        imageStream.removeListener(listener);
-      },
-      onError: (Object error, StackTrace? stackTrace) {
-        imageStream.removeListener(listener);
-      },
-    );
-    imageStream.addListener(listener);
+    final aspectRatio = width / height;
+    if (_resolvedAspectRatio == aspectRatio) return;
+    setState(() {
+      _resolvedAspectRatio = aspectRatio;
+    });
   }
 
   Widget _buildContent(BoxFit fit) {
@@ -135,6 +114,7 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
             videoId: widget.video.id,
             showPlayIcon: widget.showPlayIcon,
             borderRadius: widget.borderRadius,
+            onImageDimensionsResolved: _handleImageDimensionsResolved,
           ),
         if (widget.showPlayIcon)
           Center(
@@ -202,6 +182,7 @@ class _SafeNetworkImage extends StatelessWidget {
     this.fit = BoxFit.cover,
     this.showPlayIcon = false,
     this.borderRadius,
+    this.onImageDimensionsResolved,
   });
 
   final String url;
@@ -211,6 +192,8 @@ class _SafeNetworkImage extends StatelessWidget {
   final BoxFit fit;
   final bool showPlayIcon;
   final BorderRadius? borderRadius;
+  final void Function(String url, int width, int height)?
+  onImageDimensionsResolved;
 
   // Toggle to test with plain Image.network instead of VineCachedImage.
   // Set to true to debug cache-manager behavior.
@@ -240,29 +223,40 @@ class _SafeNetworkImage extends StatelessWidget {
 
         // Debug mode: test with plain Image.network to isolate cache issues
         if (_useSimpleImageNetwork || _shouldBypassCacheManager(url)) {
-          return Image.network(
-            url,
-            width: width,
-            height: height,
-            fit: fit,
-            cacheWidth: cacheWidth,
-            alignment: Alignment.topCenter,
-            errorBuilder: (context, error, stackTrace) {
-              Log.warning(
-                '🖼️ [Image.network] Thumbnail load failed for video $videoId:\n'
-                '  URL: $url\n'
-                '  Error type: ${error.runtimeType}\n'
-                '  Error: $error\n'
-                '  Stack: ${stackTrace?.toString().split('\n').take(5).join('\n')}',
-                name: 'VideoThumbnailWidget',
-                category: LogCategory.video,
-              );
-              return Container(
-                width: width,
-                height: height,
-                color: VineTheme.transparent,
-              );
-            },
+          final imageProvider = ResizeImage.resizeIfNeeded(
+            cacheWidth,
+            null,
+            NetworkImage(url),
+          );
+          return _ImageWithDimensionsListener(
+            imageProvider: imageProvider,
+            onImageDimensionsResolved: onImageDimensionsResolved == null
+                ? null
+                : (width, height) =>
+                      onImageDimensionsResolved!(url, width, height),
+            child: Image(
+              image: imageProvider,
+              width: width,
+              height: height,
+              fit: fit,
+              alignment: Alignment.topCenter,
+              errorBuilder: (context, error, stackTrace) {
+                Log.warning(
+                  '🖼️ [Image.network] Thumbnail load failed for video $videoId:\n'
+                  '  URL: $url\n'
+                  '  Error type: ${error.runtimeType}\n'
+                  '  Error: $error\n'
+                  '  Stack: ${stackTrace?.toString().split('\n').take(5).join('\n')}',
+                  name: 'VideoThumbnailWidget',
+                  category: LogCategory.video,
+                );
+                return Container(
+                  width: width,
+                  height: height,
+                  color: VineTheme.transparent,
+                );
+              },
+            ),
           );
         }
 
@@ -273,6 +267,10 @@ class _SafeNetworkImage extends StatelessWidget {
           fit: fit,
           memCacheWidth: cacheWidth,
           alignment: Alignment.topCenter,
+          onImageDimensionsResolved: onImageDimensionsResolved == null
+              ? null
+              : (width, height) =>
+                    onImageDimensionsResolved!(url, width, height),
           // Show transparent container so background surfaceContainer color shows through
           placeholder: (context, url) => Container(
             width: width,
@@ -318,4 +316,81 @@ class _SafeNetworkImage extends StatelessWidget {
     if (logicalWidth == null || logicalWidth <= 0) return null;
     return (logicalWidth * MediaQuery.devicePixelRatioOf(context)).ceil();
   }
+}
+
+class _ImageWithDimensionsListener extends StatefulWidget {
+  const _ImageWithDimensionsListener({
+    required this.imageProvider,
+    required this.child,
+    this.onImageDimensionsResolved,
+  });
+
+  final ImageProvider<Object> imageProvider;
+  final ImageDimensionsResolved? onImageDimensionsResolved;
+  final Widget child;
+
+  @override
+  State<_ImageWithDimensionsListener> createState() =>
+      _ImageWithDimensionsListenerState();
+}
+
+class _ImageWithDimensionsListenerState
+    extends State<_ImageWithDimensionsListener> {
+  ImageStream? _imageStream;
+  ImageStreamListener? _listener;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _resolveImageStream();
+  }
+
+  @override
+  void didUpdateWidget(covariant _ImageWithDimensionsListener oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.imageProvider != widget.imageProvider) {
+      _resolveImageStream();
+    }
+  }
+
+  @override
+  void dispose() {
+    _removeImageListener();
+    super.dispose();
+  }
+
+  void _resolveImageStream() {
+    final newStream = widget.imageProvider.resolve(
+      createLocalImageConfiguration(context),
+    );
+    if (_imageStream?.key == newStream.key) {
+      return;
+    }
+
+    _removeImageListener();
+    _imageStream = newStream;
+
+    _listener = ImageStreamListener(
+      (image, synchronousCall) {
+        final imageWidth = image.image.width;
+        final imageHeight = image.image.height;
+        image.dispose();
+        if (!mounted) return;
+        widget.onImageDimensionsResolved?.call(imageWidth, imageHeight);
+      },
+      onError: (Object error, StackTrace? stackTrace) {},
+    );
+    _imageStream!.addListener(_listener!);
+  }
+
+  void _removeImageListener() {
+    if (_imageStream != null && _listener != null) {
+      _imageStream!.removeListener(_listener!);
+    }
+    _imageStream = null;
+    _listener = null;
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
 }

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -76,8 +76,7 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
   void _handleImageDimensionsResolved(String url, int width, int height) {
     if (url != _thumbnailUrl ||
         !mounted ||
-        widget.video.width != null ||
-        widget.video.height != null ||
+        _hasUsableVideoDimensions ||
         width <= 0 ||
         height <= 0) {
       return;
@@ -88,6 +87,12 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
     setState(() {
       _resolvedAspectRatio = aspectRatio;
     });
+  }
+
+  bool get _hasUsableVideoDimensions {
+    final width = widget.video.width;
+    final height = widget.video.height;
+    return width != null && width > 0 && height != null && height > 0;
   }
 
   Widget _buildContent(BoxFit fit) {
@@ -140,9 +145,7 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
   Widget build(BuildContext context) {
     // Use video metadata dimensions, resolved image dimensions, or fallback
     final double aspectRatio;
-    if (widget.video.width != null &&
-        widget.video.height != null &&
-        widget.video.height! > 0) {
+    if (_hasUsableVideoDimensions) {
       aspectRatio = widget.video.width! / widget.video.height!;
     } else if (_resolvedAspectRatio != null) {
       aspectRatio = _resolvedAspectRatio!;
@@ -382,10 +385,22 @@ class _ImageWithDimensionsListenerState
       (image, synchronousCall) {
         final imageWidth = image.image.width;
         final imageHeight = image.image.height;
+        final onImageDimensionsResolved = widget.onImageDimensionsResolved;
         image.dispose();
         if (!mounted) return;
-        widget.onImageDimensionsResolved?.call(imageWidth, imageHeight);
+        if (onImageDimensionsResolved == null) return;
+        if (synchronousCall) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (mounted) {
+              onImageDimensionsResolved(imageWidth, imageHeight);
+            }
+          });
+        } else {
+          onImageDimensionsResolved(imageWidth, imageHeight);
+        }
       },
+      // The rendered Image handles visible failures; this listener only needs
+      // dimensions when decoding succeeds.
       onError: (Object error, StackTrace? stackTrace) {},
     );
     _imageStream!.addListener(_listener!);

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -11,6 +11,14 @@ import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Decode width (physical px) used only to probe a thumbnail's intrinsic
+/// aspect ratio when the video metadata omits dimensions.
+///
+/// Resizing preserves the aspect ratio, so a small probe avoids a
+/// full-resolution decode (which would otherwise thrash the in-memory image
+/// cache) while still yielding an accurate ratio.
+const int _aspectRatioProbeWidth = 256;
+
 /// Smart thumbnail widget that displays thumbnails with blurhash fallback
 class VideoThumbnailWidget extends StatefulWidget {
   const VideoThumbnailWidget({
@@ -80,7 +88,10 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
     // Skip if video already has dimensions
     if (widget.video.width != null && widget.video.height != null) return;
 
-    final imageStream = NetworkImage(url).resolve(ImageConfiguration.empty);
+    final imageStream = ResizeImage(
+      NetworkImage(url),
+      width: _aspectRatioProbeWidth,
+    ).resolve(ImageConfiguration.empty);
     late ImageStreamListener listener;
     listener = ImageStreamListener(
       (ImageInfo info, bool _) {
@@ -218,66 +229,93 @@ class _SafeNetworkImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Debug mode: test with plain Image.network to isolate cache issues
-    if (_useSimpleImageNetwork || _shouldBypassCacheManager(url)) {
-      return Image.network(
-        url,
-        width: width,
-        height: height,
-        fit: fit,
-        alignment: Alignment.topCenter,
-        errorBuilder: (context, error, stackTrace) {
-          Log.warning(
-            '🖼️ [Image.network] Thumbnail load failed for video $videoId:\n'
-            '  URL: $url\n'
-            '  Error type: ${error.runtimeType}\n'
-            '  Error: $error\n'
-            '  Stack: ${stackTrace?.toString().split('\n').take(5).join('\n')}',
-            name: 'VideoThumbnailWidget',
-            category: LogCategory.video,
-          );
-          return Container(
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Decode thumbnails at their on-screen size rather than full source
+        // resolution. Full-resolution decodes exhaust Flutter's in-memory image
+        // cache within a few screens of fast scrolling, evicting already-loaded
+        // thumbnails so they visibly reload on the way back. Capping the decode
+        // width keeps far more thumbnails resident in the cache.
+        final cacheWidth = _decodeWidth(context, constraints.maxWidth);
+
+        // Debug mode: test with plain Image.network to isolate cache issues
+        if (_useSimpleImageNetwork || _shouldBypassCacheManager(url)) {
+          return Image.network(
+            url,
             width: width,
             height: height,
-            color: VineTheme.transparent,
-          );
-        },
-      );
-    }
-
-    return VineCachedImage(
-      imageUrl: url,
-      width: width,
-      height: height,
-      fit: fit,
-      alignment: Alignment.topCenter,
-      // Show transparent container so background surfaceContainer color shows through
-      placeholder: (context, url) =>
-          Container(width: width, height: height, color: VineTheme.transparent),
-      errorWidget: (context, url, error) {
-        // 404s are expected — thumbnail may not exist yet.
-        final is404 = error is HttpExceptionWithStatus
-            ? error.statusCode == 404
-            : error.toString().contains('404');
-
-        if (!is404) {
-          Log.warning(
-            '🖼️ Thumbnail load failed for video $videoId:\n'
-            '  URL: $url\n'
-            '  Error type: ${error.runtimeType}\n'
-            '  Error: $error',
-            name: 'VideoThumbnailWidget',
-            category: LogCategory.video,
+            fit: fit,
+            cacheWidth: cacheWidth,
+            alignment: Alignment.topCenter,
+            errorBuilder: (context, error, stackTrace) {
+              Log.warning(
+                '🖼️ [Image.network] Thumbnail load failed for video $videoId:\n'
+                '  URL: $url\n'
+                '  Error type: ${error.runtimeType}\n'
+                '  Error: $error\n'
+                '  Stack: ${stackTrace?.toString().split('\n').take(5).join('\n')}',
+                name: 'VideoThumbnailWidget',
+                category: LogCategory.video,
+              );
+              return Container(
+                width: width,
+                height: height,
+                color: VineTheme.transparent,
+              );
+            },
           );
         }
 
-        // Show transparent so background surfaceContainer color shows through
-        return Container(
+        return VineCachedImage(
+          imageUrl: url,
           width: width,
           height: height,
-          color: VineTheme.transparent,
+          fit: fit,
+          memCacheWidth: cacheWidth,
+          alignment: Alignment.topCenter,
+          // Show transparent container so background surfaceContainer color shows through
+          placeholder: (context, url) => Container(
+            width: width,
+            height: height,
+            color: VineTheme.transparent,
+          ),
+          errorWidget: (context, url, error) {
+            // 404s are expected — thumbnail may not exist yet.
+            final is404 = error is HttpExceptionWithStatus
+                ? error.statusCode == 404
+                : error.toString().contains('404');
+
+            if (!is404) {
+              Log.warning(
+                '🖼️ Thumbnail load failed for video $videoId:\n'
+                '  URL: $url\n'
+                '  Error type: ${error.runtimeType}\n'
+                '  Error: $error',
+                name: 'VideoThumbnailWidget',
+                category: LogCategory.video,
+              );
+            }
+
+            // Show transparent so background surfaceContainer color shows through
+            return Container(
+              width: width,
+              height: height,
+              color: VineTheme.transparent,
+            );
+          },
         );
       },
     );
+  }
+
+  /// Physical-pixel decode width for the thumbnail, derived from its laid-out
+  /// [maxWidth] (or the explicit [width] when the layout is unbounded).
+  ///
+  /// Returns `null` when no finite width is available, leaving the framework to
+  /// decode at native resolution.
+  int? _decodeWidth(BuildContext context, double maxWidth) {
+    final logicalWidth = maxWidth.isFinite && maxWidth > 0 ? maxWidth : width;
+    if (logicalWidth == null || logicalWidth <= 0) return null;
+    return (logicalWidth * MediaQuery.devicePixelRatioOf(context)).ceil();
   }
 }

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -228,7 +228,7 @@ class _SafeNetworkImage extends StatelessWidget {
             null,
             NetworkImage(url),
           );
-          return _ImageWithDimensionsListener(
+          return ImageWithDimensionsListener(
             imageProvider: imageProvider,
             onImageDimensionsResolved: onImageDimensionsResolved == null
                 ? null
@@ -318,10 +318,18 @@ class _SafeNetworkImage extends StatelessWidget {
   }
 }
 
-class _ImageWithDimensionsListener extends StatefulWidget {
-  const _ImageWithDimensionsListener({
+/// Resolves [imageProvider] alongside the rendered [child] purely to report the
+/// decoded image's intrinsic dimensions via [onImageDimensionsResolved].
+///
+/// Used by the Image.network thumbnail path (which has no built-in dimension
+/// callback like [VineCachedImage]) so the aspect ratio can be recovered from
+/// the displayed image instead of a separate probe decode.
+@visibleForTesting
+class ImageWithDimensionsListener extends StatefulWidget {
+  const ImageWithDimensionsListener({
     required this.imageProvider,
     required this.child,
+    super.key,
     this.onImageDimensionsResolved,
   });
 
@@ -330,12 +338,12 @@ class _ImageWithDimensionsListener extends StatefulWidget {
   final Widget child;
 
   @override
-  State<_ImageWithDimensionsListener> createState() =>
+  State<ImageWithDimensionsListener> createState() =>
       _ImageWithDimensionsListenerState();
 }
 
 class _ImageWithDimensionsListenerState
-    extends State<_ImageWithDimensionsListener> {
+    extends State<ImageWithDimensionsListener> {
   ImageStream? _imageStream;
   ImageStreamListener? _listener;
 
@@ -346,7 +354,7 @@ class _ImageWithDimensionsListenerState
   }
 
   @override
-  void didUpdateWidget(covariant _ImageWithDimensionsListener oldWidget) {
+  void didUpdateWidget(covariant ImageWithDimensionsListener oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.imageProvider != widget.imageProvider) {
       _resolveImageStream();

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -9,6 +9,8 @@ typedef PlaceholderWidgetBuilder =
 typedef LoadingErrorWidgetBuilder =
     Widget Function(BuildContext context, String imageUrl, Object error);
 
+typedef ImageDimensionsResolved = void Function(int width, int height);
+
 /// Global image cache singleton backed by [MediaCacheManager].
 final openVineImageCache = MediaCacheManager(
   config: const MediaCacheConfig.image(cacheKey: 'openvine_image_cache'),
@@ -46,6 +48,7 @@ class VineCachedImage extends StatefulWidget {
     this.memCacheHeight,
     this.fadeInDuration = const Duration(milliseconds: 500),
     this.fadeOutDuration = const Duration(milliseconds: 1000),
+    this.onImageDimensionsResolved,
   });
 
   final String imageUrl;
@@ -59,6 +62,7 @@ class VineCachedImage extends StatefulWidget {
   final int? memCacheHeight;
   final Duration fadeInDuration;
   final Duration fadeOutDuration;
+  final ImageDimensionsResolved? onImageDimensionsResolved;
 
   @override
   State<VineCachedImage> createState() => _VineCachedImageState();
@@ -113,8 +117,12 @@ class _VineCachedImageState extends State<VineCachedImage> {
 
     _listener = ImageStreamListener(
       (image, synchronousCall) {
+        final imageWidth = image.image.width;
+        final imageHeight = image.image.height;
         image.dispose();
-        if (!mounted || _hasImage) return;
+        if (!mounted) return;
+        widget.onImageDimensionsResolved?.call(imageWidth, imageHeight);
+        if (_hasImage) return;
         setState(() {
           _hasImage = true;
           _error = null;

--- a/mobile/lib/widgets/vine_cached_image.dart
+++ b/mobile/lib/widgets/vine_cached_image.dart
@@ -119,9 +119,20 @@ class _VineCachedImageState extends State<VineCachedImage> {
       (image, synchronousCall) {
         final imageWidth = image.image.width;
         final imageHeight = image.image.height;
+        final onImageDimensionsResolved = widget.onImageDimensionsResolved;
         image.dispose();
         if (!mounted) return;
-        widget.onImageDimensionsResolved?.call(imageWidth, imageHeight);
+        if (onImageDimensionsResolved != null) {
+          if (synchronousCall) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (mounted) {
+                onImageDimensionsResolved(imageWidth, imageHeight);
+              }
+            });
+          } else {
+            onImageDimensionsResolved(imageWidth, imageHeight);
+          }
+        }
         if (_hasImage) return;
         setState(() {
           _hasImage = true;

--- a/mobile/test/services/upload_manager_owner_scope_test.dart
+++ b/mobile/test/services/upload_manager_owner_scope_test.dart
@@ -53,11 +53,11 @@ void main() {
     });
 
     tearDown(() async {
+      await TestHelpers.cleanupHiveBox('pending_uploads');
       PathProviderPlatform.instance = originalPathProviderInstance;
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);
       }
-      await TestHelpers.cleanupHiveBox('pending_uploads');
     });
 
     Future<UploadManager> createManager({

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -1,5 +1,8 @@
+import 'dart:ui' as ui;
+
 import 'package:blurhash_service/blurhash_service.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart' show SynchronousFuture;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' hide AspectRatio;
@@ -17,6 +20,33 @@ Finder _divineIcon(DivineIconName name) =>
 
 double _thumbnailAspectRatio(WidgetTester tester) =>
     tester.widget<AspectRatio>(find.byType(AspectRatio)).aspectRatio;
+
+/// An [ImageProvider] that synchronously yields a pre-built [ui.Image] so a
+/// widget test can drive the image stream without an async decode.
+class _SyncImageProvider extends ImageProvider<_SyncImageProvider> {
+  _SyncImageProvider(this.image);
+
+  final ui.Image image;
+
+  @override
+  Future<_SyncImageProvider> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<_SyncImageProvider>(this);
+
+  @override
+  ImageStreamCompleter loadImage(
+    _SyncImageProvider key,
+    ImageDecoderCallback decode,
+  ) => OneFrameImageStreamCompleter(
+    SynchronousFuture<ImageInfo>(ImageInfo(image: image)),
+  );
+}
+
+/// Creates a [ui.Image] of exactly [width] x [height] without an async decode.
+ui.Image _syncImage(int width, int height) {
+  final recorder = ui.PictureRecorder();
+  ui.Canvas(recorder);
+  return recorder.endRecording().toImageSync(width, height);
+}
 
 void main() {
   group('VideoThumbnailWidget', () {
@@ -179,6 +209,72 @@ void main() {
 
         expect(find.byType(Image), findsOneWidget);
         expect(find.byType(VineCachedImage), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'resolves aspect ratio via the Image.network path for Divine thumbnails',
+      (tester) async {
+        final divineHostedVideo = createTestVideoEvent(
+          id: 'test-divine-dims',
+          thumbnailUrl:
+              'https://media.divine.video/72d7eda61074b17e077fb9f4a8b48166cdeb65cb07e053aafa6e69d5fa165995.jpg',
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoThumbnailWidget(
+                video: divineHostedVideo,
+                width: 200,
+                height: 200,
+              ),
+            ),
+          ),
+        );
+
+        expect(_thumbnailAspectRatio(tester), equals(2 / 3));
+
+        // The Image.network path has no built-in dimension callback, so it
+        // wraps the image in an ImageWithDimensionsListener to recover the
+        // aspect ratio from the displayed image.
+        final listener = tester.widget<ImageWithDimensionsListener>(
+          find.byType(ImageWithDimensionsListener),
+        );
+        listener.onImageDimensionsResolved!(640, 360);
+        await tester.pump();
+
+        expect(_thumbnailAspectRatio(tester), equals(640 / 360));
+      },
+    );
+
+    testWidgets(
+      'ImageWithDimensionsListener reports decoded image dimensions',
+      (
+        tester,
+      ) async {
+        final image = _syncImage(640, 360);
+        addTearDown(image.dispose);
+
+        int? width;
+        int? height;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: ImageWithDimensionsListener(
+              imageProvider: _SyncImageProvider(image),
+              onImageDimensionsResolved: (w, h) {
+                width = w;
+                height = h;
+              },
+              child: const SizedBox.shrink(),
+            ),
+          ),
+        );
+
+        expect(width, equals(640));
+        expect(height, equals(360));
       },
     );
 

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -138,6 +138,41 @@ void main() {
       },
     );
 
+    testWidgets(
+      'updates partial metadata aspect ratio from the displayed cached image',
+      (tester) async {
+        final videoWithPartialDimensions = createTestVideoEvent(
+          id: 'test-partial-dimensions',
+          thumbnailUrl: 'https://example.com/thumb-partial.jpg',
+          dimensions: '640x',
+        );
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoThumbnailWidget(
+                video: videoWithPartialDimensions,
+                width: 200,
+                height: 200,
+              ),
+            ),
+          ),
+        );
+
+        expect(_thumbnailAspectRatio(tester), equals(2 / 3));
+
+        final cachedImage = tester.widget<VineCachedImage>(
+          find.byType(VineCachedImage),
+        );
+        cachedImage.onImageDimensionsResolved!(640, 360);
+        await tester.pump();
+
+        expect(_thumbnailAspectRatio(tester), equals(640 / 360));
+      },
+    );
+
     testWidgets('ignores stale image dimensions after thumbnail URL changes', (
       tester,
     ) async {
@@ -275,6 +310,26 @@ void main() {
 
         expect(width, equals(640));
         expect(height, equals(360));
+      },
+    );
+
+    testWidgets(
+      'ImageWithDimensionsListener defers synchronous parent state updates',
+      (tester) async {
+        final image = _syncImage(640, 360);
+        addTearDown(image.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: _DimensionCallbackParent(
+              imageProvider: _SyncImageProvider(image),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('640x360'), findsOneWidget);
       },
     );
 
@@ -615,4 +670,33 @@ void main() {
       expect(find.byType(VineCachedImage), findsNothing);
     });
   });
+}
+
+class _DimensionCallbackParent extends StatefulWidget {
+  const _DimensionCallbackParent({required this.imageProvider});
+
+  final ImageProvider<Object> imageProvider;
+
+  @override
+  State<_DimensionCallbackParent> createState() =>
+      _DimensionCallbackParentState();
+}
+
+class _DimensionCallbackParentState extends State<_DimensionCallbackParent> {
+  int? _width;
+  int? _height;
+
+  @override
+  Widget build(BuildContext context) {
+    return ImageWithDimensionsListener(
+      imageProvider: widget.imageProvider,
+      onImageDimensionsResolved: (width, height) {
+        setState(() {
+          _width = width;
+          _height = height;
+        });
+      },
+      child: Text('${_width ?? 0}x${_height ?? 0}'),
+    );
+  }
 }

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -2,7 +2,7 @@ import 'package:blurhash_service/blurhash_service.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:models/models.dart';
+import 'package:models/models.dart' hide AspectRatio;
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/widgets/blurhash_display.dart';
 import 'package:openvine/widgets/video_thumbnail_widget.dart';
@@ -14,6 +14,9 @@ import '../test_data/video_test_data.dart';
 
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
+
+double _thumbnailAspectRatio(WidgetTester tester) =>
+    tester.widget<AspectRatio>(find.byType(AspectRatio)).aspectRatio;
 
 void main() {
   group('VideoThumbnailWidget', () {
@@ -74,6 +77,81 @@ void main() {
 
       // Should create a VineCachedImage widget when thumbnail URL exists.
       expect(find.byType(VineCachedImage), findsOneWidget);
+    });
+
+    testWidgets(
+      'updates missing metadata aspect ratio from the displayed cached image',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(
+              body: VideoThumbnailWidget(
+                video: videoWithThumbnail,
+                width: 200,
+                height: 200,
+              ),
+            ),
+          ),
+        );
+
+        expect(_thumbnailAspectRatio(tester), equals(2 / 3));
+
+        final cachedImage = tester.widget<VineCachedImage>(
+          find.byType(VineCachedImage),
+        );
+        cachedImage.onImageDimensionsResolved!(640, 360);
+        await tester.pump();
+
+        expect(_thumbnailAspectRatio(tester), equals(640 / 360));
+      },
+    );
+
+    testWidgets('ignores stale image dimensions after thumbnail URL changes', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoThumbnailWidget(
+              video: videoWithThumbnail,
+              width: 200,
+              height: 200,
+            ),
+          ),
+        ),
+      );
+
+      final staleCallback = tester
+          .widget<VineCachedImage>(find.byType(VineCachedImage))
+          .onImageDimensionsResolved!;
+
+      final nextVideo = createTestVideoEvent(
+        id: 'test-next',
+        thumbnailUrl: 'https://example.com/thumb-next.jpg',
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoThumbnailWidget(
+              video: nextVideo,
+              width: 200,
+              height: 200,
+            ),
+          ),
+        ),
+      );
+
+      staleCallback(640, 360);
+      await tester.pump();
+
+      expect(_thumbnailAspectRatio(tester), equals(2 / 3));
     });
 
     testWidgets(


### PR DESCRIPTION
Closes #5209

## Description

Fast-scrolling the Explore grids made already-loaded thumbnails flash back through their blurhash placeholder. Root cause: Flutter's in-memory `ImageCache` (100 MB default) evicted decoded thumbnails within a few screens, so a scrolled-back item re-resolved asynchronously and showed its placeholder for a frame or two.

Changes:
- **Raise the image-cache byte budget to 256 MB** (`AppConstants.imageCacheMaxBytes`, applied in `main.dart`) so a much larger working set of decoded thumbnails stays resident. Scroll-back becomes a synchronous cache hit instead of a blurhash flash. Bounded by a hard cap.
- **Decode thumbnails at on-screen size** (`cacheWidth`/`memCacheWidth` via `LayoutBuilder`) and recover aspect ratio from the displayed image stream, so per-thumbnail memory is bounded and the larger cache stays affordable.
- **Widen the grid `cacheExtent`** (2x viewport height) so near-viewport items stay mounted and avoid rebuild churn.
- **Defer dimension callbacks on synchronous image-cache hits** so parent thumbnails are not marked dirty while a child image listener is resolving during build/dependency resolution.
- **Keep aspect-ratio recovery available for malformed/partial dimensions metadata** by only trusting video dimensions when both width and height are present and positive.
- **Harden upload-manager test teardown** by closing/deleting the `pending_uploads` Hive box before deleting the test temp directory, preventing cross-test lock-file leakage in CI.

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/5fbbcfb0-2b6f-488a-a8ec-8fb1463b826f"></video> | <video src="https://github.com/user-attachments/assets/2a41a76b-3883-4ecf-92f1-d78192733757"></video> |

## Out of Scope

- `AutomaticKeepAliveClientMixin` on grid items - deliberately avoided because the Explore feeds are infinite/paginated and unconditional keep-alive grows memory without bound.
- The 256 MB budget is a deliberate RAM trade-off (`rules/performance.md` cautions on low-end OOM); if it becomes a concern, lower `AppConstants.imageCacheMaxBytes`.

## Verification

- `mise exec -- dart format lib/widgets/vine_cached_image.dart lib/widgets/video_thumbnail_widget.dart test/widgets/video_thumbnail_widget_test.dart`
- `mise exec -- flutter analyze lib/widgets/vine_cached_image.dart lib/widgets/video_thumbnail_widget.dart test/widgets/video_thumbnail_widget_test.dart`
- `mise exec -- flutter test test/widgets/video_thumbnail_widget_test.dart`
- `mise exec -- flutter test test/widgets/video_thumbnail_aspect_ratio_test.dart test/widgets/video_thumbnail_404_test.dart test/widgets/composable_video_grid_test.dart test/screens/inbox/conversation/widgets/message_bubble_test.dart test/widgets/vine_cached_image_test.dart`
- `mise exec -- flutter analyze test/services/upload_manager_owner_scope_test.dart`
- `mise exec -- flutter test test/services/upload_manager_owner_scope_test.dart test/services/upload_manager_from_draft_test.dart`
- Pre-push hook: analyze + changed-file tests passed.
- GitHub checks: Analyze, Format, Generated Files, Tests, Mobile CI, Build Flutter Web Preview, VGV Tag Gate, semantic PR, mergeability, and CLA all pass.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
