### PR TITLE
fix(publish): REST-first video publish so a missing relay OK doesn't look failed

### DIFF
--- a/mobile/docs/FUNNELCAKE_API_REFERENCE.md
+++ b/mobile/docs/FUNNELCAKE_API_REFERENCE.md
@@ -995,7 +995,40 @@ The REST API runs alongside a Nostr WebSocket relay on the same domain:
 - **REST:** `https://relay.dvines.org/api/*` - For queries and analytics
 
 ### Publishing Content
-To publish videos or other events, use the WebSocket relay with standard Nostr protocol:
+
+Divine publishes first-party video events **REST-first**, falling back to the
+WebSocket relay only on transient failures. This avoids the false-negative
+where a relay accepts and serves an event but its NIP-20 `OK` is lost, making a
+successful upload look failed.
+
+#### REST publish (preferred)
+
+`POST {apiBaseUrl}/api/events` with the already-signed event JSON as the body:
+
+- Production: `https://api.divine.video/api/events`
+- Staging: `https://relay.staging.divine.video/api/events`
+
+Authorization is **NIP-98** (kind `27235`): `method` tag `POST`, `u` tag equal
+to the publish URL, and a `payload` tag holding the SHA-256 hex of the request
+body bytes. The auth signer pubkey must match `event.pubkey`.
+
+Success is HTTP `200 {"accepted": true, "event_id": "..."}`. `401/403/422` are
+real, non-retryable failures. Timeouts, `5xx`, and network errors are transient.
+
+```http
+POST /api/events HTTP/1.1
+Host: api.divine.video
+Content-Type: application/json
+Authorization: Nostr <base64-encoded kind-27235 event>
+
+{"id":"...","pubkey":"...","created_at":1704067200,"kind":34236,"tags":[...],"content":"...","sig":"..."}
+```
+
+#### WebSocket fallback / interactive use
+
+On transient REST failures the client falls back to publishing the **same
+signed event** (no re-signing) over the WebSocket relay, fire-and-forget:
+
 ```json
 ["EVENT", {
   "id": "...",
@@ -1007,5 +1040,8 @@ To publish videos or other events, use the WebSocket relay with standard Nostr p
   "sig": "..."
 }]
 ```
+
+Because the same event id is reused across REST and WebSocket attempts, relays
+deduplicate and no duplicate event is created.
 
 The REST API will reflect new content after ClickHouse ingestion (typically < 1 second).

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -3,12 +3,14 @@
 
 import 'dart:async';
 
+import 'package:http/http.dart' as http;
 import 'package:likes_repository/likes_repository.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
+import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/og_viner_cache_provider.dart';
@@ -23,6 +25,7 @@ import 'package:openvine/services/auth_service.dart' show AuthState;
 import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
 import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/services/event_api_client.dart';
 import 'package:openvine/services/event_router.dart';
 import 'package:openvine/services/nsfw_content_filter.dart';
 import 'package:openvine/services/pending_action_service.dart';
@@ -166,6 +169,20 @@ VideoEventPublisher videoEventPublisher(Ref ref) {
   final profileStatsDao = ref.watch(databaseProvider).profileStatsDao;
   final savedSoundsService = ref.watch(savedSoundsServiceProvider);
 
+  // REST-first publish: POST the signed event to {apiBaseUrl}/api/events with
+  // NIP-98 auth, falling back to the WebSocket relay pool on transient
+  // failures. apiBaseUrl resolves to https://api.divine.video (production) and
+  // https://relay.staging.divine.video (staging).
+  final environmentConfig = ref.watch(currentEnvironmentProvider);
+  final nip98AuthService = ref.watch(nip98AuthServiceProvider);
+  final eventApiHttpClient = http.Client();
+  ref.onDispose(eventApiHttpClient.close);
+  final eventApiClient = EventApiClient(
+    httpClient: eventApiHttpClient,
+    nip98AuthService: nip98AuthService,
+    apiBaseUrl: () => environmentConfig.apiBaseUrl,
+  );
+
   return VideoEventPublisher(
     uploadManager: uploadManager,
     nostrService: nostrService,
@@ -176,6 +193,7 @@ VideoEventPublisher videoEventPublisher(Ref ref) {
     profileRepository: profileRepository,
     profileStatsDao: profileStatsDao,
     savedSoundsService: savedSoundsService,
+    eventApiClient: eventApiClient,
   );
 }
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -375,7 +375,7 @@ final class VideoEventPublisherProvider
 }
 
 String _$videoEventPublisherHash() =>
-    r'6b1327889373d9366f38c387a953b188eba9fbcd';
+    r'262237ee460d29c871f62af6e0fce9c88508a02b';
 
 /// View event publisher for kind 22236 ephemeral analytics events
 ///

