### PR TITLE
fix(notifications): linkify nostr refs in comment quotes

### DIFF
--- a/mobile/lib/notifications/widgets/notification_comment_quote.dart
+++ b/mobile/lib/notifications/widgets/notification_comment_quote.dart
@@ -4,6 +4,11 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_navigation.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
 
 /// Renders a notification's quoted comment beneath the message text.
 ///
@@ -18,7 +23,7 @@ import 'package:flutter/material.dart';
 ///
 /// Capped at two lines so a long quote doesn't push the row's intrinsic
 /// height past the rest of the list.
-class NotificationCommentQuote extends StatelessWidget {
+class NotificationCommentQuote extends ConsumerStatefulWidget {
   /// Creates a [NotificationCommentQuote].
   const NotificationCommentQuote({
     required this.text,
@@ -36,13 +41,46 @@ class NotificationCommentQuote extends StatelessWidget {
   final String? timestamp;
 
   @override
+  ConsumerState<NotificationCommentQuote> createState() =>
+      _NotificationCommentQuoteState();
+}
+
+class _NotificationCommentQuoteState
+    extends ConsumerState<NotificationCommentQuote> {
+  List<TextSpan> _currentBodySpans = const [];
+
+  @override
   Widget build(BuildContext context) {
-    final ts = timestamp;
+    final bodyStyle = VineTheme.bodyMediumFont();
+    final linkStyle = VineTheme.bodyMediumFont(
+      color: VineTheme.info,
+    ).copyWith(fontWeight: FontWeight.w600);
+    final bodySpans = LinkifiedTextSpanBuilder(
+      text: widget.text,
+      defaultStyle: bodyStyle,
+      linkStyle: linkStyle,
+      mentionStyle: linkStyle,
+      videoLabel: Localizations.of<AppLocalizations>(
+        context,
+        AppLocalizations,
+      )?.clickableTextViewVideoLink,
+      profileLabelForHex: _profileDisplayText,
+      onHashtagTap: (hashtag) => _navigateToHashtagFeed(context, hashtag),
+      onProfileTap: (hexPubkey) => _navigateToProfile(context, hexPubkey),
+      onVideoTap: (routeReference) => _navigateToVideo(context, routeReference),
+      onMentionTap: (username) => _navigateToSearch(context, username),
+      onUrlTap: LinkifiedTextNavigation.launchRawUrl,
+    ).build();
+    _replaceCurrentBodySpans(bodySpans);
+
+    final ts = widget.timestamp;
     final showTimestamp = ts != null && ts.isNotEmpty;
     return Text.rich(
       TextSpan(
         children: [
-          TextSpan(text: '“$text”', style: VineTheme.bodyMediumFont()),
+          TextSpan(text: '“', style: bodyStyle),
+          ..._currentBodySpans,
+          TextSpan(text: '”', style: bodyStyle),
           if (showTimestamp)
             TextSpan(
               text: ' $ts',
@@ -55,5 +93,37 @@ class NotificationCommentQuote extends StatelessWidget {
       maxLines: 2,
       overflow: TextOverflow.ellipsis,
     );
+  }
+
+  String _profileDisplayText(String hexPubkey) {
+    return LinkifiedTextSupport.profileDisplayText(ref, hexPubkey);
+  }
+
+  void _navigateToHashtagFeed(BuildContext context, String hashtag) {
+    LinkifiedTextNavigation.navigateToHashtagFeed(context, hashtag);
+  }
+
+  void _navigateToProfile(BuildContext context, String hexPubkey) {
+    LinkifiedTextNavigation.navigateToProfile(context, hexPubkey);
+  }
+
+  void _navigateToVideo(BuildContext context, String routeReference) {
+    LinkifiedTextNavigation.navigateToVideo(context, routeReference);
+  }
+
+  void _navigateToSearch(BuildContext context, String username) {
+    LinkifiedTextNavigation.navigateToSearch(context, username);
+  }
+
+  void _replaceCurrentBodySpans(List<TextSpan> spans) {
+    final previousSpans = _currentBodySpans;
+    _currentBodySpans = spans;
+    LinkifiedTextSupport.disposeSpans(previousSpans);
+  }
+
+  @override
+  void dispose() {
+    LinkifiedTextSupport.disposeSpans(_currentBodySpans);
+    super.dispose();
   }
 }

--- a/mobile/lib/widgets/linkified_text/linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text.dart
@@ -1,17 +1,10 @@
-import 'dart:async';
-
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/router/nav_extensions.dart';
-import 'package:openvine/screens/hashtag_screen_router.dart';
-import 'package:openvine/screens/search_results/view/search_results_page.dart';
-import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_navigation.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 class LinkifiedText extends ConsumerStatefulWidget {
   const LinkifiedText({
@@ -102,54 +95,43 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
   }
 
   void _navigateToHashtagFeed(BuildContext context, String hashtag) {
-    widget.onVideoStateChange?.call();
-    context.push(HashtagScreenRouter.pathForTag(hashtag));
+    LinkifiedTextNavigation.navigateToHashtagFeed(
+      context,
+      hashtag,
+      beforeNavigate: widget.onVideoStateChange,
+    );
   }
 
   void _navigateToProfile(BuildContext context, String hexPubkey) {
-    widget.onVideoStateChange?.call();
-    context.pushOtherProfile(hexPubkey);
+    LinkifiedTextNavigation.navigateToProfile(
+      context,
+      hexPubkey,
+      beforeNavigate: widget.onVideoStateChange,
+    );
   }
 
   void _navigateToVideo(BuildContext context, String routeReference) {
-    widget.onVideoStateChange?.call();
-    context.push(VideoDetailScreen.pathForId(routeReference));
+    LinkifiedTextNavigation.navigateToVideo(
+      context,
+      routeReference,
+      beforeNavigate: widget.onVideoStateChange,
+    );
   }
 
   void _navigateToSearch(BuildContext context, String username) {
-    widget.onVideoStateChange?.call();
-    context.push(
-      SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
+    LinkifiedTextNavigation.navigateToSearch(
+      context,
+      username,
+      beforeNavigate: widget.onVideoStateChange,
     );
   }
 
   Future<void> _handleUrlTap(String rawUrl) async {
-    widget.onVideoStateChange?.call();
-    final customHandler = widget.onUrlTap;
-    if (customHandler != null) {
-      await customHandler(rawUrl);
-      return;
-    }
-    await _launchUrl(rawUrl);
-  }
-
-  Future<void> _launchUrl(String rawUrl) async {
-    final uri = _uriForRawUrl(rawUrl);
-    if (uri == null) return;
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
-  }
-
-  Uri? _uriForRawUrl(String rawUrl) {
-    if (_emailRegex.hasMatch(rawUrl)) {
-      return Uri(scheme: 'mailto', path: rawUrl);
-    }
-    final normalizedUrl =
-        rawUrl.startsWith(
-          RegExp('https?://', caseSensitive: false),
-        )
-        ? rawUrl
-        : 'https://$rawUrl';
-    return Uri.tryParse(normalizedUrl);
+    await LinkifiedTextNavigation.handleUrlTap(
+      rawUrl,
+      beforeNavigate: widget.onVideoStateChange,
+      customHandler: widget.onUrlTap,
+    );
   }
 
   bool _hasClickableOrStylableToken(List<TextSpan> spans, TextStyle style) =>
@@ -167,7 +149,3 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
     super.dispose();
   }
 }
-
-final _emailRegex = RegExp(
-  r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
-);

--- a/mobile/lib/widgets/linkified_text/linkified_text_navigation.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_navigation.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/router/nav_extensions.dart';
+import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
+import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Shared navigation and URL handling for linkified text renderers.
+final class LinkifiedTextNavigation {
+  const LinkifiedTextNavigation._();
+
+  static void navigateToHashtagFeed(
+    BuildContext context,
+    String hashtag, {
+    VoidCallback? beforeNavigate,
+  }) {
+    beforeNavigate?.call();
+    context.push(HashtagScreenRouter.pathForTag(hashtag));
+  }
+
+  static void navigateToProfile(
+    BuildContext context,
+    String hexPubkey, {
+    VoidCallback? beforeNavigate,
+  }) {
+    beforeNavigate?.call();
+    context.pushOtherProfile(hexPubkey);
+  }
+
+  static void navigateToVideo(
+    BuildContext context,
+    String routeReference, {
+    VoidCallback? beforeNavigate,
+  }) {
+    beforeNavigate?.call();
+    context.push(VideoDetailScreen.pathForId(routeReference));
+  }
+
+  static void navigateToSearch(
+    BuildContext context,
+    String username, {
+    VoidCallback? beforeNavigate,
+  }) {
+    beforeNavigate?.call();
+    context.push(
+      SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
+    );
+  }
+
+  static Future<void> handleUrlTap(
+    String rawUrl, {
+    VoidCallback? beforeNavigate,
+    Future<void> Function(String rawUrl)? customHandler,
+  }) async {
+    beforeNavigate?.call();
+    if (customHandler != null) {
+      await customHandler(rawUrl);
+      return;
+    }
+    await launchRawUrl(rawUrl);
+  }
+
+  static Future<void> launchRawUrl(String rawUrl) async {
+    final uri = uriForRawUrl(rawUrl);
+    if (uri == null) return;
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  static Uri? uriForRawUrl(String rawUrl) {
+    if (_emailRegex.hasMatch(rawUrl)) {
+      return Uri(scheme: 'mailto', path: rawUrl);
+    }
+    final normalizedUrl =
+        rawUrl.startsWith(
+          RegExp('https?://', caseSensitive: false),
+        )
+        ? rawUrl
+        : 'https://$rawUrl';
+    return Uri.tryParse(normalizedUrl);
+  }
+}
+
+final _emailRegex = RegExp(
+  r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
+);

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -1,16 +1,10 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-import 'package:models/models.dart' show UserProfile;
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/providers/user_profile_providers.dart';
-import 'package:openvine/router/nav_extensions.dart';
-import 'package:openvine/screens/hashtag_screen_router.dart';
-import 'package:openvine/screens/search_results/view/search_results_page.dart';
-import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_navigation.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
 
 class SelectableLinkifiedText extends ConsumerStatefulWidget {
   const SelectableLinkifiedText({
@@ -84,63 +78,30 @@ class _SelectableLinkifiedTextState
   }
 
   String _profileDisplayText(String hexPubkey) {
-    final profile = ref.watch(userProfileReactiveProvider(hexPubkey)).value;
-    final profileText = switch (profile) {
-      UserProfile(:final displayName?) when displayName.isNotEmpty =>
-        displayName,
-      UserProfile(:final name?) when name.isNotEmpty => name,
-      UserProfile(:final shortDisplayNip05?)
-          when shortDisplayNip05.isNotEmpty =>
-        shortDisplayNip05,
-      _ => UserProfile.defaultDisplayNameFor(hexPubkey),
-    };
-    return profileText.startsWith('@') ? profileText : '@$profileText';
+    return LinkifiedTextSupport.profileDisplayText(ref, hexPubkey);
   }
 
   void _navigateToHashtagFeed(BuildContext context, String hashtag) {
-    context.push(HashtagScreenRouter.pathForTag(hashtag));
+    LinkifiedTextNavigation.navigateToHashtagFeed(context, hashtag);
   }
 
   void _navigateToProfile(BuildContext context, String hexPubkey) {
-    context.pushOtherProfile(hexPubkey);
+    LinkifiedTextNavigation.navigateToProfile(context, hexPubkey);
   }
 
   void _navigateToVideo(BuildContext context, String routeReference) {
-    context.push(VideoDetailScreen.pathForId(routeReference));
+    LinkifiedTextNavigation.navigateToVideo(context, routeReference);
   }
 
   void _navigateToSearch(BuildContext context, String username) {
-    context.push(
-      SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
-    );
+    LinkifiedTextNavigation.navigateToSearch(context, username);
   }
 
   Future<void> _handleUrlTap(String rawUrl) async {
-    final customHandler = widget.onUrlTap;
-    if (customHandler != null) {
-      await customHandler(rawUrl);
-      return;
-    }
-    await _launchUrl(rawUrl);
-  }
-
-  Future<void> _launchUrl(String rawUrl) async {
-    final uri = _uriForRawUrl(rawUrl);
-    if (uri == null) return;
-    await launchUrl(uri, mode: LaunchMode.externalApplication);
-  }
-
-  Uri? _uriForRawUrl(String rawUrl) {
-    if (_emailRegex.hasMatch(rawUrl)) {
-      return Uri(scheme: 'mailto', path: rawUrl);
-    }
-    final normalizedUrl =
-        rawUrl.startsWith(
-          RegExp('https?://', caseSensitive: false),
-        )
-        ? rawUrl
-        : 'https://$rawUrl';
-    return Uri.tryParse(normalizedUrl);
+    await LinkifiedTextNavigation.handleUrlTap(
+      rawUrl,
+      customHandler: widget.onUrlTap,
+    );
   }
 
   bool _hasClickableOrStylableToken(List<TextSpan> spans, TextStyle style) =>
@@ -149,35 +110,12 @@ class _SelectableLinkifiedTextState
   void _replaceCurrentSpans(List<TextSpan> spans) {
     final previousSpans = _currentSpans;
     _currentSpans = spans;
-    _disposeSpans(previousSpans);
-  }
-
-  void _disposeSpans(List<TextSpan> spans) {
-    for (final span in spans) {
-      span.recognizer?.dispose();
-      final children = span.children;
-      if (children == null) continue;
-      _disposeInlineSpans(children);
-    }
-  }
-
-  void _disposeInlineSpans(List<InlineSpan> spans) {
-    for (final span in spans) {
-      if (span is TextSpan) {
-        span.recognizer?.dispose();
-        final children = span.children;
-        if (children != null) _disposeInlineSpans(children);
-      }
-    }
+    LinkifiedTextSupport.disposeSpans(previousSpans);
   }
 
   @override
   void dispose() {
-    _disposeSpans(_currentSpans);
+    LinkifiedTextSupport.disposeSpans(_currentSpans);
     super.dispose();
   }
 }
-
-final _emailRegex = RegExp(
-  r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$',
-);

--- a/mobile/test/notifications/widgets/notification_comment_quote_test.dart
+++ b/mobile/test/notifications/widgets/notification_comment_quote_test.dart
@@ -2,19 +2,34 @@
 // ABOUTME: optional inline timestamp suffix.
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
 import 'package:openvine/notifications/widgets/notification_comment_quote.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 
 Future<void> _pump(
   WidgetTester tester, {
   required String text,
   String? timestamp,
+  String? profileHex,
+  UserProfile? profile,
 }) async {
   await tester.pumpWidget(
-    MaterialApp(
-      home: Scaffold(
-        body: NotificationCommentQuote(text: text, timestamp: timestamp),
+    ProviderScope(
+      overrides: [
+        if (profileHex != null && profile != null)
+          userProfileReactiveProvider(
+            profileHex,
+          ).overrideWith((ref) => Stream.value(profile)),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: NotificationCommentQuote(text: text, timestamp: timestamp),
+        ),
       ),
     ),
   );
@@ -36,6 +51,9 @@ TextSpan? _findSpan(
 
 void main() {
   group(NotificationCommentQuote, () {
+    const profileHex =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
     testWidgets('wraps text in curly quotes', (tester) async {
       await _pump(tester, text: 'Hello world');
 
@@ -92,6 +110,70 @@ void main() {
       );
       expect(timestampSpan, isNotNull);
       expect(timestampSpan!.style?.color, equals(VineTheme.onSurfaceMuted55));
+    });
+
+    testWidgets('renders nostr profile references as tappable profile spans', (
+      tester,
+    ) async {
+      final npub = NostrKeyUtils.encodePubKey(profileHex);
+      final fallbackName = UserProfile.defaultDisplayNameFor(profileHex);
+
+      await _pump(
+        tester,
+        text: 'hey nostr:$npub thanks',
+        timestamp: '5h',
+      );
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final rootSpan = richText.text as TextSpan;
+      expect(rootSpan.toPlainText(), equals('“hey @$fallbackName thanks” 5h'));
+      expect(rootSpan.toPlainText(), isNot(contains(npub)));
+
+      final profileSpan = _findSpan(
+        rootSpan,
+        matching: (span) => span.text == '@$fallbackName',
+      );
+      expect(profileSpan, isNotNull);
+      expect(profileSpan!.recognizer, isA<TapGestureRecognizer>());
+    });
+
+    testWidgets('uses cached profile names for nostr profile references', (
+      tester,
+    ) async {
+      final npub = NostrKeyUtils.encodePubKey(profileHex);
+      const displayName = 'Alice Divine';
+      final profile = UserProfile(
+        pubkey: profileHex,
+        displayName: displayName,
+        rawData: const {},
+        createdAt: DateTime.utc(2026, 6, 16),
+        eventId:
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+      );
+
+      await _pump(
+        tester,
+        text: 'hey nostr:$npub thanks',
+        timestamp: '5h',
+        profileHex: profileHex,
+        profile: profile,
+      );
+      await tester.pump();
+
+      final richText = tester.widget<RichText>(find.byType(RichText));
+      final rootSpan = richText.text as TextSpan;
+      expect(rootSpan.toPlainText(), equals('“hey @$displayName thanks” 5h'));
+      expect(
+        rootSpan.toPlainText(),
+        isNot(contains(UserProfile.defaultDisplayNameFor(profileHex))),
+      );
+
+      final profileSpan = _findSpan(
+        rootSpan,
+        matching: (span) => span.text == '@$displayName',
+      );
+      expect(profileSpan, isNotNull);
+      expect(profileSpan!.recognizer, isA<TapGestureRecognizer>());
     });
   });
 }


### PR DESCRIPTION
Closes #5226

## Summary
- Linkifies notification comment quote text with the existing Nostr-aware span builder.
- Moves shared linkified navigation and URL normalization into one helper used by LinkifiedText, SelectableLinkifiedText, and NotificationCommentQuote.
- Uses cached profile display names for Nostr profile references in notification quotes, with deterministic fallback names only when no profile is available.
- Keeps quoted text, inline timestamps, two-line clamping, and recognizer disposal behavior intact.
- Removes the unrelated upload-test/VGV baseline change from this PR.

## Root Cause
Notification comment quotes were rendering the quoted body as a single plain TextSpan, so Nostr references and links inside the quote never entered the existing linkified span pipeline.

## Test Plan
- flutter test test/notifications/widgets/notification_comment_quote_test.dart test/widgets/linkified_text/linkified_text_span_builder_test.dart
- flutter analyze
- pre-push hook: analyzer plus test/notifications/widgets/notification_comment_quote_test.dart
- GitHub Actions for PR #5225