### PR TITLE
fix(profile): continue sparse liked video pagination

### DIFF
--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -21,6 +21,18 @@ part 'profile_liked_videos_state.dart';
 /// Number of videos to load per page for pagination.
 const _pageSize = 18;
 
+final class _LikedVideosPage {
+  const _LikedVideosPage({
+    required this.videos,
+    required this.nextOffset,
+    required this.hasMoreContent,
+  });
+
+  final List<VideoEvent> videos;
+  final int nextOffset;
+  final bool hasMoreContent;
+}
+
 /// BLoC for managing profile liked videos.
 ///
 /// Coordinates between:
@@ -150,11 +162,14 @@ class ProfileLikedVideosBloc
         ),
       );
 
-      final firstPageIds = likedEventIds.take(_pageSize).toList();
-      final videos = await _fetchVideos(firstPageIds, cacheResults: true);
+      final page = await _fetchVideoPage(
+        likedEventIds,
+        startOffset: 0,
+        cacheFirstBatch: true,
+      );
 
       Log.info(
-        'ProfileLikedVideosBloc: Loaded ${videos.length} videos '
+        'ProfileLikedVideosBloc: Loaded ${page.videos.length} videos '
         '(first page of ${likedEventIds.length} total)',
         name: 'ProfileLikedVideosBloc',
         category: LogCategory.video,
@@ -163,9 +178,9 @@ class ProfileLikedVideosBloc
       emit(
         state.copyWith(
           status: ProfileLikedVideosStatus.success,
-          videos: videos,
-          hasMoreContent: likedEventIds.length > firstPageIds.length,
-          nextPageOffset: firstPageIds.length,
+          videos: page.videos,
+          hasMoreContent: page.hasMoreContent,
+          nextPageOffset: page.nextOffset,
           clearError: true,
         ),
       );
@@ -219,12 +234,14 @@ class ProfileLikedVideosBloc
           ),
         );
 
-        // Fetch videos for cached IDs
-        final firstPageIds = cachedIds.take(_pageSize).toList();
-        final videos = await _fetchVideos(firstPageIds, cacheResults: true);
+        final page = await _fetchVideoPage(
+          cachedIds,
+          startOffset: 0,
+          cacheFirstBatch: true,
+        );
 
         Log.info(
-          'ProfileLikedVideosBloc: Loaded ${videos.length} videos from cache '
+          'ProfileLikedVideosBloc: Loaded ${page.videos.length} videos from cache '
           '(first page of ${cachedIds.length} total)',
           name: 'ProfileLikedVideosBloc',
           category: LogCategory.video,
@@ -233,9 +250,9 @@ class ProfileLikedVideosBloc
         emit(
           state.copyWith(
             status: ProfileLikedVideosStatus.success,
-            videos: videos,
-            hasMoreContent: cachedIds.length > firstPageIds.length,
-            nextPageOffset: firstPageIds.length,
+            videos: page.videos,
+            hasMoreContent: page.hasMoreContent,
+            nextPageOffset: page.nextOffset,
             clearError: true,
           ),
         );
@@ -294,11 +311,14 @@ class ProfileLikedVideosBloc
           ),
         );
 
