### PR TITLE
fix(categories): cache category list across app starts

### DIFF
--- a/mobile/lib/blocs/categories/categories_bloc.dart
+++ b/mobile/lib/blocs/categories/categories_bloc.dart
@@ -13,9 +13,10 @@ part 'categories_state.dart';
 
 /// BLoC for video categories.
 ///
-/// Fetches the category list via [CategoriesRepository] (which owns the
-/// in-memory TTL cache) and manages loading videos for a selected category
-/// with pagination.
+/// Fetches the category list via [CategoriesRepository.watchCategoriesCached]
+/// so cached categories render immediately across app starts while a live
+/// refresh runs in the background. Also manages loading videos for a selected
+/// category with pagination.
 class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
   CategoriesBloc({
     required CategoriesRepository categoriesRepository,
@@ -40,25 +41,61 @@ class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
     CategoriesLoadRequested event,
     Emitter<CategoriesState> emit,
   ) async {
-    if (state.categoriesStatus == CategoriesStatus.loading) return;
+    if (state.categoriesStatus == CategoriesStatus.loading ||
+        state.isRefreshing) {
+      return;
+    }
 
-    emit(state.copyWith(categoriesStatus: CategoriesStatus.loading));
+    if (state.categories.isEmpty) {
+      emit(state.copyWith(categoriesStatus: CategoriesStatus.loading));
+    } else {
+      emit(state.copyWith(isRefreshing: true));
+    }
 
     try {
-      final categories = await _categoriesRepository.getCategories();
-
-      emit(
-        state.copyWith(
-          categoriesStatus: CategoriesStatus.loaded,
-          categories: categories,
-        ),
+      await emit.forEach<CacheResult<List<VideoCategory>>>(
+        _categoriesRepository.watchCategoriesCached(),
+        onData: (result) {
+          return state.copyWith(
+            categoriesStatus: CategoriesStatus.loaded,
+            categories: result.data,
+            isRefreshing: result.isStale,
+          );
+        },
+        onError: (error, stackTrace) {
+          addError(error, stackTrace);
+          if (state.categories.isNotEmpty) {
+            return state.copyWith(
+              categoriesStatus: CategoriesStatus.loaded,
+              isRefreshing: false,
+            );
+          }
+          return state.copyWith(
+            categoriesStatus: CategoriesStatus.error,
+            isRefreshing: false,
+          );
+        },
       );
     } on FunnelcakeException catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(categoriesStatus: CategoriesStatus.error));
+      emit(
+        state.copyWith(
+          categoriesStatus: state.categories.isEmpty
+              ? CategoriesStatus.error
+              : CategoriesStatus.loaded,
+          isRefreshing: false,
+        ),
+      );
     } catch (e, stackTrace) {
       addError(e, stackTrace);
-      emit(state.copyWith(categoriesStatus: CategoriesStatus.error));
+      emit(
+        state.copyWith(
+          categoriesStatus: state.categories.isEmpty
+              ? CategoriesStatus.error
+              : CategoriesStatus.loaded,
+          isRefreshing: false,
+        ),
+      );
     }
   }
 

--- a/mobile/lib/blocs/categories/categories_bloc.dart
+++ b/mobile/lib/blocs/categories/categories_bloc.dart
@@ -52,51 +52,25 @@ class CategoriesBloc extends Bloc<CategoriesEvent, CategoriesState> {
       emit(state.copyWith(isRefreshing: true));
     }
 
