### PR TITLE
fix(feed): give the native "Verify age" button visible feedback

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -613,6 +613,7 @@
     "videoErrorVerifyAgeBody": "ይህን ቪዲዮ ለማየት እድሜዎን ያረጋግጡ።",
     "videoErrorSkip": "ዝለል",
     "videoErrorVerifyAgeButton": "ዕድሜን ያረጋግጡ",
+    "videoErrorVerifyAgeFailed": "ዕድሜህን ማረጋገጥ አልተቻለም። እባክህ እንደገና ሞክር",
     "videoFollowButtonFollowing": "በመከተል ላይ",
     "videoFollowButtonFollow": "ተከተል",
     "audioAttributionOriginalSound": "ኦሪጅናል ድምጽ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "تحقّق من عمرك لعرض هذا الفيديو.",
     "videoErrorSkip": "تخطّي",
     "videoErrorVerifyAgeButton": "تحقّق من العمر",
+    "videoErrorVerifyAgeFailed": "تعذّر التحقق من عمرك. يرجى المحاولة مرّة أخرى.",
     "videoFollowButtonFollowing": "متابع",
     "videoFollowButtonFollow": "متابعة",
     "audioAttributionOriginalSound": "صوت أصلي",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -560,6 +560,7 @@
     "videoErrorVerifyAgeBody": "Потвърди възрастта си, за да гледаш това видео.",
     "videoErrorSkip": "Пропусни",
     "videoErrorVerifyAgeButton": "Потвърди възрастта",
+    "videoErrorVerifyAgeFailed": "Възрастта ти не можа да бъде потвърдена. Опитай пак.",
     "videoFollowButtonFollowing": "Следване",
     "videoFollowButtonFollow": "Следвай",
     "audioAttributionOriginalSound": "Оригинален звук",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Verifiziere dein Alter, um dieses Video zu sehen.",
     "videoErrorSkip": "Überspringen",
     "videoErrorVerifyAgeButton": "Alter verifizieren",
+    "videoErrorVerifyAgeFailed": "Wir konnten dein Alter nicht bestätigen. Bitte versuch es nochmal.",
     "videoFollowButtonFollowing": "Gefolgt",
     "videoFollowButtonFollow": "Folgen",
     "audioAttributionOriginalSound": "Originalton",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -665,6 +665,7 @@
   "videoErrorVerifyAgeBody": "Verify your age to view this video.",
   "videoErrorSkip": "Skip",
   "videoErrorVerifyAgeButton": "Verify age",
+  "videoErrorVerifyAgeFailed": "Couldn't verify your age. Please try again.",
   "videoFollowButtonFollowing": "Following",
   "videoFollowButtonFollow": "Follow",
   "audioAttributionOriginalSound": "Original sound",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Verificá tu edad para ver este video.",
     "videoErrorSkip": "Saltar",
     "videoErrorVerifyAgeButton": "Verificar edad",
+    "videoErrorVerifyAgeFailed": "No pudimos verificar tu edad. Inténtalo de nuevo.",
     "videoFollowButtonFollowing": "Siguiendo",
     "videoFollowButtonFollow": "Seguir",
     "audioAttributionOriginalSound": "Sonido original",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -359,6 +359,7 @@
     "videoErrorVerifyAgeBody": "I-verify ang edad mo para mapanood ang video na ito.",
     "videoErrorSkip": "Laktawan",
     "videoErrorVerifyAgeButton": "I-verify ang edad",
+    "videoErrorVerifyAgeFailed": "Hindi na-verify ang edad mo. Subukan ulit.",
     "videoFollowButtonFollowing": "Sinusundan",
     "videoFollowButtonFollow": "Sundan",
     "audioAttributionOriginalSound": "Original sound",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Vérifie ton âge pour voir cette vidéo.",
     "videoErrorSkip": "Passer",
     "videoErrorVerifyAgeButton": "Vérifier l'âge",
+    "videoErrorVerifyAgeFailed": "Impossible de vérifier ton âge. Réessaie.",
     "videoFollowButtonFollowing": "Abonné",
     "videoFollowButtonFollow": "Suivre",
     "audioAttributionOriginalSound": "Son original",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Verifikasi usiamu untuk melihat video ini.",
     "videoErrorSkip": "Lewati",
     "videoErrorVerifyAgeButton": "Verifikasi usia",