-        final firstPageIds = likedEventIds.take(_pageSize).toList();
-        final videos = await _fetchVideos(firstPageIds, cacheResults: true);
+        final page = await _fetchVideoPage(
+          likedEventIds,
+          startOffset: 0,
+          cacheFirstBatch: true,
+        );
 
         Log.info(
-          'ProfileLikedVideosBloc: Loaded ${videos.length} videos '
+          'ProfileLikedVideosBloc: Loaded ${page.videos.length} videos '
           '(first page of ${likedEventIds.length} total)',
           name: 'ProfileLikedVideosBloc',
           category: LogCategory.video,
@@ -307,9 +327,9 @@ class ProfileLikedVideosBloc
         emit(
           state.copyWith(
             status: ProfileLikedVideosStatus.success,
-            videos: videos,
-            hasMoreContent: likedEventIds.length > firstPageIds.length,
-            nextPageOffset: firstPageIds.length,
+            videos: page.videos,
+            hasMoreContent: page.hasMoreContent,
+            nextPageOffset: page.nextOffset,
             clearError: true,
           ),
         );
@@ -413,9 +433,9 @@ class ProfileLikedVideosBloc
   /// Handle load more request - fetches the next page of videos.
   ///
   /// Uses [state.nextPageOffset] to track the position in [state.likedEventIds]
-  /// and fetches the next [_pageSize] IDs. The offset advances by the number
-  /// of IDs consumed, not the number of videos loaded (some IDs may not
-  /// resolve to videos due to relay unavailability or format filtering).
+  /// and consumes ID batches until it has a page of renderable videos or runs
+  /// out of IDs. The offset advances by the number of IDs consumed, not the
+  /// number of videos loaded.
   Future<void> _onLoadMoreRequested(
     ProfileLikedVideosLoadMoreRequested event,
     Emitter<ProfileLikedVideosState> emit,
@@ -446,40 +466,26 @@ class ProfileLikedVideosBloc
     emit(state.copyWith(isLoadingMore: true));
 
     try {
-      // Get the next page of IDs
-      final nextPageIds = state.likedEventIds
-          .skip(offset)
-          .take(_pageSize)
-          .toList();
-
-      // Fetch videos for the next page
-      final newVideos = await _fetchVideos(nextPageIds);
+      final page = await _fetchVideoPage(
+        state.likedEventIds,
+        startOffset: offset,
+        excludeVideoIds: state.videos.map((v) => v.id).toSet(),
+      );
 
       Log.info(
-        'ProfileLikedVideosBloc: Loaded ${newVideos.length} more videos',
+        'ProfileLikedVideosBloc: Loaded ${page.videos.length} more videos',
         name: 'ProfileLikedVideosBloc',
         category: LogCategory.video,
       );
 
-      // Deduplicate: filter out any videos already loaded
-      final existingIds = state.videos.map((v) => v.id).toSet();
-      final uniqueNewVideos = newVideos
-          .where((v) => !existingIds.contains(v.id))
-          .toList();
-
-      // Advance offset by IDs consumed (not videos loaded)
-      final newOffset = offset + nextPageIds.length;
-
-      // Append only unique videos
-      final allVideos = [...state.videos, ...uniqueNewVideos];
-      final hasMore = newOffset < totalCount;
+      final allVideos = [...state.videos, ...page.videos];
 
       emit(
         state.copyWith(
           videos: allVideos,
           isLoadingMore: false,
-          hasMoreContent: hasMore,
-          nextPageOffset: newOffset,
+          hasMoreContent: page.hasMoreContent,
+          nextPageOffset: page.nextOffset,
         ),
       );
     } catch (e) {
@@ -497,8 +503,8 @@ class ProfileLikedVideosBloc
   /// Removes any now-blocked authors from [ProfileLikedVideosState.videos].
   /// [likedEventIds] and [ProfileLikedVideosState.nextPageOffset] are left
   /// untouched: the offset indexes into [likedEventIds] for pagination, and
-  /// the next page fetch re-applies the blocklist filter via
-  /// [VideosRepository], so no offset adjustment is needed here.
+  /// the next page fetch applies the current blocklist filter through
+  /// [_fetchVideos], so no offset adjustment is needed here.
   void _onBlocklistChanged(
     ProfileLikedVideosBlocklistChanged event,
     Emitter<ProfileLikedVideosState> emit,
@@ -510,6 +516,45 @@ class ProfileLikedVideosBloc
     if (filtered.length != state.videos.length) {
       emit(state.copyWith(videos: filtered));
     }
+  }
+
+  Future<_LikedVideosPage> _fetchVideoPage(
+    List<String> likedEventIds, {
+    required int startOffset,
+    Set<String> excludeVideoIds = const {},
+    bool cacheFirstBatch = false,
+  }) async {
+    final totalCount = likedEventIds.length;
+    var offset = startOffset;
+    var isFirstBatch = true;
+    final pageVideos = <VideoEvent>[];
+    final seenIds = {...excludeVideoIds};
+
+    while (offset < totalCount && pageVideos.length < _pageSize) {
+      final batchIds = likedEventIds.skip(offset).take(_pageSize).toList();
+      if (batchIds.isEmpty) break;
+
+      final videos = await _fetchVideos(
+        batchIds,
+        cacheResults: cacheFirstBatch && isFirstBatch,
+      );
+
+      for (final video in videos) {
+        if (pageVideos.length >= _pageSize) break;
+        if (seenIds.add(video.id)) {
+          pageVideos.add(video);
+        }
+      }
+
+      offset += batchIds.length;
+      isFirstBatch = false;
+    }
+
+    return _LikedVideosPage(
+      videos: pageVideos,
+      nextOffset: offset,
+      hasMoreContent: offset < totalCount,
+    );
   }
 
   /// Fetch videos for the given event IDs.
@@ -545,8 +590,13 @@ class ProfileLikedVideosBloc
       category: LogCategory.video,
     );
 
-    // Filter unsupported formats
-    return videos.where((v) => v.isSupportedOnCurrentPlatform).toList();
+    final supported = videos
+        .where((v) => v.isSupportedOnCurrentPlatform)
+        .toList();
+    return _blocklistRepository.filterContent<VideoEvent>(
+      supported,
+      (video) => video.pubkey,
+    );
   }
 
   @override

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -57,6 +57,11 @@ void main() {
       when(
         () => mockBlocklistRepository.stateStream,
       ).thenAnswer((_) => blocklistStateController.stream);
+      when(
+        () => mockBlocklistRepository.filterContent<VideoEvent>(any(), any()),
+      ).thenAnswer(
+        (invocation) => invocation.positionalArguments[0] as List<VideoEvent>,
+      );
     });
 
     tearDown(() {
@@ -309,6 +314,76 @@ void main() {
               ),
         ],
       );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'continues initial load through sparse liked IDs until videos render',
