### PR TITLE
fix(router): redirect fullscreen feed to home when extra args are missing (web reload)

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -16,6 +16,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/notifications/view/notifications_page.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/pooled_fullscreen_feed_route.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/router/router_refresh_listenable.dart';
 import 'package:openvine/router/universal_link_resolver.dart';
@@ -89,7 +90,6 @@ import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/page_load_observer.dart';
 import 'package:openvine/services/video_stop_navigator_observer.dart';
-import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Global route observer for [RouteAware] subscribers (e.g. pausing video
@@ -141,21 +141,6 @@ String rewriteResetPasswordDeepLink(Uri uri) {
       ..write(Uri.encodeQueryComponent(email));
   }
   return buffer.toString();
-}
-
-/// Redirect target for the fullscreen video feed route.
-///
-/// The route receives its videos through in-memory `extra` args, which the web
-/// platform discards on page reload / direct navigation. When [extra] is not a
-/// valid args object, redirect to the home feed instead of showing an error
-/// screen. Returns `null` (no redirect) when the args are present.
-@visibleForTesting
-String? fullscreenFeedRedirect(Object? extra) {
-  if (extra is PooledFullscreenVideoFeedArgs ||
-      extra is ProfilePooledFullscreenVideoFeedArgs) {
-    return null;
-  }
-  return VideoFeedPage.pathForIndex(0);
 }
 
 /// Redirects deep links for people-lists routes to the home feed when the
@@ -1399,36 +1384,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         path: PooledFullscreenVideoFeedScreen.path,
         name: PooledFullscreenVideoFeedScreen.routeName,
         redirect: (context, state) => fullscreenFeedRedirect(state.extra),
-        builder: (ctx, st) {
-          final extra = st.extra;
-          if (extra is PooledFullscreenVideoFeedArgs) {
-            return PooledFullscreenVideoFeedScreen(
-              source: extra.source,
-              feedRepository: extra.feedRepository,
-              initialIndex: extra.initialIndex,
-              initialVideoId: extra.initialVideoId,
-              initialStableId: extra.initialStableId,
-              contextTitle: extra.contextTitle,
-              trafficSource: extra.trafficSource,
-              sourceDetail: extra.sourceDetail,
-              autoOpenComments: extra.autoOpenComments,
-              onPageChanged: extra.onPageChanged,
-            );
-          }
-          if (extra is ProfilePooledFullscreenVideoFeedArgs) {
-            return ProfileVideoFeedView(
-              npub: '',
-              userIdHex: extra.userIdHex,
-              videoIndex: extra.initialIndex,
-              videos: extra.seedVideos,
-              initialVideoId: extra.initialVideoId,
-              initialStableId: extra.initialStableId,
-              contextTitleOverride: extra.contextTitle,
-              onPageChanged: extra.onPageChanged ?? (_) {},
-            );
-          }
-          return RouteErrorScreen(message: ctx.l10n.routeNoVideosToDisplay);
-        },
+        builder: buildPooledFullscreenFeed,
       ),
       // Engagement lists for own videos: who liked / reposted this video.
       // Reached when the video owner taps the Like or Repost button on

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -143,6 +143,21 @@ String rewriteResetPasswordDeepLink(Uri uri) {
   return buffer.toString();
 }
 
+/// Redirect target for the fullscreen video feed route.
+///
+/// The route receives its videos through in-memory `extra` args, which the web
+/// platform discards on page reload / direct navigation. When [extra] is not a
+/// valid args object, redirect to the home feed instead of showing an error
+/// screen. Returns `null` (no redirect) when the args are present.
+@visibleForTesting
+String? fullscreenFeedRedirect(Object? extra) {
+  if (extra is PooledFullscreenVideoFeedArgs ||
+      extra is ProfilePooledFullscreenVideoFeedArgs) {
+    return null;
+  }
+  return VideoFeedPage.pathForIndex(0);
+}
+
 /// Redirects deep links for people-lists routes to the home feed when the
 /// [FeatureFlag.curatedLists] feature flag is off.
 ///
@@ -1383,6 +1398,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: PooledFullscreenVideoFeedScreen.path,
         name: PooledFullscreenVideoFeedScreen.routeName,
