### PR TITLE
refactor(profile): use BrandedLoadingIndicator in profile tab loaders

### DIFF
--- a/mobile/lib/widgets/profile/profile_tab_loading_more_sliver.dart
+++ b/mobile/lib/widgets/profile/profile_tab_loading_more_sliver.dart
@@ -1,8 +1,8 @@
 // ABOUTME: Shared loading-more sliver for profile tab grids
 // ABOUTME: Shows a spinner at the bottom of the grid during pagination
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 
 /// A [SliverToBoxAdapter] spinner displayed at the bottom of a profile
 /// tab grid while more items are being fetched.
@@ -18,9 +18,7 @@ class ProfileTabLoadingMoreSliver extends StatelessWidget {
         16,
         16 + MediaQuery.viewPaddingOf(context).bottom,
       ),
-      child: const Center(
-        child: CircularProgressIndicator(color: VineTheme.primary),
-      ),
+      child: const Center(child: BrandedLoadingIndicator(size: 64)),
     ),
   );
 }

--- a/mobile/lib/widgets/profile/profile_tab_loading_state.dart
+++ b/mobile/lib/widgets/profile/profile_tab_loading_state.dart
@@ -4,6 +4,7 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 
 /// Reusable loading indicator displayed inside a profile tab while content
 /// is being fetched.
@@ -28,7 +29,7 @@ class ProfileTabLoadingState extends StatelessWidget {
             mainAxisSize: .min,
             spacing: 16,
             children: [
-              const CircularProgressIndicator(color: VineTheme.primary),
+              const BrandedLoadingIndicator(size: 64),
               if (message != null)
                 Text(
                   message!,

--- a/mobile/test/widgets/profile/profile_collabs_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_collabs_grid_test.dart
@@ -13,6 +13,7 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_collabs_grid.dart';
 
 import '../../helpers/go_router.dart';
@@ -101,7 +102,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('loading indicator when status is loading', (
@@ -115,7 +116,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('error message when status is failure', (tester) async {
@@ -192,7 +193,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
     });
 

--- a/mobile/test/widgets/profile/profile_comments_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_comments_grid_test.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/profile_comments/profile_comments_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/profile/profile_comments_grid.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -100,7 +101,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('loading indicator when status is loading', (tester) async {
@@ -110,7 +111,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('error message when status is failure', (tester) async {
@@ -259,7 +260,7 @@ void main() {
         await tester.pumpWidget(buildSubject());
 
         // One for the bottom loading indicator
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
     });
 

--- a/mobile/test/widgets/profile/profile_liked_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_liked_grid_test.dart
@@ -10,6 +10,7 @@ import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.da
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_liked_grid.dart';
 
 import '../../helpers/go_router.dart';
@@ -94,7 +95,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('loading indicator when status is syncing', (
@@ -108,7 +109,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('loading indicator when status is loading', (
@@ -122,7 +123,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('error message when status is failure', (tester) async {
@@ -203,7 +204,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
     });
 

--- a/mobile/test/widgets/profile/profile_reposts_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_reposts_grid_test.dart
@@ -10,6 +10,7 @@ import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_b
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_reposts_grid.dart';
 
 import '../../helpers/go_router.dart';
@@ -94,7 +95,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('loading indicator when status is syncing', (
@@ -108,7 +109,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('loading indicator when status is loading', (
@@ -122,7 +123,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('error message when status is failure', (tester) async {
@@ -205,7 +206,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
     });
 

--- a/mobile/test/widgets/profile/profile_saved_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_saved_grid_test.dart
@@ -10,6 +10,7 @@ import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.da
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_event_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_saved_grid.dart';
 
 import '../../helpers/go_router.dart';
@@ -84,7 +85,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('loading indicator when status is syncing', (tester) async {
@@ -96,7 +97,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('loading indicator when status is loading', (tester) async {
@@ -108,7 +109,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('error message when status is failure', (tester) async {
@@ -167,7 +168,7 @@ void main() {
 
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
     });
 

--- a/mobile/test/widgets/profile/profile_tab_loading_more_sliver_test.dart
+++ b/mobile/test/widgets/profile/profile_tab_loading_more_sliver_test.dart
@@ -2,6 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_tab_loading_more_sliver.dart';
 
 void main() {
@@ -18,10 +19,10 @@ void main() {
     }
 
     group('renders', () {
-      testWidgets('$CircularProgressIndicator', (tester) async {
+      testWidgets('$BrandedLoadingIndicator', (tester) async {
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('$SliverToBoxAdapter', (tester) async {

--- a/mobile/test/widgets/profile/profile_tab_loading_state_test.dart
+++ b/mobile/test/widgets/profile/profile_tab_loading_state_test.dart
@@ -2,6 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/profile/profile_tab_loading_state.dart';
 
 void main() {
@@ -16,10 +17,10 @@ void main() {
     }
 
     group('renders', () {
-      testWidgets('$CircularProgressIndicator', (tester) async {
+      testWidgets('$BrandedLoadingIndicator', (tester) async {
         await tester.pumpWidget(buildSubject());
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
 
       testWidgets('$CustomScrollView with $SliverFillRemaining', (


### PR DESCRIPTION
Closes #5241

## Description

The profile tab loading state and the load-more sliver showed a plain
`CircularProgressIndicator(color: VineTheme.primary)`, inconsistent with
the branded sprite-sheet loader (`BrandedLoadingIndicator`) used across
the rest of the app — feeds, explore, sounds, followers/following, etc.

This swaps both profile-tab loaders to `BrandedLoadingIndicator(size: 64)`
and updates every widget test that asserts on the loading indicator.

**Changed loaders**
- `profile_tab_loading_state.dart` — full-tab loading spinner
- `profile_tab_loading_more_sliver.dart` — bottom-of-grid pagination spinner

**Test updates** (the grids render the two shared loaders, so their
loading assertions moved from `CircularProgressIndicator` to
`BrandedLoadingIndicator`):
- `profile_tab_loading_state_test.dart`, `profile_tab_loading_more_sliver_test.dart`
- `profile_liked_grid_test.dart`, `profile_saved_grid_test.dart`,
  `profile_reposts_grid_test.dart`, `profile_comments_grid_test.dart`,
  `profile_collabs_grid_test.dart`

`ProfileVideosGrid` (uses `PartialCircleSpinner`) and `ProfileLoadingView`
(its own indicator) are unaffected and left untouched.

**Related Issue:** Relates to # (UI consistency cleanup)

## Out of Scope

None.

## Verification

- `flutter analyze test/widgets/profile lib/widgets/profile` → no issues
- `flutter test test/widgets/profile` → 221 passed
- Pre-commit + pre-push hooks (format, analyze, codegen, changed-file tests) green

## Type of Change

- [x] 🧹 Code refactor