-    try {
-      await emit.forEach<CacheResult<List<VideoCategory>>>(
-        _categoriesRepository.watchCategoriesCached(),
-        onData: (result) {
-          return state.copyWith(
-            categoriesStatus: CategoriesStatus.loaded,
-            categories: result.data,
-            isRefreshing: result.isStale,
-          );
-        },
-        onError: (error, stackTrace) {
-          addError(error, stackTrace);
-          if (state.categories.isNotEmpty) {
-            return state.copyWith(
-              categoriesStatus: CategoriesStatus.loaded,
-              isRefreshing: false,
-            );
-          }
-          return state.copyWith(
-            categoriesStatus: CategoriesStatus.error,
-            isRefreshing: false,
-          );
-        },
-      );
-    } on FunnelcakeException catch (e, stackTrace) {
-      addError(e, stackTrace);
-      emit(
-        state.copyWith(
+    // The cache stream surfaces every failure through [onError], so all error
+    // handling lives there rather than in an outer try/catch.
+    await emit.forEach<CacheResult<List<VideoCategory>>>(
+      _categoriesRepository.watchCategoriesCached(),
+      onData: (result) => state.copyWith(
+        categoriesStatus: CategoriesStatus.loaded,
+        categories: result.data,
+        isRefreshing: result.isStale,
+      ),
+      onError: (error, stackTrace) {
+        addError(error, stackTrace);
+        return state.copyWith(
           categoriesStatus: state.categories.isEmpty
               ? CategoriesStatus.error
               : CategoriesStatus.loaded,
           isRefreshing: false,
-        ),
-      );
-    } catch (e, stackTrace) {
-      addError(e, stackTrace);
-      emit(
-        state.copyWith(
-          categoriesStatus: state.categories.isEmpty
-              ? CategoriesStatus.error
-              : CategoriesStatus.loaded,
-          isRefreshing: false,
-        ),
-      );
-    }
+        );
+      },
+    );
   }
 
   Future<void> _onCategorySelected(

--- a/mobile/lib/blocs/categories/categories_state.dart
+++ b/mobile/lib/blocs/categories/categories_state.dart
@@ -19,6 +19,7 @@ final class CategoriesState extends Equatable {
     this.videos = const [],
     this.hasMoreVideos = false,
     this.isLoadingMore = false,
+    this.isRefreshing = false,
     this.sortOrder = 'trending',
   });
 
@@ -43,6 +44,9 @@ final class CategoriesState extends Equatable {
   /// Whether a load-more request is in progress.
   final bool isLoadingMore;
 
+  /// Whether cached categories are visible while a live refresh is in flight.
+  final bool isRefreshing;
+
   /// Current sort order for category videos.
   final String sortOrder;
 
@@ -55,6 +59,7 @@ final class CategoriesState extends Equatable {
     List<VideoEvent>? videos,
     bool? hasMoreVideos,
     bool? isLoadingMore,
+    bool? isRefreshing,
     String? sortOrder,
   }) {
     return CategoriesState(
@@ -67,6 +72,7 @@ final class CategoriesState extends Equatable {
       videos: videos ?? this.videos,
       hasMoreVideos: hasMoreVideos ?? this.hasMoreVideos,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      isRefreshing: isRefreshing ?? this.isRefreshing,
       sortOrder: sortOrder ?? this.sortOrder,
     );
   }
@@ -80,6 +86,7 @@ final class CategoriesState extends Equatable {
     videos,
     hasMoreVideos,
     isLoadingMore,
+    isRefreshing,
     sortOrder,
   ];
 }

--- a/mobile/lib/widgets/categories_tab.dart
+++ b/mobile/lib/widgets/categories_tab.dart
@@ -89,7 +89,11 @@ class CategoriesDiscoveryView extends StatelessWidget {
       CategoriesStatus.initial => const SizedBox.shrink(),
     };
 
-    return LoadingOverlay(isLoading: state.isRefreshing, child: body);
+    return LoadingOverlay(
+      isLoading: state.isRefreshing,
+      padding: const .only(top: 4),
+      child: body,
+    );
   }
 }
 

--- a/mobile/lib/widgets/categories_tab.dart
+++ b/mobile/lib/widgets/categories_tab.dart
@@ -68,13 +68,13 @@ class CategoriesDiscoveryView extends StatelessWidget {
       ),
       CategoriesStatus.error => Center(
         child: Column(
+          spacing: 16,
           mainAxisSize: MainAxisSize.min,
           children: [
             Text(
               context.l10n.categoriesCouldNotLoadCategories,
-              style: const TextStyle(color: Colors.white70, fontSize: 16),
+              style: VineTheme.bodyLargeFont(color: VineTheme.secondaryText),
             ),
-            const SizedBox(height: 16),
             ElevatedButton(
               onPressed: onRetry,
               child: Text(context.l10n.commonRetry),
@@ -112,7 +112,7 @@ class _CategoriesListBody extends StatelessWidget {
       return Center(
         child: Text(
           context.l10n.categoriesNoCategoriesAvailable,
-          style: const TextStyle(color: Colors.white70, fontSize: 16),
+          style: VineTheme.bodyLargeFont(color: VineTheme.secondaryText),
         ),
       );
     }

--- a/mobile/lib/widgets/categories_tab.dart
+++ b/mobile/lib/widgets/categories_tab.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Categories discovery tab for the Explore screen.
 // ABOUTME: Renders the redesigned pinned-first category list and navigates to category detail.
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -61,52 +62,70 @@ class CategoriesDiscoveryView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    switch (state.categoriesStatus) {
-      case CategoriesStatus.loading:
-        return const Center(child: CircularProgressIndicator());
-      case CategoriesStatus.error:
-        return Center(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                context.l10n.categoriesCouldNotLoadCategories,
-                style: const TextStyle(color: Colors.white70, fontSize: 16),
-              ),
-              const SizedBox(height: 16),
-              ElevatedButton(
-                onPressed: onRetry,
-                child: Text(context.l10n.commonRetry),
-              ),
-            ],
-          ),
-        );
-      case CategoriesStatus.loaded:
-        if (state.categories.isEmpty) {
-          return Center(
-            child: Text(
-              context.l10n.categoriesNoCategoriesAvailable,
+    final body = switch (state.categoriesStatus) {
+      CategoriesStatus.loading => const Center(
+        child: CircularProgressIndicator(),
+      ),
+      CategoriesStatus.error => Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              context.l10n.categoriesCouldNotLoadCategories,
               style: const TextStyle(color: Colors.white70, fontSize: 16),
             ),
-          );
-        }
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: onRetry,
+              child: Text(context.l10n.commonRetry),
+            ),
+          ],
+        ),
+      ),
+      CategoriesStatus.loaded => _CategoriesListBody(
+        categories: state.categories,
+        onCategoryTap: onCategoryTap,
+      ),
+      CategoriesStatus.initial => const SizedBox.shrink(),
+    };
 
