### PR TITLE
fix(video-editor): show timeline audio bar for invalid composition window

### DIFF
--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -175,7 +175,14 @@ class TimelineOverlayBloc
     Float32List? leftChannel,
     Float32List? rightChannel,
   }) {
-    final sourceDuration = track.duration != null
+    // Treat a non-positive duration as "unknown" — matching
+    // _resolveSoundDurationSecs / _healMissingAudioDurations, which key off
+    // `(duration ?? 0) <= 0`. A persisted-but-zero duration must NOT become a
+    // zero-length sourceDuration: that would drive maxDuration to <= 0 and let
+    // a trim gesture immediately collapse the now-visible bar back to nothing.
+    // Falling through to null gives it the maxDuration fallback below instead.
+    final hasDuration = (track.duration ?? 0) > 0;
+    final sourceDuration = hasDuration
         ? Duration(milliseconds: (track.duration! * 1000).round())
         : null;
 

--- a/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
+++ b/mobile/lib/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart
@@ -74,7 +74,16 @@ class TimelineOverlayBloc
           item.id: item.waveformRightChannel!,
     };
 
-    final total = event.totalVideoDuration;
+    // Clips may not be measured yet during a draft load, surfacing a transient
+    // totalVideoDuration of zero. Clamping every item's end to zero would
+    // collapse the whole timeline — sounds, layers, filters and markers — and
+    // _onTotalDurationChanged would then drop the zero-length items. Fall back
+    // to maxDuration (the editor's hard duration ceiling, so nothing real is
+    // truncated) until a valid total arrives via
+    // TimelineOverlayTotalDurationChanged, which re-clamps every item.
+    final total = event.totalVideoDuration > Duration.zero
+        ? event.totalVideoDuration
+        : VideoEditorConstants.maxDuration;
 
     final sounds = <TimelineOverlayItem>[
       for (final track in event.audioTracks)
@@ -170,11 +179,22 @@ class TimelineOverlayBloc
         ? Duration(milliseconds: (track.duration! * 1000).round())
         : null;
 
+    // A persisted track can carry an invalid composition window — e.g. a sound
+    // added before its duration was known ends up with endTime=0 (see
+    // _openMusicLibrary), or a probe that never resolved leaves endTime null.
+    // Mirror the render-path heal in audioTrackFromMetaForRender: treat any
+    // missing/inverted window as "play across the whole video" so the bar
+    // spans [0, total] instead of collapsing to an invisible zero-width strip.
+    final endTime = track.endTime;
+    final hasWindow = endTime != null && endTime > track.startTime;
+
     return TimelineOverlayItem(
       id: track.id,
       type: .sound,
-      startTime: track.startTime,
-      endTime: _clampEnd(track.endTime ?? .zero, total),
+      startTime: hasWindow ? track.startTime : .zero,
+      // No valid window → span the whole video. [total] is guaranteed > 0 by
+      // _onUpdateItems (transient-zero is substituted with maxDuration there).
+      endTime: hasWindow ? _clampEnd(endTime, total) : total,
       label: track.title ?? track.pubkey,
       maxDuration: sourceDuration != null
           ? sourceDuration - track.startOffset

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -357,6 +357,41 @@ void main() {
       );
 
       blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'treats a zero duration as unknown so a trim cannot collapse the bar',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
+            // A persisted-but-zero duration must be normalized to "unknown",
+            // otherwise sourceDuration becomes zero and maxDuration <= 0, which
+            // a trim gesture would use to collapse the now-visible bar.
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: Duration.zero,
+                end: Duration.zero,
+              ).copyWith(duration: 0),
+            ],
+            totalVideoDuration: const Duration(seconds: 12),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.sourceDuration,
+                'sourceDuration',
+                isNull,
+              )
+              .having(
+                (s) => s.items.first.maxDuration,
+                'maxDuration',
+                VideoEditorConstants.maxDuration,
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
         'clears selection when not trimming',
         build: TimelineOverlayBloc.new,
         seed: () => const TimelineOverlayState(selectedItemId: 'sound-1'),

--- a/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/timeline_overlay/timeline_overlay_bloc_test.dart
@@ -198,6 +198,133 @@ void main() {
       );
 
       blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'spans the whole video when a sound carries a zero-length window',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
+            // A sound added before its duration was known persists
+            // startTime=0/endTime=0 — an invisible zero-width bar unless the
+            // timeline heals it to play across the whole video.
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: Duration.zero,
+                end: Duration.zero,
+              ),
+            ],
+            totalVideoDuration: const Duration(seconds: 12),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.startTime,
+                'startTime',
+                Duration.zero,
+              )
+              .having(
+                (s) => s.items.first.endTime,
+                'endTime',
+                const Duration(seconds: 12),
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'falls back to maxDuration when an invalid-window sound has no total',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          TimelineOverlayItemsUpdate(
+            layers: const <Layer>[],
+            filters: const <FilterState>[],
+            // total is transiently zero (clips not yet measured during a draft
+            // load); the heal must not collapse the bar back to zero width.
+            audioTracks: [
+              _audioEvent(
+                id: 'sound-1',
+                start: Duration.zero,
+                end: Duration.zero,
+              ),
+            ],
+            totalVideoDuration: Duration.zero,
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.startTime,
+                'startTime',
+                Duration.zero,
+              )
+              .having(
+                (s) => s.items.first.endTime,
+                'endTime',
+                VideoEditorConstants.maxDuration,
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'keeps markers within reach when total is transiently zero',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          const TimelineOverlayItemsUpdate(
+            layers: <Layer>[],
+            filters: <FilterState>[],
+            audioTracks: <AudioEvent>[],
+            // The shared maxDuration fallback also guards marker clamping, so a
+            // transient zero total can't collapse every marker onto 0.
+            timelineMarkers: [Duration(seconds: 3)],
+            totalVideoDuration: Duration.zero,
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>().having(
+            (s) => s.timelineMarkers,
+            'timelineMarkers',
+            const [Duration(seconds: 3)],
+          ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
+        'spans the whole video when a sound has no endTime',
+        build: TimelineOverlayBloc.new,
+        act: (bloc) => bloc.add(
+          const TimelineOverlayItemsUpdate(
+            layers: <Layer>[],
+            filters: <FilterState>[],
+            audioTracks: [
+              // endTime omitted (null): a probe that never resolved leaves the
+              // composition window open.
+              AudioEvent(
+                id: 'sound-1',
+                pubkey: 'pubkey-sound-1',
+                createdAt: 1704067200,
+                title: 'Beat',
+              ),
+            ],
+            totalVideoDuration: Duration(seconds: 12),
+          ),
+        ),
+        expect: () => [
+          isA<TimelineOverlayState>()
+              .having(
+                (s) => s.items.first.startTime,
+                'startTime',
+                Duration.zero,
+              )
+              .having(
+                (s) => s.items.first.endTime,
+                'endTime',
+                const Duration(seconds: 12),
+              ),
+        ],
+      );
+
+      blocTest<TimelineOverlayBloc, TimelineOverlayState>(
         'leaves source duration null when the track has no duration',
         build: TimelineOverlayBloc.new,
         act: (bloc) => bloc.add(


### PR DESCRIPTION
Closes #5265

## Description

Follow-up to #5232. That PR healed the **render path** so custom audio with a missing/invalid composition window still plays *across the whole video*. The **timeline display** had the matching gap, which I flagged at the time as "could still be hidden in the timeline" — this closes it.

### The bug

A sound added before its duration was known persists `endTime=0` (see `_openMusicLibrary`), and a `getMetadata` probe that never resolved leaves `endTime` null. `_soundItem` mapped that case to:

```dart
endTime: _clampEnd(track.endTime ?? .zero, total) // → 0
```

→ an invisible **zero-width bar**. The audio rendered (the #5232 render heal plays it whole-video), but it couldn't be seen or selected in the timeline. The load-time backfill (`_healMissingAudioDurations`) only recovers this when the probe **succeeds**; when the source is unreadable and the probe returns 0, the bar stayed hidden for the whole session.

Note the pre-existing asymmetry: filters and layers already defaulted a null `endTime` to `total` — sound was the odd one out at `.zero`.



### Fix

1. **`_soundItem` heal** — mirror `audioTrackFromMetaForRender`: treat any missing/inverted window (`endTime == null || endTime <= startTime`) as "play across the whole video", so the bar spans `[0, total]` instead of collapsing. The displayed bar now matches what actually renders.

2. **Shared clamp guard** — `_onUpdateItems` substitutes `maxDuration` for a transient `totalVideoDuration <= 0` (clips not yet measured during a draft load). Clamping every item end to zero would otherwise collapse the whole timeline (sounds, layers, filters, markers) and `_onTotalDurationChanged` would then drop the zero-length items. `maxDuration` is the editor's hard duration ceiling, so nothing real is truncated; a valid total arriving via `TimelineOverlayTotalDurationChanged` re-clamps every item downward.

The substitution is **display-only**: `audioTracks` are emitted unchanged, and the heal keys off `AudioEvent.duration` (still 0) — so `getMetadata` is still attempted and the real trimmed length still wins when readable.

Closes none

### Interaction with the #5232 backfill

| Source state | before this PR | after this PR |
|---|---|---|
| readable (probe > 0) | brief invisible flash → real length (heal) | no flash → real length (heal) |
| unreadable (probe = 0 / fails) | **permanently invisible** (audio still rendered) | visible, spans whole video (matches render) |

## Verification

- `flutter analyze` on both files — no issues.
- `flutter test timeline_overlay_bloc_test.dart` — all 52 pass, incl. new regressions: zero-length window, null `endTime`, transient-zero total (sound path), and a marker-path case proving the shared guard covers non-sound items.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)