### PR TITLE
fix(notifications): route inbox taps to video detail

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -14,8 +14,8 @@ import 'package:openvine/notifications/routing/notification_tap_target.dart';
 import 'package:openvine/notifications/widgets/widgets.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
-import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -242,15 +242,15 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     }
   }
 
-  /// Resolves the video route and pushes [PooledFullscreenVideoFeedScreen].
+  /// Resolves the video route and pushes [VideoDetailScreen].
   ///
   /// Returns `true` if a navigation was pushed, `false` if resolution failed
   /// (resolver returned null) and no navigation occurred. The caller decides
   /// what to do on `false` — e.g. the mention branch falls back to profile.
   ///
-  /// The video fetch runs concurrently after the push so the screen opens
-  /// immediately; if the fetch fails or the video is unavailable a snackbar
-  /// is shown on the notifications scaffold without touching the router.
+  /// This uses the durable `/video/<id>` route rather than the ephemeral
+  /// fullscreen feed route, so web builds do not depend on in-memory
+  /// GoRouter `extra` state to show the target video.
   Future<bool> _navigateToVideo(
     BuildContext context,
     String videoEventId, {
@@ -265,118 +265,44 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     );
 
     final videoEventService = ref.read(videoEventServiceProvider);
-    final videosRepository = ref.read(videosRepositoryProvider);
-
     final shouldAutoOpenComments = notificationKindOpensComments(
       notificationKind,
     );
 
     // Resolve the navigation target.
     //
-    // The stable-ID path (videoAddressableId set) and the raw-event-id
-    // fallback are synchronous. The comment/reply fallback path may require
-    // one relay round-trip to walk E/e tags, but that work belongs inside the
-    // opened screen's loading stream rather than blocking the route push.
-    Future<String?> routeIdFuture;
+    // The stable-ID path (videoAddressableId set) and raw-event-id fallback
+    // are synchronous. Comment/reply/mention targets without an addressable
+    // coordinate may be Kind 1111 comments, so resolve them to the root video
+    // before pushing the durable video route.
+    String? routeId;
     if (videoAddressableId != null && videoAddressableId.isNotEmpty) {
       // Stable path: addressable ID works even after a metadata update.
-      routeIdFuture = Future.value(videoAddressableId);
+      routeId = videoAddressableId;
     } else if (shouldAutoOpenComments) {
       // Comment/mention path: walk E/e tags to find the root video event ID.
-      routeIdFuture = NotificationTargetResolver(
+      routeId = await NotificationTargetResolver(
         videoEventService: videoEventService,
         nostrService: ref.read(nostrServiceProvider),
       ).resolveVideoEventIdFromNotificationTarget(videoEventId);
 
-      if (notificationKind == NotificationKind.mention) {
-        // Mentions can legitimately have no video context. Preserve the
-        // profile fallback by resolving before pushing only for that kind.
-        final resolved = await routeIdFuture;
-        if (!context.mounted) return false;
-        if (resolved == null) {
-          // Resolution failed — caller decides the fallback (e.g. profile).
-          return false;
-        }
-        routeIdFuture = Future.value(resolved);
+      if (!context.mounted) return false;
+      if (routeId == null) {
+        // Resolution failed — caller decides the fallback (e.g. profile).
+        return false;
       }
     } else {
       // Fallback: no addressable ID available, use raw event ID.
-      routeIdFuture = Future.value(videoEventId);
+      routeId = videoEventId;
     }
-
-    // Capture l10n and scaffold messenger before the async gap; they remain
-    // valid even after the push transitions away from this view.
-    final l10n = context.l10n;
-    final scaffoldMessenger = ScaffoldMessenger.of(context);
-
-    Future<List<VideoEvent>> loadVideo() async {
-      try {
-        final routeId = await routeIdFuture;
-        if (routeId == null || routeId.isEmpty) {
-          scaffoldMessenger.showSnackBar(
-            SnackBar(
-              content: Text(l10n.notificationsVideoNotFound),
-              duration: const Duration(seconds: 2),
-            ),
-          );
-          return <VideoEvent>[];
-        }
-
-        final video = await videosRepository.fetchVideoWithStatsForRouteId(
-          routeId,
-        );
-        if (video == null) {
-          scaffoldMessenger.showSnackBar(
-            SnackBar(
-              content: Text(l10n.notificationsVideoNotFound),
-              duration: const Duration(seconds: 2),
-            ),
-          );
-          return <VideoEvent>[];
-        }
-        if (videoEventService.shouldHideVideo(video)) {
-          scaffoldMessenger.showSnackBar(
-            SnackBar(
-              content: Text(l10n.notificationsVideoUnavailable),
-              duration: const Duration(seconds: 2),
-            ),
-          );
-          return <VideoEvent>[];
-        }
-        return [video];
-      } catch (e, stackTrace) {
-        Log.error(
-          'Failed to fetch video for notification',
-          name: 'NotificationsView',
-          category: LogCategory.ui,
-          error: e,
-          stackTrace: stackTrace,
-        );
-        scaffoldMessenger.showSnackBar(
-          SnackBar(
-            content: Text(l10n.notificationsVideoNotFound),
-            duration: const Duration(seconds: 2),
-          ),
-        );
-        return <VideoEvent>[];
-      }
-    }
-
-    // Fetch the video concurrently. The stream is consumed by the opened
-    // screen's BLoC — we never pop here to avoid touching the wrong route
-    // if the user navigated away before the fetch resolved.
-    final videoFuture = loadVideo();
 
     if (!context.mounted) return false;
 
     context.push(
-      PooledFullscreenVideoFeedScreen.path,
-      extra: PooledFullscreenVideoFeedArgs(
-        videosStream: Stream.fromFuture(videoFuture),
-        initialIndex: 0,
-        contextTitle: l10n.notificationsFromNotification,
-        autoOpenComments: shouldAutoOpenComments,
-      ),
+      VideoDetailScreen.pathForId(routeId),
+      extra: shouldAutoOpenComments
+          ? const VideoDetailRouteExtra(autoOpenComments: true)
+          : null,
     );
     return true;
   }

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -25,6 +25,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -65,27 +66,11 @@ Future<void> _pumpView(
 /// video feed and profile screens so tests can assert on either.
 typedef _RoutedViewResult = ({
   List<PooledFullscreenVideoFeedArgs> videoArgs,
+  List<({String videoId, VideoDetailRouteExtra? extra})> videoDetailRoutes,
   List<String> profileNpubs,
 });
 
-Future<List<PooledFullscreenVideoFeedArgs>> _pumpRoutedView(
-  WidgetTester tester,
-  NotificationFeedBloc bloc, {
-  required VideoEventService videoEventService,
-  required NostrClient nostrClient,
-  required VideosRepository videosRepository,
-}) async {
-  final result = await _pumpRoutedViewFull(
-    tester,
-    bloc,
-    videoEventService: videoEventService,
-    nostrClient: nostrClient,
-    videosRepository: videosRepository,
-  );
-  return result.videoArgs;
-}
-
-/// Like [_pumpRoutedView] but also captures profile navigations.
+/// Pumps [NotificationsView] with routes that capture video/profile navigation.
 Future<_RoutedViewResult> _pumpRoutedViewFull(
   WidgetTester tester,
   NotificationFeedBloc bloc, {
@@ -94,6 +79,8 @@ Future<_RoutedViewResult> _pumpRoutedViewFull(
   required VideosRepository videosRepository,
 }) async {
   final capturedVideoArgs = <PooledFullscreenVideoFeedArgs>[];
+  final capturedVideoDetailRoutes =
+      <({String videoId, VideoDetailRouteExtra? extra})>[];
   final capturedProfileNpubs = <String>[];
   final router = GoRouter(
     initialLocation: '/',
@@ -106,6 +93,16 @@ Future<_RoutedViewResult> _pumpRoutedViewFull(
         path: PooledFullscreenVideoFeedScreen.path,
         builder: (context, state) {
           capturedVideoArgs.add(state.extra! as PooledFullscreenVideoFeedArgs);
+          return const Scaffold(body: SizedBox.shrink());
+        },
+      ),
+      GoRoute(
+        path: VideoDetailScreen.path,
+        builder: (context, state) {
+          capturedVideoDetailRoutes.add((
+            videoId: state.pathParameters['id']!,
+            extra: state.extra as VideoDetailRouteExtra?,
+          ));
           return const Scaffold(body: SizedBox.shrink());
         },
       ),
@@ -140,19 +137,12 @@ Future<_RoutedViewResult> _pumpRoutedViewFull(
     ),
   );
 
-  return (videoArgs: capturedVideoArgs, profileNpubs: capturedProfileNpubs);
+  return (
+    videoArgs: capturedVideoArgs,
+    videoDetailRoutes: capturedVideoDetailRoutes,
+    profileNpubs: capturedProfileNpubs,
+  );
 }
-
-VideoEvent _video(String id) => VideoEvent(
-  id: id,
-  pubkey: 'pubkey_$id',
-  createdAt: DateTime(2026).millisecondsSinceEpoch ~/ 1000,
-  timestamp: DateTime(2026),
-  content: 'content',
-  title: 'title',
-  videoUrl: 'https://example.com/$id.mp4',
-  thumbnailUrl: 'https://example.com/$id.jpg',
-);
 
 void main() {
   group(NotificationsView, () {
@@ -408,7 +398,6 @@ void main() {
         final videosRepository = _MockVideosRepository();
         const commentEventId = 'comment_1111_event';
         const rootVideoEventId = 'root_video_event';
-        final resolvedVideo = _video(rootVideoEventId);
 
         // The comment is not a video — resolver fetches it from relay
         // and follows its uppercase E tag to the root video.
@@ -428,13 +417,6 @@ void main() {
           event.id = commentEventId;
           return event;
         });
-        when(
-          () =>
-              videosRepository.fetchVideoWithStatsForRouteId(rootVideoEventId),
-        ).thenAnswer((_) async => resolvedVideo);
-        when(
-          () => videoService.shouldHideVideo(resolvedVideo),
-        ).thenReturn(false);
 
         when(() => mockBloc.state).thenReturn(
           NotificationFeedState(
@@ -451,7 +433,7 @@ void main() {
           ),
         );
 
-        final capturedArgs = await _pumpRoutedView(
+        final result = await _pumpRoutedViewFull(
           tester,
           mockBloc,
           videoEventService: videoService,
@@ -463,15 +445,13 @@ void main() {
         await tester.pumpAndSettle();
 
         verify(() => nostrClient.fetchEventById(commentEventId)).called(1);
-        verify(
-          () =>
-              videosRepository.fetchVideoWithStatsForRouteId(rootVideoEventId),
-        ).called(1);
-        expect(capturedArgs, hasLength(1));
-        final args = capturedArgs.single;
-        expect(args.autoOpenComments, isTrue);
-        final videos = await args.videosStream.first;
-        expect(videos.single.id, resolvedVideo.id);
+        verifyNever(
+          () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+        );
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, hasLength(1));
+        expect(result.videoDetailRoutes.single.videoId, rootVideoEventId);
+        expect(result.videoDetailRoutes.single.extra?.autoOpenComments, isTrue);
       });
 
       testWidgets(
@@ -483,7 +463,6 @@ void main() {
           final videosRepository = _MockVideosRepository();
           const parentCommentId = 'parent_comment_id';
           const rootVideoEventId = 'reply_root_video';
-          final resolvedVideo = _video(rootVideoEventId);
 
           when(
             () => videoService.getVideoById(parentCommentId),
@@ -503,14 +482,6 @@ void main() {
             event.id = parentCommentId;
             return event;
           });
-          when(
-            () => videosRepository.fetchVideoWithStatsForRouteId(
-              rootVideoEventId,
-            ),
-          ).thenAnswer((_) async => resolvedVideo);
-          when(
-            () => videoService.shouldHideVideo(resolvedVideo),
-          ).thenReturn(false);
 
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
@@ -527,7 +498,7 @@ void main() {
             ),
           );
 
-          final capturedArgs = await _pumpRoutedView(
+          final result = await _pumpRoutedViewFull(
             tester,
             mockBloc,
             videoEventService: videoService,
@@ -539,25 +510,27 @@ void main() {
           await tester.pumpAndSettle();
 
           verify(() => nostrClient.fetchEventById(parentCommentId)).called(1);
-          verify(
-            () => videosRepository.fetchVideoWithStatsForRouteId(
-              rootVideoEventId,
-            ),
-          ).called(1);
-          expect(capturedArgs, hasLength(1));
-          expect(capturedArgs.single.autoOpenComments, isTrue);
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, hasLength(1));
+          expect(result.videoDetailRoutes.single.videoId, rootVideoEventId);
+          expect(
+            result.videoDetailRoutes.single.extra?.autoOpenComments,
+            isTrue,
+          );
         },
       );
 
       testWidgets(
-        'reply tap pushes video route before resolver completes',
+        'reply tap waits for root video resolution before pushing video route',
         (tester) async {
           final videoService = _MockVideoEventService();
           final nostrClient = _MockNostrClient();
           final videosRepository = _MockVideosRepository();
           const parentCommentId = 'slow_parent_comment_id';
           const rootVideoEventId = 'slow_reply_root_video';
-          final resolvedVideo = _video(rootVideoEventId);
           final resolverCompleter = Completer<Event?>();
 
           when(
@@ -566,14 +539,6 @@ void main() {
           when(
             () => nostrClient.fetchEventById(parentCommentId),
           ).thenAnswer((_) => resolverCompleter.future);
-          when(
-            () => videosRepository.fetchVideoWithStatsForRouteId(
-              rootVideoEventId,
-            ),
-          ).thenAnswer((_) async => resolvedVideo);
-          when(
-            () => videoService.shouldHideVideo(resolvedVideo),
-          ).thenReturn(false);
 
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
@@ -590,7 +555,7 @@ void main() {
             ),
           );
 
-          final capturedArgs = await _pumpRoutedView(
+          final result = await _pumpRoutedViewFull(
             tester,
             mockBloc,
             videoEventService: videoService,
@@ -601,8 +566,8 @@ void main() {
           await tester.tap(find.byType(NotificationListItem).first);
           await tester.pump();
 
-          expect(capturedArgs, hasLength(1));
-          expect(capturedArgs.single.autoOpenComments, isTrue);
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, isEmpty);
           verifyNever(
             () => videosRepository.fetchVideoWithStatsForRouteId(any()),
           );
@@ -619,13 +584,18 @@ void main() {
           event.id = parentCommentId;
           resolverCompleter.complete(event);
 
-          final videos = await capturedArgs.single.videosStream.first;
-          expect(videos.single.id, resolvedVideo.id);
-          verify(
-            () => videosRepository.fetchVideoWithStatsForRouteId(
-              rootVideoEventId,
-            ),
-          ).called(1);
+          await tester.pumpAndSettle();
+
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, hasLength(1));
+          expect(result.videoDetailRoutes.single.videoId, rootVideoEventId);
+          expect(
+            result.videoDetailRoutes.single.extra?.autoOpenComments,
+            isTrue,
+          );
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
         },
       );
 
@@ -640,7 +610,6 @@ void main() {
               '34236:'
               'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
               ':vine-id';
-          final resolvedVideo = _video('replacement_video_event');
 
           when(
             () => videoService.getVideoById(staleVideoEventId),
@@ -648,12 +617,6 @@ void main() {
           when(
             () => nostrClient.fetchEventById(staleVideoEventId),
           ).thenAnswer((_) async => null);
-          when(
-            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
-          ).thenAnswer((_) async => resolvedVideo);
-          when(
-            () => videoService.shouldHideVideo(resolvedVideo),
-          ).thenReturn(false);
 
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
@@ -674,7 +637,7 @@ void main() {
             ),
           );
 
-          final capturedArgs = await _pumpRoutedView(
+          final result = await _pumpRoutedViewFull(
             tester,
             mockBloc,
             videoEventService: videoService,
@@ -685,14 +648,17 @@ void main() {
           await tester.tap(find.byType(NotificationListItem).first);
           await tester.pumpAndSettle();
 
-          verify(
-            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
-          ).called(1);
-          expect(capturedArgs, hasLength(1));
-          final args = capturedArgs.single;
-          expect(args.autoOpenComments, isTrue);
-          final videos = await args.videosStream.first;
-          expect(videos.single.id, resolvedVideo.id);
+          verifyNever(() => nostrClient.fetchEventById(any()));
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, hasLength(1));
+          expect(result.videoDetailRoutes.single.videoId, addressableId);
+          expect(
+            result.videoDetailRoutes.single.extra?.autoOpenComments,
+            isTrue,
+          );
         },
       );
 
@@ -710,12 +676,6 @@ void main() {
               '34236:'
               'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
               ':vine-liked-comment';
-          final video = _video('liked_comment_video');
-
-          when(
-            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
-          ).thenAnswer((_) async => video);
-          when(() => videoService.shouldHideVideo(video)).thenReturn(false);
 
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
@@ -734,7 +694,7 @@ void main() {
             ),
           );
 
-          final capturedArgs = await _pumpRoutedView(
+          final result = await _pumpRoutedViewFull(
             tester,
             mockBloc,
             videoEventService: videoService,
@@ -747,13 +707,16 @@ void main() {
 
           // Resolver must NOT be called — stable path is taken directly.
           verifyNever(() => nostrClient.fetchEventById(any()));
-          verify(
-            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
-          ).called(1);
-          expect(capturedArgs, hasLength(1));
-          expect(capturedArgs.single.autoOpenComments, isTrue);
-          final videos = await capturedArgs.single.videosStream.first;
-          expect(videos.single.id, video.id);
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, hasLength(1));
+          expect(result.videoDetailRoutes.single.videoId, addressableId);
+          expect(
+            result.videoDetailRoutes.single.extra?.autoOpenComments,
+            isTrue,
+          );
         },
       );
     });
@@ -765,7 +728,7 @@ void main() {
     group('tap routing — like', () {
       testWidgets(
         'like tap opens the target video with autoOpenComments:false '
-        'using the stable addressable id',
+        'using the stable addressable id through the durable video route',
         (tester) async {
           final videoService = _MockVideoEventService();
           final nostrClient = _MockNostrClient();
@@ -774,14 +737,6 @@ void main() {
               '34236:'
               'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
               ':vine-like';
-          final likedVideo = _video('liked_video_event');
-
-          when(
-            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
-          ).thenAnswer((_) async => likedVideo);
-          when(
-            () => videoService.shouldHideVideo(likedVideo),
-          ).thenReturn(false);
 
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
@@ -813,13 +768,16 @@ void main() {
           await tester.tap(find.byType(NotificationListItem).first);
           await tester.pumpAndSettle();
 
-          verify(
-            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
-          ).called(1);
-          expect(result.videoArgs, hasLength(1));
-          expect(result.videoArgs.single.autoOpenComments, isFalse);
-          final videos = await result.videoArgs.single.videosStream.first;
-          expect(videos.single.id, likedVideo.id);
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, hasLength(1));
+          expect(
+            result.videoDetailRoutes.single.videoId,
+            equals(addressableId),
+          );
+          expect(result.videoDetailRoutes.single.extra, isNull);
         },
       );
 
@@ -830,14 +788,6 @@ void main() {
           final nostrClient = _MockNostrClient();
           final videosRepository = _MockVideosRepository();
           const rawEventId = 'raw_like_event_id';
-          final likedVideo = _video(rawEventId);
-
-          when(
-            () => videosRepository.fetchVideoWithStatsForRouteId(rawEventId),
-          ).thenAnswer((_) async => likedVideo);
-          when(
-            () => videoService.shouldHideVideo(likedVideo),
-          ).thenReturn(false);
 
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
@@ -868,11 +818,13 @@ void main() {
           await tester.tap(find.byType(NotificationListItem).first);
           await tester.pumpAndSettle();
 
-          verify(
-            () => videosRepository.fetchVideoWithStatsForRouteId(rawEventId),
-          ).called(1);
-          expect(result.videoArgs, hasLength(1));
-          expect(result.videoArgs.single.autoOpenComments, isFalse);
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, hasLength(1));
+          expect(result.videoDetailRoutes.single.videoId, rawEventId);
+          expect(result.videoDetailRoutes.single.extra, isNull);
         },
       );
     });
@@ -889,14 +841,6 @@ void main() {
               '34236:'
               'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
               ':vine-repost';
-          final repostedVideo = _video('reposted_video_event');
-
-          when(
-            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
-          ).thenAnswer((_) async => repostedVideo);
-          when(
-            () => videoService.shouldHideVideo(repostedVideo),
-          ).thenReturn(false);
 
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
@@ -935,13 +879,13 @@ void main() {
           await tester.tap(find.byType(NotificationListItem).first);
           await tester.pumpAndSettle();
 
-          verify(
-            () => videosRepository.fetchVideoWithStatsForRouteId(addressableId),
-          ).called(1);
-          expect(result.videoArgs, hasLength(1));
-          expect(result.videoArgs.single.autoOpenComments, isFalse);
-          final videos = await result.videoArgs.single.videosStream.first;
-          expect(videos.single.id, repostedVideo.id);
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, hasLength(1));
+          expect(result.videoDetailRoutes.single.videoId, addressableId);
+          expect(result.videoDetailRoutes.single.extra, isNull);
         },
       );
     });
@@ -1002,7 +946,6 @@ void main() {
           final videosRepository = _MockVideosRepository();
           const mentionEventId = 'mention_kind1_event';
           const rootVideoEventId = 'mention_root_video';
-          final mentionedInVideo = _video(rootVideoEventId);
 
           // The mention event is a kind-1 with an uppercase E tag pointing
           // to the root video — the same resolver path used for replies.
@@ -1024,14 +967,6 @@ void main() {
             event.id = mentionEventId;
             return event;
           });
-          when(
-            () => videosRepository.fetchVideoWithStatsForRouteId(
-              rootVideoEventId,
-            ),
-          ).thenAnswer((_) async => mentionedInVideo);
-          when(
-            () => videoService.shouldHideVideo(mentionedInVideo),
-          ).thenReturn(false);
 
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
@@ -1065,15 +1000,16 @@ void main() {
           verify(
             () => nostrClient.fetchEventById(mentionEventId),
           ).called(1);
-          verify(
-            () => videosRepository.fetchVideoWithStatsForRouteId(
-              rootVideoEventId,
-            ),
-          ).called(1);
-          expect(result.videoArgs, hasLength(1));
-          expect(result.videoArgs.single.autoOpenComments, isTrue);
-          final videos = await result.videoArgs.single.videosStream.first;
-          expect(videos.single.id, mentionedInVideo.id);
+          verifyNever(
+            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+          );
+          expect(result.videoArgs, isEmpty);
+          expect(result.videoDetailRoutes, hasLength(1));
+          expect(result.videoDetailRoutes.single.videoId, rootVideoEventId);
+          expect(
+            result.videoDetailRoutes.single.extra?.autoOpenComments,
+            isTrue,
+          );
         },
       );
 


### PR DESCRIPTION
## Description

- Route in-app notification video taps through the durable `/video/<id>` detail route instead of the ephemeral pooled fullscreen route.
- Preserve stable addressable IDs and auto-open-comments behavior for comment/reply/mention notifications.
- Update notification tap tests to assert the durable route contract and guard against row-tap prefetching.

**Related Issue:** Relates to notification video navigation regression in web builds.

## Out of Scope

None.

## Verification

- `mise exec -- flutter analyze`
- `mise exec -- flutter test test/notifications/view/notifications_view_test.dart test/router/route_error_routing_test.dart test/main_video_deep_link_nav_action_test.dart`
- Pre-push hook: analyzer + `test/notifications/view/notifications_view_test.dart`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore