### PR TITLE
feat(inbox): smooth Messages/Notifications switch with shared-axis transition

### DIFF
--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -42,8 +42,51 @@ class InboxView extends ConsumerStatefulWidget {
   ConsumerState<InboxView> createState() => _InboxViewState();
 }
 
-class _InboxViewState extends ConsumerState<InboxView> {
+class _InboxViewState extends ConsumerState<InboxView>
+    with SingleTickerProviderStateMixin {
+  /// Drives the shared-axis transition between the two tabs. `0` fully shows
+  /// Notifications, `1` fully shows Messages. Runs linearly; the curves are
+  /// applied per-property in [_InboxTabContent].
+  late final AnimationController _transitionController;
+
+  /// Currently selected tab.
   InboxTab _selectedTab = InboxTab.notifications;
+
+  /// Whether the Messages tab has been opened at least once. The pane is
+  /// built lazily on first open so its `ConversationListBloc` (and the DM
+  /// history backfill it kicks off) only starts when the user actually
+  /// navigates to Messages — then it stays mounted so later switches don't
+  /// reload. Notifications is the default tab and is always mounted.
+  bool _messagesActivated = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _transitionController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 160),
+      value: _selectedTab == InboxTab.notifications ? 0 : 1,
+    );
+  }
+
+  @override
+  void dispose() {
+    _transitionController.dispose();
+    super.dispose();
+  }
+
+  void _onTabSelected(InboxTab tab) {
+    if (tab == _selectedTab) return;
+    setState(() {
+      _selectedTab = tab;
+      if (tab == InboxTab.messages) _messagesActivated = true;
+    });
+    if (tab == InboxTab.messages) {
+      _transitionController.forward();
+    } else {
+      _transitionController.reverse();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -76,32 +119,130 @@ class _InboxViewState extends ConsumerState<InboxView> {
             // Segmented toggle (Messages / Notifications)
             InboxSegmentedToggle(
               selected: _selectedTab,
-              onChanged: (tab) => setState(() => _selectedTab = tab),
+              onChanged: _onTabSelected,
               notificationCount: notificationCount,
               messageCount: messageCount,
             ),
-            // Content area with rounded top corners
+            // Content area with rounded top corners. Both tabs stay mounted
+            // (Notifications always, Messages once first opened) so returning
+            // to a tab never reloads. The shared-axis transition slides +
+            // cross-fades between them; each pane sits on an opaque surface so
+            // neither the near-black background nor the other tab shows
+            // through.
             Expanded(
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(32),
                 child: ColoredBox(
                   color: VineTheme.surfaceContainerHigh,
-                  child: _selectedTab == InboxTab.messages
-                      ? KeyedSubtree(
-                          key: ValueKey('messages-$currentPubkey'),
-                          child: const _MessagesContent(),
-                        )
-                      // BLoC-driven view (video-anchored grouping +
-                      // 56x56 thumbnails + l10n messages); see
-                      // lib/notifications/view/inbox_notifications_page.dart.
-                      : KeyedSubtree(
-                          key: ValueKey('notifications-$currentPubkey'),
-                          child: const InboxNotificationsPage(),
-                        ),
+                  child: _InboxTabContent(
+                    animation: _transitionController,
+                    selected: _selectedTab,
+                    // BLoC-driven view (video-anchored grouping + 56x56
+                    // thumbnails + l10n); see
+                    // lib/notifications/view/inbox_notifications_page.dart.
+                    notifications: KeyedSubtree(
+                      key: ValueKey('notifications-$currentPubkey'),
+                      child: const InboxNotificationsPage(),
+                    ),
+                    messages: _messagesActivated
+                        ? KeyedSubtree(
+                            key: ValueKey('messages-$currentPubkey'),
+                            child: const _MessagesContent(),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
                 ),
               ),
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Horizontal travel of each pane during the transition, as a fraction of the
+/// pane width — the subtle shared-axis slide.
+const double _kTabSlideFraction = 0.06;
+
+/// Material shared-axis transition between the two inbox tabs: a short
+/// horizontal slide combined with an overlapping cross-fade.
+///
+/// [animation] runs `0` (Notifications) → `1` (Messages). Both panes stay
+/// mounted and are painted on an opaque surface, so the near-black background
+/// never flashes and the panes never bleed through one another. The selected
+/// pane is the only one that receives pointer events.
+class _InboxTabContent extends StatelessWidget {
+  const _InboxTabContent({
+    required this.animation,
+    required this.selected,
+    required this.notifications,
+    required this.messages,
+  });
+
+  final Animation<double> animation;
+  final InboxTab selected;
+  final Widget notifications;
+  final Widget messages;
+
+  @override
+  Widget build(BuildContext context) {
+    final notificationsSelected = selected == InboxTab.notifications;
+    return AnimatedBuilder(
+      animation: animation,
+      builder: (context, _) {
+        final t = animation.value;
+        final slide = Curves.easeInOut.transform(t);
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            _InboxTabPane(
+              opacity: Curves.easeInOut.transform(1 - t),
+              dx: -_kTabSlideFraction * slide,
+              active: notificationsSelected,
+              child: notifications,
+            ),
+            _InboxTabPane(
+              opacity: Curves.easeInOut.transform(t),
+              dx: _kTabSlideFraction * (1 - slide),
+              active: !notificationsSelected,
+              child: messages,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// A single inbox pane within the shared-axis transition: opaque background,
+/// [opacity] + horizontal [dx] (fraction of width) for the slide/fade, and
+/// [active] gating pointer events so the faded-out pane never intercepts taps.
+class _InboxTabPane extends StatelessWidget {
+  const _InboxTabPane({
+    required this.opacity,
+    required this.dx,
+    required this.active,
+    required this.child,
+  });
+
+  final double opacity;
+  final double dx;
+  final bool active;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      ignoring: !active,
+      child: Opacity(
+        opacity: opacity.clamp(0.0, 1.0),
+        child: FractionalTranslation(
+          translation: Offset(dx, 0),
+          child: ColoredBox(
+            color: VineTheme.surfaceContainerHigh,
+            child: child,
+          ),
         ),
       ),
     );

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -243,7 +243,9 @@ class _InboxTabContent extends StatelessWidget {
 
 /// A single inbox pane within the shared-axis transition: opaque background,
 /// [opacity] + horizontal [dx] (fraction of width) for the slide/fade, and
-/// [active] gating pointer events so the faded-out pane never intercepts taps.
+/// [active] gating pointer events, semantics, and tickers so the faded-out pane
+/// never intercepts taps, appears to assistive technologies, or keeps
+/// descendant animations running.
 class _InboxTabPane extends StatelessWidget {
   const _InboxTabPane({
     required this.opacity,
@@ -259,15 +261,21 @@ class _InboxTabPane extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return IgnorePointer(
-      ignoring: !active,
-      child: Opacity(
-        opacity: opacity.clamp(0.0, 1.0),
-        child: FractionalTranslation(
-          translation: Offset(dx, 0),
-          child: ColoredBox(
-            color: VineTheme.surfaceContainerHigh,
-            child: child,
+    return TickerMode(
+      enabled: active,
+      child: ExcludeSemantics(
+        excluding: !active,
+        child: IgnorePointer(
+          ignoring: !active,
+          child: Opacity(
+            opacity: opacity.clamp(0.0, 1.0),
+            child: FractionalTranslation(
+              translation: Offset(dx, 0),
+              child: ColoredBox(
+                color: VineTheme.surfaceContainerHigh,
+                child: child,
+              ),
+            ),
           ),
         ),
       ),

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -52,17 +52,18 @@ class _InboxViewState extends ConsumerState<InboxView>
   /// Currently selected tab.
   InboxTab _selectedTab = InboxTab.notifications;
 
-  /// Whether the Messages tab has been opened at least once. The pane is
-  /// built lazily on first open so its `ConversationListBloc` (and the DM
-  /// history backfill it kicks off) only starts when the user actually
-  /// navigates to Messages — then it stays mounted so later switches don't
-  /// reload. Notifications is the default tab and is always mounted.
+  /// Whether the Messages tab UI has been opened at least once. The
+  /// `ConversationListBloc` is provided by `InboxPage` and starts immediately
+  /// so DM backfill and streams can warm the tab before it is visible; this flag
+  /// only keeps the Messages pane out of the animated stack until first open.
+  /// After that first open, the pane stays mounted so later switches preserve
+  /// UI state. Notifications is the default tab and is always mounted.
   bool _messagesActivated = false;
 
   /// Pubkey the current tab state belongs to. When the signed-in identity
-  /// changes we collapse back to Notifications and re-arm lazy Messages
-  /// activation, so the new account doesn't eagerly start its DM backfill
-  /// before the user navigates to Messages.
+  /// changes we collapse back to Notifications and re-arm lazy Messages UI
+  /// activation. The account-scoped DM bloc still starts from `InboxPage` so
+  /// Messages can be ready by the time the user opens it.
   String? _activePubkey;
   bool _pubkeyObserved = false;
 
@@ -98,7 +99,7 @@ class _InboxViewState extends ConsumerState<InboxView>
   }
 
   /// Resets the tab state to its defaults when the signed-in identity changes,
-  /// so a new account opens on Notifications and re-arms lazy Messages loading.
+  /// so a new account opens on Notifications and re-arms lazy Messages UI.
   void _syncToIdentity(String? currentPubkey) {
     if (!_pubkeyObserved) {
       _pubkeyObserved = true;

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -59,13 +59,21 @@ class _InboxViewState extends ConsumerState<InboxView>
   /// reload. Notifications is the default tab and is always mounted.
   bool _messagesActivated = false;
 
+  /// Pubkey the current tab state belongs to. When the signed-in identity
+  /// changes we collapse back to Notifications and re-arm lazy Messages
+  /// activation, so the new account doesn't eagerly start its DM backfill
+  /// before the user navigates to Messages.
+  String? _activePubkey;
+  bool _pubkeyObserved = false;
+
   @override
   void initState() {
     super.initState();
     _transitionController = AnimationController(
       vsync: this,
-      duration: const Duration(milliseconds: 160),
-      value: _selectedTab == InboxTab.notifications ? 0 : 1,
+      duration: kInboxTabTransitionDuration,
+      // Notifications is the default tab (value 0); Messages is value 1.
+      value: 0,
     );
   }
 
@@ -81,11 +89,27 @@ class _InboxViewState extends ConsumerState<InboxView>
       _selectedTab = tab;
       if (tab == InboxTab.messages) _messagesActivated = true;
     });
-    if (tab == InboxTab.messages) {
-      _transitionController.forward();
+    final target = tab == InboxTab.messages ? 1.0 : 0.0;
+    if (MediaQuery.disableAnimationsOf(context)) {
+      _transitionController.value = target;
     } else {
-      _transitionController.reverse();
+      _transitionController.animateTo(target);
     }
+  }
+
+  /// Resets the tab state to its defaults when the signed-in identity changes,
+  /// so a new account opens on Notifications and re-arms lazy Messages loading.
+  void _syncToIdentity(String? currentPubkey) {
+    if (!_pubkeyObserved) {
+      _pubkeyObserved = true;
+      _activePubkey = currentPubkey;
+      return;
+    }
+    if (currentPubkey == _activePubkey) return;
+    _activePubkey = currentPubkey;
+    _selectedTab = InboxTab.notifications;
+    _messagesActivated = false;
+    _transitionController.value = 0;
   }
 
   @override
@@ -109,6 +133,7 @@ class _InboxViewState extends ConsumerState<InboxView>
     final notificationCount = context.watch<NotificationBadgeCubit>().state;
     final messageCount = context.watch<DmUnreadCountCubit>().state;
     final currentPubkey = ref.read(authServiceProvider).currentPublicKeyHex;
+    _syncToIdentity(currentPubkey);
 
     return ColoredBox(
       color: VineTheme.surfaceBackground,

--- a/mobile/lib/screens/inbox/widgets/inbox_segmented_toggle.dart
+++ b/mobile/lib/screens/inbox/widgets/inbox_segmented_toggle.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Messages/Notifications segmented toggle for the inbox screen.
-// ABOUTME: Matches the Figma design with primary green active state,
-// ABOUTME: muted inactive state, and unread-count badges on each tab.
+// ABOUTME: Matches the Figma design with a single green indicator pill that
+// ABOUTME: slides between the active segment, and unread-count badges per tab.
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -9,11 +9,20 @@ import 'package:openvine/l10n/l10n.dart';
 /// The two tabs available in the inbox segmented toggle.
 enum InboxTab { messages, notifications }
 
+/// Total height of each toggle segment, including the 4px inset that frames
+/// the sliding indicator pill.
+const double _kSegmentHeight = 48;
+
+/// Inset between the toggle's inner edge and the indicator pill.
+const double _kIndicatorInset = 4;
+
 /// A segmented toggle that switches between Messages and Notifications.
 ///
 /// Matches the Figma design: rounded container with `surfaceContainer` bg,
-/// `outlineMuted` 2px border, 20px radius. Active segment uses `primary` bg
-/// with `onPrimaryButton` text; inactive uses `onSurfaceMuted` text.
+/// `outlineMuted` 2px border, 20px radius. A single `primary` indicator pill
+/// animates between the two segments; the active label uses `onPrimaryButton`
+/// text, the inactive one `onSurfaceMuted`. The slide uses [kTabScrollDuration]
+/// so it stays in sync with the inbox `TabBarView` driven by the same toggle.
 class InboxSegmentedToggle extends StatelessWidget {
   const InboxSegmentedToggle({
     required this.selected,
@@ -37,25 +46,73 @@ class InboxSegmentedToggle extends StatelessWidget {
         border: Border.all(color: VineTheme.outlineMuted, width: 2),
         borderRadius: BorderRadius.circular(20),
       ),
-      child: Row(
+      child: Stack(
         children: [
-          Expanded(
-            child: _ToggleButton(
-              label: context.l10n.settingsNotifications,
-              isSelected: selected == InboxTab.notifications,
-              onTap: () => onChanged(InboxTab.notifications),
-              badgeCount: notificationCount,
-            ),
-          ),
-          Expanded(
-            child: _ToggleButton(
-              label: context.l10n.inboxMessagesTab,
-              isSelected: selected == InboxTab.messages,
-              onTap: () => onChanged(InboxTab.messages),
-              badgeCount: messageCount,
-            ),
+          Positioned.fill(child: _IndicatorPill(selected: selected)),
+          Row(
+            children: [
+              Expanded(
+                child: _ToggleButton(
+                  label: context.l10n.settingsNotifications,
+                  isSelected: selected == InboxTab.notifications,
+                  onTap: () => onChanged(InboxTab.notifications),
+                  badgeCount: notificationCount,
+                ),
+              ),
+              Expanded(
+                child: _ToggleButton(
+                  label: context.l10n.inboxMessagesTab,
+                  isSelected: selected == InboxTab.messages,
+                  onTap: () => onChanged(InboxTab.messages),
+                  badgeCount: messageCount,
+                ),
+              ),
+            ],
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Single green pill that slides between the active segment.
+class _IndicatorPill extends StatelessWidget {
+  const _IndicatorPill({required this.selected});
+
+  final InboxTab selected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(_kIndicatorInset),
+      child: AnimatedAlign(
+        duration: kTabScrollDuration,
+        curve: Curves.ease,
+        alignment: selected == InboxTab.notifications
+            ? AlignmentDirectional.centerStart
+            : AlignmentDirectional.centerEnd,
+        child: const FractionallySizedBox(
+          widthFactor: 0.5,
+          heightFactor: 1,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: VineTheme.primary,
+              borderRadius: BorderRadius.all(Radius.circular(16)),
+              boxShadow: [
+                BoxShadow(
+                  color: VineTheme.innerShadow,
+                  blurRadius: 1,
+                  offset: Offset(1, 1),
+                ),
+                BoxShadow(
+                  color: VineTheme.innerShadow,
+                  blurRadius: 0.6,
+                  offset: Offset(0.4, 0.4),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }
@@ -76,6 +133,10 @@ class _ToggleButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final fontSize = MediaQuery.textScalerOf(
+      context,
+    ).scale(VineTheme.titleMediumFont().fontSize!).clamp(0.0, 20.0);
+
     return Semantics(
       button: true,
       selected: isSelected,
@@ -83,49 +144,26 @@ class _ToggleButton extends StatelessWidget {
       child: GestureDetector(
         onTap: onTap,
         behavior: HitTestBehavior.opaque,
-        child: AnimatedContainer(
-          margin: const .all(4),
-          padding: const .symmetric(horizontal: 8),
-          duration: const Duration(milliseconds: 200),
-          curve: Curves.easeInOut,
-          height: 40,
-          decoration: BoxDecoration(
-            color: isSelected ? VineTheme.primary : VineTheme.transparent,
-            borderRadius: BorderRadius.circular(16),
-            boxShadow: isSelected
-                ? const [
-                    BoxShadow(
-                      color: VineTheme.innerShadow,
-                      blurRadius: 1,
-                      offset: Offset(1, 1),
-                    ),
-                    BoxShadow(
-                      color: VineTheme.innerShadow,
-                      blurRadius: 0.6,
-                      offset: Offset(0.4, 0.4),
-                    ),
-                  ]
-                : null,
-          ),
+        child: SizedBox(
+          height: _kSegmentHeight,
           child: Center(
             child: Stack(
               clipBehavior: Clip.none,
               children: [
-                Text(
-                  label,
-                  maxLines: 1,
-                  overflow: .ellipsis,
-                  textScaler: TextScaler.noScaling,
-                  style:
-                      VineTheme.titleMediumFont(
-                        color: isSelected
-                            ? VineTheme.onPrimaryButton
-                            : VineTheme.onSurfaceMuted,
-                      ).copyWith(
-                        fontSize: MediaQuery.textScalerOf(context)
-                            .scale(VineTheme.titleMediumFont().fontSize!)
-                            .clamp(0, 20),
-                      ),
+                AnimatedDefaultTextStyle(
+                  duration: kTabScrollDuration,
+                  curve: Curves.ease,
+                  style: VineTheme.titleMediumFont(
+                    color: isSelected
+                        ? VineTheme.onPrimaryButton
+                        : VineTheme.onSurfaceMuted,
+                  ).copyWith(fontSize: fontSize),
+                  child: Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textScaler: TextScaler.noScaling,
+                  ),
                 ),
                 if (badgeCount > 0)
                   PositionedDirectional(

--- a/mobile/lib/screens/inbox/widgets/inbox_segmented_toggle.dart
+++ b/mobile/lib/screens/inbox/widgets/inbox_segmented_toggle.dart
@@ -9,6 +9,11 @@ import 'package:openvine/l10n/l10n.dart';
 /// The two tabs available in the inbox segmented toggle.
 enum InboxTab { messages, notifications }
 
+/// Duration of an inbox tab switch. The indicator-pill slide and label fade in
+/// this toggle and the shared-axis content transition in `inbox_view.dart` both
+/// run over this single duration so the toggle and the panes move in lockstep.
+const Duration kInboxTabTransitionDuration = Duration(milliseconds: 200);
+
 /// Total height of each toggle segment, including the 4px inset that frames
 /// the sliding indicator pill.
 const double _kSegmentHeight = 48;
@@ -21,8 +26,10 @@ const double _kIndicatorInset = 4;
 /// Matches the Figma design: rounded container with `surfaceContainer` bg,
 /// `outlineMuted` 2px border, 20px radius. A single `primary` indicator pill
 /// animates between the two segments; the active label uses `onPrimaryButton`
-/// text, the inactive one `onSurfaceMuted`. The slide uses [kTabScrollDuration]
-/// so it stays in sync with the inbox `TabBarView` driven by the same toggle.
+/// text, the inactive one `onSurfaceMuted`. The pill slide and label fade run
+/// over [kInboxTabTransitionDuration] — the same duration that drives the
+/// shared-axis content transition in `inbox_view.dart` — so the toggle and the
+/// panes move together. Both collapse to no animation under reduced motion.
 class InboxSegmentedToggle extends StatelessWidget {
   const InboxSegmentedToggle({
     required this.selected,
@@ -83,11 +90,14 @@ class _IndicatorPill extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final duration = MediaQuery.disableAnimationsOf(context)
+        ? Duration.zero
+        : kInboxTabTransitionDuration;
     return Padding(
       padding: const EdgeInsets.all(_kIndicatorInset),
       child: AnimatedAlign(
-        duration: kTabScrollDuration,
-        curve: Curves.ease,
+        duration: duration,
+        curve: Curves.easeInOut,
         alignment: selected == InboxTab.notifications
             ? AlignmentDirectional.centerStart
             : AlignmentDirectional.centerEnd,
@@ -136,6 +146,9 @@ class _ToggleButton extends StatelessWidget {
     final fontSize = MediaQuery.textScalerOf(
       context,
     ).scale(VineTheme.titleMediumFont().fontSize!).clamp(0.0, 20.0);
+    final duration = MediaQuery.disableAnimationsOf(context)
+        ? Duration.zero
+        : kInboxTabTransitionDuration;
 
     return Semantics(
       button: true,
@@ -151,8 +164,8 @@ class _ToggleButton extends StatelessWidget {
               clipBehavior: Clip.none,
               children: [
                 AnimatedDefaultTextStyle(
-                  duration: kTabScrollDuration,
-                  curve: Curves.ease,
+                  duration: duration,
+                  curve: Curves.easeInOut,
                   style: VineTheme.titleMediumFont(
                     color: isSelected
                         ? VineTheme.onPrimaryButton

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -47,17 +47,19 @@ class _MockNotificationBadgeCubit extends MockCubit<int>
     implements NotificationBadgeCubit {}
 
 class _MockAuthService extends MockAuthService {
-  _MockAuthService(this._pubkey) {
+  _MockAuthService(this.pubkey) {
     when(() => authState).thenReturn(AuthState.authenticated);
     when(() => isAuthenticated).thenReturn(true);
     when(
       () => authStateStream,
     ).thenAnswer((_) => const Stream<AuthState>.empty());
   }
-  final String _pubkey;
+
+  /// Mutable so a test can simulate an account switch mid-flight.
+  String pubkey;
 
   @override
-  String? get currentPublicKeyHex => _pubkey;
+  String? get currentPublicKeyHex => pubkey;
 }
 
 void main() {
@@ -92,6 +94,7 @@ void main() {
       ConversationListState? state,
       int dmUnreadCount = 0,
       int notificationUnreadCount = 0,
+      Stream<int>? notificationStream,
     }) {
       if (state != null) {
         whenListen(
@@ -123,7 +126,7 @@ void main() {
       when(() => mockNotifBadgeCubit.state).thenReturn(notificationUnreadCount);
       whenListen(
         mockNotifBadgeCubit,
-        const Stream<int>.empty(),
+        notificationStream ?? const Stream<int>.empty(),
         initialState: notificationUnreadCount,
       );
 
@@ -293,6 +296,54 @@ void main() {
 
         expect(find.byType(ConversationTile), findsOneWidget);
       });
+
+      testWidgets(
+        'collapses back to Notifications when the signed-in identity changes',
+        (tester) async {
+          final notificationController = StreamController<int>();
+          addTearDown(notificationController.close);
+
+          final conversation = DmConversation(
+            id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+            participantPubkeys: const [currentPubkey, otherPubkey],
+            isGroup: false,
+            createdAt: nowUnix,
+            lastMessageContent: 'Hello',
+            lastMessageTimestamp: nowUnix,
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationListState(
+                status: ConversationListStatus.loaded,
+                conversations: [conversation],
+                hasMore: false,
+              ),
+              notificationStream: notificationController.stream,
+            ),
+          );
+          await tester.pump();
+
+          // Open Messages so the pane is activated and the tab is selected.
+          await tester.tap(find.text('Messages'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
+          expect(find.byType(ConversationTile), findsOneWidget);
+
+          // Simulate an account switch: the auth service reports a new pubkey
+          // and a watched cubit emits to drive the InboxView rebuild.
+          mockAuthService.pubkey = otherPubkey;
+          notificationController.add(1);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
+
+          final toggle = tester.widget<InboxSegmentedToggle>(
+            find.byType(InboxSegmentedToggle),
+          );
+          expect(toggle.selected, InboxTab.notifications);
+          expect(find.byType(ConversationTile), findsNothing);
+        },
+      );
 
       testWidgets(
         'renders $MessageRequestsBanner when request conversations exist',

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -194,6 +194,7 @@ void main() {
         // Switch to Messages tab (default is Notifications).
         await tester.tap(find.text('Messages'));
         await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
         expect(find.byType(FollowingBar), findsOneWidget);
       });
@@ -207,8 +208,18 @@ void main() {
         // Switch to Messages tab (default is Notifications).
         await tester.tap(find.text('Messages'));
         await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
-        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        // Both tabs stay alive in the TabBarView, so scope to the Messages
+        // subtree (the Notifications tab shows its own spinner with a null
+        // notification repository).
+        expect(
+          find.descendant(
+            of: find.byKey(const ValueKey('messages-$currentPubkey')),
+            matching: find.byType(CircularProgressIndicator),
+          ),
+          findsOneWidget,
+        );
       });
 
       testWidgets('renders $InboxEmptyState when status is error', (
@@ -226,6 +237,7 @@ void main() {
         // Switch to Messages tab (default is Notifications).
         await tester.tap(find.text('Messages'));
         await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
         expect(find.byType(InboxEmptyState), findsOneWidget);
       });
@@ -245,6 +257,7 @@ void main() {
           // Switch to Messages tab (default is Notifications).
           await tester.tap(find.text('Messages'));
           await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
 
           expect(find.byType(InboxEmptyState), findsOneWidget);
         },
@@ -275,7 +288,8 @@ void main() {
 
         // Switch to Messages tab (default is Notifications).
         await tester.tap(find.text('Messages'));
-        await tester.pumpAndSettle();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
         expect(find.byType(ConversationTile), findsOneWidget);
       });
@@ -306,6 +320,7 @@ void main() {
           // Switch to Messages tab (default is Notifications).
           await tester.tap(find.text('Messages'));
           await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
 
           expect(find.byType(MessageRequestsBanner), findsOneWidget);
         },
@@ -346,7 +361,8 @@ void main() {
 
           // Switch to Messages tab (default is Notifications).
           await tester.tap(find.text('Messages'));
-          await tester.pumpAndSettle();
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
 
           expect(find.byType(MessageRequestsBanner), findsOneWidget);
           expect(find.byType(ConversationTile), findsOneWidget);
@@ -370,6 +386,7 @@ void main() {
           await tester.tap(find.text('Messages'));
           // pump (not pumpAndSettle): LinearProgressIndicator animates forever.
           await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
 
           expect(find.byType(LinearProgressIndicator), findsOneWidget);
         },
@@ -390,6 +407,7 @@ void main() {
           // Switch to Messages tab (default is Notifications).
           await tester.tap(find.text('Messages'));
           await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
 
           expect(find.byType(LinearProgressIndicator), findsNothing);
         },
@@ -423,7 +441,8 @@ void main() {
         await tester.pump();
 
         await tester.tap(find.text('Messages'));
-        await tester.pumpAndSettle();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
         await tester.drag(find.byType(ListView), const Offset(0, -5000));
         await tester.pump();
@@ -457,7 +476,8 @@ void main() {
 
         // Switch to Messages tab (default is Notifications).
         await tester.tap(find.text('Messages'));
-        await tester.pumpAndSettle();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
         when(
           () => mockGoRouter.push(any(), extra: any(named: 'extra')),
@@ -500,6 +520,7 @@ void main() {
         // Switch to Messages tab (default is Notifications).
         await tester.tap(find.text('Messages'));
         await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
 
         when(() => mockGoRouter.pushNamed(any())).thenAnswer((_) async => null);
 
@@ -535,6 +556,7 @@ void main() {
         // Switch to Messages tab (default is Notifications).
         await tester.tap(find.text('Messages'));
         await tester.pump();
+        await tester.pump(const Duration(milliseconds: 350));
         await tester.pump(const Duration(milliseconds: 100));
 
         // FollowingBar uses fetchUserProfileProvider for names. When the

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -296,6 +297,82 @@ void main() {
 
         expect(find.byType(ConversationTile), findsOneWidget);
       });
+
+      testWidgets(
+        'excludes inactive mounted pane from semantics after tab switch',
+        (tester) async {
+          final semantics = tester.ensureSemantics();
+          try {
+            final conversation = DmConversation(
+              id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+              participantPubkeys: const [currentPubkey, otherPubkey],
+              isGroup: false,
+              createdAt: nowUnix,
+              lastMessageContent: 'Hello',
+              lastMessageTimestamp: nowUnix,
+            );
+
+            await tester.pumpWidget(
+              buildSubject(
+                state: ConversationListState(
+                  status: ConversationListStatus.loaded,
+                  conversations: [conversation],
+                  hasMore: false,
+                ),
+              ),
+            );
+            await tester.pump();
+
+            await tester.tap(find.text('Messages'));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 350));
+
+            final conversationLabel = UserProfile.defaultDisplayNameFor(
+              otherPubkey,
+            );
+            bool hasConversationSemantics() {
+              SemanticsNode? root;
+              bool visitPipelineOwner(PipelineOwner owner) {
+                root ??= owner.semanticsOwner?.rootSemanticsNode;
+                owner.visitChildren(visitPipelineOwner);
+                return true;
+              }
+
+              visitPipelineOwner(RendererBinding.instance.rootPipelineOwner);
+              expect(root, isNotNull);
+
+              var found = false;
+              bool visit(SemanticsNode node) {
+                if (node.label.contains(conversationLabel)) {
+                  found = true;
+                }
+                node.visitChildren(visit);
+                return true;
+              }
+
+              visit(root!);
+              return found;
+            }
+
+            expect(
+              hasConversationSemantics(),
+              isTrue,
+            );
+
+            await tester.tap(find.text('Notifications'));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 350));
+
+            expect(find.byType(ConversationTile), findsOneWidget);
+            expect(
+              hasConversationSemantics(),
+              isFalse,
+            );
+          } finally {
+            semantics.dispose();
+          }
+        },
+      );
 
       testWidgets(
         'collapses back to Notifications when the signed-in identity changes',


### PR DESCRIPTION
Closes #5268

## Description

The inbox tab switch felt janky: switching between **Messages** and **Notifications** conditionally swapped the two subtrees, which disposed the off-screen tab and re-ran its initial load (a brief loading flash) on every switch.

This keeps both tabs mounted and animates between them with a Material **shared-axis-style** transition: a short horizontal slide combined with an overlapping cross-fade, driven by a single `AnimationController`. Each pane is painted on an opaque surface, so neither the near-black inbox background nor the other tab shows through during the transition.

Also: the segmented toggle's green indicator now slides between the two segments instead of snapping.

- `inbox_view.dart`: replaced the conditional tab swap with `_InboxTabContent` (slide + cross-fade over opaque panes). Both panes stay mounted once opened, so switching back does not reload and scroll position is preserved.
- `inbox_segmented_toggle.dart`: a single green indicator pill that slides between segments (`AnimatedAlign`); the active/inactive label colors cross-fade.
- The Messages UI pane stays lazy until first opened, then stays mounted so later switches preserve UI state. Its `ConversationListBloc` still starts from `InboxPage` on inbox open, so DM history backfill and streams can warm the Messages tab before the user switches to it.
- Inactive mounted panes are now excluded from semantics and have descendant tickers disabled, so hidden tab content is not exposed to screen readers or left animating off-screen.

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/bd5db535-b3d9-40b6-884c-33082fe2f0a5"></video> | <video src="https://github.com/user-attachments/assets/a2bd5928-aa03-4afe-8f72-c9cb0e2a2120"></video> |

## Out of Scope

None.

## Verification

- `flutter analyze lib/screens/inbox` - no issues
- `flutter test test/screens/inbox/ test/notifications/view/inbox_notifications_page_test.dart` - 236 passing
- `flutter test test/screens/inbox/inbox_view_test.dart` - 18 passing
- `flutter test test/screens/inbox/inbox_view_test.dart test/screens/inbox/widgets/inbox_segmented_toggle_test.dart test/features/app/startup/startup_coordinator_test.dart` - 35 passing
- `flutter analyze lib/screens/inbox test/screens/inbox/inbox_view_test.dart` - no issues
- Pre-push hook analyzer + changed-file tests - passed
- `dart format` - clean

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