-        return ListView.separated(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
-          itemCount: state.categories.length,
-          separatorBuilder: (_, index) => const SizedBox(height: 8),
-          itemBuilder: (context, index) {
-            final category = state.categories[index];
-            return _CategoryTile(
-              category: category,
-              visuals: CategoryVisuals.forCategory(category, index),
-              onTap: () => onCategoryTap(category),
-            );
-          },
-        );
-      case CategoriesStatus.initial:
-        return const SizedBox.shrink();
+    return LoadingOverlay(isLoading: state.isRefreshing, child: body);
+  }
+}
+
+class _CategoriesListBody extends StatelessWidget {
+  const _CategoriesListBody({
+    required this.categories,
+    required this.onCategoryTap,
+  });
+
+  final List<VideoCategory> categories;
+  final ValueChanged<VideoCategory> onCategoryTap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (categories.isEmpty) {
+      return Center(
+        child: Text(
+          context.l10n.categoriesNoCategoriesAvailable,
+          style: const TextStyle(color: Colors.white70, fontSize: 16),
+        ),
+      );
     }
+
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+      itemCount: categories.length,
+      separatorBuilder: (_, index) => const SizedBox(height: 8),
+      itemBuilder: (context, index) {
+        final category = categories[index];
+        return _CategoryTile(
+          category: category,
+          visuals: CategoryVisuals.forCategory(category, index),
+          onTap: () => onCategoryTap(category),
+        );
+      },
+    );
   }
 }
 

