### PR TITLE
fix(feed): loading state on the Verify age button during retry

### DIFF
--- a/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
@@ -30,6 +30,20 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
     emit(state.withStatus(eventId, status));
   }
 
+  /// Marks an age-verification retry as in flight for [eventId], driving the
+  /// "Verify age" button's loading state. Short-circuits when already set.
+  void markVerifying(String eventId) {
+    if (state.isVerifying(eventId)) return;
+    emit(state.withVerifying(eventId, true));
+  }
+
+  /// Clears the in-flight age-verification flag for [eventId]. Short-circuits
+  /// when not set.
+  void clearVerifying(String eventId) {
+    if (!state.isVerifying(eventId)) return;
+    emit(state.withVerifying(eventId, false));
+  }
+
   /// Clears all tracked statuses (call on feed-mode change).
   void clear() {
     emit(state.cleared());

--- a/mobile/lib/blocs/video_playback_status/video_playback_status_state.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_state.dart
@@ -39,9 +39,13 @@ class VideoPlaybackStatusState extends Equatable {
   VideoPlaybackStatusState({
     this.maxEntries = _defaultMaxEntries,
     LinkedHashMap<String, PlaybackStatus>? statuses,
+    Set<String>? verifyingIds,
   }) : _statuses = statuses == null
            ? LinkedHashMap<String, PlaybackStatus>()
-           : LinkedHashMap<String, PlaybackStatus>.from(statuses);
+           : LinkedHashMap<String, PlaybackStatus>.from(statuses),
+       _verifyingIds = verifyingIds == null
+           ? <String>{}
+           : Set<String>.from(verifyingIds);
 
   static const int _defaultMaxEntries = 100;
 
@@ -50,10 +54,18 @@ class VideoPlaybackStatusState extends Equatable {
 
   final LinkedHashMap<String, PlaybackStatus> _statuses;
 
+  /// Event IDs with an age-verification retry currently in flight. Transient
+  /// and small (usually 0-1 entries); not LRU-bounded.
+  final Set<String> _verifyingIds;
+
   /// Returns the status for [eventId], or [PlaybackStatus.ready] when no
   /// status has been recorded.
   PlaybackStatus statusFor(String eventId) =>
       _statuses[eventId] ?? PlaybackStatus.ready;
+
+  /// Whether an age-verification retry is currently in flight for [eventId].
+  /// Drives the "Verify age" button's loading state.
+  bool isVerifying(String eventId) => _verifyingIds.contains(eventId);
 
   /// Returns a new state with [status] recorded for [eventId].
   ///
@@ -67,7 +79,26 @@ class VideoPlaybackStatusState extends Equatable {
     while (next.length > maxEntries) {
       next.remove(next.keys.first);
     }
-    return VideoPlaybackStatusState(maxEntries: maxEntries, statuses: next);
+    return VideoPlaybackStatusState(
+      maxEntries: maxEntries,
+      statuses: next,
+      verifyingIds: _verifyingIds,
+    );
+  }
+
+  /// Returns a new state with [eventId]'s verifying flag set to [verifying].
+  VideoPlaybackStatusState withVerifying(String eventId, bool verifying) {
+    final next = Set<String>.from(_verifyingIds);
+    if (verifying) {
+      next.add(eventId);
+    } else {
+      next.remove(eventId);
+    }
+    return VideoPlaybackStatusState(
+      maxEntries: maxEntries,
+      statuses: _statuses,
+      verifyingIds: next,
+    );
   }
 
   /// Returns a cleared state (used when switching feed modes).
@@ -84,7 +115,7 @@ class VideoPlaybackStatusState extends Equatable {
     // `_statuses.keys.toList()` catches those insertion-order changes.
     // Removing either would silently suppress a whole class of state
     // updates — do not "simplify" this.
-    return [_statuses, _statuses.keys.toList(), maxEntries];
+    return [_statuses, _statuses.keys.toList(), maxEntries, _verifyingIds];
   }
 }
 

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -31,72 +31,82 @@ Future<void> retryAgeRestrictedPooledVideo({
     category: LogCategory.video,
   );
 
-  final videoUrl = video.videoUrl;
-  if (videoUrl == null || videoUrl.isEmpty) {
-    Log.warning(
-      'Skipping age-restricted retry: missing videoUrl for event '
-      '${video.id}',
-      name: _logName,
-      category: LogCategory.video,
-    );
-    _showVerifyAgeFailed(context);
-    return;
-  }
-
-  // BUD-01 (kind 24242) viewer auth is hash-bound: the origin authorizes any
-  // variant URL of the blob, which is what lets the feed apply one header set
-  // to every resolved source. Without a sha256 the auth path falls back to
-  // URL-bound NIP-98, which would only authenticate the bare event URL and
-  // re-401 on the optimized/HLS variants — refuse the retry instead.
-  final sha256Hash = _resolveSha256(video);
-  if (sha256Hash == null) {
-    Log.warning(
-      'Skipping age-restricted retry: cannot resolve sha256 for event '
-      '${video.id}',
-      name: _logName,
-      category: LogCategory.video,
-    );
-    _showVerifyAgeFailed(context);
-    return;
-  }
-
-  final headers = await ref
-      .read(mediaAuthInterceptorProvider)
-      .handleUnauthorizedMedia(
-        context: context,
-        sha256Hash: sha256Hash,
-        url: videoUrl,
-        serverUrl: _extractServerUrl(videoUrl),
-        category: 'video',
-      );
-  if (!context.mounted) return;
-  if (headers == null) {
-    // handleUnauthorizedMedia returns null both when the viewer declines the
-    // age dialog (a deliberate choice — stay silent) and when they accept but
-    // the signed viewer-auth header could not be created (e.g. a remote signer
-    // that failed or timed out). Distinguish the two by the persisted
-    // verification flag so an auth failure isn't a silent no-op.
-    final accepted = ref
-        .read(ageVerificationServiceProvider)
-        .isAdultContentVerified;
-    if (accepted) {
-      _showVerifyAgeFailed(context);
-    }
-    return;
-  }
-
+  // Drive the "Verify age" button's loading state for the whole operation so
+  // the tap is never a silent wait. Captured up front (sync, pre-await) and
+  // cleared in `finally` regardless of which branch exits.
   final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
-  // The hash-bound token authorizes any variant of the blob, so the feed
-  // applies these headers to every resolved playback source (optimized/HLS/raw)
-  // for the retried item.
-  final playbackSucceeded = await retryPlayback(headers);
-  if (!context.mounted) return;
-  if (!playbackSucceeded) {
-    _showVerifyAgeFailed(context);
-    return;
-  }
+  playbackStatusCubit.markVerifying(video.id);
+  try {
+    final videoUrl = video.videoUrl;
+    if (videoUrl == null || videoUrl.isEmpty) {
+      Log.warning(
+        'Skipping age-restricted retry: missing videoUrl for event '
+        '${video.id}',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      _showVerifyAgeFailed(context);
+      return;
+    }
 
-  playbackStatusCubit.report(video.id, PlaybackStatus.ready);
+    // BUD-01 (kind 24242) viewer auth is hash-bound: the origin authorizes any
+    // variant URL of the blob, which is what lets the feed apply one header set
+    // to every resolved source. Without a sha256 the auth path falls back to
+    // URL-bound NIP-98, which would only authenticate the bare event URL and
+    // re-401 on the optimized/HLS variants — refuse the retry instead.
+    final sha256Hash = _resolveSha256(video);
+    if (sha256Hash == null) {
+      Log.warning(
+        'Skipping age-restricted retry: cannot resolve sha256 for event '
+        '${video.id}',
+        name: _logName,
+        category: LogCategory.video,
+      );
+      _showVerifyAgeFailed(context);
+      return;
+    }
+
+    final headers = await ref
+        .read(mediaAuthInterceptorProvider)
+        .handleUnauthorizedMedia(
+          context: context,
+          sha256Hash: sha256Hash,
+          url: videoUrl,
+          serverUrl: _extractServerUrl(videoUrl),
+          category: 'video',
+        );
+    if (!context.mounted) return;
+    if (headers == null) {
+      // handleUnauthorizedMedia returns null both when the viewer declines the
+      // age dialog (a deliberate choice — stay silent) and when they accept but
+      // the signed viewer-auth header could not be created (e.g. a remote
+      // signer that failed or timed out). Distinguish the two by the persisted
+      // verification flag so an auth failure isn't a silent no-op.
+      final accepted = ref
+          .read(ageVerificationServiceProvider)
+          .isAdultContentVerified;
+      if (accepted) {
+        _showVerifyAgeFailed(context);
+      }
+      return;
+    }
+
+    // The hash-bound token authorizes any variant of the blob, so the feed
+    // applies these headers to every resolved playback source
+    // (optimized/HLS/raw) for the retried item.
+    final playbackSucceeded = await retryPlayback(headers);
+    if (!context.mounted) return;
+    if (!playbackSucceeded) {
+      _showVerifyAgeFailed(context);
+      return;
+    }
+
+    playbackStatusCubit.report(video.id, PlaybackStatus.ready);
+  } finally {
+    if (!playbackStatusCubit.isClosed) {
+      playbackStatusCubit.clearVerifying(video.id);
+    }
+  }
 }
 
 /// Surfaces a localized failure so a tapped "Verify age" button is never a

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -35,6 +35,9 @@ Future<void> retryAgeRestrictedPooledVideo({
   // the tap is never a silent wait. Captured up front (sync, pre-await) and
   // cleared in `finally` regardless of which branch exits.
   final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
+  if (playbackStatusCubit.state.isVerifying(video.id)) {
+    return;
+  }
   playbackStatusCubit.markVerifying(video.id);
   try {
     final videoUrl = video.videoUrl;

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -340,20 +340,28 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
           final width = video.width;
           final height = video.height;
           final isSquare = width != null && height != null && width == height;
-          return PooledVideoErrorOverlay(
-            video: video,
-            onRetry: onRetry,
-            onVerifyAge: () => retryAgeRestrictedPooledVideo(
-              context: context,
-              ref: ref,
+          return BlocSelector<
+            VideoPlaybackStatusCubit,
+            VideoPlaybackStatusState,
+            bool
+          >(
+            selector: (state) => state.isVerifying(video.id),
+            builder: (context, isVerifyingAge) => PooledVideoErrorOverlay(
               video: video,
-              index: index,
-              retryPlayback: (httpHeaders) =>
-                  _retryPooledVideoAt(index, httpHeaders),
+              onRetry: onRetry,
+              onVerifyAge: () => retryAgeRestrictedPooledVideo(
+                context: context,
+                ref: ref,
+                video: video,
+                index: index,
+                retryPlayback: (httpHeaders) =>
+                    _retryPooledVideoAt(index, httpHeaders),
+              ),
+              errorType: errorType,
+              isVerifying: isVerifyingAge,
+              shouldPortraitExpand: widget.shouldPortraitExpand,
+              isSquare: isSquare,
             ),
-            errorType: errorType,
-            shouldPortraitExpand: widget.shouldPortraitExpand,
-            isSquare: isSquare,
           );
         },
         overlayBuilder: (context, index, controller, {required bool isActive}) {
@@ -577,6 +585,9 @@ class __OverlayState extends ConsumerState<_Overlay> {
     final playbackStatus = context.select(
       (VideoPlaybackStatusCubit cubit) => cubit.state.statusFor(video.id),
     );
+    final isVerifyingAge = context.select(
+      (VideoPlaybackStatusCubit cubit) => cubit.state.isVerifying(video.id),
+    );
 
     final isReady =
         widget.controller != null &&
@@ -600,6 +611,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
           status: playbackStatus,
           onSkip: _skipToNextVideo,
           onVerifyAge: _verifyAgeForVideo,
+          isVerifying: isVerifyingAge,
         );
       case _OverlayContentWarningMode(:final labels):
         return ContentWarningBlurOverlay(
@@ -903,24 +915,32 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
     );
 
     if (isRestricted) {
-      return PooledVideoErrorOverlay(
-        video: video,
-        // Retry is hidden for moderation-restricted content.
-        onRetry: () {},
-        onVerifyAge: () => retryAgeRestrictedPooledVideo(
-          context: context,
-          ref: ref,
+      return BlocSelector<
+        VideoPlaybackStatusCubit,
+        VideoPlaybackStatusState,
+        bool
+      >(
+        selector: (state) => state.isVerifying(video.id),
+        builder: (context, isVerifyingAge) => PooledVideoErrorOverlay(
           video: video,
-          index: index,
-          retryPlayback: (httpHeaders) =>
-              context
-                  .findAncestorStateOfType<InfiniteVideoFeedState>()
-                  ?.retryAt(index, httpHeaders: httpHeaders) ??
-              Future.value(false),
+          // Retry is hidden for moderation-restricted content.
+          onRetry: () {},
+          onVerifyAge: () => retryAgeRestrictedPooledVideo(
+            context: context,
+            ref: ref,
+            video: video,
+            index: index,
+            retryPlayback: (httpHeaders) =>
+                context
+                    .findAncestorStateOfType<InfiniteVideoFeedState>()
+                    ?.retryAt(index, httpHeaders: httpHeaders) ??
+                Future.value(false),
+          ),
+          errorType: VideoErrorType.notFound,
+          isVerifying: isVerifyingAge,
+          shouldPortraitExpand: shouldPortraitExpand,
+          isSquare: isSquare,
         ),
-        errorType: VideoErrorType.notFound,
-        shouldPortraitExpand: shouldPortraitExpand,
-        isSquare: isSquare,
       );
     }
 

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -34,8 +34,8 @@ import 'package:openvine/widgets/video_feed_item/double_tap_heart_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/live_engagement_counts.dart';
 import 'package:openvine/widgets/video_feed_item/moderated_content_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/paused_video_overlay.dart';
-import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
+import 'package:openvine/widgets/video_feed_item/verifying_aware_video_error_overlay.dart';
 import 'package:openvine/widgets/video_feed_item/video_feed_item.dart';
 import 'package:openvine/widgets/video_feed_item/video_interactions_bloc_key.dart';
 import 'package:openvine/widgets/video_feed_item/video_loading_placeholder.dart';
@@ -340,28 +340,15 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
           final width = video.width;
           final height = video.height;
           final isSquare = width != null && height != null && width == height;
-          return BlocSelector<
-            VideoPlaybackStatusCubit,
-            VideoPlaybackStatusState,
-            bool
-          >(
-            selector: (state) => state.isVerifying(video.id),
-            builder: (context, isVerifyingAge) => PooledVideoErrorOverlay(
-              video: video,
-              onRetry: onRetry,
-              onVerifyAge: () => retryAgeRestrictedPooledVideo(
-                context: context,
-                ref: ref,
-                video: video,
-                index: index,
-                retryPlayback: (httpHeaders) =>
-                    _retryPooledVideoAt(index, httpHeaders),
-              ),
-              errorType: errorType,
-              isVerifying: isVerifyingAge,
-              shouldPortraitExpand: widget.shouldPortraitExpand,
-              isSquare: isSquare,
-            ),
+          return VerifyingAwareVideoErrorOverlay(
+            video: video,
+            index: index,
+            onRetry: onRetry,
+            retryPlayback: (httpHeaders) =>
+                _retryPooledVideoAt(index, httpHeaders),
+            errorType: errorType,
+            shouldPortraitExpand: widget.shouldPortraitExpand,
+            isSquare: isSquare,
           );
         },
         overlayBuilder: (context, index, controller, {required bool isActive}) {
@@ -850,8 +837,8 @@ class _SubtitleLayer extends StatelessWidget {
 /// moderation API is queried via [FeedLoadingModerationCubit]. Cached
 /// videos load immediately and never reach the delay, so no unnecessary
 /// API calls are made. Once the moderation check returns a restricted
-/// status the view switches to [PooledVideoErrorOverlay] without waiting
-/// for the native player to time out with a 404.
+/// status the view switches to [VerifyingAwareVideoErrorOverlay] without
+/// waiting for the native player to time out with a 404.
 class _FeedLoadingOrRestrictedOverlay extends ConsumerWidget {
   const _FeedLoadingOrRestrictedOverlay({
     required this.video,
@@ -893,7 +880,7 @@ class _FeedLoadingOrRestrictedOverlay extends ConsumerWidget {
   }
 }
 
-class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
+class _FeedLoadingOrRestrictedOverlayView extends StatelessWidget {
   const _FeedLoadingOrRestrictedOverlayView({
     required this.video,
     required this.index,
@@ -909,38 +896,26 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
   final bool shouldPortraitExpand;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final isRestricted = context.select(
       (FeedLoadingModerationCubit c) => c.state.isRestricted,
     );
 
     if (isRestricted) {
-      return BlocSelector<
-        VideoPlaybackStatusCubit,
-        VideoPlaybackStatusState,
-        bool
-      >(
-        selector: (state) => state.isVerifying(video.id),
-        builder: (context, isVerifyingAge) => PooledVideoErrorOverlay(
-          video: video,
-          // Retry is hidden for moderation-restricted content.
-          onRetry: () {},
-          onVerifyAge: () => retryAgeRestrictedPooledVideo(
-            context: context,
-            ref: ref,
-            video: video,
-            index: index,
-            retryPlayback: (httpHeaders) =>
-                context
-                    .findAncestorStateOfType<InfiniteVideoFeedState>()
-                    ?.retryAt(index, httpHeaders: httpHeaders) ??
-                Future.value(false),
-          ),
-          errorType: VideoErrorType.notFound,
-          isVerifying: isVerifyingAge,
-          shouldPortraitExpand: shouldPortraitExpand,
-          isSquare: isSquare,
-        ),
+      return VerifyingAwareVideoErrorOverlay(
+        video: video,
+        index: index,
+        // Retry is hidden for moderation-restricted content.
+        onRetry: () {},
+        retryPlayback: (httpHeaders) =>
+            context.findAncestorStateOfType<InfiniteVideoFeedState>()?.retryAt(
+              index,
+              httpHeaders: httpHeaders,
+            ) ??
+            Future.value(false),
+        errorType: VideoErrorType.notFound,
+        shouldPortraitExpand: shouldPortraitExpand,
+        isSquare: isSquare,
       );
     }
 

--- a/mobile/lib/widgets/video_feed_item/moderated_content_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/moderated_content_overlay.dart
@@ -21,6 +21,7 @@ class ModeratedContentOverlay extends StatelessWidget {
     required this.status,
     required this.onSkip,
     this.onVerifyAge,
+    this.isVerifying = false,
     super.key,
   }) : assert(
          status == PlaybackStatus.forbidden ||
@@ -41,6 +42,10 @@ class ModeratedContentOverlay extends StatelessWidget {
   /// Called when the user taps Verify age. Must be non-null when [status]
   /// is [PlaybackStatus.ageRestricted] — enforced by an assertion.
   final VoidCallback? onVerifyAge;
+
+  /// Whether an age-verification retry is in flight. Shows the Verify age
+  /// button's loading state (which also disables it, preventing double taps).
+  final bool isVerifying;
 
   bool get _isAgeRestricted => status == PlaybackStatus.ageRestricted;
 
@@ -81,7 +86,10 @@ class ModeratedContentOverlay extends StatelessWidget {
                 if (_isAgeRestricted && onVerifyAge != null)
                   DivineButton(
                     label: context.l10n.videoErrorVerifyAgeButton,
-                    onPressed: onVerifyAge,
+                    // Disabled while a retry is in flight so a second tap
+                    // can't kick off a duplicate verification.
+                    onPressed: isVerifying ? null : onVerifyAge,
+                    isLoading: isVerifying,
                   ),
                 DivineButton(
                   label: context.l10n.videoErrorSkip,

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -28,6 +28,7 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
     required this.onRetry,
     required this.errorType,
     this.onVerifyAge,
+    this.isVerifying = false,
     this.shouldPortraitExpand = true,
     this.isSquare = false,
     super.key,
@@ -36,6 +37,11 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
   final VideoEvent video;
   final VoidCallback onRetry;
   final VoidCallback? onVerifyAge;
+
+  /// Whether an age-verification retry is in flight. Shows the Verify age
+  /// button's loading state (which also disables it, preventing double taps).
+  final bool isVerifying;
+
   final VideoErrorType? errorType;
 
   /// Mirrors `InfiniteVideoFeed.shouldPortraitExpand`. When `false`, the
@@ -165,7 +171,10 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
                     label: context.l10n.videoErrorVerifyAgeButton,
                     type: DivineButtonType.tertiary,
                     size: DivineButtonSize.small,
-                    onPressed: onVerifyAge,
+                    // Disabled while a retry is in flight so a second tap
+                    // can't kick off a duplicate verification.
+                    onPressed: isVerifying ? null : onVerifyAge,
+                    isLoading: isVerifying,
                   ),
                 if (showRetry)
                   DivineButton(

--- a/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
@@ -1,0 +1,74 @@
+// ABOUTME: Wraps PooledVideoErrorOverlay with the live "verifying age" flag
+// ABOUTME: from VideoPlaybackStatusCubit plus the Verify-age retry wiring.
+
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:infinite_video_feed/infinite_video_feed.dart'
+    show VideoErrorType;
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/screens/feed/pooled_age_restricted_retry.dart';
+import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
+
+/// [PooledVideoErrorOverlay] wired to [VideoPlaybackStatusCubit].
+///
+/// Reads the transient "age-verification in flight" flag for [video] so the
+/// Verify age button shows its loading state (and is disabled, blocking a
+/// duplicate retry) while [retryAgeRestrictedPooledVideo] runs. This keeps the
+/// cubit→overlay wiring in one place for every "Verify age" surface on the
+/// pooled feed path.
+class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
+  const VerifyingAwareVideoErrorOverlay({
+    required this.video,
+    required this.index,
+    required this.onRetry,
+    required this.retryPlayback,
+    required this.errorType,
+    required this.shouldPortraitExpand,
+    required this.isSquare,
+    super.key,
+  });
+
+  final VideoEvent video;
+  final int index;
+
+  /// Called when the user taps Retry. Hidden for moderation-restricted content.
+  final VoidCallback onRetry;
+
+  /// Reloads playback for the retried item with the signed viewer-auth headers.
+  final FutureOr<bool> Function(Map<String, String>) retryPlayback;
+
+  final VideoErrorType? errorType;
+  final bool shouldPortraitExpand;
+  final bool isSquare;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return BlocSelector<
+      VideoPlaybackStatusCubit,
+      VideoPlaybackStatusState,
+      bool
+    >(
+      selector: (state) => state.isVerifying(video.id),
+      builder: (context, isVerifying) => PooledVideoErrorOverlay(
+        video: video,
+        onRetry: onRetry,
+        onVerifyAge: () => retryAgeRestrictedPooledVideo(
+          context: context,
+          ref: ref,
+          video: video,
+          index: index,
+          retryPlayback: retryPlayback,
+        ),
+        errorType: errorType,
+        isVerifying: isVerifying,
+        shouldPortraitExpand: shouldPortraitExpand,
+        isSquare: isSquare,
+      ),
+    );
+  }
+}

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -357,7 +357,7 @@ class _DivineButtonContent extends StatelessWidget {
       child: Material(
         color: VineTheme.transparent,
         child: InkWell(
-          onTap: onPressed,
+          onTap: _isEnabled ? onPressed : null,
           borderRadius: BorderRadius.circular(_borderRadius),
           splashColor: _foregroundColor.withValues(alpha: 0.1),
           highlightColor: _foregroundColor.withValues(alpha: 0.05),

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -227,7 +227,22 @@ void main() {
         );
 
         await tester.tap(find.byType(DivineButton));
-        await tester.pumpAndSettle();
+        await tester.pump();
+
+        expect(pressed, isFalse);
+      });
+
+      testWidgets('does not call onPressed while loading', (tester) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildTestWidget(
+            onPressed: () => pressed = true,
+            isLoading: true,
+          ),
+        );
+
+        await tester.tap(find.byType(DivineButton));
+        await tester.pump();
 
         expect(pressed, isFalse);
       });

--- a/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
+++ b/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
@@ -100,6 +100,54 @@ void main() {
       expect: () => hasLength(1),
     );
 
+    group('verifying', () {
+      test('markVerifying / clearVerifying toggle the flag', () {
+        final cubit = VideoPlaybackStatusCubit();
+        expect(cubit.state.isVerifying(id1), isFalse);
+
+        cubit.markVerifying(id1);
+        expect(cubit.state.isVerifying(id1), isTrue);
+        expect(cubit.state.isVerifying(id2), isFalse);
+
+        cubit.clearVerifying(id1);
+        expect(cubit.state.isVerifying(id1), isFalse);
+      });
+
+      blocTest<VideoPlaybackStatusCubit, VideoPlaybackStatusState>(
+        'markVerifying short-circuits when already verifying',
+        build: VideoPlaybackStatusCubit.new,
+        act: (cubit) {
+          cubit.markVerifying(id1);
+          cubit.markVerifying(id1);
+        },
+        expect: () => hasLength(1),
+      );
+
+      blocTest<VideoPlaybackStatusCubit, VideoPlaybackStatusState>(
+        'clearVerifying short-circuits when not verifying',
+        build: VideoPlaybackStatusCubit.new,
+        act: (cubit) => cubit.clearVerifying(id1),
+        expect: () => isEmpty,
+      );
+
+      test('reporting a status preserves an in-flight verifying flag', () {
+        final cubit = VideoPlaybackStatusCubit();
+        cubit.markVerifying(id1);
+        cubit.report(id1, PlaybackStatus.ready);
+
+        expect(cubit.state.isVerifying(id1), isTrue);
+        expect(cubit.state.statusFor(id1), PlaybackStatus.ready);
+      });
+
+      test('clear() drops verifying flags', () {
+        final cubit = VideoPlaybackStatusCubit();
+        cubit.markVerifying(id1);
+        cubit.clear();
+
+        expect(cubit.state.isVerifying(id1), isFalse);
+      });
+    });
+
     group('playbackStatusFromError', () {
       test('maps each VideoErrorType to the expected PlaybackStatus', () {
         expect(

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests age-verification retry wiring for pooled native feed videos.
 // ABOUTME: Verifies successful auth reloads playback and failures surface feedback.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -93,6 +95,46 @@ void main() {
         PlaybackStatus.ready,
       );
       expect(find.text(_failureText), findsNothing);
+    });
+
+    testWidgets('marks the video verifying during the retry and clears it '
+        'after', (tester) async {
+      final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+      final playbackStatusCubit = VideoPlaybackStatusCubit();
+      final authCompleter = Completer<Map<String, String>?>();
+      addTearDown(playbackStatusCubit.close);
+
+      when(
+        () => mediaAuthInterceptor.handleUnauthorizedMedia(
+          context: any(named: 'context'),
+          sha256Hash: _sha256,
+          url: _videoUrl,
+          serverUrl: 'https://media.divine.video',
+          category: 'video',
+        ),
+      ).thenAnswer((_) => authCompleter.future);
+
+      await tester.pumpWidget(
+        _RetryHarness(
+          mediaAuthInterceptor: mediaAuthInterceptor,
+          playbackStatusCubit: playbackStatusCubit,
+          retryPlayback: (_) => true,
+        ),
+      );
+
+      playbackStatusCubit.report(_videoId, PlaybackStatus.ageRestricted);
+      expect(playbackStatusCubit.state.isVerifying(_videoId), isFalse);
+
+      await tester.tap(find.text('Verify'));
+      await tester.pump();
+      // markVerifying runs synchronously before the auth await.
+      expect(playbackStatusCubit.state.isVerifying(_videoId), isTrue);
+
+      authCompleter.complete({'Authorization': 'Nostr token'});
+      await tester.pump();
+      await tester.pump();
+      // Cleared in the finally once the retry resolves.
+      expect(playbackStatusCubit.state.isVerifying(_videoId), isFalse);
     });
 
     testWidgets('keeps gate state and stays silent when auth is declined', (

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -137,6 +137,62 @@ void main() {
       expect(playbackStatusCubit.state.isVerifying(_videoId), isFalse);
     });
 
+    testWidgets(
+      'ignores duplicate retry calls while verification is in flight',
+      (tester) async {
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        final playbackStatusCubit = VideoPlaybackStatusCubit();
+        final authCompleter = Completer<Map<String, String>?>();
+        var retryCount = 0;
+        addTearDown(playbackStatusCubit.close);
+
+        when(
+          () => mediaAuthInterceptor.handleUnauthorizedMedia(
+            context: any(named: 'context'),
+            sha256Hash: _sha256,
+            url: _videoUrl,
+            serverUrl: 'https://media.divine.video',
+            category: 'video',
+          ),
+        ).thenAnswer((_) => authCompleter.future);
+
+        await tester.pumpWidget(
+          _RetryHarness(
+            mediaAuthInterceptor: mediaAuthInterceptor,
+            playbackStatusCubit: playbackStatusCubit,
+            retryPlayback: (_) {
+              retryCount++;
+              return true;
+            },
+          ),
+        );
+
+        await tester.tap(find.text('Verify'));
+        await tester.pump();
+        expect(playbackStatusCubit.state.isVerifying(_videoId), isTrue);
+
+        await tester.tap(find.text('Verify'));
+        await tester.pump();
+
+        verify(
+          () => mediaAuthInterceptor.handleUnauthorizedMedia(
+            context: any(named: 'context'),
+            sha256Hash: _sha256,
+            url: _videoUrl,
+            serverUrl: 'https://media.divine.video',
+            category: 'video',
+          ),
+        ).called(1);
+
+        authCompleter.complete({'Authorization': 'Nostr token'});
+        await tester.pump();
+        await tester.pump();
+
+        expect(retryCount, 1);
+        expect(playbackStatusCubit.state.isVerifying(_videoId), isFalse);
+      },
+    );
+
     testWidgets('keeps gate state and stays silent when auth is declined', (
       tester,
     ) async {

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -44,7 +44,12 @@ void main() {
       l10n = lookupAppLocalizations(const Locale('en'));
     });
 
-    Widget buildWidget({VideoErrorType? errorType, VideoEvent? video}) {
+    Widget buildWidget({
+      VideoErrorType? errorType,
+      VideoEvent? video,
+      VoidCallback? onVerifyAge,
+      bool isVerifying = false,
+    }) {
       return ProviderScope(
         overrides: [
           videoModerationStatusProvider.overrideWith(
@@ -58,7 +63,9 @@ void main() {
             body: PooledVideoErrorOverlay(
               video: video ?? divineVideo,
               onRetry: () => retryPressed = true,
+              onVerifyAge: onVerifyAge,
               errorType: errorType,
+              isVerifying: isVerifying,
             ),
           ),
         ),
@@ -134,6 +141,28 @@ void main() {
 
         expect(find.text(l10n.videoErrorRetry), findsOneWidget);
       });
+
+      testWidgets(
+        'shows a loading spinner and disables Verify age while verifying',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidget(
+              errorType: VideoErrorType.ageRestricted,
+              onVerifyAge: () => verifyAgePressed = true,
+              isVerifying: true,
+            ),
+          );
+          // Not pumpAndSettle: the loading spinner animates indefinitely.
+          await tester.pump();
+
+          expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+          // Disabled while verifying — a tap must be a no-op.
+          await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
+          await tester.pump();
+          expect(verifyAgePressed, isFalse);
+        },
+      );
     });
 
     group('notFound', () {

--- a/mobile/test/widgets/video_feed_item/moderated_content_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/moderated_content_overlay_test.dart
@@ -17,6 +17,7 @@ void main() {
       required PlaybackStatus status,
       VoidCallback? onSkip,
       VoidCallback? onVerifyAge,
+      bool isVerifying = false,
     }) {
       return tester.pumpWidget(
         MaterialApp(
@@ -27,6 +28,7 @@ void main() {
               status: status,
               onSkip: onSkip ?? () {},
               onVerifyAge: onVerifyAge,
+              isVerifying: isVerifying,
             ),
           ),
         ),
@@ -102,6 +104,28 @@ void main() {
 
       expect(verified, equals(1));
     });
+
+    testWidgets(
+      'shows a loading spinner and disables Verify age while verifying',
+      (tester) async {
+        var verified = 0;
+        await pumpOverlay(
+          tester,
+          status: PlaybackStatus.ageRestricted,
+          onVerifyAge: () => verified++,
+          isVerifying: true,
+        );
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // Disabled while verifying — a tap must be a no-op.
+        await tester.tap(
+          find.text(ModeratedContentOverlayStrings.verifyAgeLabel),
+        );
+        await tester.pump();
+        expect(verified, equals(0));
+      },
+    );
 
     testWidgets('calls onSkip when Skip is tapped in ageRestricted state', (
       tester,

--- a/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
@@ -1,0 +1,144 @@
+// ABOUTME: Tests that VerifyingAwareVideoErrorOverlay reflects the cubit's
+// ABOUTME: in-flight verifying flag and wires Verify age to the retry helper.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_video_feed/infinite_video_feed.dart'
+    show VideoErrorType;
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/media_auth_interceptor.dart';
+import 'package:openvine/widgets/video_feed_item/verifying_aware_video_error_overlay.dart';
+
+class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
+
+class _FakeBuildContext extends Fake implements BuildContext {}
+
+const _videoId =
+    'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234';
+const _pubkey =
+    'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3';
+const _sha256 =
+    'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+const _videoUrl = 'https://media.divine.video/$_sha256/720p.mp4';
+
+final _video = VideoEvent(
+  id: _videoId,
+  pubkey: _pubkey,
+  createdAt: 1704067200,
+  content: 'Test video',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+  videoUrl: _videoUrl,
+  sha256: _sha256,
+);
+
+String get _verifyLabel =>
+    lookupAppLocalizations(const Locale('en')).videoErrorVerifyAgeButton;
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeBuildContext());
+  });
+
+  group(VerifyingAwareVideoErrorOverlay, () {
+    Future<void> pumpOverlay(
+      WidgetTester tester, {
+      required VideoPlaybackStatusCubit cubit,
+      MediaAuthInterceptor? interceptor,
+    }) {
+      return tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            if (interceptor != null)
+              mediaAuthInterceptorProvider.overrideWithValue(interceptor),
+          ],
+          child: BlocProvider<VideoPlaybackStatusCubit>.value(
+            value: cubit,
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: VerifyingAwareVideoErrorOverlay(
+                  video: _video,
+                  index: 0,
+                  onRetry: () {},
+                  retryPlayback: (_) => true,
+                  errorType: VideoErrorType.ageRestricted,
+                  shouldPortraitExpand: true,
+                  isSquare: false,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets(
+      'shows the Verify age spinner when the cubit reports verifying',
+      (
+        tester,
+      ) async {
+        final cubit = VideoPlaybackStatusCubit();
+        addTearDown(cubit.close);
+
+        await pumpOverlay(tester, cubit: cubit);
+        await tester.pump();
+
+        expect(find.text(_verifyLabel), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+
+        cubit.markVerifying(_videoId);
+        // Two pumps: the first delivers the cubit's stream emission to the
+        // BlocSelector, the second rebuilds with the spinner.
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      },
+    );
+
+    testWidgets('tapping Verify age runs the retry and toggles the flag', (
+      tester,
+    ) async {
+      final interceptor = _MockMediaAuthInterceptor();
+      final cubit = VideoPlaybackStatusCubit();
+      final authCompleter = Completer<Map<String, String>?>();
+      addTearDown(cubit.close);
+
+      when(
+        () => interceptor.handleUnauthorizedMedia(
+          context: any(named: 'context'),
+          sha256Hash: _sha256,
+          url: _videoUrl,
+          serverUrl: 'https://media.divine.video',
+          category: 'video',
+        ),
+      ).thenAnswer((_) => authCompleter.future);
+
+      await pumpOverlay(tester, cubit: cubit, interceptor: interceptor);
+      await tester.pump();
+      expect(cubit.state.isVerifying(_videoId), isFalse);
+
+      await tester.tap(find.text(_verifyLabel));
+      await tester.pump();
+      // markVerifying runs synchronously before the auth await, so the
+      // spinner is visible while the retry is in flight.
+      expect(cubit.state.isVerifying(_videoId), isTrue);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      authCompleter.complete({'Authorization': 'Nostr token'});
+      await tester.pump();
+      await tester.pump();
+      // Cleared in the retry helper's finally once playback reloads.
+      expect(cubit.state.isVerifying(_videoId), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description

Closes #5269.

After tapping **Verify age** on an age-restricted feed video, the button gave no in-progress feedback while the verification dialog, auth-header signing, and playback reload ran. A slow retry looked like a dead button, and the retry helper did not own the duplicate-submission guard.

This PR adds a transient in-flight verifying set to `VideoPlaybackStatusCubit`, marks it for the lifetime of `retryAgeRestrictedPooledVideo`, and clears it in `finally`. All pooled-feed Verify age surfaces read that single source of truth and render a spinner while disabling the button:

- `ModeratedContentOverlay` via `context.select`
- the 401 `PooledVideoErrorOverlay` path via `BlocSelector`
- the moderation-restricted `PooledVideoErrorOverlay` path via `BlocSelector`

The retry helper now also returns immediately when the same video is already verifying, so duplicate retries are blocked at the operation boundary rather than relying only on the next UI rebuild. While reviewing the loading-button behavior, this also fixes `DivineButton.isLoading` so it truly suppresses taps even if a caller accidentally leaves `onPressed` non-null.

## Scope cleanup

The unrelated startup timing de-flake was removed from this PR. It is tracked separately in #5270 and will ship in its own PR.

## Related

Part of #5243.

## Verification

- `mise exec -- dart format --set-exit-if-changed lib/screens/feed/pooled_age_restricted_retry.dart packages/divine_ui/lib/src/button/divine_button.dart packages/divine_ui/test/src/button/divine_button_test.dart test/screens/feed/pooled_age_restricted_retry_test.dart`
- `mise exec -- flutter test test/blocs/video_playback_status/video_playback_status_cubit_test.dart test/screens/feed/pooled_age_restricted_retry_test.dart test/widgets/pooled_video_error_overlay_test.dart test/widgets/video_feed_item/moderated_content_overlay_test.dart test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart packages/divine_ui/test/src/button/divine_button_test.dart`
- pre-push hook: analyzer plus changed-file tests, including `feed_videos_test.dart`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