+        redirect: (context, state) => fullscreenFeedRedirect(state.extra),
         builder: (ctx, st) {
           final extra = st.extra;
           if (extra is PooledFullscreenVideoFeedArgs) {

--- a/mobile/lib/router/pooled_fullscreen_feed_route.dart
+++ b/mobile/lib/router/pooled_fullscreen_feed_route.dart
@@ -1,0 +1,58 @@
+// ABOUTME: Builder + redirect for the /pooled-video-feed fullscreen route.
+// ABOUTME: Extracted from app_router.dart to keep that file under its size ceiling.
+
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/router/route_error_screen.dart';
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
+import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
+
+/// Redirect target for the fullscreen video feed route.
+///
+/// The route receives its videos through in-memory `extra` args, which the web
+/// platform discards on page reload / direct navigation. When [extra] is not a
+/// valid args object, redirect to the home feed instead of showing an error
+/// screen. Returns `null` (no redirect) when the args are present.
+String? fullscreenFeedRedirect(Object? extra) {
+  if (extra is PooledFullscreenVideoFeedArgs ||
+      extra is ProfilePooledFullscreenVideoFeedArgs) {
+    return null;
+  }
+  return VideoFeedPage.pathForIndex(0);
+}
+
+/// Builds the fullscreen video feed for the matched route, resolving the
+/// in-memory `extra` args. [fullscreenFeedRedirect] guarantees valid args
+/// before this runs; the final [RouteErrorScreen] is a defensive fallback.
+Widget buildPooledFullscreenFeed(BuildContext context, GoRouterState state) {
+  final extra = state.extra;
+  if (extra is PooledFullscreenVideoFeedArgs) {
+    return PooledFullscreenVideoFeedScreen(
+      source: extra.source,
+      feedRepository: extra.feedRepository,
+      initialIndex: extra.initialIndex,
+      initialVideoId: extra.initialVideoId,
+      initialStableId: extra.initialStableId,
+      contextTitle: extra.contextTitle,
+      trafficSource: extra.trafficSource,
+      sourceDetail: extra.sourceDetail,
+      autoOpenComments: extra.autoOpenComments,
+      onPageChanged: extra.onPageChanged,
+    );
+  }
+  if (extra is ProfilePooledFullscreenVideoFeedArgs) {
+    return ProfileVideoFeedView(
+      npub: '',
+      userIdHex: extra.userIdHex,
+      videoIndex: extra.initialIndex,
+      videos: extra.seedVideos,
+      initialVideoId: extra.initialVideoId,
+      initialStableId: extra.initialStableId,
+      contextTitleOverride: extra.contextTitle,
+      onPageChanged: extra.onPageChanged ?? (_) {},
+    );
+  }
+  return RouteErrorScreen(message: context.l10n.routeNoVideosToDisplay);
+}

--- a/mobile/test/router/fullscreen_feed_redirect_test.dart
+++ b/mobile/test/router/fullscreen_feed_redirect_test.dart
@@ -1,11 +1,21 @@
 // ABOUTME: Tests the fullscreen video feed route redirect — falls back to the
 // ABOUTME: home feed when its in-memory `extra` args are missing (web reload).
 
+import 'package:feed_repository/feed_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
 import 'package:openvine/router/pooled_fullscreen_feed_route.dart'
     show fullscreenFeedRedirect;
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
+
+VideoEvent _video(String id) => VideoEvent(
+  id: id,
+  pubkey: 'author',
+  createdAt: 1000,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1000 * 1000),
+);
 
 void main() {
   group('fullscreenFeedRedirect', () {
@@ -21,6 +31,16 @@ void main() {
         fullscreenFeedRedirect('not-args'),
         equals(VideoFeedPage.pathForIndex(0)),
       );
+    });
+
+    test('does not redirect when valid pooled feed args are present', () {
+      final args = PooledFullscreenVideoFeedArgs(
+        source: SingleVideoViewSource(_video('1')),
+        feedRepository: StaticFeedRepository(),
+        initialIndex: 0,
+      );
+
+      expect(fullscreenFeedRedirect(args), isNull);
     });
 
     test('does not redirect when valid profile feed args are present', () {

--- a/mobile/test/router/fullscreen_feed_redirect_test.dart
+++ b/mobile/test/router/fullscreen_feed_redirect_test.dart
@@ -2,7 +2,8 @@
 // ABOUTME: home feed when its in-memory `extra` args are missing (web reload).
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:openvine/router/app_router.dart' show fullscreenFeedRedirect;
+import 'package:openvine/router/pooled_fullscreen_feed_route.dart'
+    show fullscreenFeedRedirect;
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
 

--- a/mobile/test/router/fullscreen_feed_redirect_test.dart
+++ b/mobile/test/router/fullscreen_feed_redirect_test.dart
@@ -1,0 +1,34 @@
+// ABOUTME: Tests the fullscreen video feed route redirect — falls back to the
+// ABOUTME: home feed when its in-memory `extra` args are missing (web reload).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/app_router.dart' show fullscreenFeedRedirect;
+import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
+import 'package:openvine/screens/feed/video_feed_page.dart';
+
+void main() {
+  group('fullscreenFeedRedirect', () {
+    test('redirects to the home feed when extra is null (web reload)', () {
+      expect(
+        fullscreenFeedRedirect(null),
+        equals(VideoFeedPage.pathForIndex(0)),
+      );
+    });
+
+    test('redirects to the home feed when extra is the wrong type', () {
+      expect(
+        fullscreenFeedRedirect('not-args'),
+        equals(VideoFeedPage.pathForIndex(0)),
+      );
+    });
+
+    test('does not redirect when valid profile feed args are present', () {
+      const args = ProfilePooledFullscreenVideoFeedArgs(
+        userIdHex: 'abc',
+        initialIndex: 0,
+      );
+
+      expect(fullscreenFeedRedirect(args), isNull);
+    });
+  });
+}

--- a/mobile/test/router/route_error_routing_test.dart
+++ b/mobile/test/router/route_error_routing_test.dart
@@ -10,7 +10,6 @@ import 'package:openvine/l10n/generated/app_localizations_en.dart';
 import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/router.dart';
-import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/auth_service.dart';
 
 import '../helpers/test_provider_overrides.dart';
@@ -60,30 +59,10 @@ void main() {
     expect(find.text(strings.routeUnknownPath), findsOneWidget);
   });
 
-  testWidgets(
-    'pooled fullscreen route without feed args uses RouteErrorScreen with no videos copy',
-    (tester) async {
-      final strings = AppLocalizationsEn();
-      final container = ProviderContainer(
-        overrides: [
-          authServiceProvider.overrideWithValue(authenticatedAuth()),
-          currentMinorAccountReviewStatusProvider.overrideWith(
-            (ref) async => MinorAccountReviewStatus.active(),
-          ),
-        ],
-      );
-      addTearDown(container.dispose);
-      await container.read(currentMinorAccountReviewStatusProvider.future);
-
-      await _pumpRouter(tester, container);
-
-      container.read(goRouterProvider).go(PooledFullscreenVideoFeedScreen.path);
-      await tester.pumpAndSettle();
-
-      expect(find.byType(RouteErrorScreen), findsOneWidget);
-      expect(find.text(strings.routeNoVideosToDisplay), findsOneWidget);
-    },
-  );
+  // The pooled fullscreen route's no-args fallback (redirect to the home feed
+  // on web reload) is covered by the pure-function test in
+  // fullscreen_feed_redirect_test.dart — asserting it here would require
+  // rendering the full home feed, which the router test harness can't provide.
 }
 
 Future<void> _pumpRouter(

--- a/mobile/test/router/route_error_routing_test.dart
+++ b/mobile/test/router/route_error_routing_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Localized route error UI: unknown paths (errorBuilder) and bad pooled extras
+// ABOUTME: Localized route error UI for unknown paths via GoRouter.errorBuilder
 // ABOUTME: Covers GoRouter.errorBuilder and RouteErrorScreen from app routes (#3371)
 
 import 'package:flutter/material.dart';
@@ -59,10 +59,10 @@ void main() {
     expect(find.text(strings.routeUnknownPath), findsOneWidget);
   });
 
-  // The pooled fullscreen route's no-args fallback (redirect to the home feed
-  // on web reload) is covered by the pure-function test in
-  // fullscreen_feed_redirect_test.dart — asserting it here would require
-  // rendering the full home feed, which the router test harness can't provide.
+  // The pooled fullscreen route's no-args redirect is covered at the route
+  // helper level in fullscreen_feed_redirect_test.dart. A widget assertion for
+  // the redirect target would require rendering the full home feed, which this
+  // focused error-route harness does not provide.
 }
 
 Future<void> _pumpRouter(


### PR DESCRIPTION
Closes #5256

## Why

Reloading the web app while watching a fullscreen video, or opening `/pooled-video-feed` directly, showed an Error / No videos to display screen.

## Root Cause

The `/pooled-video-feed` route receives its videos through in-memory `go_router` `extra` args. Flutter web does not preserve `extra` across reloads or direct URL entry, so the route builder could no longer reconstruct the fullscreen feed and fell through to `RouteErrorScreen(routeNoVideosToDisplay)`.

## What Changed

- Added a route-level redirect for `/pooled-video-feed` that sends missing or wrong-type `extra` args to the home feed (`/home/0`).
- Preserved normal in-app navigation by returning no redirect for both valid fullscreen feed arg types.
- Extracted the fullscreen feed route builder and redirect helper to keep `app_router.dart` under its size ceiling.
- Cleaned up stale route-error test comments after the old error-screen behavior was intentionally removed.

## Tests

- `fullscreen_feed_redirect_test.dart`: null extra redirects to `/home/0`.
- `fullscreen_feed_redirect_test.dart`: wrong-type extra redirects to `/home/0`.
- `fullscreen_feed_redirect_test.dart`: valid `PooledFullscreenVideoFeedArgs` does not redirect.
- `fullscreen_feed_redirect_test.dart`: valid `ProfilePooledFullscreenVideoFeedArgs` does not redirect.
- `route_error_routing_test.dart`: unknown-location `GoRouter.errorBuilder` still renders `RouteErrorScreen`.

## Verification

- `mise exec -- flutter test test/router/fullscreen_feed_redirect_test.dart test/router/route_error_routing_test.dart`
- `mise exec -- flutter analyze test/router/fullscreen_feed_redirect_test.dart test/router/route_error_routing_test.dart`
- Pre-push hook: analyze clean and changed-file router tests passed (`app_router_test.dart`, `fullscreen_feed_redirect_test.dart`, `route_error_routing_test.dart`).

## Manual Test Plan

- [ ] Open a fullscreen video on web, reload the page, and confirm it lands on the home feed instead of an error.
- [ ] Open `/pooled-video-feed` directly and confirm it lands on the home feed.
- [ ] Navigate to a fullscreen video in-app and confirm it still opens normally when args are present.