### PR TITLE
feat(feed): instant cold-start home feed from disk cache

### DIFF
--- a/mobile/lib/blocs/video_feed/feed_mode_preference_store.dart
+++ b/mobile/lib/blocs/video_feed/feed_mode_preference_store.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Reads/writes the persisted home-feed source (a FeedMode or curated
+// ABOUTME: list selection), account-scoped, with conservative migration off the
+// ABOUTME: legacy global key. Extracted from VideoFeedBloc (epic #4339).
+
+part of 'video_feed_bloc.dart';
+
+/// Legacy SharedPreferences key for persisting the selected feed mode.
+///
+/// New authenticated sessions use a pubkey-scoped key so switching accounts
+/// cannot carry a previous account's Following/list selection into a newly
+/// imported key with a different social graph.
+const _legacyFeedModeKey = 'selected_feed_mode';
+
+/// Persists and restores the selected [VideoFeedSource] for [VideoFeedBloc].
+class FeedModePreferenceStore {
+  FeedModePreferenceStore({
+    required SharedPreferences? sharedPreferences,
+    required String? userPubkey,
+    required FollowRepository followRepository,
+    required CuratedListRepository curatedListRepository,
+  }) : _sharedPreferences = sharedPreferences,
+       _userPubkey = userPubkey,
+       _followRepository = followRepository,
+       _curatedListRepository = curatedListRepository;
+
+  final SharedPreferences? _sharedPreferences;
+  final String? _userPubkey;
+  final FollowRepository _followRepository;
+  final CuratedListRepository _curatedListRepository;
+
+  /// Account-scoped key the selected source is stored under.
+  String get key => _userPubkey == null
+      ? _legacyFeedModeKey
+      : '${_legacyFeedModeKey}_$_userPubkey';
+
+  /// The persisted source, or [VideoFeedSource.fromMode] of [fallbackMode] when
+  /// nothing is stored.
+  VideoFeedSource restoreSource(FeedMode fallbackMode) {
+    final saved = savedValue();
+    if (saved == null) {
+      return VideoFeedSource.fromMode(fallbackMode);
+    }
+    return sourceFromValue(saved) ?? const VideoFeedSource.forYou();
+  }
+
+  /// The stored persistence value for the active account, migrating a legacy
+  /// global value conservatively when safe.
+  String? savedValue() {
+    final prefs = _sharedPreferences;
+    if (prefs == null) return null;
+
+    final scoped = prefs.getString(key);
+    if (scoped != null) return scoped;
+
+    // Only unauthenticated/test callers should keep reading the legacy global
+    // key directly. Authenticated sessions migrate it conservatively below.
+    if (_userPubkey == null) {
+      return prefs.getString(_legacyFeedModeKey);
+    }
+
+    final legacy = prefs.getString(_legacyFeedModeKey);
+    if (legacy == null) return null;
+
+    final migratedSource = sourceFromValue(legacy);
+    if (migratedSource == null) return null;
+
+    // The bug fixed here: a newly imported key could inherit another account's
+    // Following mode and land on an empty feed. Only migrate Following when
+    // the current account already has a non-empty following list.
+    if (migratedSource.type == VideoFeedSourceType.following &&
+        _followRepository.followingPubkeys.isEmpty) {
+      return null;
+    }
+
+    // A legacy list preference cannot be proven to belong to the authenticated
+    // account because the curated-list bridge can briefly hold stale data
+    // across account switches. Only restore list selections from scoped keys.
+    if (migratedSource.type == VideoFeedSourceType.subscribedList) {
+      return null;
+    }
+
+    unawaited(persist(migratedSource));
+    return migratedSource.persistenceValue;
+  }
+
+  /// Resolves a persisted value to a [VideoFeedSource], or `null` when unknown.
+  VideoFeedSource? sourceFromValue(String saved) {
+    if (saved.startsWith('list:')) {
+      final listId = saved.substring('list:'.length);
+      final list = _curatedListRepository.getListById(listId);
+      if (list != null) {
+        return VideoFeedSource.subscribedList(
+          listId: list.id,
+          listName: list.name,
+        );
+      }
+      return null;
+    }
+    if (saved == FeedMode.following.name) {
+      return const VideoFeedSource.following();
+    }
+    if (saved == FeedMode.latest.name) {
+      return const VideoFeedSource.newVideos();
+    }
+    if (saved == FeedMode.forYou.name) {
+      return const VideoFeedSource.forYou();
+    }
+    return null;
+  }
+
+  /// Writes [source] to the scoped key and clears the legacy global key for
+  /// authenticated sessions.
+  Future<void> persist(VideoFeedSource source) async {
+    final prefs = _sharedPreferences;
+    if (prefs == null) return;
+    await prefs.setString(key, source.persistenceValue);
+    if (_userPubkey != null) {
+      await prefs.remove(_legacyFeedModeKey);
+    }
+  }
+}

--- a/mobile/lib/blocs/video_feed/home_feed_cache.dart
+++ b/mobile/lib/blocs/video_feed/home_feed_cache.dart
@@ -1,80 +1,101 @@
-// ABOUTME: Cache for home feed data using SharedPreferences.
-// ABOUTME: Enables instant feed display on cold start by serving
-// ABOUTME: cached videos while fresh data loads from the network.
+// ABOUTME: Disk-backed cache for the home feed, enabling instant cold start.
+// ABOUTME: Stores a forward window of videos starting just past the user's
+// last-viewed position, account-scoped, via CacheSync.
 
 import 'dart:convert';
 
+import 'package:cache_sync/cache_sync.dart';
 import 'package:models/models.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:videos_repository/videos_repository.dart';
 
-/// SharedPreferences key for cached Following feed JSON.
+/// Maximum age of a cached home feed before it is considered stale.
 ///
-/// Previous app versions used the unscoped `home_feed_cache` key for both
-/// Following and For You. Keep this key Following-specific so stale For You
-/// payloads from older installs are ignored after upgrade.
-const homeFeedCacheKey = 'home_feed_cache_following_v1';
+/// Tuned to cover same-day reopens (the common "closed it this morning,
+/// reopen at lunch" case) while still forcing a clean fresh load after a
+/// long absence.
+const homeFeedCacheMaxAge = Duration(hours: 6);
 
-/// SharedPreferences key for cached Following feed timestamp.
-const homeFeedCacheTimeKey = 'home_feed_cache_following_v1_time';
-
-/// Maximum age of cached home feed before it's considered stale.
-const homeFeedCacheMaxAge = Duration(hours: 1);
-
-/// Reads and writes cached Home tab feed data from SharedPreferences.
+/// Upper bound on how many videos are persisted per mode.
 ///
-/// The cache stores the latest raw JSON response for a cacheable Home tab
-/// mode so it can be parsed into [HomeFeedResult] on next cold start
-/// without any network request.
+/// The cached window only has to bridge the gap until the parallel fresh
+/// load lands (a few seconds), so it is deliberately small. It also bounds
+/// the per-swipe write cost.
+const _forwardWindowSize = 30;
+
+/// Reads and writes the cached home-feed videos for instant cold start.
 ///
-/// Cache entries older than [homeFeedCacheMaxAge] are ignored.
+/// The cache stores a **forward window**: the videos starting just past the
+/// user's last-viewed position (already-watched videos are intentionally
+/// dropped — the user resumes at the top of the window and cannot scroll back
+/// to content they have seen). On cold start the window is served at index 0
+/// while fresh data loads in parallel.
+///
+/// Entries are keyed by account pubkey and feed mode and persisted through
+/// [CacheSync], so signing out clears them via the account-scoped
+/// `CacheSync.invalidatePrefix(pubkey)` call in `AuthService`.
+///
+/// Every method degrades to a no-op (read → `null`, write → nothing) when
+/// [CacheSync] has not been initialised, so widget tests that don't boot the
+/// cache are unaffected.
 class HomeFeedCache {
   /// Creates a [HomeFeedCache].
   const HomeFeedCache();
 
-  /// Loads the cached home feed, or `null` if no valid cache exists.
-  ///
-  /// Returns `null` when:
-  /// - No cache entry exists
-  /// - The cache is older than [homeFeedCacheMaxAge]
-  /// - The cached JSON cannot be parsed
-  HomeFeedResult? read(SharedPreferences prefs) {
+  String _accountPrefix(String? pubkey) =>
+      (pubkey == null || pubkey.isEmpty) ? 'anon' : pubkey;
+
+  String _videosKey(String? pubkey, String mode) =>
+      '${_accountPrefix(pubkey)}:home_feed:$mode';
+
+  /// Returns the cached forward window for [mode], or `null` when absent or
+  /// expired.
+  Future<List<VideoEvent>?> readVideos({
+    required String? pubkey,
+    required String mode,
+  }) async {
     try {
-      final cachedJson = prefs.getString(homeFeedCacheKey);
-      if (cachedJson == null) return null;
-
-      final cachedTimeMs = prefs.getInt(homeFeedCacheTimeKey) ?? 0;
-      final cachedTime = DateTime.fromMillisecondsSinceEpoch(cachedTimeMs);
-      if (DateTime.now().difference(cachedTime) > homeFeedCacheMaxAge) {
-        return null;
-      }
-
-      return _parse(cachedJson);
-    } catch (_) {
+      return await CacheSync.read<List<VideoEvent>>(
+        key: _videosKey(pubkey, mode),
+        fromJson: _decodeVideos,
+      );
+    } on Object {
       return null;
     }
   }
 
-  /// Writes home feed JSON to cache with the current timestamp.
+  /// Persists [videos] (capped to [_forwardWindowSize]) as the cached home
+  /// feed for [mode].
   ///
-  /// Only caches when [json] is non-null and non-empty.
-  Future<void> write(SharedPreferences prefs, String json) async {
-    await prefs.setString(homeFeedCacheKey, json);
-    await prefs.setInt(
-      homeFeedCacheTimeKey,
-      DateTime.now().millisecondsSinceEpoch,
-    );
+  /// The caller passes the forward slice (videos from the resume position
+  /// onward); this stores the first [_forwardWindowSize] of them.
+  Future<void> writeVideos({
+    required String? pubkey,
+    required String mode,
+    required List<VideoEvent> videos,
+  }) async {
+    if (videos.isEmpty) return;
+    final capped = videos.length > _forwardWindowSize
+        ? videos.sublist(0, _forwardWindowSize)
+        : videos;
+    try {
+      await CacheSync.write<List<VideoEvent>>(
+        key: _videosKey(pubkey, mode),
+        value: capped,
+        toJson: _encodeVideos,
+        ttl: homeFeedCacheMaxAge,
+      );
+    } on Object {
+      // Caching is best-effort; ignore persistence failures.
+    }
   }
 
-  /// Parses raw JSON into a [HomeFeedResult].
-  static HomeFeedResult _parse(String jsonStr) {
-    final data = jsonDecode(jsonStr) as Map<String, dynamic>;
-    final videosData = data['videos'] as List<dynamic>? ?? [];
-    final videos = videosData
-        .map((v) => VideoStats.fromJson(v as Map<String, dynamic>))
-        .where((v) => v.id.isNotEmpty && v.videoUrl.isNotEmpty)
-        .toVideoEvents();
+  static String _encodeVideos(List<VideoEvent> videos) =>
+      jsonEncode({'videos': videos.map((v) => v.toJson()).toList()});
 
-    return HomeFeedResult(videos: videos);
+  static List<VideoEvent> _decodeVideos(String json) {
+    final data = jsonDecode(json) as Map<String, dynamic>;
+    final raw = data['videos'] as List<dynamic>? ?? const [];
+    return raw
+        .map((v) => VideoEvent.fromJson(v as Map<String, dynamic>))
+        .toList();
   }
 }

--- a/mobile/lib/blocs/video_feed/home_feed_cache.dart
+++ b/mobile/lib/blocs/video_feed/home_feed_cache.dart
@@ -88,6 +88,22 @@ class HomeFeedCache {
     }
   }
 
+  /// Drops the cached forward window for [mode].
+  ///
+  /// Used when the resume window is empty (the user reached the end of the
+  /// stored window): leaving the previous entry in place would re-serve
+  /// already-seen videos on the next cold start, so the key is invalidated.
+  Future<void> clearVideos({
+    required String? pubkey,
+    required String mode,
+  }) async {
+    try {
+      await CacheSync.invalidate(_videosKey(pubkey, mode));
+    } on Object {
+      // Best-effort; ignore failures.
+    }
+  }
+
   static String _encodeVideos(List<VideoEvent> videos) =>
       jsonEncode({'videos': videos.map((v) => v.toJson()).toList()});
 

--- a/mobile/lib/blocs/video_feed/home_feed_resume_manager.dart
+++ b/mobile/lib/blocs/video_feed/home_feed_resume_manager.dart
@@ -48,6 +48,15 @@ class HomeFeedResumeManager {
   ({String? pubkey, String mode, List<VideoEvent> videos, int activeIndex})?
   _pending;
 
+  /// Serialises same-key cache writes so they complete in submission order.
+  ///
+  /// Persists fire from multiple paths against the same key (serve, then the
+  /// fresh-spliced load, plus debounced swipes). Without ordering, an earlier
+  /// disk write that finishes late could overwrite the newer window. Chaining
+  /// each write after the previous one guarantees the freshest window — always
+  /// the latest submitted — is written last and wins.
+  Future<void> _writeChain = Future<void>.value();
+
   /// Reads the cached window for [mode] and content-filters it, returning the
   /// videos that can be served immediately (empty when nothing is usable).
   ///
@@ -149,17 +158,18 @@ class HomeFeedResumeManager {
     required int activeIndex,
   }) {
     final start = (activeIndex + _resumeOffset).clamp(0, videos.length);
-    if (start >= videos.length) {
-      unawaited(_cache.clearVideos(pubkey: pubkey, mode: mode));
-      return;
-    }
-    unawaited(
-      _cache.writeVideos(
-        pubkey: pubkey,
-        mode: mode,
-        videos: videos.sublist(start),
-      ),
-    );
+    final shouldClear = start >= videos.length;
+    final window = shouldClear ? const <VideoEvent>[] : videos.sublist(start);
+
+    // Append to the serialised chain so this write runs only after the
+    // previous one completes — the latest submitted window always wins.
+    _writeChain = _writeChain
+        .then(
+          (_) => shouldClear
+              ? _cache.clearVideos(pubkey: pubkey, mode: mode)
+              : _cache.writeVideos(pubkey: pubkey, mode: mode, videos: window),
+        )
+        .catchError((Object _) {});
   }
 
   /// Flushes any pending swipe persist and cancels the debounce timer.

--- a/mobile/lib/blocs/video_feed/home_feed_resume_manager.dart
+++ b/mobile/lib/blocs/video_feed/home_feed_resume_manager.dart
@@ -138,6 +138,10 @@ class HomeFeedResumeManager {
   /// Writes the videos from [activeIndex] + [_resumeOffset] onward, so the next
   /// cold start opens on the next unseen video. Already-watched videos before
   /// the offset are dropped, so the user cannot scroll back to them on resume.
+  ///
+  /// When nothing remains past the offset (the user reached the end of the
+  /// window) the key is **cleared** rather than left untouched — otherwise the
+  /// previous entry would re-serve already-seen videos on the next cold start.
   void _write({
     required String? pubkey,
     required String mode,
@@ -145,10 +149,17 @@ class HomeFeedResumeManager {
     required int activeIndex,
   }) {
     final start = (activeIndex + _resumeOffset).clamp(0, videos.length);
-    final forward = start >= videos.length
-        ? const <VideoEvent>[]
-        : videos.sublist(start);
-    unawaited(_cache.writeVideos(pubkey: pubkey, mode: mode, videos: forward));
+    if (start >= videos.length) {
+      unawaited(_cache.clearVideos(pubkey: pubkey, mode: mode));
+      return;
+    }
+    unawaited(
+      _cache.writeVideos(
+        pubkey: pubkey,
+        mode: mode,
+        videos: videos.sublist(start),
+      ),
+    );
   }
 
   /// Flushes any pending swipe persist and cancels the debounce timer.

--- a/mobile/lib/blocs/video_feed/home_feed_resume_manager.dart
+++ b/mobile/lib/blocs/video_feed/home_feed_resume_manager.dart
@@ -1,0 +1,160 @@
+// ABOUTME: Owns the cross-restart home-feed resume window for VideoFeedBloc —
+// ABOUTME: reading the serveable cached window, splicing fresh results after
+// ABOUTME: the active video, and persisting (debounced) the forward window.
+
+import 'dart:async';
+
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+/// How far past the active video the cross-restart cache resumes.
+///
+/// The forward window persisted on serve / load / swipe starts at the active
+/// index plus this offset, so the next cold start opens on the first video the
+/// user has not seen. An offset of `1` drops only the active (seen) video — the
+/// user cannot scroll back to it, but no unseen video is skipped, and a
+/// no-interaction reopen advances by a single video instead of burning through
+/// the window two at a time.
+const _resumeOffset = 1;
+
+/// Leading videos kept ahead of the active one when splicing fresh results in.
+///
+/// Keeping the active video plus its lookahead lets `InfiniteVideoFeed`'s
+/// common-prefix handling preserve the active controller, so the playing video
+/// does not restart when fresh content lands.
+const _spliceLookahead = 2;
+
+/// Debounce window for persisting the resume position on rapid swipes.
+///
+/// The resume point need not be frame-accurate, so per-swipe disk writes are
+/// coalesced — avoiding a JSON-encode + Drift write on every page change while
+/// the user scrolls quickly through the feed.
+const _persistDebounce = Duration(milliseconds: 600);
+
+/// Coordinates the persisted forward window that lets `VideoFeedBloc` serve the
+/// home feed instantly on cold start and resume past already-seen videos.
+class HomeFeedResumeManager {
+  HomeFeedResumeManager({
+    required HomeFeedCache cache,
+    required VideosRepository videosRepository,
+  }) : _cache = cache,
+       _videosRepository = videosRepository;
+
+  final HomeFeedCache _cache;
+  final VideosRepository _videosRepository;
+
+  Timer? _persistTimer;
+  ({String? pubkey, String mode, List<VideoEvent> videos, int activeIndex})?
+  _pending;
+
+  /// Reads the cached window for [mode] and content-filters it, returning the
+  /// videos that can be served immediately (empty when nothing is usable).
+  ///
+  /// The window already starts at the resume position — already-watched videos
+  /// were dropped on write — so the caller serves it at index 0.
+  Future<List<VideoEvent>> readServeableWindow({
+    required String? pubkey,
+    required String mode,
+  }) async {
+    final cached = await _cache.readVideos(pubkey: pubkey, mode: mode);
+    if (cached == null || cached.isEmpty) return const [];
+    final filtered = _videosRepository.applyContentPreferences(cached);
+    return filtered.where((v) => v.videoUrl != null).toList();
+  }
+
+  /// Keeps the active video plus one lookahead from [existing] and appends the
+  /// [fresh] results (deduped) after them, so fresh content appears right after
+  /// the current video instead of behind the whole cached window. The kept
+  /// prefix leaves the active video's controller untouched, so it does not
+  /// restart when fresh lands.
+  List<VideoEvent> splice({
+    required List<VideoEvent> existing,
+    required List<VideoEvent> fresh,
+    required int currentIndex,
+  }) {
+    if (existing.isEmpty) return fresh;
+    if (fresh.isEmpty) return existing;
+
+    final keepCount = (currentIndex + _spliceLookahead).clamp(
+      0,
+      existing.length,
+    );
+    final head = existing.sublist(0, keepCount);
+    final headIds = head.map((v) => v.id.toLowerCase()).toSet();
+    final tail = fresh.where((v) => !headIds.contains(v.id.toLowerCase()));
+    return [...head, ...tail];
+  }
+
+  /// Persists the forward window immediately (used on serve and load).
+  void persistNow({
+    required String? pubkey,
+    required String mode,
+    required List<VideoEvent> videos,
+    required int activeIndex,
+  }) {
+    _persistTimer?.cancel();
+    _pending = null;
+    _write(
+      pubkey: pubkey,
+      mode: mode,
+      videos: videos,
+      activeIndex: activeIndex,
+    );
+  }
+
+  /// Trailing-debounces a resume-window persist for the swipe hot path, so
+  /// rapid swipes coalesce into a single disk write.
+  void schedulePersist({
+    required String? pubkey,
+    required String mode,
+    required List<VideoEvent> videos,
+    required int activeIndex,
+  }) {
+    _pending = (
+      pubkey: pubkey,
+      mode: mode,
+      videos: videos,
+      activeIndex: activeIndex,
+    );
+    _persistTimer?.cancel();
+    _persistTimer = Timer(_persistDebounce, _flush);
+  }
+
+  void _flush() {
+    final pending = _pending;
+    if (pending == null) return;
+    _pending = null;
+    _persistTimer?.cancel();
+    _persistTimer = null;
+    _write(
+      pubkey: pending.pubkey,
+      mode: pending.mode,
+      videos: pending.videos,
+      activeIndex: pending.activeIndex,
+    );
+  }
+
+  /// Writes the videos from [activeIndex] + [_resumeOffset] onward, so the next
+  /// cold start opens on the next unseen video. Already-watched videos before
+  /// the offset are dropped, so the user cannot scroll back to them on resume.
+  void _write({
+    required String? pubkey,
+    required String mode,
+    required List<VideoEvent> videos,
+    required int activeIndex,
+  }) {
+    final start = (activeIndex + _resumeOffset).clamp(0, videos.length);
+    final forward = start >= videos.length
+        ? const <VideoEvent>[]
+        : videos.sublist(start);
+    unawaited(_cache.writeVideos(pubkey: pubkey, mode: mode, videos: forward));
+  }
+
+  /// Flushes any pending swipe persist and cancels the debounce timer.
+  void dispose() {
+    _flush();
+    _persistTimer?.cancel();
+    _persistTimer = null;
+  }
+}

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -24,14 +24,25 @@ part 'video_feed_state.dart';
 /// Default interval between auto-refreshes of the home feed.
 const _defaultAutoRefreshMinInterval = Duration(minutes: 10);
 
-/// How far past the last-viewed video the cross-restart cache resumes.
+/// How far past the active video the cross-restart cache resumes.
 ///
-/// On cold start the cached feed is served starting at the user's last
-/// position plus this offset, so the already-watched video and its one
-/// lookahead are skipped (the user resumes on the next, unseen video and
-/// cannot scroll back to content they have already seen). Matches the
-/// `currentIndex + 2` head kept by [VideoFeedBloc._spliceFreshVideos].
-const _homeFeedResumeOffset = 2;
+/// The forward window persisted on serve / load / swipe starts at the active
+/// index plus this offset, so on the next cold start the user resumes on the
+/// first video they have **not** seen. An offset of `1` drops only the active
+/// (seen) video — the user cannot scroll back to it, but no unseen video is
+/// skipped. Keeping it at `1` (rather than also dropping the active+1
+/// lookahead) matters for the no-interaction reopen: serving the cache, or a
+/// quick open/close before the fresh fetch lands, advances by a single video
+/// the user actually saw instead of burning through the window two at a time.
+const _homeFeedResumeOffset = 1;
+
+/// Debounce window for persisting the resume position on rapid swipes.
+///
+/// The resume point does not need to be frame-accurate, so per-swipe disk
+/// writes are coalesced: this avoids a JSON-encode + Drift write on every page
+/// change while the user scrolls quickly. Serve- and load-time persists stay
+/// immediate — they run once per load, not on the swipe hot path.
+const _resumePersistDebounce = Duration(milliseconds: 600);
 
 /// Legacy SharedPreferences key for persisting the selected feed mode.
 ///
@@ -104,6 +115,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   /// Tracks when the last successful load completed, used by
   /// [_onAutoRefreshRequested] to skip refreshes when data is fresh.
   DateTime? _lastRefreshedAt;
+
+  /// Trailing-debounce handle for the swipe-driven resume-window persist.
+  Timer? _resumePersistTimer;
+
+  /// The most recent swipe persist waiting on [_resumePersistTimer].
+  ({String mode, List<VideoEvent> videos, int activeIndex})?
+  _pendingResumePersist;
 
   /// Whether [source] participates in the cross-restart [HomeFeedCache].
   ///
@@ -237,6 +255,9 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
   @override
   Future<void> close() async {
+    // Persist any swipe still inside the debounce window before tearing down,
+    // so the last move isn't lost on dispose.
+    _flushResumePersist();
     await _followingSubscription?.cancel();
     await _curatedListsSubscription?.cancel();
     _followingSubscription = null;
@@ -883,18 +904,47 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     emit(state.copyWith(currentIndex: index));
 
     if (_usesHomeFeedCache(state.source)) {
-      _persistResumeWindow(state.source.mode.name, state.videos, index);
+      // Debounced: rapid swipes coalesce into one disk write (see
+      // [_resumePersistDebounce]). The index emit above stays immediate so the
+      // splice and resume-restore listener react without delay.
+      _schedulePersistResumeWindow(state.source.mode.name, state.videos, index);
     }
+  }
+
+  /// Schedules a trailing-debounced resume-window persist for the swipe path.
+  void _schedulePersistResumeWindow(
+    String mode,
+    List<VideoEvent> videos,
+    int activeIndex,
+  ) {
+    _pendingResumePersist = (
+      mode: mode,
+      videos: videos,
+      activeIndex: activeIndex,
+    );
+    _resumePersistTimer?.cancel();
+    _resumePersistTimer = Timer(_resumePersistDebounce, _flushResumePersist);
+  }
+
+  /// Writes the latest pending swipe resume window, if any.
+  void _flushResumePersist() {
+    final pending = _pendingResumePersist;
+    if (pending == null) return;
+    _pendingResumePersist = null;
+    _resumePersistTimer?.cancel();
+    _resumePersistTimer = null;
+    _persistResumeWindow(pending.mode, pending.videos, pending.activeIndex);
   }
 
   /// Persists the forward window — the videos from [activeIndex] +
   /// [_homeFeedResumeOffset] onward — as the cross-restart resume point.
   ///
-  /// Called on every load and swipe, so the resume point advances as the user
-  /// moves through (or simply reopens) the feed: the next cold start opens on
-  /// the next unseen video rather than the one just shown. Already-watched
-  /// videos before the offset are dropped, so the user cannot scroll back to
-  /// them on resume.
+  /// Called immediately on serve/load and, via
+  /// [_schedulePersistResumeWindow], debounced on swipe, so the resume point
+  /// advances as the user moves through (or simply reopens) the feed: the next
+  /// cold start opens on the next unseen video rather than the one just shown.
+  /// Already-watched videos before the offset are dropped, so the user cannot
+  /// scroll back to them on resume.
   void _persistResumeWindow(
     String mode,
     List<VideoEvent> videos,

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -12,6 +12,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
+import 'package:openvine/blocs/video_feed/home_feed_resume_manager.dart';
 import 'package:openvine/services/feed_performance_tracker.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -20,36 +21,10 @@ import 'package:videos_repository/videos_repository.dart';
 
 part 'video_feed_event.dart';
 part 'video_feed_state.dart';
+part 'feed_mode_preference_store.dart';
 
 /// Default interval between auto-refreshes of the home feed.
 const _defaultAutoRefreshMinInterval = Duration(minutes: 10);
-
-/// How far past the active video the cross-restart cache resumes.
-///
-/// The forward window persisted on serve / load / swipe starts at the active
-/// index plus this offset, so on the next cold start the user resumes on the
-/// first video they have **not** seen. An offset of `1` drops only the active
-/// (seen) video — the user cannot scroll back to it, but no unseen video is
-/// skipped. Keeping it at `1` (rather than also dropping the active+1
-/// lookahead) matters for the no-interaction reopen: serving the cache, or a
-/// quick open/close before the fresh fetch lands, advances by a single video
-/// the user actually saw instead of burning through the window two at a time.
-const _homeFeedResumeOffset = 1;
-
-/// Debounce window for persisting the resume position on rapid swipes.
-///
-/// The resume point does not need to be frame-accurate, so per-swipe disk
-/// writes are coalesced: this avoids a JSON-encode + Drift write on every page
-/// change while the user scrolls quickly. Serve- and load-time persists stay
-/// immediate — they run once per load, not on the swipe hot path.
-const _resumePersistDebounce = Duration(milliseconds: 600);
-
-/// Legacy SharedPreferences key for persisting the selected feed mode.
-///
-/// New authenticated sessions use a pubkey-scoped key so switching accounts
-/// cannot carry a previous account's Following/list selection into a newly
-/// imported key with a different social graph.
-const _legacyFeedModeKey = 'selected_feed_mode';
 
 /// BLoC for managing the unified video feed.
 ///
@@ -81,7 +56,16 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
        _serveCachedHomeFeed = serveCachedHomeFeed,
        _autoRefreshMinInterval = autoRefreshMinInterval,
        _feedTracker = feedTracker,
-       _homeFeedCache = homeFeedCache ?? const HomeFeedCache(),
+       _resumeManager = HomeFeedResumeManager(
+         cache: homeFeedCache ?? const HomeFeedCache(),
+         videosRepository: videosRepository,
+       ),
+       _modePreferences = FeedModePreferenceStore(
+         sharedPreferences: sharedPreferences,
+         userPubkey: userPubkey,
+         followRepository: followRepository,
+         curatedListRepository: curatedListRepository,
+       ),
        super(const VideoFeedBlocState()) {
     on<VideoFeedStarted>(_onStarted);
     on<VideoFeedModeChanged>(_onModeChanged);
@@ -108,20 +92,18 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   final bool _serveCachedHomeFeed;
   final Duration _autoRefreshMinInterval;
   final FeedPerformanceTracker? _feedTracker;
-  final HomeFeedCache _homeFeedCache;
+
+  /// Owns the cross-restart cache serve / splice / resume-persist logic.
+  final HomeFeedResumeManager _resumeManager;
+
+  /// Owns reading/writing the persisted feed-mode/source selection.
+  final FeedModePreferenceStore _modePreferences;
   StreamSubscription<List<String>>? _followingSubscription;
   StreamSubscription<List<CuratedList>>? _curatedListsSubscription;
 
   /// Tracks when the last successful load completed, used by
   /// [_onAutoRefreshRequested] to skip refreshes when data is fresh.
   DateTime? _lastRefreshedAt;
-
-  /// Trailing-debounce handle for the swipe-driven resume-window persist.
-  Timer? _resumePersistTimer;
-
-  /// The most recent swipe persist waiting on [_resumePersistTimer].
-  ({String mode, List<VideoEvent> videos, int activeIndex})?
-  _pendingResumePersist;
 
   /// Whether [source] participates in the cross-restart [HomeFeedCache].
   ///
@@ -130,9 +112,9 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   /// `forYou` staleness concern from #3861 is handled differently now: the
   /// cached feed is positioned at the user's last index and everything past
   /// the active video is replaced with fresh server data on every load
-  /// ([_spliceFreshVideos]), so the feed is never stale beyond the current
-  /// video. Subscribed curated lists are excluded — they are derived from
-  /// locally held list IDs, not a server feed.
+  /// (via [HomeFeedResumeManager]), so the feed is never stale beyond the
+  /// current video. Subscribed curated lists are excluded — they are derived
+  /// from locally held list IDs, not a server feed.
   bool _usesHomeFeedCache(VideoFeedSource source) =>
       source.type == VideoFeedSourceType.forYou ||
       source.type == VideoFeedSourceType.following ||
@@ -164,10 +146,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     VideoFeedStarted event,
     Emitter<VideoFeedBlocState> emit,
   ) async {
-    final source = _restoreSource(event.mode);
-    if (_sharedPreferences?.getString(_feedModePreferenceKey) !=
+    final source = _modePreferences.restoreSource(event.mode);
+    if (_sharedPreferences?.getString(_modePreferences.key) !=
         source.persistenceValue) {
-      await _persistSourcePreference(source);
+      await _modePreferences.persist(source);
     }
 
     final subscribedLists = _curatedListRepository.getSubscribedLists();
@@ -255,103 +237,14 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
   @override
   Future<void> close() async {
-    // Persist any swipe still inside the debounce window before tearing down,
-    // so the last move isn't lost on dispose.
-    _flushResumePersist();
+    // Flush any swipe still inside the debounce window before tearing down, so
+    // the last move isn't lost on dispose.
+    _resumeManager.dispose();
     await _followingSubscription?.cancel();
     await _curatedListsSubscription?.cancel();
     _followingSubscription = null;
     _curatedListsSubscription = null;
     return super.close();
-  }
-
-  VideoFeedSource _restoreSource(FeedMode fallbackMode) {
-    final saved = _savedSourcePreference();
-    if (saved == null) {
-      return VideoFeedSource.fromMode(fallbackMode);
-    }
-
-    return _sourceFromPersistedValue(saved) ?? const VideoFeedSource.forYou();
-  }
-
-  String get _feedModePreferenceKey => _userPubkey == null
-      ? _legacyFeedModeKey
-      : '${_legacyFeedModeKey}_$_userPubkey';
-
-  String? _savedSourcePreference() {
-    final prefs = _sharedPreferences;
-    if (prefs == null) return null;
-
-    final scoped = prefs.getString(_feedModePreferenceKey);
-    if (scoped != null) return scoped;
-
-    // Only unauthenticated/test callers should keep reading the legacy global
-    // key directly. Authenticated sessions migrate it conservatively below.
-    if (_userPubkey == null) {
-      return prefs.getString(_legacyFeedModeKey);
-    }
-
-    final legacy = prefs.getString(_legacyFeedModeKey);
-    if (legacy == null) return null;
-
-    final migratedSource = _sourceFromPersistedValue(legacy);
-    if (migratedSource == null) return null;
-
-    // The bug fixed here: a newly imported key could inherit another account's
-    // Following mode and land on an empty feed. Only migrate Following when
-    // the current account already has a non-empty following list.
-    if (migratedSource.type == VideoFeedSourceType.following &&
-        _followRepository.followingPubkeys.isEmpty) {
-      return null;
-    }
-
-    // A legacy list preference cannot be proven to belong to the authenticated
-    // account because the curated-list bridge can briefly hold stale data
-    // across account switches. Only restore list selections from scoped keys.
-    if (migratedSource.type == VideoFeedSourceType.subscribedList) {
-      return null;
-    }
-
-    unawaited(_persistSourcePreference(migratedSource));
-    return migratedSource.persistenceValue;
-  }
-
-  VideoFeedSource? _sourceFromPersistedValue(String saved) {
-    if (saved.startsWith('list:')) {
-      final listId = saved.substring('list:'.length);
-      final list = _curatedListRepository.getListById(listId);
-      if (list != null) {
-        return VideoFeedSource.subscribedList(
-          listId: list.id,
-          listName: list.name,
-        );
-      }
-      return null;
-    }
-
-    if (saved == FeedMode.following.name) {
-      return const VideoFeedSource.following();
-    }
-
-    if (saved == FeedMode.latest.name) {
-      return const VideoFeedSource.newVideos();
-    }
-
-    if (saved == FeedMode.forYou.name) {
-      return const VideoFeedSource.forYou();
-    }
-
-    return null;
-  }
-
-  Future<void> _persistSourcePreference(VideoFeedSource source) async {
-    final prefs = _sharedPreferences;
-    if (prefs == null) return;
-
-    await prefs.setString(_feedModePreferenceKey, source.persistenceValue);
-    if (_userPubkey != null) {
-      await prefs.remove(_legacyFeedModeKey);
-    }
   }
 
   /// Handle mode changed event.
@@ -379,7 +272,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       return;
     }
 
-    await _persistSourcePreference(source);
+    await _modePreferences.persist(source);
 
     emit(
       state.copyWith(
@@ -644,7 +537,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       return;
     }
 
-    // Mirror _restoreSource: if the currently selected subscribed list is no
+    // Mirror restoreSource: if the currently selected subscribed list is no
     // longer in the subscription set (user unsubscribed, list was deleted),
     // fall back to forYou instead of reloading an empty list source.
     final selectedId = state.source.listId;
@@ -654,7 +547,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         : const VideoFeedSource.forYou();
 
     if (!stillSubscribed) {
-      await _persistSourcePreference(nextSource);
+      await _modePreferences.persist(nextSource);
     }
 
     emit(
@@ -713,7 +606,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   /// feed for the mode instantly — positioned at the user's last-viewed index
   /// — while fresh data loads in the background. When the fresh result
   /// arrives it is spliced in *after* the active video so the playing video
-  /// and its next never jump ([_spliceFreshVideos]).
+  /// and its next never jump (via [HomeFeedResumeManager]).
   ///
   /// For the home feed, does NOT wait for the follow list to initialize.
   /// Instead, the follow-list stream subscription (set up in [_onStarted])
@@ -744,7 +637,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       // after the current video. The active controller is preserved by
       // InfiniteVideoFeed's common-prefix handling, so it does not restart.
       final displayedVideos = servedCache
-          ? _spliceFreshVideos(
+          ? _resumeManager.splice(
               existing: state.videos,
               fresh: validVideos,
               currentIndex: state.currentIndex,
@@ -787,10 +680,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       // reopens without scrolling. Uses the spliced list so freshly loaded
       // videos replenish the window.
       if (_usesHomeFeedCache(source)) {
-        _persistResumeWindow(
-          source.mode.name,
-          displayedVideos,
-          state.currentIndex,
+        _resumeManager.persistNow(
+          pubkey: _userPubkey,
+          mode: source.mode.name,
+          videos: displayedVideos,
+          activeIndex: state.currentIndex,
         );
       }
     } catch (e) {
@@ -835,16 +729,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     }
 
     final mode = source.mode.name;
-    final cached = await _homeFeedCache.readVideos(
+    final cachedValid = await _resumeManager.readServeableWindow(
       pubkey: _userPubkey,
       mode: mode,
     );
-    if (cached == null || cached.isEmpty) return false;
-    if (!_canEmitForSource(source, emit)) return false;
-
-    final filtered = _videosRepository.applyContentPreferences(cached);
-    final cachedValid = filtered.where((v) => v.videoUrl != null).toList();
     if (cachedValid.isEmpty) return false;
+    if (!_canEmitForSource(source, emit)) return false;
 
     // The cached window already starts at the resume position (already-watched
     // videos were dropped on write), so it is served at index 0.
@@ -864,30 +754,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     // Advance the resume point immediately so a quick reopen (before the fresh
     // fetch lands and the load-time write runs) still opens on the next video
     // rather than this one again.
-    _persistResumeWindow(mode, cachedValid, 0);
+    _resumeManager.persistNow(
+      pubkey: _userPubkey,
+      mode: mode,
+      videos: cachedValid,
+      activeIndex: 0,
+    );
     return true;
-  }
-
-  /// Keeps the active video plus one lookahead from [existing] and appends the
-  /// [fresh] results (deduped) after them, so fresh content appears right after
-  /// the current video instead of behind the whole cached window.
-  ///
-  /// The kept prefix ([0 .. currentIndex + 1]) leaves the active video and its
-  /// controller untouched, so [InfiniteVideoFeed]'s common-prefix handling
-  /// preserves it — the active video does not restart when fresh lands.
-  List<VideoEvent> _spliceFreshVideos({
-    required List<VideoEvent> existing,
-    required List<VideoEvent> fresh,
-    required int currentIndex,
-  }) {
-    if (existing.isEmpty) return fresh;
-    if (fresh.isEmpty) return existing;
-
-    final keepCount = (currentIndex + 2).clamp(0, existing.length);
-    final head = existing.sublist(0, keepCount);
-    final headIds = head.map((v) => v.id.toLowerCase()).toSet();
-    final tail = fresh.where((v) => !headIds.contains(v.id.toLowerCase()));
-    return [...head, ...tail];
   }
 
   /// Records the active video index and advances the resume window.
@@ -904,63 +777,15 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     emit(state.copyWith(currentIndex: index));
 
     if (_usesHomeFeedCache(state.source)) {
-      // Debounced: rapid swipes coalesce into one disk write (see
-      // [_resumePersistDebounce]). The index emit above stays immediate so the
-      // splice and resume-restore listener react without delay.
-      _schedulePersistResumeWindow(state.source.mode.name, state.videos, index);
-    }
-  }
-
-  /// Schedules a trailing-debounced resume-window persist for the swipe path.
-  void _schedulePersistResumeWindow(
-    String mode,
-    List<VideoEvent> videos,
-    int activeIndex,
-  ) {
-    _pendingResumePersist = (
-      mode: mode,
-      videos: videos,
-      activeIndex: activeIndex,
-    );
-    _resumePersistTimer?.cancel();
-    _resumePersistTimer = Timer(_resumePersistDebounce, _flushResumePersist);
-  }
-
-  /// Writes the latest pending swipe resume window, if any.
-  void _flushResumePersist() {
-    final pending = _pendingResumePersist;
-    if (pending == null) return;
-    _pendingResumePersist = null;
-    _resumePersistTimer?.cancel();
-    _resumePersistTimer = null;
-    _persistResumeWindow(pending.mode, pending.videos, pending.activeIndex);
-  }
-
-  /// Persists the forward window — the videos from [activeIndex] +
-  /// [_homeFeedResumeOffset] onward — as the cross-restart resume point.
-  ///
-  /// Called immediately on serve/load and, via
-  /// [_schedulePersistResumeWindow], debounced on swipe, so the resume point
-  /// advances as the user moves through (or simply reopens) the feed: the next
-  /// cold start opens on the next unseen video rather than the one just shown.
-  /// Already-watched videos before the offset are dropped, so the user cannot
-  /// scroll back to them on resume.
-  void _persistResumeWindow(
-    String mode,
-    List<VideoEvent> videos,
-    int activeIndex,
-  ) {
-    final start = (activeIndex + _homeFeedResumeOffset).clamp(0, videos.length);
-    final forward = start >= videos.length
-        ? const <VideoEvent>[]
-        : videos.sublist(start);
-    unawaited(
-      _homeFeedCache.writeVideos(
+      // The index emit above stays immediate so the splice and resume-restore
+      // listener react without delay; the disk write is debounced.
+      _resumeManager.schedulePersist(
         pubkey: _userPubkey,
-        mode: mode,
-        videos: forward,
-      ),
-    );
+        mode: state.source.mode.name,
+        videos: state.videos,
+        activeIndex: index,
+      );
+    }
   }
 
   bool _hasMoreForSource(

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -24,6 +24,15 @@ part 'video_feed_state.dart';
 /// Default interval between auto-refreshes of the home feed.
 const _defaultAutoRefreshMinInterval = Duration(minutes: 10);
 
+/// How far past the last-viewed video the cross-restart cache resumes.
+///
+/// On cold start the cached feed is served starting at the user's last
+/// position plus this offset, so the already-watched video and its one
+/// lookahead are skipped (the user resumes on the next, unseen video and
+/// cannot scroll back to content they have already seen). Matches the
+/// `currentIndex + 2` head kept by [VideoFeedBloc._spliceFreshVideos].
+const _homeFeedResumeOffset = 2;
+
 /// Legacy SharedPreferences key for persisting the selected feed mode.
 ///
 /// New authenticated sessions use a pubkey-scoped key so switching accounts
@@ -75,6 +84,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     on<VideoFeedFollowingListChanged>(_onFollowingListChanged);
     on<VideoFeedCuratedListsChanged>(_onCuratedListsChanged);
     on<VideoFeedBlocklistChanged>(_onBlocklistChanged);
+    on<VideoFeedActiveIndexChanged>(_onActiveIndexChanged);
   }
 
   final VideosRepository _videosRepository;
@@ -91,29 +101,24 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   StreamSubscription<List<String>>? _followingSubscription;
   StreamSubscription<List<CuratedList>>? _curatedListsSubscription;
 
-  /// Whether the cache has already been served for this BLoC instance.
-  ///
-  /// Prevents serving stale cached data on subsequent loads (e.g.,
-  /// follow list changes or mode switches).
-  bool _cacheServed = false;
-
   /// Tracks when the last successful load completed, used by
   /// [_onAutoRefreshRequested] to skip refreshes when data is fresh.
   DateTime? _lastRefreshedAt;
 
-  /// Whether [source] should be served from and written to the cross-restart
-  /// [HomeFeedCache] (SharedPreferences).
+  /// Whether [source] participates in the cross-restart [HomeFeedCache].
   ///
-  /// Only the chronological `following` feed is cached. Its ordering is
-  /// inherently stable, so replaying the last response on cold start is a
-  /// harmless startup optimization.
-  ///
-  /// The `forYou` feed is deliberately excluded: it is a recommendation feed
-  /// that should reflect fresh server state on every cold start. Persisting
-  /// and replaying its exact contents/order made the feed look identical on
-  /// every app reopen within the cache window (see issue #3861).
+  /// All three home modes (For You, Following, New) are served from and
+  /// written to the cache so cold start shows the last feed instantly. The
+  /// `forYou` staleness concern from #3861 is handled differently now: the
+  /// cached feed is positioned at the user's last index and everything past
+  /// the active video is replaced with fresh server data on every load
+  /// ([_spliceFreshVideos]), so the feed is never stale beyond the current
+  /// video. Subscribed curated lists are excluded — they are derived from
+  /// locally held list IDs, not a server feed.
   bool _usesHomeFeedCache(VideoFeedSource source) =>
-      source.type == VideoFeedSourceType.following;
+      source.type == VideoFeedSourceType.forYou ||
+      source.type == VideoFeedSourceType.following ||
+      source.type == VideoFeedSourceType.newVideos;
 
   bool _canEmitForSource(
     VideoFeedSource source,
@@ -366,6 +371,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         videoListSources: const {},
         listOnlyVideoIds: const {},
         clearPaginationCursor: true,
+        currentIndex: 0,
       ),
     );
 
@@ -479,6 +485,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
       // Batch-fetch profiles for new creators only.
       await _fetchCreatorProfiles(validNewVideos, source, emit);
+
+      // The cross-restart cache is written only on a genuine swipe
+      // (_onActiveIndexChanged); pagination alone does not move the resume
+      // position, so nothing is persisted here.
     } catch (e) {
       if (!_canEmitForSource(source, emit)) return;
 
@@ -506,6 +516,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         videoListSources: const {},
         listOnlyVideoIds: const {},
         clearPaginationCursor: true,
+        currentIndex: 0,
       ),
     );
 
@@ -548,6 +559,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         videoListSources: const {},
         listOnlyVideoIds: const {},
         clearPaginationCursor: true,
+        currentIndex: 0,
       ),
     );
 
@@ -636,6 +648,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         videoListSources: const {},
         listOnlyVideoIds: const {},
         clearPaginationCursor: true,
+        currentIndex: 0,
       ),
     );
 
@@ -675,9 +688,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
   /// Load videos for the specified mode.
   ///
-  /// For the home feed on cold start, serves cached data instantly while
-  /// fresh data loads in the background. The cache is only served once
-  /// per BLoC instance to avoid showing stale data on subsequent loads.
+  /// On a cache-eligible load ([skipCache] false), serves the persisted home
+  /// feed for the mode instantly — positioned at the user's last-viewed index
+  /// — while fresh data loads in the background. When the fresh result
+  /// arrives it is spliced in *after* the active video so the playing video
+  /// and its next never jump ([_spliceFreshVideos]).
   ///
   /// For the home feed, does NOT wait for the follow list to initialize.
   /// Instead, the follow-list stream subscription (set up in [_onStarted])
@@ -689,40 +704,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     Emitter<VideoFeedBlocState> emit, {
     bool skipCache = false,
   }) async {
-    // Serve cached home feed on first load for instant startup.
-    if (_serveCachedHomeFeed &&
-        !_cacheServed &&
-        _usesHomeFeedCache(source) &&
-        _sharedPreferences != null) {
-      _cacheServed = true;
-      final cached = _homeFeedCache.read(_sharedPreferences);
-      if (cached != null) {
-        final filtered = _videosRepository.applyContentPreferences(
-          cached.videos,
-        );
-        final cachedValid = filtered.where((v) => v.videoUrl != null).toList();
-        if (cachedValid.isNotEmpty) {
-          if (!_canEmitForSource(source, emit)) return;
-
-          _feedTracker?.markFirstVideosReceived(
-            source.mode.name,
-            cachedValid.length,
-          );
-          emit(
-            state.copyWith(
-              status: VideoFeedStatus.success,
-              videos: cachedValid,
-              hasMore: true,
-              clearPaginationCursor: true,
-              clearError: true,
-            ),
-          );
-          _feedTracker?.markFeedDisplayed(source.mode.name, cachedValid.length);
-          // Continue to fetch fresh data below — the emit will update
-          // the UI when the network result arrives.
-        }
-      }
-    }
+    final servedCache = await _maybeServeCachedFeed(source, emit, skipCache);
+    if (!_canEmitForSource(source, emit)) return;
 
     try {
       final result = await _fetchVideosForSource(source, skipCache: skipCache);
@@ -735,15 +718,27 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
       _lastRefreshedAt = DateTime.now();
 
+      // Keep the active video + one lookahead from the served cache and
+      // replace the rest with fresh results, so fresh content appears right
+      // after the current video. The active controller is preserved by
+      // InfiniteVideoFeed's common-prefix handling, so it does not restart.
+      final displayedVideos = servedCache
+          ? _spliceFreshVideos(
+              existing: state.videos,
+              fresh: validVideos,
+              currentIndex: state.currentIndex,
+            )
+          : validVideos;
+
       _feedTracker?.markFirstVideosReceived(
         source.mode.name,
-        validVideos.length,
+        displayedVideos.length,
       );
 
       emit(
         state.copyWith(
           status: VideoFeedStatus.success,
-          videos: validVideos,
+          videos: displayedVideos,
           // Only stop pagination when no results at all.
           // Fewer than _pageSize can happen due to server-side filtering.
           hasMore: _hasMoreForSource(
@@ -761,17 +756,20 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         ),
       );
 
-      _feedTracker?.markFeedDisplayed(source.mode.name, validVideos.length);
+      _feedTracker?.markFeedDisplayed(source.mode.name, displayedVideos.length);
 
       // Batch-fetch creator profiles to warm the Drift cache.
       await _fetchCreatorProfiles(validVideos, source, emit);
 
-      // Cache the raw response for next cold start (fire-and-forget).
-      if (_usesHomeFeedCache(source) &&
-          _sharedPreferences != null &&
-          result.rawResponseBody != null) {
-        unawaited(
-          _homeFeedCache.write(_sharedPreferences, result.rawResponseBody!),
+      // Advance the resume window past the active position so the next cold
+      // start opens on the next unseen video — even when the user just
+      // reopens without scrolling. Uses the spliced list so freshly loaded
+      // videos replenish the window.
+      if (_usesHomeFeedCache(source)) {
+        _persistResumeWindow(
+          source.mode.name,
+          displayedVideos,
+          state.currentIndex,
         );
       }
     } catch (e) {
@@ -799,6 +797,120 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         );
       }
     }
+  }
+
+  /// Serves the persisted feed for [source] at the last-viewed index when a
+  /// cache-eligible (non-[skipCache]) load is requested.
+  ///
+  /// Returns whether a cached feed was emitted, so the caller knows to splice
+  /// the fresh result in rather than replace wholesale.
+  Future<bool> _maybeServeCachedFeed(
+    VideoFeedSource source,
+    Emitter<VideoFeedBlocState> emit,
+    bool skipCache,
+  ) async {
+    if (skipCache || !_serveCachedHomeFeed || !_usesHomeFeedCache(source)) {
+      return false;
+    }
+
+    final mode = source.mode.name;
+    final cached = await _homeFeedCache.readVideos(
+      pubkey: _userPubkey,
+      mode: mode,
+    );
+    if (cached == null || cached.isEmpty) return false;
+    if (!_canEmitForSource(source, emit)) return false;
+
+    final filtered = _videosRepository.applyContentPreferences(cached);
+    final cachedValid = filtered.where((v) => v.videoUrl != null).toList();
+    if (cachedValid.isEmpty) return false;
+
+    // The cached window already starts at the resume position (already-watched
+    // videos were dropped on write), so it is served at index 0.
+    _feedTracker?.markFirstVideosReceived(mode, cachedValid.length);
+    emit(
+      state.copyWith(
+        status: VideoFeedStatus.success,
+        videos: cachedValid,
+        currentIndex: 0,
+        hasMore: true,
+        clearPaginationCursor: true,
+        clearError: true,
+      ),
+    );
+    _feedTracker?.markFeedDisplayed(mode, cachedValid.length);
+
+    // Advance the resume point immediately so a quick reopen (before the fresh
+    // fetch lands and the load-time write runs) still opens on the next video
+    // rather than this one again.
+    _persistResumeWindow(mode, cachedValid, 0);
+    return true;
+  }
+
+  /// Keeps the active video plus one lookahead from [existing] and appends the
+  /// [fresh] results (deduped) after them, so fresh content appears right after
+  /// the current video instead of behind the whole cached window.
+  ///
+  /// The kept prefix ([0 .. currentIndex + 1]) leaves the active video and its
+  /// controller untouched, so [InfiniteVideoFeed]'s common-prefix handling
+  /// preserves it — the active video does not restart when fresh lands.
+  List<VideoEvent> _spliceFreshVideos({
+    required List<VideoEvent> existing,
+    required List<VideoEvent> fresh,
+    required int currentIndex,
+  }) {
+    if (existing.isEmpty) return fresh;
+    if (fresh.isEmpty) return existing;
+
+    final keepCount = (currentIndex + 2).clamp(0, existing.length);
+    final head = existing.sublist(0, keepCount);
+    final headIds = head.map((v) => v.id.toLowerCase()).toSet();
+    final tail = fresh.where((v) => !headIds.contains(v.id.toLowerCase()));
+    return [...head, ...tail];
+  }
+
+  /// Records the active video index and advances the resume window.
+  ///
+  /// Only persists on a genuine index change, so the index-0 echo emitted when
+  /// the feed first mounts (or after a cold-start serve) doesn't double-write
+  /// (the load already persisted the window).
+  void _onActiveIndexChanged(
+    VideoFeedActiveIndexChanged event,
+    Emitter<VideoFeedBlocState> emit,
+  ) {
+    final index = event.index < 0 ? 0 : event.index;
+    if (state.currentIndex == index) return;
+    emit(state.copyWith(currentIndex: index));
+
+    if (_usesHomeFeedCache(state.source)) {
+      _persistResumeWindow(state.source.mode.name, state.videos, index);
+    }
+  }
+
+  /// Persists the forward window — the videos from [activeIndex] +
+  /// [_homeFeedResumeOffset] onward — as the cross-restart resume point.
+  ///
+  /// Called on every load and swipe, so the resume point advances as the user
+  /// moves through (or simply reopens) the feed: the next cold start opens on
+  /// the next unseen video rather than the one just shown. Already-watched
+  /// videos before the offset are dropped, so the user cannot scroll back to
+  /// them on resume.
+  void _persistResumeWindow(
+    String mode,
+    List<VideoEvent> videos,
+    int activeIndex,
+  ) {
+    final start = (activeIndex + _homeFeedResumeOffset).clamp(0, videos.length);
+    final forward = start >= videos.length
+        ? const <VideoEvent>[]
+        : videos.sublist(start);
+    unawaited(
+      _homeFeedCache.writeVideos(
+        pubkey: _userPubkey,
+        mode: mode,
+        videos: forward,
+      ),
+    );
   }
 
   bool _hasMoreForSource(

--- a/mobile/lib/blocs/video_feed/video_feed_event.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_event.dart
@@ -121,6 +121,21 @@ final class VideoFeedCuratedListsChanged extends VideoFeedEvent {
   List<Object?> get props => [subscribedLists];
 }
 
+/// The active (visible) video changed as the user swipes the feed.
+///
+/// Dispatched by the UI on each page change. The bloc records the index in
+/// state so it can splice fresh results in *after* the active video, and
+/// persists it so the position can be restored on the next cold start.
+final class VideoFeedActiveIndexChanged extends VideoFeedEvent {
+  const VideoFeedActiveIndexChanged(this.index);
+
+  /// The index of the now-active video in the feed.
+  final int index;
+
+  @override
+  List<Object?> get props => [index];
+}
+
 /// A user was blocked or the blocklist changed.
 ///
 /// When [blockedPubkey] is provided, the handler removes that user's videos

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -144,6 +144,7 @@ final class VideoFeedBlocState extends Equatable {
     this.listOnlyVideoIds = const {},
     this.creatorProfiles = const {},
     this.paginationCursor,
+    this.currentIndex = 0,
   }) : source =
            source ??
            (mode == FeedMode.following
@@ -172,6 +173,13 @@ final class VideoFeedBlocState extends Equatable {
 
   /// Whether a load-more operation is in progress.
   final bool isLoadingMore;
+
+  /// Index of the currently active video in [videos].
+  ///
+  /// Tracked here (not just in the widget) so the BLoC can splice fresh
+  /// results in *after* the active video and persist the resume position
+  /// across app restarts.
+  final int currentIndex;
 
   /// Error that occurred during loading, if any.
   final VideoFeedError? error;
@@ -230,6 +238,7 @@ final class VideoFeedBlocState extends Equatable {
     Map<String, UserProfile>? creatorProfiles,
     String? paginationCursor,
     bool clearPaginationCursor = false,
+    int? currentIndex,
   }) {
     return VideoFeedBlocState(
       status: status ?? this.status,
@@ -247,6 +256,7 @@ final class VideoFeedBlocState extends Equatable {
       paginationCursor: clearPaginationCursor
           ? null
           : (paginationCursor ?? this.paginationCursor),
+      currentIndex: currentIndex ?? this.currentIndex,
     );
   }
 
@@ -263,5 +273,6 @@ final class VideoFeedBlocState extends Equatable {
     listOnlyVideoIds,
     creatorProfiles,
     paginationCursor,
+    currentIndex,
   ];
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -731,12 +731,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
       );
     },
   );
-
-  // Critical (awaited before runApp): the home feed reads the persisted feed
-  // on its first build to serve videos instantly. If CacheSync initialised
-  // later (standard phase) the cold-start read would lose the race, fall back
-  // to null, and the loading spinner would always show. Drift opens lazily, so
-  // initialising here adds negligible startup cost.
+  // Critical: home feed reads this cache on first build (cold-start race).
   coordinator.registerService(
     name: 'CacheSync',
     phase: StartupPhase.critical,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -732,9 +732,14 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
     },
   );
 