+    "videoErrorVerifyAgeFailed": "Tidak dapat memverifikasi usia kamu. Silakan coba lagi.",
     "videoFollowButtonFollowing": "Mengikuti",
     "videoFollowButtonFollow": "Ikuti",
     "audioAttributionOriginalSound": "Suara asli",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Verifica la tua età per vedere questo video.",
     "videoErrorSkip": "Salta",
     "videoErrorVerifyAgeButton": "Verifica età",
+    "videoErrorVerifyAgeFailed": "Non è stato possibile verificare la tua età. Riprova.",
     "videoFollowButtonFollowing": "Segui già",
     "videoFollowButtonFollow": "Segui",
     "audioAttributionOriginalSound": "Audio originale",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "この動画を見るには年齢確認が必要だよ。",
     "videoErrorSkip": "スキップ",
     "videoErrorVerifyAgeButton": "年齢を確認",
+    "videoErrorVerifyAgeFailed": "年齢を確認できませんでした。もう一回試してみて",
     "videoFollowButtonFollowing": "フォロー中",
     "videoFollowButtonFollow": "フォロー",
     "audioAttributionOriginalSound": "オリジナルサウンド",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -329,6 +329,7 @@
     "videoErrorVerifyAgeBody": "이 영상을 보려면 나이를 인증해주세요.",
     "videoErrorSkip": "건너뛰기",
     "videoErrorVerifyAgeButton": "나이 인증",
+    "videoErrorVerifyAgeFailed": "나이를 확인할 수 없습니다. 다시 시도해보세요",
     "videoFollowButtonFollowing": "팔로잉",
     "videoFollowButtonFollow": "팔로우",
     "audioAttributionOriginalSound": "오리지널 사운드",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Verifieer je leeftijd om deze video te bekijken.",
     "videoErrorSkip": "Overslaan",
     "videoErrorVerifyAgeButton": "Leeftijd verifiëren",
+    "videoErrorVerifyAgeFailed": "We konden je leeftijd niet verifiëren. Probeer het opnieuw.",
     "videoFollowButtonFollowing": "Volgend",
     "videoFollowButtonFollow": "Volgen",
     "audioAttributionOriginalSound": "Origineel geluid",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Zweryfikuj swój wiek, żeby zobaczyć ten film.",
     "videoErrorSkip": "Pomiń",
     "videoErrorVerifyAgeButton": "Zweryfikuj wiek",
+    "videoErrorVerifyAgeFailed": "Nie udało się zweryfikować Twojego wieku. Spróbuj ponownie.",
     "videoFollowButtonFollowing": "Obserwujesz",
     "videoFollowButtonFollow": "Obserwuj",
     "audioAttributionOriginalSound": "Oryginalny dźwięk",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Verifique sua idade para ver este vídeo.",
     "videoErrorSkip": "Pular",
     "videoErrorVerifyAgeButton": "Verificar idade",
+    "videoErrorVerifyAgeFailed": "Não foi possível verificar sua idade. Por favor, tente novamente.",
     "videoFollowButtonFollowing": "Seguindo",
     "videoFollowButtonFollow": "Seguir",
     "audioAttributionOriginalSound": "Som original",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Verifică-ți vârsta ca să vezi acest videoclip.",
     "videoErrorSkip": "Sari peste",
     "videoErrorVerifyAgeButton": "Verifică vârsta",
+    "videoErrorVerifyAgeFailed": "Nu am putut verifica vârsta. Încearcă din nou.",
     "videoFollowButtonFollowing": "Urmărit",
     "videoFollowButtonFollow": "Urmărește",
     "audioAttributionOriginalSound": "Sunet original",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Verifiera din ålder för att se den här videon.",
     "videoErrorSkip": "Hoppa över",
     "videoErrorVerifyAgeButton": "Verifiera ålder",
+    "videoErrorVerifyAgeFailed": "Det gick inte att verifiera din ålder. Försök igen.",
     "videoFollowButtonFollowing": "Följer",
     "videoFollowButtonFollow": "Följ",
     "audioAttributionOriginalSound": "Originalljud",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -531,6 +531,7 @@
     "videoErrorVerifyAgeBody": "Bu videoyu görüntülemek için yaşını doğrula.",
     "videoErrorSkip": "Atla",
     "videoErrorVerifyAgeButton": "Yaşı doğrula",