+        setUp: () {
+          final likedIds = List.generate(40, (index) => 'event${index + 1}');
+          final secondBatchVideos = List.generate(
+            18,
+            (index) => createTestVideo('event${index + 19}'),
+          );
+
+          when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
+            (_) async => LikesSyncResult(
+              orderedEventIds: likedIds,
+              eventIdToReactionId: const {},
+            ),
+          );
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((invocation) async {
+            final ids = invocation.positionalArguments[0] as List<String>;
+            if (ids.first == 'event19') {
+              return secondBatchVideos;
+            }
+            return <VideoEvent>[];
+          });
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        expect: () => [
+          const ProfileLikedVideosState(
+            status: ProfileLikedVideosStatus.syncing,
+          ),
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.status,
+            'status',
+            ProfileLikedVideosStatus.loading,
+          ),
+          isA<ProfileLikedVideosState>()
+              .having(
+                (s) => s.status,
+                'status',
+                ProfileLikedVideosStatus.success,
+              )
+              .having((s) => s.videos.length, 'videos count', 18)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 36)
+              .having((s) => s.hasMoreContent, 'hasMoreContent', true),
+        ],
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.getVideosByIds(
+              any(
+                that: equals(List.generate(18, (index) => 'event${index + 1}')),
+              ),
+              cacheResults: true,
+            ),
+          ).called(1);
+          verify(
+            () => mockVideosRepository.getVideosByIds(
+              any(
+                that: equals(
+                  List.generate(18, (index) => 'event${index + 19}'),
+                ),
+              ),
+            ),
+          ).called(1);
+        },
+      );
     });
 
     group('ProfileLikedVideosSubscriptionRequested', () {
@@ -538,6 +613,48 @@ void main() {
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'continues load more through sparse liked IDs until a full page renders',
+        setUp: () {
+          final nextVisibleVideos = List.generate(
+            18,
+            (index) => createTestVideo('event${index + 21}'),
+          );
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((invocation) async {
+            final ids = invocation.positionalArguments[0] as List<String>;
+            if (ids.first == 'event21') {
+              return nextVisibleVideos;
+            }
+            return <VideoEvent>[];
+          });
+        },
+        build: createBloc,
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          likedEventIds: List.generate(42, (index) => 'event${index + 1}'),
+          videos: [createTestVideo('event1'), createTestVideo('event2')],
+          nextPageOffset: 2,
+        ),
+        act: (bloc) => bloc.add(const ProfileLikedVideosLoadMoreRequested()),
+        expect: () => [
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
+              .having((s) => s.videos.length, 'videos count', 20)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 38)
+              .having((s) => s.hasMoreContent, 'hasMoreContent', true),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'emits hasMoreContent false when '
         'nextPageOffset >= likedEventIds.length',
         build: createBloc,
@@ -603,6 +720,48 @@ void main() {
               ])
               .having((s) => s.nextPageOffset, 'nextPageOffset', 3)
               .having((s) => s.hasMoreContent, 'hasMoreContent', false),
+        ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'filters blocked authors from newly fetched videos',
+        setUp: () {
+          final blockedVideo = createTestVideo('event2');
+          final allowedVideo = createTestVideo('event3');
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((_) async => [blockedVideo, allowedVideo]);
+          when(
+            () =>
+                mockBlocklistRepository.filterContent<VideoEvent>(any(), any()),
+          ).thenAnswer((invocation) {
+            final videos =
+                invocation.positionalArguments[0] as List<VideoEvent>;
+            return videos.where((video) => video.id != 'event2').toList();
+          });
+        },
+        build: createBloc,
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          likedEventIds: const ['event1', 'event2', 'event3'],
+          videos: [createTestVideo('event1')],
+          nextPageOffset: 1,
+        ),
+        act: (bloc) => bloc.add(const ProfileLikedVideosLoadMoreRequested()),
+        expect: () => [
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'video IDs',
+            ['event1', 'event3'],
+          ),
         ],
       );
 