+  // Critical (awaited before runApp): the home feed reads the persisted feed
+  // on its first build to serve videos instantly. If CacheSync initialised
+  // later (standard phase) the cold-start read would lose the race, fall back
+  // to null, and the loading spinner would always show. Drift opens lazily, so
+  // initialising here adds negligible startup cost.
   coordinator.registerService(
     name: 'CacheSync',
-    phase: StartupPhase.standard,
+    phase: StartupPhase.critical,
     initialize: CacheSync.init,
     optional: true,
   );

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -76,7 +76,10 @@ class VideoFeedPage extends ConsumerWidget {
             contentBlocklistRepository: blocklistRepository,
             userPubkey: authService.currentPublicKeyHex,
             sharedPreferences: sharedPreferences,
-            serveCachedHomeFeed: !showDivineHostedOnly,
+            // Cached-feed serving stays on (constructor default) regardless of
+            // the Divine-hosted-only filter: applyContentPreferences re-filters
+            // on read and the splice-on-refresh keeps the post-active tail
+            // fresh, so the cached serve is never stale to the viewer.
             feedTracker: FeedPerformanceTracker(),
           )..add(VideoFeedStarted(mode: initialMode)),
         ),
@@ -114,6 +117,14 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// Guards so startup milestones fire only once.
   bool _hasMarkedUIReady = false;
   bool _hasMarkedVideoReady = false;