--- a/mobile/lib/services/event_api_client.dart
+++ b/mobile/lib/services/event_api_client.dart
@@ -159,7 +159,7 @@ class EventApiClient {
         final decoded = jsonDecode(response.body) as Map<String, dynamic>;
         final accepted = decoded['accepted'] == true;
         final eventId = decoded['event_id'] as String?;
-        if (accepted && eventId != null && eventId.isNotEmpty) {
+        if (accepted && eventId != null && eventId == event.id) {
           Log.info(
             'REST publish accepted event $eventId',
             name: _logName,
@@ -168,7 +168,8 @@ class EventApiClient {
           return EventApiAccepted(eventId);
         }
         Log.warning(
-          'REST publish 200 without accepted:true for ${event.id}: '
+          'REST publish 200 without accepted:true and matching event_id '
+          'for ${event.id}: '
           '${response.body}',
           name: _logName,
           category: LogCategory.video,

--- a/mobile/lib/services/event_api_client.dart
+++ b/mobile/lib/services/event_api_client.dart
@@ -1,0 +1,207 @@
+// ABOUTME: REST client for publishing signed Nostr events to the Divine events API
+// ABOUTME: POSTs the signed event JSON to /api/events with NIP-98 auth, classifying outcomes
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Outcome of a REST publish attempt against `POST {apiBaseUrl}/api/events`.
+sealed class EventApiPublishResult {
+  const EventApiPublishResult();
+}
+
+/// The API accepted the event (HTTP 200 `{accepted: true, event_id}`).
+final class EventApiAccepted extends EventApiPublishResult {
+  const EventApiAccepted(this.eventId);
+
+  /// The `event_id` echoed back by the API.
+  final String eventId;
+}
+
+/// The API rejected the event with an actionable, non-retryable status
+/// (401/403/422, or a client-side signer/identity mismatch).
+final class EventApiRejected extends EventApiPublishResult {
+  const EventApiRejected({required this.statusCode, required this.reason});
+
+  /// HTTP status code, or `0` for a client-side rejection before the request.
+  final int statusCode;
+
+  /// Human-readable reason for logging.
+  final String reason;
+}
+
+/// A transient failure (timeout, network error, 5xx, or a malformed/
+/// non-accepting 200). Callers should fall back to WebSocket publish.
+final class EventApiTransientFailure extends EventApiPublishResult {
+  const EventApiTransientFailure(this.reason);
+
+  /// Human-readable reason for logging.
+  final String reason;
+}
+
+/// Publishes signed Nostr events to the first-party Divine events REST API.
+///
+/// The request body is the already-signed event JSON. Authorization is
+/// NIP-98 (kind 27235) over the exact publish URL, `POST` method, and a
+/// payload hash of the request body. Outcomes are classified so the caller
+/// can treat acceptances as published, 401/403/422 as real failures, and
+/// everything else (timeouts, 5xx, network errors) as transient — at which
+/// point the caller should fall back to a WebSocket publish.
+class EventApiClient {
+  EventApiClient({
+    required http.Client httpClient,
+    required Nip98AuthService nip98AuthService,
+    required String Function() apiBaseUrl,
+    Duration timeout = const Duration(seconds: 15),
+  }) : _httpClient = httpClient,
+       _nip98 = nip98AuthService,
+       _apiBaseUrl = apiBaseUrl,
+       _timeout = timeout;
+
+  final http.Client _httpClient;
+  final Nip98AuthService _nip98;
+  final String Function() _apiBaseUrl;
+  final Duration _timeout;
+
+  /// Path of the events endpoint, appended to the resolved API base URL.
+  static const eventsPath = '/api/events';
+
+  static const _logName = 'EventApiClient';
+
+  /// The fully-qualified publish URL for the current environment, e.g.
+  /// `https://api.divine.video/api/events`.
+  String get publishUrl {
+    final base = _apiBaseUrl();
+    final trimmed = base.endsWith('/')
+        ? base.substring(0, base.length - 1)
+        : base;
+    return '$trimmed$eventsPath';
+  }
+
+  /// Publishes [event] (already signed) to the events API.
+  Future<EventApiPublishResult> publishEvent(Event event) async {
+    final url = publishUrl;
+    final body = jsonEncode(event.toJson());
+
+    final token = await _nip98.createAuthToken(
+      url: url,
+      method: HttpMethod.post,
+      payload: body,
+    );
+
+    if (token == null) {
+      Log.error(
+        'Cannot publish event ${event.id} — NIP-98 token unavailable '
+        '(not authenticated?)',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return const EventApiTransientFailure('nip98_token_unavailable');
+    }
+
+    // The signer that minted the auth token must be the same key that signed
+    // the event; otherwise the API would attribute the publish to the wrong
+    // author. Refuse before hitting the network.
+    if (token.signedEvent.pubkey != event.pubkey) {
+      Log.error(
+        'NIP-98 signer pubkey ${token.signedEvent.pubkey} does not match '
+        'event pubkey ${event.pubkey}; refusing to publish ${event.id}',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return const EventApiRejected(
+        statusCode: 0,
+        reason: 'signer_pubkey_mismatch',
+      );
+    }
+
+    final http.Response response;
+    try {
+      response = await _httpClient
+          .post(
+            Uri.parse(url),
+            headers: {
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+              'Authorization': token.authorizationHeader,
+            },
+            body: body,
+          )
+          .timeout(_timeout);
+    } on TimeoutException {
+      Log.warning(
+        'REST publish timed out after ${_timeout.inSeconds}s for ${event.id}',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return const EventApiTransientFailure('timeout');
+    } catch (e) {
+      Log.warning(
+        'REST publish network error for ${event.id}: $e',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return EventApiTransientFailure('network_error: $e');
+    }
+
+    return _classify(event, response);
+  }
+
+  EventApiPublishResult _classify(Event event, http.Response response) {
+    final status = response.statusCode;
+
+    if (status == 200) {
+      try {
+        final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+        final accepted = decoded['accepted'] == true;
+        final eventId = decoded['event_id'] as String?;
+        if (accepted && eventId != null && eventId.isNotEmpty) {
+          Log.info(
+            'REST publish accepted event $eventId',
+            name: _logName,
+            category: LogCategory.video,
+          );
+          return EventApiAccepted(eventId);
+        }
+        Log.warning(
+          'REST publish 200 without accepted:true for ${event.id}: '
+          '${response.body}',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        return EventApiTransientFailure('not_accepted: ${response.body}');
+      } catch (e) {
+        Log.warning(
+          'REST publish 200 with unparseable body for ${event.id}: $e',
+          name: _logName,
+          category: LogCategory.video,
+        );
+        return EventApiTransientFailure('invalid_response: $e');
+      }
+    }
+
+    // Authentication, authorization, and validation failures are real and
+    // non-retryable — surface them with actionable logs.
+    if (status == 401 || status == 403 || status == 422) {
+      Log.error(
+        'REST publish rejected ($status) for event ${event.id}: '
+        '${response.body}',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      return EventApiRejected(statusCode: status, reason: response.body);
+    }
+
+    // 5xx and any other status: transient — caller falls back to WebSocket.
+    Log.warning(
+      'REST publish transient HTTP $status for ${event.id}: ${response.body}',
+      name: _logName,
+      category: LogCategory.video,
+    );
+    return EventApiTransientFailure('http_$status');
+  }
+}

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -9,12 +9,14 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:blurhash_service/blurhash_service.dart';
 import 'package:crypto/crypto.dart';
 //adding c2pa support for publishing c2pa manifest data into nostr
-import 'package:db_client/db_client.dart';
+import 'package:db_client/db_client.dart' hide Filter;
+import 'package:meta/meta.dart';
 import 'package:models/models.dart'
     hide LogCategory, NIP71VideoKinds, PendingUpload, UploadStatus;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/filter.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/relay/relay_pool.dart';
 import 'package:openvine/constants/nip71_migration.dart';
@@ -24,6 +26,7 @@ import 'package:openvine/models/video_reply_context.dart';
 import 'package:openvine/services/audio_extraction_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/c2pa_signing_service.dart';
+import 'package:openvine/services/event_api_client.dart';
 import 'package:openvine/services/personal_event_cache_service.dart';
 import 'package:openvine/services/saved_sounds_service.dart';
 import 'package:openvine/services/upload_manager.dart';
@@ -131,6 +134,20 @@ List<List<String>> _buildMentionPTags(
   return tags;
 }
 
+/// Result of a single REST-then-WebSocket publish attempt.
+enum _EventPublishOutcome {
+  /// The event was accepted (REST 200, or a WebSocket send succeeded).
+  published,
+
+  /// The REST API rejected the event (401/403/422 or signer mismatch).
+  /// Non-retryable — do not fall back or retry.
+  permanentlyRejected,
+
+  /// A transient failure (REST 5xx/timeout/network and the WebSocket
+  /// fallback also failed). The caller may retry.
+  transientFailure,
+}
+
 /// Service for publishing processed videos to Nostr relays
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class VideoEventPublisher {
@@ -145,6 +162,7 @@ class VideoEventPublisher {
     AudioExtractionService? audioExtractionService,
     ProfileStatsDao? profileStatsDao,
     SavedSoundsService? savedSoundsService,
+    EventApiClient? eventApiClient,
   }) : _uploadManager = uploadManager,
        _nostrService = nostrService,
        _authService = authService,
@@ -154,7 +172,8 @@ class VideoEventPublisher {
        _profileRepository = profileRepository,
        _audioExtractionService = audioExtractionService,
        _profileStatsDao = profileStatsDao,
-       _savedSoundsService = savedSoundsService;
+       _savedSoundsService = savedSoundsService,
+       _eventApiClient = eventApiClient;
   final UploadManager _uploadManager;
   final NostrClient _nostrService;
   final AuthService? _authService;
@@ -165,6 +184,12 @@ class VideoEventPublisher {
   final AudioExtractionService? _audioExtractionService;
   final ProfileStatsDao? _profileStatsDao;
   final SavedSoundsService? _savedSoundsService;
+
+  /// REST-first publish client. When non-null, video events are published
+  /// via `POST /api/events` first and only fall back to the WebSocket relay
+  /// pool on transient REST failures. When null (legacy / test wiring), the
+  /// publisher uses the WebSocket-only retry path.
+  final EventApiClient? _eventApiClient;
 
   // Statistics
   int _totalEventsPublished = 0;
@@ -458,6 +483,258 @@ class VideoEventPublisher {
       );
       return false;
     }
+  }
+
+  /// Publishes an already-signed video [event] for [upload] using the
+  /// REST-first strategy with a WebSocket fire-and-forget fallback.
+  ///
+  /// Behaviour when an [EventApiClient] is configured:
+  /// 1. If [isRetry], first query configured relays by event id and by
+  ///    `author+kind+d-tag`; if the event is already on a relay, mark it
+  ///    published and stop (avoids re-publishing a previously accepted
+  ///    event whose `OK` was lost).
+  /// 2. Up to 3 attempts of `POST /api/events`. A 200 acceptance is
+  ///    published; a 401/403/422 is a non-retryable failure; a transient
+  ///    REST failure falls back to a WebSocket `publishEvent`
+  ///    (fire-and-forget, not `publishEventAwaitOk`).
+  /// 3. Before each retry, re-check relay presence so a false-negative
+  ///    WebSocket `OK` does not produce a duplicate publish.
+  ///
+  /// When no [EventApiClient] is configured, the legacy WebSocket-only
+  /// retry path is used unchanged.
+  ///
+  /// The same signed [event] is reused across all attempts — no event is
+  /// re-signed per retry, so relays deduplicate by id.
+  @visibleForTesting
+  Future<bool> publishSignedVideoEvent({
+    required PendingUpload upload,
+    required Event event,
+    bool isRetry = false,
+  }) async {
+    final apiClient = _eventApiClient;
+    if (apiClient == null) {
+      return _publishWithWebSocketRetries(event);
+    }
+
+    if (isRetry && await _existsOnConfiguredRelays(event)) {
+      Log.info(
+        '♻️ Recovered already-published video event ${event.id} from relays; '
+        'skipping re-publish',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return true;
+    }
+
+    const maxRetries = 3;
+    for (var attempt = 1; attempt <= maxRetries; attempt++) {
+      // A lost OK on a prior attempt can leave the event already stored on
+      // a relay; re-check before re-broadcasting to avoid duplicates.
+      if (attempt > 1 && await _existsOnConfiguredRelays(event)) {
+        Log.info(
+          '♻️ Event ${event.id} found on relay before retry $attempt; '
+          'marking published',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+        return true;
+      }
+
+      final outcome = await _publishViaRestThenWebSocket(apiClient, event);
+      switch (outcome) {
+        case _EventPublishOutcome.published:
+          if (attempt > 1) {
+            Log.info(
+              '✅ Publish succeeded on attempt $attempt',
+              name: 'VideoEventPublisher',
+              category: LogCategory.video,
+            );
+          }
+          return true;
+        case _EventPublishOutcome.permanentlyRejected:
+          Log.error(
+            '❌ Publish permanently rejected for ${event.id}; not retrying',
+            name: 'VideoEventPublisher',
+            category: LogCategory.video,
+          );
+          return false;
+        case _EventPublishOutcome.transientFailure:
+          if (attempt < maxRetries) {
+            final delaySeconds = attempt * 2; // 2s, 4s backoff
+            Log.warning(
+              '⚠️ Publish attempt $attempt failed, retrying in '
+              '${delaySeconds}s...',
+              name: 'VideoEventPublisher',
+              category: LogCategory.video,
+            );
+            await Future<void>.delayed(Duration(seconds: delaySeconds));
+          } else {
+            Log.error(
+              '❌ All $maxRetries publish attempts failed',
+              name: 'VideoEventPublisher',
+              category: LogCategory.video,
+            );
+          }
+      }
+    }
+    return false;
+  }
+
+  /// One publish attempt: REST first, WebSocket fire-and-forget on transient
+  /// REST failure.
+  Future<_EventPublishOutcome> _publishViaRestThenWebSocket(
+    EventApiClient apiClient,
+    Event event,
+  ) async {
+    final restResult = await apiClient.publishEvent(event);
+    switch (restResult) {
+      case EventApiAccepted():
+        return _EventPublishOutcome.published;
+      case EventApiRejected(:final statusCode, :final reason):
+        Log.error(
+          '❌ REST publish rejected ($statusCode) for ${event.id}: $reason',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+        return _EventPublishOutcome.permanentlyRejected;
+      case EventApiTransientFailure(:final reason):
+        Log.warning(
+          '⚠️ REST publish transient failure for ${event.id} ($reason); '
+          'falling back to WebSocket fire-and-forget',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+        final sent = await _publishViaWebSocketFireAndForget(event);
+        return sent
+            ? _EventPublishOutcome.published
+            : _EventPublishOutcome.transientFailure;
+    }
+  }
+
+  /// Sends [event] over the WebSocket relay pool without waiting for a NIP-20
+  /// `OK` (fire-and-forget). A [PublishSuccess] frame counts as sent.
+  ///
+  /// Video publishes intentionally avoid `publishEventAwaitOk` here: relays
+  /// that accept and serve the event but drop the `OK` would otherwise make a
+  /// successful upload look failed.
+  Future<bool> _publishViaWebSocketFireAndForget(Event event) async {
+    try {
+      if (!_nostrService.isInitialized) {
+        await _nostrService.initialize();
+      }
+      final outerTimeout = currentOuterPublishTimeout;
+      PublishResult? result;
+      try {
+        result = await _nostrService.publishEvent(event).timeout(outerTimeout);
+      } on TimeoutException {
+        Log.error(
+          '⏱️ WebSocket publishEvent timed out after '
+          '${outerTimeout.inSeconds}s for ${event.id}',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+        return false;
+      }
+      if (result is PublishSuccess) {
+        Log.info(
+          '📡 Event sent to relays (fire-and-forget): ${event.id}',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+        return true;
+      }
+      Log.error(
+        '❌ WebSocket publishEvent failed for ${event.id}: '
+        '${result.failureReason ?? 'unknown'}',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return false;
+    } catch (e) {
+      Log.error(
+        'WebSocket fire-and-forget publish failed for ${event.id}: $e',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return false;
+    }
+  }
+
+  /// Legacy WebSocket-only publish with the original 3-attempt, 2s/4s backoff
+  /// retry loop. Used only when no [EventApiClient] is configured.
+  Future<bool> _publishWithWebSocketRetries(Event event) async {
+    const maxRetries = 3;
+    for (var attempt = 1; attempt <= maxRetries; attempt++) {
+      if (await _publishEventToNostr(event)) {
+        if (attempt > 1) {
+          Log.info(
+            '✅ Publish succeeded on attempt $attempt',
+            name: 'VideoEventPublisher',
+            category: LogCategory.video,
+          );
+        }
+        return true;
+      }
+
+      if (attempt < maxRetries) {
+        final delaySeconds = attempt * 2; // 2s, 4s backoff
+        Log.warning(
+          '⚠️ Publish attempt $attempt failed, retrying in ${delaySeconds}s...',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+        await Future<void>.delayed(Duration(seconds: delaySeconds));
+      } else {
+        Log.error(
+          '❌ All $maxRetries publish attempts failed',
+          name: 'VideoEventPublisher',
+          category: LogCategory.video,
+        );
+      }
+    }
+    return false;
+  }
+
+  /// Returns true if [event] is already retrievable from the configured
+  /// relays, queried both by event id and by `author+kind+d-tag`.
+  Future<bool> _existsOnConfiguredRelays(Event event) async {
+    try {
+      final dTag = _dTagOf(event);
+      final filters = <Filter>[
+        Filter(ids: [event.id], limit: 1),
+        if (dTag != null && dTag.isNotEmpty)
+          Filter(
+            authors: [event.pubkey],
+            kinds: [event.kind],
+            d: [dTag],
+            limit: 1,
+          ),
+      ];
+      final found = await _nostrService.queryEvents(filters, useCache: false);
+      for (final candidate in found) {
+        if (candidate.id == event.id) return true;
+        if (candidate.pubkey == event.pubkey &&
+            candidate.kind == event.kind &&
+            _dTagOf(candidate) == dTag) {
+          return true;
+        }
+      }
+      return false;
+    } catch (e) {
+      Log.warning(
+        'Recovery query failed for ${event.id}: $e',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return false;
+    }
+  }
+
+  String? _dTagOf(Event event) {
+    for (final tag in event.tags) {
+      if (tag.length >= 2 && tag[0] == 'd') return tag[1];
+    }
+    return null;
   }
 
   Event? _loadRetryableSignedEvent(PendingUpload upload) {
@@ -1162,8 +1439,9 @@ class VideoEventPublisher {
         category: LogCategory.video,
       );
 
+      final reusedEvent = _loadRetryableSignedEvent(upload);
       final event =
-          _loadRetryableSignedEvent(upload) ??
+          reusedEvent ??
           await _authService.createAndSignEvent(
             kind:
                 NIP71VideoKinds.getPreferredAddressableKind(), // NIP-71 addressable short video
@@ -1197,42 +1475,11 @@ class VideoEventPublisher {
         category: LogCategory.video,
       );
 
-      // Retry up to 3 times with exponential backoff. Success means a
-      // relay confirmed acceptance with `OK true` (NIP-20). We still skip
-      // read-back verification — indexing lag can delay queries even
-      // after a relay has accepted the event.
-      const maxRetries = 3;
-      var publishResult = false;
-
-      for (var attempt = 1; attempt <= maxRetries; attempt++) {
-        if (await _publishEventToNostr(event)) {
-          publishResult = true;
-          if (attempt > 1) {
-            Log.info(
-              '✅ Publish succeeded on attempt $attempt',
-              name: 'VideoEventPublisher',
-              category: LogCategory.video,
-            );
-          }
-          break;
-        }
-
-        if (attempt < maxRetries) {
-          final delaySeconds = attempt * 2; // 2s, 4s backoff
-          Log.warning(
-            '⚠️ Publish attempt $attempt failed, retrying in ${delaySeconds}s...',
-            name: 'VideoEventPublisher',
-            category: LogCategory.video,
-          );
-          await Future<void>.delayed(Duration(seconds: delaySeconds));
-        } else {
-          Log.error(
-            '❌ All $maxRetries publish attempts failed',
-            name: 'VideoEventPublisher',
-            category: LogCategory.video,
-          );
-        }
-      }
+      final publishResult = await publishSignedVideoEvent(
+        upload: upload,
+        event: event,
+        isRetry: reusedEvent != null,
+      );
 
       if (publishResult) {
         final shouldAddToDiscoveryCache =

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -148,6 +148,8 @@ enum _EventPublishOutcome {
   transientFailure,
 }
 
+enum _RelayPresence { found, notFound, unknown }
+
 /// Service for publishing processed videos to Nostr relays
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class VideoEventPublisher {
@@ -511,33 +513,46 @@ class VideoEventPublisher {
     required Event event,
     bool isRetry = false,
   }) async {
+    final outcome = await _publishSignedVideoEventOutcome(
+      upload: upload,
+      event: event,
+      isRetry: isRetry,
+    );
+    return outcome == _EventPublishOutcome.published;
+  }
+
+  Future<_EventPublishOutcome> _publishSignedVideoEventOutcome({
+    required PendingUpload upload,
+    required Event event,
+    bool isRetry = false,
+  }) async {
     final apiClient = _eventApiClient;
     if (apiClient == null) {
       return _publishWithWebSocketRetries(event);
     }
 
-    if (isRetry && await _existsOnConfiguredRelays(event)) {
+    if (isRetry && await _relayPresence(event) == _RelayPresence.found) {
       Log.info(
         '♻️ Recovered already-published video event ${event.id} from relays; '
         'skipping re-publish',
         name: 'VideoEventPublisher',
         category: LogCategory.video,
       );
-      return true;
+      return _EventPublishOutcome.published;
     }
 
     const maxRetries = 3;
     for (var attempt = 1; attempt <= maxRetries; attempt++) {
       // A lost OK on a prior attempt can leave the event already stored on
       // a relay; re-check before re-broadcasting to avoid duplicates.
-      if (attempt > 1 && await _existsOnConfiguredRelays(event)) {
+      if (attempt > 1 && await _relayPresence(event) == _RelayPresence.found) {
         Log.info(
           '♻️ Event ${event.id} found on relay before retry $attempt; '
           'marking published',
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );
-        return true;
+        return _EventPublishOutcome.published;
       }
 
       final outcome = await _publishViaRestThenWebSocket(apiClient, event);
@@ -550,14 +565,14 @@ class VideoEventPublisher {
               category: LogCategory.video,
             );
           }
-          return true;
+          return _EventPublishOutcome.published;
         case _EventPublishOutcome.permanentlyRejected:
           Log.error(
             '❌ Publish permanently rejected for ${event.id}; not retrying',
             name: 'VideoEventPublisher',
             category: LogCategory.video,
           );
-          return false;
+          return _EventPublishOutcome.permanentlyRejected;
         case _EventPublishOutcome.transientFailure:
           if (attempt < maxRetries) {
             final delaySeconds = attempt * 2; // 2s, 4s backoff
@@ -577,7 +592,7 @@ class VideoEventPublisher {
           }
       }
     }
-    return false;
+    return _EventPublishOutcome.transientFailure;
   }
 
   /// One publish attempt: REST first, WebSocket fire-and-forget on transient
@@ -604,10 +619,7 @@ class VideoEventPublisher {
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );
-        final sent = await _publishViaWebSocketFireAndForget(event);
-        return sent
-            ? _EventPublishOutcome.published
-            : _EventPublishOutcome.transientFailure;
+        return _publishViaWebSocketFireAndForget(event);
     }
   }
 
@@ -617,7 +629,9 @@ class VideoEventPublisher {
   /// Video publishes intentionally avoid `publishEventAwaitOk` here: relays
   /// that accept and serve the event but drop the `OK` would otherwise make a
   /// successful upload look failed.
-  Future<bool> _publishViaWebSocketFireAndForget(Event event) async {
+  Future<_EventPublishOutcome> _publishViaWebSocketFireAndForget(
+    Event event,
+  ) async {
     try {
       if (!_nostrService.isInitialized) {
         await _nostrService.initialize();
@@ -633,7 +647,7 @@ class VideoEventPublisher {
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );
-        return false;
+        return _EventPublishOutcome.transientFailure;
       }
       if (result is PublishSuccess) {
         Log.info(
@@ -641,7 +655,7 @@ class VideoEventPublisher {
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );
-        return true;
+        return _EventPublishOutcome.published;
       }
       Log.error(
         '❌ WebSocket publishEvent failed for ${event.id}: '
@@ -649,20 +663,20 @@ class VideoEventPublisher {
         name: 'VideoEventPublisher',
         category: LogCategory.video,
       );
-      return false;
+      return _EventPublishOutcome.transientFailure;
     } catch (e) {
       Log.error(
         'WebSocket fire-and-forget publish failed for ${event.id}: $e',
         name: 'VideoEventPublisher',
         category: LogCategory.video,
       );
-      return false;
+      return _EventPublishOutcome.transientFailure;
     }
   }
 
   /// Legacy WebSocket-only publish with the original 3-attempt, 2s/4s backoff
   /// retry loop. Used only when no [EventApiClient] is configured.
-  Future<bool> _publishWithWebSocketRetries(Event event) async {
+  Future<_EventPublishOutcome> _publishWithWebSocketRetries(Event event) async {
     const maxRetries = 3;
     for (var attempt = 1; attempt <= maxRetries; attempt++) {
       if (await _publishEventToNostr(event)) {
@@ -673,7 +687,7 @@ class VideoEventPublisher {
             category: LogCategory.video,
           );
         }
-        return true;
+        return _EventPublishOutcome.published;
       }
 
       if (attempt < maxRetries) {
@@ -692,17 +706,17 @@ class VideoEventPublisher {
         );
       }
     }
-    return false;
+    return _EventPublishOutcome.transientFailure;
   }
 
-  /// Returns true if [event] is already retrievable from the configured
-  /// relays, queried both by event id and by `author+kind+d-tag`.
-  Future<bool> _existsOnConfiguredRelays(Event event) async {
+  /// Checks whether [event] is already retrievable from the configured relays,
+  /// queried both by event id and by `author+kind+d-tag`.
+  Future<_RelayPresence> _relayPresence(Event event) async {
     try {
       final dTag = _dTagOf(event);
       final filters = <Filter>[
         Filter(ids: [event.id], limit: 1),
-        if (dTag != null && dTag.isNotEmpty)
+        if (dTag.isNotEmpty)
           Filter(
             authors: [event.pubkey],
             kinds: [event.kind],
@@ -712,29 +726,33 @@ class VideoEventPublisher {
       ];
       final found = await _nostrService.queryEvents(filters, useCache: false);
       for (final candidate in found) {
-        if (candidate.id == event.id) return true;
+        if (candidate.id == event.id) return _RelayPresence.found;
         if (candidate.pubkey == event.pubkey &&
             candidate.kind == event.kind &&
             _dTagOf(candidate) == dTag) {
-          return true;
+          return _RelayPresence.found;
         }
       }
-      return false;
+      return _RelayPresence.notFound;
     } catch (e) {
       Log.warning(
         'Recovery query failed for ${event.id}: $e',
         name: 'VideoEventPublisher',
         category: LogCategory.video,
       );
-      return false;
+      return _RelayPresence.unknown;
     }
   }
 
-  String? _dTagOf(Event event) {
+  String _dTagOf(Event event) {
+    var dTag = '';
     for (final tag in event.tags) {
-      if (tag.length >= 2 && tag[0] == 'd') return tag[1];
+      if (tag.length >= 2 && tag[0] == 'd') {
+        dTag = tag[1];
+        break;
+      }
     }
-    return null;
+    return dTag;
   }
 
   Event? _loadRetryableSignedEvent(PendingUpload upload) {

--- a/mobile/test/services/event_api_client_test.dart
+++ b/mobile/test/services/event_api_client_test.dart
@@ -143,7 +143,7 @@ void main() {
       final client = buildClient(
         MockClient(
           (_) async => http.Response(
-            jsonEncode({'accepted': true, 'event_id': 'server-event-id'}),
+            jsonEncode({'accepted': true, 'event_id': event.id}),
             200,
           ),
         ),
@@ -152,7 +152,24 @@ void main() {
       final result = await client.publishEvent(event);
 
       expect(result, isA<EventApiAccepted>());
-      expect((result as EventApiAccepted).eventId, equals('server-event-id'));
+      expect((result as EventApiAccepted).eventId, equals(event.id));
+    });
+
+    test('returns transient failure when accepted event_id differs', () async {
+      stubToken(buildToken());
+      final event = buildVideoEvent();
+      final client = buildClient(
+        MockClient(
+          (_) async => http.Response(
+            jsonEncode({'accepted': true, 'event_id': 'server-event-id'}),
+            200,
+          ),
+        ),
+      );
+
+      final result = await client.publishEvent(event);
+
+      expect(result, isA<EventApiTransientFailure>());
     });
 
     test('returns transient failure on 200 without accepted:true', () async {

--- a/mobile/test/services/event_api_client_test.dart
+++ b/mobile/test/services/event_api_client_test.dart
@@ -1,0 +1,298 @@
+// ABOUTME: Tests for EventApiClient REST-first Nostr event publishing
+// ABOUTME: Covers 200/401/403/422/5xx classification, NIP-98 wiring, signer match
+
+import 'dart:convert';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/event_api_client.dart';
+import 'package:openvine/services/nip98_auth_service.dart';
+
+class _MockNip98AuthService extends Mock implements Nip98AuthService {}
+
+void main() {
+  const testPubkey =
+      '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+  const otherPubkey =
+      'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+  late _MockNip98AuthService mockNip98;
+
+  setUpAll(() {
+    registerFallbackValue(HttpMethod.post);
+  });
+
+  setUp(() {
+    mockNip98 = _MockNip98AuthService();
+  });
+
+  Event buildVideoEvent({String pubkey = testPubkey}) {
+    return Event(
+      pubkey,
+      34236,
+      const [
+        ['d', 'test-video-id'],
+        ['title', 'Plants'],
+      ],
+      'A plant video',
+      createdAt: 1700000000,
+    );
+  }
+
+  Nip98Token buildToken({String signerPubkey = testPubkey}) {
+    final signedEvent = Event(
+      signerPubkey,
+      27235,
+      const [
+        ['u', 'https://api.divine.video/api/events'],
+        ['method', 'POST'],
+      ],
+      '',
+      createdAt: 1700000000,
+    );
+    final now = clock.now();
+    return Nip98Token(
+      token: 'fake-base64-token',
+      signedEvent: signedEvent,
+      createdAt: now,
+      expiresAt: now.add(const Duration(seconds: 45)),
+    );
+  }
+
+  void stubToken(Nip98Token? token) {
+    when(
+      () => mockNip98.createAuthToken(
+        url: any(named: 'url'),
+        method: any(named: 'method'),
+        payload: any(named: 'payload'),
+      ),
+    ).thenAnswer((_) async => token);
+  }
+
+  EventApiClient buildClient(http.Client httpClient) {
+    return EventApiClient(
+      httpClient: httpClient,
+      nip98AuthService: mockNip98,
+      apiBaseUrl: () => 'https://api.divine.video',
+    );
+  }
+
+  group(EventApiClient, () {
+    test('POSTs signed event JSON to {apiBaseUrl}/api/events', () async {
+      stubToken(buildToken());
+      final event = buildVideoEvent();
+      http.Request? captured;
+      final client = buildClient(
+        MockClient((request) async {
+          captured = request;
+          return http.Response(
+            jsonEncode({'accepted': true, 'event_id': event.id}),
+            200,
+          );
+        }),
+      );
+
+      await client.publishEvent(event);
+
+      expect(captured, isNotNull);
+      expect(captured!.method, equals('POST'));
+      expect(
+        captured!.url.toString(),
+        equals('https://api.divine.video/api/events'),
+      );
+      expect(captured!.body, equals(jsonEncode(event.toJson())));
+      expect(
+        captured!.headers['Authorization'],
+        equals('Nostr fake-base64-token'),
+      );
+    });
+
+    test('requests NIP-98 token for the publish URL, POST, and body', () async {
+      stubToken(buildToken());
+      final event = buildVideoEvent();
+      final client = buildClient(
+        MockClient(
+          (_) async => http.Response(
+            jsonEncode({'accepted': true, 'event_id': event.id}),
+            200,
+          ),
+        ),
+      );
+
+      await client.publishEvent(event);
+
+      final captured = verify(
+        () => mockNip98.createAuthToken(
+          url: captureAny(named: 'url'),
+          method: captureAny(named: 'method'),
+          payload: captureAny(named: 'payload'),
+        ),
+      ).captured;
+      expect(captured[0], equals('https://api.divine.video/api/events'));
+      expect(captured[1], equals(HttpMethod.post));
+      expect(captured[2], equals(jsonEncode(event.toJson())));
+    });
+
+    test('returns EventApiAccepted on 200 {accepted:true, event_id}', () async {
+      stubToken(buildToken());
+      final event = buildVideoEvent();
+      final client = buildClient(
+        MockClient(
+          (_) async => http.Response(
+            jsonEncode({'accepted': true, 'event_id': 'server-event-id'}),
+            200,
+          ),
+        ),
+      );
+
+      final result = await client.publishEvent(event);
+
+      expect(result, isA<EventApiAccepted>());
+      expect((result as EventApiAccepted).eventId, equals('server-event-id'));
+    });
+
+    test('returns transient failure on 200 without accepted:true', () async {
+      stubToken(buildToken());
+      final client = buildClient(
+        MockClient(
+          (_) async => http.Response(jsonEncode({'accepted': false}), 200),
+        ),
+      );
+
+      final result = await client.publishEvent(buildVideoEvent());
+
+      expect(result, isA<EventApiTransientFailure>());
+    });
+
+    for (final status in [401, 403, 422]) {
+      test('returns EventApiRejected on $status', () async {
+        stubToken(buildToken());
+        final client = buildClient(
+          MockClient((_) async => http.Response('rejected', status)),
+        );
+
+        final result = await client.publishEvent(buildVideoEvent());
+
+        expect(result, isA<EventApiRejected>());
+        expect((result as EventApiRejected).statusCode, equals(status));
+      });
+    }
+
+    test('returns transient failure on 500', () async {
+      stubToken(buildToken());
+      final client = buildClient(
+        MockClient((_) async => http.Response('server error', 500)),
+      );
+
+      final result = await client.publishEvent(buildVideoEvent());
+
+      expect(result, isA<EventApiTransientFailure>());
+    });
+
+    test('returns transient failure on network error', () async {
+      stubToken(buildToken());
+      final client = buildClient(
+        MockClient((_) async => throw const SocketExceptionStub()),
+      );
+
+      final result = await client.publishEvent(buildVideoEvent());
+
+      expect(result, isA<EventApiTransientFailure>());
+    });
+
+    test('returns transient failure on timeout', () async {
+      stubToken(buildToken());
+      final client = EventApiClient(
+        httpClient: MockClient((_) async {
+          await Future<void>.delayed(const Duration(seconds: 30));
+          return http.Response('', 200);
+        }),
+        nip98AuthService: mockNip98,
+        apiBaseUrl: () => 'https://api.divine.video',
+        timeout: const Duration(milliseconds: 50),
+      );
+
+      final result = await client.publishEvent(buildVideoEvent());
+
+      expect(result, isA<EventApiTransientFailure>());
+    });
+
+    test(
+      'returns transient failure when NIP-98 token is unavailable',
+      () async {
+        stubToken(null);
+        var requested = false;
+        final client = buildClient(
+          MockClient((_) async {
+            requested = true;
+            return http.Response('', 200);
+          }),
+        );
+
+        final result = await client.publishEvent(buildVideoEvent());
+
+        expect(result, isA<EventApiTransientFailure>());
+        expect(requested, isFalse, reason: 'must not POST without a token');
+      },
+    );
+
+    test(
+      'rejects when NIP-98 signer pubkey does not match event pubkey',
+      () async {
+        stubToken(buildToken(signerPubkey: otherPubkey));
+        var requested = false;
+        final client = buildClient(
+          MockClient((_) async {
+            requested = true;
+            return http.Response('', 200);
+          }),
+        );
+
+        final result = await client.publishEvent(buildVideoEvent());
+
+        expect(result, isA<EventApiRejected>());
+        expect(
+          requested,
+          isFalse,
+          reason: 'must not POST under a mismatched key',
+        );
+      },
+    );
+
+    test(
+      'builds the events URL for a staging base without double slashes',
+      () async {
+        stubToken(buildToken());
+        final event = buildVideoEvent();
+        http.Request? captured;
+        final client = EventApiClient(
+          httpClient: MockClient((request) async {
+            captured = request;
+            return http.Response(
+              jsonEncode({'accepted': true, 'event_id': event.id}),
+              200,
+            );
+          }),
+          nip98AuthService: mockNip98,
+          apiBaseUrl: () => 'https://relay.staging.divine.video',
+        );
+
+        await client.publishEvent(event);
+
+        expect(
+          captured!.url.toString(),
+          equals('https://relay.staging.divine.video/api/events'),
+        );
+      },
+    );
+  });
+}
+
+/// Stand-in for a transport-level failure thrown by the HTTP client.
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+}

--- a/mobile/test/services/video_event_publisher_rest_publish_test.dart
+++ b/mobile/test/services/video_event_publisher_rest_publish_test.dart
@@ -1,0 +1,321 @@
+// ABOUTME: Tests for VideoEventPublisher REST-first publish with WebSocket fallback
+// ABOUTME: Covers REST accept, transient fallback, recovery, retry reuse, no-duplicate
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show VideoEvent;
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/event_api_client.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_event_publisher.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockUploadManager extends Mock implements UploadManager {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockPersonalEventCacheService extends Mock
+    implements PersonalEventCacheService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockEventApiClient extends Mock implements EventApiClient {}
+
+class _FakeEvent extends Fake implements Event {}
+
+class _FakeVideoEvent extends Fake implements VideoEvent {}
+
+void main() {
+  const testPubkey =
+      '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+
+  late _MockUploadManager mockUploadManager;
+  late _MockNostrClient mockNostrClient;
+  late _MockAuthService mockAuthService;
+  late _MockPersonalEventCacheService mockPersonalEventCache;
+  late _MockVideoEventService mockVideoEventService;
+  late _MockEventApiClient mockEventApiClient;
+  late VideoEventPublisher publisher;
+
+  setUpAll(() {
+    registerFallbackValue(_FakeEvent());
+    registerFallbackValue(_FakeVideoEvent());
+    registerFallbackValue(UploadStatus.pending);
+    registerFallbackValue(<Filter>[]);
+  });
+
+  setUp(() {
+    mockUploadManager = _MockUploadManager();
+    mockNostrClient = _MockNostrClient();
+    mockAuthService = _MockAuthService();
+    mockPersonalEventCache = _MockPersonalEventCacheService();
+    mockVideoEventService = _MockVideoEventService();
+    mockEventApiClient = _MockEventApiClient();
+
+    publisher = VideoEventPublisher(
+      uploadManager: mockUploadManager,
+      nostrService: mockNostrClient,
+      authService: mockAuthService,
+      personalEventCache: mockPersonalEventCache,
+      videoEventService: mockVideoEventService,
+      eventApiClient: mockEventApiClient,
+    );
+
+    when(() => mockAuthService.isAuthenticated).thenReturn(true);
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
+
+    when(() => mockNostrClient.isInitialized).thenReturn(true);
+    when(() => mockNostrClient.configuredRelayCount).thenReturn(1);
+    when(() => mockNostrClient.connectedRelayCount).thenReturn(1);
+    when(
+      () => mockNostrClient.configuredRelays,
+    ).thenReturn(const ['wss://relay.divine.video']);
+    when(
+      () => mockNostrClient.connectedRelays,
+    ).thenReturn(const ['wss://relay.divine.video']);
+    when(() => mockNostrClient.publicKey).thenReturn(testPubkey);
+
+    // Recovery queries return nothing unless a test overrides this.
+    when(
+      () => mockNostrClient.queryEvents(
+        any(),
+        useCache: any(named: 'useCache'),
+      ),
+    ).thenAnswer((_) async => <Event>[]);
+
+    when(
+      () => mockUploadManager.updateUploadStatus(
+        any(),
+        any(),
+        nostrEventId: any(named: 'nostrEventId'),
+      ),
+    ).thenAnswer((_) async {});
+
+    when(() => mockPersonalEventCache.cacheUserEvent(any())).thenReturn(null);
+    when(() => mockPersonalEventCache.getEventById(any())).thenReturn(null);
+    when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+  });
+
+  PendingUpload createUpload() {
+    return PendingUpload(
+      id: 'test-upload-id',
+      localVideoPath: '/tmp/test.mp4',
+      nostrPubkey: testPubkey,
+      status: UploadStatus.readyToPublish,
+      createdAt: DateTime.now(),
+      videoId: 'test-video-id',
+      title: 'Plants',
+      cdnUrl: 'https://cdn.example.com/video.mp4',
+      fallbackUrl: 'https://cdn.example.com/video.mp4',
+    );
+  }
+
+  Event createSignedEvent() {
+    return Event(
+      testPubkey,
+      NIP71VideoKinds.getPreferredAddressableKind(),
+      const [
+        ['d', 'test-video-id'],
+        ['title', 'Plants'],
+        ['imeta', 'url https://cdn.example.com/video.mp4', 'm video/mp4'],
+      ],
+      'A plant video',
+      createdAt: 1700000000,
+    );
+  }
+
+  void stubSigning(Event event) {
+    when(
+      () => mockAuthService.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer((_) async => event);
+  }
+
+  void stubRest(EventApiPublishResult result) {
+    when(
+      () => mockEventApiClient.publishEvent(any()),
+    ).thenAnswer((_) async => result);
+  }
+
+  void stubWebSocket(PublishResult result) {
+    when(
+      () => mockNostrClient.publishEvent(any()),
+    ).thenAnswer((_) async => result);
+  }
+
+  group('VideoEventPublisher REST-first publish', () {
+    test('REST 200 acceptance marks the upload published', () async {
+      final signedEvent = createSignedEvent();
+      stubSigning(signedEvent);
+      stubRest(const EventApiAccepted('server-event-id'));
+
+      final result = await publisher.publishDirectUpload(createUpload());
+
+      expect(result, isTrue);
+      verify(() => mockEventApiClient.publishEvent(any())).called(1);
+      verify(
+        () => mockUploadManager.updateUploadStatus(
+          'test-upload-id',
+          UploadStatus.published,
+          nostrEventId: signedEvent.id,
+        ),
+      ).called(1);
+      // REST succeeded — no WebSocket fallback.
+      verifyNever(() => mockNostrClient.publishEvent(any()));
+    });
+
+    test(
+      'REST transient failure falls back to WebSocket send success',
+      () async {
+        final signedEvent = createSignedEvent();
+        stubSigning(signedEvent);
+        stubRest(const EventApiTransientFailure('http_503'));
+        stubWebSocket(PublishSuccess(event: signedEvent));
+
+        final result = await publisher.publishDirectUpload(createUpload());
+
+        expect(result, isTrue);
+        verify(() => mockEventApiClient.publishEvent(any())).called(1);
+        verify(() => mockNostrClient.publishEvent(signedEvent)).called(1);
+        verify(
+          () => mockUploadManager.updateUploadStatus(
+            'test-upload-id',
+            UploadStatus.published,
+            nostrEventId: signedEvent.id,
+          ),
+        ).called(1);
+      },
+    );
+
+    test('REST 401/403/422 fails without WebSocket fallback', () async {
+      final signedEvent = createSignedEvent();
+      stubSigning(signedEvent);
+      stubRest(const EventApiRejected(statusCode: 422, reason: 'bad event'));
+
+      final result = await publisher.publishDirectUpload(createUpload());
+
+      expect(result, isFalse);
+      verifyNever(() => mockNostrClient.publishEvent(any()));
+      verifyNever(
+        () => mockUploadManager.updateUploadStatus(
+          any(),
+          UploadStatus.published,
+          nostrEventId: any(named: 'nostrEventId'),
+        ),
+      );
+    });
+
+    test('retry reuses the original signed event id (no re-sign)', () async {
+      final signedEvent = createSignedEvent();
+      final retryUpload = createUpload().copyWith(
+        nostrEventId: signedEvent.id,
+      );
+      when(
+        () => mockPersonalEventCache.getEventById(signedEvent.id),
+      ).thenReturn(signedEvent);
+      stubRest(const EventApiAccepted('server-event-id'));
+
+      final result = await publisher.publishDirectUpload(retryUpload);
+
+      expect(result, isTrue);
+      // No new event signed — the cached event is reused.
+      verifyNever(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      );
+      final captured = verify(
+        () => mockEventApiClient.publishEvent(captureAny()),
+      ).captured;
+      expect((captured.single as Event).id, equals(signedEvent.id));
+    });
+
+    test(
+      'recovery: existing relay event marks published without re-publishing',
+      () async {
+        final signedEvent = createSignedEvent();
+        final retryUpload = createUpload().copyWith(
+          nostrEventId: signedEvent.id,
+        );
+        when(
+          () => mockPersonalEventCache.getEventById(signedEvent.id),
+        ).thenReturn(signedEvent);
+        // The event is already on a configured relay.
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer((_) async => [signedEvent]);
+
+        final result = await publisher.publishDirectUpload(retryUpload);
+
+        expect(result, isTrue);
+        verifyNever(() => mockEventApiClient.publishEvent(any()));
+        verifyNever(() => mockNostrClient.publishEvent(any()));
+        verify(
+          () => mockUploadManager.updateUploadStatus(
+            'test-upload-id',
+            UploadStatus.published,
+            nostrEventId: signedEvent.id,
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'WebSocket false-negative does not create a duplicate event',
+      () async {
+        final signedEvent = createSignedEvent();
+        stubSigning(signedEvent);
+        // REST keeps failing transiently across attempts.
+        stubRest(const EventApiTransientFailure('http_503'));
+        // WebSocket reports failure even though the relay actually stored it
+        // during the first send — so the pre-retry recovery query finds it.
+        stubWebSocket(const PublishFailed());
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer((_) async => [signedEvent]);
+
+        final result = await publisher.publishDirectUpload(createUpload());
+
+        expect(result, isTrue);
+        // The event is signed exactly once and reused across attempts — a
+        // retry never re-signs, so relays cannot receive a second distinct id.
+        verify(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).called(1);
+        // Exactly one WebSocket send — the second attempt short-circuits on
+        // recovery rather than re-broadcasting and creating a duplicate.
+        verify(() => mockNostrClient.publishEvent(signedEvent)).called(1);
+        verify(
+          () => mockUploadManager.updateUploadStatus(
+            'test-upload-id',
+            UploadStatus.published,
+            nostrEventId: signedEvent.id,
+          ),
+        ).called(1);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Why

First-party video events were published over the WebSocket relay with `publishEventAwaitOk`. A relay that accepted and served an event but dropped its NIP-20 `OK` made a **successful upload look failed**. This makes video publishing REST-first, with a WebSocket fire-and-forget fallback, so a missing `OK` no longer surfaces as a failure.

## What

**REST-first publish (`EventApiClient`, new)**
- `POST {apiBaseUrl}/api/events` with the already-signed event JSON as the body.
  - Production → `https://api.divine.video/api/events`
  - Staging → `https://relay.staging.divine.video/api/events`
- NIP-98 auth (kind `27235`): `method=POST`, `u` = exact publish URL, `payload` = SHA-256 hex of the request body bytes. Refuses to publish if the auth signer pubkey ≠ `event.pubkey`.
- Outcome classification: `200 {accepted:true,event_id}` → published; `401/403/422` → real, non-retryable failure (actionable logs); timeouts / `5xx` / network → transient.

**Orchestration (`VideoEventPublisher.publishSignedVideoEvent`)**
- Reuses the **same signed event** across all attempts — no per-retry re-signing, so relays deduplicate by id.
- Before retrying a `readyToPublish` upload, queries configured relays by **event id** and by **author+kind+d-tag**; if the event is already on a relay, marks the upload published and stops.
- Up to 3 attempts: REST first → accepted=published, `401/403/422`=fail-fast, transient → WebSocket `publishEvent` **fire-and-forget** (not `publishEventAwaitOk`). Re-checks relay presence before each retry so a false-negative `OK` cannot create a duplicate.
- When no `EventApiClient` is wired, the legacy WebSocket-only path is unchanged.

**Wiring** — `videoEventPublisherProvider` builds `EventApiClient` from `environmentConfig.apiBaseUrl` + `nip98AuthServiceProvider`.

**Docs** — `FUNNELCAKE_API_REFERENCE.md` "Publishing Content" rewritten from WebSocket-only to REST-first + fallback.

## Tests (20 new, all green)

- `event_api_client_test.dart` (14): URL/body, NIP-98 wiring, `200/401/403/422/5xx`/timeout/network classification, accepted `event_id` must match the signed event id, signer-pubkey mismatch, staging URL.
- `video_event_publisher_rest_publish_test.dart` (6): REST 200 → published; REST transient → WebSocket send success; `401/403/422` no fallback; retry reuses original signed event id; existing-relay recovery → published; WebSocket false-negative → no duplicate event.

## Verification

- `flutter analyze lib test` — clean.
- New suites green; existing `video_event_publisher*` suites (54 tests) still pass. Run from `mobile/`.

## Test plan

- [ ] Publish a video on a flaky relay that withholds `OK` → upload shows published (REST path).
- [ ] Force REST `5xx`/timeout → falls back to WebSocket, still publishes.
- [ ] Retry a `readyToPublish` upload whose event already reached a relay → recovered as published, no duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5230