+    "videoErrorVerifyAgeFailed": "Yaşın doğrulanamadı. Lütfen tekrar dene.",
     "videoFollowButtonFollowing": "Takip ediliyor",
     "videoFollowButtonFollow": "Takip et",
     "audioAttributionOriginalSound": "Orijinal ses",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -2500,6 +2500,12 @@ abstract class AppLocalizations {
   /// **'Verify age'**
   String get videoErrorVerifyAgeButton;
 
+  /// No description provided for @videoErrorVerifyAgeFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t verify your age. Please try again.'**
+  String get videoErrorVerifyAgeFailed;
+
   /// No description provided for @videoFollowButtonFollowing.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -1358,6 +1358,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'ዕድሜን ያረጋግጡ';
 
   @override
+  String get videoErrorVerifyAgeFailed => 'ዕድሜህን ማረጋገጥ አልተቻለም። እባክህ እንደገና ሞክር';
+
+  @override
   String get videoFollowButtonFollowing => 'በመከተል ላይ';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -1374,6 +1374,10 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'تحقّق من العمر';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'تعذّر التحقق من عمرك. يرجى المحاولة مرّة أخرى.';
+
+  @override
   String get videoFollowButtonFollowing => 'متابع';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -1417,6 +1417,10 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Потвърди възрастта';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Възрастта ти не можа да бъде потвърдена. Опитай пак.';
+
+  @override
   String get videoFollowButtonFollowing => 'Следване';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -1413,6 +1413,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Alter verifizieren';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Wir konnten dein Alter nicht bestätigen. Bitte versuch es nochmal.';
+
+  @override
   String get videoFollowButtonFollowing => 'Gefolgt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -1395,6 +1395,10 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Verify age';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Couldn\'t verify your age. Please try again.';
+
+  @override
   String get videoFollowButtonFollowing => 'Following';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -1415,6 +1415,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Verificar edad';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'No pudimos verificar tu edad. Inténtalo de nuevo.';
+
+  @override
   String get videoFollowButtonFollowing => 'Siguiendo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -1422,6 +1422,10 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'I-verify ang edad';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Hindi na-verify ang edad mo. Subukan ulit.';
+
+  @override
   String get videoFollowButtonFollowing => 'Sinusundan';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -1422,6 +1422,10 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Vérifier l\'âge';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Impossible de vérifier ton âge. Réessaie.';
+
+  @override
   String get videoFollowButtonFollowing => 'Abonné';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -1372,6 +1372,10 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Verifikasi usia';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Tidak dapat memverifikasi usia kamu. Silakan coba lagi.';
+
+  @override
   String get videoFollowButtonFollowing => 'Mengikuti';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -1417,6 +1417,10 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Verifica età';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Non è stato possibile verificare la tua età. Riprova.';
+
+  @override
   String get videoFollowButtonFollowing => 'Segui già';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -1306,6 +1306,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoErrorVerifyAgeButton => '年齢を確認';
 
   @override
+  String get videoErrorVerifyAgeFailed => '年齢を確認できませんでした。もう一回試してみて';
+
+  @override
   String get videoFollowButtonFollowing => 'フォロー中';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -1314,6 +1314,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoErrorVerifyAgeButton => '나이 인증';
 
   @override
+  String get videoErrorVerifyAgeFailed => '나이를 확인할 수 없습니다. 다시 시도해보세요';
+
+  @override
   String get videoFollowButtonFollowing => '팔로잉';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -1403,6 +1403,10 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Leeftijd verifiëren';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'We konden je leeftijd niet verifiëren. Probeer het opnieuw.';
+
+  @override
   String get videoFollowButtonFollowing => 'Volgend';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -1414,6 +1414,10 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Zweryfikuj wiek';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Nie udało się zweryfikować Twojego wieku. Spróbuj ponownie.';
+
+  @override
   String get videoFollowButtonFollowing => 'Obserwujesz';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -1413,6 +1413,10 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Verificar idade';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Não foi possível verificar sua idade. Por favor, tente novamente.';
+
+  @override
   String get videoFollowButtonFollowing => 'Seguindo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -1430,6 +1430,10 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Verifică vârsta';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Nu am putut verifica vârsta. Încearcă din nou.';
+
+  @override
   String get videoFollowButtonFollowing => 'Urmărit';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -1391,6 +1391,10 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Verifiera ålder';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Det gick inte att verifiera din ålder. Försök igen.';
+
+  @override
   String get videoFollowButtonFollowing => 'Följer';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -1377,6 +1377,10 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoErrorVerifyAgeButton => 'Yaşı doğrula';
 
   @override
+  String get videoErrorVerifyAgeFailed =>
+      'Yaşın doğrulanamadı. Lütfen tekrar dene.';
+
+  @override
   String get videoFollowButtonFollowing => 'Takip ediliyor';
 
   @override

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -20,6 +22,15 @@ Future<void> retryAgeRestrictedPooledVideo({
   required int index,
   required FutureOr<bool> Function(Map<String, String>) retryPlayback,
 }) async {
+  // The pooled overlays (ModeratedContentOverlay / PooledVideoErrorOverlay)
+  // emit no tap-time log of their own, so this is the only record that the
+  // user actually pressed "Verify age" on the native feed path.
+  Log.info(
+    '🔐 [AGE-GATE] User tapped Verify age (pooled) for video ${video.id}',
+    name: _logName,
+    category: LogCategory.video,
+  );
+
   final videoUrl = video.videoUrl;
   if (videoUrl == null || videoUrl.isEmpty) {
     Log.warning(
@@ -28,6 +39,7 @@ Future<void> retryAgeRestrictedPooledVideo({
       name: _logName,
       category: LogCategory.video,
     );
+    _showVerifyAgeFailed(context);
     return;
   }
 
@@ -44,6 +56,7 @@ Future<void> retryAgeRestrictedPooledVideo({
       name: _logName,
       category: LogCategory.video,
     );
+    _showVerifyAgeFailed(context);
     return;
   }
 
@@ -56,7 +69,19 @@ Future<void> retryAgeRestrictedPooledVideo({
         serverUrl: _extractServerUrl(videoUrl),
         category: 'video',
       );
-  if (headers == null || !context.mounted) {
+  if (!context.mounted) return;
+  if (headers == null) {
+    // handleUnauthorizedMedia returns null both when the viewer declines the
+    // age dialog (a deliberate choice — stay silent) and when they accept but
+    // the signed viewer-auth header could not be created (e.g. a remote signer
+    // that failed or timed out). Distinguish the two by the persisted
+    // verification flag so an auth failure isn't a silent no-op.
+    final accepted = ref
+        .read(ageVerificationServiceProvider)
+        .isAdultContentVerified;
+    if (accepted) {
+      _showVerifyAgeFailed(context);
+    }
     return;
   }
 
@@ -65,9 +90,22 @@ Future<void> retryAgeRestrictedPooledVideo({
   // applies these headers to every resolved playback source (optimized/HLS/raw)
   // for the retried item.
   final playbackSucceeded = await retryPlayback(headers);
-  if (!context.mounted || !playbackSucceeded) return;
+  if (!context.mounted) return;
+  if (!playbackSucceeded) {
+    _showVerifyAgeFailed(context);
+    return;
+  }
 
   playbackStatusCubit.report(video.id, PlaybackStatus.ready);
+}
+
+/// Surfaces a localized failure so a tapped "Verify age" button is never a
+/// silent no-op when verification can't complete.
+void _showVerifyAgeFailed(BuildContext context) {
+  if (!context.mounted) return;
+  ScaffoldMessenger.of(context).showSnackBar(
+    DivineSnackbarContainer.snackBar(context.l10n.videoErrorVerifyAgeFailed),
+  );
 }
 
 String? _resolveSha256(VideoEvent video) {

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests age-verification retry wiring for pooled native feed videos.
-// ABOUTME: Verifies successful auth triggers playback reload and clears gate state.
+// ABOUTME: Verifies successful auth reloads playback and failures surface feedback.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -9,11 +9,16 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
+import 'package:openvine/services/age_verification_service.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
 
 class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
+
+class _MockAgeVerificationService extends Mock
+    implements AgeVerificationService {}
 
 class _FakeBuildContext extends Fake implements BuildContext {}
 
@@ -24,6 +29,15 @@ const _pubkey =
 const _sha256 =
     'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
 const _videoUrl = 'https://media.divine.video/$_sha256/720p.mp4';
+
+String get _failureText =>
+    lookupAppLocalizations(const Locale('en')).videoErrorVerifyAgeFailed;
+
+AgeVerificationService _ageService({required bool verified}) {
+  final service = _MockAgeVerificationService();
+  when(() => service.isAdultContentVerified).thenReturn(verified);
+  return service;
+}
 
 void main() {
   setUpAll(() {
@@ -70,6 +84,7 @@ void main() {
 
       await tester.tap(find.text('Verify'));
       await tester.pump();
+      await tester.pump();
 
       expect(retryCount, 1);
       expect(retryHeaders, equals({'Authorization': 'Nostr token'}));
@@ -77,9 +92,12 @@ void main() {
         playbackStatusCubit.state.statusFor(_videoId),
         PlaybackStatus.ready,
       );
+      expect(find.text(_failureText), findsNothing);
     });
 
-    testWidgets('keeps gate state when auth is cancelled', (tester) async {
+    testWidgets('keeps gate state and stays silent when auth is declined', (
+      tester,
+    ) async {
       final mediaAuthInterceptor = _MockMediaAuthInterceptor();
       final playbackStatusCubit = VideoPlaybackStatusCubit();
       var retryCount = 0;
@@ -99,6 +117,8 @@ void main() {
         _RetryHarness(
           mediaAuthInterceptor: mediaAuthInterceptor,
           playbackStatusCubit: playbackStatusCubit,
+          // Declining the age dialog leaves the viewer unverified.
+          ageVerificationService: _ageService(verified: false),
           retryPlayback: (_) {
             retryCount++;
             return true;
@@ -110,15 +130,66 @@ void main() {
 
       await tester.tap(find.text('Verify'));
       await tester.pump();
+      await tester.pump();
 
       expect(retryCount, 0);
       expect(
         playbackStatusCubit.state.statusFor(_videoId),
         PlaybackStatus.ageRestricted,
       );
+      // A deliberate decline must not surface a failure message.
+      expect(find.text(_failureText), findsNothing);
     });
 
-    testWidgets('keeps gate state when authenticated retry fails', (
+    testWidgets(
+      'surfaces feedback when the viewer accepts but auth headers cannot be '
+      'created',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        final playbackStatusCubit = VideoPlaybackStatusCubit();
+        var retryCount = 0;
+        addTearDown(playbackStatusCubit.close);
+
+        // handleUnauthorizedMedia returns null even though the viewer accepted
+        // (e.g. a remote signer that failed to produce the viewer-auth header).
+        when(
+          () => mediaAuthInterceptor.handleUnauthorizedMedia(
+            context: any(named: 'context'),
+            sha256Hash: _sha256,
+            url: _videoUrl,
+            serverUrl: 'https://media.divine.video',
+            category: 'video',
+          ),
+        ).thenAnswer((_) async => null);
+
+        await tester.pumpWidget(
+          _RetryHarness(
+            mediaAuthInterceptor: mediaAuthInterceptor,
+            playbackStatusCubit: playbackStatusCubit,
+            ageVerificationService: _ageService(verified: true),
+            retryPlayback: (_) {
+              retryCount++;
+              return true;
+            },
+          ),
+        );
+
+        playbackStatusCubit.report(_videoId, PlaybackStatus.ageRestricted);
+
+        await tester.tap(find.text('Verify'));
+        await tester.pump();
+        await tester.pump();
+
+        expect(retryCount, 0);
+        expect(
+          playbackStatusCubit.state.statusFor(_videoId),
+          PlaybackStatus.ageRestricted,
+        );
+        expect(find.text(_failureText), findsOneWidget);
+      },
+    );
+
+    testWidgets('surfaces feedback when authenticated retry fails', (
       tester,
     ) async {
       final mediaAuthInterceptor = _MockMediaAuthInterceptor();
@@ -151,16 +222,18 @@ void main() {
 
       await tester.tap(find.text('Verify'));
       await tester.pump();
+      await tester.pump();
 
       expect(retryCount, 1);
       expect(
         playbackStatusCubit.state.statusFor(_videoId),
         PlaybackStatus.ageRestricted,
       );
+      expect(find.text(_failureText), findsOneWidget);
     });
 
     testWidgets(
-      'refuses retry when sha256 cannot be resolved (no NIP-98 fallback)',
+      'refuses retry and surfaces feedback when sha256 cannot be resolved',
       (tester) async {
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
         final playbackStatusCubit = VideoPlaybackStatusCubit();
@@ -196,6 +269,7 @@ void main() {
 
         await tester.tap(find.text('Verify'));
         await tester.pump();
+        await tester.pump();
 
         expect(retryCount, 0);
         verifyNever(
@@ -211,6 +285,7 @@ void main() {
           playbackStatusCubit.state.statusFor(_videoId),
           PlaybackStatus.ageRestricted,
         );
+        expect(find.text(_failureText), findsOneWidget);
       },
     );
   });
@@ -222,22 +297,30 @@ class _RetryHarness extends StatelessWidget {
     required this.playbackStatusCubit,
     required this.retryPlayback,
     this.video,
+    this.ageVerificationService,
   });
 
   final MediaAuthInterceptor mediaAuthInterceptor;
   final VideoPlaybackStatusCubit playbackStatusCubit;
   final bool Function(Map<String, String>) retryPlayback;
   final VideoEvent? video;
+  final AgeVerificationService? ageVerificationService;
 
   @override
   Widget build(BuildContext context) {
     return ProviderScope(
       overrides: [
         mediaAuthInterceptorProvider.overrideWithValue(mediaAuthInterceptor),
+        if (ageVerificationService != null)
+          ageVerificationServiceProvider.overrideWithValue(
+            ageVerificationService!,
+          ),
       ],
       child: BlocProvider<VideoPlaybackStatusCubit>.value(
         value: playbackStatusCubit,
         child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
             body: Consumer(
               builder: (context, ref, _) {


### PR DESCRIPTION
## Description

A TestFlight user reported the **Verify age** button on age-restricted feed videos is "visible but unresponsive." Root cause: the native pooled age-gate retry (`retryAgeRestrictedPooledVideo`) aborts silently on every failure path, and the overlays render the button with no loading/error state — so a tap that can't complete looks like a dead button. The only verify-age widget that logged on tap (`VideoErrorOverlay`) has been dead code since #4682, so the failure was invisible even in exported logs.

This PR makes the button always give feedback:

- Logs the tap on the pooled path (`🔐 [AGE-GATE] User tapped Verify age (pooled)`) so future exported sessions capture which surface fired and where the retry aborted.
- Shows a localized **"Couldn't verify your age. Please try again."** snackbar on every genuine failure (missing url/sha256, accepted-but-auth-header-failed, authenticated-reload-failed), while staying **silent when the viewer deliberately declines** the age dialog (distinguished via the persisted adult-content verification flag).
- New copy `videoErrorVerifyAgeFailed`, localized across all 18 locales (not English fallback).

**Related Issue:** Relates to #5243

### Steps to reproduce the original bug

1. Sign in (most reproducible with a Divine OAuth / Keycast remote-signer account — no local nsec on device).
2. Scroll the feed to an age-restricted video (its media returns HTTP 401), so the **Verify age** overlay appears.
3. Tap **Verify age**.
4. If the viewer-auth header can't be created (e.g. the remote signer fails or times out) or the authenticated reload still 401s, nothing happens — no spinner, no message, no log. The button appears dead.

**After this PR:** the tap is logged, and any failure surfaces the "Couldn't verify your age. Please try again." snackbar; a deliberate **No** on the age dialog stays silent. The four failure/decline branches are covered deterministically by the widget tests below.

## Out of Scope

Tracked as remaining work in #5243:

- In-button loading spinner while the retry is in flight (needs plumbing through three feed hosts, incl. the stateless `_FeedLoadingOrRestrictedOverlayView`).
- Remote-signer fast-fail: a caller-side signing timeout shorter than Keycast's 30s, plus a signer-reachability check in `canCreateAuthHeaders`.
- Deleting the dead `lib/widgets/video_feed_item/video_error_overlay.dart`.
- Reconciling the #4895 / #4896 cubit-desync and `_lastReportedError` dedupe gaps.

## Verification

- `flutter analyze lib/screens/feed/pooled_age_restricted_retry.dart test/screens/feed/pooled_age_restricted_retry_test.dart lib/l10n/generated` — clean.
- `flutter test test/screens/feed/pooled_age_restricted_retry_test.dart test/l10n/arb_consistency_test.dart` — 7/7 pass (decline-stays-silent, accept-but-auth-fails, authed-reload-fails, unresolvable-sha256, success-clears-status, ARB consistency).
- `flutter gen-l10n` regenerated; all 18 locale ARBs translated.

The UI change is a transient failure snackbar (best demonstrated by the new widget tests); happy to attach a screen recording if useful.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
