### PR TITLE
fix(startup): hold splash until the redirect leaves /welcome (#5242)

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1593,18 +1593,16 @@ class _DivineAppState extends ConsumerState<DivineApp> {
   @override
   void initState() {
     super.initState();
-    // Hold the native splash until an authenticated user's `/welcome` → `/home`
-    // redirect has been applied, so the sign-in page never flashes (#5242).
-    // Constructed synchronously here — before deferred startup triggers
-    // AuthService.initialize() — so it is subscribed before the auth state
-    // settles. Reading goRouterProvider builds the cached router instance.
+    // Subscribe before deferred startup settles auth; routerDelegate reliably
+    // notifies after redirect configuration changes (#5242).
     final router = ref.read(goRouterProvider);
     final authService = ref.read(authServiceProvider);
     _splashReleaseController = StartupSplashReleaseController(
       authStateStream: authService.authStateStream,
       currentAuthState: () => authService.authState,
-      locationListenable: router.routeInformationProvider,
-      currentLocation: () => router.routeInformationProvider.value.uri.path,
+      locationListenable: router.routerDelegate,
+      currentLocation: () =>
+          router.routerDelegate.currentConfiguration.uri.path,
       isAuthEntryLocation: isAuthEntryLocation,
     );
     // Start deferred startup after the first frame so the shell can paint first.

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -73,7 +73,6 @@ import 'package:openvine/screens/profile_screen_router.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
-import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/back_button_handler.dart';
 import 'package:openvine/services/bandwidth_tracker_service.dart';
 import 'package:openvine/services/collaborator_invite_service.dart';
@@ -101,6 +100,7 @@ import 'package:openvine/services/startup_performance_service.dart';
 import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
+import 'package:openvine/startup/startup_splash_release_controller.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/platform_support.dart';
@@ -925,35 +925,6 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
   return coordinator;
 }
 
-void _removeSplashWhenStartupAuthSettles(AuthService authService) {
-  unawaited(
-    _waitForStartupAuthTerminalState(authService)
-        .timeout(AuthService.startupAuthRestoreTimeout)
-        .catchError((Object error, StackTrace stackTrace) {
-          Log.warning(
-            '[INIT] Auth startup did not settle before splash timeout: $error',
-            name: 'Main',
-            category: LogCategory.system,
-          );
-        })
-        .whenComplete(FlutterNativeSplash.remove),
-  );
-}
-
-Future<void> _waitForStartupAuthTerminalState(AuthService authService) async {
-  if (_isTerminalStartupAuthState(authService.authState)) return;
-  await authService.authStateStream.firstWhere(_isTerminalStartupAuthState);
-}
-
-bool _isTerminalStartupAuthState(AuthState state) {
-  return switch (state) {
-    AuthState.unauthenticated ||
-    AuthState.awaitingTosAcceptance ||
-    AuthState.authenticated => true,
-    AuthState.checking || AuthState.authenticating => false,
-  };
-}
-
 Future<void> _startOpenVineApp() async {
   // Add timing logs for startup diagnostics
   final startTime = DateTime.now();
@@ -1359,7 +1330,10 @@ Future<void> _startOpenVineApp() async {
   );
 
   final startupCoordinator = _createStartupCoordinator(container);
-  _removeSplashWhenStartupAuthSettles(container.read(authServiceProvider));
+  // The native splash is released by [StartupSplashReleaseController], wired in
+  // _DivineAppState.initState once the router exists, so that an authenticated
+  // user's `/welcome` → `/home` redirect is applied before the splash lifts
+  // (#5242). It cannot run here because the GoRouter is built in runApp.
   await startupCoordinator.initializeThrough(StartupPhase.critical);
 
   Log.info('Divine starting...', name: 'Main');
@@ -1614,10 +1588,25 @@ class _DivineAppState extends ConsumerState<DivineApp> {
   StreamSubscription<void>? _shakeSubscription;
   StreamSubscription<NotificationTapEvent>? _notificationTapSubscription;
   QuickActionsCoordinator? _quickActionsCoordinator;
+  late final StartupSplashReleaseController _splashReleaseController;
 
   @override
   void initState() {
     super.initState();
+    // Hold the native splash until an authenticated user's `/welcome` → `/home`
+    // redirect has been applied, so the sign-in page never flashes (#5242).
+    // Constructed synchronously here — before deferred startup triggers
+    // AuthService.initialize() — so it is subscribed before the auth state
+    // settles. Reading goRouterProvider builds the cached router instance.
+    final router = ref.read(goRouterProvider);
+    final authService = ref.read(authServiceProvider);
+    _splashReleaseController = StartupSplashReleaseController(
+      authStateStream: authService.authStateStream,
+      currentAuthState: () => authService.authState,
+      locationListenable: router.routeInformationProvider,
+      currentLocation: () => router.routeInformationProvider.value.uri.path,
+      isAuthEntryLocation: isAuthEntryLocation,
+    );
     // Start deferred startup after the first frame so the shell can paint first.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -1633,6 +1622,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
 
   @override
   void dispose() {
+    _splashReleaseController.dispose();
     _notificationTapSubscription?.cancel();
     unawaited(_quickActionsCoordinator?.dispose());
     _shakeSubscription?.cancel();

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1603,7 +1603,11 @@ class _DivineAppState extends ConsumerState<DivineApp> {
       locationListenable: router.routerDelegate,
       currentLocation: () =>
           router.routerDelegate.currentConfiguration.uri.path,
-      isAuthEntryLocation: isAuthEntryLocation,
+      authenticatedRedirectPending: (location) =>
+          authenticatedRedirectsFromAuthEntry(
+            location,
+            hasExpiredOAuthSession: authService.hasExpiredOAuthSession,
+          ),
     );
     // Start deferred startup after the first frame so the shell can paint first.
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -211,15 +211,6 @@ String? _moderationConversationId(
   return DmRepository.computeConversationId([currentPubkey, moderationPubkey]);
 }
 
-/// Whether [location] belongs to the unauthenticated auth-entry flow
-/// (welcome/sign-in and its sub-paths, key import, nostrconnect, invite gate,
-/// reset-password, email verification, and the public minor-account review
-/// entry screens).
-///
-/// Used by the router redirect and by the startup splash-release controller
-/// (#5242), which keeps the native splash up for an authenticated user until
-/// the redirect has navigated off this flow — otherwise the `/welcome` page
-/// flashes before `/home` paints.
 bool isAuthEntryLocation(String location) {
   return location == WelcomeScreen.path ||
       location.startsWith('${WelcomeScreen.path}/') ||

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -177,7 +177,7 @@ String minorAccountReviewReturnLocationForTest(Uri uri) {
   }
 
   final fromLocation = Uri.parse(from).path;
-  if (_isAuthEntryLocation(fromLocation) ||
+  if (isAuthEntryLocation(fromLocation) ||
       fromLocation == MinorAccountReviewLoadingScreen.path) {
     return VideoFeedPage.pathForIndex(0);
   }
@@ -211,7 +211,16 @@ String? _moderationConversationId(
   return DmRepository.computeConversationId([currentPubkey, moderationPubkey]);
 }
 
-bool _isAuthEntryLocation(String location) {
+/// Whether [location] belongs to the unauthenticated auth-entry flow
+/// (welcome/sign-in and its sub-paths, key import, nostrconnect, invite gate,
+/// reset-password, email verification, and the public minor-account review
+/// entry screens).
+///
+/// Used by the router redirect and by the startup splash-release controller
+/// (#5242), which keeps the native splash up for an authenticated user until
+/// the redirect has navigated off this flow — otherwise the `/welcome` page
+/// flashes before `/home` paints.
+bool isAuthEntryLocation(String location) {
   return location == WelcomeScreen.path ||
       location.startsWith('${WelcomeScreen.path}/') ||
       location.startsWith(KeyImportScreen.path) ||
@@ -325,7 +334,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
 
       // Auth routes don't require authentication — user is in the
       // process of logging in.
-      final isAuthRoute = _isAuthEntryLocation(location);
+      final isAuthRoute = isAuthEntryLocation(location);
 
       // Only bounce to the loading screen on a true cold load (no value yet).
       // Riverpod keeps the previous value during a background refetch

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -225,40 +225,6 @@ bool _isAuthEntryLocation(String location) {
       location == MinorAccountReviewUnder13Screen.path;
 }
 
-/// Whether an authenticated user currently on [location] is one the router's
-/// auth-route redirect bounces home to the feed.
-///
-/// Mirrors the authenticated auth-route redirect in [goRouterProvider]: an
-/// authenticated user is only redirected home from the sign-in entry points
-/// (`/welcome`, `/nostr-connect`, `/welcome/invite`, `/welcome/create-account`,
-/// `/welcome/login-options`), with the same expired-session exception for login
-/// options (an expired-session user must reach login options to re-authenticate
-/// rather than be bounced home).
-///
-/// It is deliberately narrower than [_isAuthEntryLocation]: auth-entry routes an
-/// authenticated user is intentionally left on — reset-password and
-/// email-verification deep links, key import (an account-switch route), and the
-/// minor-account-review entry routes — return `false`.
-///
-/// The startup splash gate (`StartupSplashReleaseController`, #5242) uses this
-/// to hold the splash only while a home-redirect is actually pending, so a
-/// cold-start auth deep link releases the splash as soon as auth settles
-/// instead of waiting for the restore timeout. Keep this in sync with the
-/// auth-route redirect above; `login_flow_redirect_test` exercises it directly.
-bool authenticatedRedirectsFromAuthEntry(
-  String location, {
-  required bool hasExpiredOAuthSession,
-}) {
-  if (hasExpiredOAuthSession && location == WelcomeScreen.loginOptionsPath) {
-    return false;
-  }
-  return location == WelcomeScreen.path ||
-      location == NostrConnectScreen.path ||
-      location == WelcomeScreen.inviteGatePath ||
-      location == WelcomeScreen.createAccountPath ||
-      location == WelcomeScreen.loginOptionsPath;
-}
-
 @visibleForTesting
 int homeInitialIndexFromPathParameters(Map<String, String> pathParameters) {
   final rawIndex = int.tryParse(pathParameters['index'] ?? '') ?? 0;

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -177,7 +177,7 @@ String minorAccountReviewReturnLocationForTest(Uri uri) {
   }
 
   final fromLocation = Uri.parse(from).path;
-  if (isAuthEntryLocation(fromLocation) ||
+  if (_isAuthEntryLocation(fromLocation) ||
       fromLocation == MinorAccountReviewLoadingScreen.path) {
     return VideoFeedPage.pathForIndex(0);
   }
@@ -211,7 +211,7 @@ String? _moderationConversationId(
   return DmRepository.computeConversationId([currentPubkey, moderationPubkey]);
 }
 
-bool isAuthEntryLocation(String location) {
+bool _isAuthEntryLocation(String location) {
   return location == WelcomeScreen.path ||
       location.startsWith('${WelcomeScreen.path}/') ||
       location.startsWith(KeyImportScreen.path) ||
@@ -223,6 +223,40 @@ bool isAuthEntryLocation(String location) {
       location == MinorAccountReviewScreen.welcomePath ||
       location == MinorAccountReviewParentConsentScreen.path ||
       location == MinorAccountReviewUnder13Screen.path;
+}
+
+/// Whether an authenticated user currently on [location] is one the router's
+/// auth-route redirect bounces home to the feed.
+///
+/// Mirrors the authenticated auth-route redirect in [goRouterProvider]: an
+/// authenticated user is only redirected home from the sign-in entry points
+/// (`/welcome`, `/nostr-connect`, `/welcome/invite`, `/welcome/create-account`,
+/// `/welcome/login-options`), with the same expired-session exception for login
+/// options (an expired-session user must reach login options to re-authenticate
+/// rather than be bounced home).
+///
+/// It is deliberately narrower than [_isAuthEntryLocation]: auth-entry routes an
+/// authenticated user is intentionally left on — reset-password and
+/// email-verification deep links, key import (an account-switch route), and the
+/// minor-account-review entry routes — return `false`.
+///
+/// The startup splash gate (`StartupSplashReleaseController`, #5242) uses this
+/// to hold the splash only while a home-redirect is actually pending, so a
+/// cold-start auth deep link releases the splash as soon as auth settles
+/// instead of waiting for the restore timeout. Keep this in sync with the
+/// auth-route redirect above; `login_flow_redirect_test` exercises it directly.
+bool authenticatedRedirectsFromAuthEntry(
+  String location, {
+  required bool hasExpiredOAuthSession,
+}) {
+  if (hasExpiredOAuthSession && location == WelcomeScreen.loginOptionsPath) {
+    return false;
+  }
+  return location == WelcomeScreen.path ||
+      location == NostrConnectScreen.path ||
+      location == WelcomeScreen.inviteGatePath ||
+      location == WelcomeScreen.createAccountPath ||
+      location == WelcomeScreen.loginOptionsPath;
 }
 
 @visibleForTesting
@@ -325,7 +359,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
 
       // Auth routes don't require authentication — user is in the
       // process of logging in.
-      final isAuthRoute = isAuthEntryLocation(location);
+      final isAuthRoute = _isAuthEntryLocation(location);
 
       // Only bounce to the loading screen on a true cold load (no value yet).
       // Riverpod keeps the previous value during a background refetch

--- a/mobile/lib/router/auth_entry_redirect.dart
+++ b/mobile/lib/router/auth_entry_redirect.dart
@@ -1,0 +1,38 @@
+import 'package:openvine/screens/auth/nostr_connect_screen.dart';
+import 'package:openvine/screens/auth/welcome_screen.dart';
+
+/// Whether an authenticated user currently on [location] is one the router's
+/// authenticated auth-route redirect bounces home to the feed.
+///
+/// Mirrors that redirect in `goRouterProvider` (`app_router.dart`): an
+/// authenticated user is only redirected home from the sign-in entry points
+/// (`/welcome`, `/nostr-connect`, `/welcome/invite`, `/welcome/create-account`,
+/// `/welcome/login-options`), with the same expired-session exception for login
+/// options (an expired-session user must reach login options to re-authenticate
+/// rather than be bounced home).
+///
+/// It is deliberately narrower than `app_router.dart`'s broad auth-entry check:
+/// auth-entry routes an authenticated user is intentionally left on —
+/// reset-password and email-verification deep links, key import (an
+/// account-switch route), and the minor-account-review entry routes — return
+/// `false`.
+///
+/// The startup splash gate (`StartupSplashReleaseController`, #5242) uses this
+/// to hold the splash only while a home-redirect is actually pending, so a
+/// cold-start auth deep link releases the splash as soon as auth settles
+/// instead of waiting for the restore timeout. Keep this in sync with the
+/// auth-route redirect in `app_router.dart`; `login_flow_redirect_test`
+/// exercises it directly.
+bool authenticatedRedirectsFromAuthEntry(
+  String location, {
+  required bool hasExpiredOAuthSession,
+}) {
+  if (hasExpiredOAuthSession && location == WelcomeScreen.loginOptionsPath) {
+    return false;
+  }
+  return location == WelcomeScreen.path ||
+      location == NostrConnectScreen.path ||
+      location == WelcomeScreen.inviteGatePath ||
+      location == WelcomeScreen.createAccountPath ||
+      location == WelcomeScreen.loginOptionsPath;
+}

--- a/mobile/lib/router/router.dart
+++ b/mobile/lib/router/router.dart
@@ -1,5 +1,6 @@
 export 'app_router.dart';
 export 'app_shell.dart';
+export 'auth_entry_redirect.dart';
 export 'navigator_keys.dart';
 export 'providers/providers.dart';
 export 'route_error_screen.dart';

--- a/mobile/lib/startup/startup_splash_release_controller.dart
+++ b/mobile/lib/startup/startup_splash_release_controller.dart
@@ -5,8 +5,8 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:openvine/services/auth_service.dart';
 
 /// Releases the native splash once startup auth has settled — and, for an
-/// authenticated user, only after the router has navigated off the auth-entry
-/// flow (`/welcome`).
+/// authenticated user, only after the router reports it has navigated off the
+/// auth-entry flow (`/welcome`).
 ///
 /// This reproduces the synchronous-after-redirect ordering proven in #2953
 /// (commit b7e06144a) while keeping splash logic out of [AuthService] (#5074).
@@ -27,8 +27,8 @@ class StartupSplashReleaseController {
   ///
   /// [authStateStream] / [currentAuthState] report the auth state;
   /// [locationListenable] / [currentLocation] report the current router
-  /// location (e.g. `GoRouter.routeInformationProvider` and
-  /// `() => router.routeInformationProvider.value.uri.path`);
+  /// location. Use a signal that fires after redirects, such as
+  /// `GoRouter.routerDelegate` with `currentConfiguration.uri.path`.
   /// [isAuthEntryLocation] is the router predicate of the same name.
   /// [release] defaults to [FlutterNativeSplash.remove]; [timeout] defaults to
   /// [AuthService.startupAuthRestoreTimeout].

--- a/mobile/lib/startup/startup_splash_release_controller.dart
+++ b/mobile/lib/startup/startup_splash_release_controller.dart
@@ -5,8 +5,8 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:openvine/services/auth_service.dart';
 
 /// Releases the native splash once startup auth has settled — and, for an
-/// authenticated user, only after the router reports it has navigated off the
-/// auth-entry flow (`/welcome`).
+/// authenticated user, only while the router still has a pending home-redirect
+/// off the auth-entry flow (`/welcome`).
 ///
 /// This reproduces the synchronous-after-redirect ordering proven in #2953
 /// (commit b7e06144a) while keeping splash logic out of [AuthService] (#5074).
@@ -16,10 +16,14 @@ import 'package:openvine/services/auth_service.dart';
 ///
 /// Release fires exactly once, on the first of:
 ///  * **settled**: `isTerminal(authState) && (authState != authenticated ||
-///    !isAuthEntryLocation(location))` — authenticated users wait for the
-///    redirect to leave `/welcome`; unauthenticated / `awaitingTosAcceptance`
-///    users (whose destination *is* `/welcome`) and non-auth-entry routes
-///    (e.g. the public `/video-recorder`) release immediately; or
+///    !authenticatedRedirectPending(location))` — an authenticated user holds
+///    only while the router still has a home-redirect pending for the current
+///    auth-entry route (e.g. `/welcome`). Once that redirect lands, or for any
+///    location an authenticated user is left on (the feed, a reset-password /
+///    email-verification deep link, an expired-session login-options screen,
+///    the public `/video-recorder`), and for unauthenticated /
+///    `awaitingTosAcceptance` users (whose destination *is* `/welcome`), it
+///    releases immediately; or
 ///  * **timeout**: an independent [timeout] floor so a hung restore can never
 ///    strand the splash.
 class StartupSplashReleaseController {
@@ -29,7 +33,10 @@ class StartupSplashReleaseController {
   /// [locationListenable] / [currentLocation] report the current router
   /// location. Use a signal that fires after redirects, such as
   /// `GoRouter.routerDelegate` with `currentConfiguration.uri.path`.
-  /// [isAuthEntryLocation] is the router predicate of the same name.
+  /// [authenticatedRedirectPending] reports whether an authenticated user on a
+  /// given location still has a home-redirect pending — wire it to
+  /// `authenticatedRedirectsFromAuthEntry` in the router so the splash gate
+  /// stays aligned with the actual redirect.
   /// [release] defaults to [FlutterNativeSplash.remove]; [timeout] defaults to
   /// [AuthService.startupAuthRestoreTimeout].
   StartupSplashReleaseController({
@@ -37,14 +44,14 @@ class StartupSplashReleaseController {
     required AuthState Function() currentAuthState,
     required Listenable locationListenable,
     required String Function() currentLocation,
-    required bool Function(String location) isAuthEntryLocation,
+    required bool Function(String location) authenticatedRedirectPending,
     Duration timeout = AuthService.startupAuthRestoreTimeout,
     void Function() release = FlutterNativeSplash.remove,
     bool Function(AuthState state)? isTerminal,
   }) : _currentAuthState = currentAuthState,
        _locationListenable = locationListenable,
        _currentLocation = currentLocation,
-       _isAuthEntryLocation = isAuthEntryLocation,
+       _authenticatedRedirectPending = authenticatedRedirectPending,
        _release = release,
        _isTerminal = isTerminal ?? _defaultIsTerminal {
     // Cover the case where startup already settled before we subscribed
@@ -59,7 +66,7 @@ class StartupSplashReleaseController {
   final AuthState Function() _currentAuthState;
   final Listenable _locationListenable;
   final String Function() _currentLocation;
-  final bool Function(String location) _isAuthEntryLocation;
+  final bool Function(String location) _authenticatedRedirectPending;
   final void Function() _release;
   final bool Function(AuthState state) _isTerminal;
 
@@ -73,7 +80,7 @@ class StartupSplashReleaseController {
     if (!_isTerminal(state)) return;
     final settled =
         state != AuthState.authenticated ||
-        !_isAuthEntryLocation(_currentLocation());
+        !_authenticatedRedirectPending(_currentLocation());
     if (settled) _releaseOnce();
   }
 

--- a/mobile/lib/startup/startup_splash_release_controller.dart
+++ b/mobile/lib/startup/startup_splash_release_controller.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:openvine/services/auth_service.dart';
+
+/// Releases the native splash once startup auth has settled — and, for an
+/// authenticated user, only after the router has navigated off the auth-entry
+/// flow (`/welcome`).
+///
+/// This reproduces the synchronous-after-redirect ordering proven in #2953
+/// (commit b7e06144a) while keeping splash logic out of [AuthService] (#5074).
+/// PR #5074 released the splash on the bare terminal auth event via a multi-hop
+/// async chain, which let the `/welcome` sign-in page paint before the
+/// `authenticated → /home` redirect was applied — the regression in #5242.
+///
+/// Release fires exactly once, on the first of:
+///  * **settled**: `isTerminal(authState) && (authState != authenticated ||
+///    !isAuthEntryLocation(location))` — authenticated users wait for the
+///    redirect to leave `/welcome`; unauthenticated / `awaitingTosAcceptance`
+///    users (whose destination *is* `/welcome`) and non-auth-entry routes
+///    (e.g. the public `/video-recorder`) release immediately; or
+///  * **timeout**: an independent [timeout] floor so a hung restore can never
+///    strand the splash.
+class StartupSplashReleaseController {
+  /// Creates the controller and immediately begins watching for release.
+  ///
+  /// [authStateStream] / [currentAuthState] report the auth state;
+  /// [locationListenable] / [currentLocation] report the current router
+  /// location (e.g. `GoRouter.routeInformationProvider` and
+  /// `() => router.routeInformationProvider.value.uri.path`);
+  /// [isAuthEntryLocation] is the router predicate of the same name.
+  /// [release] defaults to [FlutterNativeSplash.remove]; [timeout] defaults to
+  /// [AuthService.startupAuthRestoreTimeout].
+  StartupSplashReleaseController({
+    required Stream<AuthState> authStateStream,
+    required AuthState Function() currentAuthState,
+    required Listenable locationListenable,
+    required String Function() currentLocation,
+    required bool Function(String location) isAuthEntryLocation,
+    Duration timeout = AuthService.startupAuthRestoreTimeout,
+    void Function() release = FlutterNativeSplash.remove,
+    bool Function(AuthState state)? isTerminal,
+  }) : _currentAuthState = currentAuthState,
+       _locationListenable = locationListenable,
+       _currentLocation = currentLocation,
+       _isAuthEntryLocation = isAuthEntryLocation,
+       _release = release,
+       _isTerminal = isTerminal ?? _defaultIsTerminal {
+    // Cover the case where startup already settled before we subscribed
+    // (e.g. a warm local-key restore).
+    _maybeRelease();
+    if (_released) return;
+    _authSubscription = authStateStream.listen((_) => _maybeRelease());
+    _locationListenable.addListener(_maybeRelease);
+    _timeoutTimer = Timer(timeout, _releaseOnce);
+  }
+
+  final AuthState Function() _currentAuthState;
+  final Listenable _locationListenable;
+  final String Function() _currentLocation;
+  final bool Function(String location) _isAuthEntryLocation;
+  final void Function() _release;
+  final bool Function(AuthState state) _isTerminal;
+
+  StreamSubscription<AuthState>? _authSubscription;
+  Timer? _timeoutTimer;
+  bool _released = false;
+
+  void _maybeRelease() {
+    if (_released) return;
+    final state = _currentAuthState();
+    if (!_isTerminal(state)) return;
+    final settled =
+        state != AuthState.authenticated ||
+        !_isAuthEntryLocation(_currentLocation());
+    if (settled) _releaseOnce();
+  }
+
+  void _releaseOnce() {
+    if (_released) return;
+    _released = true;
+    _release();
+    _teardown();
+  }
+
+  void _teardown() {
+    unawaited(_authSubscription?.cancel());
+    _authSubscription = null;
+    _locationListenable.removeListener(_maybeRelease);
+    _timeoutTimer?.cancel();
+    _timeoutTimer = null;
+  }
+
+  /// Detaches all listeners and the timeout without releasing the splash if it
+  /// has not already fired. Safe to call multiple times.
+  void dispose() {
+    _released = true;
+    _teardown();
+  }
+
+  static bool _defaultIsTerminal(AuthState state) => switch (state) {
+    AuthState.unauthenticated ||
+    AuthState.awaitingTosAcceptance ||
+    AuthState.authenticated => true,
+    AuthState.checking || AuthState.authenticating => false,
+  };
+}

--- a/mobile/test/router/login_flow_redirect_test.dart
+++ b/mobile/test/router/login_flow_redirect_test.dart
@@ -17,8 +17,11 @@ import 'package:openvine/services/auth_service.dart';
 /// function. This helps us understand what SHOULD happen without Firebase
 /// dependencies.
 ///
-/// IMPORTANT: This must stay in sync with the `redirect` callback in
-/// `app_router.dart`. When you add a new auth route there, add it here too.
+/// The authenticated auth-route decision (rule 1, including the expired-session
+/// login-options exception) delegates to the real
+/// [authenticatedRedirectsFromAuthEntry] helper, so that branch cannot drift
+/// from the router. Only the unauthenticated `isAuthRoute` mirror (rule 2)
+/// remains a local copy — keep it in sync when adding a new auth route.
 ///
 /// The actual redirect logic is:
 /// 1. If authenticated AND on top-level auth entry routes -> redirect to /home/0
@@ -42,22 +45,14 @@ String? testRedirectLogic({
       location.startsWith(ResetPasswordScreen.path) ||
       location.startsWith(EmailVerificationScreen.path);
 
-  // Authenticated users should be redirected from top-level auth entry routes.
-  // Deep-link auth routes remain accessible while authenticated.
-  final shouldRedirectAuthenticated =
-      location == WelcomeScreen.path ||
-      location == NostrConnectScreen.path ||
-      location == WelcomeScreen.inviteGatePath ||
-      location == WelcomeScreen.createAccountPath ||
-      location == WelcomeScreen.loginOptionsPath;
-
   // Rule 1: Authenticated users on redirectable auth routes go to home.
-  if (authState == AuthState.authenticated && shouldRedirectAuthenticated) {
-    // Allow expired-session users through to login options
-    // so they can re-authenticate instead of being bounced home
-    if (hasExpiredOAuthSession && location == WelcomeScreen.loginOptionsPath) {
-      return null;
-    }
+  // Delegates to the real shared helper so this mirror cannot drift from the
+  // router; the expired-session login-options exception lives there too.
+  if (authState == AuthState.authenticated &&
+      authenticatedRedirectsFromAuthEntry(
+        location,
+        hasExpiredOAuthSession: hasExpiredOAuthSession,
+      )) {
     return VideoFeedPage.pathForIndex(0);
   }
 
@@ -488,5 +483,72 @@ void main() {
         expect(rebuilt, equals(KeyImportScreen.path));
       },
     );
+  });
+
+  group('authenticatedRedirectsFromAuthEntry', () {
+    group('redirects an authenticated user home from', () {
+      for (final location in <String>[
+        WelcomeScreen.path,
+        NostrConnectScreen.path,
+        WelcomeScreen.inviteGatePath,
+        WelcomeScreen.createAccountPath,
+        WelcomeScreen.loginOptionsPath,
+      ]) {
+        test(location, () {
+          expect(
+            authenticatedRedirectsFromAuthEntry(
+              location,
+              hasExpiredOAuthSession: false,
+            ),
+            isTrue,
+            reason: '$location is a sign-in entry point — bounce home',
+          );
+        });
+      }
+    });
+
+    group('leaves an authenticated user on', () {
+      for (final location in <String>[
+        WelcomeScreen.resetPasswordPath,
+        ResetPasswordScreen.path,
+        EmailVerificationScreen.path,
+        KeyImportScreen.path,
+        VideoFeedPage.pathForIndex(0),
+        ExploreScreen.path,
+      ]) {
+        test(location, () {
+          expect(
+            authenticatedRedirectsFromAuthEntry(
+              location,
+              hasExpiredOAuthSession: false,
+            ),
+            isFalse,
+            reason: '$location is a route the router leaves the user on',
+          );
+        });
+      }
+    });
+
+    test('leaves an expired-session user on login options', () {
+      expect(
+        authenticatedRedirectsFromAuthEntry(
+          WelcomeScreen.loginOptionsPath,
+          hasExpiredOAuthSession: true,
+        ),
+        isFalse,
+        reason: 'expired-session users must reach login options to re-auth',
+      );
+    });
+
+    test('still redirects an expired-session user from /welcome', () {
+      expect(
+        authenticatedRedirectsFromAuthEntry(
+          WelcomeScreen.path,
+          hasExpiredOAuthSession: true,
+        ),
+        isTrue,
+        reason: 'the expired-session exception only applies to login options',
+      );
+    });
   });
 }

--- a/mobile/test/startup/startup_splash_release_controller_test.dart
+++ b/mobile/test/startup/startup_splash_release_controller_test.dart
@@ -1,0 +1,252 @@
+import 'dart:async';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/startup/startup_splash_release_controller.dart';
+
+/// Regression coverage for #5242: the native splash must stay up for an
+/// authenticated user until the `/welcome` → `/home` redirect has been applied,
+/// while releasing immediately for everyone else, and always within the
+/// timeout floor. Fired exactly once.
+void main() {
+  group(StartupSplashReleaseController, () {
+    bool isAuthEntryLocation(String location) =>
+        location == '/welcome' || location.startsWith('/welcome/');
+
+    // A non-default timeout keeps the floor explicit in the elapse math.
+    const timeout = Duration(seconds: 5);
+
+    test('authenticated holds the splash until the router leaves /welcome', () {
+      fakeAsync((async) {
+        final auth = StreamController<AuthState>.broadcast();
+        final location = ValueNotifier<String>('/welcome');
+        var state = AuthState.checking;
+        var releases = 0;
+
+        final controller = StartupSplashReleaseController(
+          authStateStream: auth.stream,
+          currentAuthState: () => state,
+          locationListenable: location,
+          currentLocation: () => location.value,
+          isAuthEntryLocation: isAuthEntryLocation,
+          timeout: timeout,
+          release: () => releases++,
+        );
+
+        async.flushMicrotasks();
+        expect(releases, 0, reason: 'checking must not release');
+
+        state = AuthState.authenticated;
+        auth.add(AuthState.authenticated);
+        async.flushMicrotasks();
+        expect(
+          releases,
+          0,
+          reason: 'authenticated while still on /welcome must not release',
+        );
+
+        location.value = '/home';
+        expect(
+          releases,
+          1,
+          reason: 'redirect off /welcome releases the splash',
+        );
+
+        controller.dispose();
+        location.dispose();
+        unawaited(auth.close());
+      });
+    });
+
+    test('unauthenticated releases immediately while on /welcome', () {
+      fakeAsync((async) {
+        final auth = StreamController<AuthState>.broadcast();
+        final location = ValueNotifier<String>('/welcome');
+        var state = AuthState.checking;
+        var releases = 0;
+
+        final controller = StartupSplashReleaseController(
+          authStateStream: auth.stream,
+          currentAuthState: () => state,
+          locationListenable: location,
+          currentLocation: () => location.value,
+          isAuthEntryLocation: isAuthEntryLocation,
+          timeout: timeout,
+          release: () => releases++,
+        );
+
+        state = AuthState.unauthenticated;
+        auth.add(AuthState.unauthenticated);
+        async.flushMicrotasks();
+        expect(
+          releases,
+          1,
+          reason: 'unauthenticated correctly lands on /welcome — release now',
+        );
+
+        controller.dispose();
+        location.dispose();
+        unawaited(auth.close());
+      });
+    });
+
+    test('awaitingTosAcceptance releases immediately', () {
+      fakeAsync((async) {
+        final auth = StreamController<AuthState>.broadcast();
+        final location = ValueNotifier<String>('/welcome');
+        var state = AuthState.checking;
+        var releases = 0;
+
+        final controller = StartupSplashReleaseController(
+          authStateStream: auth.stream,
+          currentAuthState: () => state,
+          locationListenable: location,
+          currentLocation: () => location.value,
+          isAuthEntryLocation: isAuthEntryLocation,
+          timeout: timeout,
+          release: () => releases++,
+        );
+
+        state = AuthState.awaitingTosAcceptance;
+        auth.add(AuthState.awaitingTosAcceptance);
+        async.flushMicrotasks();
+        expect(releases, 1);
+
+        controller.dispose();
+        location.dispose();
+        unawaited(auth.close());
+      });
+    });
+
+    test('public recorder route releases an authenticated launch', () {
+      fakeAsync((async) {
+        final auth = StreamController<AuthState>.broadcast();
+        final location = ValueNotifier<String>('/video-recorder');
+        var state = AuthState.checking;
+        var releases = 0;
+
+        final controller = StartupSplashReleaseController(
+          authStateStream: auth.stream,
+          currentAuthState: () => state,
+          locationListenable: location,
+          currentLocation: () => location.value,
+          isAuthEntryLocation: isAuthEntryLocation,
+          timeout: timeout,
+          release: () => releases++,
+        );
+
+        state = AuthState.authenticated;
+        auth.add(AuthState.authenticated);
+        async.flushMicrotasks();
+        expect(
+          releases,
+          1,
+          reason: '/video-recorder is not an auth-entry route — release',
+        );
+
+        controller.dispose();
+        location.dispose();
+        unawaited(auth.close());
+      });
+    });
+
+    test('timeout floor releases when no terminal state is reached', () {
+      fakeAsync((async) {
+        final auth = StreamController<AuthState>.broadcast();
+        final location = ValueNotifier<String>('/welcome');
+        var releases = 0;
+
+        final controller = StartupSplashReleaseController(
+          authStateStream: auth.stream,
+          currentAuthState: () => AuthState.checking,
+          locationListenable: location,
+          currentLocation: () => location.value,
+          isAuthEntryLocation: isAuthEntryLocation,
+          timeout: timeout,
+          release: () => releases++,
+        );
+
+        async.elapse(timeout - const Duration(milliseconds: 1));
+        expect(releases, 0, reason: 'splash held until the floor elapses');
+
+        async.elapse(const Duration(milliseconds: 1));
+        expect(releases, 1, reason: 'timeout floor releases a hung restore');
+
+        controller.dispose();
+        location.dispose();
+        unawaited(auth.close());
+      });
+    });
+
+    test('releases exactly once across later changes and the timeout', () {
+      fakeAsync((async) {
+        final auth = StreamController<AuthState>.broadcast();
+        final location = ValueNotifier<String>('/welcome');
+        var state = AuthState.checking;
+        var releases = 0;
+
+        final controller = StartupSplashReleaseController(
+          authStateStream: auth.stream,
+          currentAuthState: () => state,
+          locationListenable: location,
+          currentLocation: () => location.value,
+          isAuthEntryLocation: isAuthEntryLocation,
+          timeout: timeout,
+          release: () => releases++,
+        );
+
+        state = AuthState.authenticated;
+        auth.add(AuthState.authenticated);
+        async.flushMicrotasks();
+        location.value = '/home';
+        expect(releases, 1);
+
+        // Further churn must not re-fire.
+        location.value = '/welcome';
+        location.value = '/explore';
+        auth.add(AuthState.authenticated);
+        async.flushMicrotasks();
+        async.elapse(timeout * 2);
+        expect(releases, 1, reason: 'release is idempotent');
+
+        controller.dispose();
+        location.dispose();
+        unawaited(auth.close());
+      });
+    });
+
+    test('releases synchronously when already settled at construction', () {
+      fakeAsync((async) {
+        final auth = StreamController<AuthState>.broadcast();
+        final location = ValueNotifier<String>('/home');
+        var releases = 0;
+
+        final controller = StartupSplashReleaseController(
+          authStateStream: auth.stream,
+          currentAuthState: () => AuthState.authenticated,
+          locationListenable: location,
+          currentLocation: () => location.value,
+          isAuthEntryLocation: isAuthEntryLocation,
+          timeout: timeout,
+          release: () => releases++,
+        );
+
+        expect(
+          releases,
+          1,
+          reason: 'authenticated + already off /welcome releases at once',
+        );
+
+        // No lingering timer to fire later.
+        async.elapse(timeout * 2);
+        expect(releases, 1);
+
+        controller.dispose();
+        location.dispose();
+        unawaited(auth.close());
+      });
+    });
+  });
+}

--- a/mobile/test/startup/startup_splash_release_controller_test.dart
+++ b/mobile/test/startup/startup_splash_release_controller_test.dart
@@ -60,6 +60,52 @@ void main() {
       });
     });
 
+    test(
+      'authenticated release follows delegate-style redirect notification',
+      () {
+        fakeAsync((async) {
+          final auth = StreamController<AuthState>.broadcast();
+          final location = _RouterDelegateLocation('/welcome');
+          var state = AuthState.checking;
+          var releases = 0;
+
+          final controller = StartupSplashReleaseController(
+            authStateStream: auth.stream,
+            currentAuthState: () => state,
+            locationListenable: location,
+            currentLocation: () => location.value,
+            isAuthEntryLocation: isAuthEntryLocation,
+            timeout: timeout,
+            release: () => releases++,
+          );
+
+          state = AuthState.authenticated;
+          auth.add(AuthState.authenticated);
+          async.flushMicrotasks();
+          expect(releases, 0);
+
+          location.setSilently('/home');
+          expect(
+            releases,
+            0,
+            reason:
+                'GoRouteInformationProvider redirect writeback does not notify',
+          );
+
+          location.notifyRedirectApplied();
+          expect(
+            releases,
+            1,
+            reason:
+                'GoRouterDelegate notifies after currentConfiguration updates',
+          );
+
+          controller.dispose();
+          unawaited(auth.close());
+        });
+      },
+    );
+
     test('unauthenticated releases immediately while on /welcome', () {
       fakeAsync((async) {
         final auth = StreamController<AuthState>.broadcast();
@@ -249,4 +295,18 @@ void main() {
       });
     });
   });
+}
+
+class _RouterDelegateLocation extends ChangeNotifier {
+  _RouterDelegateLocation(this.value);
+
+  String value;
+
+  void setSilently(String nextValue) {
+    value = nextValue;
+  }
+
+  void notifyRedirectApplied() {
+    notifyListeners();
+  }
 }

--- a/mobile/test/startup/startup_splash_release_controller_test.dart
+++ b/mobile/test/startup/startup_splash_release_controller_test.dart
@@ -12,8 +12,16 @@ import 'package:openvine/startup/startup_splash_release_controller.dart';
 /// timeout floor. Fired exactly once.
 void main() {
   group(StartupSplashReleaseController, () {
-    bool isAuthEntryLocation(String location) =>
-        location == '/welcome' || location.startsWith('/welcome/');
+    // Mirrors the redirect-away set in `authenticatedRedirectsFromAuthEntry`:
+    // an authenticated user is bounced home only from the sign-in entry
+    // points, not from the deep-link auth routes they are left on
+    // (reset-password, email verification, key import).
+    bool authenticatedRedirectPending(String location) =>
+        location == '/welcome' ||
+        location == '/welcome/login-options' ||
+        location == '/welcome/create-account' ||
+        location == '/welcome/invite' ||
+        location == '/nostr-connect';
 
     // A non-default timeout keeps the floor explicit in the elapse math.
     const timeout = Duration(seconds: 5);
@@ -30,7 +38,7 @@ void main() {
           currentAuthState: () => state,
           locationListenable: location,
           currentLocation: () => location.value,
-          isAuthEntryLocation: isAuthEntryLocation,
+          authenticatedRedirectPending: authenticatedRedirectPending,
           timeout: timeout,
           release: () => releases++,
         );
@@ -74,7 +82,7 @@ void main() {
             currentAuthState: () => state,
             locationListenable: location,
             currentLocation: () => location.value,
-            isAuthEntryLocation: isAuthEntryLocation,
+            authenticatedRedirectPending: authenticatedRedirectPending,
             timeout: timeout,
             release: () => releases++,
           );
@@ -118,7 +126,7 @@ void main() {
           currentAuthState: () => state,
           locationListenable: location,
           currentLocation: () => location.value,
-          isAuthEntryLocation: isAuthEntryLocation,
+          authenticatedRedirectPending: authenticatedRedirectPending,
           timeout: timeout,
           release: () => releases++,
         );
@@ -150,7 +158,7 @@ void main() {
           currentAuthState: () => state,
           locationListenable: location,
           currentLocation: () => location.value,
-          isAuthEntryLocation: isAuthEntryLocation,
+          authenticatedRedirectPending: authenticatedRedirectPending,
           timeout: timeout,
           release: () => releases++,
         );
@@ -178,7 +186,7 @@ void main() {
           currentAuthState: () => state,
           locationListenable: location,
           currentLocation: () => location.value,
-          isAuthEntryLocation: isAuthEntryLocation,
+          authenticatedRedirectPending: authenticatedRedirectPending,
           timeout: timeout,
           release: () => releases++,
         );
@@ -198,6 +206,91 @@ void main() {
       });
     });
 
+    test(
+      'authenticated reset-password deep link releases without waiting for '
+      'the timeout',
+      () {
+        fakeAsync((async) {
+          final auth = StreamController<AuthState>.broadcast();
+          // A cold-start deep link lands an authenticated user directly on the
+          // nested reset-password route, which the router intentionally leaves
+          // them on — no home-redirect is pending, so the splash must release
+          // at once rather than hang until the timeout floor (#5242 review).
+          final location = ValueNotifier<String>(
+            '/welcome/login-options/reset-password',
+          );
+          var state = AuthState.checking;
+          var releases = 0;
+
+          final controller = StartupSplashReleaseController(
+            authStateStream: auth.stream,
+            currentAuthState: () => state,
+            locationListenable: location,
+            currentLocation: () => location.value,
+            authenticatedRedirectPending: authenticatedRedirectPending,
+            timeout: timeout,
+            release: () => releases++,
+          );
+
+          state = AuthState.authenticated;
+          auth.add(AuthState.authenticated);
+          async.flushMicrotasks();
+          expect(
+            releases,
+            1,
+            reason:
+                'an authenticated deep-link auth route the router leaves the '
+                'user on must release immediately, not at the timeout',
+          );
+
+          // No lingering timer to fire later.
+          async.elapse(timeout * 2);
+          expect(releases, 1);
+
+          controller.dispose();
+          location.dispose();
+          unawaited(auth.close());
+        });
+      },
+    );
+
+    test(
+      'authenticated email-verification deep link releases immediately',
+      () {
+        fakeAsync((async) {
+          final auth = StreamController<AuthState>.broadcast();
+          final location = ValueNotifier<String>('/verify-email');
+          var state = AuthState.checking;
+          var releases = 0;
+
+          final controller = StartupSplashReleaseController(
+            authStateStream: auth.stream,
+            currentAuthState: () => state,
+            locationListenable: location,
+            currentLocation: () => location.value,
+            authenticatedRedirectPending: authenticatedRedirectPending,
+            timeout: timeout,
+            release: () => releases++,
+          );
+
+          state = AuthState.authenticated;
+          auth.add(AuthState.authenticated);
+          async.flushMicrotasks();
+          expect(
+            releases,
+            1,
+            reason:
+                '/verify-email is a deep-link auth route an authenticated user '
+                'stays on — release',
+          );
+
+          controller.dispose();
+          location.dispose();
+          unawaited(auth.close());
+        });
+      },
+    );
+
     test('timeout floor releases when no terminal state is reached', () {
       fakeAsync((async) {
         final auth = StreamController<AuthState>.broadcast();
@@ -209,7 +302,7 @@ void main() {
           currentAuthState: () => AuthState.checking,
           locationListenable: location,
           currentLocation: () => location.value,
-          isAuthEntryLocation: isAuthEntryLocation,
+          authenticatedRedirectPending: authenticatedRedirectPending,
           timeout: timeout,
           release: () => releases++,
         );
@@ -238,7 +331,7 @@ void main() {
           currentAuthState: () => state,
           locationListenable: location,
           currentLocation: () => location.value,
-          isAuthEntryLocation: isAuthEntryLocation,
+          authenticatedRedirectPending: authenticatedRedirectPending,
           timeout: timeout,
           release: () => releases++,
         );
@@ -274,7 +367,7 @@ void main() {
           currentAuthState: () => AuthState.authenticated,
           locationListenable: location,
           currentLocation: () => location.value,
-          isAuthEntryLocation: isAuthEntryLocation,
+          authenticatedRedirectPending: authenticatedRedirectPending,
           timeout: timeout,
           release: () => releases++,
         );


### PR DESCRIPTION
## Description

Signed-in users briefly saw the sign-in (`/welcome`) page on Android cold start before the app navigated to the feed.

**Root cause — a startup-splash regression from #5074, not the Riverpod→BLoC migration.** #5074 replaced the prior synchronous-after-redirect splash removal (commit `b7e06144a`, in `AuthService.initialize()`'s `finally`, run after the post-`authenticated` awaits so GoRouter's `/welcome → /home` redirect was already applied) with a multi-hop async chain `firstWhere(terminal).timeout().catchError().whenComplete(remove)` that lifts the native splash on the bare `authenticated` event — before the redirect is applied. That is the exact multi-hop-async-release-races-the-redirect pattern `b7e06144a` documented as having "produced a welcome flash on device", now reintroduced. The Riverpod→BLoC welcome migration is not involved: the `isAuthLoading` welcome gate is byte-identical since before the prior fix, and the whole flash path (`main.dart` splash timing, `/welcome` initialLocation, the redirect, `RouterRefreshListenable`) is non-BLoC.

**Fix.** Release the splash from a small, injectable, widget-free `StartupSplashReleaseController` wired in `_DivineAppState`:

- **authenticated** → hold until the router leaves the auth-entry flow (`isAuthEntryLocation` is false), reproducing `b7e06144a`'s synchronous-after-redirect ordering;
- **unauthenticated / awaitingTosAcceptance** (whose correct destination *is* `/welcome`) and the public `/video-recorder` route → release immediately;
- an **independent timeout floor** (`AuthService.startupAuthRestoreTimeout`, 21s) always releases a hung restore;
- release fires exactly once (idempotent).

Splash logic stays out of `AuthService`, preserving #5074's intentional decoupling, bounded restore, recorder-route move, and anonymous-draft claiming.

### Files
- `lib/startup/startup_splash_release_controller.dart` — new controller.
- `lib/main.dart` — remove the #5074 multi-hop watcher + helpers; wire the controller in `_DivineAppState` (subscribed synchronously in `initState`, before auth init runs).
- `lib/router/app_router.dart` — promote `_isAuthEntryLocation` → public `isAuthEntryLocation`.
- `test/startup/startup_splash_release_controller_test.dart` — fresh regression test.

**Related Issue:** Closes #5242 · Relates to #4338 (architecture/state-migration epic — recorded here only to confirm this is **not** caused by that migration).

## Out of Scope

- The exact current-Flutter leaked-frame mechanism (a `/welcome` composite vs the Android `windowBackground` raster gap) would be pinned by a signed-in Android cold-launch device trace; the fix closes the window deterministically regardless, so it is not a blocker.
- An unrelated `ios/.../Package.resolved` drift was intentionally left out of this PR.

## Verification

- `flutter analyze lib test integration_test` → No issues found.
- `flutter test test/startup/` (new controller, 7 cases: authenticated-settle, unauth-immediate, awaitingTos-immediate, recorder route, timeout floor, idempotency, already-settled) → pass.
- `flutter test test/router/` → pass (no regression from the `isAuthEntryLocation` rename).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)