### PR TITLE
fix(feed): fast-fail age-gate viewer auth on a hung remote signer

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -301,6 +301,15 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// (post-router-gate) to get a guaranteed non-null value.
   NostrIdentity? get currentIdentity => _currentIdentity;
 
+  /// Whether the current identity signs over a non-interactive network RPC
+  /// (the Keycast OAuth-only signer) and so can hang on a flaky connection.
+  ///
+  /// Viewer-media auth uses this to bound signing with a short timeout. Local
+  /// and interactive remote signers (bunker / Amber / NIP-07) return `false`
+  /// and are never timed out. Defaults to `false` when no identity is set.
+  bool get viewerAuthSignsRemotely =>
+      _currentIdentity?.signsRemotelyNonInteractive ?? false;
+
   /// The current user's signing identity, guaranteed non-null.
   ///
   /// Throws [StateError] if called when no identity is set. This should only

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -301,15 +301,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// (post-router-gate) to get a guaranteed non-null value.
   NostrIdentity? get currentIdentity => _currentIdentity;
 
-  /// Whether the current identity signs over a non-interactive network RPC
-  /// (the Keycast OAuth-only signer) and so can hang on a flaky connection.
-  ///
-  /// Viewer-media auth uses this to bound signing with a short timeout. Local
-  /// and interactive remote signers (bunker / Amber / NIP-07) return `false`
-  /// and are never timed out. Defaults to `false` when no identity is set.
-  bool get viewerAuthSignsRemotely =>
-      _currentIdentity?.signsRemotelyNonInteractive ?? false;
-
   /// The current user's signing identity, guaranteed non-null.
   ///
   /// Throws [StateError] if called when no identity is set. This should only
