### PR TITLE
feat(feed): warm adjacent feeds during foreground idle

### DIFF
--- a/mobile/build_macos.sh
+++ b/mobile/build_macos.sh
@@ -178,6 +178,19 @@ verify_macos_keychain_entitlements() {
     codesign --verify --deep --strict --verbose=2 "$app_path"
 }
 
+verify_macos_embedded_provisioning_profile() {
+    local app_path="$1"
+
+    if [[ -f "$app_path/Contents/embedded.provisionprofile" ]] || \
+       [[ -f "$app_path/Contents/embedded.mobileprovision" ]]; then
+        return 0
+    fi
+
+    echo "❌ macOS app is missing an embedded provisioning profile." >&2
+    echo "   Restricted entitlements will be rejected by AMFI at launch." >&2
+    return 1
+}
+
 sign_macos_app() {
     local app_path="$1"
     local build_mode="$2"
@@ -229,6 +242,56 @@ sign_macos_app() {
 
     rm -f "$expanded_entitlements"
     verify_macos_keychain_entitlements "$app_path" "$expected_access_group"
+}
+
+xcodebuild_signed_macos_app() {
+    local build_mode="$1"
+    local configuration
+    local app_path
+    local identity
+    local team_id
+    local expected_access_group
+    local symroot
+
+    if [[ "$build_mode" == "release" ]]; then
+        configuration="Release"
+        app_path="$RELEASE_APP_PATH"
+    else
+        configuration="Debug"
+        app_path="$DEBUG_APP_PATH"
+    fi
+
+    identity="$(find_macos_signing_identity)"
+    if [[ -z "$identity" ]]; then
+        echo "❌ No Apple Development codesigning identity found." >&2
+        echo "   Install a local Apple Development certificate or set MACOS_SIGNING_IDENTITY." >&2
+        return 1
+    fi
+
+    team_id="$(team_id_from_identity "$identity")"
+    expected_access_group="${team_id}.${MACOS_BUNDLE_ID}"
+    symroot="$(pwd)/build/macos/Build/Products"
+
+    echo "🔏 Building signed macOS $build_mode app with Xcode automatic signing..."
+    echo "🔐 Keychain access group: $expected_access_group"
+    (
+        cd macos
+        xcodebuild -workspace Runner.xcworkspace \
+                   -scheme Runner \
+                   -configuration "$configuration" \
+                   -destination platform=macOS \
+                   SYMROOT="$symroot" \
+                   CODE_SIGNING_ALLOWED=YES \
+                   CODE_SIGNING_REQUIRED=YES \
+                   CODE_SIGN_STYLE=Automatic \
+                   DEVELOPMENT_TEAM="$team_id" \
+                   PRODUCT_BUNDLE_IDENTIFIER="$MACOS_BUNDLE_ID" \
+                   -allowProvisioningUpdates \
+                   build
+    )
+
+    verify_macos_keychain_entitlements "$app_path" "$expected_access_group"
+    verify_macos_embedded_provisioning_profile "$app_path"
 }
 
 # Reset camera permissions to fix stuck TCC state
@@ -420,7 +483,7 @@ EOF
     cd ..
 else
     flutter build macos --debug $DART_DEFINES
-    sign_macos_app "$DEBUG_APP_PATH" "debug"
+    xcodebuild_signed_macos_app "debug"
 fi
 
 echo "✅ macOS build complete!"

--- a/mobile/build_macos.sh
+++ b/mobile/build_macos.sh
@@ -74,6 +74,163 @@ fi
 echo "🖥️  Building macOS App..."
 cd "$(dirname "$0")"
 
+DEBUG_APP_PATH="build/macos/Build/Products/Debug/Divine.app"
+RELEASE_APP_PATH="build/macos/Build/Products/Release/Divine.app"
+MACOS_BUNDLE_ID="${MACOS_BUNDLE_ID:-co.openvine.app}"
+
+find_macos_signing_identity() {
+    if [[ -n "${MACOS_SIGNING_IDENTITY:-}" ]]; then
+        echo "$MACOS_SIGNING_IDENTITY"
+        return 0
+    fi
+
+    local hash
+    local display_identity
+    local tmp_file
+    local signature_details
+    local team_id
+
+    while IFS='|' read -r hash display_identity; do
+        [[ -n "$hash" ]] || continue
+        tmp_file="$(mktemp "${TMPDIR:-/tmp}/divine-codesign-probe.XXXXXX")"
+        printf 'codesign probe\n' > "$tmp_file"
+
+        if codesign --force --sign "$hash" "$tmp_file" >/dev/null 2>&1; then
+            signature_details="$(codesign -dvvv "$tmp_file" 2>&1)"
+            team_id="$(sed -n 's/^TeamIdentifier=//p' <<<"$signature_details" | head -1)"
+            rm -f "$tmp_file"
+
+            if [[ -n "$team_id" && "$team_id" != "not set" ]]; then
+                echo "$hash|$display_identity|$team_id"
+                return 0
+            fi
+        else
+            rm -f "$tmp_file"
+        fi
+    done < <(
+        security find-identity -v -p codesigning \
+            | sed -n 's/^[[:space:]]*[0-9]*)[[:space:]]*\([A-F0-9]\{40\}\)[[:space:]]*"\(Apple Development:.*\)"/\1|\2/p'
+    )
+
+    return 1
+}
+
+team_id_from_identity() {
+    local identity="$1"
+    local detected_team_id
+
+    if [[ "$identity" == *"|"*"|"* ]]; then
+        detected_team_id="${identity##*|}"
+        if [[ -n "$detected_team_id" ]]; then
+            echo "$detected_team_id"
+            return 0
+        fi
+    fi
+
+    if [[ -n "${MACOS_DEVELOPMENT_TEAM:-}" ]]; then
+        echo "$MACOS_DEVELOPMENT_TEAM"
+        return 0
+    fi
+
+    echo "❌ Could not infer Apple Team ID from signing identity: $identity" >&2
+    echo "   Set MACOS_DEVELOPMENT_TEAM=<TEAMID> and rerun." >&2
+    return 1
+}
+
+expand_macos_entitlements() {
+    local source_plist="$1"
+    local output_plist="$2"
+    local team_id="$3"
+    local bundle_id="$4"
+
+    sed \
+        -e "s/\\\$(AppIdentifierPrefix)/${team_id}./g" \
+        -e "s/\\\$(CFBundleIdentifier)/${bundle_id}/g" \
+        "$source_plist" > "$output_plist"
+}
+
+verify_macos_keychain_entitlements() {
+    local app_path="$1"
+    local expected_access_group="$2"
+    local signature_details
+    local entitlements
+
+    signature_details="$(codesign -dvvv "$app_path" 2>&1)"
+    if grep -q 'Signature=adhoc' <<<"$signature_details"; then
+        echo "❌ macOS app is still ad-hoc signed; Keychain will fail with OSStatus -34018." >&2
+        return 1
+    fi
+    if grep -q 'TeamIdentifier=not set' <<<"$signature_details"; then
+        echo "❌ macOS app has no TeamIdentifier; Keychain entitlements are not usable." >&2
+        return 1
+    fi
+
+    entitlements="$(codesign -d --entitlements :- "$app_path" 2>&1)"
+    if ! grep -q 'keychain-access-groups' <<<"$entitlements"; then
+        echo "❌ macOS app is missing keychain-access-groups entitlement." >&2
+        return 1
+    fi
+    if ! grep -q "$expected_access_group" <<<"$entitlements"; then
+        echo "❌ macOS app keychain entitlement does not include $expected_access_group." >&2
+        return 1
+    fi
+
+    codesign --verify --deep --strict --verbose=2 "$app_path"
+}
+
+sign_macos_app() {
+    local app_path="$1"
+    local build_mode="$2"
+    local source_entitlements
+    local identity
+    local signing_identity
+    local display_identity
+    local team_id
+    local expanded_entitlements
+    local expected_access_group
+
+    if [[ ! -d "$app_path" ]]; then
+        echo "❌ macOS app not found at $app_path" >&2
+        return 1
+    fi
+
+    if [[ "$build_mode" == "release" ]]; then
+        source_entitlements="macos/Runner/Release.entitlements"
+    else
+        source_entitlements="macos/Runner/DebugProfile.entitlements"
+    fi
+
+    identity="$(find_macos_signing_identity)"
+    if [[ -z "$identity" ]]; then
+        echo "❌ No Apple Development codesigning identity found." >&2
+        echo "   Install a local Apple Development certificate or set MACOS_SIGNING_IDENTITY." >&2
+        return 1
+    fi
+
+    team_id="$(team_id_from_identity "$identity")"
+    if [[ "$identity" == *"|"* ]]; then
+        signing_identity="${identity%%|*}"
+        display_identity="${identity#*|}"
+        display_identity="${display_identity%|*}"
+    else
+        signing_identity="$identity"
+        display_identity="$identity"
+    fi
+
+    expected_access_group="${team_id}.${MACOS_BUNDLE_ID}"
+    expanded_entitlements="$(mktemp "${TMPDIR:-/tmp}/divine-macos-entitlements.XXXXXX")"
+    expand_macos_entitlements "$source_entitlements" "$expanded_entitlements" "$team_id" "$MACOS_BUNDLE_ID"
+
+    echo "🔏 Signing macOS app with identity: $display_identity"
+    echo "🔐 Keychain access group: $expected_access_group"
+    codesign --force --deep --sign "$signing_identity" \
+        --entitlements "$expanded_entitlements" \
+        "$app_path"
+
+    rm -f "$expanded_entitlements"
+    verify_macos_keychain_entitlements "$app_path" "$expected_access_group"
+}
+
 # Reset camera permissions to fix stuck TCC state
 echo "🔐 Resetting camera permissions for fresh build..."
 tccutil reset Camera com.openvine.divine 2>/dev/null || true
@@ -187,7 +344,8 @@ echo "🚀 Building macOS app..."
 if [[ "$BUILD_MODE" == "release" ]]; then
     echo "🏗️  Building Flutter macOS release..."
     flutter build macos --release $DART_DEFINES
-    
+    sign_macos_app "$RELEASE_APP_PATH" "release"
+
     echo "📦 Creating Xcode archive..."
     cd macos
     
@@ -262,6 +420,7 @@ EOF
     cd ..
 else
     flutter build macos --debug $DART_DEFINES
+    sign_macos_app "$DEBUG_APP_PATH" "debug"
 fi
 
 echo "✅ macOS build complete!"

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1330,28 +1330,25 @@ Future<void> _startOpenVineApp() async {
   // This also forces package:sqlite3 onto the SQLCipher build (Android) and
   // runs the one-time plaintext→encrypted migration, both of which must happen
   // before any sqlite3 open. (#570, finding C2)
-  String? dbCipherKey;
-  try {
-    dbCipherKey = await DatabaseEncryptionBootstrap(
-      // resetOnError MUST stay false here: the cipher key is the one secret
-      // whose loss makes the encrypted DB unrecoverable. A transient keystore
-      // read error must throw (caught below → plaintext this launch, retry
-      // next) rather than silently deleting the key and triggering the §6
-      // key-loss recovery. (#570 C2)
+  final dbCipherKey = await resolveStartupDatabaseCipherKey(
+    // resetOnError MUST stay false here: the cipher key is the one secret
+    // whose loss makes the encrypted DB unrecoverable. A transient keystore
+    // read error must throw rather than silently deleting the key and
+    // triggering the §6 key-loss recovery. (#570 C2)
+    resolveCipherKey: () => DatabaseEncryptionBootstrap(
       secureStorage: const FlutterSecureStorage(
         aOptions: AndroidOptions(encryptedSharedPreferences: true),
       ),
-    ).resolveCipherKey();
-  } catch (error, stack) {
-    // SQLCipher build misconfiguration or an unexpected keystore failure.
-    // Report and degrade to a plaintext database so the app still launches;
-    // the device-QA gate prevents an unencrypted build from shipping. (#570 C2)
-    await CrashReportingService.instance.recordError(
+    ).resolveCipherKey(),
+    // SQLCipher build misconfiguration or secure-storage failures must fail
+    // closed after reporting. Continuing with a null key would open an
+    // existing encrypted DB as plaintext and spam SQLITE_NOTADB.
+    recordError: (error, stack) => CrashReportingService.instance.recordError(
       error,
       stack,
       reason: 'DatabaseEncryptionBootstrap.resolveCipherKey failed',
-    );
-  }
+    ),
+  );
 
   // Create ProviderContainer to initialize services BEFORE runApp
   final container = ProviderContainer(

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -59,8 +59,8 @@ import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/db_cipher_key_provider.dart';
 import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
-import 'package:openvine/providers/popular_now_feed_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
@@ -1750,28 +1750,9 @@ class _DivineAppState extends ConsumerState<DivineApp> {
     );
   }
 
-  /// Initialize opportunistic background warmups owned by the app shell.
+  /// Initialize opportunistic foreground-idle warmups owned by the app shell.
   void _initializeBackgroundServices() {
-    Future.microtask(() {
-      unawaited(
-        ref
-            .read(popularNowFeedProvider.future)
-            .then((state) {
-              Log.info(
-                '[INIT] Warmed New feed with ${state.videos.length} videos',
-                name: 'Main',
-                category: LogCategory.system,
-              );
-            })
-            .catchError((Object error, StackTrace stackTrace) {
-              Log.warning(
-                '[INIT] New feed warmup failed (non-critical): $error',
-                name: 'Main',
-                category: LogCategory.system,
-              );
-            }),
-      );
-    });
+    ref.read(foregroundIdleWarmupSchedulerProvider).start();
 
     // Block/mute list sync is handled by blocklistSyncBridgeProvider
     // (watched in AppShell) which reacts to auth state changes and

--- a/mobile/lib/notifications/services/notification_refresh_coordinator.dart
+++ b/mobile/lib/notifications/services/notification_refresh_coordinator.dart
@@ -13,6 +13,9 @@ import 'package:unified_logger/unified_logger.dart';
 enum NotificationRefreshReason {
   /// App returned to foreground after background/inactive state.
   appResume,
+
+  /// App is foreground and idle enough to opportunistically warm notifications.
+  foregroundIdleWarmup,
 }
 
 /// Forwards an unexpected refresh failure to the crash reporter.

--- a/mobile/lib/providers/foreground_idle_warmup_provider.dart
+++ b/mobile/lib/providers/foreground_idle_warmup_provider.dart
@@ -1,0 +1,91 @@
+// ABOUTME: App-shell providers for foreground-idle data warmups.
+// ABOUTME: Warms existing feed and notification caches without prefetching media bytes.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/for_you_provider.dart';
+import 'package:openvine/providers/new_videos_feed_provider.dart';
+import 'package:openvine/providers/popular_videos_feed_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/services/foreground_idle_warmup_coordinator.dart';
+
+/// Coordinates low-priority data warmups for adjacent app surfaces.
+final foregroundIdleWarmupCoordinatorProvider =
+    Provider<ForegroundIdleWarmupCoordinator>((ref) {
+      return ForegroundIdleWarmupCoordinator(
+        isForeground: () => ref.read(appForegroundProvider),
+        // The scheduler only fires after startup settles and then very
+        // occasionally. Keep this gate explicit so richer idle signals can be
+        // added without changing task semantics.
+        isIdle: () => ref.read(appForegroundProvider),
+        tasks: [
+          ForegroundIdleWarmupTask(
+            id: ForegroundIdleWarmupTaskId.forYou,
+            cooldown: const Duration(minutes: 10),
+            run: () async {
+              await ref.read(forYouFeedProvider.future);
+            },
+          ),
+          ForegroundIdleWarmupTask(
+            id: ForegroundIdleWarmupTaskId.following,
+            cooldown: const Duration(minutes: 10),
+            run: () async {
+              final following = ref
+                  .read(followRepositoryProvider)
+                  .followingPubkeys;
+              if (following.isEmpty) return;
+
+              await ref
+                  .read(videosRepositoryProvider)
+                  .getHomeFeedVideos(
+                    authors: following,
+                    userPubkey: ref
+                        .read(authServiceProvider)
+                        .currentPublicKeyHex,
+                    limit: AppConstants.paginationBatchSize,
+                  );
+            },
+          ),
+          ForegroundIdleWarmupTask(
+            id: ForegroundIdleWarmupTaskId.newVideos,
+            cooldown: const Duration(minutes: 10),
+            run: () async {
+              await ref.read(newVideosFeedProvider.future);
+            },
+          ),
+          ForegroundIdleWarmupTask(
+            id: ForegroundIdleWarmupTaskId.popular,
+            cooldown: const Duration(minutes: 10),
+            run: () async {
+              await ref.read(popularVideosFeedProvider.future);
+            },
+          ),
+          ForegroundIdleWarmupTask(
+            id: ForegroundIdleWarmupTaskId.notifications,
+            cooldown: const Duration(minutes: 1),
+            run: () async {
+              await ref
+                  .read(notificationRefreshCoordinatorProvider)
+                  ?.refresh(
+                    reason: NotificationRefreshReason.foregroundIdleWarmup,
+                  );
+            },
+          ),
+        ],
+      );
+    });
+
+/// Starts the foreground-idle warmup schedule for the app shell.
+final foregroundIdleWarmupSchedulerProvider =
+    Provider<ForegroundIdleWarmupScheduler>((ref) {
+      final coordinator = ref.watch(foregroundIdleWarmupCoordinatorProvider);
+      final scheduler = ForegroundIdleWarmupScheduler(
+        requestWarmup: (trigger) => coordinator.requestWarmup(trigger: trigger),
+      );
+      ref.onDispose(scheduler.stop);
+      return scheduler;
+    });

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -117,6 +117,25 @@ class DatabaseEncryptionBootstrap {
   }
 }
 
+/// Resolves the startup DB cipher key and fails closed on bootstrap errors.
+///
+/// Native app startup must not continue with a `null` cipher key after a
+/// secure-storage or SQLCipher bootstrap failure: an existing encrypted DB
+/// would be opened as plaintext and repeatedly surface SQLITE_NOTADB. Web and
+/// intentional plaintext migration deferrals still return `null` from
+/// [resolveCipherKey].
+Future<String?> resolveStartupDatabaseCipherKey({
+  required Future<String?> Function() resolveCipherKey,
+  required Future<void> Function(Object error, StackTrace stack) recordError,
+}) async {
+  try {
+    return await resolveCipherKey();
+  } catch (error, stack) {
+    await recordError(error, stack);
+    Error.throwWithStackTrace(error, stack);
+  }
+}
+
 bool _isValidCipherKey(String value) =>
     RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(value);
 

--- a/mobile/lib/services/foreground_idle_warmup_coordinator.dart
+++ b/mobile/lib/services/foreground_idle_warmup_coordinator.dart
@@ -1,0 +1,158 @@
+// ABOUTME: Runs low-priority feed and notification warmups while the app is foreground idle.
+// ABOUTME: Keeps warmups serialized, rate-limited, and non-critical.
+
+import 'dart:async';
+
+import 'package:unified_logger/unified_logger.dart';
+
+/// App signals that can opportunistically trigger a lightweight warmup pass.
+enum ForegroundIdleWarmupTrigger {
+  /// Startup finished and the first frames have had time to settle.
+  startupSettled,
+
+  /// A foreground video has settled enough that tiny data requests are safe.
+  videoPlaybackSettled,
+
+  /// A periodic foreground-idle check fired.
+  periodicIdleCheck,
+}
+
+/// Function used by the scheduler to request a warmup pass.
+typedef ForegroundIdleWarmupRequest =
+    Future<void> Function(ForegroundIdleWarmupTrigger trigger);
+
+/// Starts delayed and periodic foreground-idle warmup requests.
+class ForegroundIdleWarmupScheduler {
+  /// Creates a scheduler.
+  ForegroundIdleWarmupScheduler({
+    required ForegroundIdleWarmupRequest requestWarmup,
+    Duration startupDelay = const Duration(seconds: 10),
+    Duration interval = const Duration(minutes: 5),
+  }) : _requestWarmup = requestWarmup,
+       _startupDelay = startupDelay,
+       _interval = interval;
+
+  final ForegroundIdleWarmupRequest _requestWarmup;
+  final Duration _startupDelay;
+  final Duration _interval;
+
+  Timer? _startupTimer;
+  Timer? _periodicTimer;
+
+  /// Starts the scheduler once.
+  void start() {
+    if (_startupTimer != null || _periodicTimer != null) return;
+
+    _startupTimer = Timer(_startupDelay, () {
+      unawaited(_requestWarmup(ForegroundIdleWarmupTrigger.startupSettled));
+    });
+    _periodicTimer = Timer.periodic(_interval, (_) {
+      unawaited(_requestWarmup(ForegroundIdleWarmupTrigger.periodicIdleCheck));
+    });
+  }
+
+  /// Cancels all scheduled warmup requests.
+  void stop() {
+    _startupTimer?.cancel();
+    _periodicTimer?.cancel();
+    _startupTimer = null;
+    _periodicTimer = null;
+  }
+}
+
+/// Logical warmup surfaces.
+enum ForegroundIdleWarmupTaskId {
+  forYou,
+  following,
+  newVideos,
+  popular,
+  notifications,
+}
+
+/// A lightweight data warmup task.
+class ForegroundIdleWarmupTask {
+  /// Creates a warmup task.
+  const ForegroundIdleWarmupTask({
+    required this.id,
+    required this.run,
+    required this.cooldown,
+  });
+
+  /// Surface warmed by this task.
+  final ForegroundIdleWarmupTaskId id;
+
+  /// Minimum time between successful runs.
+  final Duration cooldown;
+
+  /// Performs the data-only warmup.
+  final Future<void> Function() run;
+}
+
+/// Serial, best-effort coordinator for foreground-idle data warmups.
+class ForegroundIdleWarmupCoordinator {
+  /// Creates a coordinator.
+  ForegroundIdleWarmupCoordinator({
+    required List<ForegroundIdleWarmupTask> tasks,
+    required bool Function() isForeground,
+    required bool Function() isIdle,
+    DateTime Function()? now,
+  }) : _tasks = List.unmodifiable(tasks),
+       _isForeground = isForeground,
+       _isIdle = isIdle,
+       _now = now ?? DateTime.now;
+
+  final List<ForegroundIdleWarmupTask> _tasks;
+  final bool Function() _isForeground;
+  final bool Function() _isIdle;
+  final DateTime Function() _now;
+
+  final Map<ForegroundIdleWarmupTaskId, DateTime> _lastSuccessAt = {};
+  Future<void>? _inFlight;
+
+  /// Requests a best-effort warmup pass.
+  ///
+  /// If another pass is running, returns the same future. Each pass checks the
+  /// foreground/idle gates before every task so user interaction can stop the
+  /// queue quickly.
+  Future<void> requestWarmup({
+    required ForegroundIdleWarmupTrigger trigger,
+  }) {
+    final inFlight = _inFlight;
+    if (inFlight != null) return inFlight;
+
+    if (!_canRun) return Future<void>.value();
+
+    final future = _run(trigger).whenComplete(() {
+      _inFlight = null;
+    });
+    _inFlight = future;
+    return future;
+  }
+
+  bool get _canRun => _isForeground() && _isIdle();
+
+  Future<void> _run(ForegroundIdleWarmupTrigger trigger) async {
+    for (final task in _tasks) {
+      if (!_canRun) return;
+      if (_isCoolingDown(task)) continue;
+
+      try {
+        await task.run();
+        _lastSuccessAt[task.id] = _now();
+      } catch (error) {
+        Log.warning(
+          'Foreground idle warmup failed '
+          '(${task.id.name}, ${trigger.name}): $error',
+          name: 'ForegroundIdleWarmupCoordinator',
+          category: LogCategory.system,
+        );
+      }
+    }
+  }
+
+  bool _isCoolingDown(ForegroundIdleWarmupTask task) {
+    final lastSuccessAt = _lastSuccessAt[task.id];
+    if (lastSuccessAt == null) return false;
+    return _now().difference(lastSuccessAt) < task.cooldown;
+  }
+}

--- a/mobile/lib/services/foreground_idle_warmup_coordinator.dart
+++ b/mobile/lib/services/foreground_idle_warmup_coordinator.dart
@@ -44,10 +44,10 @@ class ForegroundIdleWarmupScheduler {
     if (_startupTimer != null || _periodicTimer != null) return;
 
     _startupTimer = Timer(_startupDelay, () {
-      unawaited(_requestWarmup(ForegroundIdleWarmupTrigger.startupSettled));
+      _requestSafely(ForegroundIdleWarmupTrigger.startupSettled);
     });
     _periodicTimer = Timer.periodic(_interval, (_) {
-      unawaited(_requestWarmup(ForegroundIdleWarmupTrigger.periodicIdleCheck));
+      _requestSafely(ForegroundIdleWarmupTrigger.periodicIdleCheck);
     });
   }
 
@@ -57,6 +57,19 @@ class ForegroundIdleWarmupScheduler {
     _periodicTimer?.cancel();
     _startupTimer = null;
     _periodicTimer = null;
+  }
+
+  void _requestSafely(ForegroundIdleWarmupTrigger trigger) {
+    unawaited(
+      Future.sync(() => _requestWarmup(trigger)).catchError((Object error) {
+        Log.warning(
+          'Scheduled foreground idle warmup failed '
+          '(${trigger.name}): $error',
+          name: 'ForegroundIdleWarmupScheduler',
+          category: LogCategory.system,
+        );
+      }),
+    );
   }
 }
 

--- a/mobile/lib/services/foreground_idle_warmup_coordinator.dart
+++ b/mobile/lib/services/foreground_idle_warmup_coordinator.dart
@@ -41,7 +41,22 @@ class ForegroundIdleWarmupScheduler {
 
   /// Starts the scheduler once.
   void start() {
-    if (_startupTimer != null || _periodicTimer != null) return;
+    if (_startupTimer != null || _periodicTimer != null) {
+      Log.debug(
+        'Foreground idle warmup scheduler already started',
+        name: 'ForegroundIdleWarmupScheduler',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
+    Log.info(
+      'Foreground idle warmup scheduler started '
+      '(startupDelay=${_startupDelay.inSeconds}s, '
+      'interval=${_interval.inMinutes}m)',
+      name: 'ForegroundIdleWarmupScheduler',
+      category: LogCategory.system,
+    );
 
     _startupTimer = Timer(_startupDelay, () {
       _requestSafely(ForegroundIdleWarmupTrigger.startupSettled);
@@ -53,6 +68,13 @@ class ForegroundIdleWarmupScheduler {
 
   /// Cancels all scheduled warmup requests.
   void stop() {
+    if (_startupTimer != null || _periodicTimer != null) {
+      Log.info(
+        'Foreground idle warmup scheduler stopped',
+        name: 'ForegroundIdleWarmupScheduler',
+        category: LogCategory.system,
+      );
+    }
     _startupTimer?.cancel();
     _periodicTimer?.cancel();
     _startupTimer = null;
@@ -60,6 +82,11 @@ class ForegroundIdleWarmupScheduler {
   }
 
   void _requestSafely(ForegroundIdleWarmupTrigger trigger) {
+    Log.info(
+      'Foreground idle warmup scheduler fired (${trigger.name})',
+      name: 'ForegroundIdleWarmupScheduler',
+      category: LogCategory.system,
+    );
     unawaited(
       Future.sync(() => _requestWarmup(trigger)).catchError((Object error) {
         Log.warning(
@@ -89,6 +116,7 @@ class ForegroundIdleWarmupTask {
     required this.id,
     required this.run,
     required this.cooldown,
+    this.timeout = const Duration(seconds: 12),
   });
 
   /// Surface warmed by this task.
@@ -96,6 +124,9 @@ class ForegroundIdleWarmupTask {
 
   /// Minimum time between successful runs.
   final Duration cooldown;
+
+  /// Maximum time this low-priority task may occupy the serial queue.
+  final Duration timeout;
 
   /// Performs the data-only warmup.
   final Future<void> Function() run;
@@ -131,9 +162,24 @@ class ForegroundIdleWarmupCoordinator {
     required ForegroundIdleWarmupTrigger trigger,
   }) {
     final inFlight = _inFlight;
-    if (inFlight != null) return inFlight;
+    if (inFlight != null) {
+      Log.debug(
+        'Foreground idle warmup coalesced (${trigger.name})',
+        name: 'ForegroundIdleWarmupCoordinator',
+        category: LogCategory.system,
+      );
+      return inFlight;
+    }
 
-    if (!_canRun) return Future<void>.value();
+    if (!_canRun) {
+      Log.debug(
+        'Foreground idle warmup skipped (${trigger.name}): '
+        'foreground=${_isForeground()}, idle=${_isIdle()}',
+        name: 'ForegroundIdleWarmupCoordinator',
+        category: LogCategory.system,
+      );
+      return Future<void>.value();
+    }
 
     final future = _run(trigger).whenComplete(() {
       _inFlight = null;
@@ -145,13 +191,51 @@ class ForegroundIdleWarmupCoordinator {
   bool get _canRun => _isForeground() && _isIdle();
 
   Future<void> _run(ForegroundIdleWarmupTrigger trigger) async {
+    Log.info(
+      'Foreground idle warmup started (${trigger.name})',
+      name: 'ForegroundIdleWarmupCoordinator',
+      category: LogCategory.system,
+    );
+
     for (final task in _tasks) {
-      if (!_canRun) return;
-      if (_isCoolingDown(task)) continue;
+      if (!_canRun) {
+        Log.info(
+          'Foreground idle warmup stopped before ${task.id.name}: '
+          'foreground=${_isForeground()}, idle=${_isIdle()}',
+          name: 'ForegroundIdleWarmupCoordinator',
+          category: LogCategory.system,
+        );
+        return;
+      }
+      if (_isCoolingDown(task)) {
+        Log.debug(
+          'Foreground idle warmup skipped ${task.id.name}: cooling down',
+          name: 'ForegroundIdleWarmupCoordinator',
+          category: LogCategory.system,
+        );
+        continue;
+      }
 
       try {
-        await task.run();
+        Log.debug(
+          'Foreground idle warmup running ${task.id.name}',
+          name: 'ForegroundIdleWarmupCoordinator',
+          category: LogCategory.system,
+        );
+        await task.run().timeout(task.timeout);
         _lastSuccessAt[task.id] = _now();
+        Log.info(
+          'Foreground idle warmup completed ${task.id.name}',
+          name: 'ForegroundIdleWarmupCoordinator',
+          category: LogCategory.system,
+        );
+      } on TimeoutException {
+        Log.warning(
+          'Foreground idle warmup timed out '
+          '(${task.id.name}, ${trigger.name}, ${task.timeout.inSeconds}s)',
+          name: 'ForegroundIdleWarmupCoordinator',
+          category: LogCategory.system,
+        );
       } catch (error) {
         Log.warning(
           'Foreground idle warmup failed '

--- a/mobile/test/macos/build_macos_signing_test.dart
+++ b/mobile/test/macos/build_macos_signing_test.dart
@@ -10,23 +10,25 @@ void main() {
       script = File('build_macos.sh').readAsStringSync();
     });
 
-    test('debug builds are explicitly signed with expanded entitlements', () {
+    test('debug builds use Xcode signing and provisioning', () {
       expect(
         script,
-        contains(r'sign_macos_app "$DEBUG_APP_PATH" "debug"'),
+        contains('xcodebuild_signed_macos_app "debug"'),
         reason:
-            'Debug builds must not rely on Flutter ad-hoc signing because '
-            'Keychain-backed secure storage needs real entitlements.',
+            'Debug builds must not rely on Flutter ad-hoc signing or bare '
+            'manual codesign because Keychain-backed secure storage needs '
+            'real entitlements and a matching provisioning profile.',
       );
       expect(
         script,
-        contains('expand_macos_entitlements'),
+        contains('-allowProvisioningUpdates'),
         reason:
-            'The entitlements plist contains Xcode build-setting placeholders '
-            'that must be expanded before manual codesign.',
+            'Xcode needs permission to create or refresh the Mac team '
+            'provisioning profile for restricted entitlements.',
       );
-      expect(script, contains(r'$(AppIdentifierPrefix)'));
-      expect(script, contains(r'$(CFBundleIdentifier)'));
+      expect(script, contains('CODE_SIGNING_ALLOWED=YES'));
+      expect(script, contains('CODE_SIGNING_REQUIRED=YES'));
+      expect(script, contains(r'SYMROOT="$symroot"'));
     });
 
     test('release build output is signed before archiving', () {
@@ -50,6 +52,20 @@ void main() {
       expect(script, contains('Signature=adhoc'));
       expect(script, contains('TeamIdentifier=not set'));
       expect(script, contains('keychain-access-groups'));
+    });
+
+    test('xcode signed debug app is verified for embedded provisioning', () {
+      expect(
+        script,
+        contains(r'verify_macos_embedded_provisioning_profile "$app_path"'),
+        reason:
+            'A valid code signature alone is not enough. macOS AMFI rejects '
+            'restricted entitlements at launch when no matching profile is '
+            'embedded.',
+      );
+      expect(script, contains('embedded.provisionprofile'));
+      expect(script, contains('embedded.mobileprovision'));
+      expect(script, contains('Restricted entitlements will be rejected'));
     });
   });
 }

--- a/mobile/test/macos/build_macos_signing_test.dart
+++ b/mobile/test/macos/build_macos_signing_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('build_macos.sh signing guard', () {
+    late String script;
+
+    setUpAll(() {
+      script = File('build_macos.sh').readAsStringSync();
+    });
+
+    test('debug builds are explicitly signed with expanded entitlements', () {
+      expect(
+        script,
+        contains(r'sign_macos_app "$DEBUG_APP_PATH" "debug"'),
+        reason:
+            'Debug builds must not rely on Flutter ad-hoc signing because '
+            'Keychain-backed secure storage needs real entitlements.',
+      );
+      expect(
+        script,
+        contains('expand_macos_entitlements'),
+        reason:
+            'The entitlements plist contains Xcode build-setting placeholders '
+            'that must be expanded before manual codesign.',
+      );
+      expect(script, contains(r'$(AppIdentifierPrefix)'));
+      expect(script, contains(r'$(CFBundleIdentifier)'));
+    });
+
+    test('release build output is signed before archiving', () {
+      expect(
+        script,
+        contains(r'sign_macos_app "$RELEASE_APP_PATH" "release"'),
+        reason:
+            'The standalone release .app produced by flutter build macos '
+            'should have the same keychain entitlements as the archived app.',
+      );
+    });
+
+    test('signed app is verified for non-ad-hoc keychain entitlements', () {
+      expect(
+        script,
+        contains('verify_macos_keychain_entitlements'),
+        reason:
+            'The script should fail fast if codesign produced an app that '
+            'will hit OSStatus -34018 at runtime.',
+      );
+      expect(script, contains('Signature=adhoc'));
+      expect(script, contains('TeamIdentifier=not set'));
+      expect(script, contains('keychain-access-groups'));
+    });
+  });
+}

--- a/mobile/test/providers/foreground_idle_warmup_provider_test.dart
+++ b/mobile/test/providers/foreground_idle_warmup_provider_test.dart
@@ -1,0 +1,198 @@
+// ABOUTME: Provider wiring tests for foreground-idle warmup tasks.
+// ABOUTME: Verifies app-shell gates and dependency arguments without real IO.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
+import 'package:openvine/providers/app_foreground_provider.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/for_you_provider.dart';
+import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
+import 'package:openvine/providers/new_videos_feed_provider.dart';
+import 'package:openvine/providers/popular_videos_feed_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/foreground_idle_warmup_coordinator.dart';
+import 'package:openvine/state/video_feed_state.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockVideosRepository extends Mock implements VideosRepository {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockNotificationRefreshCoordinator extends Mock
+    implements NotificationRefreshCoordinator {}
+
+final _feedBuilds = <String>[];
+
+class _TestForYouFeed extends ForYouFeed {
+  @override
+  Future<VideoFeedState> build() async {
+    _feedBuilds.add('forYou');
+    return const VideoFeedState(videos: [], hasMoreContent: false);
+  }
+}
+
+class _TestNewVideosFeed extends NewVideosFeed {
+  @override
+  Future<VideoFeedState> build() async {
+    _feedBuilds.add('newVideos');
+    return const VideoFeedState(videos: [], hasMoreContent: false);
+  }
+}
+
+class _TestPopularVideosFeed extends PopularVideosFeed {
+  @override
+  Future<VideoFeedState> build() async {
+    _feedBuilds.add('popular');
+    return const VideoFeedState(videos: [], hasMoreContent: false);
+  }
+}
+
+void main() {
+  group('foregroundIdleWarmupCoordinatorProvider', () {
+    late _MockFollowRepository followRepository;
+    late _MockVideosRepository videosRepository;
+    late _MockAuthService authService;
+    late _MockNotificationRefreshCoordinator notificationCoordinator;
+
+    ProviderContainer createContainer({required List<String> following}) {
+      when(() => followRepository.followingPubkeys).thenReturn(following);
+      when(() => authService.currentPublicKeyHex).thenReturn('viewer-pubkey');
+      when(
+        () => videosRepository.getHomeFeedVideos(
+          authors: any(named: 'authors'),
+          videoRefs: any(named: 'videoRefs'),
+          userPubkey: any(named: 'userPubkey'),
+          limit: any(named: 'limit'),
+          until: any(named: 'until'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      ).thenAnswer((_) async => const HomeFeedResult(videos: []));
+      when(
+        () => notificationCoordinator.refresh(
+          reason: NotificationRefreshReason.foregroundIdleWarmup,
+        ),
+      ).thenAnswer((_) async {});
+
+      final container = ProviderContainer(
+        overrides: [
+          followRepositoryProvider.overrideWithValue(followRepository),
+          videosRepositoryProvider.overrideWithValue(videosRepository),
+          authServiceProvider.overrideWithValue(authService),
+          notificationRefreshCoordinatorProvider.overrideWithValue(
+            notificationCoordinator,
+          ),
+          forYouFeedProvider.overrideWith(_TestForYouFeed.new),
+          newVideosFeedProvider.overrideWith(_TestNewVideosFeed.new),
+          popularVideosFeedProvider.overrideWith(_TestPopularVideosFeed.new),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    setUp(() {
+      followRepository = _MockFollowRepository();
+      videosRepository = _MockVideosRepository();
+      authService = _MockAuthService();
+      notificationCoordinator = _MockNotificationRefreshCoordinator();
+      _feedBuilds.clear();
+    });
+
+    test('foreground=false gates all warmup work', () async {
+      final container = createContainer(following: const ['author-pubkey']);
+      container.read(appForegroundProvider.notifier).setForeground(false);
+
+      await container
+          .read(foregroundIdleWarmupCoordinatorProvider)
+          .requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+          );
+
+      expect(_feedBuilds, isEmpty);
+      verifyNever(() => followRepository.followingPubkeys);
+      verifyNever(
+        () => videosRepository.getHomeFeedVideos(
+          authors: any(named: 'authors'),
+          videoRefs: any(named: 'videoRefs'),
+          userPubkey: any(named: 'userPubkey'),
+          limit: any(named: 'limit'),
+          until: any(named: 'until'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      );
+      verifyNever(
+        () => notificationCoordinator.refresh(
+          reason: NotificationRefreshReason.foregroundIdleWarmup,
+        ),
+      );
+    });
+
+    test('empty following list skips home feed repository fetch', () async {
+      final container = createContainer(following: const []);
+
+      await container
+          .read(foregroundIdleWarmupCoordinatorProvider)
+          .requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+          );
+
+      expect(_feedBuilds, ['forYou', 'newVideos', 'popular']);
+      verify(() => followRepository.followingPubkeys).called(1);
+      verifyNever(
+        () => videosRepository.getHomeFeedVideos(
+          authors: any(named: 'authors'),
+          videoRefs: any(named: 'videoRefs'),
+          userPubkey: any(named: 'userPubkey'),
+          limit: any(named: 'limit'),
+          until: any(named: 'until'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      );
+    });
+
+    test('notification warmup uses foreground idle warmup reason', () async {
+      final container = createContainer(following: const []);
+
+      await container
+          .read(foregroundIdleWarmupCoordinatorProvider)
+          .requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+          );
+
+      verify(
+        () => notificationCoordinator.refresh(
+          reason: NotificationRefreshReason.foregroundIdleWarmup,
+        ),
+      ).called(1);
+    });
+
+    test(
+      'non-empty following fetches home feed with current user and batch size',
+      () async {
+        final container = createContainer(following: const ['author-pubkey']);
+
+        await container
+            .read(foregroundIdleWarmupCoordinatorProvider)
+            .requestWarmup(
+              trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+            );
+
+        verify(
+          () => videosRepository.getHomeFeedVideos(
+            authors: const ['author-pubkey'],
+            userPubkey: 'viewer-pubkey',
+            limit: AppConstants.paginationBatchSize,
+          ),
+        ).called(1);
+      },
+    );
+  });
+}

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -144,4 +144,26 @@ void main() {
       expect(store[dbCipherKeyStorageKey], equals(key));
     });
   });
+
+  group('resolveStartupDatabaseCipherKey', () {
+    test('records and rethrows bootstrap failures', () async {
+      final error = StateError('secure storage unavailable');
+      Object? recordedError;
+      StackTrace? recordedStack;
+
+      await expectLater(
+        resolveStartupDatabaseCipherKey(
+          resolveCipherKey: () async => throw error,
+          recordError: (error, stack) async {
+            recordedError = error;
+            recordedStack = stack;
+          },
+        ),
+        throwsA(same(error)),
+      );
+
+      expect(recordedError, same(error));
+      expect(recordedStack, isNotNull);
+    });
+  });
 }

--- a/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
+++ b/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
@@ -255,6 +255,50 @@ void main() {
       expect(calls, ['forYou', 'popular', 'forYou']);
     });
 
+    test('timed out tasks do not block later tasks or consume cooldown', () {
+      fakeAsync((async) {
+        final slowTask = Completer<void>();
+        final coordinator = coordinatorWith([
+          ForegroundIdleWarmupTask(
+            id: ForegroundIdleWarmupTaskId.forYou,
+            cooldown: const Duration(minutes: 5),
+            timeout: const Duration(seconds: 1),
+            run: () async {
+              calls.add('forYou');
+              await slowTask.future;
+            },
+          ),
+          task(ForegroundIdleWarmupTaskId.newVideos),
+          task(ForegroundIdleWarmupTaskId.popular),
+        ]);
+
+        unawaited(
+          coordinator.requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.startupSettled,
+          ),
+        );
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        expect(calls, ['forYou', 'newVideos', 'popular']);
+
+        unawaited(
+          coordinator.requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+          ),
+        );
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        expect(calls, [
+          'forYou',
+          'newVideos',
+          'popular',
+          'forYou',
+        ]);
+      });
+    });
+
     test('stops before the next task if the app stops being idle', () async {
       final coordinator = coordinatorWith([
         task(

--- a/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
+++ b/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
@@ -1,0 +1,274 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/foreground_idle_warmup_coordinator.dart';
+
+void main() {
+  group('ForegroundIdleWarmupCoordinator', () {
+    late DateTime now;
+    late bool isForeground;
+    late bool isIdle;
+    late List<String> calls;
+
+    ForegroundIdleWarmupCoordinator coordinatorWith(
+      List<ForegroundIdleWarmupTask> tasks,
+    ) {
+      return ForegroundIdleWarmupCoordinator(
+        tasks: tasks,
+        isForeground: () => isForeground,
+        isIdle: () => isIdle,
+        now: () => now,
+      );
+    }
+
+    ForegroundIdleWarmupTask task(
+      ForegroundIdleWarmupTaskId id, {
+      Duration cooldown = const Duration(minutes: 5),
+      Future<void> Function()? run,
+    }) {
+      return ForegroundIdleWarmupTask(
+        id: id,
+        cooldown: cooldown,
+        run: run ?? () async => calls.add(id.name),
+      );
+    }
+
+    setUp(() {
+      now = DateTime(2026, 6, 17, 12);
+      isForeground = true;
+      isIdle = true;
+      calls = [];
+    });
+
+    test('runs eligible warmups when the app is foreground and idle', () async {
+      final coordinator = coordinatorWith([
+        task(ForegroundIdleWarmupTaskId.forYou),
+        task(ForegroundIdleWarmupTaskId.newVideos),
+        task(ForegroundIdleWarmupTaskId.popular),
+        task(ForegroundIdleWarmupTaskId.notifications),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+
+      expect(calls, [
+        'forYou',
+        'newVideos',
+        'popular',
+        'notifications',
+      ]);
+    });
+
+    test('does not run while the app is backgrounded', () async {
+      isForeground = false;
+      final coordinator = coordinatorWith([
+        task(ForegroundIdleWarmupTaskId.forYou),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+
+      expect(calls, isEmpty);
+    });
+
+    test('does not run while the app is not idle', () async {
+      isIdle = false;
+      final coordinator = coordinatorWith([
+        task(ForegroundIdleWarmupTaskId.forYou),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+
+      expect(calls, isEmpty);
+    });
+
+    test('coalesces concurrent warmup requests into one serial run', () async {
+      final completer = Completer<void>();
+      final coordinator = coordinatorWith([
+        task(
+          ForegroundIdleWarmupTaskId.forYou,
+          run: () async {
+            calls.add('forYou-start');
+            await completer.future;
+            calls.add('forYou-end');
+          },
+        ),
+        task(ForegroundIdleWarmupTaskId.popular),
+      ]);
+
+      final first = coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+      final second = coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(identical(first, second), isTrue);
+      expect(calls, ['forYou-start']);
+
+      completer.complete();
+      await first;
+
+      expect(calls, ['forYou-start', 'forYou-end', 'popular']);
+    });
+
+    test('skips tasks inside their cooldown window', () async {
+      final coordinator = coordinatorWith([
+        task(ForegroundIdleWarmupTaskId.forYou),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(calls, ['forYou']);
+
+      now = now.add(const Duration(minutes: 5, seconds: 1));
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(calls, ['forYou', 'forYou']);
+    });
+
+    test('failed tasks do not consume cooldown or block later tasks', () async {
+      var shouldFail = true;
+      final coordinator = coordinatorWith([
+        task(
+          ForegroundIdleWarmupTaskId.forYou,
+          run: () async {
+            calls.add('forYou');
+            if (shouldFail) {
+              throw StateError('network failed');
+            }
+          },
+        ),
+        task(ForegroundIdleWarmupTaskId.popular),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+
+      expect(calls, ['forYou', 'popular']);
+
+      shouldFail = false;
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(calls, ['forYou', 'popular', 'forYou']);
+    });
+
+    test('stops before the next task if the app stops being idle', () async {
+      final coordinator = coordinatorWith([
+        task(
+          ForegroundIdleWarmupTaskId.forYou,
+          run: () async {
+            calls.add('forYou');
+            isIdle = false;
+          },
+        ),
+        task(ForegroundIdleWarmupTaskId.popular),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+
+      expect(calls, ['forYou']);
+    });
+  });
+
+  group('ForegroundIdleWarmupScheduler', () {
+    test('runs an initial warmup after the startup delay', () {
+      fakeAsync((async) {
+        final triggers = <ForegroundIdleWarmupTrigger>[];
+        final scheduler = ForegroundIdleWarmupScheduler(
+          requestWarmup: (trigger) {
+            triggers.add(trigger);
+            return Future<void>.value();
+          },
+        );
+
+        scheduler.start();
+        async.elapse(const Duration(seconds: 9));
+
+        expect(triggers, isEmpty);
+
+        async.elapse(const Duration(seconds: 1));
+
+        expect(triggers, [ForegroundIdleWarmupTrigger.startupSettled]);
+        scheduler.stop();
+      });
+    });
+
+    test('runs periodic warmups after start', () {
+      fakeAsync((async) {
+        final triggers = <ForegroundIdleWarmupTrigger>[];
+        final scheduler = ForegroundIdleWarmupScheduler(
+          requestWarmup: (trigger) {
+            triggers.add(trigger);
+            return Future<void>.value();
+          },
+        );
+
+        scheduler.start();
+        async.elapse(const Duration(seconds: 10));
+        async.elapse(const Duration(minutes: 10));
+
+        expect(triggers, [
+          ForegroundIdleWarmupTrigger.startupSettled,
+          ForegroundIdleWarmupTrigger.periodicIdleCheck,
+          ForegroundIdleWarmupTrigger.periodicIdleCheck,
+        ]);
+        scheduler.stop();
+      });
+    });
+
+    test('start is idempotent', () {
+      fakeAsync((async) {
+        final triggers = <ForegroundIdleWarmupTrigger>[];
+        final scheduler = ForegroundIdleWarmupScheduler(
+          requestWarmup: (trigger) {
+            triggers.add(trigger);
+            return Future<void>.value();
+          },
+        );
+
+        scheduler.start();
+        scheduler.start();
+        async.elapse(const Duration(seconds: 10));
+
+        expect(triggers, [ForegroundIdleWarmupTrigger.startupSettled]);
+        scheduler.stop();
+      });
+    });
+
+    test('stop cancels scheduled warmups', () {
+      fakeAsync((async) {
+        final triggers = <ForegroundIdleWarmupTrigger>[];
+        final scheduler = ForegroundIdleWarmupScheduler(
+          requestWarmup: (trigger) {
+            triggers.add(trigger);
+            return Future<void>.value();
+          },
+        );
+
+        scheduler.start();
+        scheduler.stop();
+        async.elapse(const Duration(minutes: 10));
+
+        expect(triggers, isEmpty);
+      });
+    });
+  });
+}

--- a/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
+++ b/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
@@ -87,6 +87,26 @@ void main() {
       expect(calls, isEmpty);
     });
 
+    test('blocked requests do not prevent later eligible warmups', () async {
+      isForeground = false;
+      final coordinator = coordinatorWith([
+        task(ForegroundIdleWarmupTaskId.forYou),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+
+      expect(calls, isEmpty);
+
+      isForeground = true;
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(calls, ['forYou']);
+    });
+
     test('coalesces concurrent warmup requests into one serial run', () async {
       final completer = Completer<void>();
       final coordinator = coordinatorWith([
@@ -117,6 +137,37 @@ void main() {
       expect(calls, ['forYou-start', 'forYou-end', 'popular']);
     });
 
+    test('coalesces in-flight requests after gates close', () async {
+      final completer = Completer<void>();
+      final coordinator = coordinatorWith([
+        task(
+          ForegroundIdleWarmupTaskId.forYou,
+          run: () async {
+            calls.add('forYou-start');
+            await completer.future;
+            calls.add('forYou-end');
+          },
+        ),
+        task(ForegroundIdleWarmupTaskId.popular),
+      ]);
+
+      final first = coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+      isIdle = false;
+      final second = coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(identical(first, second), isTrue);
+      expect(calls, ['forYou-start']);
+
+      completer.complete();
+      await first;
+
+      expect(calls, ['forYou-start', 'forYou-end']);
+    });
+
     test('skips tasks inside their cooldown window', () async {
       final coordinator = coordinatorWith([
         task(ForegroundIdleWarmupTaskId.forYou),
@@ -137,6 +188,42 @@ void main() {
       );
 
       expect(calls, ['forYou', 'forYou']);
+    });
+
+    test('runs tasks again at the cooldown boundary', () async {
+      final coordinator = coordinatorWith([
+        task(ForegroundIdleWarmupTaskId.forYou),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+      now = now.add(const Duration(minutes: 5));
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(calls, ['forYou', 'forYou']);
+    });
+
+    test('applies cooldowns independently per task', () async {
+      final coordinator = coordinatorWith([
+        task(ForegroundIdleWarmupTaskId.forYou),
+        task(
+          ForegroundIdleWarmupTaskId.popular,
+          cooldown: Duration.zero,
+        ),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(calls, ['forYou', 'popular', 'popular']);
     });
 
     test('failed tasks do not consume cooldown or block later tasks', () async {
@@ -175,6 +262,25 @@ void main() {
           run: () async {
             calls.add('forYou');
             isIdle = false;
+          },
+        ),
+        task(ForegroundIdleWarmupTaskId.popular),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+      );
+
+      expect(calls, ['forYou']);
+    });
+
+    test('stops before the next task if the app is backgrounded', () async {
+      final coordinator = coordinatorWith([
+        task(
+          ForegroundIdleWarmupTaskId.forYou,
+          run: () async {
+            calls.add('forYou');
+            isForeground = false;
           },
         ),
         task(ForegroundIdleWarmupTaskId.popular),
@@ -247,8 +353,12 @@ void main() {
         scheduler.start();
         scheduler.start();
         async.elapse(const Duration(seconds: 10));
+        async.elapse(const Duration(minutes: 5));
 
-        expect(triggers, [ForegroundIdleWarmupTrigger.startupSettled]);
+        expect(triggers, [
+          ForegroundIdleWarmupTrigger.startupSettled,
+          ForegroundIdleWarmupTrigger.periodicIdleCheck,
+        ]);
         scheduler.stop();
       });
     });
@@ -268,6 +378,93 @@ void main() {
         async.elapse(const Duration(minutes: 10));
 
         expect(triggers, isEmpty);
+        expect(async.nonPeriodicTimerCount, 0);
+        expect(async.periodicTimerCount, 0);
+      });
+    });
+
+    test('stop cancels periodic warmups after startup fires', () {
+      fakeAsync((async) {
+        final triggers = <ForegroundIdleWarmupTrigger>[];
+        final scheduler = ForegroundIdleWarmupScheduler(
+          requestWarmup: (trigger) {
+            triggers.add(trigger);
+            return Future<void>.value();
+          },
+        );
+
+        scheduler.start();
+        async.elapse(const Duration(seconds: 10));
+        expect(async.nonPeriodicTimerCount, 0);
+        expect(async.periodicTimerCount, 1);
+
+        scheduler.stop();
+        async.elapse(const Duration(minutes: 5));
+
+        expect(triggers, [ForegroundIdleWarmupTrigger.startupSettled]);
+        expect(async.nonPeriodicTimerCount, 0);
+        expect(async.periodicTimerCount, 0);
+      });
+    });
+
+    test('can be restarted after stop', () {
+      fakeAsync((async) {
+        final triggers = <ForegroundIdleWarmupTrigger>[];
+        final scheduler = ForegroundIdleWarmupScheduler(
+          requestWarmup: (trigger) {
+            triggers.add(trigger);
+            return Future<void>.value();
+          },
+        );
+
+        scheduler.start();
+        scheduler.stop();
+        async.elapse(const Duration(seconds: 10));
+
+        scheduler.start();
+        async.elapse(const Duration(seconds: 10));
+
+        expect(triggers, [ForegroundIdleWarmupTrigger.startupSettled]);
+        scheduler.stop();
+        expect(async.nonPeriodicTimerCount, 0);
+        expect(async.periodicTimerCount, 0);
+      });
+    });
+
+    test('handles failed scheduled warmup futures', () {
+      fakeAsync((async) {
+        final scheduler = ForegroundIdleWarmupScheduler(
+          requestWarmup: (_) => Future<void>.error(StateError('boom')),
+        );
+
+        scheduler.start();
+        async.elapse(const Duration(seconds: 10));
+
+        expect(() => async.flushMicrotasks(), returnsNormally);
+        scheduler.stop();
+      });
+    });
+
+    test('delegates overlapping periodic ticks to request coalescing', () {
+      fakeAsync((async) {
+        final completer = Completer<void>();
+        var calls = 0;
+        final scheduler = ForegroundIdleWarmupScheduler(
+          startupDelay: const Duration(days: 1),
+          interval: const Duration(seconds: 1),
+          requestWarmup: (_) {
+            calls++;
+            return completer.future;
+          },
+        );
+
+        scheduler.start();
+        async.elapse(const Duration(seconds: 3));
+
+        expect(calls, 3);
+        completer.complete();
+        async.flushMicrotasks();
+        scheduler.stop();
       });
     });
   });


### PR DESCRIPTION
Closes #5249

## Summary
- replace the one-off startup feed warmup with a foreground-idle warmup scheduler for For You, Following, New, Popular, and Notifications
- add serial/coalesced warmup coordination with foreground/idle gates, cooldowns, timeouts, and failure containment
- fail closed when DB encryption bootstrap cannot read secure storage so an encrypted SQLCipher DB is never opened as plaintext
- sign/provision macOS debug builds through Xcode so keychain-access-groups has a matching embedded provisioning profile

## Root Cause Notes
- macOS debug builds were manually codesigned with `keychain-access-groups`, but lacked an embedded provisioning profile, so AMFI rejected the restricted entitlement.
- `flutter_secure_storage` then surfaced Keychain OSStatus `-34018`; the app continued with no DB cipher key and Drift opened the encrypted DB as plaintext, causing repeated `SqliteException(26): file is not a database` failures.
- The DB cipher key is separate from the user's Nostr key. If the local DB key is genuinely lost, the existing recovery path backs up the unrecoverable DB and recreates it under a new key.

## Verification
- `flutter test test/services/database_encryption_bootstrap_test.dart test/macos/build_macos_signing_test.dart test/services/foreground_idle_warmup_coordinator_test.dart test/notifications/services/notification_refresh_coordinator_test.dart test/providers/foreground_idle_warmup_provider_test.dart`
- `dart analyze lib/services/database_encryption_bootstrap.dart lib/main.dart lib/services/foreground_idle_warmup_coordinator.dart lib/providers/foreground_idle_warmup_provider.dart lib/notifications/services/notification_refresh_coordinator.dart test/services/database_encryption_bootstrap_test.dart test/macos/build_macos_signing_test.dart test/services/foreground_idle_warmup_coordinator_test.dart test/providers/foreground_idle_warmup_provider_test.dart`
- `bash -n build_macos.sh`
- `git diff --check -- mobile/build_macos.sh mobile/lib/main.dart mobile/lib/services/database_encryption_bootstrap.dart mobile/lib/services/foreground_idle_warmup_coordinator.dart mobile/lib/providers/foreground_idle_warmup_provider.dart mobile/lib/notifications/services/notification_refresh_coordinator.dart mobile/test/macos/build_macos_signing_test.dart mobile/test/services/database_encryption_bootstrap_test.dart mobile/test/services/foreground_idle_warmup_coordinator_test.dart mobile/test/providers/foreground_idle_warmup_provider_test.dart`
- local signed macOS debug app launch checked in `/tmp/divine-macos-run.log`: no `-34018`, no `SqliteException(26)`, no `file is not a database`, no provisioning rejection
