### PR TITLE
fix(notifications): parse funnelcake notification fields

### DIFF
--- a/mobile/packages/funnelcake_api_client/lib/src/models/notification_response.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/notification_response.dart
@@ -23,7 +23,7 @@ class NotificationResponse {
       unreadCount: json['unread_count'] as int? ?? 0,
       nextCursor: json['next_cursor'] as String?,
       nextCursorId: json['next_cursor_id'] as String?,
-      hasMore: json['has_more'] as bool? ?? false,
+      hasMore: _boolValue(json['has_more']),
     );
   }
 
@@ -65,7 +65,9 @@ class MarkReadResponse {
   factory MarkReadResponse.fromJson(Map<String, dynamic> json) {
     final error = json['error'] as String?;
     return MarkReadResponse(
-      success: (json['success'] as bool?) ?? (error == null),
+      success: json.containsKey('success')
+          ? _boolValue(json['success'])
+          : error == null,
       markedCount: json['marked_count'] as int? ?? 0,
       error: error,
     );
@@ -79,4 +81,14 @@ class MarkReadResponse {
 
   /// An optional error message when the operation fails.
   final String? error;
+}
+
+bool _boolValue(Object? value) {
+  if (value is bool) {
+    return value;
+  }
+  if (value is int) {
+    return value != 0;
+  }
+  return false;
 }

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -140,7 +140,7 @@ class RelayNotification {
   static String? _nonEmpty(String? value) =>
       value == null || value.isEmpty ? null : value;
 
-  static int? _intValue(Object? value) => value is int ? value : null;
+  static int? _intValue(Object? value) => value is num ? value.toInt() : null;
 
   static bool _boolValue(Object? value) {
     if (value is bool) {

--- a/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
+++ b/mobile/packages/funnelcake_api_client/lib/src/models/relay_notification.dart
@@ -51,9 +51,12 @@ class RelayNotification {
       referencedEventId: json['referenced_event_id'] as String?,
       notificationType: json['notification_type'] as String? ?? '',
       createdAt: DateTime.fromMillisecondsSinceEpoch(
-        ((json['created_at'] as int?) ?? 0) * 1000,
+        (_intValue(json['source_created_at']) ??
+                _intValue(json['created_at']) ??
+                0) *
+            1000,
       ),
-      read: json['read'] as bool? ?? false,
+      read: _boolValue(json['read']),
       content: json['content'] as String?,
       isReferencedVideo: referencedVideoMap != null,
       referencedVideoTitle: (videoTitle != null && videoTitle.isNotEmpty)
@@ -136,4 +139,16 @@ class RelayNotification {
 
   static String? _nonEmpty(String? value) =>
       value == null || value.isEmpty ? null : value;
+
+  static int? _intValue(Object? value) => value is int ? value : null;
+
+  static bool _boolValue(Object? value) {
+    if (value is bool) {
+      return value;
+    }
+    if (value is int) {
+      return value != 0;
+    }
+    return false;
+  }
 }

--- a/mobile/packages/funnelcake_api_client/test/src/models/notification_response_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/notification_response_test.dart
@@ -56,14 +56,25 @@ void main() {
       expect(response.nextCursorId, isNull);
       expect(response.hasMore, isFalse);
     });
+
+    test('parses integer has_more flags from notifications API', () {
+      final withoutMore = NotificationResponse.fromJson({
+        'notifications': <Map<String, dynamic>>[],
+        'has_more': 0,
+      });
+      final withMore = NotificationResponse.fromJson({
+        'notifications': <Map<String, dynamic>>[],
+        'has_more': 1,
+      });
+
+      expect(withoutMore.hasMore, isFalse);
+      expect(withMore.hasMore, isTrue);
+    });
   });
 
   group('MarkReadResponse', () {
     test('honors explicit `success: true` when the server sends it', () {
-      final json = {
-        'success': true,
-        'marked_count': 10,
-      };
+      final json = {'success': true, 'marked_count': 10};
 
       final response = MarkReadResponse.fromJson(json);
 
@@ -86,25 +97,39 @@ void main() {
       expect(response.error, equals('unauthorized'));
     });
 
-    test(
-      'treats the real funnelcake response shape (no `success` field) as '
-      'success',
-      () {
-        // Per https://relay.divine.video/docs/llm-guide the server
-        // returns {"marked_count": N, "marked_all": bool} on success.
-        // There is no `success` field — PR #4271 assumed one and
-        // defaulted to `false`, which made every successful mark-read
-        // parse as a soft-failure and bounce the notifications badge
-        // back up via the repository's rollback path.
-        final json = {'marked_count': 5, 'marked_all': true};
+    test('parses integer success flags when the server sends them', () {
+      final rejected = MarkReadResponse.fromJson({
+        'success': 0,
+        'marked_count': 0,
+        'error': 'unauthorized',
+      });
+      final accepted = MarkReadResponse.fromJson({
+        'success': 1,
+        'marked_count': 3,
+      });
 
-        final response = MarkReadResponse.fromJson(json);
+      expect(rejected.success, isFalse);
+      expect(rejected.error, equals('unauthorized'));
+      expect(accepted.success, isTrue);
+      expect(accepted.markedCount, equals(3));
+    });
 
-        expect(response.success, isTrue);
-        expect(response.markedCount, equals(5));
-        expect(response.error, isNull);
-      },
-    );
+    test('treats the real funnelcake response shape (no `success` field) as '
+        'success', () {
+      // Per https://relay.divine.video/docs/llm-guide the server
+      // returns {"marked_count": N, "marked_all": bool} on success.
+      // There is no `success` field — PR #4271 assumed one and
+      // defaulted to `false`, which made every successful mark-read
+      // parse as a soft-failure and bounce the notifications badge
+      // back up via the repository's rollback path.
+      final json = {'marked_count': 5, 'marked_all': true};
+
+      final response = MarkReadResponse.fromJson(json);
+
+      expect(response.success, isTrue);
+      expect(response.markedCount, equals(5));
+      expect(response.error, isNull);
+    });
 
     test('treats a body with an `error` field as failure', () {
       // No `success` field but an `error` string → still a failure.

--- a/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/models/relay_notification_test.dart
@@ -334,6 +334,48 @@ void main() {
         );
       });
 
+      test('prefers source_created_at over notification row created_at', () {
+        final json = {
+          'id': 'notif_123',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 1111,
+          'notification_type': 'comment',
+          'source_created_at': 1712000000,
+          'created_at': 1712345678,
+          'read': false,
+        };
+
+        final notification = RelayNotification.fromJson(json);
+
+        expect(
+          notification.createdAt,
+          equals(
+            DateTime.fromMillisecondsSinceEpoch(1712000000 * 1000),
+          ),
+        );
+      });
+
+      test('parses integer read flags from notifications API', () {
+        final unreadJson = {
+          'id': 'notif_unread',
+          'source_pubkey': 'aabbccdd' * 8,
+          'source_event_id': '11223344' * 8,
+          'source_kind': 1111,
+          'notification_type': 'comment',
+          'created_at': 1712345678,
+          'read': 0,
+        };
+        final readJson = {
+          ...unreadJson,
+          'id': 'notif_read',
+          'read': 1,
+        };
+
+        expect(RelayNotification.fromJson(unreadJson).read, isFalse);
+        expect(RelayNotification.fromJson(readJson).read, isTrue);
+      });
+
       test(
         'parses staging NIP-22 comment anchor fields',
         () {


### PR DESCRIPTION
Closes #5224

## Summary
- Parse FunnelCake notification read values when the API sends integer flags.
- Prefer source_created_at over notification row created_at for notification timestamps.
- Add DTO regressions covering the comment notification payload shape.

## Verification
- flutter test test/src/models/relay_notification_test.dart test/src/models/notification_response_test.dart from mobile/packages/funnelcake_api_client
- flutter test test/src/notification_repository_test.dart from mobile/packages/notification_repository
- flutter test test/main_notification_tap_routing_test.dart test/main_video_deep_link_nav_action_test.dart test/screens/comments/comments_screen_test.dart from mobile
- flutter analyze from mobile
- pre-push hook analyzer and changed-file tests passed