+
+  /// Whether the app has actually been backgrounded since the last resume.
+  ///
+  /// The launch `resumed` lifecycle event would otherwise trigger an
+  /// auto-refresh that wipes the just-served cached feed and resets the
+  /// resume index back to the first video. Only a genuine background →
+  /// foreground transition should auto-refresh.
+  bool _wasBackgrounded = false;
 
   /// Tracks the current fractional page position for scroll-driven overlay opacity.
   late final ValueNotifier<double> _pagePosition;
@@ -155,7 +166,16 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
+    if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden) {
+      _wasBackgrounded = true;
+      return;
+    }
+    // Only auto-refresh on a genuine background → foreground transition. The
+    // spurious `resumed` event during cold start must not fire, or it would
+    // wipe the just-served cached feed and reset the resume index.
+    if (state == AppLifecycleState.resumed && _wasBackgrounded) {
+      _wasBackgrounded = false;
       context.read<VideoFeedBloc>().add(const VideoFeedAutoRefreshRequested());
     }
   }
@@ -231,6 +251,19 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                 ref
                     .read(lastTabPositionProvider.notifier)
                     .recordPosition(RouteType.home, 0);
+              },
+            ),
+            // Seed the page position from the BLoC's restored index (cold-start
+            // resume / mode switch). Runs before the builder, so [FeedVideos]
+            // mounts at the right page. Echoes of the user's own swipe are
+            // ignored because [_currentIndex] already matches.
+            BlocListener<VideoFeedBloc, VideoFeedBlocState>(
+              listenWhen: (previous, current) =>
+                  previous.currentIndex != current.currentIndex,
+              listener: (_, state) {
+                if (state.currentIndex == _currentIndex) return;
+                _currentIndex = state.currentIndex;
+                _pagePosition.value = state.currentIndex.toDouble();
               },
             ),
             // Mark UI ready when videos first become available.