--- a/mobile/packages/cache_sync/lib/src/cache_sync.dart
+++ b/mobile/packages/cache_sync/lib/src/cache_sync.dart
@@ -208,14 +208,14 @@ abstract final class CacheSync {
     // 1. Serve from cache when applicable.
     var servedCachedValue = false;
     if (policy != CacheFetchPolicy.networkOnly) {
-      final cached = await _dao.read(key);
+      final cached = await _readPayloadBestEffort(key);
       if (cached != null && cached.isNotEmpty) {
         try {
           controller.add(CacheResult.cached(fromJson(cached)));
           servedCachedValue = true;
         } on Object {
           // Corrupted cache entry — ignore and fetch fresh.
-          await _dao.delete(key);
+          await _deletePayloadBestEffort(key);
         }
       }
     }
@@ -231,7 +231,7 @@ abstract final class CacheSync {
       final value = await fetch();
       final payload = toJson(value);
       if (payload.isNotEmpty) {
-        await _dao.write(key: key, payload: payload, ttl: ttl);
+        await _writePayloadBestEffort(key: key, payload: payload, ttl: ttl);
       }
       if (!controller.isClosed) {
         controller.add(CacheResult.live(value));
@@ -258,13 +258,13 @@ abstract final class CacheSync {
     // 1. Serve from cache when applicable.
     var servedCachedValue = false;
     if (policy != CacheFetchPolicy.networkOnly) {
-      final cached = await _dao.read(key);
+      final cached = await _readPayloadBestEffort(key);
       if (cached != null && cached.isNotEmpty) {
         try {
           controller.add(CacheResult.cached(fromJson(cached)));
           servedCachedValue = true;
         } on Object {
-          await _dao.delete(key);
+          await _deletePayloadBestEffort(key);
         }
       }
     }
@@ -278,15 +278,17 @@ abstract final class CacheSync {
     // 2. Subscribe to source stream.
     if (controller.isClosed) return;
 
-    final iterator = StreamIterator<T>(source());
-    registerIterator(iterator);
+    StreamIterator<T>? iterator;
 
     try {
+      iterator = StreamIterator<T>(source());
+      registerIterator(iterator);
+
       while (!controller.isClosed && await iterator.moveNext()) {
         final value = iterator.current;
         final payload = toJson(value);
         if (payload.isNotEmpty) {
-          await _dao.write(key: key, payload: payload, ttl: ttl);
+          await _writePayloadBestEffort(key: key, payload: payload, ttl: ttl);
         }
         if (!controller.isClosed) {
           controller.add(CacheResult.live(value));
@@ -297,8 +299,36 @@ abstract final class CacheSync {
         controller.addError(e, st);
       }
     } finally {
-      await iterator.cancel();
+      await iterator?.cancel();
       if (!controller.isClosed) await controller.close();
+    }
+  }
+
+  static Future<String?> _readPayloadBestEffort(String key) async {
+    try {
+      return await _dao.read(key);
+    } on Object {
+      return null;
+    }
+  }
+
+  static Future<void> _writePayloadBestEffort({
+    required String key,
+    required String payload,
+    required Duration? ttl,
+  }) async {
+    try {
+      await _dao.write(key: key, payload: payload, ttl: ttl);
+    } on Object {
+      // Cache persistence is best-effort; callers must still receive live data.
+    }
+  }
+
+  static Future<void> _deletePayloadBestEffort(String key) async {
+    try {
+      await _dao.delete(key);
+    } on Object {
+      // Corrupt entries should not prevent a live refresh.
     }
   }
 }

--- a/mobile/packages/cache_sync/test/cache_sync_watch_one_test.dart
+++ b/mobile/packages/cache_sync/test/cache_sync_watch_one_test.dart
@@ -197,6 +197,47 @@ void main() {
       expect(events[0].data, equals(3));
     });
 
+    test('fetches live data when cache read fails', () async {
+      await CacheSync.init(dao: ThrowingCacheDao(throwOnRead: true));
+
+      final events = await CacheSync.watchOne<int>(
+        key: 'read:fails',
+        fetch: () async => 4,
+        fromJson: int.parse,
+        toJson: (v) => '$v',
+      ).toList();
+
+      expect(events, equals([const CacheResult.live(4)]));
+    });
+
+    test('fetches live data when corrupted cache delete fails', () async {
+      await CacheSync.init(
+        dao: ThrowingCacheDao(readPayload: 'bad', throwOnDelete: true),
+      );
+
+      final events = await CacheSync.watchOne<int>(
+        key: 'delete:fails',
+        fetch: () async => 5,
+        fromJson: int.parse,
+        toJson: (v) => '$v',
+      ).toList();
+
+      expect(events, equals([const CacheResult.live(5)]));
+    });
+
+    test('emits live data when cache write fails', () async {
+      await CacheSync.init(dao: ThrowingCacheDao(throwOnWrite: true));
+
+      final events = await CacheSync.watchOne<int>(
+        key: 'write:fails',
+        fetch: () async => 6,
+        fromJson: int.parse,
+        toJson: (v) => '$v',
+      ).toList();
+
+      expect(events, equals([const CacheResult.live(6)]));
+    });
+
     test('respects TTL option — writes entry with expiry', () async {
       await CacheSync.watchOne<int>(
         key: 'ttl:key',

--- a/mobile/packages/cache_sync/test/cache_sync_watch_stream_test.dart
+++ b/mobile/packages/cache_sync/test/cache_sync_watch_stream_test.dart
@@ -201,6 +201,47 @@ void main() {
       expect(dao.rawRead('ws:corrupt'), equals('42'));
     });
 
+    test('serves live events when cache read fails', () async {
+      await CacheSync.init(dao: ThrowingCacheDao(throwOnRead: true));
+
+      final events = await CacheSync.watchStream<int>(
+        key: 'ws:read:fails',
+        source: () => Stream.value(4),
+        fromJson: int.parse,
+        toJson: (v) => '$v',
+      ).toList();
+
+      expect(events, equals([const CacheResult.live(4)]));
+    });
+
+    test('serves live events when corrupted cache delete fails', () async {
+      await CacheSync.init(
+        dao: ThrowingCacheDao(readPayload: 'bad', throwOnDelete: true),
+      );
+
+      final events = await CacheSync.watchStream<int>(
+        key: 'ws:delete:fails',
+        source: () => Stream.value(5),
+        fromJson: int.parse,
+        toJson: (v) => '$v',
+      ).toList();
+
+      expect(events, equals([const CacheResult.live(5)]));
+    });
+
+    test('emits live events when cache write fails', () async {
+      await CacheSync.init(dao: ThrowingCacheDao(throwOnWrite: true));
+
+      final events = await CacheSync.watchStream<int>(
+        key: 'ws:write:fails',
+        source: () => Stream.value(6),
+        fromJson: int.parse,
+        toJson: (v) => '$v',
+      ).toList();
+
+      expect(events, equals([const CacheResult.live(6)]));
+    });
+
     test(
       'cancelling outer subscription cancels source stream immediately',
       () async {

--- a/mobile/packages/cache_sync/test/fake_cache_dao.dart
+++ b/mobile/packages/cache_sync/test/fake_cache_dao.dart
@@ -72,6 +72,50 @@ class FakeCacheDao implements CacheDao {
   String? rawRead(String key) => _store[key]?.payload;
 }
 
+/// [CacheDao] test double that can fail individual storage operations.
+class ThrowingCacheDao implements CacheDao {
+  ThrowingCacheDao({
+    this.readPayload,
+    this.throwOnRead = false,
+    this.throwOnWrite = false,
+    this.throwOnDelete = false,
+  });
+
+  final String? readPayload;
+  final bool throwOnRead;
+  final bool throwOnWrite;
+  final bool throwOnDelete;
+
+  @override
+  Future<String?> read(String key) async {
+    if (throwOnRead) throw StateError('cache read failed');
+    return readPayload;
+  }
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    if (throwOnWrite) throw StateError('cache write failed');
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    if (throwOnDelete) throw StateError('cache delete failed');
+  }
+
+  @override
+  Future<void> deletePrefix(String prefix) async {}
+
+  @override
+  Future<int> totalPayloadBytes() async => 0;
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
 class _Entry {
   _Entry({required this.payload, this.expiresAt})
     : cachedAt = DateTime.now().toUtc();

--- a/mobile/packages/categories_repository/lib/categories_repository.dart
+++ b/mobile/packages/categories_repository/lib/categories_repository.dart
@@ -1,4 +1,5 @@
 /// Repository for fetching and caching video categories.
 library;
 
+export 'package:cache_sync/cache_sync.dart' show CacheResult;
 export 'src/categories_repository.dart';

--- a/mobile/packages/categories_repository/lib/src/categories_repository.dart
+++ b/mobile/packages/categories_repository/lib/src/categories_repository.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Repository for video categories from the Funnelcake REST API.
-// ABOUTME: Owns the in-memory TTL cache for the categories list.
+// ABOUTME: Owns in-memory and CacheSync-backed caches for the categories list.
 
+import 'dart:convert';
+
+import 'package:cache_sync/cache_sync.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:models/models.dart';
 
@@ -24,7 +27,8 @@ final class CategoryVideosPage {
 /// Wraps [FunnelcakeApiClient.getCategories] and applies
 /// featured-first ordering. Results are cached in memory for
 /// 10 minutes so repeated screen opens do not fire redundant
-/// network requests.
+/// network requests, and can be observed through [watchCategoriesCached]
+/// for disk-backed stale-while-revalidate loading across app starts.
 class CategoriesRepository {
   /// Creates a [CategoriesRepository].
   CategoriesRepository({
@@ -41,6 +45,8 @@ class CategoriesRepository {
 
   List<VideoCategory>? _cache;
   DateTime? _cachedAt;
+
+  static const _categoriesCacheKey = 'global:categories:v1';
 
   bool get _isCacheValid =>
       _cache != null &&
@@ -84,6 +90,25 @@ class CategoriesRepository {
     _cachedAt = DateTime.now();
 
     return ordered;
+  }
+
+  /// Watches the ordered category list through [CacheSync].
+  ///
+  /// Emits cached categories immediately when available, then emits the live
+  /// Funnelcake result once it resolves. The cache intentionally has no TTL:
+  /// categories are safe to show stale while the background refresh catches up.
+  Stream<CacheResult<List<VideoCategory>>> watchCategoriesCached({
+    bool forceRefresh = false,
+  }) {
+    return CacheSync.watchOne<List<VideoCategory>>(
+      key: _categoriesCacheKey,
+      fetch: () => getCategories(forceRefresh: forceRefresh),
+      fromJson: _categoriesFromJson,
+      toJson: _categoriesToJson,
+      policy: forceRefresh
+          ? CacheFetchPolicy.networkOnly
+          : CacheFetchPolicy.cacheAndNetwork,
+    );
   }
 
   /// Returns a filtered page of videos for [category].
@@ -130,5 +155,25 @@ class CategoriesRepository {
   void invalidateCache() {
     _cache = null;
     _cachedAt = null;
+  }
+
+  static List<VideoCategory> _categoriesFromJson(String payload) {
+    final decoded = jsonDecode(payload) as List<dynamic>;
+    return decoded
+        .map((item) => VideoCategory.fromJson(item as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
+  static String _categoriesToJson(List<VideoCategory> categories) {
+    return jsonEncode(
+      categories
+          .map(
+            (category) => {
+              'name': category.name,
+              'video_count': category.videoCount,
+            },
+          )
+          .toList(growable: false),
+    );
   }
 }

--- a/mobile/packages/categories_repository/pubspec.yaml
+++ b/mobile/packages/categories_repository/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
   sdk: ^3.11.0
 
 dependencies:
+  cache_sync:
+    path: ../cache_sync
   funnelcake_api_client:
     path: ../funnelcake_api_client
   models:

--- a/mobile/packages/categories_repository/test/src/categories_repository_test.dart
+++ b/mobile/packages/categories_repository/test/src/categories_repository_test.dart
@@ -1,12 +1,15 @@
 // ABOUTME: Tests for CategoriesRepository
 // ABOUTME: Verifies caching, filtering, and featured-first ordering
 
+import 'package:cache_sync/cache_sync.dart';
 import 'package:categories_repository/categories_repository.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart'
     show RecommendationsResponse, VideoCategory, VideoStats;
 import 'package:test/test.dart';
+
+import '../../../cache_sync/test/fake_cache_dao.dart';
 
 class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
 
@@ -106,6 +109,72 @@ void main() {
 
         // 'animals' is featured, so should come first
         expect(result.first.name, equals('animals'));
+      });
+    });
+
+    group('watchCategoriesCached', () {
+      late FakeCacheDao cacheDao;
+
+      setUp(() async {
+        cacheDao = FakeCacheDao();
+        await CacheSync.init(dao: cacheDao);
+      });
+
+      test('emits disk-cached categories before live refresh', () async {
+        const refreshedCategories = <VideoCategory>[
+          VideoCategory(name: 'animals', videoCount: 350),
+          VideoCategory(name: 'music', videoCount: 250),
+        ];
+        var calls = 0;
+        when(() => apiClient.getCategories(limit: 100)).thenAnswer((_) async {
+          calls += 1;
+          return calls == 1 ? sampleCategories : refreshedCategories;
+        });
+
+        await repository.watchCategoriesCached().toList();
+
+        final restartedRepository = CategoriesRepository(
+          funnelcakeApiClient: apiClient,
+          blockFilter: (pubkey) => pubkey == blockedPubkey,
+        );
+
+        final results = await restartedRepository
+            .watchCategoriesCached()
+            .toList();
+
+        expect(results, hasLength(2));
+        expect(results[0].isStale, isTrue);
+        expect(results[0].data, [
+          const VideoCategory(name: 'animals', videoCount: 300),
+          const VideoCategory(name: 'music', videoCount: 200),
+          const VideoCategory(name: 'comedy', videoCount: 500),
+        ]);
+        expect(results[1].isLive, isTrue);
+        expect(results[1].data, refreshedCategories);
+        verify(() => apiClient.getCategories(limit: 100)).called(2);
+      });
+
+      test('force refresh bypasses the disk cache', () async {
+        var calls = 0;
+        when(() => apiClient.getCategories(limit: 100)).thenAnswer((_) async {
+          calls += 1;
+          return calls == 1
+              ? sampleCategories
+              : const [VideoCategory(name: 'music', videoCount: 250)];
+        });
+
+        await repository.watchCategoriesCached().toList();
+
+        final results = await repository
+            .watchCategoriesCached(forceRefresh: true)
+            .toList();
+
+        expect(results, hasLength(1));
+        expect(results.single.isLive, isTrue);
+        expect(results.single.data, [
+          const VideoCategory(name: 'music', videoCount: 250),
+        ]);
+        verify(() => apiClient.getCategories(limit: 100)).called(2);
       });
     });
 

--- a/mobile/packages/divine_ui/lib/src/loading_overlay.dart
+++ b/mobile/packages/divine_ui/lib/src/loading_overlay.dart
@@ -21,6 +21,7 @@ class LoadingOverlay extends StatelessWidget {
   const LoadingOverlay({
     required this.child,
     required this.isLoading,
+    this.padding = .zero,
     super.key,
   });
 
@@ -30,6 +31,9 @@ class LoadingOverlay extends StatelessWidget {
   /// When true, a [LinearProgressIndicator] is shown at the top edge.
   final bool isLoading;
 
+  /// Optional padding applied around the loading indicator.
+  final EdgeInsets padding;
+
   static const _animationDuration = Duration(milliseconds: 200);
 
   @override
@@ -38,16 +42,19 @@ class LoadingOverlay extends StatelessWidget {
       children: [
         child,
 
-        AnimatedSize(
-          duration: _animationDuration,
-          child: Align(
-            alignment: Alignment.topCenter,
-            child: isLoading
-                ? const LinearProgressIndicator(
-                    color: VineTheme.primary,
-                    backgroundColor: Colors.transparent,
-                  )
-                : const SizedBox(width: .infinity),
+        Padding(
+          padding: padding,
+          child: AnimatedSize(
+            duration: _animationDuration,
+            child: Align(
+              alignment: Alignment.topCenter,
+              child: isLoading
+                  ? const LinearProgressIndicator(
+                      color: VineTheme.primary,
+                      backgroundColor: Colors.transparent,
+                    )
+                  : const SizedBox(width: .infinity),
+            ),
           ),
         ),
       ],

--- a/mobile/packages/divine_ui/test/src/loading_overlay_test.dart
+++ b/mobile/packages/divine_ui/test/src/loading_overlay_test.dart
@@ -7,11 +7,13 @@ void main() {
     Widget buildSubject({
       required bool isLoading,
       Widget child = const SizedBox(),
+      EdgeInsets padding = EdgeInsets.zero,
     }) {
       return MaterialApp(
         home: Scaffold(
           body: LoadingOverlay(
             isLoading: isLoading,
+            padding: padding,
             child: child,
           ),
         ),
@@ -59,6 +61,25 @@ void main() {
           ),
         );
         expect(align.alignment, Alignment.topCenter);
+      },
+    );
+
+    testWidgets(
+      'applies the provided padding around the indicator',
+      (tester) async {
+        await tester.pumpWidget(
+          buildSubject(isLoading: true, padding: const EdgeInsets.only(top: 4)),
+        );
+
+        final padding = tester.widget<Padding>(
+          find
+              .ancestor(
+                of: find.byType(LinearProgressIndicator),
+                matching: find.byType(Padding),
+              )
+              .first,
+        );
+        expect(padding.padding, const EdgeInsets.only(top: 4));
       },
     );
   });

--- a/mobile/test/blocs/categories/categories_bloc_test.dart
+++ b/mobile/test/blocs/categories/categories_bloc_test.dart
@@ -41,8 +41,8 @@ void main() {
         'emits [loading, loaded] when categories load successfully',
         setUp: () {
           when(
-            () => mockRepository.getCategories(),
-          ).thenAnswer((_) async => categories);
+            () => mockRepository.watchCategoriesCached(),
+          ).thenAnswer((_) => Stream.value(CacheResult.live(categories)));
         },
         build: () => CategoriesBloc(
           categoriesRepository: mockRepository,
@@ -61,16 +61,16 @@ void main() {
           ),
         ],
         verify: (_) {
-          verify(() => mockRepository.getCategories()).called(1);
+          verify(() => mockRepository.watchCategoriesCached()).called(1);
         },
       );
 
       blocTest<CategoriesBloc, CategoriesState>(
         'emits [loading, error] when repository throws',
         setUp: () {
-          when(
-            () => mockRepository.getCategories(),
-          ).thenThrow(const FunnelcakeException('Network error'));
+          when(() => mockRepository.watchCategoriesCached()).thenAnswer(
+            (_) => Stream.error(const FunnelcakeException('Network error')),
+          );
         },
         build: () => CategoriesBloc(
           categoriesRepository: mockRepository,
@@ -93,13 +93,43 @@ void main() {
         ],
       );
 
+      blocTest<CategoriesBloc, CategoriesState>(
+        'shows cached categories as refreshing until live categories arrive',
+        setUp: () {
+          when(() => mockRepository.watchCategoriesCached()).thenAnswer(
+            (_) => Stream.fromIterable([
+              const CacheResult.cached([
+                VideoCategory(name: 'animals', videoCount: 300),
+              ]),
+              const CacheResult.live([
+                VideoCategory(name: 'animals', videoCount: 350),
+              ]),
+            ]),
+          );
+        },
+        build: () => CategoriesBloc(categoriesRepository: mockRepository),
+        act: (bloc) => bloc.add(const CategoriesLoadRequested()),
+        expect: () => [
+          const CategoriesState(categoriesStatus: CategoriesStatus.loading),
+          const CategoriesState(
+            categoriesStatus: CategoriesStatus.loaded,
+            categories: [VideoCategory(name: 'animals', videoCount: 300)],
+            isRefreshing: true,
+          ),
+          const CategoriesState(
+            categoriesStatus: CategoriesStatus.loaded,
+            categories: [VideoCategory(name: 'animals', videoCount: 350)],
+          ),
+        ],
+      );
+
       test('does not re-fetch while a load is already in progress', () async {
         // Use a Completer to keep the first request suspended so the second
         // event arrives while the bloc is still in loading state.
-        final completer = Completer<List<VideoCategory>>();
+        final controller = StreamController<CacheResult<List<VideoCategory>>>();
         when(
-          () => mockRepository.getCategories(),
-        ).thenAnswer((_) => completer.future);
+          () => mockRepository.watchCategoriesCached(),
+        ).thenAnswer((_) => controller.stream);
 
         final bloc = CategoriesBloc(categoriesRepository: mockRepository);
 
@@ -112,10 +142,10 @@ void main() {
         await Future<void>.delayed(Duration.zero);
 
         // Only one network call should have been made.
-        verify(() => mockRepository.getCategories()).called(1);
+        verify(() => mockRepository.watchCategoriesCached()).called(1);
 
         // Clean up.
-        completer.complete([]);
+        await controller.close();
         await bloc.close();
       });
     });

--- a/mobile/test/widgets/categories_tab_test.dart
+++ b/mobile/test/widgets/categories_tab_test.dart
@@ -108,6 +108,24 @@ void main() {
       expect(styleTopLeft.dy, lessThan(technologyTopLeft.dy));
     });
 
+    testWidgets('shows a linear refresh indicator over cached categories', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        buildSubject(
+          state: const CategoriesState(
+            categoriesStatus: CategoriesStatus.loaded,
+            categories: [VideoCategory(name: 'animals', videoCount: 1500)],
+            isRefreshing: true,
+          ),
+        ),
+      );
+
+      expect(find.text('Animals'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
     testWidgets('localizes category video counts for Amharic', (tester) async {
       await tester.pumpWidget(
         buildSubject(


### PR DESCRIPTION
Closes #5278

## Summary
- Add a CacheSync-backed stale-while-revalidate watcher for the categories list.
- Update CategoriesBloc to render cached categories immediately and track background refresh state.
- Show the existing LoadingOverlay/LinearProgressIndicator over cached category content while live data refreshes.
- Harden CacheSync watch operations so cache read/delete/write failures do not prevent live data from reaching callers.
- Cover repository cache replay, bloc cached/live emissions, cache storage-failure fallbacks, and the refresh indicator UI with tests.

## Root Cause
The categories repository only had an in-memory TTL cache, so every cold app start lost the cached category list and the tab fell back to the blocking loading state.

During review, we also found that CacheSync watcher storage failures could escape before live fetch/source data was emitted. Since CacheSync startup is optional and the underlying database opens lazily, a cache-layer failure could leave new cached consumers stuck in loading instead of falling back to the network result.

## Impact
The Categories tab can now show the last known category list across app starts while the network refresh catches up, avoiding the empty spinner-first experience for returning users.

CacheSync watchers now treat storage as best-effort: stale cache is used when available, but cache read/delete/write failures no longer block live results. Fetch/source failures still surface as stream errors so existing UI error handling remains intact.

## Validation
- flutter test from mobile/packages/cache_sync
- flutter test test/src/categories_repository_test.dart from mobile/packages/categories_repository
- flutter test test/src/loading_overlay_test.dart from mobile/packages/divine_ui
- flutter test test/blocs/categories/categories_bloc_test.dart test/widgets/categories_tab_test.dart from mobile
- flutter analyze from mobile
- Pre-push hook analyzer and changed-file tests passed