@@ -2413,10 +2404,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
   Future<void> _clearOAuthSessionForSignOut() async {
     if (_oauthClient != null) {
-      await _runSignOutCleanupWithRetry(
-        'OAuth logout',
-        _oauthClient.logout,
-      );
+      await _runSignOutCleanupWithRetry('OAuth logout', _oauthClient.logout);
     }
 
     await _runSignOutCleanupWithRetry(

--- a/mobile/lib/services/media_viewer_auth_service.dart
+++ b/mobile/lib/services/media_viewer_auth_service.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart';
@@ -16,10 +18,30 @@ class MediaViewerAuthService {
   final BlossomAuthService _blossomAuthService;
   final Nip98AuthService _nip98AuthService;
 
+  /// Caller-side bound on remote viewer-auth signing. Sits well under
+  /// Keycast's 30s RPC ceiling (`keycast_rpc.dart`) yet far above the observed
+  /// ~200-430ms happy-path round-trip, so a healthy signer is never cut off
+  /// while an unreachable one fails fast into the existing retry UI.
+  static const Duration _signTimeout = Duration(seconds: 6);
+
+  /// Whether viewer auth headers can be created at all (the user is
+  /// authenticated).
+  ///
+  /// This is a synchronous gate, not a signer-reachability check — a live
+  /// probe would itself hang on the same remote RPC. The [createAuthHeaders]
+  /// timeout is the de-facto reachability proxy for remote signers.
   bool get canCreateHeaders => _authService.isAuthenticated;
 
   /// Returns request headers for a media GET, or null when no viewer auth can
   /// be created for the current user/request shape.
+  ///
+  /// For the Keycast OAuth-only remote signer
+  /// ([AuthService.viewerAuthSignsRemotely]) the signing round-trip is bounded
+  /// by [_signTimeout]; if the signer does not respond in time this returns
+  /// null — the same "no headers" result every caller already handles — rather
+  /// than hanging on Keycast's 30s ceiling. Local and interactive remote
+  /// signers (bunker / Amber / NIP-07) are awaited unbounded so a human
+  /// approval step is never cut off.
   Future<Map<String, String>?> createAuthHeaders({
     String? sha256Hash,
     String? url,
@@ -29,23 +51,45 @@ class MediaViewerAuthService {
       return null;
     }
 
+    final boundSigning = _authService.viewerAuthSignsRemotely;
+
     if (sha256Hash != null && sha256Hash.isNotEmpty) {
-      final header = await _blossomAuthService.createGetAuthHeader(
-        sha256Hash: sha256Hash,
-        serverUrl: serverUrl,
+      final header = await _bound(
+        boundSigning,
+        () => _blossomAuthService.createGetAuthHeader(
+          sha256Hash: sha256Hash,
+          serverUrl: serverUrl,
+        ),
       );
       return _authorizationHeaders(header);
     }
 
     if (url != null && url.isNotEmpty) {
-      final token = await _nip98AuthService.createAuthToken(
-        url: url,
-        method: HttpMethod.get,
+      final token = await _bound(
+        boundSigning,
+        () => _nip98AuthService.createAuthToken(
+          url: url,
+          method: HttpMethod.get,
+        ),
       );
       return _authorizationHeaders(token?.authorizationHeader);
     }
 
     return null;
+  }
+
+  /// Awaits [sign]. When [bound] (the non-interactive remote signer), the call
+  /// is capped at [_signTimeout] and a timeout yields null — the same "no
+  /// headers" result every caller already handles — instead of hanging on the
+  /// remote RPC's own 30s ceiling. Unbounded otherwise, so a local or
+  /// interactive (human-approved) sign is never cut off.
+  Future<T?> _bound<T>(bool bound, Future<T?> Function() sign) async {
+    if (!bound) return sign();
+    try {
+      return await sign().timeout(_signTimeout);
+    } on TimeoutException {
+      return null;
+    }
   }
 
   Map<String, String>? _authorizationHeaders(String? authorizationHeader) {

--- a/mobile/lib/services/media_viewer_auth_service.dart
+++ b/mobile/lib/services/media_viewer_auth_service.dart
@@ -35,12 +35,11 @@ class MediaViewerAuthService {
   /// Returns request headers for a media GET, or null when no viewer auth can
   /// be created for the current user/request shape.
   ///
-  /// For the Keycast OAuth-only remote signer
-  /// ([AuthService.viewerAuthSignsRemotely]) the signing round-trip is bounded
-  /// by [_signTimeout]; if the signer does not respond in time this returns
-  /// null — the same "no headers" result every caller already handles — rather
-  /// than hanging on Keycast's 30s ceiling. Local and interactive remote
-  /// signers (bunker / Amber / NIP-07) are awaited unbounded so a human
+  /// For the Keycast OAuth-only remote signer, the signing round-trip is
+  /// bounded by [_signTimeout]; if the signer does not respond in time this
+  /// returns null — the same "no headers" result every caller already handles
+  /// — rather than hanging on Keycast's 30s ceiling. Local and interactive
+  /// remote signers (bunker / Amber / NIP-07) are awaited unbounded so a human
   /// approval step is never cut off.
   Future<Map<String, String>?> createAuthHeaders({
     String? sha256Hash,
@@ -51,7 +50,8 @@ class MediaViewerAuthService {
       return null;
     }
 
-    final boundSigning = _authService.viewerAuthSignsRemotely;
+    final boundSigning =
+        _authService.currentIdentity?.signsRemotelyNonInteractive ?? false;
 
     if (sha256Hash != null && sha256Hash.isNotEmpty) {
       final header = await _bound(
@@ -67,10 +67,8 @@ class MediaViewerAuthService {
     if (url != null && url.isNotEmpty) {
       final token = await _bound(
         boundSigning,
-        () => _nip98AuthService.createAuthToken(
-          url: url,
-          method: HttpMethod.get,
-        ),
+        () =>
+            _nip98AuthService.createAuthToken(url: url, method: HttpMethod.get),
       );
       return _authorizationHeaders(token?.authorizationHeader);
     }

--- a/mobile/lib/services/nostr_identity.dart
+++ b/mobile/lib/services/nostr_identity.dart
@@ -28,6 +28,16 @@ sealed class NostrIdentity implements NostrSigner {
   /// `sign_canonical` RPC. NIP-46 (bunker) and NIP-55 (amber) identities
   /// always return null because their protocols only define event signing.
   Future<String?> signCanonicalPayload(Uint8List payload);
+
+  /// Whether this identity signs remotely over a non-interactive network
+  /// round-trip (no human approval step in the loop).
+  ///
+  /// True ONLY for the Keycast OAuth-only signer, whose signing is bounded by
+  /// a network RPC and can therefore hang on a flaky connection. Viewer-media
+  /// auth uses this to apply a short caller-side timeout. Interactive remote
+  /// signers (NIP-46 bunker, NIP-55 Amber, NIP-07 extension) are human-paced —
+  /// the user reads a prompt and approves — so they must NOT be timed out.
+  bool get signsRemotelyNonInteractive;
 }
 
 /// Identity backed by a local [SecureKeyContainer] with a private key.
@@ -50,6 +60,9 @@ class LocalNostrIdentity extends NostrIdentity implements IsolateDecryptSigner {
   @override
   Future<String?> signCanonicalPayload(Uint8List payload) =>
       _signer.signCanonicalPayload(payload);
+
+  @override
+  bool get signsRemotelyNonInteractive => false;
 
   @override
   bool get canDecryptInIsolate => _signer.canDecryptInIsolate;
@@ -150,6 +163,12 @@ class KeycastNostrIdentity extends NostrIdentity
     return null;
   }
 
+  /// OAuth-only Keycast (no matching local key) signs over the network RPC,
+  /// so viewer-media auth bounds it with a short timeout. When a local signer
+  /// is present, signing is in-process and fast — not timed out.
+  @override
+  bool get signsRemotelyNonInteractive => _localSigner == null;
+
   @override
   bool get canDecryptInIsolate => _localSigner?.canDecryptInIsolate ?? false;
 
@@ -232,6 +251,11 @@ class BunkerNostrIdentity extends NostrIdentity {
   @override
   Future<String?> signCanonicalPayload(Uint8List payload) async => null;
 
+  // Interactive (NIP-46): the user approves in their bunker app, so signing
+  // is human-paced and must not be timed out.
+  @override
+  bool get signsRemotelyNonInteractive => false;
+
   @override
   Future<Map?> getRelays() => _remoteSigner.getRelays();
 
@@ -279,6 +303,11 @@ class AmberNostrIdentity extends NostrIdentity {
   /// gracefully.
   @override
   Future<String?> signCanonicalPayload(Uint8List payload) async => null;
+
+  // Interactive (NIP-55): the user approves in Amber, so signing is
+  // human-paced and must not be timed out.
+  @override
+  bool get signsRemotelyNonInteractive => false;
 
   @override
   Future<Map?> getRelays() => _amberSigner.getRelays();
@@ -329,6 +358,11 @@ class Nip07NostrIdentity extends NostrIdentity {
 
   @override
   Future<String?> signCanonicalPayload(Uint8List payload) async => null;
+
+  // Interactive (NIP-07): the user approves in the browser extension, so
+  // signing is human-paced and must not be timed out.
+  @override
+  bool get signsRemotelyNonInteractive => false;
 
   @override
   Future<Map?> getRelays() => _nip07Signer.getRelays();

--- a/mobile/test/services/media_viewer_auth_service_test.dart
+++ b/mobile/test/services/media_viewer_auth_service_test.dart
@@ -4,10 +4,11 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/media_viewer_auth_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart';
+import 'package:openvine/services/nostr_identity.dart';
 
 class MockAuthService extends Mock implements AuthService {}
 
@@ -15,10 +16,16 @@ class MockBlossomAuthService extends Mock implements BlossomAuthService {}
 
 class MockNip98AuthService extends Mock implements Nip98AuthService {}
 
+class MockNostrSigner extends Mock implements NostrSigner {}
+
+const _testPublicKey =
+    'aabbccdd0123456789abcdef0123456789abcdef0123456789abcdef01234567';
+
 void main() {
   late MockAuthService mockAuthService;
   late MockBlossomAuthService mockBlossomAuthService;
   late MockNip98AuthService mockNip98AuthService;
+  late MockNostrSigner mockNostrSigner;
   late MediaViewerAuthService service;
 
   setUpAll(() {
@@ -29,10 +36,16 @@ void main() {
     mockAuthService = MockAuthService();
     mockBlossomAuthService = MockBlossomAuthService();
     mockNip98AuthService = MockNip98AuthService();
+    mockNostrSigner = MockNostrSigner();
     // Default: the signer is not the non-interactive remote one, so signing is
     // awaited unbounded (matches every pre-existing test's expectation). The
     // timeout tests below opt in by stubbing this true.
-    when(() => mockAuthService.viewerAuthSignsRemotely).thenReturn(false);
+    when(() => mockAuthService.currentIdentity).thenReturn(
+      BunkerNostrIdentity(
+        pubkey: _testPublicKey,
+        remoteSigner: mockNostrSigner,
+      ),
+    );
     service = MediaViewerAuthService(
       authService: mockAuthService,
       blossomAuthService: mockBlossomAuthService,
@@ -161,9 +174,12 @@ void main() {
         () {
           fakeAsync((async) {
             when(() => mockAuthService.isAuthenticated).thenReturn(true);
-            when(
-              () => mockAuthService.viewerAuthSignsRemotely,
-            ).thenReturn(true);
+            when(() => mockAuthService.currentIdentity).thenReturn(
+              KeycastNostrIdentity(
+                pubkey: _testPublicKey,
+                rpcSigner: mockNostrSigner,
+              ),
+            );
             // Signer never responds (e.g. unreachable Keycast RPC).
             when(
               () => mockBlossomAuthService.createGetAuthHeader(
@@ -201,9 +217,12 @@ void main() {
         () {
           fakeAsync((async) {
             when(() => mockAuthService.isAuthenticated).thenReturn(true);
-            when(
-              () => mockAuthService.viewerAuthSignsRemotely,
-            ).thenReturn(true);
+            when(() => mockAuthService.currentIdentity).thenReturn(
+              KeycastNostrIdentity(
+                pubkey: _testPublicKey,
+                rpcSigner: mockNostrSigner,
+              ),
+            );
             when(
               () => mockNip98AuthService.createAuthToken(
                 url: any(named: 'url'),
@@ -231,7 +250,12 @@ void main() {
 
       test('a fast remote sign still returns real headers', () async {
         when(() => mockAuthService.isAuthenticated).thenReturn(true);
-        when(() => mockAuthService.viewerAuthSignsRemotely).thenReturn(true);
+        when(() => mockAuthService.currentIdentity).thenReturn(
+          KeycastNostrIdentity(
+            pubkey: _testPublicKey,
+            rpcSigner: mockNostrSigner,
+          ),
+        );
         when(
           () => mockBlossomAuthService.createGetAuthHeader(
             sha256Hash: any(named: 'sha256Hash'),
@@ -247,49 +271,49 @@ void main() {
         expect(headers, equals({'Authorization': 'Nostr fast-token'}));
       });
 
-      test(
-        'does NOT bound a non-interactive=false signer — a slow-but-valid '
-        'sign past the timeout still returns headers',
-        () {
-          fakeAsync((async) {
-            when(() => mockAuthService.isAuthenticated).thenReturn(true);
-            // Interactive / local signer: must never be truncated.
-            when(
-              () => mockAuthService.viewerAuthSignsRemotely,
-            ).thenReturn(false);
-            final completer = Completer<String?>();
-            when(
-              () => mockBlossomAuthService.createGetAuthHeader(
-                sha256Hash: any(named: 'sha256Hash'),
-                serverUrl: any(named: 'serverUrl'),
-              ),
-            ).thenAnswer((_) => completer.future);
+      test('does NOT bound a non-interactive=false signer — a slow-but-valid '
+          'sign past the timeout still returns headers', () {
+        fakeAsync((async) {
+          when(() => mockAuthService.isAuthenticated).thenReturn(true);
+          // Interactive / local signer: must never be truncated.
+          when(() => mockAuthService.currentIdentity).thenReturn(
+            BunkerNostrIdentity(
+              pubkey: _testPublicKey,
+              remoteSigner: mockNostrSigner,
+            ),
+          );
+          final completer = Completer<String?>();
+          when(
+            () => mockBlossomAuthService.createGetAuthHeader(
+              sha256Hash: any(named: 'sha256Hash'),
+              serverUrl: any(named: 'serverUrl'),
+            ),
+          ).thenAnswer((_) => completer.future);
 
-            Map<String, String>? result;
-            var completed = false;
-            service
-                .createAuthHeaders(
-                  sha256Hash: 'abc123',
-                  serverUrl: 'https://media.divine.video',
-                )
-                .then((r) {
-                  result = r;
-                  completed = true;
-                });
+          Map<String, String>? result;
+          var completed = false;
+          service
+              .createAuthHeaders(
+                sha256Hash: 'abc123',
+                serverUrl: 'https://media.divine.video',
+              )
+              .then((r) {
+                result = r;
+                completed = true;
+              });
 
-            // Well past the 6s timeout: because the timeout is NOT applied to
-            // this signer, the call is still awaiting the human approval.
-            async.elapse(const Duration(seconds: 20));
-            expect(completed, isFalse);
+          // Well past the 6s timeout: because the timeout is NOT applied to
+          // this signer, the call is still awaiting the human approval.
+          async.elapse(const Duration(seconds: 20));
+          expect(completed, isFalse);
 
-            // The valid signature finally arrives and is used.
-            completer.complete('Nostr slow-token');
-            async.flushMicrotasks();
-            expect(completed, isTrue);
-            expect(result, equals({'Authorization': 'Nostr slow-token'}));
-          });
-        },
-      );
+          // The valid signature finally arrives and is used.
+          completer.complete('Nostr slow-token');
+          async.flushMicrotasks();
+          expect(completed, isTrue);
+          expect(result, equals({'Authorization': 'Nostr slow-token'}));
+        });
+      });
     });
   });
 }
@@ -299,8 +323,7 @@ Event _createMockEvent() {
   return Event.fromJson({
     'id': 'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
     'kind': 27235,
-    'pubkey':
-        'aabbccdd0123456789abcdef0123456789abcdef0123456789abcdef01234567',
+    'pubkey': _testPublicKey,
     'created_at': timestamp,
     'content': '',
     'tags': const <List<String>>[

--- a/mobile/test/services/media_viewer_auth_service_test.dart
+++ b/mobile/test/services/media_viewer_auth_service_test.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_sdk/event.dart';
@@ -26,6 +29,10 @@ void main() {
     mockAuthService = MockAuthService();
     mockBlossomAuthService = MockBlossomAuthService();
     mockNip98AuthService = MockNip98AuthService();
+    // Default: the signer is not the non-interactive remote one, so signing is
+    // awaited unbounded (matches every pre-existing test's expectation). The
+    // timeout tests below opt in by stubbing this true.
+    when(() => mockAuthService.viewerAuthSignsRemotely).thenReturn(false);
     service = MediaViewerAuthService(
       authService: mockAuthService,
       blossomAuthService: mockBlossomAuthService,
@@ -145,6 +152,143 @@ void main() {
           url: any(named: 'url'),
           method: any(named: 'method'),
         ),
+      );
+    });
+
+    group('remote-signer timeout', () {
+      test(
+        'bounds a hung remote Blossom sign and returns null at the timeout',
+        () {
+          fakeAsync((async) {
+            when(() => mockAuthService.isAuthenticated).thenReturn(true);
+            when(
+              () => mockAuthService.viewerAuthSignsRemotely,
+            ).thenReturn(true);
+            // Signer never responds (e.g. unreachable Keycast RPC).
+            when(
+              () => mockBlossomAuthService.createGetAuthHeader(
+                sha256Hash: any(named: 'sha256Hash'),
+                serverUrl: any(named: 'serverUrl'),
+              ),
+            ).thenAnswer((_) => Completer<String?>().future);
+
+            Map<String, String>? result;
+            var completed = false;
+            service
+                .createAuthHeaders(
+                  sha256Hash: 'abc123',
+                  serverUrl: 'https://media.divine.video',
+                )
+                .then((r) {
+                  result = r;
+                  completed = true;
+                });
+
+            // Still pending just before the 6s caller-side timeout.
+            async.elapse(const Duration(seconds: 5));
+            expect(completed, isFalse);
+
+            // Fires at the timeout, far short of Keycast's 30s ceiling.
+            async.elapse(const Duration(seconds: 2));
+            expect(completed, isTrue);
+            expect(result, isNull);
+          });
+        },
+      );
+
+      test(
+        'bounds a hung remote NIP-98 sign and returns null at the timeout',
+        () {
+          fakeAsync((async) {
+            when(() => mockAuthService.isAuthenticated).thenReturn(true);
+            when(
+              () => mockAuthService.viewerAuthSignsRemotely,
+            ).thenReturn(true);
+            when(
+              () => mockNip98AuthService.createAuthToken(
+                url: any(named: 'url'),
+                method: any(named: 'method'),
+              ),
+            ).thenAnswer((_) => Completer<Nip98Token?>().future);
+
+            Map<String, String>? result;
+            var completed = false;
+            service
+                .createAuthHeaders(
+                  url: 'https://media.divine.video/no-hash/playlist.m3u8',
+                )
+                .then((r) {
+                  result = r;
+                  completed = true;
+                });
+
+            async.elapse(const Duration(seconds: 7));
+            expect(completed, isTrue);
+            expect(result, isNull);
+          });
+        },
+      );
+
+      test('a fast remote sign still returns real headers', () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(() => mockAuthService.viewerAuthSignsRemotely).thenReturn(true);
+        when(
+          () => mockBlossomAuthService.createGetAuthHeader(
+            sha256Hash: any(named: 'sha256Hash'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer((_) async => 'Nostr fast-token');
+
+        final headers = await service.createAuthHeaders(
+          sha256Hash: 'abc123',
+          serverUrl: 'https://media.divine.video',
+        );
+
+        expect(headers, equals({'Authorization': 'Nostr fast-token'}));
+      });
+
+      test(
+        'does NOT bound a non-interactive=false signer — a slow-but-valid '
+        'sign past the timeout still returns headers',
+        () {
+          fakeAsync((async) {
+            when(() => mockAuthService.isAuthenticated).thenReturn(true);
+            // Interactive / local signer: must never be truncated.
+            when(
+              () => mockAuthService.viewerAuthSignsRemotely,
+            ).thenReturn(false);
+            final completer = Completer<String?>();
+            when(
+              () => mockBlossomAuthService.createGetAuthHeader(
+                sha256Hash: any(named: 'sha256Hash'),
+                serverUrl: any(named: 'serverUrl'),
+              ),
+            ).thenAnswer((_) => completer.future);
+
+            Map<String, String>? result;
+            var completed = false;
+            service
+                .createAuthHeaders(
+                  sha256Hash: 'abc123',
+                  serverUrl: 'https://media.divine.video',
+                )
+                .then((r) {
+                  result = r;
+                  completed = true;
+                });
+
+            // Well past the 6s timeout: because the timeout is NOT applied to
+            // this signer, the call is still awaiting the human approval.
+            async.elapse(const Duration(seconds: 20));
+            expect(completed, isFalse);
+
+            // The valid signature finally arrives and is used.
+            completer.complete('Nostr slow-token');
+            async.flushMicrotasks();
+            expect(completed, isTrue);
+            expect(result, equals({'Authorization': 'Nostr slow-token'}));
+          });
+        },
       );
     });
   });

--- a/mobile/test/services/nostr_identity_test.dart
+++ b/mobile/test/services/nostr_identity_test.dart
@@ -569,4 +569,68 @@ void main() {
       }
     });
   });
+
+  group('signsRemotelyNonInteractive', () {
+    late _MockNostrSigner mockSigner;
+
+    setUp(() {
+      mockSigner = _MockNostrSigner();
+    });
+
+    test('LocalNostrIdentity signs in-process — false', () {
+      final mockKeyContainer = _MockSecureKeyContainer();
+      when(() => mockKeyContainer.publicKeyHex).thenReturn(testPublicKey);
+      when(() => mockKeyContainer.isDisposed).thenReturn(false);
+
+      final identity = LocalNostrIdentity(keyContainer: mockKeyContainer);
+
+      expect(identity.signsRemotelyNonInteractive, isFalse);
+    });
+
+    test('KeycastNostrIdentity without a local signer (OAuth-only) — true', () {
+      final identity = KeycastNostrIdentity(
+        pubkey: testPublicKey,
+        rpcSigner: mockSigner,
+      );
+
+      expect(identity.signsRemotelyNonInteractive, isTrue);
+    });
+
+    test('KeycastNostrIdentity with a local signer signs locally — false', () {
+      final identity = KeycastNostrIdentity(
+        pubkey: testPublicKey,
+        rpcSigner: mockSigner,
+        localSigner: _MockLocalKeySigner(),
+      );
+
+      expect(identity.signsRemotelyNonInteractive, isFalse);
+    });
+
+    test('BunkerNostrIdentity is interactive (human-paced) — false', () {
+      final identity = BunkerNostrIdentity(
+        pubkey: testPublicKey,
+        remoteSigner: mockSigner,
+      );
+
+      expect(identity.signsRemotelyNonInteractive, isFalse);
+    });
+
+    test('AmberNostrIdentity is interactive (human-paced) — false', () {
+      final identity = AmberNostrIdentity(
+        pubkey: testPublicKey,
+        amberSigner: mockSigner,
+      );
+
+      expect(identity.signsRemotelyNonInteractive, isFalse);
+    });
+
+    test('Nip07NostrIdentity is interactive (human-paced) — false', () {
+      final identity = Nip07NostrIdentity(
+        pubkey: testPublicKey,
+        nip07Signer: mockSigner,
+      );
+
+      expect(identity.signsRemotelyNonInteractive, isFalse);
+    });
+  });
 }


### PR DESCRIPTION
## Description

When a viewer taps **Verify age** on an age-restricted feed video, the viewer-auth header is produced by signing a kind-24242 / NIP-98 event. For the **Keycast OAuth-only remote signer** (no local key) that signing round-trips over the network bounded only by Keycast's 30s RPC ceiling, so an unreachable signer left the user on the button for ~30s (worst case ~60s) before #5245's failure snackbar appeared.

This bounds the sign with a **6s caller-side timeout** at the single viewer-media choke point (`MediaViewerAuthService.createAuthHeaders`). A timeout yields `null` - the same "no headers" result every caller already handles - which #5245 surfaces as the existing snackbar. **No new l10n, no interceptor contract change, no decline-logic change.**

### Gated to the non-interactive remote signer

A naive unconditional timeout would wrongly abort **interactive** remote signers - NIP-46 bunker, NIP-55 Amber, NIP-07 extension - where latency is a human reading a prompt and tapping "Approve." So the timeout is gated behind `NostrIdentity.signsRemotelyNonInteractive` (`true` **only** for `KeycastNostrIdentity` with no local signer). Local signing is in-process and fast; interactive remote signers are awaited unbounded and never cut off mid-approval.

`canCreateHeaders` stays `isAuthenticated` - a live reachability probe would itself hang on the same RPC, so the timeout *is* the reachability proxy.

The follow-up cleanup keeps that predicate usage inside `MediaViewerAuthService` instead of adding a wrapper getter to the already-frozen `AuthService` god service, so the file-size ceiling ratchet stays green.

Closes #5272.
Related: #5243.

### Steps to reproduce the original behaviour

1. Sign in with a Divine OAuth / Keycast account that has **no local key** (remote signer).
2. With the signer slow or unreachable, scroll to an age-restricted (HTTP 401) feed video and tap **Verify age**.
3. Before: the button sits unresponsive for ~30s (worst case ~60s) before any feedback.
4. After: it fails at ~6s into the existing "Couldn't verify your age. Please try again." snackbar.

(Deterministic coverage is in the unit tests; a real repro needs a degraded signer.)

## Out of Scope

- A distinct "signer unreachable" message (needs new copy in all 18 locales + a richer interceptor return type) - product-gated follow-up.
- Any `canCreateHeaders` semantics change; timeouts in the shared lower-level `createGetAuthHeader` / `createAuthToken` primitives (used by uploads/zendesk/notifications/api); cancellation.

The shared `individual_video_providers` caller inherits the 6s bound - verified benign (its nulls already degrade to "cache without auth"; no snackbar there).

## Verification

- `bash scripts/check_file_size_ceiling.sh` - clean after the follow-up cleanup.
- `git diff --check` - clean.
- Pre-push hook - clean:
  - Analyzer passed on the changed Dart files.
  - `flutter test test/services/media_viewer_auth_service_test.dart test/services/nostr_identity_test.dart` - 44 passed.
- CI before cleanup: `flutter analyze`, `Format`, and `Tests` were green; `Generated Files` failed only because `AuthService` grew past the frozen file-size ceiling.
- GitHub Actions on the cleanup commit - all checks green.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