@@ -313,6 +346,9 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                       trafficSource: ViewTrafficSource.home,
                       onActiveVideoChanged: (video, index) {
                         _currentIndex = index;
+                        context.read<VideoFeedBloc>().add(
+                          VideoFeedActiveIndexChanged(index),
+                        );
                         ref
                             .read(lastTabPositionProvider.notifier)
                             .recordPosition(RouteType.home, index);

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -281,6 +281,12 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
             ),
           ],
           child: BlocBuilder<VideoFeedBloc, VideoFeedBlocState>(
+            // The builder renders from the widget's own [_currentIndex], never
+            // [state.currentIndex], so a per-swipe index emit must not rebuild
+            // the whole feed. Rebuild only when some other field changed.
+            buildWhen: (previous, current) =>
+                current !=
+                previous.copyWith(currentIndex: current.currentIndex),
             builder: (context, state) {
               final itemCount = state.videos.length;
               final clampedIndex = _clampIndexForItemCount(

--- a/mobile/packages/cache_sync/lib/src/cache_sync.dart
+++ b/mobile/packages/cache_sync/lib/src/cache_sync.dart
@@ -123,6 +123,42 @@ abstract final class CacheSync {
     return controller.stream;
   }
 
+  /// Reads the cached value for [key], or `null` when absent, expired, or
+  /// corrupt.
+  ///
+  /// This is the direct disk-read counterpart to [watchOne] — it never
+  /// performs a network fetch. A cache entry that fails [fromJson] is
+  /// deleted and `null` is returned.
+  static Future<T?> read<T>({
+    required String key,
+    required T Function(String json) fromJson,
+  }) async {
+    final cached = await _dao.read(key);
+    if (cached == null || cached.isEmpty) return null;
+    try {
+      return fromJson(cached);
+    } on Object {
+      await _dao.delete(key);
+      return null;
+    }
+  }
+
+  /// Writes [value] to the cache under [key].
+  ///
+  /// When [toJson] returns an empty string the value is **not** persisted —
+  /// the same "do not cache" signal [watchOne] honours. [ttl] sets the
+  /// entry's expiry; `null` means it never expires.
+  static Future<void> write<T>({
+    required String key,
+    required T value,
+    required String Function(T value) toJson,
+    Duration? ttl,
+  }) async {
+    final payload = toJson(value);
+    if (payload.isEmpty) return;
+    await _dao.write(key: key, payload: payload, ttl: ttl);
+  }
+
   /// Removes the cached entry for [key].
   static Future<void> invalidate(String key) => _dao.delete(key);
 

--- a/mobile/packages/cache_sync/test/cache_sync_read_write_test.dart
+++ b/mobile/packages/cache_sync/test/cache_sync_read_write_test.dart
@@ -1,0 +1,68 @@
+import 'package:cache_sync/cache_sync.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'fake_cache_dao.dart';
+
+void main() {
+  late FakeCacheDao dao;
+
+  setUp(() async {
+    dao = FakeCacheDao();
+    await CacheSync.init(dao: dao);
+  });
+
+  group('CacheSync.write', () {
+    test('persists a value that read can return', () async {
+      await CacheSync.write<int>(
+        key: 'k',
+        value: 7,
+        toJson: (v) => '$v',
+      );
+
+      final value = await CacheSync.read<int>(
+        key: 'k',
+        fromJson: int.parse,
+      );
+      expect(value, equals(7));
+    });
+
+    test('does not persist when toJson returns an empty string', () async {
+      await CacheSync.write<int>(
+        key: 'k',
+        value: 7,
+        toJson: (_) => '',
+      );
+
+      expect(dao.rawRead('k'), isNull);
+    });
+
+    test('applies the provided ttl', () async {
+      await CacheSync.write<int>(
+        key: 'k',
+        value: 7,
+        toJson: (v) => '$v',
+        ttl: const Duration(microseconds: 1),
+      );
+
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      final value = await CacheSync.read<int>(key: 'k', fromJson: int.parse);
+      expect(value, isNull);
+    });
+  });
+
+  group('CacheSync.read', () {
+    test('returns null for an absent key', () async {
+      final value = await CacheSync.read<int>(key: 'nope', fromJson: int.parse);
+      expect(value, isNull);
+    });
+
+    test('deletes and returns null on a corrupt entry', () async {
+      await dao.write(key: 'k', payload: 'not-an-int');
+
+      final value = await CacheSync.read<int>(key: 'k', fromJson: int.parse);
+
+      expect(value, isNull);
+      expect(dao.rawRead('k'), isNull);
+    });
+  });
+}

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -422,38 +422,34 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _syncCurrentAutoPlayGate(oldWidget);
     if (widget.videos == oldWidget.videos) return;
 
-    // Append-only: the new list starts with exactly the same items in the
-    // same order — same id AND same effective playback source — only new
-    // items were appended (e.g. pagination). Existing controllers are
-    // still valid; just let _onIndexChanged extend the window. If the
-    // resolved URL for an existing index changed (e.g. the caller updated
-    // the playback source for the same id) the cached controller is stale
-    // and we must fall through to the non-append teardown path.
-    final oldLen = oldWidget.videos.length;
-    var isAppendOnly = widget.videos.length >= oldLen;
-    if (isAppendOnly) {
-      for (var i = 0; i < oldLen; i++) {
-        final oldVideo = oldWidget.videos[i];
-        final newVideo = widget.videos[i];
-        if (oldVideo.id != newVideo.id ||
-            _resolvedSourceFor(oldVideo, oldWidget.urlResolver) !=
-                _resolvedSourceFor(newVideo, widget.urlResolver)) {
-          isAppendOnly = false;
-          break;
-        }
-      }
-    }
+    // How many leading items are unchanged — same id AND same resolved
+    // playback source. A changed resolved URL for an existing index (e.g. the
+    // caller swapped the playback source for the same id) ends the common
+    // prefix there, so its stale controller is rebuilt below.
+    final commonPrefix = _commonPrefixLength(oldWidget, widget);
 
-    if (isAppendOnly) {
+    // The active video and everything before it are unchanged when the common
+    // prefix extends past the current index. Keep those controllers and only
+    // rebuild the changed tail (indices >= commonPrefix), so the active video
+    // does not restart. This covers append-only pagination and a tail
+    // replacement (fresh feed spliced in after the current video). Disposing
+    // the changed tail first lets _onIndexChanged re-init any stale controller
+    // that falls inside the live window; out-of-window ones it disposes itself.
+    if (commonPrefix > _currentIndex) {
+      _prefetcher.cancelActive();
+      _controllers.keys
+          .where((index) => index >= commonPrefix)
+          .toList()
+          .forEach(_disposeAt);
       unawaited(_onIndexChanged(_currentIndex));
       return;
     }
 
-    // Non-append-only change (e.g. tab switch forYou → following, or full
-    // feed replacement). Tear down all live controllers, reset to the
-    // caller's intended starting index, and jump the PageController so
-    // the next frame opens on the right item instead of whatever stale
-    // page the previous feed was on.
+    // The change reaches the current video (or before it) — e.g. a tab switch
+    // forYou → following or a full feed replacement. Tear down all live
+    // controllers, reset to the caller's intended starting index, and jump the
+    // PageController so the next frame opens on the right item instead of
+    // whatever stale page the previous feed was on.
     _log(
       'Non-append-only video list change — tearing down all controllers '
       '(old=${oldWidget.videos.length} new=${widget.videos.length})',
@@ -487,6 +483,29 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     VideoEvent video,
     String? Function(VideoEvent video)? resolver,
   ) => resolver?.call(video) ?? video.videoUrl;
+
+  /// Number of leading items shared by [oldWidget] and [widget] — equal id and
+  /// equal resolved playback source at each index.
+  int _commonPrefixLength(
+    InfiniteVideoFeed oldWidget,
+    InfiniteVideoFeed newWidget,
+  ) {
+    final maxLength = oldWidget.videos.length < newWidget.videos.length
+        ? oldWidget.videos.length
+        : newWidget.videos.length;
+    var i = 0;
+    while (i < maxLength) {
+      final oldVideo = oldWidget.videos[i];
+      final newVideo = newWidget.videos[i];
+      if (oldVideo.id != newVideo.id ||
+          _resolvedSourceFor(oldVideo, oldWidget.urlResolver) !=
+              _resolvedSourceFor(newVideo, newWidget.urlResolver)) {
+        break;
+      }
+      i++;
+    }
+    return i;
+  }
 
   @override
   void dispose() {

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -1501,6 +1501,62 @@ void main() {
           expect(pageView.controller!.page?.round(), equals(2));
         },
       );
+
+      testWidgets(
+        'tail replacement past the active index keeps the active index',
+        (tester) async {
+          final key = GlobalKey<InfiniteVideoFeedState>();
+          final videos1 = List.generate(5, (i) => _makeVideo('v$i'));
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos1,
+                cache: cache,
+                preloadGracePeriod: Duration.zero,
+                prefetchCount: 0,
+              ),
+            ),
+          );
+          await tester.pump(const Duration(milliseconds: 50));
+
+          // Move to index 1 (distinct from initialIndex 0).
+          unawaited(key.currentState!.animateToPage(1));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 400));
+          expect(key.currentState!.currentIndex, equals(1));
+
+          // Splice: keep the prefix past the active index ([v0, v1, v2]) and
+          // replace the tail with fresh videos.
+          final videos2 = [
+            videos1[0],
+            videos1[1],
+            videos1[2],
+            _makeVideo('fresh0'),
+            _makeVideo('fresh1'),
+          ];
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos2,
+                cache: cache,
+                preloadGracePeriod: Duration.zero,
+                prefetchCount: 0,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(Duration.zero);
+
+          // The active index is preserved (not reset to initialIndex 0) and the
+          // PageController does not jump — the active video is not restarted.
+          expect(key.currentState!.currentIndex, equals(1));
+          final pageView = tester.widget<PageView>(find.byType(PageView));
+          expect(pageView.controller!.page?.round(), equals(1));
+        },
+      );
     });
 
     group('overlayBuilder', () {

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -201,6 +201,90 @@ class VideoEvent {
     this.proofSummary,
   });
 
+  /// Reconstructs a [VideoEvent] from a map produced by [toJson].
+  ///
+  /// Inverse of [toJson], used to rehydrate cached feed snapshots. The
+  /// internal fields that [toJson] deliberately omits (`nostrEventTags`,
+  /// `moderationLabels`, `warnLabels`) are not restored and fall back to
+  /// their defaults — they are republishing / UI-only state, irrelevant to
+  /// a cached feed row.
+  factory VideoEvent.fromJson(Map<String, dynamic> json) {
+    List<String> stringList(Object? value) =>
+        (value as List<dynamic>?)?.map((e) => e.toString()).toList() ??
+        const [];
+    int? optInt(Object? value) => (value as num?)?.toInt();
+    DateTime? optDate(Object? value) =>
+        value == null ? null : DateTime.parse(value as String);
+
+    final createdAt = optInt(json['createdAt']) ?? 0;
+    final timestamp = json['timestamp'];
+    return VideoEvent(
+      id: json['id'] as String? ?? '',
+      pubkey: json['pubkey'] as String? ?? '',
+      createdAt: createdAt,
+      content: json['content'] as String? ?? '',
+      timestamp: timestamp is String
+          ? DateTime.parse(timestamp)
+          : DateTime.fromMillisecondsSinceEpoch(createdAt * 1000, isUtc: true),
+      title: json['title'] as String?,
+      videoUrl: json['videoUrl'] as String?,
+      thumbnailUrl: json['thumbnailUrl'] as String?,
+      duration: optInt(json['duration']),
+      dimensions: json['dimensions'] as String?,
+      mimeType: json['mimeType'] as String?,
+      sha256: json['sha256'] as String?,
+      fileSize: optInt(json['fileSize']),
+      hashtags: stringList(json['hashtags']),
+      categories: stringList(json['categories']),
+      publishedAt: json['publishedAt'] as String?,
+      rawTags:
+          (json['rawTags'] as Map<String, dynamic>?)?.map(
+            (key, value) => MapEntry(key, value.toString()),
+          ) ??
+          const {},
+      vineId: json['vineId'] as String?,
+      group: json['group'] as String?,
+      altText: json['altText'] as String?,
+      blurhash: json['blurhash'] as String?,
+      isRepost: json['isRepost'] as bool? ?? false,
+      reposterId: json['reposterId'] as String?,
+      reposterPubkey: json['reposterPubkey'] as String?,
+      reposterPubkeys: json['reposterPubkeys'] == null
+          ? null
+          : stringList(json['reposterPubkeys']),
+      repostedAt: optDate(json['repostedAt']),
+      isFlaggedContent: json['isFlaggedContent'] as bool? ?? false,
+      moderationStatus: json['moderationStatus'] as String?,
+      originalLoops: optInt(json['originalLoops']),
+      originalLikes: optInt(json['originalLikes']),
+      originalComments: optInt(json['originalComments']),
+      originalReposts: optInt(json['originalReposts']),
+      expirationTimestamp: optInt(json['expirationTimestamp']),
+      audioEventId: json['audioEventId'] as String?,
+      audioEventRelay: json['audioEventRelay'] as String?,
+      nostrLikeCount: optInt(json['nostrLikeCount']),
+      nostrCommentCount: optInt(json['nostrCommentCount']),
+      nostrRepostCount: optInt(json['nostrRepostCount']),
+      authorName: json['authorName'] as String?,
+      authorAvatar: json['authorAvatar'] as String?,
+      collaboratorPubkeys: stringList(json['collaboratorPubkeys']),
+      inspiredByVideo: json['inspiredByVideo'] == null
+          ? null
+          : InspiredByInfo.fromJson(
+              json['inspiredByVideo'] as Map<String, dynamic>,
+            ),
+      inspiredByNpub: json['inspiredByNpub'] as String?,
+      textTrackRef: json['textTrackRef'] as String?,
+      textTrackContent: json['textTrackContent'] as String?,
+      contentWarningLabels: stringList(json['contentWarningLabels']),
+      proofSummary: json['proofSummary'] == null
+          ? null
+          : ProofVerificationSummary.fromJson(
+              json['proofSummary'] as Map<String, dynamic>,
+            ),
+    );
+  }
+
   /// Create VideoEvent from Nostr event
   ///
   /// [permissive] - When true, accepts all NIP-71 video kinds (21, 22, 34235,

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -203,11 +203,15 @@ class VideoEvent {
 
   /// Reconstructs a [VideoEvent] from a map produced by [toJson].
   ///
-  /// Inverse of [toJson], used to rehydrate cached feed snapshots. The
-  /// internal fields that [toJson] deliberately omits (`nostrEventTags`,
-  /// `moderationLabels`, `warnLabels`) are not restored and fall back to
-  /// their defaults — they are republishing / UI-only state, irrelevant to
-  /// a cached feed row.
+  /// Inverse of [toJson], used to rehydrate cached feed snapshots.
+  ///
+  /// `moderationLabels` is persisted and restored because it is a hard
+  /// content-filter "hide" signal — dropping it would let a moderated video
+  /// slip through the content-preference filter on cold start when the user's
+  /// preferences changed between sessions. The remaining omitted fields
+  /// (`nostrEventTags`, `warnLabels`) fall back to their defaults: `warnLabels`
+  /// is recomputed by the warning-labels resolver on read, and `nostrEventTags`
+  /// is heavy republishing state the content-label path does not consult.
   factory VideoEvent.fromJson(Map<String, dynamic> json) {
     List<String> stringList(Object? value) =>
         (value as List<dynamic>?)?.map((e) => e.toString()).toList() ??
@@ -277,6 +281,7 @@ class VideoEvent {
       textTrackRef: json['textTrackRef'] as String?,
       textTrackContent: json['textTrackContent'] as String?,
       contentWarningLabels: stringList(json['contentWarningLabels']),
+      moderationLabels: stringList(json['moderationLabels']),
       proofSummary: json['proofSummary'] == null
           ? null
           : ProofVerificationSummary.fromJson(
@@ -1538,6 +1543,7 @@ class VideoEvent {
     'textTrackRef': textTrackRef,
     'textTrackContent': textTrackContent,
     'contentWarningLabels': contentWarningLabels,
+    'moderationLabels': moderationLabels,
     'proofSummary': proofSummary?.toJson(),
   };
 

--- a/mobile/packages/models/test/src/video_event_from_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_from_json_test.dart
@@ -1,0 +1,203 @@
+// ABOUTME: Round-trip tests for VideoEvent.fromJson (inverse of toJson).
+// ABOUTME: Guarantees a cached feed snapshot rehydrates with the same
+// ABOUTME: persisted field values it was serialized from.
+
+import 'dart:convert';
+
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+final String _id = 'a' * 64;
+final String _pubkey = 'b' * 64;
+final String _reposterId = '1' * 64;
+final String _reposterPubkey = 'c' * 64;
+final String _otherCollab = 'd' * 64;
+final String _audioEventId = 'e' * 64;
+final String _sha256 = 'f' * 64;
+
+VideoEvent _fullVideo() => VideoEvent(
+  id: _id,
+  pubkey: _pubkey,
+  createdAt: 1704067200,
+  content: 'hello vine',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(
+    1704067200 * 1000,
+    isUtc: true,
+  ),
+  title: 'A short loop',
+  videoUrl: 'https://cdn.divine.video/video.mp4',
+  thumbnailUrl: 'https://cdn.divine.video/thumb.jpg',
+  duration: 6,
+  dimensions: '720x1280',
+  mimeType: 'video/mp4',
+  sha256: _sha256,
+  fileSize: 4096,
+  hashtags: const ['vine', 'test'],
+  categories: const ['music'],
+  publishedAt: '1704067200',
+  rawTags: const {'platform': 'vine', 'views': '42'},
+  vineId: 'abc123def',
+  group: 'community',
+  altText: 'A person waves at the camera',
+  blurhash: 'LKO2?U%2Tw=w',
+  isRepost: true,
+  reposterId: _reposterId,
+  reposterPubkey: _reposterPubkey,
+  reposterPubkeys: [_reposterPubkey],
+  repostedAt: DateTime.fromMillisecondsSinceEpoch(
+    1704067260 * 1000,
+    isUtc: true,
+  ),
+  isFlaggedContent: true,
+  moderationStatus: 'approved',
+  originalLoops: 13565,
+  originalLikes: 732,
+  originalComments: 24,
+  originalReposts: 9,
+  expirationTimestamp: 4102444800,
+  audioEventId: _audioEventId,
+  audioEventRelay: 'wss://relay.divine.video',
+  nostrLikeCount: 12,
+  nostrCommentCount: 3,
+  nostrRepostCount: 2,
+  authorName: 'Test Author',
+  authorAvatar: 'https://cdn.divine.video/avatar.jpg',
+  collaboratorPubkeys: [_otherCollab],
+  inspiredByVideo: const InspiredByInfo(
+    addressableId: '34236:abc123:my-video',
+    relayUrl: 'wss://relay.divine.video',
+  ),
+  inspiredByNpub: 'npub1examplenpubvalue',
+  textTrackRef: 'https://cdn.divine.video/captions.vtt',
+  textTrackContent: 'WEBVTT\n\n00:00.000 --> 00:06.000\nHello',
+  contentWarningLabels: const ['nudity'],
+  proofSummary: ProofVerificationSummary(
+    status: 'present',
+    level: 'basic_proof',
+    checkedAt: DateTime.fromMillisecondsSinceEpoch(
+      1779494400 * 1000,
+      isUtc: true,
+    ),
+    version: 1,
+    checks: const {'proofmode_present': true},
+  ),
+);
+
+void main() {
+  group('VideoEvent.fromJson', () {
+    test('restores every persisted scalar field from toJson', () {
+      final original = _fullVideo();
+      final restored = VideoEvent.fromJson(original.toJson());
+
+      expect(restored.id, equals(original.id));
+      expect(restored.pubkey, equals(original.pubkey));
+      expect(restored.createdAt, equals(original.createdAt));
+      expect(restored.content, equals(original.content));
+      expect(restored.timestamp, equals(original.timestamp));
+      expect(restored.title, equals(original.title));
+      expect(restored.videoUrl, equals(original.videoUrl));
+      expect(restored.thumbnailUrl, equals(original.thumbnailUrl));
+      expect(restored.duration, equals(original.duration));
+      expect(restored.dimensions, equals(original.dimensions));
+      expect(restored.mimeType, equals(original.mimeType));
+      expect(restored.sha256, equals(original.sha256));
+      expect(restored.fileSize, equals(original.fileSize));
+      expect(restored.publishedAt, equals(original.publishedAt));
+      expect(restored.vineId, equals(original.vineId));
+      expect(restored.group, equals(original.group));
+      expect(restored.altText, equals(original.altText));
+      expect(restored.blurhash, equals(original.blurhash));
+      expect(restored.isRepost, equals(original.isRepost));
+      expect(restored.reposterId, equals(original.reposterId));
+      expect(restored.reposterPubkey, equals(original.reposterPubkey));
+      expect(restored.repostedAt, equals(original.repostedAt));
+      expect(restored.isFlaggedContent, equals(original.isFlaggedContent));
+      expect(restored.moderationStatus, equals(original.moderationStatus));
+      expect(restored.originalLoops, equals(original.originalLoops));
+      expect(restored.originalLikes, equals(original.originalLikes));
+      expect(restored.originalComments, equals(original.originalComments));
+      expect(restored.originalReposts, equals(original.originalReposts));
+      expect(
+        restored.expirationTimestamp,
+        equals(original.expirationTimestamp),
+      );
+      expect(restored.audioEventId, equals(original.audioEventId));
+      expect(restored.audioEventRelay, equals(original.audioEventRelay));
+      expect(restored.nostrLikeCount, equals(original.nostrLikeCount));
+      expect(restored.nostrCommentCount, equals(original.nostrCommentCount));
+      expect(restored.nostrRepostCount, equals(original.nostrRepostCount));
+      expect(restored.authorName, equals(original.authorName));
+      expect(restored.authorAvatar, equals(original.authorAvatar));
+      expect(restored.inspiredByNpub, equals(original.inspiredByNpub));
+      expect(restored.textTrackRef, equals(original.textTrackRef));
+      expect(restored.textTrackContent, equals(original.textTrackContent));
+    });
+
+    test('restores list and map fields', () {
+      final restored = VideoEvent.fromJson(_fullVideo().toJson());
+
+      expect(restored.hashtags, equals(['vine', 'test']));
+      expect(restored.categories, equals(['music']));
+      expect(restored.reposterPubkeys, equals([_reposterPubkey]));
+      expect(restored.collaboratorPubkeys, equals([_otherCollab]));
+      expect(restored.contentWarningLabels, equals(['nudity']));
+      expect(restored.rawTags, equals({'platform': 'vine', 'views': '42'}));
+    });
+
+    test('restores nested inspiredByVideo and proofSummary', () {
+      final restored = VideoEvent.fromJson(_fullVideo().toJson());
+
+      expect(restored.inspiredByVideo, isNotNull);
+      expect(
+        restored.inspiredByVideo!.addressableId,
+        equals('34236:abc123:my-video'),
+      );
+      expect(
+        restored.inspiredByVideo!.relayUrl,
+        equals('wss://relay.divine.video'),
+      );
+
+      expect(restored.proofSummary, isNotNull);
+      expect(restored.proofSummary!.status, equals('present'));
+      expect(restored.proofSummary!.level, equals('basic_proof'));
+      expect(restored.proofSummary!.version, equals(1));
+      expect(restored.proofSummary!.checks['proofmode_present'], isTrue);
+    });
+
+    test('survives a jsonEncode/jsonDecode round-trip', () {
+      final original = _fullVideo();
+      final encoded = jsonEncode(original.toJson());
+      final restored = VideoEvent.fromJson(
+        jsonDecode(encoded) as Map<String, dynamic>,
+      );
+
+      expect(restored.id, equals(original.id));
+      expect(restored.videoUrl, equals(original.videoUrl));
+      expect(restored.timestamp, equals(original.timestamp));
+      expect(restored.originalLoops, equals(original.originalLoops));
+    });
+
+    test('restores a minimal video with null optionals', () {
+      final minimal = VideoEvent(
+        id: _id,
+        pubkey: _pubkey,
+        createdAt: 1704067200,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(
+          1704067200 * 1000,
+          isUtc: true,
+        ),
+      );
+      final restored = VideoEvent.fromJson(minimal.toJson());
+
+      expect(restored.id, equals(_id));
+      expect(restored.videoUrl, isNull);
+      expect(restored.inspiredByVideo, isNull);
+      expect(restored.proofSummary, isNull);
+      expect(restored.reposterPubkeys, isNull);
+      expect(restored.hashtags, isEmpty);
+      expect(restored.rawTags, isEmpty);
+      expect(restored.isRepost, isFalse);
+    });
+  });
+}

--- a/mobile/packages/models/test/src/video_event_from_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_from_json_test.dart
@@ -71,6 +71,7 @@ VideoEvent _fullVideo() => VideoEvent(
   textTrackRef: 'https://cdn.divine.video/captions.vtt',
   textTrackContent: 'WEBVTT\n\n00:00.000 --> 00:06.000\nHello',
   contentWarningLabels: const ['nudity'],
+  moderationLabels: const ['violence'],
   proofSummary: ProofVerificationSummary(
     status: 'present',
     level: 'basic_proof',
@@ -141,6 +142,7 @@ void main() {
       expect(restored.reposterPubkeys, equals([_reposterPubkey]));
       expect(restored.collaboratorPubkeys, equals([_otherCollab]));
       expect(restored.contentWarningLabels, equals(['nudity']));
+      expect(restored.moderationLabels, equals(['violence']));
       expect(restored.rawTags, equals({'platform': 'vine', 'views': '42'}));
     });
 
@@ -196,6 +198,7 @@ void main() {
       expect(restored.proofSummary, isNull);
       expect(restored.reposterPubkeys, isNull);
       expect(restored.hashtags, isEmpty);
+      expect(restored.moderationLabels, isEmpty);
       expect(restored.rawTags, isEmpty);
       expect(restored.isRepost, isFalse);
     });

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -138,6 +138,7 @@ const _expectedKeys = <String>{
   'textTrackRef',
   'textTrackContent',
   'contentWarningLabels',
+  'moderationLabels',
   'proofSummary',
 };
 
@@ -193,7 +194,6 @@ const _excludedDerivedGetters = <String>{
 
 const _excludedInternalFields = <String>{
   'nostrEventTags',
-  'moderationLabels',
   'warnLabels',
 };
 

--- a/mobile/packages/videos_repository/lib/src/home_feed_result.dart
+++ b/mobile/packages/videos_repository/lib/src/home_feed_result.dart
@@ -27,7 +27,6 @@ class HomeFeedResult extends Equatable {
     this.nextCursor,
     this.paginationCursor,
     this.hasMore,
-    this.rawResponseBody,
   });
 
   /// All videos (following + list), sorted by createdAt descending.
@@ -59,13 +58,6 @@ class HomeFeedResult extends Equatable {
 
   /// Whether the upstream feed has more data to fetch.
   final bool? hasMore;
-
-  /// The raw JSON response body from the API, if available.
-  ///
-  /// Populated on initial (non-paginated) home feed fetches so the
-  /// BLoC can cache it for instant display on next cold start.
-  /// Excluded from equality checks.
-  final String? rawResponseBody;
 
   @override
   List<Object?> get props => [

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -222,7 +222,7 @@ class VideosRepository {
     }
 
     // 1. Fetch following videos (Funnelcake API → Nostr relay waterfall)
-    final (:videos, :rawBody) = await _fetchFollowingVideos(
+    final videos = await _fetchFollowingVideos(
       authors: authors,
       userPubkey: userPubkey,
       limit: limit,
@@ -231,7 +231,7 @@ class VideosRepository {
 
     // 2. If no list refs, return following-only result
     if (videoRefs.isEmpty) {
-      final result = HomeFeedResult(videos: videos, rawResponseBody: rawBody);
+      final result = HomeFeedResult(videos: videos);
       if (until == null) _inMemoryFeedCache?.set('home', result);
       return result;
     }
@@ -246,10 +246,7 @@ class VideosRepository {
   }
 
   /// Fetches videos from followed users via Funnelcake API or Nostr relays.
-  ///
-  /// Returns a record with the videos and the raw JSON response body
-  /// (when available from Funnelcake initial page) for cache-first loading.
-  Future<({List<VideoEvent> videos, String? rawBody})> _fetchFollowingVideos({
+  Future<List<VideoEvent>> _fetchFollowingVideos({
     required List<String> authors,
     String? userPubkey,
     int limit = _defaultLimit,
@@ -281,8 +278,7 @@ class VideosRepository {
     );
   }
 
-  Future<({List<VideoEvent> videos, String? rawBody})>
-  _fetchVisibleHomeVideosFromStatsApi({
+  Future<List<VideoEvent>> _fetchVisibleHomeVideosFromStatsApi({
     required String userPubkey,
     required int limit,
     int? until,
@@ -290,7 +286,6 @@ class VideosRepository {
     var cursor = until;
     final visible = <VideoEvent>[];
     final seenIds = <String>{};
-    String? rawBody;
 
     // Intentionally walk until we have enough visible videos or the upstream
     // feed is exhausted. A hard page cap caused premature EOF on reply-dense
@@ -305,7 +300,6 @@ class VideosRepository {
       final videos = _transformVideoStats(response.videos);
       final hydratedVideos = await _hydrateVideosWithBulkStats(videos);
       _appendUniqueVideos(visible, hydratedVideos, seenIds: seenIds);
-      rawBody ??= response.rawBody;
       if (response.videos.length < limit || !response.hasMore) break;
 
       final nextCursor =
@@ -314,18 +308,17 @@ class VideosRepository {
       cursor = nextCursor;
     }
 
-    return (videos: visible.take(limit).toList(), rawBody: rawBody);
+    return visible.take(limit).toList();
   }
 
-  Future<({List<VideoEvent> videos, String? rawBody})>
-  _fetchVisibleHomeVideosFromRelays({
+  Future<List<VideoEvent>> _fetchVisibleHomeVideosFromRelays({
     required List<String> authors,
     required int limit,
     int? until,
   }) async {
     // Nostr fallback — skip when authors list is empty (fast-path startup
     // before follow list is ready).
-    if (authors.isEmpty) return (videos: <VideoEvent>[], rawBody: null);
+    if (authors.isEmpty) return <VideoEvent>[];
 
     var cursor = until;
     final visible = <VideoEvent>[];
@@ -355,7 +348,7 @@ class VideosRepository {
       cursor = nextCursor;
     }
 
-    return (videos: visible.take(limit).toList(), rawBody: null);
+    return visible.take(limit).toList();
   }
 
   Future<List<VideoEvent>> _hydrateVideosWithBulkStats(
@@ -2492,7 +2485,6 @@ class VideosRepository {
       videos: videos,
       paginationCursor: response.nextCursor,
       hasMore: response.hasMore,
-      rawResponseBody: response.rawBody,
     );
     if (isFirstPage) {
       _recommendationSessionSeed = requestSeed;

--- a/mobile/packages/videos_repository/test/src/home_feed_result_test.dart
+++ b/mobile/packages/videos_repository/test/src/home_feed_result_test.dart
@@ -151,39 +151,7 @@ void main() {
       expect(result1, isNot(equals(result2)));
     });
 
-    test('rawResponseBody defaults to null', () {
-      const result = HomeFeedResult(videos: []);
-
-      expect(result.rawResponseBody, isNull);
-    });
-
-    test('stores rawResponseBody when provided', () {
-      const result = HomeFeedResult(
-        videos: [],
-        rawResponseBody: '{"videos":[]}',
-      );
-
-      expect(result.rawResponseBody, equals('{"videos":[]}'));
-    });
-
-    test('rawResponseBody is excluded from equality', () {
-      final video = createVideo(id: 'v1');
-
-      final result1 = HomeFeedResult(
-        videos: [video],
-        rawResponseBody: '{"videos":[{"id":"v1"}]}',
-      );
-
-      final result2 = HomeFeedResult(
-        videos: [video],
-        rawResponseBody: '{"videos":[{"id":"different"}]}',
-      );
-
-      // Same videos, different rawResponseBody — should be equal
-      expect(result1, equals(result2));
-    });
-
-    test('props includes all fields except rawResponseBody', () {
+    test('props includes all fields', () {
       final video = createVideo(id: 'v1');
       const sources = {
         'v1': {'list-a'},
@@ -198,7 +166,6 @@ void main() {
         nextCursor: 1234,
         paginationCursor: 'o:2',
         hasMore: true,
-        rawResponseBody: '{"videos":[]}',
       );
 
       expect(result.props, hasLength(7));

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -9959,10 +9959,6 @@ void main() {
         expect(result.videos.single.id, equals('recommended-video'));
         expect(result.videoListSources, isEmpty);
         expect(result.listOnlyVideoIds, isEmpty);
-        expect(
-          result.rawResponseBody,
-          equals('{"videos":[{"id":"recommended-video"}]}'),
-        );
         verify(
           () => mockFunnelcakeClient.getRecommendations(
             seed: any(named: 'seed'),

--- a/mobile/test/blocs/video_feed/home_feed_cache_test.dart
+++ b/mobile/test/blocs/video_feed/home_feed_cache_test.dart
@@ -1,189 +1,175 @@
-// ABOUTME: Tests for HomeFeedCache - cache read/write for home feed data
-// ABOUTME: Verifies SharedPreferences caching with expiry logic
+// ABOUTME: Tests for HomeFeedCache - CacheSync-backed home feed persistence.
+// ABOUTME: Verifies per-mode, account-scoped video + index read/write.
 
-import 'dart:convert';
-
+import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+
+class _FakeCacheDao implements CacheDao {
+  final Map<String, ({String payload, DateTime? expiresAt})> store = {};
+
+  @override
+  Future<String?> read(String key) async {
+    final entry = store[key];
+    if (entry == null) return null;
+    final expiresAt = entry.expiresAt;
+    if (expiresAt != null && DateTime.now().toUtc().isAfter(expiresAt)) {
+      store.remove(key);
+      return null;
+    }
+    return entry.payload;
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    store[key] = (
+      payload: payload,
+      expiresAt: ttl == null ? null : DateTime.now().toUtc().add(ttl),
+    );
+  }
+
+  @override
+  Future<void> delete(String key) async => store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      store.values.fold<int>(0, (sum, e) => sum + e.payload.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
+VideoEvent _video(String id) => VideoEvent(
+  id: id,
+  pubkey: 'a' * 64,
+  createdAt: 1700000000,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(
+    1700000000 * 1000,
+    isUtc: true,
+  ),
+  videoUrl: 'https://cdn.divine.video/$id.mp4',
+);
 
 void main() {
   group(HomeFeedCache, () {
-    late HomeFeedCache cache;
+    late _FakeCacheDao dao;
+    const cache = HomeFeedCache();
+    final pubkey = 'b' * 64;
 
-    setUp(() {
-      cache = const HomeFeedCache();
+    setUp(() async {
+      dao = _FakeCacheDao();
+      await CacheSync.init(dao: dao);
     });
 
-    String validFeedJson({int videoCount = 2}) {
-      final videos = List.generate(
-        videoCount,
-        (i) => {
-          'id': 'video-$i',
-          'pubkey': '0' * 64,
-          'video_url': 'https://example.com/video-$i.mp4',
-          'created_at': DateTime.now().millisecondsSinceEpoch ~/ 1000 - i,
-        },
-      );
-      return jsonEncode({'videos': videos});
-    }
-
-    group('read', () {
-      test('returns null when no cache exists', () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-
-        final result = cache.read(prefs);
-
+    group('videos', () {
+      test('returns null when nothing is cached', () async {
+        final result = await cache.readVideos(pubkey: pubkey, mode: 'forYou');
         expect(result, isNull);
       });
 
-      test('returns null when cache is expired', () async {
-        final expiredTime = DateTime.now()
-            .subtract(const Duration(hours: 2))
-            .millisecondsSinceEpoch;
+      test('round-trips written videos by mode', () async {
+        await cache.writeVideos(
+          pubkey: pubkey,
+          mode: 'forYou',
+          videos: [_video('a'), _video('b')],
+        );
 
-        SharedPreferences.setMockInitialValues({
-          homeFeedCacheKey: validFeedJson(),
-          homeFeedCacheTimeKey: expiredTime,
-        });
-        final prefs = await SharedPreferences.getInstance();
-
-        final result = cache.read(prefs);
-
-        expect(result, isNull);
-      });
-
-      test('returns cached result when cache is fresh', () async {
-        final freshTime = DateTime.now()
-            .subtract(const Duration(minutes: 30))
-            .millisecondsSinceEpoch;
-
-        SharedPreferences.setMockInitialValues({
-          homeFeedCacheKey: validFeedJson(),
-          homeFeedCacheTimeKey: freshTime,
-        });
-        final prefs = await SharedPreferences.getInstance();
-
-        final result = cache.read(prefs);
-
+        final result = await cache.readVideos(pubkey: pubkey, mode: 'forYou');
         expect(result, isNotNull);
-        expect(result!.videos, hasLength(2));
-        expect(result.videos[0].id, equals('video-0'));
-        expect(result.videos[1].id, equals('video-1'));
+        expect(result!.map((v) => v.id), equals(['a', 'b']));
+      });
+
+      test('does not persist an empty list', () async {
+        await cache.writeVideos(pubkey: pubkey, mode: 'forYou', videos: []);
+        expect(dao.store, isEmpty);
+      });
+
+      test('caps the persisted forward window', () async {
+        final videos = List.generate(80, (i) => _video('v$i'));
+        await cache.writeVideos(
+          pubkey: pubkey,
+          mode: 'following',
+          videos: videos,
+        );
+
+        final result = await cache.readVideos(
+          pubkey: pubkey,
+          mode: 'following',
+        );
+        expect(result, hasLength(30));
+        expect(result!.first.id, equals('v0'));
+        expect(result.last.id, equals('v29'));
+      });
+
+      test('separates videos per feed mode', () async {
+        await cache.writeVideos(
+          pubkey: pubkey,
+          mode: 'forYou',
+          videos: [_video('foryou')],
+        );
+        await cache.writeVideos(
+          pubkey: pubkey,
+          mode: 'following',
+          videos: [_video('following')],
+        );
+
+        final forYou = await cache.readVideos(pubkey: pubkey, mode: 'forYou');
+        final following = await cache.readVideos(
+          pubkey: pubkey,
+          mode: 'following',
+        );
+        expect(forYou!.single.id, equals('foryou'));
+        expect(following!.single.id, equals('following'));
       });
 
       test(
-        'ignores legacy unscoped cache entries from older app versions',
+        'scopes entries by account so other accounts do not read them',
         () async {
-          final freshTime = DateTime.now().millisecondsSinceEpoch;
+          await cache.writeVideos(
+            pubkey: pubkey,
+            mode: 'forYou',
+            videos: [_video('mine')],
+          );
 
-          SharedPreferences.setMockInitialValues({
-            'home_feed_cache': validFeedJson(),
-            'home_feed_cache_time': freshTime,
-          });
-          final prefs = await SharedPreferences.getInstance();
-
-          final result = cache.read(prefs);
-
-          expect(result, isNull);
+          final otherAccount = await cache.readVideos(
+            pubkey: 'c' * 64,
+            mode: 'forYou',
+          );
+          final anon = await cache.readVideos(pubkey: null, mode: 'forYou');
+          expect(otherAccount, isNull);
+          expect(anon, isNull);
         },
       );
 
-      test('returns null when cached JSON is invalid', () async {
-        final freshTime = DateTime.now().millisecondsSinceEpoch;
+      test(
+        'keys are prefixed by pubkey so sign-out invalidation clears them',
+        () async {
+          await cache.writeVideos(
+            pubkey: pubkey,
+            mode: 'forYou',
+            videos: [_video('mine')],
+          );
 
-        SharedPreferences.setMockInitialValues({
-          homeFeedCacheKey: 'not valid json',
-          homeFeedCacheTimeKey: freshTime,
-        });
-        final prefs = await SharedPreferences.getInstance();
+          expect(dao.store.keys.single, startsWith('$pubkey:'));
 
-        final result = cache.read(prefs);
-
-        expect(result, isNull);
-      });
-
-      test('filters out videos without valid URLs', () async {
-        final freshTime = DateTime.now().millisecondsSinceEpoch;
-        final json = jsonEncode({
-          'videos': [
-            {
-              'id': 'valid',
-              'pubkey': '0' * 64,
-              'video_url': 'https://example.com/valid.mp4',
-              'created_at': 1000,
-            },
-            {
-              'id': 'no-url',
-              'pubkey': '0' * 64,
-              'video_url': '',
-              'created_at': 999,
-            },
-            {
-              'id': '',
-              'pubkey': '0' * 64,
-              'video_url': 'https://example.com/no-id.mp4',
-              'created_at': 998,
-            },
-          ],
-        });
-
-        SharedPreferences.setMockInitialValues({
-          homeFeedCacheKey: json,
-          homeFeedCacheTimeKey: freshTime,
-        });
-        final prefs = await SharedPreferences.getInstance();
-
-        final result = cache.read(prefs);
-
-        expect(result, isNotNull);
-        expect(result!.videos, hasLength(1));
-        expect(result.videos[0].id, equals('valid'));
-      });
-
-      test('returns null when cache time key is missing', () async {
-        SharedPreferences.setMockInitialValues({
-          homeFeedCacheKey: validFeedJson(),
-          // No time key — defaults to epoch 0, which is > 1 hour ago
-        });
-        final prefs = await SharedPreferences.getInstance();
-
-        final result = cache.read(prefs);
-
-        expect(result, isNull);
-      });
-    });
-
-    group('write', () {
-      test('stores JSON and timestamp in SharedPreferences', () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final json = validFeedJson();
-
-        await cache.write(prefs, json);
-
-        expect(prefs.getString(homeFeedCacheKey), equals(json));
-        expect(prefs.getInt(homeFeedCacheTimeKey), isNotNull);
-        // Timestamp should be within last second
-        final storedTime = prefs.getInt(homeFeedCacheTimeKey)!;
-        final diff = DateTime.now().millisecondsSinceEpoch - storedTime;
-        expect(diff, lessThan(1000));
-      });
-    });
-
-    group('round-trip', () {
-      test('write then read returns valid result', () async {
-        SharedPreferences.setMockInitialValues({});
-        final prefs = await SharedPreferences.getInstance();
-        final json = validFeedJson(videoCount: 3);
-
-        await cache.write(prefs, json);
-        final result = cache.read(prefs);
-
-        expect(result, isNotNull);
-        expect(result!.videos, hasLength(3));
-      });
+          await CacheSync.invalidatePrefix(pubkey);
+          final afterSignOut = await cache.readVideos(
+            pubkey: pubkey,
+            mode: 'forYou',
+          );
+          expect(afterSignOut, isNull);
+        },
+      );
     });
   });
 }

--- a/mobile/test/blocs/video_feed/home_feed_cache_test.dart
+++ b/mobile/test/blocs/video_feed/home_feed_cache_test.dart
@@ -94,6 +94,28 @@ void main() {
         expect(dao.store, isEmpty);
       });
 
+      test(
+        'clearVideos drops an existing entry so a later read is null',
+        () async {
+          await cache.writeVideos(
+            pubkey: pubkey,
+            mode: 'forYou',
+            videos: [_video('a'), _video('b')],
+          );
+          expect(
+            await cache.readVideos(pubkey: pubkey, mode: 'forYou'),
+            isNotNull,
+          );
+
+          await cache.clearVideos(pubkey: pubkey, mode: 'forYou');
+
+          expect(
+            await cache.readVideos(pubkey: pubkey, mode: 'forYou'),
+            isNull,
+          );
+        },
+      );
+
       test('caps the persisted forward window', () async {
         final videos = List.generate(80, (i) => _video('v$i'));
         await cache.writeVideos(

--- a/mobile/test/blocs/video_feed/home_feed_resume_manager_test.dart
+++ b/mobile/test/blocs/video_feed/home_feed_resume_manager_test.dart
@@ -1,0 +1,157 @@
+// ABOUTME: Tests for HomeFeedResumeManager — verifies same-key resume-window
+// ABOUTME: writes are serialised so a slow earlier write cannot clobber the
+// ABOUTME: freshest window.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
+import 'package:openvine/blocs/video_feed/home_feed_resume_manager.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+class _MockVideosRepository extends Mock implements VideosRepository {}
+
+/// [HomeFeedCache] fake whose writes block until [releaseNextWrite] is called,
+/// recording the order in which writes actually *complete* (not just start).
+class _GatedCache implements HomeFeedCache {
+  final List<Completer<void>> _gates = [];
+  final List<List<String>> completedWrites = [];
+  int writeCallCount = 0;
+  int clearCallCount = 0;
+
+  @override
+  Future<void> writeVideos({
+    required String? pubkey,
+    required String mode,
+    required List<VideoEvent> videos,
+  }) async {
+    writeCallCount++;
+    final gate = Completer<void>();
+    _gates.add(gate);
+    await gate.future;
+    completedWrites.add(videos.map((v) => v.id).toList());
+  }
+
+  void releaseNextWrite() {
+    _gates.firstWhere((gate) => !gate.isCompleted).complete();
+  }
+
+  @override
+  Future<void> clearVideos({
+    required String? pubkey,
+    required String mode,
+  }) async {
+    clearCallCount++;
+  }
+
+  @override
+  Future<List<VideoEvent>?> readVideos({
+    required String? pubkey,
+    required String mode,
+  }) async => null;
+}
+
+VideoEvent _video(String id) => VideoEvent(
+  id: id,
+  pubkey: 'a' * 64,
+  createdAt: 1700000000,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(
+    1700000000 * 1000,
+    isUtc: true,
+  ),
+  videoUrl: 'https://cdn.divine.video/$id.mp4',
+);
+
+Future<void> _pump() => Future<void>.delayed(Duration.zero);
+
+void main() {
+  group(HomeFeedResumeManager, () {
+    late _GatedCache cache;
+    late HomeFeedResumeManager manager;
+
+    setUp(() {
+      cache = _GatedCache();
+      manager = HomeFeedResumeManager(
+        cache: cache,
+        videosRepository: _MockVideosRepository(),
+      );
+    });
+
+    test(
+      'serialises same-key writes so a slow earlier write cannot clobber the '
+      'freshest window',
+      () async {
+        // Cold-start order: the stale served window is persisted first, then
+        // the fresh-spliced window. (_resumeOffset is 1, so activeIndex 0
+        // persists sublist(1).)
+        manager.persistNow(
+          pubkey: 'p',
+          mode: 'forYou',
+          videos: [_video('s0'), _video('s1'), _video('s2')],
+          activeIndex: 0,
+        );
+        manager.persistNow(
+          pubkey: 'p',
+          mode: 'forYou',
+          videos: [_video('f0'), _video('f1'), _video('f2')],
+          activeIndex: 0,
+        );
+
+        // The second (fresh) write must not even be issued until the first
+        // completes — without serialisation both would fire immediately and
+        // could complete out of order.
+        await _pump();
+        expect(
+          cache.writeCallCount,
+          1,
+          reason: 'fresh write must wait for the stale write to complete',
+        );
+
+        // Complete the stale write → the fresh write is now issued.
+        cache.releaseNextWrite();
+        await _pump();
+        expect(cache.writeCallCount, 2);
+
+        cache.releaseNextWrite();
+        await _pump();
+
+        // Writes completed strictly in submission order, so the fresh window
+        // is written last and wins.
+        expect(cache.completedWrites, [
+          ['s1', 's2'],
+          ['f1', 'f2'],
+        ]);
+      },
+    );
+
+    test('runs a later write even after an earlier one completes', () async {
+      manager.persistNow(
+        pubkey: 'p',
+        mode: 'forYou',
+        videos: [_video('a0'), _video('a1')],
+        activeIndex: 0,
+      );
+      await _pump();
+      cache.releaseNextWrite();
+      await _pump();
+
+      manager.persistNow(
+        pubkey: 'p',
+        mode: 'forYou',
+        videos: [_video('b0'), _video('b1')],
+        activeIndex: 0,
+      );
+      await _pump();
+      cache.releaseNextWrite();
+      await _pump();
+
+      expect(cache.completedWrites, [
+        ['a1'],
+        ['b1'],
+      ]);
+    });
+  });
+}

--- a/mobile/test/blocs/video_feed/home_feed_resume_manager_test.dart
+++ b/mobile/test/blocs/video_feed/home_feed_resume_manager_test.dart
@@ -153,5 +153,32 @@ void main() {
         ['b1'],
       ]);
     });
+
+    test('serialises a clear behind an earlier in-flight write', () async {
+      manager.persistNow(
+        pubkey: 'p',
+        mode: 'forYou',
+        videos: [_video('a0'), _video('a1')],
+        activeIndex: 0,
+      );
+      manager.persistNow(
+        pubkey: 'p',
+        mode: 'forYou',
+        videos: [_video('b0')],
+        activeIndex: 0,
+      );
+
+      await _pump();
+      expect(cache.writeCallCount, 1);
+      expect(
+        cache.clearCallCount,
+        0,
+        reason: 'clear must wait for the older write to complete',
+      );
+
+      cache.releaseNextWrite();
+      await _pump();
+      expect(cache.clearCallCount, 1);
+    });
   });
 }

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -6,6 +6,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
@@ -33,6 +34,38 @@ class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 class _MockHomeFeedCache extends Mock implements HomeFeedCache {}
 
+/// No-op cache DAO so the bloc tests never touch the shared on-disk
+/// [CacheSync] database. Under CI's parallel test isolates the
+/// path_provider-mocked `/tmp/documents` DB is shared, so the cold-start serve
+/// path cross-contaminates between tests and fails non-deterministically.
+/// Wiring [CacheSync] to a no-op DAO in `setUp` keeps every bloc — whatever
+/// factory built it — on the deterministic fresh-load path. Cache-serve
+/// behaviour is covered separately by the 'cache-first home feed' group, which
+/// injects its own [HomeFeedCache] mock.
+class _FakeCacheDao implements CacheDao {
+  @override
+  Future<String?> read(String key) async => null;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {}
+
+  @override
+  Future<void> delete(String key) async {}
+
+  @override
+  Future<void> deletePrefix(String prefix) async {}
+
+  @override
+  Future<int> totalPayloadBytes() async => 0;
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
 class _FakeSharedPreferences extends Fake implements SharedPreferences {}
 
 void main() {
@@ -45,7 +78,11 @@ void main() {
     late StreamController<List<CuratedList>> curatedListsController;
     late VideoFeedBloc savedModeBloc;
 
-    setUp(() {
+    setUp(() async {
+      // Route the disk cache to a no-op DAO so no bloc — whatever factory
+      // creates it — reads or writes the shared on-disk CacheSync DB.
+      await CacheSync.init(dao: _FakeCacheDao());
+
       mockVideosRepository = _MockVideosRepository();
       mockFollowRepository = _MockFollowRepository();
       mockCuratedListRepository = _MockCuratedListRepository();

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -3102,6 +3102,12 @@ void main() {
             videos: any(named: 'videos'),
           ),
         ).thenAnswer((_) async {});
+        when(
+          () => mockCache.clearVideos(
+            pubkey: any(named: 'pubkey'),
+            mode: any(named: 'mode'),
+          ),
+        ).thenAnswer((_) async {});
       });
 
       tearDown(() {
@@ -3415,6 +3421,41 @@ void main() {
           ).captured;
           final window = captured.last as List<VideoEvent>;
           expect(window.map((v) => v.id), equals(['fresh-3', 'fresh-4']));
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'clears the resume cache when swiped to the end of the window',
+        setUp: () => stubFollowingFetch(createTestVideos(3, idPrefix: 'fresh')),
+        build: createBlocWithCache,
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.following));
+          await Future<void>.delayed(Duration.zero);
+          // Index 2 + offset 1 = 3 == length → nothing left to resume to.
+          bloc.add(const VideoFeedActiveIndexChanged(2));
+        },
+        wait: const Duration(milliseconds: 700),
+        verify: (_) {
+          // An empty forward window must invalidate the key, not no-op — else
+          // the next cold start re-serves already-seen videos.
+          verify(
+            () => mockCache.clearVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: 'following',
+            ),
+          ).called(1);
+          // No write should ever carry an empty list (those route to clear).
+          final writes = verify(
+            () => mockCache.writeVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: any(named: 'mode'),
+              videos: captureAny(named: 'videos'),
+            ),
+          ).captured;
+          expect(
+            writes.every((w) => (w as List<VideoEvent>).isNotEmpty),
+            isTrue,
+          );
         },
       );
     });

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -3365,8 +3365,8 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         verify: (_) {
-          // Active index 0 + offset 2 = 2 → forward window is [fresh-2], so the
-          // next cold start opens past the just-shown video.
+          // Active index 0 + offset 1 = 1 → forward window starts past the
+          // just-shown video, dropping only it.
           final captured = verify(
             () => mockCache.writeVideos(
               pubkey: any(named: 'pubkey'),
@@ -3375,7 +3375,7 @@ void main() {
             ),
           ).captured;
           final window = captured.last as List<VideoEvent>;
-          expect(window.map((v) => v.id), equals(['fresh-2']));
+          expect(window.map((v) => v.id), equals(['fresh-1', 'fresh-2']));
         },
       );
 
@@ -3388,6 +3388,9 @@ void main() {
           await Future<void>.delayed(Duration.zero);
           bloc.add(const VideoFeedActiveIndexChanged(2));
         },
+        // The swipe persist is trailing-debounced, so wait past the debounce
+        // window for the disk write to fire.
+        wait: const Duration(milliseconds: 700),
         expect: () => [
           const VideoFeedBlocState(mode: FeedMode.following),
           isA<VideoFeedBlocState>()
@@ -3400,8 +3403,9 @@ void main() {
           ),
         ],
         verify: (_) {
-          // Last write is the swipe: active index 2 + offset 2 = 4 → [fresh-4].
-          // (An earlier load-time write from index 0 also occurs.)
+          // Last write is the swipe: active index 2 + offset 1 = 3 →
+          // [fresh-3, fresh-4]. (An earlier load-time write from index 0 also
+          // occurs.)
           final captured = verify(
             () => mockCache.writeVideos(
               pubkey: any(named: 'pubkey'),
@@ -3410,7 +3414,7 @@ void main() {
             ),
           ).captured;
           final window = captured.last as List<VideoEvent>;
-          expect(window.map((v) => v.id), equals(['fresh-4']));
+          expect(window.map((v) => v.id), equals(['fresh-3', 'fresh-4']));
         },
       );
     });

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -3086,6 +3086,22 @@ void main() {
           (invocation) =>
               invocation.positionalArguments.first as List<VideoEvent>,
         );
+
+        // Default cache stubs: empty cache, no-op writes. Tests override the
+        // reads to exercise the serve / splice / restore paths.
+        when(
+          () => mockCache.readVideos(
+            pubkey: any(named: 'pubkey'),
+            mode: any(named: 'mode'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockCache.writeVideos(
+            pubkey: any(named: 'pubkey'),
+            mode: any(named: 'mode'),
+            videos: any(named: 'videos'),
+          ),
+        ).thenAnswer((_) async {});
       });
 
       tearDown(() {
@@ -3101,166 +3117,70 @@ void main() {
         homeFeedCache: mockCache,
       );
 
-      blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'emits cached videos then fresh videos on cold start',
-        setUp: () {
-          final cachedVideos = createTestVideos(2, idPrefix: 'cached');
-          final freshVideos = createTestVideos(3, idPrefix: 'fresh');
-
-          when(
-            () => mockCache.read(sharedPreferences),
-          ).thenReturn(HomeFeedResult(videos: cachedVideos));
-          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
-          when(
-            () => mockVideosRepository.getHomeFeedVideos(
-              authors: any(named: 'authors'),
-              videoRefs: any(named: 'videoRefs'),
-              userPubkey: any(named: 'userPubkey'),
-              limit: any(named: 'limit'),
-              until: any(named: 'until'),
-              skipCache: any(named: 'skipCache'),
-            ),
-          ).thenAnswer(
-            (_) async => HomeFeedResult(
-              videos: freshVideos,
-              rawResponseBody: '{"videos":[]}',
-            ),
-          );
-        },
-        build: createBlocWithCache,
-        act: (bloc) =>
-            bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
-        expect: () => [
-          // 1. Loading state from _onStarted
-          const VideoFeedBlocState(mode: FeedMode.following),
-          // 2. Cached videos served immediately
-          isA<VideoFeedBlocState>()
-              .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'cached count', 2)
-              .having((s) => s.videos[0].id, 'first cached id', 'cached-0'),
-          // 3. Fresh videos replace cached
-          isA<VideoFeedBlocState>()
-              .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'fresh count', 3)
-              .having((s) => s.videos[0].id, 'first fresh id', 'fresh-0'),
-        ],
-        verify: (_) {
-          verify(() => mockCache.read(sharedPreferences)).called(1);
-        },
-      );
+      void stubFollowingFetch(List<VideoEvent> videos) {
+        when(
+          () => mockVideosRepository.getHomeFeedVideos(
+            authors: any(named: 'authors'),
+            videoRefs: any(named: 'videoRefs'),
+            userPubkey: any(named: 'userPubkey'),
+            limit: any(named: 'limit'),
+            until: any(named: 'until'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+      }
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'skips cache when no SharedPreferences provided',
+        'serves cached videos then splices fresh after the active video',
         setUp: () {
-          final videos = createTestVideos(3);
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
           when(
-            () => mockVideosRepository.getHomeFeedVideos(
-              authors: any(named: 'authors'),
-              videoRefs: any(named: 'videoRefs'),
-              userPubkey: any(named: 'userPubkey'),
-              limit: any(named: 'limit'),
-              until: any(named: 'until'),
-              skipCache: any(named: 'skipCache'),
+            () => mockCache.readVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: any(named: 'mode'),
             ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
-        },
-        build: () => VideoFeedBloc(
-          videosRepository: mockVideosRepository,
-          followRepository: mockFollowRepository,
-          curatedListRepository: mockCuratedListRepository,
-          homeFeedCache: mockCache,
-          // No sharedPreferences — cache should be skipped
-        ),
-        act: (bloc) =>
-            bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
-        expect: () => [
-          const VideoFeedBlocState(mode: FeedMode.following),
-          isA<VideoFeedBlocState>()
-              .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'count', 3),
-        ],
-        verify: (_) {
-          verifyNever(() => mockCache.read(any()));
-        },
-      );
-
-      blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'skips cache when cache returns null',
-        setUp: () {
-          final videos = createTestVideos(3);
-          when(() => mockCache.read(sharedPreferences)).thenReturn(null);
-          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
-          when(
-            () => mockVideosRepository.getHomeFeedVideos(
-              authors: any(named: 'authors'),
-              videoRefs: any(named: 'videoRefs'),
-              userPubkey: any(named: 'userPubkey'),
-              limit: any(named: 'limit'),
-              until: any(named: 'until'),
-              skipCache: any(named: 'skipCache'),
-            ),
-          ).thenAnswer(
-            (_) async => HomeFeedResult(
-              videos: videos,
-              rawResponseBody: '{"videos":[]}',
-            ),
-          );
+          ).thenAnswer((_) async => createTestVideos(5, idPrefix: 'cached'));
+          stubFollowingFetch(createTestVideos(3, idPrefix: 'fresh'));
         },
         build: createBlocWithCache,
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
           const VideoFeedBlocState(mode: FeedMode.following),
+          // Cached window served instantly at index 0.
           isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'count', 3),
+              .having((s) => s.videos.length, 'cached count', 5)
+              .having((s) => s.currentIndex, 'served index', 0)
+              .having((s) => s.videos.first.id, 'first cached id', 'cached-0'),
+          // Splice: keep [0 .. currentIndex + 1] (cached-0, cached-1) then
+          // fresh, so fresh appears right after the active video:
+          // [cached-0, cached-1, fresh-0, fresh-1, fresh-2].
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'spliced count', 5)
+              .having((s) => s.videos[0].id, 'kept head id', 'cached-0')
+              .having((s) => s.videos[1].id, 'kept lookahead id', 'cached-1')
+              .having((s) => s.videos[2].id, 'first fresh id', 'fresh-0'),
         ],
-      );
-
-      blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'writes raw response body to cache after fresh fetch',
-        setUp: () {
-          final videos = createTestVideos(3);
-          when(() => mockCache.read(sharedPreferences)).thenReturn(null);
-          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
-          when(
-            () => mockVideosRepository.getHomeFeedVideos(
-              authors: any(named: 'authors'),
-              videoRefs: any(named: 'videoRefs'),
-              userPubkey: any(named: 'userPubkey'),
-              limit: any(named: 'limit'),
-              until: any(named: 'until'),
-              skipCache: any(named: 'skipCache'),
-            ),
-          ).thenAnswer(
-            (_) async => HomeFeedResult(
-              videos: videos,
-              rawResponseBody: '{"videos":[{"id":"v1"}]}',
-            ),
-          );
-        },
-        build: createBlocWithCache,
-        act: (bloc) =>
-            bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         verify: (_) {
           verify(
-            () =>
-                mockCache.write(sharedPreferences, '{"videos":[{"id":"v1"}]}'),
+            () => mockCache.readVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: any(named: 'mode'),
+            ),
           ).called(1);
         },
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'does not write forYou response to Home tab cache after fresh fetch',
+        'serves cached For You then refreshes (supersedes #3861 exclusion)',
         setUp: () {
-          final videos = createTestVideos(3);
-          when(() => mockCache.read(sharedPreferences)).thenReturn(null);
-          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+          when(
+            () => mockCache.readVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: any(named: 'mode'),
+            ),
+          ).thenAnswer((_) async => createTestVideos(2, idPrefix: 'cached'));
           when(
             () => mockVideosRepository.getRecommendedVideos(
               userPubkey: any(named: 'userPubkey'),
@@ -3269,136 +3189,55 @@ void main() {
               skipCache: any(named: 'skipCache'),
             ),
           ).thenAnswer(
-            (_) async => HomeFeedResult(
-              videos: videos,
-              rawResponseBody: '{"videos":[{"id":"for-you"}]}',
-            ),
+            (_) async =>
+                HomeFeedResult(videos: createTestVideos(3, idPrefix: 'rec')),
           );
-        },
-        build: createBlocWithCache,
-        act: (bloc) => bloc.add(const VideoFeedStarted()),
-        verify: (_) {
-          // forYou is a recommendation feed and must not be persisted to the
-          // cross-restart cache, otherwise the feed looks identical on every
-          // app reopen (issue #3861).
-          verifyNever(() => mockCache.write(any(), any()));
-        },
-      );
-
-      blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'does not write cache when rawResponseBody is null',
-        setUp: () {
-          final videos = createTestVideos(3);
-          when(() => mockCache.read(sharedPreferences)).thenReturn(null);
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
-          when(
-            () => mockVideosRepository.getHomeFeedVideos(
-              authors: any(named: 'authors'),
-              videoRefs: any(named: 'videoRefs'),
-              userPubkey: any(named: 'userPubkey'),
-              limit: any(named: 'limit'),
-              until: any(named: 'until'),
-              skipCache: any(named: 'skipCache'),
-            ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
-        },
-        build: createBlocWithCache,
-        act: (bloc) =>
-            bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
-        verify: (_) {
-          verifyNever(() => mockCache.write(any(), any()));
-        },
-      );
-
-      blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'does not serve cache for subscribed list source',
-        setUp: () async {
-          final videos = createTestVideos(3);
-          SharedPreferences.setMockInitialValues({
-            'selected_feed_mode': 'list:list-a',
-          });
-          sharedPreferences = await SharedPreferences.getInstance();
-          when(
-            () => mockCuratedListRepository.getListById('list-a'),
-          ).thenReturn(createTestList());
-          when(
-            () => mockCuratedListRepository.getOrderedVideoIds('list-a'),
-          ).thenReturn(['video-a', 'video-b']);
-          when(
-            () => mockVideosRepository.getVideosForList(['video-a', 'video-b']),
-          ).thenAnswer((_) async => videos);
-        },
-        build: createBlocWithCache,
-        act: (bloc) => bloc.add(const VideoFeedStarted()),
-        expect: () => [
-          isA<VideoFeedBlocState>().having(
-            (s) => s.source.type,
-            'source',
-            VideoFeedSourceType.subscribedList,
-          ),
-          isA<VideoFeedBlocState>()
-              .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'count', 3),
-        ],
-        verify: (_) {
-          verifyNever(() => mockCache.read(any()));
-        },
-      );
-
-      blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'does not serve cached Home tab data for forYou recommendations',
-        setUp: () {
-          final recommendedVideos = createTestVideos(
-            3,
-            idPrefix: 'recommended',
-          );
-
-          when(
-            () => mockCache.read(sharedPreferences),
-          ).thenReturn(HomeFeedResult(videos: createTestVideos(2)));
-          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
-          when(
-            () => mockVideosRepository.getRecommendedVideos(
-              userPubkey: any(named: 'userPubkey'),
-              limit: any(named: 'limit'),
-              until: any(named: 'until'),
-              skipCache: any(named: 'skipCache'),
-            ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: recommendedVideos));
         },
         build: createBlocWithCache,
         act: (bloc) => bloc.add(const VideoFeedStarted()),
         expect: () => [
           const VideoFeedBlocState(),
-          // No cached state is emitted — the first success state is the fresh
-          // recommendations straight from the network (issue #3861).
           isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'recommended count', 3)
-              .having(
-                (s) => s.videos.first.id,
-                'first recommended id',
-                'recommended-0',
-              ),
+              .having((s) => s.videos.length, 'cached count', 2)
+              .having((s) => s.videos.first.id, 'first cached id', 'cached-0'),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.videos.length, 'spliced count', 5)
+              .having((s) => s.videos[2].id, 'first fresh id', 'rec-0'),
         ],
         verify: (_) {
-          // forYou must never read the cross-restart cache, otherwise the feed
-          // is identical on every app reopen.
-          verifyNever(() => mockCache.read(any()));
-          verifyNever(() => mockCache.write(any(), any()));
+          verify(
+            () => mockCache.readVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: any(named: 'mode'),
+            ),
+          ).called(1);
         },
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'keeps cached data visible when network fails',
-        setUp: () {
-          final cachedVideos = createTestVideos(2, idPrefix: 'cached');
+        'replaces wholesale when no cache exists',
+        setUp: () => stubFollowingFetch(createTestVideos(3)),
+        build: createBlocWithCache,
+        act: (bloc) =>
+            bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
+        expect: () => [
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'count', 3),
+        ],
+      );
 
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'keeps cached data visible when the network fails',
+        setUp: () {
           when(
-            () => mockCache.read(sharedPreferences),
-          ).thenReturn(HomeFeedResult(videos: cachedVideos));
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+            () => mockCache.readVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: any(named: 'mode'),
+            ),
+          ).thenAnswer((_) async => createTestVideos(2, idPrefix: 'cached'));
           when(
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
@@ -3414,59 +3253,58 @@ void main() {
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          // 1. Loading state
           const VideoFeedBlocState(mode: FeedMode.following),
-          // 2. Cached videos served
           isA<VideoFeedBlocState>()
               .having((s) => s.status, 'status', VideoFeedStatus.success)
               .having((s) => s.videos.length, 'cached count', 2),
-          // No failure state emitted because cached data is displayed
+          // No failure state — cached data stays visible.
         ],
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'serves cache only once per bloc instance',
-        setUp: () {
-          final cachedVideos = createTestVideos(2, idPrefix: 'cached');
-          final freshVideos = createTestVideos(3, idPrefix: 'fresh');
-
+        'does not serve cache for a subscribed list source',
+        setUp: () async {
+          SharedPreferences.setMockInitialValues({
+            'selected_feed_mode': 'list:list-a',
+          });
+          sharedPreferences = await SharedPreferences.getInstance();
           when(
-            () => mockCache.read(sharedPreferences),
-          ).thenReturn(HomeFeedResult(videos: cachedVideos));
-          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
+            () => mockCuratedListRepository.getListById('list-a'),
+          ).thenReturn(createTestList());
           when(
-            () => mockFollowRepository.followingPubkeys,
-          ).thenReturn(['author1']);
+            () => mockCuratedListRepository.getOrderedVideoIds('list-a'),
+          ).thenReturn(['video-a', 'video-b']);
           when(
-            () => mockVideosRepository.getHomeFeedVideos(
-              authors: any(named: 'authors'),
-              videoRefs: any(named: 'videoRefs'),
-              userPubkey: any(named: 'userPubkey'),
-              limit: any(named: 'limit'),
-              until: any(named: 'until'),
-              skipCache: any(named: 'skipCache'),
-            ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: freshVideos));
+            () => mockVideosRepository.getVideosForList(['video-a', 'video-b']),
+          ).thenAnswer((_) async => createTestVideos(3));
         },
         build: createBlocWithCache,
-        act: (bloc) async {
-          bloc.add(const VideoFeedStarted(mode: FeedMode.following));
-          await Future<void>.delayed(Duration.zero);
-          // Trigger a refresh — should NOT serve cache again
-          bloc.add(const VideoFeedRefreshRequested());
-        },
+        act: (bloc) => bloc.add(const VideoFeedStarted()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (s) => s.source.type,
+            'source',
+            VideoFeedSourceType.subscribedList,
+          ),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'count', 3),
+        ],
         verify: (_) {
-          // Cache read should only be called once (on first load)
-          verify(() => mockCache.read(sharedPreferences)).called(1);
+          verifyNever(
+            () => mockCache.readVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: any(named: 'mode'),
+            ),
+          );
         },
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
-        'filters cached videos through '
-        'VideosRepository.applyContentPreferences before emitting them',
+        'filters cached videos through applyContentPreferences',
         setUp: () {
           final hidden = VideoEvent(
-            id: '1111111111111111111111111111111111111111111111111111111111111111',
+            id: '1' * 64,
             pubkey: '0' * 64,
             createdAt: 1704067200,
             content: '',
@@ -3476,7 +3314,7 @@ void main() {
             moderationLabels: const ['nudity'],
           );
           final visible = VideoEvent(
-            id: '2222222222222222222222222222222222222222222222222222222222222222',
+            id: '2' * 64,
             pubkey: '0' * 64,
             createdAt: 1704067200,
             content: '',
@@ -3486,72 +3324,93 @@ void main() {
           );
 
           when(
-            () => mockCache.read(sharedPreferences),
-          ).thenReturn(HomeFeedResult(videos: [hidden, visible]));
-          when(() => mockCache.write(any(), any())).thenAnswer((_) async {});
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
-
-          // Override the default passthrough: drop the hidden video.
+            () => mockCache.readVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: any(named: 'mode'),
+            ),
+          ).thenAnswer((_) async => [hidden, visible]);
           when(
             () => mockVideosRepository.applyContentPreferences(any()),
           ).thenReturn([visible]);
-
-          // Fresh fetch returns the raw, unfiltered pair. This mirrors the
-          // behavior if the cache-path filter were bypassed: the fresh fetch
-          // would still surface the hidden video. The cache-path filter is
-          // the only thing that should drop `hidden` from the emitted state.
-          when(
-            () => mockVideosRepository.getHomeFeedVideos(
-              authors: any(named: 'authors'),
-              videoRefs: any(named: 'videoRefs'),
-              userPubkey: any(named: 'userPubkey'),
-              limit: any(named: 'limit'),
-              until: any(named: 'until'),
-              skipCache: any(named: 'skipCache'),
-            ),
-          ).thenAnswer((_) async => HomeFeedResult(videos: [hidden, visible]));
+          stubFollowingFetch([hidden, visible]);
         },
         build: createBlocWithCache,
         act: (bloc) =>
             bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
         expect: () => [
-          // 1. Loading state from _onStarted
           const VideoFeedBlocState(mode: FeedMode.following),
-          // 2. Cached emission: hidden filtered out via applyContentPreferences
           isA<VideoFeedBlocState>()
-              .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'cached count', 1)
-              .having(
-                (s) => s.videos.first.id,
-                'cached visible id',
-                '2222222222222222222222222222222222222222222222222222222222222222',
-              ),
-          // 3. Fresh fetch result replaces cached state (unfiltered on the
-          //    fresh path — only the cache path is under test here).
-          isA<VideoFeedBlocState>()
-              .having((s) => s.status, 'status', VideoFeedStatus.success)
-              .having((s) => s.videos.length, 'fresh count', 2),
+              .having((s) => s.videos.length, 'filtered cached count', 1)
+              .having((s) => s.videos.first.id, 'visible id', '2' * 64),
+          isA<VideoFeedBlocState>().having(
+            (s) => s.videos.length,
+            'spliced count',
+            2,
+          ),
         ],
         verify: (_) {
-          // Secondary guardrail: confirm the filter was called with the raw,
-          // unfiltered cached list (both hidden and visible).
           final captured = verify(
             () => mockVideosRepository.applyContentPreferences(captureAny()),
           ).captured;
-          expect(captured, isNotEmpty);
           final list = captured.first as List<VideoEvent>;
-          expect(
-            list.map((v) => v.id),
-            contains(
-              '1111111111111111111111111111111111111111111111111111111111111111',
+          expect(list.map((v) => v.id), contains('1' * 64));
+          expect(list.map((v) => v.id), contains('2' * 64));
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'advances the resume window past the active position on a fetch',
+        setUp: () => stubFollowingFetch(createTestVideos(3, idPrefix: 'fresh')),
+        build: createBlocWithCache,
+        act: (bloc) =>
+            bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
+        verify: (_) {
+          // Active index 0 + offset 2 = 2 → forward window is [fresh-2], so the
+          // next cold start opens past the just-shown video.
+          final captured = verify(
+            () => mockCache.writeVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: 'following',
+              videos: captureAny(named: 'videos'),
             ),
-          );
-          expect(
-            list.map((v) => v.id),
-            contains(
-              '2222222222222222222222222222222222222222222222222222222222222222',
+          ).captured;
+          final window = captured.last as List<VideoEvent>;
+          expect(window.map((v) => v.id), equals(['fresh-2']));
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'on swipe, persists the forward window starting past the active video',
+        setUp: () => stubFollowingFetch(createTestVideos(5, idPrefix: 'fresh')),
+        build: createBlocWithCache,
+        act: (bloc) async {
+          bloc.add(const VideoFeedStarted(mode: FeedMode.following));
+          await Future<void>.delayed(Duration.zero);
+          bloc.add(const VideoFeedActiveIndexChanged(2));
+        },
+        expect: () => [
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'count', 5),
+          isA<VideoFeedBlocState>().having(
+            (s) => s.currentIndex,
+            'active index',
+            2,
+          ),
+        ],
+        verify: (_) {
+          // Last write is the swipe: active index 2 + offset 2 = 4 → [fresh-4].
+          // (An earlier load-time write from index 0 also occurs.)
+          final captured = verify(
+            () => mockCache.writeVideos(
+              pubkey: any(named: 'pubkey'),
+              mode: 'following',
+              videos: captureAny(named: 'videos'),
             ),
-          );
+          ).captured;
+          final window = captured.last as List<VideoEvent>;
+          expect(window.map((v) => v.id), equals(['fresh-4']));
         },
       );
     });

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -231,7 +231,9 @@ void main() {
       await tester.pump();
     });
 
-    testWidgets('requests auto-refresh when app resumes', (tester) async {
+    testWidgets('requests auto-refresh when app returns from background', (
+      tester,
+    ) async {
       final video = createTestVideoEvent();
       final state = VideoFeedBlocState(
         status: VideoFeedStatus.success,
@@ -260,6 +262,10 @@ void main() {
       );
       await tester.pump();
 
+      // A genuine background → foreground transition: background first, then
+      // resume. Only then should an auto-refresh be requested.
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+      await tester.pump();
       tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
       await tester.pump();
 
@@ -271,6 +277,54 @@ void main() {
       await tester.pumpWidget(const SizedBox());
       await tester.pump();
     });
+
+    testWidgets(
+      'does not auto-refresh on cold-start resume (no prior background)',
+      (tester) async {
+        final video = createTestVideoEvent();
+        final state = VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: [video],
+        );
+        when(() => videoFeedBloc.state).thenReturn(state);
+        whenListen(
+          videoFeedBloc,
+          const Stream<VideoFeedBlocState>.empty(),
+          initialState: state,
+        );
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+                BlocProvider<VideoPlaybackStatusCubit>(
+                  create: (_) => VideoPlaybackStatusCubit(),
+                ),
+                BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+              ],
+              child: const VideoFeedView(),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // The launch `resumed` event with no preceding background must not
+        // trigger an auto-refresh — it would wipe the just-served cached feed.
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pump();
+
+        verifyNever(
+          () => videoFeedBloc.add(const VideoFeedAutoRefreshRequested()),
+        );
+
+        await tester.pump(const Duration(seconds: 3));
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      },
+    );
 
     testWidgets('passes restored home index to FeedVideos', (tester) async {
       final videos = [

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -157,6 +157,27 @@ void main() {
 
         expect(filter(video), isFalse);
       });
+
+      test(
+        'still hides a video whose moderationLabels survived a cache '
+        'round-trip',
+        () {
+          final filter = createNsfwFilter(
+            contentFilterService,
+            moderationLabelService: moderationLabelService,
+          );
+          // The home-feed cache stores videos via toJson and rehydrates them
+          // via fromJson on cold start. The ML "hide" signal must survive that
+          // trip, otherwise a moderated video slips past the filter while the
+          // cached window is served.
+          final original = _createVideo(moderationLabels: ['nudity']);
+          final cached = VideoEvent.fromJson(original.toJson());
+
+          expect(filter(original), isTrue);
+          expect(cached.moderationLabels, equals(['nudity']));
+          expect(filter(cached), isTrue);
+        },
+      );
     });
 
     group('NSFW hashtag detection', () {


### PR DESCRIPTION
## Description

Eliminates the 2–3s cold-start loading spinner on the home feed by serving a
locally-cached **forward window** of videos instantly, while refreshing from
funnelcake in parallel.

**Behaviour (For You / Following / New — Explore unchanged):**

- **Cold start:** the cached forward window is served instantly at index 0
  (no spinner). Already-watched videos are not included, so the user resumes on
  the next unseen video and can't scroll back into seen content.
- **Resume advances forward:** the resume window is persisted on serve, load,
  and swipe (active position + 2), so each reopen continues forward instead of
  repeating the same video.
- **Fresh splice without a restart:** when the funnelcake response lands, the
  list is trimmed to the active video + 1 lookahead and the fresh results are
  spliced in right after it. `InfiniteVideoFeed` now preserves the controllers
  for the unchanged common prefix and rebuilds only the changed tail, so the
  currently-playing video is **not** torn down/restarted.

**Key pieces:**

- `HomeFeedCache` — stores the forward window via `CacheSync`, account- and
  mode-scoped (sign-out clears it through the existing `invalidatePrefix`).
- `VideoFeedBloc` — serve-before-fetch, splice-after-active, advance-on-reopen.
- `InfiniteVideoFeed` — common-prefix-preserving list updates (full teardown
  only when the active video or something before it actually changes, e.g. a
  For You → Following switch).
- `CacheSync.read/write` (direct disk access), `VideoEvent.fromJson`
  (cache round-trip), and `CacheSync.init` moved to the **critical** startup
  phase so the cache is ready before the feed's first read.

**Related Issue:** Relates to #3861 and #5021 — the resume + always-fresh-tail
design supersedes their earlier For You cold-start mitigations.

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/728d6584-3a5f-4369-8e66-402e8ac53808" width="300" controls></video> | <video src="https://github.com/user-attachments/assets/032fb977-47dd-4424-9781-3c774f6126ee" width="300" controls></video> |

## Out of Scope

- Removing the brief loading-indicator overlay on `VideoLoadingPlaceholder`
  (the spinner painted over the thumbnail while the player decodes the first
  frame). Root-caused but intentionally **not** changed here.

## Verification

- `flutter analyze lib test integration_test` → No issues found
- App tests: `video_feed_bloc_test`, `home_feed_cache_test`,
  `video_feed_page_test`, `feed_videos_test`, `video_loading_placeholder_test`
- Package tests: `cache_sync`, `models` (`video_event_from_json`),
  `infinite_video_feed` widget tests (incl. new "tail replacement past the
  active index keeps the active index")
- Note: 4 timing/environment-sensitive **service** tests in
  `infinite_video_feed` (`load_watchdog`, `stale_playback_detector`,
  `controller_subscriptions`, `source_loader`) fail in the sandbox
  independently of this change (verified by reverting the diff) — not touched
  by this PR.

**Manual test plan:**
- Scroll to ~video N, kill the app, reopen → resumes near N+2 instantly,
  no spinner, no scroll-back to seen videos.
- When the fresh feed lands, the active video keeps playing (no reload/spinner).
- Reopen without scrolling → advances to the next video.
- Explore feed loads as before.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
