### PR TITLE
chore(comments): VineTheme author-name fonts + localize empty-state test (#4632)

### DIFF
--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -336,22 +336,16 @@ class _CommentHeader extends ConsumerWidget {
                   child: profile == null
                       ? Text(
                           UserProfile.generatedNameFor(authorPubkey),
-                          style: const TextStyle(
+                          style: VineTheme.titleSmallFont(
                             color: VineTheme.onSurface,
-                            fontSize: 14,
-                            fontWeight: FontWeight.w800,
-                            letterSpacing: 0.1,
                           ),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         )
                       : UserName.fromUserProfile(
                           profile,
-                          style: const TextStyle(
+                          style: VineTheme.titleSmallFont(
                             color: VineTheme.onSurface,
-                            fontSize: 14,
-                            fontWeight: FontWeight.w800,
-                            letterSpacing: 0.1,
                           ),
                         ),
                 ),
@@ -418,6 +412,8 @@ class _CommentContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final isEmoji = _isEmojiOnly(content);
     final baseStyle = isEmoji
+        // Raw style: no VineTheme helper exists at the 40px emoji-only display
+        // size (_emojiOnlyFontSize).
         ? const TextStyle(
             color: VineTheme.onSurface,
             fontSize: _emojiOnlyFontSize,

--- a/mobile/test/screens/comments/comments_empty_state_test.dart
+++ b/mobile/test/screens/comments/comments_empty_state_test.dart
@@ -18,8 +18,9 @@ void main() {
           ),
         );
 
-        expect(find.text('No comments yet'), findsOneWidget);
-        expect(find.text('Get the party started!'), findsOneWidget);
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.commentsEmptyTitle), findsOneWidget);
+        expect(find.text(l10n.commentsEmptySubtitle), findsOneWidget);
       });
 
       testWidgets(
@@ -99,9 +100,10 @@ void main() {
         );
 
         // Should show both the Classic Vine notice AND the empty state message
+        final l10n = lookupAppLocalizations(const Locale('en'));
         expect(find.text('Classic Vine'), findsOneWidget);
-        expect(find.text('No comments yet'), findsOneWidget);
-        expect(find.text('Get the party started!'), findsOneWidget);
+        expect(find.text(l10n.commentsEmptyTitle), findsOneWidget);
+        expect(find.text(l10n.commentsEmptySubtitle), findsOneWidget);
       });
 
       testWidgets('has styled container for Classic Vine notice', (


### PR DESCRIPTION
## Description

Cleanup follow-up to #4618. Verifying the #4632 checklist against current
`main` showed **14 of 16 items are already resolved** — by the #4890 l10n
sweep (which localized the comments widgets) and the #4803/#5233 Icons→DivineIcon
ratchet. This PR addresses the two remaining design-system items that are safe to
fix mechanically:

- **N2** — `comment_item.dart`: the two comment author-name `TextStyle`s now use
  `VineTheme.titleSmallFont` instead of raw `TextStyle`. **Heads-up, this is a
  visible change:** the app's default `textTheme` sets no `fontFamily`, so the
  author name previously rendered in the platform font; `titleSmallFont` is
  Bricolage Grotesque (800 / 14 / letterSpacing 0.1 + the canonical 20/14 line
  height). No `VineTheme` helper preserves the platform font, so the design-system
  fix necessarily changes the font. The emoji-only 40px style is intentionally
  left raw (no helper exists at that display size) with a justifying comment.
- **I7 (sibling)** — `comments_empty_state_test.dart`: the empty-state
  assertions now resolve via `lookupAppLocalizations(const Locale('en'))`
  (`commentsEmptyTitle` / `commentsEmptySubtitle`) instead of hardcoded English,
  matching the I7 fix already done in the other comments tests.

The other 14 items (I1–I7 in the named files, N1, N3, N5, N6, N7, N8, N9, ARB)
were verified already-fixed on `main`; no change needed.

**Related Issue:** Relates to #4632

## Out of Scope

- **N4** (raw `Icons.*` in `_CommentsSortToggle`) is left for a separate,
  design-owned change. There is no faithful `DivineIconName` glyph for
  `schedule` / `local_fire_department` / `history` (none of the 207 glyphs is a
  clock/flame/history), so it fails the "clean swaps only" DivineIcon policy and
  needs either a substitute-glyph decision or new SVG assets (tracked under
  #4833). `comments_screen.dart` is already baselined at ceiling 3 in
  `scripts/baseline/raw_icons.txt`, so it does not fail CI and no baseline change
  is included here.

## Verification

- `dart format` — clean (no changes)
- `flutter analyze lib/screens/comments/widgets/comment_item.dart test/screens/comments/comments_empty_state_test.dart` — No issues found
- `flutter test test/screens/comments/{comments_empty_state,comment_item,comments_screen,comments_list}_test.dart` — 43 passing
- No goldens in the comments tests; `comment_item_test` finds the author name by
  text (not style), so the font change does not affect existing assertions.

## Type of Change

- [x] 🧹 Code refactor
- [x] 🗑️ Chore
