### PR TITLE
feat(env): bottom indicator line for environment and non-Divine relays

### DIFF
--- a/docs/superpowers/specs/2026-06-17-environment-relay-indicator-line-design.md
+++ b/docs/superpowers/specs/2026-06-17-environment-relay-indicator-line-design.md
@@ -1,6 +1,6 @@
 # Environment / relay indicator line
 
-Status: Approved (brainstorm) — pending implementation
+Status: Implemented in PR #5253
 Date: 2026-06-17
 
 ## Problem
@@ -32,11 +32,13 @@ Purple takes precedence when both conditions hold.
 - **Visibility:** non-production **OR** using non-Divine relays. Hidden in
   production when on Divine-only relays.
 - **Precedence:** purple wins over the environment color.
-- **Purple trigger:** the client's **configured/outbox relay set**
-  (`NostrClient.configuredRelays` = env relay + the user's NIP-65 relays).
-  Transient read/indexer relays (e.g. `purplepag.es`) are not in this set and
-  do not trigger purple.
-- **Style:** a ~3px non-interactive line at the bottom edge.
+- **Purple trigger:** the client's current **configured/outbox relay set**
+  (`NostrClient.configuredRelays` = env relay + the user's NIP-65 relays),
+  excluding relays every account is auto-seeded with for indexer lookup and DM
+  reachability. Transient read/indexer relays (e.g. `purplepag.es`) do not
+  trigger purple unless they are also genuinely user-chosen relays.
+- **Style:** a 4px non-interactive line above the bottom navigation bar, with
+  rounded top corners.
 
 ## Non-goals
 
@@ -64,31 +66,39 @@ bool isDivineHostedRelayUrl(String url) {
   return _divineHostedRelayHosts.contains(host) || isLoopbackHost(host);
 }
 
-/// True if any relay in [configuredRelays] is not Divine-hosted.
-bool hasNonDivineRelay(Iterable<String> configuredRelays) =>
-    configuredRelays.any((url) => !isDivineHostedRelayUrl(url));
+/// True if [configuredRelays] includes a relay the user added beyond the
+/// Divine-operated relays, loopback, and the app's own [defaultRelayUrls].
+bool usesUserChosenRelay(
+  Iterable<String> configuredRelays, {
+  required Iterable<String> defaultRelayUrls,
+}) { ... }
 ```
 
 Reuses the existing `isLoopbackHost` helper in the same file. The host list is
-the set of `EnvironmentConfig.relayUrl` hosts across environments; kept as a
-const here (the util already owns `_divineRelayHost`).
+the set of `EnvironmentConfig.relayUrl` hosts across environments. The default
+relay exclusion covers `EnvironmentConfig.indexerRelays` and
+`IndexerRelayConfig.safeFallbackRelays`, so a fresh account seeded with app
+plumbing does not show as user-chosen non-Divine relay use.
 
 ### 2. State — `environmentIndicatorColorProvider` → `Color?`
 
-A Riverpod provider (colocated with the widget or in `environment_provider`)
-that returns the line color, or `null` when the line should be hidden.
+A Riverpod provider that returns the line color, or `null` when the line should
+be hidden.
 
 - `ref.watch(currentEnvironmentProvider)` — recompute on environment switch.
-- `ref.watch(relayStatisticsStreamProvider)` (or the equivalent relay-status
-  stream provider) — recompute when the relay set changes (add / remove /
-  NIP-65 discovery). The value is only used as a change trigger.
-- Reads `nostrService.configuredRelays`.
+- `ref.watch(configuredRelayUrlsProvider)` — recompute when the configured
+  relay set changes (add / remove / NIP-65 discovery). The provider is updated
+  by `relaySetChangeBridge` from the current relay-status map keys, which are
+  created from the configured relays and pruned on removal, so the
+  always-mounted indicator does not initialize the Nostr client itself.
 
 Logic:
 
 ```
-final relays = nostrService.configuredRelays;
-if (hasNonDivineRelay(relays)) return <purple>;
+final relays = ref.watch(configuredRelayUrlsProvider);
+if (usesUserChosenRelay(relays, defaultRelayUrls: defaultRelayUrls)) {
+  return <purple>;
+}
 if (!environment.isProduction) return Color(environment.indicatorColorValue);
 return null; // production + Divine-only → hidden
 ```
@@ -101,23 +111,32 @@ already uses) — no raw `Color(0x...)` literal in the widget.
 ```dart
 final color = ref.watch(environmentIndicatorColorProvider);
 if (color == null) return const SizedBox.shrink();
-return Container(height: 3, width: double.infinity, color: color);
+return ExcludeSemantics(
+  child: SizedBox(
+    height: 4,
+    width: double.infinity,
+    child: ClipRRect(
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+      child: ColoredBox(color: color),
+    ),
+  ),
+);
 ```
 
-Mounted at the bottom edge of `lib/router/app_shell.dart`, full width, below
-the bottom navigation bar and above the system home-indicator inset. Excluded
-from semantics (decorative).
+Mounted in `lib/router/app_shell.dart`, full width, above the bottom navigation
+bar. Excluded from semantics (decorative).
 
 ## Testing
 
 - `relay_url_utils` unit tests: `isDivineHostedRelayUrl` true for each Divine
   host + loopback, false for `purplepag.es` / `wss://relay.nos.social` /
-  malformed; `hasNonDivineRelay` true/false cases.
+  malformed; `usesUserChosenRelay` true/false/default-relay cases.
 - Provider tests (ProviderContainer with overrides): purple when configured
-  relays include a non-Divine host; environment color in non-production with
-  Divine-only relays; null in production with Divine-only relays.
-- Widget test: renders a 3px line of the provided color; renders
-  `SizedBox.shrink` when the provider is null.
+  relays include a user-chosen relay; environment color in non-production with
+  Divine-only relays; null in production with Divine/default relays; purple
+  clears after the user-chosen relay is removed.
+- Widget test: renders a colored line of the provided color; renders nothing
+  when the provider is null.
 
 ## Risk / rollback
 

--- a/docs/superpowers/specs/2026-06-17-environment-relay-indicator-line-design.md
+++ b/docs/superpowers/specs/2026-06-17-environment-relay-indicator-line-design.md
@@ -1,0 +1,127 @@
+# Environment / relay indicator line
+
+Status: Approved (brainstorm) — pending implementation
+Date: 2026-06-17
+
+## Problem
+
+There is no always-visible signal for two things a tester/user needs to know
+at a glance:
+
+1. Which non-production environment the app is pointed at (staging/poc/test/
+   local).
+2. Whether the client is configured to use relays **beyond Divine-hosted
+   ones** (a user's own NIP-65 relays), i.e. content may flow to relays Divine
+   does not operate.
+
+Today only a top app-bar `EnvironmentBadge` exists, shown in non-production
+only. There is no relay-awareness signal and no bottom indicator.
+
+## Goal
+
+A thin colored line pinned to the bottom edge of the app that:
+
+- shows the **environment color** in any non-production environment, and
+- shows **purple** whenever the configured relay set includes a non-Divine
+  host (in any environment, production included).
+
+Purple takes precedence when both conditions hold.
+
+## Decisions (from brainstorm)
+
+- **Visibility:** non-production **OR** using non-Divine relays. Hidden in
+  production when on Divine-only relays.
+- **Precedence:** purple wins over the environment color.
+- **Purple trigger:** the client's **configured/outbox relay set**
+  (`NostrClient.configuredRelays` = env relay + the user's NIP-65 relays).
+  Transient read/indexer relays (e.g. `purplepag.es`) are not in this set and
+  do not trigger purple.
+- **Style:** a ~3px non-interactive line at the bottom edge.
+
+## Non-goals
+
+- No change to the existing top `EnvironmentBadge`.
+- No tap/interaction on the line.
+- No per-relay UI (that's the separate outbox-management feature).
+
+## Design
+
+### 1. Detection — `lib/utils/relay_url_utils.dart` (pure)
+
+```dart
+const _divineHostedRelayHosts = <String>{
+  'relay.divine.video',
+  'relay.staging.divine.video',
+  'relay.poc.dvines.org',
+  'relay.test.dvines.org',
+};
+
+/// True when [url]'s host is a Divine-operated relay host or a loopback host
+/// (the `local` environment relay). Malformed URLs return false.
+bool isDivineHostedRelayUrl(String url) {
+  final host = Uri.tryParse(url)?.host.toLowerCase();
+  if (host == null || host.isEmpty) return false;
+  return _divineHostedRelayHosts.contains(host) || isLoopbackHost(host);
+}
+
+/// True if any relay in [configuredRelays] is not Divine-hosted.
+bool hasNonDivineRelay(Iterable<String> configuredRelays) =>
+    configuredRelays.any((url) => !isDivineHostedRelayUrl(url));
+```
+
+Reuses the existing `isLoopbackHost` helper in the same file. The host list is
+the set of `EnvironmentConfig.relayUrl` hosts across environments; kept as a
+const here (the util already owns `_divineRelayHost`).
+
+### 2. State — `environmentIndicatorColorProvider` → `Color?`
+
+A Riverpod provider (colocated with the widget or in `environment_provider`)
+that returns the line color, or `null` when the line should be hidden.
+
+- `ref.watch(currentEnvironmentProvider)` — recompute on environment switch.
+- `ref.watch(relayStatisticsStreamProvider)` (or the equivalent relay-status
+  stream provider) — recompute when the relay set changes (add / remove /
+  NIP-65 discovery). The value is only used as a change trigger.
+- Reads `nostrService.configuredRelays`.
+
+Logic:
+
+```
+final relays = nostrService.configuredRelays;
+if (hasNonDivineRelay(relays)) return <purple>;
+if (!environment.isProduction) return Color(environment.indicatorColorValue);
+return null; // production + Divine-only → hidden
+```
+
+Purple is a `VineTheme` purple (the same `accentPurple` the `local` environment
+already uses) — no raw `Color(0x...)` literal in the widget.
+
+### 3. Widget — `EnvironmentIndicatorLine` (ConsumerWidget)
+
+```dart
+final color = ref.watch(environmentIndicatorColorProvider);
+if (color == null) return const SizedBox.shrink();
+return Container(height: 3, width: double.infinity, color: color);
+```
+
+Mounted at the bottom edge of `lib/router/app_shell.dart`, full width, below
+the bottom navigation bar and above the system home-indicator inset. Excluded
+from semantics (decorative).
+
+## Testing
+
+- `relay_url_utils` unit tests: `isDivineHostedRelayUrl` true for each Divine
+  host + loopback, false for `purplepag.es` / `wss://relay.nos.social` /
+  malformed; `hasNonDivineRelay` true/false cases.
+- Provider tests (ProviderContainer with overrides): purple when configured
+  relays include a non-Divine host; environment color in non-production with
+  Divine-only relays; null in production with Divine-only relays.
+- Widget test: renders a 3px line of the provided color; renders
+  `SizedBox.shrink` when the provider is null.
+
+## Risk / rollback
+
+Purely additive UI. In production with the default Divine relay only, the
+provider returns null and nothing renders — no change to today's production
+appearance. A production user with their own NIP-65 relays will see a thin
+purple line (intended transparency).

--- a/mobile/lib/providers/environment_indicator_provider.dart
+++ b/mobile/lib/providers/environment_indicator_provider.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Provider + color logic for the environment / relay indicator bar.
+// ABOUTME: Lives in the provider layer so it can wire the relay service config.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+import 'package:openvine/utils/relay_url_utils.dart';
+
+/// Resolves the indicator bar color for the given [environment] and
+/// [configuredRelays], or `null` when the indicator should be hidden.
+///
+/// - A user-chosen relay beyond Divine + the app's [defaultRelayUrls] →
+///   purple (wins over the environment color).
+/// - Otherwise, a non-production environment → its environment color.
+/// - Otherwise (production on Divine / default relays) → `null` (hidden).
+Color? environmentIndicatorColor({
+  required EnvironmentConfig environment,
+  required List<String> configuredRelays,
+  required Iterable<String> defaultRelayUrls,
+}) {
+  if (usesUserChosenRelay(
+    configuredRelays,
+    defaultRelayUrls: defaultRelayUrls,
+  )) {
+    return VineTheme.accentPurple;
+  }
+  if (!environment.isProduction) {
+    return Color(environment.indicatorColorValue);
+  }
+  return null;
+}
+
+/// The current indicator bar color, or `null` when hidden.
+///
+/// Sources the active relay set from [relayStatisticsStreamProvider] (keyed by
+/// relay URL) rather than the Nostr client, so the always-mounted indicator
+/// never forces the client to initialise at shell build. Until relay stats
+/// exist, the relay set is empty and the indicator falls back to
+/// environment-only logic.
+final environmentIndicatorColorProvider = Provider<Color?>((ref) {
+  final environment = ref.watch(currentEnvironmentProvider);
+  final relayStats = ref.watch(relayStatisticsStreamProvider);
+  final activeRelays =
+      relayStats.asData?.value.keys.toList() ?? const <String>[];
+  return environmentIndicatorColor(
+    environment: environment,
+    configuredRelays: activeRelays,
+    // Relays every account is auto-seeded with (NIP-65 indexers + DM
+    // fallbacks). Excluded so only genuinely user-added relays show purple.
+    defaultRelayUrls: <String>{
+      ...environment.indexerRelays,
+      ...IndexerRelayConfig.safeFallbackRelays,
+    },
+  );
+});

--- a/mobile/lib/providers/environment_indicator_provider.dart
+++ b/mobile/lib/providers/environment_indicator_provider.dart
@@ -36,19 +36,16 @@ Color? environmentIndicatorColor({
 
 /// The current indicator bar color, or `null` when hidden.
 ///
-/// Sources the active relay set from [relayStatisticsStreamProvider] (keyed by
-/// relay URL) rather than the Nostr client, so the always-mounted indicator
-/// never forces the client to initialise at shell build. Until relay stats
-/// exist, the relay set is empty and the indicator falls back to
-/// environment-only logic.
+/// Sources the active relay set from [configuredRelayUrlsProvider], which is
+/// updated by the app-shell relay bridge from the current relay status map.
+/// This keeps the always-mounted decorative indicator from forcing client
+/// initialization, while still tracking relay additions and removals.
 final environmentIndicatorColorProvider = Provider<Color?>((ref) {
   final environment = ref.watch(currentEnvironmentProvider);
-  final relayStats = ref.watch(relayStatisticsStreamProvider);
-  final activeRelays =
-      relayStats.asData?.value.keys.toList() ?? const <String>[];
+  final configuredRelays = ref.watch(configuredRelayUrlsProvider);
   return environmentIndicatorColor(
     environment: environment,
-    configuredRelays: activeRelays,
+    configuredRelays: configuredRelays,
     // Relays every account is auto-seeded with (NIP-65 indexers + DM
     // fallbacks). Excluded so only genuinely user-added relays show purple.
     defaultRelayUrls: <String>{

--- a/mobile/lib/providers/relay_providers.dart
+++ b/mobile/lib/providers/relay_providers.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nostr_client/nostr_client.dart'
     show RelayConnectionStatus, RelayState;
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -15,6 +16,24 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'relay_providers.g.dart';
+
+/// Current configured relay URLs, including the environment default relay.
+///
+/// Updated by [relaySetChangeBridge] from the active relay status map so UI
+/// that only needs the relay set can react without constructing its own client.
+final configuredRelayUrlsProvider =
+    NotifierProvider<ConfiguredRelayUrls, List<String>>(
+      ConfiguredRelayUrls.new,
+    );
+
+class ConfiguredRelayUrls extends Notifier<List<String>> {
+  @override
+  List<String> build() => const <String>[];
+
+  void setUrls(List<String> urls) {
+    state = List.unmodifiable(urls);
+  }
+}
 
 /// Connection status service for monitoring network connectivity
 @Riverpod(keepAlive: true)
@@ -144,8 +163,13 @@ void relaySetChangeBridge(Ref ref) {
 
   Set<String> previousRelaySet = nostrService.relayStatuses.keys.toSet();
   Timer? debounceTimer;
+  var disposed = false;
 
   void processStatuses(Map<String, RelayConnectionStatus> statuses) {
+    ref
+        .read(configuredRelayUrlsProvider.notifier)
+        .setUrls(statuses.keys.toList(growable: false));
+
     final currentRelaySet = statuses.keys.toSet();
 
     // Only trigger if the set of relay URLs has changed (not just status)
@@ -194,13 +218,20 @@ void relaySetChangeBridge(Ref ref) {
     }
   }
 
-  // Process current state immediately to establish baseline
-  processStatuses(nostrService.relayStatuses);
+  // Publish the initial relay set after provider initialization. Riverpod
+  // disallows mutating another provider while this bridge is building.
+  Timer.run(() {
+    if (disposed) return;
+    ref
+        .read(configuredRelayUrlsProvider.notifier)
+        .setUrls(nostrService.relayStatuses.keys.toList(growable: false));
+  });
 
   // Listen to relay status stream for future updates
   final subscription = nostrService.relayStatusStream.listen(processStatuses);
 
   ref.onDispose(() {
+    disposed = true;
     debounceTimer?.cancel();
     subscription.cancel();
   });

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -339,4 +339,4 @@ final class RelaySetChangeBridgeProvider
 }
 
 String _$relaySetChangeBridgeHash() =>
-    r'69fd17051348b968d05f92adbaf87cc6844dea05';
+    r'a7a24101b27fb9a1722c4e22982bb63ec89c1adb';

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -24,6 +24,7 @@ import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/npub_hex.dart';
 import 'package:openvine/widgets/environment_indicator.dart';
+import 'package:openvine/widgets/environment_indicator_line.dart';
 import 'package:openvine/widgets/vine_bottom_nav.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -381,9 +382,15 @@ class _AppShellState extends ConsumerState<AppShell> {
       //
       // The nav itself lives in [VineBottomNav] so home / explore /
       // inbox / profile-router all render the same shared widget.
-      bottomNavigationBar: PointerInterceptor(
-        intercepting: kIsWeb,
-        child: VineBottomNav(currentIndex: currentIndex),
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const EnvironmentIndicatorLine(),
+          PointerInterceptor(
+            intercepting: kIsWeb,
+            child: VineBottomNav(currentIndex: currentIndex),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -39,9 +39,32 @@ bool isDivineHostedRelayUrl(String url) {
   return _divineHostedRelayHosts.contains(host) || isLoopbackHost(host);
 }
 
-/// True if any relay in [configuredRelays] is not Divine-hosted.
-bool hasNonDivineRelay(Iterable<String> configuredRelays) =>
-    configuredRelays.any((url) => !isDivineHostedRelayUrl(url));
+/// True if [configuredRelays] includes a relay the user added beyond the
+/// Divine-operated relays, loopback, and the app's own [defaultRelayUrls].
+///
+/// Every account — including a brand-new one — is auto-seeded with NIP-65
+/// indexer relays and DM-reachability fallback relays. Those are app plumbing,
+/// not relays the user chose, so they must be passed in via [defaultRelayUrls]
+/// and excluded; otherwise a fresh Divine-only account would falsely register
+/// as "using non-Divine relays".
+bool usesUserChosenRelay(
+  Iterable<String> configuredRelays, {
+  required Iterable<String> defaultRelayUrls,
+}) {
+  final allowedHosts = <String>{
+    ..._divineHostedRelayHosts,
+    for (final url in defaultRelayUrls)
+      if (Uri.tryParse(url)?.host.toLowerCase() case final String host
+          when host.isNotEmpty)
+        host,
+  };
+  return configuredRelays.any((url) {
+    final host = Uri.tryParse(url)?.host.toLowerCase();
+    if (host == null || host.isEmpty) return false;
+    if (allowedHosts.contains(host) || isLoopbackHost(host)) return false;
+    return true;
+  });
+}
 
 /// True if [url] is a relay URL the app is allowed to connect to.
 ///

--- a/mobile/lib/utils/relay_url_utils.dart
+++ b/mobile/lib/utils/relay_url_utils.dart
@@ -14,16 +14,34 @@ const _divineApiBaseUrl = 'https://api.divine.video';
 ///  * `mobile/android/app/src/main/res/xml/network_security_config.xml`
 ///  * `mobile/packages/nostr_sdk/lib/nip46/nostr_remote_signer_info.dart`
 ///  * `mobile/packages/nostr_client/lib/src/relay_manager.dart`
-const _loopbackHosts = <String>{
-  'localhost',
-  '127.0.0.1',
-  '10.0.2.2',
-  '::1',
-};
+const _loopbackHosts = <String>{'localhost', '127.0.0.1', '10.0.2.2', '::1'};
 
 /// True if [host] is a recognized loopback address that may be reached over
 /// cleartext (`ws://` / `http://`).
 bool isLoopbackHost(String host) => _loopbackHosts.contains(host.toLowerCase());
+
+/// Relay hosts operated by Divine across all environments.
+///
+/// Matches the `EnvironmentConfig.relayUrl` hosts. Loopback (the `local`
+/// environment relay) is covered separately via [isLoopbackHost].
+const _divineHostedRelayHosts = <String>{
+  'relay.divine.video',
+  'relay.staging.divine.video',
+  'relay.poc.dvines.org',
+  'relay.test.dvines.org',
+};
+
+/// True when [url]'s host is a Divine-operated relay host or a loopback host
+/// (the `local` environment relay). Malformed URLs return false.
+bool isDivineHostedRelayUrl(String url) {
+  final host = Uri.tryParse(url)?.host.toLowerCase();
+  if (host == null || host.isEmpty) return false;
+  return _divineHostedRelayHosts.contains(host) || isLoopbackHost(host);
+}
+
+/// True if any relay in [configuredRelays] is not Divine-hosted.
+bool hasNonDivineRelay(Iterable<String> configuredRelays) =>
+    configuredRelays.any((url) => !isDivineHostedRelayUrl(url));
 
 /// True if [url] is a relay URL the app is allowed to connect to.
 ///

--- a/mobile/lib/widgets/environment_indicator_line.dart
+++ b/mobile/lib/widgets/environment_indicator_line.dart
@@ -1,0 +1,72 @@
+// ABOUTME: Thin bottom-edge line signalling the environment and relay scope.
+// ABOUTME: Environment color in non-production; purple on non-Divine relays.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/utils/relay_url_utils.dart';
+
+/// Resolves the indicator line color for the given [environment] and
+/// [configuredRelays], or `null` when the line should be hidden.
+///
+/// - Any non-Divine relay in the configured set → purple (wins over the
+///   environment color).
+/// - Otherwise, a non-production environment → its environment color.
+/// - Otherwise (production on Divine-only relays) → `null` (hidden).
+Color? environmentIndicatorColor({
+  required EnvironmentConfig environment,
+  required List<String> configuredRelays,
+}) {
+  if (hasNonDivineRelay(configuredRelays)) return VineTheme.accentPurple;
+  if (!environment.isProduction) {
+    return Color(environment.indicatorColorValue);
+  }
+  return null;
+}
+
+/// The current indicator line color, or `null` when hidden.
+///
+/// Recomputes on environment switch and whenever the relay set / connections
+/// change (via [relayStatisticsStreamProvider]).
+final environmentIndicatorColorProvider = Provider<Color?>((ref) {
+  final environment = ref.watch(currentEnvironmentProvider);
+  // Watched purely as a change trigger so the line updates when relays are
+  // added/removed or NIP-65 discovery runs.
+  ref.watch(relayStatisticsStreamProvider);
+  // Degrade gracefully: a decorative line must never crash the shell if the
+  // Nostr client is transiently uninitialised / in error. No relays known →
+  // fall back to environment-only logic.
+  List<String> configuredRelays;
+  try {
+    configuredRelays = ref.watch(nostrServiceProvider).configuredRelays;
+  } on Object {
+    configuredRelays = const <String>[];
+  }
+  return environmentIndicatorColor(
+    environment: environment,
+    configuredRelays: configuredRelays,
+  );
+});
+
+/// A ~3px line pinned to the bottom edge of the app, colored by
+/// [environmentIndicatorColorProvider]. Decorative (excluded from semantics).
+class EnvironmentIndicatorLine extends ConsumerWidget {
+  const EnvironmentIndicatorLine({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final color = ref.watch(environmentIndicatorColorProvider);
+    if (color == null) return const SizedBox.shrink();
+    return ExcludeSemantics(
+      child: SizedBox(
+        height: 3,
+        width: double.infinity,
+        child: ColoredBox(color: color),
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/environment_indicator_line.dart
+++ b/mobile/lib/widgets/environment_indicator_line.dart
@@ -1,18 +1,17 @@
-// ABOUTME: Thin bottom-edge line signalling the environment and relay scope.
-// ABOUTME: Environment color in non-production; purple on non-Divine relays.
+// ABOUTME: Small bottom indicator pill signalling the environment / relay scope.
+// ABOUTME: Environment color in non-production; purple on user-added relays.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/environment_provider.dart';
-import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/utils/relay_url_utils.dart';
 
-/// Resolves the indicator line color for the given [environment] and
-/// [configuredRelays], or `null` when the line should be hidden.
+/// Resolves the indicator pill color for the given [environment] and
+/// [configuredRelays], or `null` when the indicator should be hidden.
 ///
 /// - A user-chosen relay beyond Divine + the app's [defaultRelayUrls] →
 ///   purple (wins over the environment color).
@@ -35,27 +34,21 @@ Color? environmentIndicatorColor({
   return null;
 }
 
-/// The current indicator line color, or `null` when hidden.
+/// The current indicator pill color, or `null` when hidden.
 ///
-/// Recomputes on environment switch and whenever the relay set / connections
-/// change (via [relayStatisticsStreamProvider]).
+/// Sources the active relay set from [relayStatisticsStreamProvider] (keyed by
+/// relay URL) rather than the Nostr client, so this always-mounted indicator
+/// never forces the client to initialise at shell build. Until relay stats
+/// exist, the relay set is empty and the indicator falls back to
+/// environment-only logic.
 final environmentIndicatorColorProvider = Provider<Color?>((ref) {
   final environment = ref.watch(currentEnvironmentProvider);
-  // Watched purely as a change trigger so the line updates when relays are
-  // added/removed or NIP-65 discovery runs.
-  ref.watch(relayStatisticsStreamProvider);
-  // Degrade gracefully: a decorative line must never crash the shell if the
-  // Nostr client is transiently uninitialised / in error. No relays known →
-  // fall back to environment-only logic.
-  List<String> configuredRelays;
-  try {
-    configuredRelays = ref.watch(nostrServiceProvider).configuredRelays;
-  } on Object {
-    configuredRelays = const <String>[];
-  }
+  final relayStats = ref.watch(relayStatisticsStreamProvider);
+  final activeRelays =
+      relayStats.asData?.value.keys.toList() ?? const <String>[];
   return environmentIndicatorColor(
     environment: environment,
-    configuredRelays: configuredRelays,
+    configuredRelays: activeRelays,
     // Relays every account is auto-seeded with (NIP-65 indexers + DM
     // fallbacks). Excluded so only genuinely user-added relays show purple.
     defaultRelayUrls: <String>{
@@ -65,20 +58,32 @@ final environmentIndicatorColorProvider = Provider<Color?>((ref) {
   );
 });
 
-/// A ~3px line pinned to the bottom edge of the app, colored by
-/// [environmentIndicatorColorProvider]. Decorative (excluded from semantics).
+/// A small rounded pill, centered just above the bottom nav, colored by
+/// [environmentIndicatorColorProvider]. Inset so it never reaches the
+/// rounded corners. Decorative (excluded from semantics).
 class EnvironmentIndicatorLine extends ConsumerWidget {
   const EnvironmentIndicatorLine({super.key});
+
+  static const double _height = 4;
+  static const double _width = 72;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final color = ref.watch(environmentIndicatorColorProvider);
     if (color == null) return const SizedBox.shrink();
     return ExcludeSemantics(
-      child: SizedBox(
-        height: 3,
-        width: double.infinity,
-        child: ColoredBox(color: color),
+      child: Padding(
+        padding: const EdgeInsets.only(bottom: 6),
+        child: Center(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(_height / 2),
+            child: SizedBox(
+              height: _height,
+              width: _width,
+              child: ColoredBox(color: color),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/mobile/lib/widgets/environment_indicator_line.dart
+++ b/mobile/lib/widgets/environment_indicator_line.dart
@@ -1,88 +1,33 @@
-// ABOUTME: Small bottom indicator pill signalling the environment / relay scope.
-// ABOUTME: Environment color in non-production; purple on user-added relays.
+// ABOUTME: Full-width bottom indicator bar signalling the environment / relay
+// ABOUTME: scope, with rounded top corners that curve up to meet the feed above.
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:openvine/models/environment_config.dart';
-import 'package:openvine/providers/environment_provider.dart';
-import 'package:openvine/providers/relay_providers.dart';
-import 'package:openvine/services/relay_discovery_service.dart';
-import 'package:openvine/utils/relay_url_utils.dart';
+import 'package:openvine/providers/environment_indicator_provider.dart';
 
-/// Resolves the indicator pill color for the given [environment] and
-/// [configuredRelays], or `null` when the indicator should be hidden.
-///
-/// - A user-chosen relay beyond Divine + the app's [defaultRelayUrls] →
-///   purple (wins over the environment color).
-/// - Otherwise, a non-production environment → its environment color.
-/// - Otherwise (production on Divine / default relays) → `null` (hidden).
-Color? environmentIndicatorColor({
-  required EnvironmentConfig environment,
-  required List<String> configuredRelays,
-  required Iterable<String> defaultRelayUrls,
-}) {
-  if (usesUserChosenRelay(
-    configuredRelays,
-    defaultRelayUrls: defaultRelayUrls,
-  )) {
-    return VineTheme.accentPurple;
-  }
-  if (!environment.isProduction) {
-    return Color(environment.indicatorColorValue);
-  }
-  return null;
-}
-
-/// The current indicator pill color, or `null` when hidden.
-///
-/// Sources the active relay set from [relayStatisticsStreamProvider] (keyed by
-/// relay URL) rather than the Nostr client, so this always-mounted indicator
-/// never forces the client to initialise at shell build. Until relay stats
-/// exist, the relay set is empty and the indicator falls back to
-/// environment-only logic.
-final environmentIndicatorColorProvider = Provider<Color?>((ref) {
-  final environment = ref.watch(currentEnvironmentProvider);
-  final relayStats = ref.watch(relayStatisticsStreamProvider);
-  final activeRelays =
-      relayStats.asData?.value.keys.toList() ?? const <String>[];
-  return environmentIndicatorColor(
-    environment: environment,
-    configuredRelays: activeRelays,
-    // Relays every account is auto-seeded with (NIP-65 indexers + DM
-    // fallbacks). Excluded so only genuinely user-added relays show purple.
-    defaultRelayUrls: <String>{
-      ...environment.indexerRelays,
-      ...IndexerRelayConfig.safeFallbackRelays,
-    },
-  );
-});
-
-/// A small rounded pill, centered just above the bottom nav, colored by
-/// [environmentIndicatorColorProvider]. Inset so it never reaches the
-/// rounded corners. Decorative (excluded from semantics).
+/// A full-width bar pinned at the bottom edge of the app, colored by
+/// [environmentIndicatorColorProvider]. Its top corners are rounded so the
+/// color curves up to meet the rounded bottom of the feed above it.
+/// Decorative (excluded from semantics).
 class EnvironmentIndicatorLine extends ConsumerWidget {
   const EnvironmentIndicatorLine({super.key});
 
   static const double _height = 4;
-  static const double _width = 72;
+  static const double _cornerRadius = 16;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final color = ref.watch(environmentIndicatorColorProvider);
     if (color == null) return const SizedBox.shrink();
     return ExcludeSemantics(
-      child: Padding(
-        padding: const EdgeInsets.only(bottom: 6),
-        child: Center(
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(_height / 2),
-            child: SizedBox(
-              height: _height,
-              width: _width,
-              child: ColoredBox(color: color),
-            ),
+      child: SizedBox(
+        height: _height,
+        width: double.infinity,
+        child: ClipRRect(
+          borderRadius: const BorderRadius.vertical(
+            top: Radius.circular(_cornerRadius),
           ),
+          child: ColoredBox(color: color),
         ),
       ),
     );

--- a/mobile/lib/widgets/environment_indicator_line.dart
+++ b/mobile/lib/widgets/environment_indicator_line.dart
@@ -8,20 +8,27 @@ import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/utils/relay_url_utils.dart';
 
 /// Resolves the indicator line color for the given [environment] and
 /// [configuredRelays], or `null` when the line should be hidden.
 ///
-/// - Any non-Divine relay in the configured set → purple (wins over the
-///   environment color).
+/// - A user-chosen relay beyond Divine + the app's [defaultRelayUrls] →
+///   purple (wins over the environment color).
 /// - Otherwise, a non-production environment → its environment color.
-/// - Otherwise (production on Divine-only relays) → `null` (hidden).
+/// - Otherwise (production on Divine / default relays) → `null` (hidden).
 Color? environmentIndicatorColor({
   required EnvironmentConfig environment,
   required List<String> configuredRelays,
+  required Iterable<String> defaultRelayUrls,
 }) {
-  if (hasNonDivineRelay(configuredRelays)) return VineTheme.accentPurple;
+  if (usesUserChosenRelay(
+    configuredRelays,
+    defaultRelayUrls: defaultRelayUrls,
+  )) {
+    return VineTheme.accentPurple;
+  }
   if (!environment.isProduction) {
     return Color(environment.indicatorColorValue);
   }
@@ -49,6 +56,12 @@ final environmentIndicatorColorProvider = Provider<Color?>((ref) {
   return environmentIndicatorColor(
     environment: environment,
     configuredRelays: configuredRelays,
+    // Relays every account is auto-seeded with (NIP-65 indexers + DM
+    // fallbacks). Excluded so only genuinely user-added relays show purple.
+    defaultRelayUrls: <String>{
+      ...environment.indexerRelays,
+      ...IndexerRelayConfig.safeFallbackRelays,
+    },
   );
 });
 

--- a/mobile/test/utils/relay_url_utils_test.dart
+++ b/mobile/test/utils/relay_url_utils_test.dart
@@ -226,29 +226,61 @@ void main() {
     });
   });
 
-  group('hasNonDivineRelay', () {
+  group('usesUserChosenRelay', () {
+    const defaultRelayUrls = [
+      'wss://purplepag.es',
+      'wss://relay.nos.social',
+      'wss://relay.damus.io',
+      'wss://nos.lol',
+    ];
+
     test('false when every relay is Divine-hosted', () {
       expect(
-        hasNonDivineRelay(const [
-          'wss://relay.divine.video',
-          'wss://relay.staging.divine.video',
-        ]),
+        usesUserChosenRelay(
+          const [
+            'wss://relay.divine.video',
+            'wss://relay.staging.divine.video',
+          ],
+          defaultRelayUrls: defaultRelayUrls,
+        ),
         isFalse,
       );
     });
 
-    test('true when any relay is not Divine-hosted', () {
+    test('false for a fresh account seeded with app default relays', () {
+      // Divine relay + auto-seeded indexer/fallback relays — none user-chosen.
       expect(
-        hasNonDivineRelay(const [
-          'wss://relay.divine.video',
-          'wss://purplepag.es',
-        ]),
+        usesUserChosenRelay(
+          const [
+            'wss://relay.divine.video',
+            'wss://purplepag.es',
+            'wss://relay.nos.social',
+            'wss://nos.lol',
+          ],
+          defaultRelayUrls: defaultRelayUrls,
+        ),
+        isFalse,
+      );
+    });
+
+    test('true when a relay outside Divine and the defaults is configured', () {
+      expect(
+        usesUserChosenRelay(
+          const [
+            'wss://relay.divine.video',
+            'wss://my-personal-relay.example',
+          ],
+          defaultRelayUrls: defaultRelayUrls,
+        ),
         isTrue,
       );
     });
 
     test('false for an empty relay set', () {
-      expect(hasNonDivineRelay(const []), isFalse);
+      expect(
+        usesUserChosenRelay(const [], defaultRelayUrls: defaultRelayUrls),
+        isFalse,
+      );
     });
   });
 }

--- a/mobile/test/utils/relay_url_utils_test.dart
+++ b/mobile/test/utils/relay_url_utils_test.dart
@@ -190,4 +190,65 @@ void main() {
       );
     });
   });
+
+  group('isDivineHostedRelayUrl', () {
+    test('accepts every Divine-operated relay host', () {
+      expect(isDivineHostedRelayUrl('wss://relay.divine.video'), isTrue);
+      expect(
+        isDivineHostedRelayUrl('wss://relay.staging.divine.video'),
+        isTrue,
+      );
+      expect(isDivineHostedRelayUrl('wss://relay.poc.dvines.org'), isTrue);
+      expect(isDivineHostedRelayUrl('wss://relay.test.dvines.org'), isTrue);
+    });
+
+    test('accepts loopback relays (local environment)', () {
+      expect(isDivineHostedRelayUrl('ws://10.0.2.2:47777'), isTrue);
+      expect(isDivineHostedRelayUrl('ws://localhost:47777'), isTrue);
+    });
+
+    test('rejects non-Divine relays', () {
+      expect(isDivineHostedRelayUrl('wss://purplepag.es'), isFalse);
+      expect(isDivineHostedRelayUrl('wss://relay.nos.social'), isFalse);
+      expect(isDivineHostedRelayUrl('wss://relay.example.com'), isFalse);
+    });
+
+    test('rejects suffix-match attacks on a Divine host', () {
+      expect(
+        isDivineHostedRelayUrl('wss://relay.divine.video.attacker.example'),
+        isFalse,
+      );
+    });
+
+    test('rejects malformed URLs', () {
+      expect(isDivineHostedRelayUrl(''), isFalse);
+      expect(isDivineHostedRelayUrl('http://example.com'), isFalse);
+    });
+  });
+
+  group('hasNonDivineRelay', () {
+    test('false when every relay is Divine-hosted', () {
+      expect(
+        hasNonDivineRelay(const [
+          'wss://relay.divine.video',
+          'wss://relay.staging.divine.video',
+        ]),
+        isFalse,
+      );
+    });
+
+    test('true when any relay is not Divine-hosted', () {
+      expect(
+        hasNonDivineRelay(const [
+          'wss://relay.divine.video',
+          'wss://purplepag.es',
+        ]),
+        isTrue,
+      );
+    });
+
+    test('false for an empty relay set', () {
+      expect(hasNonDivineRelay(const []), isFalse);
+    });
+  });
 }

--- a/mobile/test/widgets/environment_indicator_line_test.dart
+++ b/mobile/test/widgets/environment_indicator_line_test.dart
@@ -1,0 +1,93 @@
+// ABOUTME: Tests the environment/relay indicator line color logic and widget.
+// ABOUTME: Purple when on non-Divine relays; environment color otherwise.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/widgets/environment_indicator_line.dart';
+
+void main() {
+  const divineRelays = ['wss://relay.divine.video'];
+  const withNonDivineRelay = [
+    'wss://relay.divine.video',
+    'wss://purplepag.es',
+  ];
+
+  group('environmentIndicatorColor', () {
+    test('hidden in production on Divine-only relays', () {
+      expect(
+        environmentIndicatorColor(
+          environment: EnvironmentConfig.production,
+          configuredRelays: divineRelays,
+        ),
+        isNull,
+      );
+    });
+
+    test('environment color in non-production on Divine-only relays', () {
+      const staging = EnvironmentConfig(environment: AppEnvironment.staging);
+      expect(
+        environmentIndicatorColor(
+          environment: staging,
+          configuredRelays: divineRelays,
+        ),
+        equals(Color(staging.indicatorColorValue)),
+      );
+    });
+
+    test('purple in production when a non-Divine relay is configured', () {
+      expect(
+        environmentIndicatorColor(
+          environment: EnvironmentConfig.production,
+          configuredRelays: withNonDivineRelay,
+        ),
+        equals(VineTheme.accentPurple),
+      );
+    });
+
+    test('purple wins over the environment color', () {
+      expect(
+        environmentIndicatorColor(
+          environment: const EnvironmentConfig(
+            environment: AppEnvironment.staging,
+          ),
+          configuredRelays: withNonDivineRelay,
+        ),
+        equals(VineTheme.accentPurple),
+      );
+    });
+  });
+
+  group(EnvironmentIndicatorLine, () {
+    Widget pump(Color? color) {
+      return ProviderScope(
+        overrides: [
+          environmentIndicatorColorProvider.overrideWithValue(color),
+        ],
+        child: const MaterialApp(home: EnvironmentIndicatorLine()),
+      );
+    }
+
+    Finder lineBox() => find.descendant(
+      of: find.byType(EnvironmentIndicatorLine),
+      matching: find.byType(ColoredBox),
+    );
+
+    testWidgets('renders a colored line when the color is non-null', (
+      tester,
+    ) async {
+      await tester.pumpWidget(pump(VineTheme.accentPurple));
+
+      final box = tester.widget<ColoredBox>(lineBox());
+      expect(box.color, equals(VineTheme.accentPurple));
+    });
+
+    testWidgets('renders nothing when the color is null', (tester) async {
+      await tester.pumpWidget(pump(null));
+
+      expect(lineBox(), findsNothing);
+    });
+  });
+}

--- a/mobile/test/widgets/environment_indicator_line_test.dart
+++ b/mobile/test/widgets/environment_indicator_line_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/environment_indicator_provider.dart';
+import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/widgets/environment_indicator_line.dart';
 
 void main() {
@@ -79,6 +81,64 @@ void main() {
         ),
         equals(VineTheme.accentPurple),
       );
+    });
+  });
+
+  group('environmentIndicatorColorProvider', () {
+    ProviderContainer createContainer(EnvironmentConfig environment) {
+      final container = ProviderContainer(
+        overrides: [currentEnvironmentProvider.overrideWithValue(environment)],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    test('returns null in production with only Divine/default relays', () {
+      final container = createContainer(EnvironmentConfig.production);
+      container
+          .read(configuredRelayUrlsProvider.notifier)
+          .setUrls(freshAccountRelays);
+
+      expect(container.read(environmentIndicatorColorProvider), isNull);
+    });
+
+    test('returns environment color for non-production Divine-only relays', () {
+      const staging = EnvironmentConfig(environment: AppEnvironment.staging);
+      final container = createContainer(staging);
+      container
+          .read(configuredRelayUrlsProvider.notifier)
+          .setUrls(divineRelays);
+
+      expect(
+        container.read(environmentIndicatorColorProvider),
+        equals(Color(staging.indicatorColorValue)),
+      );
+    });
+
+    test('returns purple for a user-chosen relay', () {
+      final container = createContainer(EnvironmentConfig.production);
+      container
+          .read(configuredRelayUrlsProvider.notifier)
+          .setUrls(withUserChosenRelay);
+
+      expect(
+        container.read(environmentIndicatorColorProvider),
+        equals(VineTheme.accentPurple),
+      );
+    });
+
+    test('clears purple after the user-chosen relay is removed', () {
+      final container = createContainer(EnvironmentConfig.production);
+      final relayState = container.read(configuredRelayUrlsProvider.notifier);
+
+      relayState.setUrls(withUserChosenRelay);
+      expect(
+        container.read(environmentIndicatorColorProvider),
+        equals(VineTheme.accentPurple),
+      );
+
+      relayState.setUrls(divineRelays);
+      expect(container.read(environmentIndicatorColorProvider), isNull);
     });
   });
 

--- a/mobile/test/widgets/environment_indicator_line_test.dart
+++ b/mobile/test/widgets/environment_indicator_line_test.dart
@@ -10,9 +10,15 @@ import 'package:openvine/widgets/environment_indicator_line.dart';
 
 void main() {
   const divineRelays = ['wss://relay.divine.video'];
-  const withNonDivineRelay = [
+  const defaultRelayUrls = ['wss://purplepag.es', 'wss://relay.nos.social'];
+  const freshAccountRelays = [
     'wss://relay.divine.video',
     'wss://purplepag.es',
+    'wss://relay.nos.social',
+  ];
+  const withUserChosenRelay = [
+    'wss://relay.divine.video',
+    'wss://my-personal-relay.example',
   ];
 
   group('environmentIndicatorColor', () {
@@ -21,6 +27,18 @@ void main() {
         environmentIndicatorColor(
           environment: EnvironmentConfig.production,
           configuredRelays: divineRelays,
+          defaultRelayUrls: defaultRelayUrls,
+        ),
+        isNull,
+      );
+    });
+
+    test('hidden for a fresh account seeded with app default relays', () {
+      expect(
+        environmentIndicatorColor(
+          environment: EnvironmentConfig.production,
+          configuredRelays: freshAccountRelays,
+          defaultRelayUrls: defaultRelayUrls,
         ),
         isNull,
       );
@@ -32,16 +50,18 @@ void main() {
         environmentIndicatorColor(
           environment: staging,
           configuredRelays: divineRelays,
+          defaultRelayUrls: defaultRelayUrls,
         ),
         equals(Color(staging.indicatorColorValue)),
       );
     });
 
-    test('purple in production when a non-Divine relay is configured', () {
+    test('purple in production when a user-chosen relay is configured', () {
       expect(
         environmentIndicatorColor(
           environment: EnvironmentConfig.production,
-          configuredRelays: withNonDivineRelay,
+          configuredRelays: withUserChosenRelay,
+          defaultRelayUrls: defaultRelayUrls,
         ),
         equals(VineTheme.accentPurple),
       );
@@ -53,7 +73,8 @@ void main() {
           environment: const EnvironmentConfig(
             environment: AppEnvironment.staging,
           ),
-          configuredRelays: withNonDivineRelay,
+          configuredRelays: withUserChosenRelay,
+          defaultRelayUrls: defaultRelayUrls,
         ),
         equals(VineTheme.accentPurple),
       );

--- a/mobile/test/widgets/environment_indicator_line_test.dart
+++ b/mobile/test/widgets/environment_indicator_line_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/providers/environment_indicator_provider.dart';
 import 'package:openvine/widgets/environment_indicator_line.dart';
 
 void main() {


### PR DESCRIPTION
Closes #5254

## Why

Testers and users need an always-visible signal for two states that are easy to miss today: which non-production environment the app is pointed at, and whether the current configured relay set includes a user-chosen relay beyond Divine-operated/default relay plumbing.

## What

Adds a 4px decorative line above the bottom nav:

- **Environment color** in any non-production environment (staging/poc/test/local).
- **Purple** whenever the current configured relay set includes a genuinely user-chosen relay beyond Divine-operated relays and app-seeded indexer/DM fallback relays. Purple wins when both conditions apply.
- **Hidden** in production when only Divine/default relays are configured.

### Pieces

- `relay_url_utils.dart`: `isDivineHostedRelayUrl` and `usesUserChosenRelay`, including Divine host/loopback handling and exclusion for app-seeded default relays.
- `relay_providers.dart`: `configuredRelayUrlsProvider`, updated by the existing relay-set bridge from current relay-status map keys so removed relays are pruned and the indicator does not read stale relay statistics.
- `environment_indicator_provider.dart`: combines environment state, configured relays, and default-relay exclusions into the indicator color.
- `environment_indicator_line.dart`: decorative full-width 4px curved bar, excluded from semantics.
- `app_shell.dart`: mounts the line above the bottom nav.

## Tests

- `mise exec -- flutter test test/widgets/environment_indicator_line_test.dart test/utils/relay_url_utils_test.dart test/unit/providers/relay_set_change_bridge_test.dart`
- `mise exec -- flutter analyze lib test`
- `mise exec -- flutter test test/router/app_shell_notification_badge_test.dart test/router/app_shell_todo_test.dart`
- Pre-push hook: merge-conflict check, analyzer, generated-file verification, and changed-file tests all passed.

## Manual test plan

- [ ] Switch to staging: a staging-colored line appears above the bottom nav.
- [ ] Add a user-chosen non-Divine relay in production or staging: the line turns purple.
- [ ] Remove that user-chosen relay: production with only Divine/default relays returns to no line.

Spec: `docs/superpowers/specs/2026-06-17-environment-relay-indicator-line-design.md`