### PR TITLE
fix(relay): lock non-production sessions to the environment relay host

### DIFF
--- a/docs/superpowers/specs/2026-06-17-relay-environment-isolation-design.md
+++ b/docs/superpowers/specs/2026-06-17-relay-environment-isolation-design.md
@@ -1,0 +1,160 @@
+# Relay environment isolation
+
+Status: Approved (brainstorm) — pending implementation
+Date: 2026-06-17
+
+## Problem
+
+When the app is set to a non-production environment (staging / poc / test /
+local) and the user records a video, the event is published to the
+**production** relay (`wss://relay.divine.video`).
+
+### Root cause
+
+The `NostrClient` is seeded with the environment relay **plus** the user's
+NIP-65 (kind 10002) relay list, which is added unconditionally with no
+environment filtering:
+
+- `lib/services/nostr_service_factory.dart` seeds `defaultRelayUrl =
+  environmentConfig.relayUrl` (correct).
+- `lib/providers/nostr_client_provider.dart` adds `authService.userRelays`
+  (the user's kind 10002 list) via `client.addRelays(...)` in `build()`, on
+  auth-state change, and via the discovered-relays callback. A kind:10002
+  bootstrap publisher adds more.
+- A production account's kind 10002 list contains `wss://relay.divine.video`,
+  so a staging session connects to staging **and** production.
+- Video publish (`video_event_publisher.dart`) calls publish with no
+  `targetRelays`, fanning out to **all** connected relays → the event lands on
+  production.
+- `environment_service.dart` clears the persisted `configured_relays` on
+  switch, but `authService.userRelays` is never cleared, so the production
+  relay is re-added every session.
+
+This affects every publish (likes, comments, profile, kind 10002) and
+subscriptions — not just video.
+
+## Goal
+
+In non-production environments, the app must connect to and publish on **only
+the environment relay host** — never production, never public indexers.
+Production behavior is unchanged.
+
+## Non-goals (deferred to the outbox-relay management feature)
+
+- Any relay-management UI changes.
+- Per-user override of the lock (e.g. a tester opting a specific relay in).
+- NIP-65 read/write (inbox/outbox) markers or publishing kind 10002 from a
+  management screen.
+
+## Design
+
+The enforcement lives centrally in `RelayManager` (one source of truth). It is
+expressed declaratively, not as an injected closure: the only two cases are
+"allow all" (production) and "lock to one host" (non-production), so a single
+nullable host field is exactly enough.
+
+### 1. `allowedRelayHost` on `RelayManagerConfig` + `isRelayAllowed` on `RelayManager`
+
+Add one optional field to `RelayManagerConfig`
+(`packages/nostr_client/lib/src/models/relay_manager_config.dart`), threaded
+through `copyWith`:
+
+```dart
+/// When set, only relays whose host equals this value are admitted.
+/// Null means no restriction (default — production behavior).
+final String? allowedRelayHost;
+```
+
+`RelayManager` (`packages/nostr_client/lib/src/relay_manager.dart`) exposes one
+public check that is the single source of truth for the rule:
+
+```dart
+bool isRelayAllowed(String url) {
+  final normalized = _normalizeUrl(url);
+  if (normalized == null) return false;
+  final host = _config.allowedRelayHost;
+  if (host == null) return true;
+  return Uri.parse(normalized).host == host;
+}
+```
+
+It is consulted (alongside the existing `_isBlockedRelay` dead-relay check) at
+every admission point:
+
+- the storage-load filter in `initialize()` — drops a persisted production
+  relay on the next staging launch (re-save already happens there today),
+- the default-relay insert,
+- `addRelay()` and `addRelays()`.
+
+`removeRelay()` is unaffected. This single chokepoint covers the env relay,
+user NIP-65 relays, the discovered-relays callback, and the kind:10002
+bootstrap — no per-call-site filtering in `nostr_client_provider`.
+
+### 2. Temp-relay filtering in `NostrClient`
+
+`targetRelays` / `tempRelays` are passed below `RelayManager` straight into the
+nostr_sdk send/query path, so they bypass the admission points above.
+`NostrClient` (`packages/nostr_client/lib/src/nostr_client.dart`) filters them
+with the **same** `RelayManager.isRelayAllowed` — not a second copy of the rule
+— before handing them to the SDK in `publishEvent`, `publishEventAwaitOk`, and
+`queryEvents`. A single private helper (`_allowedRelays(List<String>?)`) is
+applied at those call sites.
+
+### 3. Wiring — `nostr_service_factory`
+
+The factory holds `environmentConfig`, so it sets the field:
+
+- **Production** (`environmentConfig.isProduction`) → `allowedRelayHost: null`
+  (no restriction; unchanged).
+- **Non-production** → `allowedRelayHost: Uri.parse(environmentConfig.relayUrl).host`
+  (e.g. `relay.staging.divine.video`; `10.0.2.2` for local — host-based, not
+  host:port). Production `relay.divine.video` and public indexer relays are
+  rejected.
+
+### 4. Adjacent fix — `RelaySettingsCubit.restoreDefaultRelay()`
+
+Currently adds the hardcoded `AppConstants.defaultRelayUrl` (production), which
+the predicate would now reject on staging (surfacing as `failed`). Point it at
+the manager's env-aware default relay instead so "restore" works in every
+environment.
+
+## Testing
+
+`nostr_client` package (strict tests):
+
+- `RelayManager.isRelayAllowed`: with `allowedRelayHost` set, returns `false`
+  for a different host (production) and `true` for the env host; with it null,
+  returns `true` for any valid relay.
+- `RelayManager`: with `allowedRelayHost` set, `addRelay(production)` →
+  `false`; `addRelay(envHost)` → `true`; `initialize()` filters a persisted
+  production relay out of storage and re-saves; the default-relay insert still
+  works; `removeRelay` unaffected.
+- `NostrClient`: `publishEvent` / `publishEventAwaitOk` / `queryEvents` drop
+  `targetRelays` / `tempRelays` that fail `isRelayAllowed` before reaching the
+  SDK.
+
+App layer:
+
+- `nostr_service_factory`: production builds a null/allow-all predicate;
+  staging builds a predicate that rejects production and accepts the staging
+  host.
+- Isolation behavior: after a production NIP-65 relay is offered in a staging
+  session, `configuredRelays` contains only the env host.
+- `RelaySettingsCubit.restoreDefaultRelay()` restores the env relay (not
+  production) under a non-production config.
+
+## Consequences
+
+- On staging/poc/test, NIP-50 search and profile/NIP-65 discovery that rely on
+  external relays (`purplepag.es`, `user.kindpag.es`, `relay.nos.social`) stop
+  returning results, because those hosts are now rejected. This is the intended
+  meaning of "lock fully to env host"; the env relay must serve whatever a
+  tester needs, or the tester uses the per-user override from the follow-up
+  feature.
+
+## Risk / rollback
+
+`allowedRelayHost` defaults to null (no restriction), so production is
+byte-for-byte unchanged. The blast radius is non-production sessions only. If
+the lock proves too strict for staging, the follow-up outbox-management feature
+introduces the explicit per-user override.

--- a/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
+++ b/mobile/lib/blocs/relay_settings/relay_settings_cubit.dart
@@ -5,7 +5,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:openvine/blocs/relay_settings/relay_settings_state.dart';
-import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/services/relay_capability_service.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:openvine/utils/relay_url_utils.dart';
@@ -42,6 +41,10 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
   final NostrClient _nostrClient;
   final RelayCapabilityService _relayCapabilityService;
   final VideoEventService _videoEventService;
+
+  /// The environment default relay URL (e.g. the staging relay on staging),
+  /// used by the View to name the relay in the restore-default confirmation.
+  String get defaultRelayUrl => _nostrClient.defaultRelayUrl;
 
   void load() {
     emit(state.copyWith(relays: _nostrClient.configuredRelays));
@@ -121,7 +124,7 @@ class RelaySettingsCubit extends Cubit<RelaySettingsState> {
 
   Future<RestoreDefaultRelayOutcome> restoreDefaultRelay() async {
     try {
-      final success = await _nostrClient.addRelay(AppConstants.defaultRelayUrl);
+      final success = await _nostrClient.addRelay(defaultRelayUrl);
       if (!success) return RestoreDefaultRelayOutcome.failed;
       refreshRelays();
       return RestoreDefaultRelayOutcome.restored;

--- a/mobile/lib/screens/relay_settings_screen.dart
+++ b/mobile/lib/screens/relay_settings_screen.dart
@@ -9,7 +9,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/relay_settings/relay_settings_cubit.dart';
 import 'package:openvine/blocs/relay_settings/relay_settings_state.dart';
-import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -868,7 +867,7 @@ Future<void> _restoreDefaultRelay(BuildContext context) async {
       messenger.showSnackBar(
         SnackBar(
           content: Text(
-            l10n.relaySettingsRestoredDefault(AppConstants.defaultRelayUrl),
+            l10n.relaySettingsRestoredDefault(cubit.defaultRelayUrl),
           ),
           backgroundColor: VineTheme.success,
         ),

--- a/mobile/lib/services/nostr_service_factory.dart
+++ b/mobile/lib/services/nostr_service_factory.dart
@@ -45,11 +45,22 @@ class NostrServiceFactory {
 
     final config = NostrClientConfig(signer: effectiveSigner);
 
+    // In non-production environments, lock relays to the environment host so a
+    // user's NIP-65 list (which may carry production relays) cannot pull the
+    // client onto a different environment's relays. Production is unrestricted.
+    final isProduction = environmentConfig?.isProduction ?? true;
+    final relayHost = Uri.tryParse(divineRelayUrl)?.host;
+    final allowedRelayHost =
+        (isProduction || relayHost == null || relayHost.isEmpty)
+        ? null
+        : relayHost;
+
     // Create relay manager config with persistent storage
     // The Divine relay is always the default relay (cannot be removed)
     final relayManagerConfig = RelayManagerConfig(
       defaultRelayUrl: divineRelayUrl,
       storage: SharedPreferencesRelayStorage(),
+      allowedRelayHost: allowedRelayHost,
     );
 
     // Create the NostrClient

--- a/mobile/packages/nostr_client/lib/src/models/relay_manager_config.dart
+++ b/mobile/packages/nostr_client/lib/src/models/relay_manager_config.dart
@@ -49,10 +49,18 @@ class RelayManagerConfig {
     this.maxReconnectAttempts = 5,
     this.reconnectDelayMs = 2000,
     this.webSocketChannelFactory,
+    this.allowedRelayHost,
   });
 
   /// The default relay URL that is always included and cannot be removed
   final String defaultRelayUrl;
+
+  /// When set, only relays whose host equals this value are admitted.
+  ///
+  /// Null means no restriction (production behavior). Used to lock a
+  /// non-production environment to its own relay host so a user's NIP-65
+  /// relay list cannot pull in a different environment's relays.
+  final String? allowedRelayHost;
 
   /// Storage implementation for persisting relay configuration
   /// If null, relays are only kept in memory
@@ -80,6 +88,7 @@ class RelayManagerConfig {
     int? maxReconnectAttempts,
     int? reconnectDelayMs,
     WebSocketChannelFactory? webSocketChannelFactory,
+    String? allowedRelayHost,
   }) {
     return RelayManagerConfig(
       defaultRelayUrl: defaultRelayUrl ?? this.defaultRelayUrl,
@@ -89,6 +98,7 @@ class RelayManagerConfig {
       reconnectDelayMs: reconnectDelayMs ?? this.reconnectDelayMs,
       webSocketChannelFactory:
           webSocketChannelFactory ?? this.webSocketChannelFactory,
+      allowedRelayHost: allowedRelayHost ?? this.allowedRelayHost,
     );
   }
 }

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -337,6 +337,7 @@ class NostrClient {
     Event event, {
     List<String>? targetRelays,
   }) async {
+    final effectiveTargets = _allowedRelays(targetRelays);
     await _prepareEventForPublish(event);
     final useOptimisticCache = _canOptimisticallyCache(event.kind);
 
@@ -360,12 +361,12 @@ class NostrClient {
 
     final sentEvent = await _nostr.sendEvent(
       event,
-      targetRelays: targetRelays,
+      targetRelays: effectiveTargets,
       // Also pass as tempRelays so the SDK creates temporary connections
       // to target relays not already in the connected pool. Without this,
       // targetRelays only filters the existing pool and the event could
       // be sent to zero relays.
-      tempRelays: targetRelays,
+      tempRelays: effectiveTargets,
     );
 
     if (sentEvent == null) {
@@ -415,6 +416,7 @@ class NostrClient {
     Duration timeout = const Duration(seconds: 15),
     String? diagnosticTag,
   }) async {
+    final effectiveTargets = _allowedRelays(targetRelays);
     await _prepareEventForPublish(event);
     final useOptimisticCache = _canOptimisticallyCache(event.kind);
 
@@ -429,7 +431,8 @@ class NostrClient {
       return outcome;
     }
 
-    final hasExplicitTargets = targetRelays != null && targetRelays.isNotEmpty;
+    final hasExplicitTargets =
+        effectiveTargets != null && effectiveTargets.isNotEmpty;
 
     if (_relayManager.connectedRelays.isEmpty && !hasExplicitTargets) {
       await retryDisconnectedRelays();
@@ -449,14 +452,14 @@ class NostrClient {
         await (diagnosticTag == null
             ? _nostr.sendEventAwaitOk(
                 event,
-                targetRelays: targetRelays,
-                tempRelays: targetRelays,
+                targetRelays: effectiveTargets,
+                tempRelays: effectiveTargets,
                 timeout: timeout,
               )
             : _nostr.sendEventAwaitOk(
                 event,
-                targetRelays: targetRelays,
-                tempRelays: targetRelays,
+                targetRelays: effectiveTargets,
+                tempRelays: effectiveTargets,
                 timeout: timeout,
                 diagnosticTag: diagnosticTag,
               )) ??
@@ -500,6 +503,7 @@ class NostrClient {
     bool useCache = true,
     Duration timeout = const Duration(seconds: 5),
   }) async {
+    final effectiveTempRelays = _allowedRelays(tempRelays);
     final cacheResults = <Event>[];
 
     // 1. Get cache results (don't return early - we'll merge with network)
@@ -514,14 +518,14 @@ class NostrClient {
     // empty result (RelayPool completes immediately when no relay accepts
     // the REQ). Reconnect first, mirroring publish()/subscribe(). See #5202.
     if (_relayManager.connectedRelays.isEmpty &&
-        (tempRelays == null || tempRelays.isEmpty)) {
+        (effectiveTempRelays == null || effectiveTempRelays.isEmpty)) {
       await retryDisconnectedRelays();
     }
     final filtersJson = filters.map((f) => f.toJson()).toList();
     final websocketEvents = await _nostr.queryEvents(
       filtersJson,
       id: subscriptionId,
-      tempRelays: tempRelays,
+      tempRelays: effectiveTempRelays,
       relayTypes: relayTypes,
       sendAfterAuth: sendAfterAuth,
       timeout: timeout,
@@ -574,6 +578,7 @@ class NostrClient {
     List<int> relayTypes = RelayType.all,
     Duration timeout = const Duration(seconds: 5),
   }) async {
+    final effectiveTempRelays = _allowedRelays(tempRelays);
     final filtersJson = filters.map((f) => f.toJson()).toList();
 
     try {
@@ -581,7 +586,7 @@ class NostrClient {
       final response = await _nostr.countEvents(
         filtersJson,
         id: subscriptionId,
-        tempRelays: tempRelays,
+        tempRelays: effectiveTempRelays,
         relayTypes: relayTypes,
         timeout: timeout,
       );
@@ -594,7 +599,7 @@ class NostrClient {
       // Fall back to fetching events and counting client-side
       final events = await queryEvents(
         filters,
-        tempRelays: tempRelays,
+        tempRelays: effectiveTempRelays,
         relayTypes: relayTypes,
       );
 
@@ -698,6 +703,8 @@ class NostrClient {
     bool sendAfterAuth = false,
     void Function()? onEose,
   }) {
+    final effectiveTempRelays = _allowedRelays(tempRelays);
+    final effectiveTargetRelays = _allowedRelays(targetRelays);
     // Generate deterministic subscription ID based on filter content
     final filterHash = _generateFilterHash(filters);
     final id = subscriptionId ?? 'sub_$filterHash';
@@ -744,8 +751,8 @@ class NostrClient {
         statisticsObserver?.onEventReceived();
       },
       id: id,
-      tempRelays: tempRelays,
-      targetRelays: targetRelays,
+      tempRelays: effectiveTempRelays,
+      targetRelays: effectiveTargetRelays,
       relayTypes: relayTypes,
       sendAfterAuth: sendAfterAuth,
       onEose: onEose,
@@ -810,12 +817,35 @@ class NostrClient {
     return addedCount;
   }
 
+  /// Filters one-off [relays] (e.g. `targetRelays` / `tempRelays`) to those
+  /// admissible in the current environment, using the same rule as
+  /// [RelayManager.isRelayAllowed].
+  ///
+  /// Returns null when [relays] is null or nothing survives the filter, so the
+  /// caller falls back to the already-env-locked connected pool rather than an
+  /// ambiguous empty target list.
+  List<String>? _allowedRelays(List<String>? relays) {
+    if (relays == null) return null;
+    final allowed = relays.where(_relayManager.isRelayAllowed).toList();
+    return allowed.isEmpty ? null : allowed;
+  }
+
   /// Removes a relay connection
   ///
   /// Delegates to RelayManager.
   Future<bool> removeRelay(String relayUrl) async {
     return _relayManager.removeRelay(relayUrl);
   }
+
+  /// Whether [url] is admissible under the configured environment lock.
+  ///
+  /// Delegates to [RelayManager.isRelayAllowed] — the single source of truth
+  /// for the rule. Non-production builds lock to their own relay host.
+  bool isRelayAllowed(String url) => _relayManager.isRelayAllowed(url);
+
+  /// The environment default relay URL that is always included and cannot be
+  /// removed. Resolves per environment (e.g. the staging relay on staging).
+  String get defaultRelayUrl => _relayManager.defaultRelayUrl;
 
   /// Gets list of configured relay URLs
   List<String> get configuredRelays => _relayManager.configuredRelays;

--- a/mobile/packages/nostr_client/lib/src/relay_manager.dart
+++ b/mobile/packages/nostr_client/lib/src/relay_manager.dart
@@ -65,6 +65,21 @@ class RelayManager {
     }
   }
 
+  /// Whether [url] is admissible under the configured environment lock.
+  ///
+  /// Returns false for malformed URLs. When `config.allowedRelayHost` is set,
+  /// only relays whose host equals it are admitted (non-production lock);
+  /// when null, any valid relay is admitted (production). This is the single
+  /// source of truth for the rule — callers that bypass [addRelay] (e.g.
+  /// one-off `tempRelays` in `NostrClient`) consult it directly.
+  bool isRelayAllowed(String url) {
+    final normalized = _normalizeUrl(url);
+    if (normalized == null) return false;
+    final allowedHost = _config.allowedRelayHost;
+    if (allowedHost == null) return true;
+    return Uri.parse(normalized).host == allowedHost;
+  }
+
   final RelayManagerConfig _config;
   final RelayPool _relayPool;
   final Relay Function(String url)? _relayFactory;
@@ -163,6 +178,12 @@ class RelayManager {
           blockedCount++;
           continue;
         }
+        if (!isRelayAllowed(normalized)) {
+          // Persisted from another environment (e.g. a production relay
+          // saved before switching to staging). Drop and re-save below.
+          droppedCount++;
+          continue;
+        }
         if (!_configuredRelays.contains(normalized)) {
           _configuredRelays.add(normalized);
         }
@@ -186,6 +207,7 @@ class RelayManager {
     // (uses normalized URL for comparison)
     final normalizedDefault = _normalizeUrl(_config.defaultRelayUrl);
     if (normalizedDefault != null &&
+        isRelayAllowed(normalizedDefault) &&
         !_configuredRelays.contains(normalizedDefault)) {
       _configuredRelays.insert(0, normalizedDefault);
       _log('Added default relay: $normalizedDefault');
@@ -229,6 +251,12 @@ class RelayManager {
     // Block known-dead relays
     if (_isBlockedRelay(normalizedUrl)) {
       _log('Blocked dead relay: $normalizedUrl');
+      return false;
+    }
+
+    // Reject relays outside the configured environment host.
+    if (!isRelayAllowed(normalizedUrl)) {
+      _log('Relay not allowed in this environment: $normalizedUrl');
       return false;
     }
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -98,6 +98,9 @@ void main() {
       when(
         () => mockRelayManager.connectedRelays,
       ).thenReturn(['wss://relay.example.com']);
+      // Default: no environment lock (production behavior). Tests that
+      // exercise the lock override specific URLs to false.
+      when(() => mockRelayManager.isRelayAllowed(any())).thenReturn(true);
 
       client = NostrClient.forTesting(
         nostr: mockNostr,
@@ -266,6 +269,42 @@ void main() {
 
         expect(result, isA<PublishFailed>());
       });
+
+      test(
+        'drops targetRelays rejected by the environment host lock',
+        () async {
+          const envRelay = 'wss://relay.staging.divine.video';
+          const crossEnvRelay = 'wss://relay.divine.video';
+          final event = _createTestEvent();
+          when(
+            () => mockRelayManager.isRelayAllowed(envRelay),
+          ).thenReturn(true);
+          when(
+            () => mockRelayManager.isRelayAllowed(crossEnvRelay),
+          ).thenReturn(false);
+          when(
+            () => mockNostr.sendEvent(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => event);
+
+          await client.publishEvent(
+            event,
+            targetRelays: const [envRelay, crossEnvRelay],
+          );
+
+          final captured = verify(
+            () => mockNostr.sendEvent(
+              any(),
+              targetRelays: captureAny(named: 'targetRelays'),
+              tempRelays: any(named: 'tempRelays'),
+            ),
+          ).captured;
+          expect(captured.single, equals(const [envRelay]));
+        },
+      );
 
       test('attempts reconnection when no relays connected', () async {
         final event = _createTestEvent();

--- a/mobile/packages/nostr_client/test/src/relay_manager_test.dart
+++ b/mobile/packages/nostr_client/test/src/relay_manager_test.dart
@@ -35,11 +35,13 @@ RelayManagerConfig _createTestConfig({
   String? defaultRelayUrl,
   RelayStorage? storage,
   bool autoReconnect = true,
+  String? allowedRelayHost,
 }) {
   return RelayManagerConfig(
     defaultRelayUrl: defaultRelayUrl ?? testDefaultRelayUrl,
     storage: storage,
     autoReconnect: autoReconnect,
+    allowedRelayHost: allowedRelayHost,
   );
 }
 
@@ -84,17 +86,12 @@ void main() {
     when(() => mockRelayPool.activeRelays()).thenReturn([]);
     when(() => mockRelayPool.getRelay(any())).thenReturn(null);
     when(
-      () => mockRelayPool.add(
-        any(),
-        autoSubscribe: any(named: 'autoSubscribe'),
-      ),
+      () =>
+          mockRelayPool.add(any(), autoSubscribe: any(named: 'autoSubscribe')),
     ).thenAnswer((_) async => true);
     when(() => mockRelayPool.remove(any())).thenReturn(null);
 
-    manager = RelayManager(
-      config: config,
-      relayPool: mockRelayPool,
-    );
+    manager = RelayManager(config: config, relayPool: mockRelayPool);
   });
 
   tearDown(() {
@@ -147,9 +144,9 @@ void main() {
       });
 
       test('loads relays from storage during initialization', () async {
-        when(() => mockStorage.loadRelays()).thenAnswer(
-          (_) async => [testCustomRelayUrl],
-        );
+        when(
+          () => mockStorage.loadRelays(),
+        ).thenAnswer((_) async => [testCustomRelayUrl]);
         when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
 
         final configWithStorage = _createTestConfig(storage: mockStorage);
@@ -172,9 +169,9 @@ void main() {
       });
 
       test('ensures default relay is always included', () async {
-        when(() => mockStorage.loadRelays()).thenAnswer(
-          (_) async => [testCustomRelayUrl],
-        );
+        when(
+          () => mockStorage.loadRelays(),
+        ).thenAnswer((_) async => [testCustomRelayUrl]);
         when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
 
         final configWithStorage = _createTestConfig(storage: mockStorage);
@@ -205,9 +202,9 @@ void main() {
       });
 
       test('connects to all configured relays', () async {
-        when(() => mockStorage.loadRelays()).thenAnswer(
-          (_) async => [testCustomRelayUrl, testCustomRelayUrl2],
-        );
+        when(
+          () => mockStorage.loadRelays(),
+        ).thenAnswer((_) async => [testCustomRelayUrl, testCustomRelayUrl2]);
         when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
 
         final configWithStorage = _createTestConfig(storage: mockStorage);
@@ -231,10 +228,7 @@ void main() {
         'persists filtered list when storage contains insecure URLs (#3362)',
         () async {
           when(() => mockStorage.loadRelays()).thenAnswer(
-            (_) async => [
-              testCustomRelayUrl,
-              'ws://attacker.example.com',
-            ],
+            (_) async => [testCustomRelayUrl, 'ws://attacker.example.com'],
           );
           when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
 
@@ -257,9 +251,7 @@ void main() {
           );
 
           final captured =
-              verify(
-                    () => mockStorage.saveRelays(captureAny()),
-                  ).captured.last
+              verify(() => mockStorage.saveRelays(captureAny())).captured.last
                   as List<String>;
           expect(captured, contains(testCustomRelayUrl));
           expect(captured, isNot(contains('ws://attacker.example.com')));
@@ -612,10 +604,7 @@ void main() {
 
         // Last emission should show error state
         final lastUpdate = statusUpdates.last;
-        expect(
-          lastUpdate[testCustomRelayUrl]?.state,
-          equals(RelayState.error),
-        );
+        expect(lastUpdate[testCustomRelayUrl]?.state, equals(RelayState.error));
       });
     });
 
@@ -643,10 +632,7 @@ void main() {
         final result = await manager.removeRelay(testDefaultRelayUrl);
 
         expect(result, isTrue);
-        expect(
-          manager.configuredRelays,
-          isNot(contains(testDefaultRelayUrl)),
-        );
+        expect(manager.configuredRelays, isNot(contains(testDefaultRelayUrl)));
       });
 
       test('returns false for non-configured relay', () async {
@@ -1158,10 +1144,7 @@ void main() {
         await manager.initialize();
 
         var streamClosed = false;
-        manager.statusStream.listen(
-          (_) {},
-          onDone: () => streamClosed = true,
-        );
+        manager.statusStream.listen((_) {}, onDone: () => streamClosed = true);
 
         await manager.dispose();
 
@@ -1220,10 +1203,7 @@ void main() {
         final statuses = manager.currentStatuses;
 
         // Map.unmodifiable throws UnsupportedError on modification
-        expect(
-          () => statuses['new_key'],
-          returnsNormally,
-        );
+        expect(() => statuses['new_key'], returnsNormally);
         // Verify it's actually unmodifiable by checking the runtime type
         expect(statuses.runtimeType.toString(), contains('Unmodifiable'));
       });
@@ -1341,9 +1321,7 @@ void main() {
 
   group('RelayManagerConfig', () {
     test('creates config with required fields', () {
-      final config = RelayManagerConfig(
-        defaultRelayUrl: testDefaultRelayUrl,
-      );
+      final config = RelayManagerConfig(defaultRelayUrl: testDefaultRelayUrl);
 
       expect(config.defaultRelayUrl, equals(testDefaultRelayUrl));
       expect(config.storage, isNull);
@@ -1367,9 +1345,7 @@ void main() {
     });
 
     test('copyWith creates new instance with updated fields', () {
-      final original = RelayManagerConfig(
-        defaultRelayUrl: testDefaultRelayUrl,
-      );
+      final original = RelayManagerConfig(defaultRelayUrl: testDefaultRelayUrl);
       final copied = original.copyWith(autoReconnect: false);
 
       expect(copied.autoReconnect, isFalse);
@@ -1496,6 +1472,78 @@ void main() {
       expect(savedRelays, isNot(contains('wss://index.coracle.social')));
       expect(savedRelays, contains(testDefaultRelayUrl));
       expect(savedRelays, contains(testCustomRelayUrl));
+    });
+
+    group('environment host lock (allowedRelayHost)', () {
+      const envRelayUrl = 'wss://relay.staging.divine.video';
+      const envHost = 'relay.staging.divine.video';
+      const productionRelayUrl = 'wss://relay.divine.video';
+
+      test('isRelayAllowed allows any valid relay when host is null', () {
+        expect(manager.isRelayAllowed(productionRelayUrl), isTrue);
+        expect(manager.isRelayAllowed(envRelayUrl), isTrue);
+      });
+
+      test('isRelayAllowed rejects non-relay URLs', () {
+        expect(manager.isRelayAllowed('http://example.com'), isFalse);
+      });
+
+      test('isRelayAllowed allows only the locked host', () {
+        final locked = RelayManager(
+          config: _createTestConfig(
+            defaultRelayUrl: envRelayUrl,
+            allowedRelayHost: envHost,
+          ),
+          relayPool: mockRelayPool,
+        );
+
+        expect(locked.isRelayAllowed(envRelayUrl), isTrue);
+        expect(locked.isRelayAllowed(productionRelayUrl), isFalse);
+      });
+
+      test('addRelay rejects a host other than the locked host', () async {
+        final locked = RelayManager(
+          config: _createTestConfig(
+            defaultRelayUrl: envRelayUrl,
+            allowedRelayHost: envHost,
+          ),
+          relayPool: mockRelayPool,
+        );
+        await locked.initialize();
+
+        final added = await locked.addRelay(productionRelayUrl);
+
+        expect(added, isFalse);
+        expect(locked.configuredRelays, isNot(contains(productionRelayUrl)));
+        expect(locked.configuredRelays, contains(envRelayUrl));
+      });
+
+      test(
+        'initialize filters a persisted disallowed relay and re-saves',
+        () async {
+          when(
+            () => mockStorage.loadRelays(),
+          ).thenAnswer((_) async => [productionRelayUrl, envRelayUrl]);
+          when(() => mockStorage.saveRelays(any())).thenAnswer((_) async {});
+
+          final locked = RelayManager(
+            config: _createTestConfig(
+              defaultRelayUrl: envRelayUrl,
+              storage: mockStorage,
+              allowedRelayHost: envHost,
+            ),
+            relayPool: mockRelayPool,
+          );
+          await locked.initialize();
+
+          expect(locked.configuredRelays, contains(envRelayUrl));
+          expect(locked.configuredRelays, isNot(contains(productionRelayUrl)));
+          final saved =
+              verify(() => mockStorage.saveRelays(captureAny())).captured.last
+                  as List<String>;
+          expect(saved, isNot(contains(productionRelayUrl)));
+        },
+      );
     });
   });
 }

--- a/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
+++ b/mobile/test/blocs/relay_settings/relay_settings_cubit_test.dart
@@ -239,8 +239,11 @@ void main() {
     );
 
     blocTest<RelaySettingsCubit, RelaySettingsState>(
-      'restoreDefaultRelay delegates to addRelay(defaultUrl)',
+      "restoreDefaultRelay restores the client's environment default relay",
       setUp: () {
+        when(
+          () => nostr.defaultRelayUrl,
+        ).thenReturn('wss://relay.staging.divine.video');
         when(() => nostr.configuredRelays).thenReturn(['wss://default']);
       },
       build: buildCubit,
@@ -251,7 +254,9 @@ void main() {
         );
       },
       verify: (_) {
-        verify(() => nostr.addRelay(any())).called(1);
+        verify(
+          () => nostr.addRelay('wss://relay.staging.divine.video'),
+        ).called(1);
       },
     );
 

--- a/mobile/test/screens/relay_settings_screen_layout_test.dart
+++ b/mobile/test/screens/relay_settings_screen_layout_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
-import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -261,39 +260,40 @@ void main() {
       },
     );
 
-    testWidgets('restore-default snackbar names the default relay constant', (
-      tester,
-    ) async {
-      final nostrService = _MockNostrService();
-      when(
-        () => nostrService.addRelay(AppConstants.defaultRelayUrl),
-      ).thenAnswer((_) async => true);
+    testWidgets(
+      'restore-default snackbar names the environment default relay',
+      (
+        tester,
+      ) async {
+        const envDefaultRelay = 'wss://relay.staging.divine.video';
+        final nostrService = _MockNostrService();
+        when(() => nostrService.defaultRelayUrl).thenReturn(envDefaultRelay);
+        when(
+          () => nostrService.addRelay(envDefaultRelay),
+        ).thenAnswer((_) async => true);
 
-      await pumpScreen(tester, nostrService: nostrService);
+        await pumpScreen(tester, nostrService: nostrService);
 
-      when(
-        () => nostrService.configuredRelays,
-      ).thenReturn(['wss://not-the-default.example']);
+        when(
+          () => nostrService.configuredRelays,
+        ).thenReturn(['wss://not-the-default.example']);
 
-      final l10n = lookupAppLocalizations(const Locale('en'));
-      await tester.tap(find.text(l10n.relaySettingsRestoreDefaultRelay));
-      await tester.pumpAndSettle();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.tap(find.text(l10n.relaySettingsRestoreDefaultRelay));
+        await tester.pumpAndSettle();
 
-      expect(
-        find.text(
-          l10n.relaySettingsRestoredDefault(AppConstants.defaultRelayUrl),
-        ),
-        findsOneWidget,
-      );
-      expect(
-        find.text(
-          l10n.relaySettingsRestoredDefault('wss://not-the-default.example'),
-        ),
-        findsNothing,
-      );
-      verify(
-        () => nostrService.addRelay(AppConstants.defaultRelayUrl),
-      ).called(1);
-    });
+        expect(
+          find.text(l10n.relaySettingsRestoredDefault(envDefaultRelay)),
+          findsOneWidget,
+        );
+        expect(
+          find.text(
+            l10n.relaySettingsRestoredDefault('wss://not-the-default.example'),
+          ),
+          findsNothing,
+        );
+        verify(() => nostrService.addRelay(envDefaultRelay)).called(1);
+      },
+    );
   });
 }

--- a/mobile/test/services/nostr_service_factory_test.dart
+++ b/mobile/test/services/nostr_service_factory_test.dart
@@ -3,6 +3,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/services/nostr_identity.dart';
 import 'package:openvine/services/nostr_service_factory.dart';
 
@@ -37,6 +38,41 @@ void main() {
 
         expect(client, isA<NostrClient>());
         expect(client.publicKey, isEmpty);
+      });
+    });
+
+    group('environment relay isolation', () {
+      test('production allows any relay host', () {
+        final client = NostrServiceFactory.create(
+          signer: _MockNostrSigner(),
+          environmentConfig: EnvironmentConfig.production,
+        );
+
+        expect(client.isRelayAllowed('wss://relay.divine.video'), isTrue);
+        expect(client.isRelayAllowed('wss://relay.example.com'), isTrue);
+      });
+
+      test('no environment config falls back to allow-all', () {
+        final client = NostrServiceFactory.create(signer: _MockNostrSigner());
+
+        expect(client.isRelayAllowed('wss://relay.divine.video'), isTrue);
+        expect(client.isRelayAllowed('wss://relay.example.com'), isTrue);
+      });
+
+      test('staging locks to the staging relay host', () {
+        final client = NostrServiceFactory.create(
+          signer: _MockNostrSigner(),
+          environmentConfig: const EnvironmentConfig(
+            environment: AppEnvironment.staging,
+          ),
+        );
+
+        expect(
+          client.isRelayAllowed('wss://relay.staging.divine.video'),
+          isTrue,
+        );
+        expect(client.isRelayAllowed('wss://relay.divine.video'), isFalse);
+        expect(client.isRelayAllowed('wss://relay.example.com'), isFalse);
       });
     });
   });


### PR DESCRIPTION
Closes #5251

## Why

A video recorded while the app was set to **staging/poc** showed up on the **production** relay (`wss://relay.divine.video`).

**Root cause:** the `NostrClient` is seeded with the environment relay **plus** the user's NIP-65 (kind 10002) relay list, added unconditionally (`nostr_client_provider.dart`). A production account's 10002 list contains the production relay, so a non-production session connected to production too — and `publishEvent` fans out to all connected relays, so the event landed there. `environment_service` clears persisted `configured_relays` on switch but never clears the user's NIP-65 relays, so production got re-added every session.

This affected every publish (likes, comments, profile, kind 10002) and subscriptions — not just video.

## What

A single environment lock, enforced **centrally** in `RelayManager` (one source of truth), expressed declaratively (no injected closures).

- **`RelayManagerConfig.allowedRelayHost`** (`String?`, null = no restriction).
- **`RelayManager.isRelayAllowed(url)`** — consulted at every admission point: the storage-load filter (drops a persisted production relay on the next staging launch and re-saves), the default-relay insert, and `addRelay`/`addRelays`. This one chokepoint covers the env relay, the user's NIP-65 relays, the discovered-relays callback, and the kind:10002 bootstrap — no per-call-site filtering in the provider.
- **`NostrClient` temp-relay filtering** — `targetRelays`/`tempRelays` bypass `RelayManager` and go straight to the SDK, so they're filtered through the same `isRelayAllowed` in `publishEvent`, `publishEventAwaitOk`, `queryEvents`, `countEvents`, and `subscribe`. `sendLike`/`sendProfile`/`sendRepost`/`sendContactList` delegate to the filtered publish methods, so they're covered transitively.
- **Wiring** (`nostr_service_factory`): non-production → `allowedRelayHost = host(environmentConfig.relayUrl)`; production → `null` (unrestricted, byte-for-byte unchanged).
- **Adjacent fix**: `RelaySettingsCubit.restoreDefaultRelay()` and the settings-screen snackbar now use the client's env-aware default relay instead of the hardcoded production constant.

## Consequence (intended)

On staging/poc/test, external NIP-50 search and profile/NIP-65 discovery relays (`purplepag.es`, etc.) stop returning results — that's the literal meaning of "lock fully to the env host." A per-user override is deferred to the follow-up outbox-relay management feature.

## Tests (all green)

- `RelayManager`: `isRelayAllowed` null/locked cases; `addRelay` rejects a non-locked host; `initialize` filters a persisted disallowed relay and re-saves.
- `NostrClient`: `publishEvent` drops `targetRelays` rejected by the lock (filtered before reaching the SDK). Full package suite: 277 tests.
- `nostr_service_factory`: production/no-config allow-all; staging locks to the staging host.
- `RelaySettingsCubit` + settings screen: restore-default uses the env-aware relay.

`flutter analyze lib test` clean; `nostr_client` package `analyze` + 277 tests green; relay-settings screen/cubit suites green. Run from `mobile/`.

## Risk / rollback

`allowedRelayHost` defaults to null, so production behavior is unchanged. Blast radius is non-production sessions only.

## Test plan

- [ ] On staging, record a video → it appears only on the staging relay, never production.
- [ ] Switch staging → production → staging; confirm no production relay lingers in the configured set.
- [ ] Production: confirm the user's full NIP-65 relay set still connects normally.

Spec: `docs/superpowers/specs/2026-06-17-relay-environment-isolation-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)