### PR TITLE
fix(dm): recover full conversation list after reinstall regression (#5202)

### DIFF
--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -77,15 +77,22 @@ class ConversationListBloc
     // Stream 1: accepted conversations (paginated, user has sent).
     // Stream 2: potential requests (unpaginated, user has NOT sent).
     // Stream 3: following list changes (triggers re-classification).
+    // Stream 4: history-recovery progress (drives the restore indicator).
     // Combining ensures requests are never truncated by pagination
     // and follow-list changes are handled automatically.
     await emit.forEach(
-      Rx.combineLatest3(
+      Rx.combineLatest4(
         _dmRepository.watchAcceptedConversations(limit: state.currentLimit),
         _dmRepository.watchPotentialRequests(),
         _followRepository.followingStream.startWith(const []),
-        (accepted, potentialRequests, _) =>
-            (accepted: accepted, potentialRequests: potentialRequests),
+        _dmRepository.historyRecoveryStream.startWith(
+          _dmRepository.isRecoveringHistory,
+        ),
+        (accepted, potentialRequests, _, isRestoring) => (
+          accepted: accepted,
+          potentialRequests: potentialRequests,
+          isRestoring: isRestoring,
+        ),
       ),
       onData: (data) {
         final split = DmRepository.classifyPotentialRequests(
@@ -112,6 +119,7 @@ class ConversationListBloc
           potentialRequests: data.potentialRequests,
           hasMore: data.accepted.length == state.currentLimit,
           isLoadingMore: false,
+          isRestoringHistory: data.isRestoring,
         );
       },
       onError: (error, stackTrace) {

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -59,6 +59,11 @@ class ConversationListBloc
     // pool, not the divine-only pool present at cold start. See #4953.
     unawaited(_dmRepository.backfillHistoryIfNeeded());
 
+    // Replay any gift wraps that failed decryption on a previous pass (e.g.
+    // a transient Keycast RPC failure during the drain burst) so a flaky
+    // remote signer never permanently loses a conversation. See #5202.
+    unawaited(_dmRepository.retryPendingDecryptions());
+
     // Only show the loading spinner and reset limit on first load.
     if (state.status == ConversationListStatus.initial) {
       emit(

--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_state.dart
@@ -28,6 +28,7 @@ class ConversationListState extends Equatable {
     this.potentialRequests = const [],
     this.hasMore = true,
     this.isLoadingMore = false,
+    this.isRestoringHistory = false,
     this.currentLimit = ConversationListState.pageSize,
     this.navigationTarget,
   });
@@ -54,6 +55,11 @@ class ConversationListState extends Equatable {
   /// Whether a load-more operation is currently in progress.
   final bool isLoadingMore;
 
+  /// Whether a one-time DM history recovery (reinstall backfill / failed-
+  /// decrypt replay) is actively running. Drives the restore progress
+  /// indicator at the top of the Messages list. See #5202.
+  final bool isRestoringHistory;
+
   /// Current watch limit — grows as the user loads more pages.
   final int currentLimit;
 
@@ -72,6 +78,7 @@ class ConversationListState extends Equatable {
     List<DmConversation>? potentialRequests,
     bool? hasMore,
     bool? isLoadingMore,
+    bool? isRestoringHistory,
     int? currentLimit,
     ConversationNavigationTarget? navigationTarget,
     bool clearNavigationTarget = false,
@@ -83,6 +90,7 @@ class ConversationListState extends Equatable {
       potentialRequests: potentialRequests ?? this.potentialRequests,
       hasMore: hasMore ?? this.hasMore,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      isRestoringHistory: isRestoringHistory ?? this.isRestoringHistory,
       currentLimit: currentLimit ?? this.currentLimit,
       navigationTarget: clearNavigationTarget
           ? null
@@ -98,6 +106,7 @@ class ConversationListState extends Equatable {
     potentialRequests,
     hasMore,
     isLoadingMore,
+    isRestoringHistory,
     currentLimit,
     navigationTarget,
   ];

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2588,6 +2588,7 @@
         }
     },
     "inboxRemovedConversation": "ውይይት ተወግዷል",
+    "inboxRestoringMessages": "መልዕክቶችዎን ወደነበሩበት በመመለስ ላይ…",
     "inboxEmptyTitle": "እስካሁን ምንም መልዕክቶች የሉም",
     "inboxEmptySubtitle": "ያ + ቁልፍ አይነክሰውም።",
     "inboxActionMute": "ውይይት ድምጸ-ከል አድርግ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2343,6 +2343,7 @@
     "inboxRemoveConfirmConfirm": "إزالة",
     "inboxRemoveConfirmTitle": "إزالة المحادثة؟",
     "inboxRemovedConversation": "تمت إزالة المحادثة",
+    "inboxRestoringMessages": "جارٍ استعادة رسائلك…",
     "inboxReportedUser": "تم الإبلاغ عن {displayName}",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2448,6 +2448,7 @@
         }
     },
     "inboxRemovedConversation": "Премахнат разговор",
+    "inboxRestoringMessages": "Възстановяваме съобщенията ти…",
     "inboxEmptyTitle": "Все още няма съобщения",
     "inboxEmptySubtitle": "Този бутон + няма да ухапе.",
     "inboxActionMute": "Заглушаване на разговора",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmConfirm": "Entfernen",
     "inboxRemoveConfirmTitle": "Unterhaltung entfernen?",
     "inboxRemovedConversation": "Unterhaltung entfernt",
+    "inboxRestoringMessages": "Deine Nachrichten werden wiederhergestellt…",
     "inboxReportedUser": "{displayName} gemeldet",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2930,6 +2930,10 @@
     }
   },
   "inboxRemovedConversation": "Removed conversation",
+  "inboxRestoringMessages": "Restoring your messages…",
+  "@inboxRestoringMessages": {
+    "description": "Accessibility label on the progress bar shown at the top of the Messages list while a one-time DM history recovery (after reinstall) is still running, so the user knows older chats are still being restored."
+  },
   "inboxEmptyTitle": "No messages yet",
   "inboxEmptySubtitle": "That + button won't bite.",
   "inboxActionMute": "Mute conversation",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2355,6 +2355,7 @@
     "inboxRemoveConfirmConfirm": "Eliminar",
     "inboxRemoveConfirmTitle": "¿Eliminar conversación?",
     "inboxRemovedConversation": "Conversación eliminada",
+    "inboxRestoringMessages": "Restaurando tus mensajes…",
     "inboxReportedUser": "Reportaste a {displayName}",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1438,6 +1438,7 @@
     "inboxBlockedUser": "Na-block si {displayName}",
     "inboxUnblockedUser": "Na-unblock si {displayName}",
     "inboxRemovedConversation": "Inalis ang conversation",
+    "inboxRestoringMessages": "Ibinabalik ang mga message mo…",
     "inboxEmptyTitle": "Wala pang messages",
     "inboxEmptySubtitle": "Hindi ka kakagatin ng + button na 'yan.",
     "inboxActionMute": "I-mute ang conversation",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmConfirm": "Supprimer",
     "inboxRemoveConfirmTitle": "Supprimer la conversation ?",
     "inboxRemovedConversation": "Conversation supprimée",
+    "inboxRestoringMessages": "Restauration de vos messages…",
     "inboxReportedUser": "{displayName} signalé(e)",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2350,6 +2350,7 @@
     "inboxRemoveConfirmConfirm": "Hapus",
     "inboxRemoveConfirmTitle": "Hapus percakapan?",
     "inboxRemovedConversation": "Percakapan dihapus",
+    "inboxRestoringMessages": "Memulihkan pesan Anda…",
     "inboxReportedUser": "{displayName} dilaporkan",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmConfirm": "Rimuovi",
     "inboxRemoveConfirmTitle": "Rimuovere la conversazione?",
     "inboxRemovedConversation": "Conversazione rimossa",
+    "inboxRestoringMessages": "Ripristino dei messaggi…",
     "inboxReportedUser": "{displayName} segnalato/a",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2343,6 +2343,7 @@
     "inboxRemoveConfirmConfirm": "削除",
     "inboxRemoveConfirmTitle": "会話を削除する？",
     "inboxRemovedConversation": "会話を削除したよ",
+    "inboxRestoringMessages": "メッセージを復元中…",
     "inboxReportedUser": "{displayName}を報告したよ",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1639,6 +1639,7 @@
     "inboxRemoveConfirmConfirm": "삭제",
     "inboxRemoveConfirmTitle": "대화를 삭제할까요?",
     "inboxRemovedConversation": "대화를 삭제했어요",
+    "inboxRestoringMessages": "메시지를 복구하는 중…",
     "inboxReportedUser": "{displayName}을(를) 신고했어요",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmConfirm": "Verwijderen",
     "inboxRemoveConfirmTitle": "Gesprek verwijderen?",
     "inboxRemovedConversation": "Gesprek verwijderd",
+    "inboxRestoringMessages": "Je berichten worden hersteld…",
     "inboxReportedUser": "{displayName} gerapporteerd",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmConfirm": "Usuń",
     "inboxRemoveConfirmTitle": "Usunąć rozmowę?",
     "inboxRemovedConversation": "Usunięto rozmowę",
+    "inboxRestoringMessages": "Odzyskiwanie wiadomości…",
     "inboxReportedUser": "Zgłoszono {displayName}",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmConfirm": "Remover",
     "inboxRemoveConfirmTitle": "Remover conversa?",
     "inboxRemovedConversation": "Conversa removida",
+    "inboxRestoringMessages": "Restaurando suas mensagens…",
     "inboxReportedUser": "{displayName} denunciado(a)",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmConfirm": "Elimină",
     "inboxRemoveConfirmTitle": "Elimini conversația?",
     "inboxRemovedConversation": "Conversație eliminată",
+    "inboxRestoringMessages": "Se restaurează mesajele tale…",
     "inboxReportedUser": "{displayName} a fost raportat(ă)",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2351,6 +2351,7 @@
     "inboxRemoveConfirmConfirm": "Ta bort",
     "inboxRemoveConfirmTitle": "Ta bort konversation?",
     "inboxRemovedConversation": "Konversation borttagen",
+    "inboxRestoringMessages": "Återställer dina meddelanden…",
     "inboxReportedUser": "{displayName} rapporterad",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2350,6 +2350,7 @@
     "inboxRemoveConfirmConfirm": "Kaldır",
     "inboxRemoveConfirmTitle": "Sohbet kaldırılsın mı?",
     "inboxRemovedConversation": "Sohbet kaldırıldı",
+    "inboxRestoringMessages": "Mesajların geri yükleniyor…",
     "inboxReportedUser": "{displayName} bildirildi",
     "@inboxReportedUser": {
         "placeholders": {

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -9536,6 +9536,12 @@ abstract class AppLocalizations {
   /// **'Removed conversation'**
   String get inboxRemovedConversation;
 
+  /// Accessibility label on the progress bar shown at the top of the Messages list while a one-time DM history recovery (after reinstall) is still running, so the user knows older chats are still being restored.
+  ///
+  /// In en, this message translates to:
+  /// **'Restoring your messages…'**
+  String get inboxRestoringMessages;
+
   /// No description provided for @inboxEmptyTitle.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -5306,6 +5306,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get inboxRemovedConversation => 'ውይይት ተወግዷል';
 
   @override
+  String get inboxRestoringMessages => 'መልዕክቶችዎን ወደነበሩበት በመመለስ ላይ…';
+
+  @override
   String get inboxEmptyTitle => 'እስካሁን ምንም መልዕክቶች የሉም';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -5365,6 +5365,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get inboxRemovedConversation => 'تمت إزالة المحادثة';
 
   @override
+  String get inboxRestoringMessages => 'جارٍ استعادة رسائلك…';
+
+  @override
   String get inboxEmptyTitle => 'لا توجد رسائل بعد';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -5468,6 +5468,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get inboxRemovedConversation => 'Премахнат разговор';
 
   @override
+  String get inboxRestoringMessages => 'Възстановяваме съобщенията ти…';
+
+  @override
   String get inboxEmptyTitle => 'Все още няма съобщения';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -5478,6 +5478,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get inboxRemovedConversation => 'Unterhaltung entfernt';
 
   @override
+  String get inboxRestoringMessages =>
+      'Deine Nachrichten werden wiederhergestellt…';
+
+  @override
   String get inboxEmptyTitle => 'Noch keine Nachrichten';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -5416,6 +5416,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get inboxRemovedConversation => 'Removed conversation';
 
   @override
+  String get inboxRestoringMessages => 'Restoring your messages…';
+
+  @override
   String get inboxEmptyTitle => 'No messages yet';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -5462,6 +5462,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversación eliminada';
 
   @override
+  String get inboxRestoringMessages => 'Restaurando tus mensajes…';
+
+  @override
   String get inboxEmptyTitle => 'Aún no hay mensajes';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -5483,6 +5483,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get inboxRemovedConversation => 'Inalis ang conversation';
 
   @override
+  String get inboxRestoringMessages => 'Ibinabalik ang mga message mo…';
+
+  @override
   String get inboxEmptyTitle => 'Wala pang messages';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -5485,6 +5485,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversation supprimée';
 
   @override
+  String get inboxRestoringMessages => 'Restauration de vos messages…';
+
+  @override
   String get inboxEmptyTitle => 'Aucun message pour le moment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -5392,6 +5392,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get inboxRemovedConversation => 'Percakapan dihapus';
 
   @override
+  String get inboxRestoringMessages => 'Memulihkan pesan Anda…';
+
+  @override
   String get inboxEmptyTitle => 'Belum ada pesan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -5465,6 +5465,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversazione rimossa';
 
   @override
+  String get inboxRestoringMessages => 'Ripristino dei messaggi…';
+
+  @override
   String get inboxEmptyTitle => 'Ancora nessun messaggio';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5193,6 +5193,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get inboxRemovedConversation => '会話を削除したよ';
 
   @override
+  String get inboxRestoringMessages => 'メッセージを復元中…';
+
+  @override
   String get inboxEmptyTitle => 'まだメッセージはないよ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5209,6 +5209,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get inboxRemovedConversation => '대화를 삭제했어요';
 
   @override
+  String get inboxRestoringMessages => '메시지를 복구하는 중…';
+
+  @override
   String get inboxEmptyTitle => '아직 메시지가 없어요';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -5437,6 +5437,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get inboxRemovedConversation => 'Gesprek verwijderd';
 
   @override
+  String get inboxRestoringMessages => 'Je berichten worden hersteld…';
+
+  @override
   String get inboxEmptyTitle => 'Nog geen berichten';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -5547,6 +5547,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get inboxRemovedConversation => 'Usunięto rozmowę';
 
   @override
+  String get inboxRestoringMessages => 'Odzyskiwanie wiadomości…';
+
+  @override
   String get inboxEmptyTitle => 'Brak wiadomości';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -5448,6 +5448,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversa removida';
 
   @override
+  String get inboxRestoringMessages => 'Restaurando suas mensagens…';
+
+  @override
   String get inboxEmptyTitle => 'Ainda sem mensagens';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -5563,6 +5563,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get inboxRemovedConversation => 'Conversație eliminată';
 
   @override
+  String get inboxRestoringMessages => 'Se restaurează mesajele tale…';
+
+  @override
   String get inboxEmptyTitle => 'Încă niciun mesaj';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -5415,6 +5415,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get inboxRemovedConversation => 'Konversation borttagen';
 
   @override
+  String get inboxRestoringMessages => 'Återställer dina meddelanden…';
+
+  @override
   String get inboxEmptyTitle => 'Inga meddelanden än';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -5397,6 +5397,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get inboxRemovedConversation => 'Sohbet kaldırıldı';
 
   @override
+  String get inboxRestoringMessages => 'Mesajların geri yükleniyor…';
+
+  @override
   String get inboxEmptyTitle => 'Henüz mesaj yok';
 
   @override

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -489,6 +489,7 @@ DmRepository dmRepository(Ref ref) {
     directMessagesDao: db.directMessagesDao,
     conversationsDao: db.conversationsDao,
     outgoingDmsDao: db.outgoingDmsDao,
+    pendingGiftWrapsDao: db.pendingGiftWrapsDao,
     syncState: DmSyncState(prefs),
     reactionsRepository: reactionsRepository,
     errorReporter: (error, stackTrace, {required site}) {

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -775,7 +775,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'8615e6933fe33237f950109dfd78803e8d709093';
+String _$dmRepositoryHash() => r'db555e77673032bf3d1c10788e9b448c363e81e0';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -357,6 +357,10 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
         }
         await db.directMessagesDao.clearAll();
         await db.conversationsDao.clearAll();
+        // Raw failed-decrypt gift wraps are encrypted DM data of the same
+        // class as direct_messages — wipe them on the same path so they never
+        // outlive the account's decrypted DMs. See #5202.
+        await db.pendingGiftWrapsDao.clearAll();
         await db.notificationsDao.clearAll();
         // Clear DM sync cursors so the next login triggers a full re-fetch
         // from relays instead of using stale `since:` boundaries.

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -482,7 +482,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'ce46d352767c246631f008d3742cd5705f978aef';
+    r'd71f520c626677c7120300d8b0739ac2f46e5228';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -242,12 +242,19 @@ class _RestoringHistoryIndicator extends StatelessWidget {
     final isRestoring = context.select<ConversationListBloc, bool>(
       (bloc) => bloc.state.isRestoringHistory,
     );
-    if (!isRestoring) return const SizedBox.shrink();
-    return LinearProgressIndicator(
-      minHeight: 2,
-      backgroundColor: VineTheme.surfaceContainerHigh,
-      color: VineTheme.primary,
-      semanticsLabel: context.l10n.inboxRestoringMessages,
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+    return AnimatedSwitcher(
+      duration: reduceMotion
+          ? Duration.zero
+          : const Duration(milliseconds: 200),
+      child: isRestoring
+          ? LinearProgressIndicator(
+              minHeight: 2,
+              backgroundColor: VineTheme.surfaceContainerHigh,
+              color: VineTheme.primary,
+              semanticsLabel: context.l10n.inboxRestoringMessages,
+            )
+          : const SizedBox.shrink(),
     );
   }
 }

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -178,6 +178,9 @@ class _MessagesContent extends ConsumerWidget {
                   );
                 },
               ),
+              // Thin restore progress bar while the one-time reinstall
+              // history recovery is still running (#5202).
+              const _RestoringHistoryIndicator(),
               // Conversation list or empty state
               Expanded(
                 child: _ConversationListContent(
@@ -225,6 +228,27 @@ class _MessagesContent extends ConsumerWidget {
       selectedUser.pubkey,
     ]);
     _pushConversation(context, conversationId, [selectedUser.pubkey]);
+  }
+}
+
+/// Thin progress bar shown at the top of the Messages list while the one-time
+/// DM history recovery (reinstall backfill / failed-decrypt replay) is still
+/// running, so the user knows older chats are still being restored. See #5202.
+class _RestoringHistoryIndicator extends StatelessWidget {
+  const _RestoringHistoryIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    final isRestoring = context.select<ConversationListBloc, bool>(
+      (bloc) => bloc.state.isRestoringHistory,
+    );
+    if (!isRestoring) return const SizedBox.shrink();
+    return LinearProgressIndicator(
+      minHeight: 2,
+      backgroundColor: VineTheme.surfaceContainerHigh,
+      color: VineTheme.primary,
+      semanticsLabel: context.l10n.inboxRestoringMessages,
+    );
   }
 }
 

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -35,6 +35,7 @@ const _notificationRetentionDays = 7;
     Conversations,
     OutgoingDms,
     PendingViewEvents,
+    PendingGiftWraps,
   ],
   daos: [
     UserProfilesDao,
@@ -55,6 +56,7 @@ const _notificationRetentionDays = 7;
     ConversationsDao,
     OutgoingDmsDao,
     PendingViewEventsDao,
+    PendingGiftWrapsDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -567,6 +569,35 @@ class AppDatabase extends _$AppDatabase {
     await customStatement('''
       CREATE INDEX IF NOT EXISTS idx_pending_view_events_created_at
       ON pending_view_events (created_at)
+    ''');
+
+    // Check if pending_gift_wraps table exists, create if missing.
+    // Added for #5202 (durable failed-decrypt gift-wrap retry queue).
+    // Schema version stays at 1 — same runtime CREATE-IF-NOT-EXISTS pattern
+    // as outgoing_dms / pending_view_events above.
+    final pendingGiftWrapsResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='pending_gift_wraps'",
+    ).get();
+
+    if (pendingGiftWrapsResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE pending_gift_wraps (
+          gift_wrap_id TEXT NOT NULL,
+          owner_pubkey TEXT NOT NULL,
+          raw_json TEXT NOT NULL,
+          created_at INTEGER NOT NULL,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          last_attempt_at INTEGER,
+          PRIMARY KEY (gift_wrap_id, owner_pubkey)
+        )
+      ''');
+    }
+    // Create the index unconditionally so the runtime path matches Drift's
+    // m.createAll() output (the schema-parity test pins this).
+    await customStatement('''
+      CREATE INDEX IF NOT EXISTS idx_pending_gift_wraps_owner_attempts
+      ON pending_gift_wraps (owner_pubkey, attempts)
     ''');
 
     // Populate new columns from existing JSON data blobs

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -13095,6 +13095,457 @@ class PendingViewEventsCompanion extends UpdateCompanion<PendingViewEventRow> {
   }
 }
 
+class $PendingGiftWrapsTable extends PendingGiftWraps
+    with TableInfo<$PendingGiftWrapsTable, PendingGiftWrapRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PendingGiftWrapsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _giftWrapIdMeta = const VerificationMeta(
+    'giftWrapId',
+  );
+  @override
+  late final GeneratedColumn<String> giftWrapId = GeneratedColumn<String>(
+    'gift_wrap_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _ownerPubkeyMeta = const VerificationMeta(
+    'ownerPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> ownerPubkey = GeneratedColumn<String>(
+    'owner_pubkey',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _rawJsonMeta = const VerificationMeta(
+    'rawJson',
+  );
+  @override
+  late final GeneratedColumn<String> rawJson = GeneratedColumn<String>(
+    'raw_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<int> createdAt = GeneratedColumn<int>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _attemptsMeta = const VerificationMeta(
+    'attempts',
+  );
+  @override
+  late final GeneratedColumn<int> attempts = GeneratedColumn<int>(
+    'attempts',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _lastAttemptAtMeta = const VerificationMeta(
+    'lastAttemptAt',
+  );
+  @override
+  late final GeneratedColumn<int> lastAttemptAt = GeneratedColumn<int>(
+    'last_attempt_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    giftWrapId,
+    ownerPubkey,
+    rawJson,
+    createdAt,
+    attempts,
+    lastAttemptAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'pending_gift_wraps';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PendingGiftWrapRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('gift_wrap_id')) {
+      context.handle(
+        _giftWrapIdMeta,
+        giftWrapId.isAcceptableOrUnknown(
+          data['gift_wrap_id']!,
+          _giftWrapIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_giftWrapIdMeta);
+    }
+    if (data.containsKey('owner_pubkey')) {
+      context.handle(
+        _ownerPubkeyMeta,
+        ownerPubkey.isAcceptableOrUnknown(
+          data['owner_pubkey']!,
+          _ownerPubkeyMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_ownerPubkeyMeta);
+    }
+    if (data.containsKey('raw_json')) {
+      context.handle(
+        _rawJsonMeta,
+        rawJson.isAcceptableOrUnknown(data['raw_json']!, _rawJsonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_rawJsonMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('attempts')) {
+      context.handle(
+        _attemptsMeta,
+        attempts.isAcceptableOrUnknown(data['attempts']!, _attemptsMeta),
+      );
+    }
+    if (data.containsKey('last_attempt_at')) {
+      context.handle(
+        _lastAttemptAtMeta,
+        lastAttemptAt.isAcceptableOrUnknown(
+          data['last_attempt_at']!,
+          _lastAttemptAtMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {giftWrapId, ownerPubkey};
+  @override
+  PendingGiftWrapRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PendingGiftWrapRow(
+      giftWrapId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}gift_wrap_id'],
+      )!,
+      ownerPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}owner_pubkey'],
+      )!,
+      rawJson: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}raw_json'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}created_at'],
+      )!,
+      attempts: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}attempts'],
+      )!,
+      lastAttemptAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_attempt_at'],
+      ),
+    );
+  }
+
+  @override
+  $PendingGiftWrapsTable createAlias(String alias) {
+    return $PendingGiftWrapsTable(attachedDatabase, alias);
+  }
+}
+
+class PendingGiftWrapRow extends DataClass
+    implements Insertable<PendingGiftWrapRow> {
+  /// The kind 1059 gift-wrap event id (outer). Dedup key with [ownerPubkey].
+  final String giftWrapId;
+
+  /// Recipient pubkey this wrap was addressed to (multi-account scope).
+  final String ownerPubkey;
+
+  /// The raw gift-wrap event JSON, replayed through the decrypt pipeline.
+  final String rawJson;
+
+  /// Outer gift-wrap `created_at` (unix seconds). Ordering only — NIP-17
+  /// randomizes it, so it is not the true message time.
+  final int createdAt;
+
+  /// Number of decryption attempts so far. Retries stop at a cap so a
+  /// permanently-undecryptable wrap cannot loop forever.
+  final int attempts;
+
+  /// Last attempt time (unix seconds), informational.
+  final int? lastAttemptAt;
+  const PendingGiftWrapRow({
+    required this.giftWrapId,
+    required this.ownerPubkey,
+    required this.rawJson,
+    required this.createdAt,
+    required this.attempts,
+    this.lastAttemptAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['gift_wrap_id'] = Variable<String>(giftWrapId);
+    map['owner_pubkey'] = Variable<String>(ownerPubkey);
+    map['raw_json'] = Variable<String>(rawJson);
+    map['created_at'] = Variable<int>(createdAt);
+    map['attempts'] = Variable<int>(attempts);
+    if (!nullToAbsent || lastAttemptAt != null) {
+      map['last_attempt_at'] = Variable<int>(lastAttemptAt);
+    }
+    return map;
+  }
+
+  PendingGiftWrapsCompanion toCompanion(bool nullToAbsent) {
+    return PendingGiftWrapsCompanion(
+      giftWrapId: Value(giftWrapId),
+      ownerPubkey: Value(ownerPubkey),
+      rawJson: Value(rawJson),
+      createdAt: Value(createdAt),
+      attempts: Value(attempts),
+      lastAttemptAt: lastAttemptAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastAttemptAt),
+    );
+  }
+
+  factory PendingGiftWrapRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PendingGiftWrapRow(
+      giftWrapId: serializer.fromJson<String>(json['giftWrapId']),
+      ownerPubkey: serializer.fromJson<String>(json['ownerPubkey']),
+      rawJson: serializer.fromJson<String>(json['rawJson']),
+      createdAt: serializer.fromJson<int>(json['createdAt']),
+      attempts: serializer.fromJson<int>(json['attempts']),
+      lastAttemptAt: serializer.fromJson<int?>(json['lastAttemptAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'giftWrapId': serializer.toJson<String>(giftWrapId),
+      'ownerPubkey': serializer.toJson<String>(ownerPubkey),
+      'rawJson': serializer.toJson<String>(rawJson),
+      'createdAt': serializer.toJson<int>(createdAt),
+      'attempts': serializer.toJson<int>(attempts),
+      'lastAttemptAt': serializer.toJson<int?>(lastAttemptAt),
+    };
+  }
+
+  PendingGiftWrapRow copyWith({
+    String? giftWrapId,
+    String? ownerPubkey,
+    String? rawJson,
+    int? createdAt,
+    int? attempts,
+    Value<int?> lastAttemptAt = const Value.absent(),
+  }) => PendingGiftWrapRow(
+    giftWrapId: giftWrapId ?? this.giftWrapId,
+    ownerPubkey: ownerPubkey ?? this.ownerPubkey,
+    rawJson: rawJson ?? this.rawJson,
+    createdAt: createdAt ?? this.createdAt,
+    attempts: attempts ?? this.attempts,
+    lastAttemptAt: lastAttemptAt.present
+        ? lastAttemptAt.value
+        : this.lastAttemptAt,
+  );
+  PendingGiftWrapRow copyWithCompanion(PendingGiftWrapsCompanion data) {
+    return PendingGiftWrapRow(
+      giftWrapId: data.giftWrapId.present
+          ? data.giftWrapId.value
+          : this.giftWrapId,
+      ownerPubkey: data.ownerPubkey.present
+          ? data.ownerPubkey.value
+          : this.ownerPubkey,
+      rawJson: data.rawJson.present ? data.rawJson.value : this.rawJson,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      attempts: data.attempts.present ? data.attempts.value : this.attempts,
+      lastAttemptAt: data.lastAttemptAt.present
+          ? data.lastAttemptAt.value
+          : this.lastAttemptAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingGiftWrapRow(')
+          ..write('giftWrapId: $giftWrapId, ')
+          ..write('ownerPubkey: $ownerPubkey, ')
+          ..write('rawJson: $rawJson, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('attempts: $attempts, ')
+          ..write('lastAttemptAt: $lastAttemptAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    giftWrapId,
+    ownerPubkey,
+    rawJson,
+    createdAt,
+    attempts,
+    lastAttemptAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PendingGiftWrapRow &&
+          other.giftWrapId == this.giftWrapId &&
+          other.ownerPubkey == this.ownerPubkey &&
+          other.rawJson == this.rawJson &&
+          other.createdAt == this.createdAt &&
+          other.attempts == this.attempts &&
+          other.lastAttemptAt == this.lastAttemptAt);
+}
+
+class PendingGiftWrapsCompanion extends UpdateCompanion<PendingGiftWrapRow> {
+  final Value<String> giftWrapId;
+  final Value<String> ownerPubkey;
+  final Value<String> rawJson;
+  final Value<int> createdAt;
+  final Value<int> attempts;
+  final Value<int?> lastAttemptAt;
+  final Value<int> rowid;
+  const PendingGiftWrapsCompanion({
+    this.giftWrapId = const Value.absent(),
+    this.ownerPubkey = const Value.absent(),
+    this.rawJson = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.attempts = const Value.absent(),
+    this.lastAttemptAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PendingGiftWrapsCompanion.insert({
+    required String giftWrapId,
+    required String ownerPubkey,
+    required String rawJson,
+    required int createdAt,
+    this.attempts = const Value.absent(),
+    this.lastAttemptAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : giftWrapId = Value(giftWrapId),
+       ownerPubkey = Value(ownerPubkey),
+       rawJson = Value(rawJson),
+       createdAt = Value(createdAt);
+  static Insertable<PendingGiftWrapRow> custom({
+    Expression<String>? giftWrapId,
+    Expression<String>? ownerPubkey,
+    Expression<String>? rawJson,
+    Expression<int>? createdAt,
+    Expression<int>? attempts,
+    Expression<int>? lastAttemptAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (giftWrapId != null) 'gift_wrap_id': giftWrapId,
+      if (ownerPubkey != null) 'owner_pubkey': ownerPubkey,
+      if (rawJson != null) 'raw_json': rawJson,
+      if (createdAt != null) 'created_at': createdAt,
+      if (attempts != null) 'attempts': attempts,
+      if (lastAttemptAt != null) 'last_attempt_at': lastAttemptAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PendingGiftWrapsCompanion copyWith({
+    Value<String>? giftWrapId,
+    Value<String>? ownerPubkey,
+    Value<String>? rawJson,
+    Value<int>? createdAt,
+    Value<int>? attempts,
+    Value<int?>? lastAttemptAt,
+    Value<int>? rowid,
+  }) {
+    return PendingGiftWrapsCompanion(
+      giftWrapId: giftWrapId ?? this.giftWrapId,
+      ownerPubkey: ownerPubkey ?? this.ownerPubkey,
+      rawJson: rawJson ?? this.rawJson,
+      createdAt: createdAt ?? this.createdAt,
+      attempts: attempts ?? this.attempts,
+      lastAttemptAt: lastAttemptAt ?? this.lastAttemptAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (giftWrapId.present) {
+      map['gift_wrap_id'] = Variable<String>(giftWrapId.value);
+    }
+    if (ownerPubkey.present) {
+      map['owner_pubkey'] = Variable<String>(ownerPubkey.value);
+    }
+    if (rawJson.present) {
+      map['raw_json'] = Variable<String>(rawJson.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<int>(createdAt.value);
+    }
+    if (attempts.present) {
+      map['attempts'] = Variable<int>(attempts.value);
+    }
+    if (lastAttemptAt.present) {
+      map['last_attempt_at'] = Variable<int>(lastAttemptAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PendingGiftWrapsCompanion(')
+          ..write('giftWrapId: $giftWrapId, ')
+          ..write('ownerPubkey: $ownerPubkey, ')
+          ..write('rawJson: $rawJson, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('attempts: $attempts, ')
+          ..write('lastAttemptAt: $lastAttemptAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -13122,6 +13573,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $OutgoingDmsTable outgoingDms = $OutgoingDmsTable(this);
   late final $PendingViewEventsTable pendingViewEvents =
       $PendingViewEventsTable(this);
+  late final $PendingGiftWrapsTable pendingGiftWraps = $PendingGiftWrapsTable(
+    this,
+  );
   late final UserProfilesDao userProfilesDao = UserProfilesDao(
     this as AppDatabase,
   );
@@ -13171,6 +13625,9 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final PendingViewEventsDao pendingViewEventsDao = PendingViewEventsDao(
     this as AppDatabase,
   );
+  late final PendingGiftWrapsDao pendingGiftWrapsDao = PendingGiftWrapsDao(
+    this as AppDatabase,
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -13194,6 +13651,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     conversations,
     outgoingDms,
     pendingViewEvents,
+    pendingGiftWraps,
   ];
 }
 
@@ -19259,6 +19717,241 @@ typedef $$PendingViewEventsTableProcessedTableManager =
       PendingViewEventRow,
       PrefetchHooks Function()
     >;
+typedef $$PendingGiftWrapsTableCreateCompanionBuilder =
+    PendingGiftWrapsCompanion Function({
+      required String giftWrapId,
+      required String ownerPubkey,
+      required String rawJson,
+      required int createdAt,
+      Value<int> attempts,
+      Value<int?> lastAttemptAt,
+      Value<int> rowid,
+    });
+typedef $$PendingGiftWrapsTableUpdateCompanionBuilder =
+    PendingGiftWrapsCompanion Function({
+      Value<String> giftWrapId,
+      Value<String> ownerPubkey,
+      Value<String> rawJson,
+      Value<int> createdAt,
+      Value<int> attempts,
+      Value<int?> lastAttemptAt,
+      Value<int> rowid,
+    });
+
+class $$PendingGiftWrapsTableFilterComposer
+    extends Composer<_$AppDatabase, $PendingGiftWrapsTable> {
+  $$PendingGiftWrapsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get giftWrapId => $composableBuilder(
+    column: $table.giftWrapId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get rawJson => $composableBuilder(
+    column: $table.rawJson,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get attempts => $composableBuilder(
+    column: $table.attempts,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$PendingGiftWrapsTableOrderingComposer
+    extends Composer<_$AppDatabase, $PendingGiftWrapsTable> {
+  $$PendingGiftWrapsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get giftWrapId => $composableBuilder(
+    column: $table.giftWrapId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get rawJson => $composableBuilder(
+    column: $table.rawJson,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get attempts => $composableBuilder(
+    column: $table.attempts,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$PendingGiftWrapsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PendingGiftWrapsTable> {
+  $$PendingGiftWrapsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get giftWrapId => $composableBuilder(
+    column: $table.giftWrapId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get rawJson =>
+      $composableBuilder(column: $table.rawJson, builder: (column) => column);
+
+  GeneratedColumn<int> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<int> get attempts =>
+      $composableBuilder(column: $table.attempts, builder: (column) => column);
+
+  GeneratedColumn<int> get lastAttemptAt => $composableBuilder(
+    column: $table.lastAttemptAt,
+    builder: (column) => column,
+  );
+}
+
+class $$PendingGiftWrapsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PendingGiftWrapsTable,
+          PendingGiftWrapRow,
+          $$PendingGiftWrapsTableFilterComposer,
+          $$PendingGiftWrapsTableOrderingComposer,
+          $$PendingGiftWrapsTableAnnotationComposer,
+          $$PendingGiftWrapsTableCreateCompanionBuilder,
+          $$PendingGiftWrapsTableUpdateCompanionBuilder,
+          (
+            PendingGiftWrapRow,
+            BaseReferences<
+              _$AppDatabase,
+              $PendingGiftWrapsTable,
+              PendingGiftWrapRow
+            >,
+          ),
+          PendingGiftWrapRow,
+          PrefetchHooks Function()
+        > {
+  $$PendingGiftWrapsTableTableManager(
+    _$AppDatabase db,
+    $PendingGiftWrapsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PendingGiftWrapsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PendingGiftWrapsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PendingGiftWrapsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> giftWrapId = const Value.absent(),
+                Value<String> ownerPubkey = const Value.absent(),
+                Value<String> rawJson = const Value.absent(),
+                Value<int> createdAt = const Value.absent(),
+                Value<int> attempts = const Value.absent(),
+                Value<int?> lastAttemptAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PendingGiftWrapsCompanion(
+                giftWrapId: giftWrapId,
+                ownerPubkey: ownerPubkey,
+                rawJson: rawJson,
+                createdAt: createdAt,
+                attempts: attempts,
+                lastAttemptAt: lastAttemptAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String giftWrapId,
+                required String ownerPubkey,
+                required String rawJson,
+                required int createdAt,
+                Value<int> attempts = const Value.absent(),
+                Value<int?> lastAttemptAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PendingGiftWrapsCompanion.insert(
+                giftWrapId: giftWrapId,
+                ownerPubkey: ownerPubkey,
+                rawJson: rawJson,
+                createdAt: createdAt,
+                attempts: attempts,
+                lastAttemptAt: lastAttemptAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$PendingGiftWrapsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PendingGiftWrapsTable,
+      PendingGiftWrapRow,
+      $$PendingGiftWrapsTableFilterComposer,
+      $$PendingGiftWrapsTableOrderingComposer,
+      $$PendingGiftWrapsTableAnnotationComposer,
+      $$PendingGiftWrapsTableCreateCompanionBuilder,
+      $$PendingGiftWrapsTableUpdateCompanionBuilder,
+      (
+        PendingGiftWrapRow,
+        BaseReferences<
+          _$AppDatabase,
+          $PendingGiftWrapsTable,
+          PendingGiftWrapRow
+        >,
+      ),
+      PendingGiftWrapRow,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -19299,4 +19992,6 @@ class $AppDatabaseManager {
       $$OutgoingDmsTableTableManager(_db, _db.outgoingDms);
   $$PendingViewEventsTableTableManager get pendingViewEvents =>
       $$PendingViewEventsTableTableManager(_db, _db.pendingViewEvents);
+  $$PendingGiftWrapsTableTableManager get pendingGiftWraps =>
+      $$PendingGiftWrapsTableTableManager(_db, _db.pendingGiftWraps);
 }

--- a/mobile/packages/db_client/lib/src/database/daos/daos.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/daos.dart
@@ -9,6 +9,7 @@ export 'nostr_events_dao.dart';
 export 'notifications_dao.dart';
 export 'outgoing_dms_dao.dart';
 export 'pending_actions_dao.dart';
+export 'pending_gift_wraps_dao.dart';
 export 'pending_uploads_dao.dart';
 export 'pending_view_events_dao.dart';
 export 'personal_reactions_dao.dart';

--- a/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.dart
@@ -91,6 +91,26 @@ class PendingGiftWrapsDao extends DatabaseAccessor<AppDatabase>
         .go();
   }
 
+  /// Deletes rows for [ownerPubkey] that have reached [maxAttempts] — wraps
+  /// declared permanently undecryptable. Bounds queue growth so a
+  /// never-decryptable or spammed gift wrap cannot accumulate forever.
+  Future<int> deleteExhausted({
+    required String ownerPubkey,
+    required int maxAttempts,
+  }) {
+    return (delete(pendingGiftWraps)..where(
+          (t) =>
+              t.ownerPubkey.equals(ownerPubkey) &
+              t.attempts.isBiggerOrEqualValue(maxAttempts),
+        ))
+        .go();
+  }
+
+  /// Removes every pending row. Called during account cleanup (switch /
+  /// destructive sign-out) alongside the other DM-table wipes so an account's
+  /// raw (still-encrypted) gift wraps never outlive its decrypted DM data.
+  Future<int> clearAll() => delete(pendingGiftWraps).go();
+
   /// Returns rows for [ownerPubkey] still below [maxAttempts], newest first
   /// (so recent conversations are recovered before older ones).
   Future<List<PendingGiftWrap>> getRetryable({

--- a/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.dart
@@ -1,0 +1,133 @@
+// ABOUTME: Data Access Object for the durable failed-decrypt gift-wrap queue.
+// ABOUTME: Persists raw kind-1059 wraps that failed decryption, for retry.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+import 'package:meta/meta.dart';
+
+part 'pending_gift_wraps_dao.g.dart';
+
+/// A gift wrap that failed decryption and is queued for a later retry.
+@immutable
+class PendingGiftWrap {
+  const PendingGiftWrap({
+    required this.giftWrapId,
+    required this.ownerPubkey,
+    required this.rawJson,
+    required this.createdAt,
+    this.attempts = 0,
+    this.lastAttemptAt,
+  });
+
+  final String giftWrapId;
+  final String ownerPubkey;
+  final String rawJson;
+  final int createdAt;
+  final int attempts;
+  final int? lastAttemptAt;
+}
+
+@DriftAccessor(tables: [PendingGiftWraps])
+class PendingGiftWrapsDao extends DatabaseAccessor<AppDatabase>
+    with _$PendingGiftWrapsDaoMixin {
+  PendingGiftWrapsDao(super.attachedDatabase);
+
+  /// Records a failed decryption for [giftWrapId]. Inserts a new row
+  /// (attempts = 1) or increments the attempt count of an existing one.
+  /// The raw event is stored only on first insert.
+  Future<void> recordFailedDecrypt({
+    required String giftWrapId,
+    required String ownerPubkey,
+    required String rawJson,
+    required int createdAt,
+  }) async {
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await transaction(() async {
+      final existing =
+          await (select(pendingGiftWraps)..where(
+                (t) =>
+                    t.giftWrapId.equals(giftWrapId) &
+                    t.ownerPubkey.equals(ownerPubkey),
+              ))
+              .getSingleOrNull();
+      if (existing == null) {
+        await into(pendingGiftWraps).insert(
+          PendingGiftWrapsCompanion.insert(
+            giftWrapId: giftWrapId,
+            ownerPubkey: ownerPubkey,
+            rawJson: rawJson,
+            createdAt: createdAt,
+            attempts: const Value(1),
+            lastAttemptAt: Value(now),
+          ),
+        );
+      } else {
+        await (update(pendingGiftWraps)..where(
+              (t) =>
+                  t.giftWrapId.equals(giftWrapId) &
+                  t.ownerPubkey.equals(ownerPubkey),
+            ))
+            .write(
+              PendingGiftWrapsCompanion(
+                attempts: Value(existing.attempts + 1),
+                lastAttemptAt: Value(now),
+              ),
+            );
+      }
+    });
+  }
+
+  /// Removes the pending row for [giftWrapId] (no-op if absent). Called when
+  /// a wrap finally decrypts or is otherwise resolved.
+  Future<void> deletePending({
+    required String giftWrapId,
+    required String ownerPubkey,
+  }) async {
+    await (delete(pendingGiftWraps)..where(
+          (t) =>
+              t.giftWrapId.equals(giftWrapId) &
+              t.ownerPubkey.equals(ownerPubkey),
+        ))
+        .go();
+  }
+
+  /// Returns rows for [ownerPubkey] still below [maxAttempts], newest first
+  /// (so recent conversations are recovered before older ones).
+  Future<List<PendingGiftWrap>> getRetryable({
+    required String ownerPubkey,
+    required int maxAttempts,
+  }) async {
+    final rows =
+        await (select(pendingGiftWraps)
+              ..where(
+                (t) =>
+                    t.ownerPubkey.equals(ownerPubkey) &
+                    t.attempts.isSmallerThanValue(maxAttempts),
+              )
+              ..orderBy([
+                (t) => OrderingTerm(
+                  expression: t.createdAt,
+                  mode: OrderingMode.desc,
+                ),
+              ]))
+            .get();
+    return rows.map(_rowToModel).toList();
+  }
+
+  /// Total pending rows for [ownerPubkey] (diagnostics / tests).
+  Future<int> countForOwner(String ownerPubkey) async {
+    final rows = await (select(
+      pendingGiftWraps,
+    )..where((t) => t.ownerPubkey.equals(ownerPubkey))).get();
+    return rows.length;
+  }
+
+  PendingGiftWrap _rowToModel(PendingGiftWrapRow row) => PendingGiftWrap(
+    giftWrapId: row.giftWrapId,
+    ownerPubkey: row.ownerPubkey,
+    rawJson: row.rawJson,
+    createdAt: row.createdAt,
+    attempts: row.attempts,
+    lastAttemptAt: row.lastAttemptAt,
+  );
+}

--- a/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/pending_gift_wraps_dao.g.dart
@@ -1,0 +1,20 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_gift_wraps_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$PendingGiftWrapsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $PendingGiftWrapsTable get pendingGiftWraps =>
+      attachedDatabase.pendingGiftWraps;
+  PendingGiftWrapsDaoManager get managers => PendingGiftWrapsDaoManager(this);
+}
+
+class PendingGiftWrapsDaoManager {
+  final _$PendingGiftWrapsDaoMixin _db;
+  PendingGiftWrapsDaoManager(this._db);
+  $$PendingGiftWrapsTableTableManager get pendingGiftWraps =>
+      $$PendingGiftWrapsTableTableManager(
+        _db.attachedDatabase,
+        _db.pendingGiftWraps,
+      );
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1219,3 +1219,48 @@ class PendingViewEvents extends Table {
     ),
   ];
 }
+
+/// Durable queue of gift-wrap (kind 1059) events that failed NIP-44
+/// decryption — e.g. a transient Keycast RPC failure while the one-time
+/// history drain processes a burst of gift wraps for a remote-signer
+/// account. Persisting the raw, still-encrypted event lets a later
+/// `DmRepository.retryPendingDecryptions` pass recover the conversation
+/// without re-fetching from the relay, so flaky remote-signer decryption
+/// never permanently loses a chat. See #5202.
+@DataClassName('PendingGiftWrapRow')
+class PendingGiftWraps extends Table {
+  @override
+  String get tableName => 'pending_gift_wraps';
+
+  /// The kind 1059 gift-wrap event id (outer). Dedup key with [ownerPubkey].
+  TextColumn get giftWrapId => text().named('gift_wrap_id')();
+
+  /// Recipient pubkey this wrap was addressed to (multi-account scope).
+  TextColumn get ownerPubkey => text().named('owner_pubkey')();
+
+  /// The raw gift-wrap event JSON, replayed through the decrypt pipeline.
+  TextColumn get rawJson => text().named('raw_json')();
+
+  /// Outer gift-wrap `created_at` (unix seconds). Ordering only — NIP-17
+  /// randomizes it, so it is not the true message time.
+  IntColumn get createdAt => integer().named('created_at')();
+
+  /// Number of decryption attempts so far. Retries stop at a cap so a
+  /// permanently-undecryptable wrap cannot loop forever.
+  IntColumn get attempts => integer().withDefault(const Constant(0))();
+
+  /// Last attempt time (unix seconds), informational.
+  IntColumn get lastAttemptAt =>
+      integer().nullable().named('last_attempt_at')();
+
+  @override
+  Set<Column> get primaryKey => {giftWrapId, ownerPubkey};
+
+  List<Index> get indexes => [
+    Index(
+      'idx_pending_gift_wraps_owner_attempts',
+      'CREATE INDEX IF NOT EXISTS idx_pending_gift_wraps_owner_attempts '
+          'ON pending_gift_wraps (owner_pubkey, attempts)',
+    ),
+  ];
+}

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -475,6 +475,108 @@ void main() {
         },
       );
 
+      test('upgrade path recreates pending_gift_wraps when missing', () async {
+        await database.customStatement('DROP TABLE pending_gift_wraps');
+
+        final droppedCheck = await database
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='table' "
+              "AND name='pending_gift_wraps'",
+            )
+            .get();
+        expect(
+          droppedCheck,
+          isEmpty,
+          reason: 'precondition: pending_gift_wraps must be missing',
+        );
+
+        await database.close();
+        database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+        final tableCheck = await database
+            .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='table' "
+              "AND name='pending_gift_wraps'",
+            )
+            .get();
+        expect(
+          tableCheck,
+          hasLength(1),
+          reason: 'pending_gift_wraps must be re-created on reopen',
+        );
+
+        final indexNames = await _collectIndexNames(
+          database,
+          'pending_gift_wraps',
+        );
+        expect(
+          indexNames,
+          containsAll(<String>{'idx_pending_gift_wraps_owner_attempts'}),
+        );
+
+        final dao = database.pendingGiftWrapsDao;
+        await dao.recordFailedDecrypt(
+          giftWrapId: 'upgrade-wrap-id',
+          ownerPubkey: testPubkey,
+          rawJson: '{"id":"upgrade-wrap-id"}',
+          createdAt: 1700000000,
+        );
+        final rows = await dao.getRetryable(
+          ownerPubkey: testPubkey,
+          maxAttempts: 10,
+        );
+        expect(rows, hasLength(1));
+        expect(rows.single.attempts, 1);
+      });
+
+      test(
+        'schema parity — pending_gift_wraps fresh-install matches runtime '
+        'CREATE-IF-NOT-EXISTS path',
+        () async {
+          final freshColumns = await _collectTableInfo(
+            database,
+            'pending_gift_wraps',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'pending_gift_wraps',
+          );
+
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason:
+                'precondition: fresh install should have pending_gift_wraps',
+          );
+
+          await database.customStatement('DROP TABLE pending_gift_wraps');
+          for (final indexName in freshIndexes) {
+            await database.customStatement('DROP INDEX IF EXISTS $indexName');
+          }
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='pending_gift_wraps'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'pending_gift_wraps',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'pending_gift_wraps',
+          );
+
+          expect(recreatedColumns, equals(freshColumns));
+          expect(recreatedIndexes, equals(freshIndexes));
+        },
+      );
+
       test('does not delete non-expired data', () async {
         final eventsDao = database.nostrEventsDao;
         final profileStatsDao = database.profileStatsDao;

--- a/mobile/packages/db_client/test/src/database/daos/pending_gift_wraps_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_gift_wraps_dao_test.dart
@@ -1,0 +1,167 @@
+// ABOUTME: Unit tests for PendingGiftWrapsDao — the durable failed-decrypt
+// ABOUTME: gift-wrap retry queue (#5202).
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase database;
+  late PendingGiftWrapsDao dao;
+  late String tempDbPath;
+
+  const ownerA =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const ownerB =
+      'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+  const wrap1 =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const wrap2 =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  setUp(() async {
+    final tempDir = Directory.systemTemp.createTempSync('pgw_test_');
+    tempDbPath = '${tempDir.path}/test.db';
+    database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    dao = database.pendingGiftWrapsDao;
+  });
+
+  tearDown(() async {
+    await database.close();
+    final file = File(tempDbPath);
+    if (file.existsSync()) file.deleteSync();
+  });
+
+  group(PendingGiftWrapsDao, () {
+    test('recordFailedDecrypt inserts a new row with attempts=1', () async {
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap1,
+        ownerPubkey: ownerA,
+        rawJson: '{"id":"x"}',
+        createdAt: 100,
+      );
+
+      final rows = await dao.getRetryable(ownerPubkey: ownerA, maxAttempts: 10);
+      expect(rows, hasLength(1));
+      expect(rows.single.giftWrapId, wrap1);
+      expect(rows.single.attempts, 1);
+      expect(rows.single.rawJson, '{"id":"x"}');
+      expect(rows.single.createdAt, 100);
+    });
+
+    test(
+      'recordFailedDecrypt increments attempts on repeat and keeps the '
+      'original raw payload',
+      () async {
+        await dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: ownerA,
+          rawJson: 'first',
+          createdAt: 100,
+        );
+        await dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: ownerA,
+          rawJson: 'second',
+          createdAt: 999,
+        );
+
+        final rows = await dao.getRetryable(
+          ownerPubkey: ownerA,
+          maxAttempts: 10,
+        );
+        expect(rows, hasLength(1));
+        expect(rows.single.attempts, 2);
+        // First insert wins — the raw bytes never change for a given wrap.
+        expect(rows.single.rawJson, 'first');
+        expect(rows.single.createdAt, 100);
+      },
+    );
+
+    test('getRetryable excludes rows at or over the attempt cap', () async {
+      for (var i = 0; i < 3; i++) {
+        await dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: ownerA,
+          rawJson: 'r',
+          createdAt: 100,
+        );
+      }
+
+      expect(
+        await dao.getRetryable(ownerPubkey: ownerA, maxAttempts: 3),
+        isEmpty,
+      );
+      expect(
+        await dao.getRetryable(ownerPubkey: ownerA, maxAttempts: 4),
+        hasLength(1),
+      );
+    });
+
+    test('getRetryable scopes by owner and orders newest-first', () async {
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap1,
+        ownerPubkey: ownerA,
+        rawJson: 'r',
+        createdAt: 100,
+      );
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap2,
+        ownerPubkey: ownerA,
+        rawJson: 'r',
+        createdAt: 300,
+      );
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap1,
+        ownerPubkey: ownerB,
+        rawJson: 'r',
+        createdAt: 200,
+      );
+
+      final rows = await dao.getRetryable(ownerPubkey: ownerA, maxAttempts: 10);
+      expect(rows.map((r) => r.giftWrapId).toList(), [wrap2, wrap1]);
+      expect(await dao.countForOwner(ownerB), 1);
+    });
+
+    test('deletePending removes the row and is a no-op when absent', () async {
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap1,
+        ownerPubkey: ownerA,
+        rawJson: 'r',
+        createdAt: 100,
+      );
+
+      await dao.deletePending(giftWrapId: wrap1, ownerPubkey: ownerA);
+      expect(await dao.countForOwner(ownerA), 0);
+
+      // Absent row — must not throw.
+      await dao.deletePending(giftWrapId: wrap2, ownerPubkey: ownerA);
+      expect(await dao.countForOwner(ownerA), 0);
+    });
+
+    test(
+      'the same gift-wrap id under different owners is independent',
+      () async {
+        await dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: ownerA,
+          rawJson: 'r',
+          createdAt: 100,
+        );
+        await dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: ownerB,
+          rawJson: 'r',
+          createdAt: 100,
+        );
+
+        await dao.deletePending(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+        expect(await dao.countForOwner(ownerA), 0);
+        expect(await dao.countForOwner(ownerB), 1);
+      },
+    );
+  });
+}

--- a/mobile/packages/db_client/test/src/database/daos/pending_gift_wraps_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/pending_gift_wraps_dao_test.dart
@@ -163,5 +163,78 @@ void main() {
         expect(await dao.countForOwner(ownerB), 1);
       },
     );
+
+    test('deleteExhausted removes only rows at or above the cap', () async {
+      // wrap1: 3 attempts; wrap2: 1 attempt.
+      for (var i = 0; i < 3; i++) {
+        await dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: ownerA,
+          rawJson: 'r',
+          createdAt: 100,
+        );
+      }
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap2,
+        ownerPubkey: ownerA,
+        rawJson: 'r',
+        createdAt: 200,
+      );
+
+      final deleted = await dao.deleteExhausted(
+        ownerPubkey: ownerA,
+        maxAttempts: 3,
+      );
+
+      expect(deleted, 1);
+      final remaining = await dao.getRetryable(
+        ownerPubkey: ownerA,
+        maxAttempts: 999,
+      );
+      expect(remaining.map((r) => r.giftWrapId).toList(), [wrap2]);
+    });
+
+    test('deleteExhausted is owner-scoped', () async {
+      for (var i = 0; i < 3; i++) {
+        await dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: ownerA,
+          rawJson: 'r',
+          createdAt: 100,
+        );
+        await dao.recordFailedDecrypt(
+          giftWrapId: wrap1,
+          ownerPubkey: ownerB,
+          rawJson: 'r',
+          createdAt: 100,
+        );
+      }
+
+      await dao.deleteExhausted(ownerPubkey: ownerA, maxAttempts: 3);
+
+      expect(await dao.countForOwner(ownerA), 0);
+      expect(await dao.countForOwner(ownerB), 1);
+    });
+
+    test('clearAll removes every row across all owners', () async {
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap1,
+        ownerPubkey: ownerA,
+        rawJson: 'r',
+        createdAt: 100,
+      );
+      await dao.recordFailedDecrypt(
+        giftWrapId: wrap2,
+        ownerPubkey: ownerB,
+        rawJson: 'r',
+        createdAt: 100,
+      );
+
+      final deleted = await dao.clearAll();
+
+      expect(deleted, 2);
+      expect(await dao.countForOwner(ownerA), 0);
+      expect(await dao.countForOwner(ownerB), 0);
+    });
   });
 }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -83,6 +83,13 @@ abstract class DmHistoryDrainConfig {
 
   /// Maximum pages fetched in a single drain (≈ [pageSize] × this events).
   static const int maxPages = 50;
+
+  /// Maximum NIP-44 decryption attempts for a single gift wrap before the
+  /// failed-decrypt retry queue gives up on it. Generous so a transient
+  /// remote-signer (Keycast RPC) outage spanning several inbox opens still
+  /// recovers, while a permanently-undecryptable wrap cannot loop forever.
+  /// See #5202.
+  static const int maxDecryptRetries = 10;
 }
 
 const _relayLoopbackHosts = <String>{
@@ -132,6 +139,7 @@ class DmRepository {
     required DirectMessagesDao directMessagesDao,
     required ConversationsDao conversationsDao,
     OutgoingDmsDao? outgoingDmsDao,
+    PendingGiftWrapsDao? pendingGiftWrapsDao,
     DmSyncState? syncState,
     NIP17MessageService? messageService,
     String? userPubkey,
@@ -144,6 +152,7 @@ class DmRepository {
        _directMessagesDao = directMessagesDao,
        _conversationsDao = conversationsDao,
        _outgoingDmsDao = outgoingDmsDao,
+       _pendingGiftWrapsDao = pendingGiftWrapsDao,
        _syncState = syncState,
        _messageService = messageService,
        _userPubkey = userPubkey ?? '',
@@ -164,6 +173,14 @@ class DmRepository {
   /// fixtures working without rewiring — when `null`, [sendMessage]
   /// keeps its previous direct-write behaviour.
   final OutgoingDmsDao? _outgoingDmsDao;
+
+  /// Optional DAO for the durable failed-decrypt gift-wrap retry queue.
+  /// When provided, gift wraps that fail NIP-44 decryption are persisted
+  /// here (instead of being silently dropped) so [retryPendingDecryptions]
+  /// can recover them on a later inbox open — the H2 resilience path for
+  /// flaky remote-signer (Keycast RPC) decryption. Nullable to keep older
+  /// test fixtures working without rewiring. See #5202.
+  final PendingGiftWrapsDao? _pendingGiftWrapsDao;
 
   final DmSyncState? _syncState;
   NIP17MessageService? _messageService;
@@ -470,6 +487,57 @@ class DmRepository {
     return drain;
   }
 
+  /// Replays gift wraps that previously failed NIP-44 decryption.
+  ///
+  /// On remote-signer accounts (Keycast RPC) each gift-wrap decrypt is a
+  /// network call, so a transient failure during the history-drain burst
+  /// would otherwise silently drop the conversation. Those wraps are
+  /// persisted raw (see [_handleGiftWrapEvent]); this replays each back
+  /// through the decrypt + persist pipeline, newest first, capped at
+  /// [DmHistoryDrainConfig.maxDecryptRetries] attempts per wrap so a
+  /// permanently-undecryptable wrap cannot loop forever. A no-op when no
+  /// failed-decrypt DAO is wired. Safe to fire-and-forget from the inbox
+  /// BLoC on every open. See #5202.
+  Future<void> retryPendingDecryptions() async {
+    if (!isInitialized) return;
+    final dao = _pendingGiftWrapsDao;
+    if (dao == null) return;
+    final pubkey = _userPubkey;
+    final pending = await dao.getRetryable(
+      ownerPubkey: pubkey,
+      maxAttempts: DmHistoryDrainConfig.maxDecryptRetries,
+    );
+    for (final row in pending) {
+      if (_disposed || _userPubkey != pubkey) return;
+      // Already recovered by the live sub / drain — clear the stale row so
+      // it does not linger and re-query on every inbox open.
+      if (await _directMessagesDao.hasGiftWrap(row.giftWrapId)) {
+        await dao.deletePending(
+          giftWrapId: row.giftWrapId,
+          ownerPubkey: pubkey,
+        );
+        continue;
+      }
+      final Event giftWrapEvent;
+      try {
+        giftWrapEvent = Event.fromJson(
+          jsonDecode(row.rawJson) as Map<String, dynamic>,
+        );
+      } on Object {
+        // Corrupt stored JSON — drop it so it cannot loop. We wrote this
+        // JSON ourselves, so a parse failure is a programming invariant.
+        await dao.deletePending(
+          giftWrapId: row.giftWrapId,
+          ownerPubkey: pubkey,
+        );
+        continue;
+      }
+      // Replays decrypt + persist. A successful decrypt deletes the pending
+      // row inside [_handleGiftWrapEvent]; a failure increments its attempts.
+      await _handleGiftWrapEvent(giftWrapEvent);
+    }
+  }
+
   Future<void> _runHistoryDrain() async {
     if (!isInitialized) return;
     final syncState = _syncState;
@@ -477,6 +545,12 @@ class DmRepository {
     // Pin the user for the whole drain so an account switch mid-drain can
     // never mark the wrong pubkey complete or query for the new user.
     final pubkey = _userPubkey;
+    // One-time forced re-drain: installs that completed under an older,
+    // buggy drain (pre-#5202) are stuck with historyDrainComplete=true while
+    // the relay still holds unrecovered history. A drain-version bump clears
+    // the stale flag once so recovery runs again. No-op once at the current
+    // version, so it does not loop on every inbox open. See #5202.
+    await syncState.upgradeDrainVersionIfNeeded(pubkey);
     if (syncState.historyDrainComplete(pubkey)) {
       Log.info(
         'DM history drain skipped for $pubkey: already complete',
@@ -521,6 +595,21 @@ class DmRepository {
         pagesRun++;
         totalEvents += events.length;
         if (events.isEmpty) {
+          // An empty page is genuine history exhaustion ONLY if a relay was
+          // actually connected to answer it. With 0 connected relays the
+          // query short-circuits to [] — marking the drain complete then
+          // would permanently strand unrecovered history (the #5202 root
+          // cause). Defer instead: leave historyDrainComplete unset and the
+          // cursor persisted so the next inbox open resumes once relays
+          // are up.
+          if (_nostrClient.connectedRelayCount == 0) {
+            Log.warning(
+              'DM history drain saw an empty page with 0 connected relays '
+              'for $pubkey; deferring completion to the next inbox open.',
+              category: LogCategory.system,
+            );
+            return;
+          }
           reachedEnd = true;
           break;
         }
@@ -695,12 +784,28 @@ class DmRepository {
 
       final rumorEvent = await _decryptRumor(nostr, giftWrapEvent);
       if (rumorEvent == null) {
+        // Persist the still-encrypted wrap so a later retry can recover the
+        // conversation instead of losing it — flaky remote-signer (Keycast
+        // RPC) decryption must not be permanent data loss. See #5202.
+        await _pendingGiftWrapsDao?.recordFailedDecrypt(
+          giftWrapId: giftWrapEvent.id,
+          ownerPubkey: _userPubkey,
+          rawJson: jsonEncode(giftWrapEvent.toJson()),
+          createdAt: giftWrapEvent.createdAt,
+        );
         Log.debug(
-          'Failed to decrypt gift wrap event ${giftWrapEvent.id}',
+          'Failed to decrypt gift wrap event ${giftWrapEvent.id}; '
+          'queued for retry',
           category: LogCategory.system,
         );
         return;
       }
+      // Decrypt succeeded — drop any prior failed-decrypt record so the
+      // retry queue stops reprocessing this wrap. See #5202.
+      await _pendingGiftWrapsDao?.deletePending(
+        giftWrapId: giftWrapEvent.id,
+        ownerPubkey: _userPubkey,
+      );
 
       // NIP-17 spec line 14 explicitly permits kind 7 reactions inside
       // the gift-wrap envelope. Reaction deletions are also wrapped by

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -220,6 +220,15 @@ class DmRepository {
   /// counter. Cleared when the pass settles. See #5202.
   Future<void>? _pendingDecryptRetry;
 
+  /// Count of in-flight recovery operations doing real work — history-drain
+  /// paging and failed-decrypt replay passes. Drives [isRecoveringHistory] /
+  /// [historyRecoveryStream] so the inbox can show a restore progress
+  /// indicator while a reinstall backfill runs (it can take a while on
+  /// remote-signer accounts that decrypt each wrap over RPC). See #5202.
+  int _activeRecoveryOps = 0;
+  final StreamController<bool> _recoveryStateController =
+      StreamController<bool>.broadcast();
+
   /// User-scoped subscription ID to prevent collision when the provider
   /// rebuilds during auth transitions (old unsubscribe won't kill new sub).
   String _subscriptionId = 'dm_inbox';
@@ -294,6 +303,14 @@ class DmRepository {
     // user can start fresh; the running loops bail on the _userPubkey change.
     _historyDrain = null;
     _pendingDecryptRetry = null;
+    // Abandon the recovery signal for the outgoing user. The bailing loops'
+    // _endRecovery() then no-ops (guarded on the zeroed counter).
+    if (_activeRecoveryOps > 0) {
+      _activeRecoveryOps = 0;
+      if (!_recoveryStateController.isClosed) {
+        _recoveryStateController.add(false);
+      }
+    }
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     unawaited(_giftWrapSubscription?.cancel());
@@ -464,6 +481,32 @@ class DmRepository {
     return events;
   }
 
+  /// Whether a DM history recovery (the backfill drain or a failed-decrypt
+  /// replay) is actively doing work right now. The inbox surfaces this as a
+  /// restore progress indicator so the user knows chats are still being
+  /// recovered after a reinstall. See #5202.
+  bool get isRecoveringHistory => _activeRecoveryOps > 0;
+
+  /// Broadcasts changes to [isRecoveringHistory]. Does not replay the current
+  /// value, so callers should seed with [isRecoveringHistory] (e.g.
+  /// `historyRecoveryStream.startWith(repo.isRecoveringHistory)`). See #5202.
+  Stream<bool> get historyRecoveryStream => _recoveryStateController.stream;
+
+  void _beginRecovery() {
+    _activeRecoveryOps++;
+    if (_activeRecoveryOps == 1 && !_recoveryStateController.isClosed) {
+      _recoveryStateController.add(true);
+    }
+  }
+
+  void _endRecovery() {
+    if (_activeRecoveryOps == 0) return;
+    _activeRecoveryOps--;
+    if (_activeRecoveryOps == 0 && !_recoveryStateController.isClosed) {
+      _recoveryStateController.add(false);
+    }
+  }
+
   /// Recovers the user's full DM history from relays once per install.
   ///
   /// On reinstall the local DB and [DmSyncState] are wiped, so the live
@@ -527,6 +570,7 @@ class DmRepository {
     final dao = _pendingGiftWrapsDao;
     if (dao == null) return;
     final pubkey = _userPubkey;
+    var began = false;
     try {
       // Drop wraps that exhausted the retry cap so the queue cannot grow
       // without bound — a permanently-undecryptable wrap or spammed kind-1059
@@ -539,6 +583,11 @@ class DmRepository {
         ownerPubkey: pubkey,
         maxAttempts: DmHistoryDrainConfig.maxDecryptRetries,
       );
+      if (pending.isEmpty) return;
+      // Only signal "recovering" once there is genuine work, so a normal
+      // inbox open (empty queue) never flickers the progress indicator.
+      _beginRecovery();
+      began = true;
       for (final row in pending) {
         if (_disposed || _userPubkey != pubkey) return;
         // Already recovered by the live sub / drain — clear the stale row so
@@ -583,6 +632,8 @@ class DmRepository {
         error: e,
         stackTrace: stackTrace,
       );
+    } finally {
+      if (began) _endRecovery();
     }
   }
 
@@ -614,6 +665,7 @@ class DmRepository {
       category: LogCategory.system,
     );
 
+    _beginRecovery();
     try {
       // The relay filters `until:` on the OUTER gift-wrap created_at, which
       // NIP-59 randomizes up to 2 days into the past — so the cursor tracks
@@ -716,6 +768,8 @@ class DmRepository {
           site: DmRepositoryReportableSites.historyDrainUnexpectedFailure,
         );
       }
+    } finally {
+      _endRecovery();
     }
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -213,6 +213,13 @@ class DmRepository {
   /// launch overlapping drains. Cleared when the drain settles.
   Future<void>? _historyDrain;
 
+  /// The in-flight failed-decrypt retry pass, shared by concurrent callers so
+  /// repeated [retryPendingDecryptions] calls (every inbox open, plus
+  /// load-more / blocklist re-dispatches) never run overlapping passes that
+  /// would double the Keycast RPC decrypts or race the per-wrap attempt
+  /// counter. Cleared when the pass settles. See #5202.
+  Future<void>? _pendingDecryptRetry;
+
   /// User-scoped subscription ID to prevent collision when the provider
   /// rebuilds during auth transitions (old unsubscribe won't kill new sub).
   String _subscriptionId = 'dm_inbox';
@@ -283,9 +290,10 @@ class DmRepository {
   void _resetState() {
     _disposed = true;
     _eventLock = null;
-    // Drop the in-flight history drain so the next user can start a fresh
-    // one; the running loop bails on the _userPubkey change.
+    // Drop the in-flight history drain and decrypt-retry pass so the next
+    // user can start fresh; the running loops bail on the _userPubkey change.
     _historyDrain = null;
+    _pendingDecryptRetry = null;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     unawaited(_giftWrapSubscription?.cancel());
@@ -495,46 +503,86 @@ class DmRepository {
   /// persisted raw (see [_handleGiftWrapEvent]); this replays each back
   /// through the decrypt + persist pipeline, newest first, capped at
   /// [DmHistoryDrainConfig.maxDecryptRetries] attempts per wrap so a
-  /// permanently-undecryptable wrap cannot loop forever. A no-op when no
+  /// permanently-undecryptable wrap cannot loop forever (rows that exhaust
+  /// the cap are dropped). Each replay routes through [_handleIncomingEvent]
+  /// so it serializes on the same `_eventLock` as the live subscription and
+  /// the drain. Concurrent callers share one in-flight pass. A no-op when no
   /// failed-decrypt DAO is wired. Safe to fire-and-forget from the inbox
   /// BLoC on every open. See #5202.
-  Future<void> retryPendingDecryptions() async {
+  Future<void> retryPendingDecryptions() {
+    final existing = _pendingDecryptRetry;
+    if (existing != null) return existing;
+    final run = _runPendingDecryptRetry();
+    _pendingDecryptRetry = run;
+    unawaited(
+      run.whenComplete(() {
+        if (identical(_pendingDecryptRetry, run)) _pendingDecryptRetry = null;
+      }),
+    );
+    return run;
+  }
+
+  Future<void> _runPendingDecryptRetry() async {
     if (!isInitialized) return;
     final dao = _pendingGiftWrapsDao;
     if (dao == null) return;
     final pubkey = _userPubkey;
-    final pending = await dao.getRetryable(
-      ownerPubkey: pubkey,
-      maxAttempts: DmHistoryDrainConfig.maxDecryptRetries,
-    );
-    for (final row in pending) {
-      if (_disposed || _userPubkey != pubkey) return;
-      // Already recovered by the live sub / drain — clear the stale row so
-      // it does not linger and re-query on every inbox open.
-      if (await _directMessagesDao.hasGiftWrap(row.giftWrapId)) {
-        await dao.deletePending(
-          giftWrapId: row.giftWrapId,
-          ownerPubkey: pubkey,
-        );
-        continue;
+    try {
+      // Drop wraps that exhausted the retry cap so the queue cannot grow
+      // without bound — a permanently-undecryptable wrap or spammed kind-1059
+      // events addressed to the user would otherwise linger forever. See #5202.
+      await dao.deleteExhausted(
+        ownerPubkey: pubkey,
+        maxAttempts: DmHistoryDrainConfig.maxDecryptRetries,
+      );
+      final pending = await dao.getRetryable(
+        ownerPubkey: pubkey,
+        maxAttempts: DmHistoryDrainConfig.maxDecryptRetries,
+      );
+      for (final row in pending) {
+        if (_disposed || _userPubkey != pubkey) return;
+        // Already recovered by the live sub / drain — clear the stale row so
+        // it does not linger and re-query on every inbox open.
+        if (await _directMessagesDao.hasGiftWrap(row.giftWrapId)) {
+          await dao.deletePending(
+            giftWrapId: row.giftWrapId,
+            ownerPubkey: pubkey,
+          );
+          continue;
+        }
+        final Event giftWrapEvent;
+        try {
+          giftWrapEvent = Event.fromJson(
+            jsonDecode(row.rawJson) as Map<String, dynamic>,
+          );
+        } on Object {
+          // Corrupt stored JSON — drop it so it cannot loop. We wrote this
+          // JSON ourselves, so a parse failure is a programming invariant.
+          await dao.deletePending(
+            giftWrapId: row.giftWrapId,
+            ownerPubkey: pubkey,
+          );
+          continue;
+        }
+        // Re-check after the awaits above so an account switch mid-pass never
+        // replays the old user's wrap under the new session.
+        if (_disposed || _userPubkey != pubkey) return;
+        // Route through _handleIncomingEvent so the replay serializes on the
+        // same _eventLock as the live subscription and the drain. A
+        // successful decrypt deletes the pending row inside
+        // _handleGiftWrapEvent; a failure increments its attempts.
+        await _handleIncomingEvent(giftWrapEvent);
       }
-      final Event giftWrapEvent;
-      try {
-        giftWrapEvent = Event.fromJson(
-          jsonDecode(row.rawJson) as Map<String, dynamic>,
-        );
-      } on Object {
-        // Corrupt stored JSON — drop it so it cannot loop. We wrote this
-        // JSON ourselves, so a parse failure is a programming invariant.
-        await dao.deletePending(
-          giftWrapId: row.giftWrapId,
-          ownerPubkey: pubkey,
-        );
-        continue;
-      }
-      // Replays decrypt + persist. A successful decrypt deletes the pending
-      // row inside [_handleGiftWrapEvent]; a failure increments its attempts.
-      await _handleGiftWrapEvent(giftWrapEvent);
+    } on Object catch (e, stackTrace) {
+      // Relay/DB/IO failures here are expected (e.g. a transient read-only
+      // DB) and NOT reportable; the pass resumes on the next inbox open since
+      // rows are removed only on success, cap, or corruption.
+      Log.error(
+        'DM decrypt-retry pass failed (will resume on next inbox open): $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -24,6 +24,17 @@ class DmSyncState {
   static const _oldestPrefix = 'dm.oldestSyncedAt.';
   static const _drainCompletePrefix = 'dm.historyDrainComplete.';
   static const _drainCursorPrefix = 'dm.historyDrainCursor.';
+  static const _drainVersionPrefix = 'dm.historyDrainVersion.';
+
+  /// Current history-drain logic version. Installs whose persisted
+  /// [drainVersion] is below this re-run the drain once, even if
+  /// [historyDrainComplete] is already `true` — this unsticks installs that
+  /// completed under an older, buggy drain that could mark complete without
+  /// fully recovering history (a cold-start empty page, or dropped
+  /// decryptions). Pre-#5202 installs have no version key (reads as 0). Bump
+  /// this whenever a drain-correctness fix must force one more recovery pass.
+  /// See #5202.
+  static const int currentDrainVersion = 2;
 
   /// Returns the newest (highest) `created_at` unix timestamp we have
   /// successfully processed for [pubkey], or `null` if nothing has been
@@ -70,6 +81,32 @@ class DmSyncState {
     await _prefs.remove('$_drainCursorPrefix$pubkey');
   }
 
+  /// The history-drain logic version last completed for [pubkey], or `0`
+  /// if none has been recorded (pre-#5202 installs, fresh installs).
+  int drainVersion(String pubkey) =>
+      _prefs.getInt('$_drainVersionPrefix$pubkey') ?? 0;
+
+  /// Records that [pubkey] has been brought up to drain logic [version].
+  Future<void> setDrainVersion(String pubkey, int version) async {
+    await _prefs.setInt('$_drainVersionPrefix$pubkey', version);
+  }
+
+  /// Forces a one-time re-drain for [pubkey] when its persisted
+  /// [drainVersion] is below [currentDrainVersion], by clearing the
+  /// completion flag and resume cursor, then stamping the current version.
+  ///
+  /// This is the recovery path for installs stranded by an older drain that
+  /// marked [historyDrainComplete] without fully recovering history (#5202).
+  /// A no-op for fresh installs (nothing to clear) and for installs already
+  /// at the current version. Idempotent: after the bump the version matches,
+  /// so it does not loop on every inbox open.
+  Future<void> upgradeDrainVersionIfNeeded(String pubkey) async {
+    if (drainVersion(pubkey) >= currentDrainVersion) return;
+    await _prefs.remove('$_drainCompletePrefix$pubkey');
+    await _prefs.remove('$_drainCursorPrefix$pubkey');
+    await setDrainVersion(pubkey, currentDrainVersion);
+  }
+
   /// The outer gift-wrap `created_at` (unix seconds) the history drain has
   /// paged down to for [pubkey], or `null` if no drain has persisted a
   /// boundary yet.
@@ -97,6 +134,7 @@ class DmSyncState {
     await _prefs.remove('$_oldestPrefix$pubkey');
     await _prefs.remove('$_drainCompletePrefix$pubkey');
     await _prefs.remove('$_drainCursorPrefix$pubkey');
+    await _prefs.remove('$_drainVersionPrefix$pubkey');
   }
 
   /// Removes all DM sync state entries for every pubkey.
@@ -111,7 +149,8 @@ class DmSyncState {
               key.startsWith(_newestPrefix) ||
               key.startsWith(_oldestPrefix) ||
               key.startsWith(_drainCompletePrefix) ||
-              key.startsWith(_drainCursorPrefix),
+              key.startsWith(_drainCursorPrefix) ||
+              key.startsWith(_drainVersionPrefix),
         )
         .toList();
     for (final key in keysToRemove) {

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -30,10 +30,12 @@ class DmSyncState {
   /// [drainVersion] is below this re-run the drain once, even if
   /// [historyDrainComplete] is already `true` — this unsticks installs that
   /// completed under an older, buggy drain that could mark complete without
-  /// fully recovering history (a cold-start empty page, or dropped
-  /// decryptions). Pre-#5202 installs have no version key (reads as 0). Bump
-  /// this whenever a drain-correctness fix must force one more recovery pass.
-  /// See #5202.
+  /// fully recovering history (a cold-start empty page, or a wrap a prior run
+  /// failed to decrypt). The re-drain re-fetches and re-decrypts whatever the
+  /// relays still serve; gift wraps a relay has since pruned cannot be
+  /// recovered (inherent reinstall-recovery limit). Pre-#5202 installs have no
+  /// version key (reads as 0). Bump this whenever a drain-correctness fix must
+  /// force one more recovery pass. See #5202.
   static const int currentDrainVersion = 2;
 
   /// Returns the newest (highest) `created_at` unix timestamp we have

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -2432,6 +2432,50 @@ void main() {
       );
 
       test(
+        'emits recovery true→false on historyRecoveryStream around an '
+        'actual drain (#5202)',
+        () async {
+          final capturedUntil = <int?>[];
+          stubFiniteHistory([deletion(50)], capturedUntil);
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          final recovery = <bool>[];
+          final sub = repository.historyRecoveryStream.listen(recovery.add);
+
+          expect(repository.isRecoveringHistory, isFalse);
+          await repository.backfillHistoryIfNeeded();
+          await Future<void>.delayed(Duration.zero);
+          await sub.cancel();
+
+          expect(recovery, [true, false]);
+          expect(repository.isRecoveringHistory, isFalse);
+        },
+      );
+
+      test(
+        'does not emit recovery for an already-complete drain (#5202)',
+        () async {
+          final syncState = _FakeDmSyncState()
+            ..drainCompleteOverride = true
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          final recovery = <bool>[];
+          final sub = repository.historyRecoveryStream.listen(recovery.add);
+
+          await repository.backfillHistoryIfNeeded();
+          await Future<void>.delayed(Duration.zero);
+          await sub.cancel();
+
+          expect(recovery, isEmpty);
+          expect(repository.isRecoveringHistory, isFalse);
+        },
+      );
+
+      test(
         'pages newest→oldest from oldestSyncedAt until the relay is empty, '
         'then marks the drain complete',
         () async {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -20,6 +20,8 @@ import 'package:nostr_sdk/signer/nostr_signer.dart';
 
 class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
 
+class _MockPendingGiftWrapsDao extends Mock implements PendingGiftWrapsDao {}
+
 class _FakeOutgoingDm extends Fake implements OutgoingDm {}
 
 class _MockNostrClient extends Mock implements NostrClient {}
@@ -44,8 +46,10 @@ class _FakeDmSyncState implements DmSyncState {
   int? oldestOverride;
   bool drainCompleteOverride = false;
   int? drainCursorOverride;
+  int drainVersionOverride = 0;
   final List<String> markedCompletePubkeys = <String>[];
   final List<int> persistedDrainCursors = <int>[];
+  final List<String> upgradedPubkeys = <String>[];
   final List<({String pubkey, int createdAt})> recorded =
       <({String pubkey, int createdAt})>[];
 
@@ -63,6 +67,23 @@ class _FakeDmSyncState implements DmSyncState {
     markedCompletePubkeys.add(pubkey);
     drainCompleteOverride = true;
     drainCursorOverride = null;
+  }
+
+  @override
+  int drainVersion(String pubkey) => drainVersionOverride;
+
+  @override
+  Future<void> setDrainVersion(String pubkey, int version) async {
+    drainVersionOverride = version;
+  }
+
+  @override
+  Future<void> upgradeDrainVersionIfNeeded(String pubkey) async {
+    if (drainVersionOverride >= DmSyncState.currentDrainVersion) return;
+    upgradedPubkeys.add(pubkey);
+    drainCompleteOverride = false;
+    drainCursorOverride = null;
+    drainVersionOverride = DmSyncState.currentDrainVersion;
   }
 
   @override
@@ -91,6 +112,7 @@ class _FakeDmSyncState implements DmSyncState {
     oldestOverride = null;
     drainCompleteOverride = false;
     drainCursorOverride = null;
+    drainVersionOverride = 0;
   }
 
   @override
@@ -99,6 +121,7 @@ class _FakeDmSyncState implements DmSyncState {
     oldestOverride = null;
     drainCompleteOverride = false;
     drainCursorOverride = null;
+    drainVersionOverride = 0;
     recorded.clear();
   }
 }
@@ -248,6 +271,7 @@ void main() {
       Nip04Decryptor? nip04Decryptor,
       DmSyncState? syncState,
       OutgoingDmsDao? outgoingDmsDao,
+      PendingGiftWrapsDao? pendingGiftWrapsDao,
       DmReactionsRepository? reactionsRepository,
     }) {
       return DmRepository(
@@ -256,6 +280,7 @@ void main() {
         directMessagesDao: mockDirectMessagesDao,
         conversationsDao: mockConversationsDao,
         outgoingDmsDao: outgoingDmsDao,
+        pendingGiftWrapsDao: pendingGiftWrapsDao,
         userPubkey: userPubkey ?? _validPubkeyA,
         signer: LocalNostrSigner(_validPrivateKey),
         rumorDecryptor: rumorDecryptor,
@@ -1387,6 +1412,136 @@ void main() {
         await repository.stopListening();
       });
 
+      test(
+        'queues a failed-decrypt gift wrap for retry instead of dropping it '
+        '(#5202)',
+        () async {
+          final giftWrap = createGiftWrapEvent();
+          final pendingDao = _MockPendingGiftWrapsDao();
+          when(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              rawJson: any(named: 'rawJson'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          ).thenAnswer((_) async {});
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => null,
+            pendingGiftWrapsDao: pendingDao,
+          );
+
+          await repository.startListening();
+          controller.add(giftWrap);
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: _giftWrapEventId,
+              ownerPubkey: _validPubkeyA,
+              rawJson: any(named: 'rawJson'),
+              createdAt: 1700000000,
+            ),
+          ).called(1);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      test(
+        'retryPendingDecryptions recovers a previously undecryptable wrap '
+        'and clears its pending row (#5202)',
+        () async {
+          final giftWrap = createGiftWrapEvent();
+          final rumor = createRumorEvent();
+          final pendingDao = _MockPendingGiftWrapsDao();
+
+          when(
+            () => pendingDao.getRetryable(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxAttempts: any(named: 'maxAttempts'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              PendingGiftWrap(
+                giftWrapId: _giftWrapEventId,
+                ownerPubkey: _validPubkeyA,
+                rawJson: jsonEncode(giftWrap.toJson()),
+                createdAt: 1700000000,
+                attempts: 1,
+              ),
+            ],
+          );
+          when(
+            () => pendingDao.deletePending(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+          stubDaoInserts();
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => rumor,
+            pendingGiftWrapsDao: pendingDao,
+          );
+
+          await repository.retryPendingDecryptions();
+          await Future<void>.delayed(Duration.zero);
+
+          // The wrap decrypted and persisted…
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: _rumorEventId,
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: _validPubkeyB,
+              content: 'Hello from B!',
+              createdAt: 1700000000,
+              giftWrapId: _giftWrapEventId,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
+          // …and the pending row was cleared so it stops being retried.
+          verify(
+            () => pendingDao.deletePending(
+              giftWrapId: _giftWrapEventId,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).called(1);
+        },
+      );
+
       test('skips events with wrong kind', () async {
         final giftWrap = createGiftWrapEvent();
         // kind 1 instead of kind 14
@@ -2199,6 +2354,78 @@ void main() {
       }
 
       test(
+        'does NOT mark complete on an empty page when no relays are '
+        'connected — defers to the next inbox open (#5202)',
+        () async {
+          // queryEvents short-circuits to [] when the relay pool has not
+          // connected yet; treating that as exhaustion would permanently
+          // strand unrecovered history (the reported regression).
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(0);
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(const <Event>[], capturedUntil);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // Queried once, got empty, but deferred instead of completing.
+          expect(capturedUntil, [100]);
+          expect(syncState.drainCompleteOverride, isFalse);
+          expect(syncState.markedCompletePubkeys, isEmpty);
+        },
+      );
+
+      test(
+        'marks complete on an empty page when at least one relay is '
+        'connected (genuine exhaustion)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(const <Event>[], capturedUntil);
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(syncState.drainCompleteOverride, isTrue);
+        },
+      );
+
+      test(
+        're-runs once for an install stranded complete by an older drain '
+        '(drainVersion below current) — #5202',
+        () async {
+          final capturedUntil = <int?>[];
+          stubFiniteHistory(const <Event>[], capturedUntil);
+
+          // Pre-#5202 install: flagged complete at an older drain version
+          // while history still exists on the relay.
+          final syncState = _FakeDmSyncState()
+            ..drainCompleteOverride = true
+            ..drainVersionOverride = 0;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The version bump cleared the stale flag and the drain re-ran,
+          // then re-completed cleanly (default 3 relays connected).
+          expect(syncState.upgradedPubkeys, isNotEmpty);
+          expect(capturedUntil, isNotEmpty);
+          expect(syncState.drainCompleteOverride, isTrue);
+          expect(
+            syncState.drainVersionOverride,
+            DmSyncState.currentDrainVersion,
+          );
+        },
+      );
+
+      test(
         'pages newest→oldest from oldestSyncedAt until the relay is empty, '
         'then marks the drain complete',
         () async {
@@ -2229,7 +2456,9 @@ void main() {
       );
 
       test('is a no-op when the drain already completed', () async {
-        final syncState = _FakeDmSyncState()..drainCompleteOverride = true;
+        final syncState = _FakeDmSyncState()
+          ..drainCompleteOverride = true
+          ..drainVersionOverride = DmSyncState.currentDrainVersion;
         final repository = createRepository(syncState: syncState);
 
         await repository.backfillHistoryIfNeeded();
@@ -2310,7 +2539,8 @@ void main() {
           // subscription's oldestSyncedAt boundary.
           final syncState = _FakeDmSyncState()
             ..oldestOverride = 1000
-            ..drainCursorOverride = 45;
+            ..drainCursorOverride = 45
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
           final repository = createRepository(syncState: syncState);
 
           await repository.backfillHistoryIfNeeded();

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -1471,6 +1471,12 @@ void main() {
           final pendingDao = _MockPendingGiftWrapsDao();
 
           when(
+            () => pendingDao.deleteExhausted(
+              ownerPubkey: any(named: 'ownerPubkey'),
+              maxAttempts: any(named: 'maxAttempts'),
+            ),
+          ).thenAnswer((_) async => 0);
+          when(
             () => pendingDao.getRetryable(
               ownerPubkey: any(named: 'ownerPubkey'),
               maxAttempts: any(named: 'maxAttempts'),

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -202,5 +202,62 @@ void main() {
         expect(state.historyDrainCursor(pkB), isNull);
       });
     });
+
+    group('drainVersion', () {
+      test('defaults to 0 when never recorded', () {
+        expect(state.drainVersion(pkA), equals(0));
+      });
+
+      test('setDrainVersion persists per pubkey', () async {
+        await state.setDrainVersion(pkA, 2);
+
+        expect(state.drainVersion(pkA), equals(2));
+        expect(state.drainVersion(pkB), equals(0));
+      });
+
+      test(
+        'upgradeDrainVersionIfNeeded clears a stale completion flag + cursor '
+        'and stamps the current version when below it',
+        () async {
+          // Simulate an install stranded by an older, buggy drain.
+          await state.markHistoryDrainComplete(pkA);
+          await state.setHistoryDrainCursor(pkA, 1234);
+          expect(state.historyDrainComplete(pkA), isTrue);
+
+          await state.upgradeDrainVersionIfNeeded(pkA);
+
+          expect(state.historyDrainComplete(pkA), isFalse);
+          expect(state.historyDrainCursor(pkA), isNull);
+          expect(state.drainVersion(pkA), DmSyncState.currentDrainVersion);
+        },
+      );
+
+      test(
+        'upgradeDrainVersionIfNeeded is idempotent at the current version',
+        () async {
+          await state.upgradeDrainVersionIfNeeded(pkA);
+          // A genuine completion at the current version must survive a second
+          // upgrade pass (no re-drain loop on every inbox open).
+          await state.markHistoryDrainComplete(pkA);
+
+          await state.upgradeDrainVersionIfNeeded(pkA);
+
+          expect(state.historyDrainComplete(pkA), isTrue);
+          expect(state.drainVersion(pkA), DmSyncState.currentDrainVersion);
+        },
+      );
+
+      test('clear and clearAll reset the drain version', () async {
+        await state.setDrainVersion(pkA, DmSyncState.currentDrainVersion);
+        await state.setDrainVersion(pkB, DmSyncState.currentDrainVersion);
+
+        await state.clear(pkA);
+        expect(state.drainVersion(pkA), equals(0));
+        expect(state.drainVersion(pkB), DmSyncState.currentDrainVersion);
+
+        await state.clearAll();
+        expect(state.drainVersion(pkB), equals(0));
+      });
+    });
   });
 }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -508,7 +508,15 @@ class NostrClient {
       cacheResults.addAll(await dao.getEventsByFilter(filters.first));
     }
 
-    // 2. Query via WebSocket
+    // 2. Query via WebSocket.
+    // A cold query — e.g. the DM history drain firing before the relay
+    // pool has finished connecting — would otherwise short-circuit to an
+    // empty result (RelayPool completes immediately when no relay accepts
+    // the REQ). Reconnect first, mirroring publish()/subscribe(). See #5202.
+    if (_relayManager.connectedRelays.isEmpty &&
+        (tempRelays == null || tempRelays.isEmpty)) {
+      await retryDisconnectedRelays();
+    }
     final filtersJson = filters.map((f) => f.toJson()).toList();
     final websocketEvents = await _nostr.queryEvents(
       filtersJson,

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -126,6 +126,92 @@ void main() {
       });
     });
 
+    group('queryEvents', () {
+      test(
+        'reconnects before querying when no relays are connected (#5202)',
+        () async {
+          // A cold query (e.g. the DM history drain firing before the pool
+          // connects) must reconnect first, mirroring publishEvent().
+          when(() => mockRelayManager.connectedRelays).thenReturn([]);
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) async {});
+          when(
+            () => mockNostr.queryEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => <Event>[]);
+
+          await client.queryEvents(
+            [
+              Filter(kinds: const [1059]),
+            ],
+            useCache: false,
+          );
+
+          verify(mockRelayManager.retryDisconnectedRelays).called(1);
+        },
+      );
+
+      test('does not reconnect when relays are already connected', () async {
+        // Default mock has a connected relay.
+        when(
+          () => mockNostr.queryEvents(
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => <Event>[]);
+
+        await client.queryEvents(
+          [
+            Filter(kinds: const [1059]),
+          ],
+          useCache: false,
+        );
+
+        verifyNever(mockRelayManager.retryDisconnectedRelays);
+      });
+
+      test(
+        'does not reconnect when explicit tempRelays are provided',
+        () async {
+          when(() => mockRelayManager.connectedRelays).thenReturn([]);
+          when(
+            mockRelayManager.retryDisconnectedRelays,
+          ).thenAnswer((_) async {});
+          when(
+            () => mockNostr.queryEvents(
+              any(),
+              id: any(named: 'id'),
+              tempRelays: any(named: 'tempRelays'),
+              relayTypes: any(named: 'relayTypes'),
+              sendAfterAuth: any(named: 'sendAfterAuth'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => <Event>[]);
+
+          await client.queryEvents(
+            [
+              Filter(kinds: const [1059]),
+            ],
+            tempRelays: const ['wss://temp.example.com'],
+            useCache: false,
+          );
+
+          verifyNever(mockRelayManager.retryDisconnectedRelays);
+        },
+      );
+    });
+
     group('publishEvent', () {
       test('publishes event successfully', () async {
         final event = _createTestEvent();

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -90,6 +90,10 @@ void main() {
       when(
         () => mockDmRepository.backfillHistoryIfNeeded(),
       ).thenAnswer((_) async {});
+      // Failed-decrypt retry pass, also fired on every inbox open (#5202).
+      when(
+        () => mockDmRepository.retryPendingDecryptions(),
+      ).thenAnswer((_) async {});
     });
 
     ConversationListBloc createBloc() => ConversationListBloc(
@@ -1071,6 +1075,9 @@ void main() {
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
       when(
         () => mockDmRepository.backfillHistoryIfNeeded(),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.retryPendingDecryptions(),
       ).thenAnswer((_) async {});
     });
 

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -58,6 +58,8 @@ void _stubStreams(
   _MockDmRepository repo, {
   List<DmConversation> accepted = const [],
   List<DmConversation> potentialRequests = const [],
+  Stream<bool>? recoveryStream,
+  bool isRecovering = false,
 }) {
   when(
     () => repo.watchAcceptedConversations(limit: any(named: 'limit')),
@@ -65,6 +67,10 @@ void _stubStreams(
   when(
     () => repo.watchPotentialRequests(),
   ).thenAnswer((_) => Stream.value(potentialRequests));
+  when(() => repo.isRecoveringHistory).thenReturn(isRecovering);
+  when(
+    () => repo.historyRecoveryStream,
+  ).thenAnswer((_) => recoveryStream ?? const Stream<bool>.empty());
 }
 
 void main() {
@@ -121,6 +127,34 @@ void main() {
         act: (bloc) => bloc.add(const ConversationListStarted()),
         verify: (_) {
           verify(() => mockDmRepository.backfillHistoryIfNeeded()).called(1);
+        },
+      );
+
+      blocTest<ConversationListBloc, ConversationListState>(
+        'surfaces history-recovery progress as isRestoringHistory (#5202)',
+        setUp: () {
+          _stubStreams(
+            mockDmRepository,
+            recoveryStream: Stream.value(true),
+            isRecovering: true,
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ConversationListStarted()),
+        verify: (bloc) {
+          expect(bloc.state.isRestoringHistory, isTrue);
+        },
+      );
+
+      blocTest<ConversationListBloc, ConversationListState>(
+        'isRestoringHistory is false when no recovery is running',
+        setUp: () {
+          _stubStreams(mockDmRepository);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ConversationListStarted()),
+        verify: (bloc) {
+          expect(bloc.state.isRestoringHistory, isFalse);
         },
       );
 
@@ -182,6 +216,10 @@ void main() {
           when(
             () => mockDmRepository.watchPotentialRequests(),
           ).thenAnswer((_) => Stream.value(const []));
+          when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+          when(
+            () => mockDmRepository.historyRecoveryStream,
+          ).thenAnswer((_) => const Stream<bool>.empty());
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ConversationListStarted()),
@@ -231,6 +269,10 @@ void main() {
           when(
             () => mockDmRepository.watchPotentialRequests(),
           ).thenAnswer((_) => requestsController.stream);
+          when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+          when(
+            () => mockDmRepository.historyRecoveryStream,
+          ).thenAnswer((_) => const Stream<bool>.empty());
 
           // Emit initial empty requests, then accepted values.
           Future<void>.delayed(const Duration(milliseconds: 10)).then((_) {
@@ -496,6 +538,11 @@ void main() {
               if (requestsCallCount == 1) return requestsCtrl1.stream;
               return requestsCtrl2.stream;
             });
+
+            when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+            when(
+              () => mockDmRepository.historyRecoveryStream,
+            ).thenAnswer((_) => const Stream<bool>.empty());
 
             // First streams emit quickly
             Future<void>.delayed(const Duration(milliseconds: 10)).then((_) {
@@ -949,7 +996,8 @@ void main() {
         const <DmConversation>[],
         const <DmConversation>[],
         true,
-        false,
+        false, // isLoadingMore
+        false, // isRestoringHistory
         ConversationListState.pageSize,
         null,
       ]);

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -352,6 +352,48 @@ void main() {
           expect(find.byType(ConversationTile), findsOneWidget);
         },
       );
+
+      testWidgets(
+        'shows restoring progress bar when isRestoringHistory is true',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationListState(
+                status: ConversationListStatus.loaded,
+                isRestoringHistory: true,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          // Switch to Messages tab (default is Notifications).
+          await tester.tap(find.text('Messages'));
+          // pump (not pumpAndSettle): LinearProgressIndicator animates forever.
+          await tester.pump();
+
+          expect(find.byType(LinearProgressIndicator), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'hides restoring progress bar when isRestoringHistory is false',
+        (tester) async {
+          await tester.pumpWidget(
+            buildSubject(
+              state: const ConversationListState(
+                status: ConversationListStatus.loaded,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          // Switch to Messages tab (default is Notifications).
+          await tester.tap(find.text('Messages'));
+          await tester.pump();
+
+          expect(find.byType(LinearProgressIndicator), findsNothing);
+        },
+      );
     });
 
     group('navigation', () {

--- a/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
@@ -51,6 +51,9 @@ void main() {
       when(
         () => mockDmRepository.backfillHistoryIfNeeded(),
       ).thenAnswer((_) async {});
+      when(
+        () => mockDmRepository.retryPendingDecryptions(),
+      ).thenAnswer((_) async {});
 
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
       when(() => mockAuthService.isAuthenticated).thenReturn(true);

--- a/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
@@ -45,6 +45,10 @@ void main() {
       when(
         () => mockDmRepository.watchPotentialRequests(),
       ).thenAnswer((_) => Stream.value(const []));
+      when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+      when(
+        () => mockDmRepository.historyRecoveryStream,
+      ).thenAnswer((_) => const Stream<bool>.empty());
       when(() => mockDmRepository.userPubkey).thenReturn(testPubkey);
       when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});


### PR DESCRIPTION
## Description

After reinstalling and signing back in, only a few DM conversations were restored even though the relay still held the full history. Root cause is **client-side**: the one-time DM history **drain** marked itself **permanently complete** on the first empty relay page without verifying recovery had actually happened. Two paths trip this:

1. **Cold-start relay race** — the drain fires on inbox open gated only on signer readiness, not relay connectivity. `queryEvents` (unlike `publish`/`subscribe`) did not retry-connect, and the relay pool completes a query immediately with an empty result when no relay has accepted it. A drain that fired before the WebSocket pool connected fetched nothing, then permanently marked itself complete.
2. **Remote-signer decryption failure** — for Keycast / `divineOAuth` accounts every gift-wrap decrypt is an RPC call. A wrap that failed to decrypt was silently dropped (no row, no dedup marker) while the drain still completed, so those conversations were lost.

The conversation list is a pure local-DB projection, so unrecovered history was invisible with no UI path back. Verified directly against `relay.divine.video`: the affected account has **122 gift wraps on the relay** (readable without auth) while the app showed **3**.

### What changed
- **Connectivity-gated completion** — the drain marks complete on an empty page only when at least one relay was connected to answer it; with 0 connected relays it defers and resumes on the next inbox open.
- **`queryEvents` retry-connect** — matches `publish`/`subscribe`, so a cold query reconnects instead of returning empty instantly.
- **One-time re-drain** — a `DmSyncState.drainVersion` bump clears the stale "complete" flag once, so installs already stranded by the old drain recover **without another reinstall**.
- **Durable failed-decrypt queue** — wraps that fail NIP-44 decryption are persisted to a new `pending_gift_wraps` table and replayed by `retryPendingDecryptions()` on inbox open (capped per wrap), so flaky remote-signer decryption never permanently loses a conversation.

**Related Issue:** Closes #5202

## Reproducing steps

**Before this PR**
1. Use an account with many DM conversations (ideally a Keycast / Divine-OAuth account).
2. Uninstall and reinstall the app.
3. Sign back into the same account and open **Messages** on the first cold start.
4. Only a few chats are restored. Logs show a `DM history drain ... complete` once, then `DM history drain skipped ... already complete` on every later open — permanently — while the relay still holds the full history.

**After this PR**
- On the first post-reinstall open, the drain no longer completes against an unconnected pool, and wraps that fail to decrypt are queued and retried, so the full conversation list is restored. Installs already stranded recover on their next inbox open via the drain-version re-run.

## Out of Scope
- Pinning which of the two paths (cold-start race vs remote-signer decrypt failure) was the proximate trigger for a given report — the fix covers both. A device log line (`DM history drain complete ... eventsFetched=N`) would distinguish them but is not required for the fix.

## Verification
- `dart format` + `flutter analyze` clean across `dm_repository`, `nostr_client`, `db_client`, and the changed `mobile/lib` files.
- Package suites green: `db_client` (664), `dm_repository` (309), `nostr_client` (271).
- Mobile DM suites green: `test/blocs/dm/` and `test/screens/inbox/`.
- Drift schema-parity + migration tests pass with the new `pending_gift_wraps` table (added via the existing runtime `CREATE TABLE IF NOT EXISTS` pattern — no schema-version bump).
- New tests: drain connectivity-gated completion (defer on 0 relays / complete on ≥1 relay), drain-version re-run, failed-decrypt → pending queue, `retryPendingDecryptions` recovery, `PendingGiftWrapsDao` CRUD + retry cap, `DmSyncState.drainVersion`, and `queryEvents` retry-connect.
- Not yet exercised on a physical device.

## Type of Change
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