@@ -735,11 +894,9 @@ void main() {
         act: (bloc) => bloc.add(const ProfileLikedVideosBlocklistChanged()),
         expect: () => [
           isA<ProfileLikedVideosState>()
-              .having(
-                (s) => s.videos.map((v) => v.id).toList(),
-                'videos',
-                ['b'],
-              )
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'b',
+              ])
               .having((s) => s.likedEventIds, 'likedEventIds', ['a', 'b'])
               .having((s) => s.nextPageOffset, 'nextPageOffset', 2),
         ],

--- a/mobile/test/services/upload_manager_from_draft_test.dart
+++ b/mobile/test/services/upload_manager_from_draft_test.dart
@@ -5,12 +5,11 @@ import 'dart:io';
 
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' show AspectRatio;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
-import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/models/pending_upload.dart' show UploadStatus;
 import 'package:openvine/services/upload_manager.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -34,6 +33,7 @@ void main() {
     late PathProviderPlatform originalPathProviderInstance;
 
     setUp(() async {
+      await TestHelpers.cleanupHiveBox('pending_uploads');
       tempDir = await Directory.systemTemp.createTemp('upload_draft_test_');
       originalPathProviderInstance = PathProviderPlatform.instance;
       final mockPathProvider = MockPathProviderPlatform()
@@ -79,10 +79,7 @@ void main() {
       // box before deleting tempDir, so neither leaks into the merged VGV
       // optimizer isolate (#5159).
       uploadManager.dispose();
-      if (Hive.isBoxOpen('pending_uploads')) {
-        await Hive.box<PendingUpload>('pending_uploads').close();
-      }
-      await Hive.deleteBoxFromDisk('pending_uploads');
+      await TestHelpers.cleanupHiveBox('pending_uploads');
       PathProviderPlatform.instance = originalPathProviderInstance;
       if (tempDir.existsSync()) {
         await tempDir.delete(recursive: true);


### PR DESCRIPTION
## Summary

Closes #5210.

This fixes the profile Liked Videos tab getting stuck when a page of liked event IDs resolves to too few renderable videos. Liked reactions can point at deleted/unavailable events, unsupported formats, comments, or content hidden by policy, so consuming exactly 18 liked IDs did not guarantee 18 visible grid items. If the first resolved page was too short to make the grid scrollable, the scroll listener never requested the next page.

## What changed

- Added BLoC-level liked-video page assembly that keeps consuming liked ID batches until it has a page of visible videos or exhausts the available IDs.
- Kept pagination offsets based on IDs consumed, so skipped/unavailable IDs are not retried forever.
- Preserved existing deduplication behavior when appending load-more results.
- Applied the existing content blocklist filter during liked-video fetches, matching the BLoC's blocklist refresh behavior and preventing newly fetched blocked authors from being appended.
- Added regression coverage for sparse initial loads, sparse load-more batches, and blocklist filtering of newly fetched liked videos.
- Replaced brittle direct Hive cleanup in the upload-from-draft test with the shared test helper after CI exposed cross-test `pending_uploads` box leakage.

## Root cause

The previous implementation treated `_pageSize` as a count of liked event IDs, but the UI needs renderable `VideoEvent`s. When the first 18 IDs resolved to only a handful of videos, the grid could be shorter than the viewport. Since load-more is triggered only by near-bottom scroll events, there was no way to request more despite `hasMoreContent == true`.

## Validation

- `mise exec flutter@3.44.0 -- flutter test test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart`
- `mise exec flutter@3.44.0 -- flutter test test/services/upload_manager_from_draft_test.dart`
- `mise exec flutter@3.44.0 -- flutter analyze`
- Push hook reran analyzer and changed-file tests successfully.
