### PR TITLE
feat(profile): cache video tabs with stale-while-revalidate

### DIFF
--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -202,7 +202,11 @@ class ProfileCollabVideosBloc
     try {
       await CacheSync.write<ProfileVideoCursorSnapshot>(
         key: _cacheKey,
-        value: snapshot,
+        value: ProfileVideoCursorSnapshot.capped(
+          videos: snapshot.videos,
+          paginationCursor: snapshot.paginationCursor,
+          hasMoreContent: snapshot.hasMoreContent,
+        ),
         toJson: (s) => s.toJson(),
       );
     } on Object catch (e) {

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -1,9 +1,13 @@
 // ABOUTME: BLoC for managing profile collab videos grid
 // ABOUTME: Fetches Funnelcake-confirmed collaborator videos for a profile
 
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_video_cursor_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
@@ -29,60 +33,52 @@ class ProfileCollabVideosBloc
   }) : _videosRepository = videosRepository,
        _targetUserPubkey = targetUserPubkey,
        super(const ProfileCollabVideosState()) {
-    on<ProfileCollabVideosFetchRequested>(_onFetchRequested);
+    on<ProfileCollabVideosFetchRequested>(
+      _onFetchRequested,
+      transformer: droppable(),
+    );
     on<ProfileCollabVideosLoadMoreRequested>(_onLoadMoreRequested);
   }
 
   final VideosRepository _videosRepository;
   final String _targetUserPubkey;
 
-  /// Handle fetch request - loads collab videos for the target user.
+  /// Cache key for this profile's collab-videos snapshot.
+  String get _cacheKey => '$_targetUserPubkey:profile_collab_videos';
+
+  /// Handle fetch request using stale-while-revalidate backed by [CacheSync].
+  ///
+  /// On reopen the persisted snapshot is served immediately; revalidation then
+  /// re-fetches just the first page and prepends any genuinely-new collab
+  /// videos — it never re-fetches the whole loaded feed.
   Future<void> _onFetchRequested(
     ProfileCollabVideosFetchRequested event,
     Emitter<ProfileCollabVideosState> emit,
   ) async {
-    // Don't re-fetch if already loading
-    if (state.status == ProfileCollabVideosStatus.loading) return;
+    if (state.videos.isNotEmpty && !state.isRefreshing) {
+      emit(state.copyWith(isRefreshing: true));
+    }
 
-    Log.info(
-      'ProfileCollabVideosBloc: Fetching collab videos for '
-      '$_targetUserPubkey',
-      name: 'ProfileCollabVideosBloc',
-      category: LogCategory.video,
-    );
-
-    emit(state.copyWith(status: ProfileCollabVideosStatus.loading));
-
-    try {
-      final videos = await _videosRepository.getCollabVideos(
-        taggedPubkey: _targetUserPubkey,
-        limit: _pageSize,
-      );
-
-      final collabVideos = videos
-          .where((v) => v.isSupportedOnCurrentPlatform)
-          .toList();
-
-      // Determine pagination cursor from last video's createdAt
-      final cursor = collabVideos.isNotEmpty
-          ? collabVideos.last.createdAt
-          : null;
-
-      Log.info(
-        'ProfileCollabVideosBloc: Loaded ${collabVideos.length} collab '
-        'videos (from ${videos.length} total results)',
-        name: 'ProfileCollabVideosBloc',
-        category: LogCategory.video,
-      );
-
+    final cached = await _readCachedSnapshot();
+    if (isClosed) return;
+    if (cached != null && cached.videos.isNotEmpty) {
       emit(
         state.copyWith(
           status: ProfileCollabVideosStatus.success,
-          videos: collabVideos,
-          hasMoreContent: videos.length >= _pageSize,
-          paginationCursor: cursor,
+          videos: cached.videos,
+          hasMoreContent: cached.hasMoreContent,
+          paginationCursor: cached.paginationCursor,
+          isRefreshing: true,
         ),
       );
+    }
+
+    try {
+      if (state.videos.isEmpty) {
+        await _coldLoad(emit);
+      } else {
+        await _warmRevalidate(emit);
+      }
     } catch (e, stackTrace) {
       Log.error(
         'ProfileCollabVideosBloc: Failed to fetch collab videos - $e',
@@ -90,7 +86,130 @@ class ProfileCollabVideosBloc
         category: LogCategory.video,
       );
       addError(e, stackTrace);
+      if (isClosed) return;
+      if (state.videos.isNotEmpty) {
+        emit(state.copyWith(isRefreshing: false));
+        return;
+      }
       emit(state.copyWith(status: ProfileCollabVideosStatus.failure));
+    }
+  }
+
+  /// Cold path: nothing cached. Fetch the first page from the collabs feed.
+  Future<void> _coldLoad(Emitter<ProfileCollabVideosState> emit) async {
+    emit(state.copyWith(status: ProfileCollabVideosStatus.loading));
+
+    final videos = await _videosRepository.getCollabVideos(
+      taggedPubkey: _targetUserPubkey,
+      limit: _pageSize,
+    );
+    if (isClosed) return;
+
+    final collabVideos = videos
+        .where((v) => v.isSupportedOnCurrentPlatform)
+        .toList();
+    final cursor = collabVideos.isNotEmpty ? collabVideos.last.createdAt : null;
+    final hasMore = videos.length >= _pageSize;
+
+    emit(
+      state.copyWith(
+        status: ProfileCollabVideosStatus.success,
+        videos: collabVideos,
+        hasMoreContent: hasMore,
+        paginationCursor: cursor,
+        isRefreshing: false,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoCursorSnapshot(
+        videos: collabVideos,
+        paginationCursor: cursor,
+        hasMoreContent: hasMore,
+      ),
+    );
+  }
+
+  /// Warm path: cached videos are already on screen. Re-fetch just the first
+  /// page and prepend any genuinely-new collab videos. No bulk re-fetch.
+  Future<void> _warmRevalidate(Emitter<ProfileCollabVideosState> emit) async {
+    final firstPage = await _videosRepository.getCollabVideos(
+      taggedPubkey: _targetUserPubkey,
+      limit: _pageSize,
+    );
+    if (isClosed) return;
+
+    // getCollabVideos is the authoritative confirmed-collab endpoint, so the
+    // fresh first page replaces the cached head — this picks up reorders and
+    // drops videos no longer confirmed. Cached videos beyond the first page
+    // (not re-fetched) are kept, deduped against the fresh page.
+    final fresh = firstPage
+        .where((v) => v.isSupportedOnCurrentPlatform)
+        .toList();
+    final freshIds = fresh.map((v) => v.id).toSet();
+    final tail = state.videos
+        .skip(_pageSize)
+        .where((v) => !freshIds.contains(v.id))
+        .toList();
+    final allVideos = [...fresh, ...tail];
+    // A short fresh page means the feed ends there; the cached tail (if any)
+    // is no longer confirmed.
+    final hasMore = firstPage.length >= _pageSize && state.hasMoreContent;
+
+    final unchanged = listEquals(
+      allVideos.map((v) => v.id).toList(),
+      state.videos.map((v) => v.id).toList(),
+    );
+    if (unchanged && hasMore == state.hasMoreContent) {
+      emit(state.copyWith(isRefreshing: false));
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        status: ProfileCollabVideosStatus.success,
+        videos: allVideos,
+        hasMoreContent: hasMore,
+        isRefreshing: false,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoCursorSnapshot(
+        videos: allVideos,
+        paginationCursor: state.paginationCursor,
+        hasMoreContent: hasMore,
+      ),
+    );
+  }
+
+  Future<ProfileVideoCursorSnapshot?> _readCachedSnapshot() async {
+    try {
+      return await CacheSync.read<ProfileVideoCursorSnapshot>(
+        key: _cacheKey,
+        fromJson: ProfileVideoCursorSnapshot.fromJson,
+      );
+    } on Object catch (e) {
+      Log.warning(
+        'ProfileCollabVideosBloc: Failed to read cached snapshot - $e',
+        name: 'ProfileCollabVideosBloc',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+  }
+
+  Future<void> _persistSnapshot(ProfileVideoCursorSnapshot snapshot) async {
+    try {
+      await CacheSync.write<ProfileVideoCursorSnapshot>(
+        key: _cacheKey,
+        value: snapshot,
+        toJson: (s) => s.toJson(),
+      );
+    } on Object catch (e) {
+      Log.warning(
+        'ProfileCollabVideosBloc: Failed to persist snapshot - $e',
+        name: 'ProfileCollabVideosBloc',
+        category: LogCategory.video,
+      );
     }
   }
 
@@ -146,12 +265,20 @@ class ProfileCollabVideosBloc
         category: LogCategory.video,
       );
 
+      final hasMore = videos.length >= _pageSize;
       emit(
         state.copyWith(
           videos: allVideos,
           isLoadingMore: false,
-          hasMoreContent: videos.length >= _pageSize,
+          hasMoreContent: hasMore,
           paginationCursor: cursor,
+        ),
+      );
+      await _persistSnapshot(
+        ProfileVideoCursorSnapshot(
+          videos: allVideos,
+          paginationCursor: cursor,
+          hasMoreContent: hasMore,
         ),
       );
     } catch (e) {

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -117,6 +117,7 @@ class ProfileCollabVideosBloc
         videos: collabVideos,
         hasMoreContent: hasMore,
         paginationCursor: cursor,
+        clearCursor: cursor == null,
         isRefreshing: false,
       ),
     );

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_bloc.dart
@@ -147,10 +147,12 @@ class ProfileCollabVideosBloc
         .where((v) => v.isSupportedOnCurrentPlatform)
         .toList();
     final freshIds = fresh.map((v) => v.id).toSet();
-    final tail = state.videos
-        .skip(_pageSize)
-        .where((v) => !freshIds.contains(v.id))
-        .toList();
+    final tail = firstPage.length >= _pageSize
+        ? state.videos
+              .skip(_tailStartAfterFreshOverlap(fresh))
+              .where((v) => !freshIds.contains(v.id))
+              .toList()
+        : <VideoEvent>[];
     final allVideos = [...fresh, ...tail];
     // A short fresh page means the feed ends there; the cached tail (if any)
     // is no longer confirmed.
@@ -180,6 +182,19 @@ class ProfileCollabVideosBloc
         hasMoreContent: hasMore,
       ),
     );
+  }
+
+  int _tailStartAfterFreshOverlap(List<VideoEvent> fresh) {
+    if (fresh.isEmpty) return 0;
+
+    final freshIds = fresh.map((v) => v.id).toSet();
+    for (var i = state.videos.length - 1; i >= 0; i--) {
+      if (freshIds.contains(state.videos[i].id)) {
+        return i + 1;
+      }
+    }
+
+    return fresh.length.clamp(0, state.videos.length);
   }
 
   Future<ProfileVideoCursorSnapshot?> _readCachedSnapshot() async {

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_state.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_state.dart
@@ -63,6 +63,10 @@ final class ProfileCollabVideosState extends Equatable {
   bool get isLoading => status == ProfileCollabVideosStatus.loading;
 
   /// Create a copy with updated values.
+  ///
+  /// Pass [clearCursor] to reset [paginationCursor] back to `null` (the
+  /// end-of-feed signal) — a plain `paginationCursor: null` cannot do this
+  /// because the null-coalescing fallback would keep the old value.
   ProfileCollabVideosState copyWith({
     ProfileCollabVideosStatus? status,
     List<VideoEvent>? videos,
@@ -70,6 +74,7 @@ final class ProfileCollabVideosState extends Equatable {
     bool? isRefreshing,
     bool? hasMoreContent,
     int? paginationCursor,
+    bool clearCursor = false,
   }) {
     return ProfileCollabVideosState(
       status: status ?? this.status,
@@ -77,7 +82,9 @@ final class ProfileCollabVideosState extends Equatable {
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       isRefreshing: isRefreshing ?? this.isRefreshing,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
-      paginationCursor: paginationCursor ?? this.paginationCursor,
+      paginationCursor: clearCursor
+          ? null
+          : (paginationCursor ?? this.paginationCursor),
     );
   }
 

--- a/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_state.dart
+++ b/mobile/lib/blocs/profile_collab_videos/profile_collab_videos_state.dart
@@ -32,6 +32,7 @@ final class ProfileCollabVideosState extends Equatable {
     this.status = ProfileCollabVideosStatus.initial,
     this.videos = const [],
     this.isLoadingMore = false,
+    this.isRefreshing = false,
     this.hasMoreContent = true,
     this.paginationCursor,
   });
@@ -44,6 +45,10 @@ final class ProfileCollabVideosState extends Equatable {
 
   /// Whether more videos are being loaded (pagination).
   final bool isLoadingMore;
+
+  /// Whether a background revalidation is in progress while cached content is
+  /// already on screen. Drives the sticky progress bar in the tab bar.
+  final bool isRefreshing;
 
   /// Whether there are more videos to load.
   final bool hasMoreContent;
@@ -62,6 +67,7 @@ final class ProfileCollabVideosState extends Equatable {
     ProfileCollabVideosStatus? status,
     List<VideoEvent>? videos,
     bool? isLoadingMore,
+    bool? isRefreshing,
     bool? hasMoreContent,
     int? paginationCursor,
   }) {
@@ -69,6 +75,7 @@ final class ProfileCollabVideosState extends Equatable {
       status: status ?? this.status,
       videos: videos ?? this.videos,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      isRefreshing: isRefreshing ?? this.isRefreshing,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
       paginationCursor: paginationCursor ?? this.paginationCursor,
     );
@@ -79,6 +86,7 @@ final class ProfileCollabVideosState extends Equatable {
     status,
     videos,
     isLoadingMore,
+    isRefreshing,
     hasMoreContent,
     paginationCursor,
   ];

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -587,8 +587,8 @@ class ProfileLikedVideosBloc
   ///
   /// Re-fetching (rather than only filtering the held list down) is what lets a
   /// now-UNBLOCKED author's liked videos reappear — the cached snapshot stores
-  /// the previously-filtered window, so dropping-only would never restore them
-  /// (#codex-review). The videos are already in local storage, so
+  /// the previously-filtered window, so dropping-only would never restore them.
+  /// The videos are already in local storage, so
   /// [_fetchVideos] is a cache-first read, not a relay round-trip, and the
   /// re-resolved (re-filtered) window is persisted so a reopen stays correct.
   Future<void> _onBlocklistChanged(

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -301,12 +301,14 @@ class ProfileLikedVideosBloc
   Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
   _reconcile(List<String> freshIds) async {
     final byId = {for (final video in state.videos) video.id: video};
-    final addedCount = (freshIds.length - state.likedEventIds.length).clamp(
-      0,
-      freshIds.length,
-    );
+    // Count items newly prepended at the top by anchoring on the previous
+    // top ID rather than on a length delta. A length delta breaks when the
+    // persisted ID list was capped (its length no longer reflects the true
+    // previous total), which would otherwise balloon the window to a full
+    // re-fetch on reopen. Falls back to 0 (no growth) if the old top is gone.
+    final newAtTop = _newItemsAtTop(freshIds);
     final windowSize =
-        (max(state.nextPageOffset, state.videos.length) + addedCount).clamp(
+        (max(state.nextPageOffset, state.videos.length) + newAtTop).clamp(
           0,
           freshIds.length,
         );
@@ -328,6 +330,16 @@ class ProfileLikedVideosBloc
       nextPageOffset: windowIds.length,
       hasMoreContent: windowIds.length < freshIds.length,
     );
+  }
+
+  /// Number of fresh IDs prepended above the previous top item, located by
+  /// finding the old top ID in [freshIds]. Returns 0 when there is no prior
+  /// list or the old top is gone, so a capped persisted list can never
+  /// balloon the reconcile window into a full re-fetch.
+  int _newItemsAtTop(List<String> freshIds) {
+    if (state.likedEventIds.isEmpty) return 0;
+    final index = freshIds.indexOf(state.likedEventIds.first);
+    return index < 0 ? 0 : index;
   }
 
   static const ProfileVideoListSnapshot _emptySnapshot =
@@ -362,7 +374,12 @@ class ProfileLikedVideosBloc
     try {
       await CacheSync.write<ProfileVideoListSnapshot>(
         key: _cacheKey,
-        value: snapshot,
+        value: ProfileVideoListSnapshot.capped(
+          videos: snapshot.videos,
+          itemIds: snapshot.itemIds,
+          nextPageOffset: snapshot.nextPageOffset,
+          hasMoreContent: snapshot.hasMoreContent,
+        ),
         toJson: (s) => s.toJson(),
       );
     } on Object catch (e) {

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_bloc.dart
@@ -3,7 +3,10 @@
 // ABOUTME: (cache-aware relay fetch with SQLite local storage)
 
 import 'dart:async';
+import 'dart:math';
 
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:equatable/equatable.dart';
@@ -11,6 +14,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
@@ -20,18 +24,6 @@ part 'profile_liked_videos_state.dart';
 
 /// Number of videos to load per page for pagination.
 const _pageSize = 18;
-
-final class _LikedVideosPage {
-  const _LikedVideosPage({
-    required this.videos,
-    required this.nextOffset,
-    required this.hasMoreContent,
-  });
-
-  final List<VideoEvent> videos;
-  final int nextOffset;
-  final bool hasMoreContent;
-}
 
 /// BLoC for managing profile liked videos.
 ///
@@ -60,10 +52,20 @@ class ProfileLikedVideosBloc
        _currentUserPubkey = currentUserPubkey,
        _targetUserPubkey = targetUserPubkey,
        super(const ProfileLikedVideosState()) {
-    on<ProfileLikedVideosSyncRequested>(_onSyncRequested);
+    on<ProfileLikedVideosSyncRequested>(
+      _onSyncRequested,
+      transformer: droppable(),
+    );
     on<ProfileLikedVideosSubscriptionRequested>(_onSubscriptionRequested);
+    on<ProfileLikedVideosReconcileRequested>(
+      _onReconcileRequested,
+      transformer: sequential(),
+    );
     on<ProfileLikedVideosLoadMoreRequested>(_onLoadMoreRequested);
-    on<ProfileLikedVideosBlocklistChanged>(_onBlocklistChanged);
+    on<ProfileLikedVideosBlocklistChanged>(
+      _onBlocklistChanged,
+      transformer: droppable(),
+    );
 
     // Re-filter the loaded grid whenever the blocklist changes. Broad changes
     // (account switch / identity adoption, relay-synced blocked-by-others,
@@ -92,21 +94,34 @@ class ProfileLikedVideosBloc
   bool get _isOtherUserProfile =>
       _targetUserPubkey != null && _targetUserPubkey != _currentUserPubkey;
 
-  /// Handle sync request - syncs liked IDs from repository then loads videos.
+  /// Cache key for this profile's liked-videos snapshot.
   ///
-  /// For own profile: Uses "show cached first, refresh in background" pattern:
-  /// 1. Load cached IDs from local storage (instant)
-  /// 2. Fetch videos for cached IDs and show immediately
-  /// 3. Sync from relay in background, update if new likes found
+  /// Follows the `${pubkey}:${operation}` convention (RFC #4244) so that
+  /// `CacheSync.invalidatePrefix(currentPubkey)` at sign-out clears the
+  /// signed-out user's own-profile entry.
+  String get _cacheKey {
+    // Scoped to the VIEWER (current user) as well as the target, because the
+    // cached videos are blocklist-filtered per the signed-in user. A
+    // target-only key would let another account on the same device reuse a
+    // different viewer's filtered window. The current-user prefix also keeps
+    // sign-out's `invalidatePrefix(currentPubkey)` clearing every entry.
+    final target = _targetUserPubkey ?? _currentUserPubkey;
+    return '$_currentUserPubkey:$target:profile_liked_videos';
+  }
+
+  /// Handle sync request using stale-while-revalidate backed by [CacheSync].
   ///
-  /// For other profiles: Fetch from relay (no cache available).
+  /// On reopen the persisted snapshot is deserialized **once** and served
+  /// immediately (full scrolled list, [ProfileLikedVideosState.isRefreshing]
+  /// on). Revalidation then only refreshes the liked-ID list and reconciles
+  /// it against the already-shown videos — it never re-fetches or
+  /// re-serializes the whole window, which previously janked the UI thread
+  /// when fresh data arrived. On a cold open the state stays loading until
+  /// the first page resolves.
   Future<void> _onSyncRequested(
     ProfileLikedVideosSyncRequested event,
     Emitter<ProfileLikedVideosState> emit,
   ) async {
-    // Don't re-sync if already syncing
-    if (state.status == ProfileLikedVideosStatus.syncing) return;
-
     Log.info(
       'ProfileLikedVideosBloc: Starting sync for '
       '${_isOtherUserProfile ? "other user" : "own profile"}',
@@ -114,257 +129,285 @@ class ProfileLikedVideosBloc
       category: LogCategory.video,
     );
 
-    // For other profiles, use the original flow (no cache available)
-    if (_isOtherUserProfile) {
-      await _syncOtherUserLikes(emit);
-      return;
+    // Reopen / refresh: keep the cached grid on screen and surface the thin
+    // progress bar straight away rather than flashing the full-screen spinner.
+    if (state.videos.isNotEmpty && !state.isRefreshing) {
+      emit(state.copyWith(isRefreshing: true));
     }
 
-    // For own profile: show cached data first, then refresh in background
-    await _syncOwnProfileLikes(emit);
-  }
-
-  /// Sync likes for other user's profile (no cache available).
-  Future<void> _syncOtherUserLikes(
-    Emitter<ProfileLikedVideosState> emit,
-  ) async {
-    emit(state.copyWith(status: ProfileLikedVideosStatus.syncing));
-
-    try {
-      final likedEventIds = await _likesRepository.fetchUserLikes(
-        _targetUserPubkey!,
-      );
-
-      Log.info(
-        'ProfileLikedVideosBloc: Fetched ${likedEventIds.length} liked IDs '
-        'for other user',
-        name: 'ProfileLikedVideosBloc',
-        category: LogCategory.video,
-      );
-
-      if (likedEventIds.isEmpty) {
-        emit(
-          state.copyWith(
-            status: ProfileLikedVideosStatus.success,
-            videos: [],
-            likedEventIds: [],
-            hasMoreContent: false,
-            clearError: true,
-          ),
-        );
-        return;
-      }
-
-      emit(
-        state.copyWith(
-          status: ProfileLikedVideosStatus.loading,
-          likedEventIds: likedEventIds,
-        ),
-      );
-
-      final page = await _fetchVideoPage(
-        likedEventIds,
-        startOffset: 0,
-        cacheFirstBatch: true,
-      );
-
-      Log.info(
-        'ProfileLikedVideosBloc: Loaded ${page.videos.length} videos '
-        '(first page of ${likedEventIds.length} total)',
-        name: 'ProfileLikedVideosBloc',
-        category: LogCategory.video,
-      );
-
+    // 1. Serve the persisted snapshot instantly (single deserialize).
+    final cached = await _readCachedSnapshot();
+    if (isClosed) return;
+    if (cached != null && cached.videos.isNotEmpty) {
       emit(
         state.copyWith(
           status: ProfileLikedVideosStatus.success,
-          videos: page.videos,
-          hasMoreContent: page.hasMoreContent,
-          nextPageOffset: page.nextOffset,
+          videos: cached.videos,
+          likedEventIds: cached.itemIds,
+          nextPageOffset: cached.nextPageOffset,
+          hasMoreContent: cached.hasMoreContent,
+          isRefreshing: true,
           clearError: true,
         ),
       );
-    } on FetchLikesFailedException catch (e) {
-      Log.error(
-        'ProfileLikedVideosBloc: Fetch likes failed - ${e.message}',
-        name: 'ProfileLikedVideosBloc',
-        category: LogCategory.video,
-      );
-      emit(
-        state.copyWith(
-          status: ProfileLikedVideosStatus.failure,
-          error: ProfileLikedVideosError.syncFailed,
-        ),
-      );
-    } catch (e) {
-      Log.error(
-        'ProfileLikedVideosBloc: Failed to load videos - $e',
-        name: 'ProfileLikedVideosBloc',
-        category: LogCategory.video,
-      );
-      emit(
-        state.copyWith(
-          status: ProfileLikedVideosStatus.failure,
-          error: ProfileLikedVideosError.loadFailed,
-        ),
-      );
     }
-  }
 
-  /// Sync likes for own profile using "show cached first" pattern.
-  Future<void> _syncOwnProfileLikes(
-    Emitter<ProfileLikedVideosState> emit,
-  ) async {
+    // 2. Revalidate.
     try {
-      // Step 1: Get cached IDs from local storage (instant - no relay)
-      final cachedIds = await _likesRepository.getOrderedLikedEventIds();
-
-      Log.info(
-        'ProfileLikedVideosBloc: Got ${cachedIds.length} cached liked IDs',
-        name: 'ProfileLikedVideosBloc',
-        category: LogCategory.video,
-      );
-
-      // If we have cached data, load videos immediately
-      if (cachedIds.isNotEmpty) {
-        emit(
-          state.copyWith(
-            status: ProfileLikedVideosStatus.loading,
-            likedEventIds: cachedIds,
-          ),
-        );
-
-        final page = await _fetchVideoPage(
-          cachedIds,
-          startOffset: 0,
-          cacheFirstBatch: true,
-        );
-
-        Log.info(
-          'ProfileLikedVideosBloc: Loaded ${page.videos.length} videos from cache '
-          '(first page of ${cachedIds.length} total)',
-          name: 'ProfileLikedVideosBloc',
-          category: LogCategory.video,
-        );
-
-        emit(
-          state.copyWith(
-            status: ProfileLikedVideosStatus.success,
-            videos: page.videos,
-            hasMoreContent: page.hasMoreContent,
-            nextPageOffset: page.nextOffset,
-            clearError: true,
-          ),
-        );
-
-        // Step 2: Sync from relay in background (fire and forget)
-        // The subscription handler will update the list if new likes are found
-        unawaited(
-          _likesRepository
-              .syncUserReactions()
-              .then((_) {
-                Log.debug(
-                  'ProfileLikedVideosBloc: Background relay sync completed',
-                  name: 'ProfileLikedVideosBloc',
-                  category: LogCategory.video,
-                );
-              })
-              .catchError((e) {
-                Log.warning(
-                  'ProfileLikedVideosBloc: Background sync failed - $e',
-                  name: 'ProfileLikedVideosBloc',
-                  category: LogCategory.video,
-                );
-              }),
-        );
+      if (state.videos.isEmpty) {
+        await _coldLoad(emit);
       } else {
-        // No cached data - need to sync from relay (show loading state)
-        emit(state.copyWith(status: ProfileLikedVideosStatus.syncing));
-
-        final syncResult = await _likesRepository.syncUserReactions();
-        final likedEventIds = syncResult.orderedEventIds;
-
-        Log.info(
-          'ProfileLikedVideosBloc: Synced ${likedEventIds.length} liked IDs '
-          'from relay (no cache)',
-          name: 'ProfileLikedVideosBloc',
-          category: LogCategory.video,
-        );
-
-        if (likedEventIds.isEmpty) {
-          emit(
-            state.copyWith(
-              status: ProfileLikedVideosStatus.success,
-              videos: [],
-              likedEventIds: [],
-              hasMoreContent: false,
-              clearError: true,
-            ),
-          );
-          return;
-        }
-
-        emit(
-          state.copyWith(
-            status: ProfileLikedVideosStatus.loading,
-            likedEventIds: likedEventIds,
-          ),
-        );
-
-        final page = await _fetchVideoPage(
-          likedEventIds,
-          startOffset: 0,
-          cacheFirstBatch: true,
-        );
-
-        Log.info(
-          'ProfileLikedVideosBloc: Loaded ${page.videos.length} videos '
-          '(first page of ${likedEventIds.length} total)',
-          name: 'ProfileLikedVideosBloc',
-          category: LogCategory.video,
-        );
-
-        emit(
-          state.copyWith(
-            status: ProfileLikedVideosStatus.success,
-            videos: page.videos,
-            hasMoreContent: page.hasMoreContent,
-            nextPageOffset: page.nextOffset,
-            clearError: true,
-          ),
-        );
+        await _warmRevalidate(emit);
       }
-    } on SyncFailedException catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
-        'ProfileLikedVideosBloc: Sync failed - ${e.message}',
+        'ProfileLikedVideosBloc: Sync failed - $e',
         name: 'ProfileLikedVideosBloc',
         category: LogCategory.video,
       );
+      addError(e, stackTrace);
+      if (isClosed) return;
+      // Keep cached content on screen; only show the failure screen cold.
+      if (state.videos.isNotEmpty) {
+        emit(state.copyWith(isRefreshing: false));
+        return;
+      }
       emit(
         state.copyWith(
           status: ProfileLikedVideosStatus.failure,
-          error: ProfileLikedVideosError.syncFailed,
-        ),
-      );
-    } catch (e) {
-      Log.error(
-        'ProfileLikedVideosBloc: Failed to load videos - $e',
-        name: 'ProfileLikedVideosBloc',
-        category: LogCategory.video,
-      );
-      emit(
-        state.copyWith(
-          status: ProfileLikedVideosStatus.failure,
-          error: ProfileLikedVideosError.loadFailed,
+          isRefreshing: false,
+          error: _errorFor(e),
         ),
       );
     }
   }
 
-  /// Subscribe to liked IDs changes and update the video list reactively.
+  /// Cold path: nothing cached. Resolve the liked-ID list (own profile prefers
+  /// the instant local list, falling back to the relay) and fetch just the
+  /// first page.
+  Future<void> _coldLoad(Emitter<ProfileLikedVideosState> emit) async {
+    final List<String> likedEventIds;
+    if (_isOtherUserProfile) {
+      likedEventIds = await _likesRepository.fetchUserLikes(_targetUserPubkey!);
+    } else {
+      final localIds = await _likesRepository.getOrderedLikedEventIds();
+      if (localIds.isNotEmpty) {
+        _scheduleBackgroundRelaySync();
+        likedEventIds = localIds;
+      } else {
+        likedEventIds =
+            (await _likesRepository.syncUserReactions()).orderedEventIds;
+      }
+    }
+    if (isClosed) return;
+
+    if (likedEventIds.isEmpty) {
+      emit(
+        state.copyWith(
+          status: ProfileLikedVideosStatus.success,
+          videos: [],
+          likedEventIds: [],
+          nextPageOffset: 0,
+          hasMoreContent: false,
+          isRefreshing: false,
+          clearError: true,
+        ),
+      );
+      await _persistSnapshot(_emptySnapshot);
+      return;
+    }
+
+    // Fill a page through sparse IDs (some may not resolve to videos) and
+    // apply the blocklist, so the first screen renders a full grid.
+    final page = await _fetchVideoPage(
+      likedEventIds,
+      startOffset: 0,
+      cacheFirstBatch: true,
+    );
+    if (isClosed) return;
+
+    final snapshot = ProfileVideoListSnapshot(
+      videos: page.videos,
+      itemIds: likedEventIds,
+      nextPageOffset: page.nextOffset,
+      hasMoreContent: page.hasMoreContent,
+    );
+    emit(
+      state.copyWith(
+        status: ProfileLikedVideosStatus.success,
+        videos: page.videos,
+        likedEventIds: likedEventIds,
+        nextPageOffset: page.nextOffset,
+        hasMoreContent: page.hasMoreContent,
+        isRefreshing: false,
+        clearError: true,
+      ),
+    );
+    await _persistSnapshot(snapshot);
+  }
+
+  /// Warm path: cached videos are already on screen. Refresh the liked-ID list
+  /// against the relay and reconcile it against the shown videos.
   ///
-  /// Uses emit.forEach to listen to the repository stream and emit state
-  /// changes when liked IDs change (videos added or removed).
+  /// Deliberately does **not** re-resolve or re-serialize the whole loaded
+  /// window: when the ID list is unchanged (the common reopen) this is just a
+  /// flag flip; when it changed, [_reconcile] drops unliked videos and fetches
+  /// only the newly-liked IDs in the window, so the UI thread never does bulk
+  /// video work here.
+  Future<void> _warmRevalidate(Emitter<ProfileLikedVideosState> emit) async {
+    final List<String> freshIds;
+    if (_isOtherUserProfile) {
+      freshIds = await _likesRepository.fetchUserLikes(_targetUserPubkey!);
+    } else {
+      freshIds = (await _likesRepository.syncUserReactions()).orderedEventIds;
+    }
+    if (isClosed) return;
+
+    if (listEquals(freshIds, state.likedEventIds)) {
+      // Nothing changed — just hide the bar. No re-fetch, no re-serialize.
+      emit(state.copyWith(isRefreshing: false));
+      return;
+    }
+
+    final reconciled = await _reconcile(freshIds);
+    if (isClosed) return;
+    emit(
+      state.copyWith(
+        status: ProfileLikedVideosStatus.success,
+        videos: reconciled.videos,
+        likedEventIds: freshIds,
+        nextPageOffset: reconciled.nextPageOffset,
+        hasMoreContent: reconciled.hasMoreContent,
+        isRefreshing: false,
+        clearError: true,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoListSnapshot(
+        videos: reconciled.videos,
+        itemIds: freshIds,
+        nextPageOffset: reconciled.nextPageOffset,
+        hasMoreContent: reconciled.hasMoreContent,
+      ),
+    );
+  }
+
+  /// Reconciles the displayed videos against a fresh [freshIds] list.
+  ///
+  /// Keeps videos still liked (in fresh order), drops unliked ones, and
+  /// fetches only the liked IDs in the loaded window that have no video yet —
+  /// typically just the clip the user (or another device) liked at the top.
+  /// Bounded to the loaded window so it never bulk-fetches.
+  Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
+  _reconcile(List<String> freshIds) async {
+    final byId = {for (final video in state.videos) video.id: video};
+    final addedCount = (freshIds.length - state.likedEventIds.length).clamp(
+      0,
+      freshIds.length,
+    );
+    final windowSize =
+        (max(state.nextPageOffset, state.videos.length) + addedCount).clamp(
+          0,
+          freshIds.length,
+        );
+    final windowIds = freshIds.take(windowSize).toList();
+
+    final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
+    if (missingIds.isNotEmpty) {
+      for (final video in await _fetchVideos(missingIds, cacheResults: true)) {
+        byId[video.id] = video;
+      }
+    }
+
+    final videos = windowIds
+        .map((id) => byId[id])
+        .whereType<VideoEvent>()
+        .toList();
+    return (
+      videos: videos,
+      nextPageOffset: windowIds.length,
+      hasMoreContent: windowIds.length < freshIds.length,
+    );
+  }
+
+  static const ProfileVideoListSnapshot _emptySnapshot =
+      ProfileVideoListSnapshot(
+        videos: [],
+        itemIds: [],
+        nextPageOffset: 0,
+        hasMoreContent: false,
+      );
+
+  /// Reads and deserializes the persisted snapshot once; `null` on miss or
+  /// failure (cache problems must never break the load).
+  Future<ProfileVideoListSnapshot?> _readCachedSnapshot() async {
+    try {
+      return await CacheSync.read<ProfileVideoListSnapshot>(
+        key: _cacheKey,
+        fromJson: ProfileVideoListSnapshot.fromJson,
+      );
+    } on Object catch (e) {
+      Log.warning(
+        'ProfileLikedVideosBloc: Failed to read cached snapshot - $e',
+        name: 'ProfileLikedVideosBloc',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+  }
+
+  /// Persists [snapshot] under [_cacheKey] so reopening restores it. Cache
+  /// failures are swallowed — they must never break an otherwise-fine load.
+  Future<void> _persistSnapshot(ProfileVideoListSnapshot snapshot) async {
+    try {
+      await CacheSync.write<ProfileVideoListSnapshot>(
+        key: _cacheKey,
+        value: snapshot,
+        toJson: (s) => s.toJson(),
+      );
+    } on Object catch (e) {
+      Log.warning(
+        'ProfileLikedVideosBloc: Failed to persist snapshot - $e',
+        name: 'ProfileLikedVideosBloc',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  /// Fire-and-forget relay sync that keeps the in-memory liked list fresh for
+  /// the live subscription after serving an instant local snapshot.
+  void _scheduleBackgroundRelaySync() {
+    unawaited(
+      _likesRepository
+          .syncUserReactions()
+          .then((_) {
+            Log.debug(
+              'ProfileLikedVideosBloc: Background relay sync completed',
+              name: 'ProfileLikedVideosBloc',
+              category: LogCategory.video,
+            );
+          })
+          .catchError((Object e) {
+            Log.warning(
+              'ProfileLikedVideosBloc: Background sync failed - $e',
+              name: 'ProfileLikedVideosBloc',
+              category: LogCategory.video,
+            );
+          }),
+    );
+  }
+
+  ProfileLikedVideosError _errorFor(Object error) =>
+      error is SyncFailedException || error is FetchLikesFailedException
+      ? ProfileLikedVideosError.syncFailed
+      : ProfileLikedVideosError.loadFailed;
+
+  /// Subscribe to liked IDs changes and reconcile the video list reactively.
+  ///
+  /// Whenever the liked set changes (like or unlike), dispatches a
+  /// [ProfileLikedVideosReconcileRequested] so the async handler can drop
+  /// unliked videos and fetch a just-liked clip — `emit.forEach`'s callback is
+  /// synchronous and cannot await the fetch itself.
   ///
   /// Note: This only works for the current user's own profile, as the
   /// LikesRepository only tracks the authenticated user's likes.
@@ -380,62 +423,71 @@ class ProfileLikedVideosBloc
     await emit.forEach<List<String>>(
       _likesRepository.watchLikedEventIds(),
       onData: (newIds) {
-        // Skip if IDs haven't changed
-        if (listEquals(newIds, state.likedEventIds)) return state;
-
-        // Skip if we haven't done initial sync yet
-        if (state.status == ProfileLikedVideosStatus.initial ||
+        // Skip if IDs haven't changed, or before the initial sync completes.
+        if (listEquals(newIds, state.likedEventIds) ||
+            state.status == ProfileLikedVideosStatus.initial ||
             state.status == ProfileLikedVideosStatus.syncing) {
           return state;
         }
 
         Log.info(
-          'ProfileLikedVideosBloc: Liked IDs changed, updating list',
+          'ProfileLikedVideosBloc: Liked IDs changed, reconciling list',
           name: 'ProfileLikedVideosBloc',
           category: LogCategory.video,
         );
-
-        // If a video was unliked, remove it from the list immediately
-        if (newIds.length < state.likedEventIds.length) {
-          final removedIds = state.likedEventIds
-              .where((id) => !newIds.contains(id))
-              .toSet();
-          final updatedVideos = state.videos
-              .where((v) => !removedIds.contains(v.id))
-              .toList();
-
-          // Clamp offset to new list length (removed IDs may shift it)
-          final adjustedOffset = state.nextPageOffset.clamp(0, newIds.length);
-
-          return state.copyWith(
-            likedEventIds: newIds,
-            videos: updatedVideos,
-            nextPageOffset: adjustedOffset,
-          );
-        }
-
-        // If a video was liked, we need to fetch it asynchronously.
-        // New likes are prepended (most recent first), so shift the offset
-        // forward to keep existing pagination position correct.
-        if (newIds.length > state.likedEventIds.length) {
-          final addedCount = newIds.length - state.likedEventIds.length;
-          return state.copyWith(
-            likedEventIds: newIds,
-            nextPageOffset: state.nextPageOffset + addedCount,
-          );
-        }
-
+        add(ProfileLikedVideosReconcileRequested(newIds));
         return state;
       },
     );
   }
 
+  /// Reconcile the displayed videos against a fresh liked-ID list (dispatched
+  /// from [_onSubscriptionRequested]). Drops unliked videos and fetches any
+  /// newly-liked clip in the loaded window so it shows immediately.
+  Future<void> _onReconcileRequested(
+    ProfileLikedVideosReconcileRequested event,
+    Emitter<ProfileLikedVideosState> emit,
+  ) async {
+    final freshIds = event.likedEventIds;
+    if (listEquals(freshIds, state.likedEventIds)) return;
+
+    try {
+      final reconciled = await _reconcile(freshIds);
+      if (isClosed) return;
+      emit(
+        state.copyWith(
+          status: ProfileLikedVideosStatus.success,
+          videos: reconciled.videos,
+          likedEventIds: freshIds,
+          nextPageOffset: reconciled.nextPageOffset,
+          hasMoreContent: reconciled.hasMoreContent,
+          clearError: true,
+        ),
+      );
+      await _persistSnapshot(
+        ProfileVideoListSnapshot(
+          videos: reconciled.videos,
+          itemIds: freshIds,
+          nextPageOffset: reconciled.nextPageOffset,
+          hasMoreContent: reconciled.hasMoreContent,
+        ),
+      );
+    } catch (e, stackTrace) {
+      Log.error(
+        'ProfileLikedVideosBloc: Failed to reconcile liked videos - $e',
+        name: 'ProfileLikedVideosBloc',
+        category: LogCategory.video,
+      );
+      addError(e, stackTrace);
+    }
+  }
+
   /// Handle load more request - fetches the next page of videos.
   ///
   /// Uses [state.nextPageOffset] to track the position in [state.likedEventIds]
-  /// and consumes ID batches until it has a page of renderable videos or runs
-  /// out of IDs. The offset advances by the number of IDs consumed, not the
-  /// number of videos loaded.
+  /// and fetches the next [_pageSize] IDs. The offset advances by the number
+  /// of IDs consumed, not the number of videos loaded (some IDs may not
+  /// resolve to videos due to relay unavailability or format filtering).
   Future<void> _onLoadMoreRequested(
     ProfileLikedVideosLoadMoreRequested event,
     Emitter<ProfileLikedVideosState> emit,
@@ -466,10 +518,13 @@ class ProfileLikedVideosBloc
     emit(state.copyWith(isLoadingMore: true));
 
     try {
+      // Fill a full page through sparse IDs, deduping against what's shown and
+      // persisting the first batch so re-loading resolves from cache.
       final page = await _fetchVideoPage(
         state.likedEventIds,
         startOffset: offset,
         excludeVideoIds: state.videos.map((v) => v.id).toSet(),
+        cacheFirstBatch: true,
       );
 
       Log.info(
@@ -479,13 +534,26 @@ class ProfileLikedVideosBloc
       );
 
       final allVideos = [...state.videos, ...page.videos];
+      final newOffset = page.nextOffset;
+      final hasMore = page.hasMoreContent;
 
       emit(
         state.copyWith(
           videos: allVideos,
           isLoadingMore: false,
-          hasMoreContent: page.hasMoreContent,
-          nextPageOffset: page.nextOffset,
+          hasMoreContent: hasMore,
+          nextPageOffset: newOffset,
+        ),
+      );
+
+      // Grow the persisted snapshot so reopening restores the full scrolled
+      // list (not just the first page) and the user does not re-paginate.
+      await _persistSnapshot(
+        ProfileVideoListSnapshot(
+          videos: allVideos,
+          itemIds: state.likedEventIds,
+          nextPageOffset: newOffset,
+          hasMoreContent: hasMore,
         ),
       );
     } catch (e) {
@@ -498,17 +566,60 @@ class ProfileLikedVideosBloc
     }
   }
 
-  /// Re-filter the loaded videos against the current blocklist.
+  /// Re-resolve the loaded window against the **current** blocklist.
   ///
-  /// Removes any now-blocked authors from [ProfileLikedVideosState.videos].
-  /// [likedEventIds] and [ProfileLikedVideosState.nextPageOffset] are left
-  /// untouched: the offset indexes into [likedEventIds] for pagination, and
-  /// the next page fetch applies the current blocklist filter through
-  /// [_fetchVideos], so no offset adjustment is needed here.
-  void _onBlocklistChanged(
+  /// Re-fetching (rather than only filtering the held list down) is what lets a
+  /// now-UNBLOCKED author's liked videos reappear — the cached snapshot stores
+  /// the previously-filtered window, so dropping-only would never restore them
+  /// (#codex-review). The videos are already in local storage, so
+  /// [_fetchVideos] is a cache-first read, not a relay round-trip, and the
+  /// re-resolved (re-filtered) window is persisted so a reopen stays correct.
+  Future<void> _onBlocklistChanged(
     ProfileLikedVideosBlocklistChanged event,
     Emitter<ProfileLikedVideosState> emit,
-  ) {
+  ) async {
+    if (state.likedEventIds.isEmpty || state.nextPageOffset == 0) {
+      _dropBlockedFromCurrentList(emit);
+      return;
+    }
+
+    final windowIds = state.likedEventIds.take(state.nextPageOffset).toList();
+    final List<VideoEvent> videos;
+    try {
+      videos = await _fetchVideos(windowIds);
+    } catch (e, stackTrace) {
+      Log.warning(
+        'ProfileLikedVideosBloc: Blocklist re-resolve failed - $e',
+        name: 'ProfileLikedVideosBloc',
+        category: LogCategory.video,
+      );
+      addError(e, stackTrace);
+      if (!isClosed) _dropBlockedFromCurrentList(emit);
+      return;
+    }
+    if (isClosed) return;
+
+    if (listEquals(
+      videos.map((v) => v.id).toList(),
+      state.videos.map((v) => v.id).toList(),
+    )) {
+      return;
+    }
+
+    emit(state.copyWith(videos: videos));
+    await _persistSnapshot(
+      ProfileVideoListSnapshot(
+        videos: videos,
+        itemIds: state.likedEventIds,
+        nextPageOffset: state.nextPageOffset,
+        hasMoreContent: state.hasMoreContent,
+      ),
+    );
+  }
+
+  /// Fallback when there is no window to re-resolve: drop newly-blocked authors
+  /// from the held list (cannot restore unblocked ones without a window).
+  void _dropBlockedFromCurrentList(Emitter<ProfileLikedVideosState> emit) {
     final filtered = _blocklistRepository.filterContent(
       state.videos,
       (video) => video.pubkey,
@@ -518,6 +629,53 @@ class ProfileLikedVideosBloc
     }
   }
 
+  /// Fetch videos for the given event IDs.
+  ///
+  /// Uses [VideosRepository.getVideosByIds] which implements cache-first:
+  /// 1. Checks SQLite local storage for cached events
+  /// 2. Queries Nostr relays only for missing events
+  /// 3. Optionally saves fetched events to cache
+  ///
+  /// When [cacheResults] is true, videos fetched from relay are saved to
+  /// local storage for future cache hits. Only use for first page loads
+  /// to avoid bloating the cache.
+  ///
+  /// Returns videos in the same order as [eventIds], excluding:
+  /// - Videos not found in cache or relay
+  /// - Unsupported video formats (WebM on iOS/macOS)
+  Future<List<VideoEvent>> _fetchVideos(
+    List<String> eventIds, {
+    bool cacheResults = false,
+  }) async {
+    if (eventIds.isEmpty) return [];
+
+    // VideosRepository handles cache-first lookup internally
+    final videos = await _videosRepository.getVideosByIds(
+      eventIds,
+      cacheResults: cacheResults,
+    );
+
+    Log.debug(
+      'ProfileLikedVideosBloc: Fetched ${videos.length}/${eventIds.length} videos '
+      '(cacheResults: $cacheResults)',
+      name: 'ProfileLikedVideosBloc',
+      category: LogCategory.video,
+    );
+
+    // Filter unsupported formats, then blocked authors.
+    final supported = videos
+        .where((v) => v.isSupportedOnCurrentPlatform)
+        .toList();
+    return _blocklistRepository.filterContent<VideoEvent>(
+      supported,
+      (video) => video.pubkey,
+    );
+  }
+
+  /// Fetches videos until a full [_pageSize] page is filled or the IDs run
+  /// out, skipping over IDs that don't resolve (sparse likes) and deduping
+  /// against [excludeVideoIds]. Returns the consumed-ID offset so pagination
+  /// advances past dead IDs.
   Future<_LikedVideosPage> _fetchVideoPage(
     List<String> likedEventIds, {
     required int startOffset,
@@ -557,51 +715,22 @@ class ProfileLikedVideosBloc
     );
   }
 
-  /// Fetch videos for the given event IDs.
-  ///
-  /// Uses [VideosRepository.getVideosByIds] which implements cache-first:
-  /// 1. Checks SQLite local storage for cached events
-  /// 2. Queries Nostr relays only for missing events
-  /// 3. Optionally saves fetched events to cache
-  ///
-  /// When [cacheResults] is true, videos fetched from relay are saved to
-  /// local storage for future cache hits. Only use for first page loads
-  /// to avoid bloating the cache.
-  ///
-  /// Returns videos in the same order as [eventIds], excluding:
-  /// - Videos not found in cache or relay
-  /// - Unsupported video formats (WebM on iOS/macOS)
-  Future<List<VideoEvent>> _fetchVideos(
-    List<String> eventIds, {
-    bool cacheResults = false,
-  }) async {
-    if (eventIds.isEmpty) return [];
-
-    // VideosRepository handles cache-first lookup internally
-    final videos = await _videosRepository.getVideosByIds(
-      eventIds,
-      cacheResults: cacheResults,
-    );
-
-    Log.debug(
-      'ProfileLikedVideosBloc: Fetched ${videos.length}/${eventIds.length} videos '
-      '(cacheResults: $cacheResults)',
-      name: 'ProfileLikedVideosBloc',
-      category: LogCategory.video,
-    );
-
-    final supported = videos
-        .where((v) => v.isSupportedOnCurrentPlatform)
-        .toList();
-    return _blocklistRepository.filterContent<VideoEvent>(
-      supported,
-      (video) => video.pubkey,
-    );
-  }
-
   @override
   Future<void> close() {
     _blocklistSubscription.cancel();
     return super.close();
   }
+}
+
+/// A page of liked videos resolved through possibly-sparse liked IDs.
+final class _LikedVideosPage {
+  const _LikedVideosPage({
+    required this.videos,
+    required this.nextOffset,
+    required this.hasMoreContent,
+  });
+
+  final List<VideoEvent> videos;
+  final int nextOffset;
+  final bool hasMoreContent;
 }

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_event.dart
@@ -45,3 +45,17 @@ final class ProfileLikedVideosLoadMoreRequested
 final class ProfileLikedVideosBlocklistChanged extends ProfileLikedVideosEvent {
   const ProfileLikedVideosBlocklistChanged();
 }
+
+/// Internal: reconcile the displayed videos against a fresh liked-ID list.
+///
+/// Dispatched from the [LikesRepository.watchLikedEventIds] subscription when
+/// the liked set changes. Drops unliked videos and fetches any newly-liked
+/// IDs in the loaded window (e.g. a video the user just liked at the top) so
+/// it appears without re-resolving the whole window.
+final class ProfileLikedVideosReconcileRequested
+    extends ProfileLikedVideosEvent {
+  const ProfileLikedVideosReconcileRequested(this.likedEventIds);
+
+  /// The fresh, ordered (most-recent-first) liked event IDs.
+  final List<String> likedEventIds;
+}

--- a/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
+++ b/mobile/lib/blocs/profile_liked_videos/profile_liked_videos_state.dart
@@ -45,6 +45,7 @@ final class ProfileLikedVideosState extends Equatable {
     this.likedEventIds = const [],
     this.error,
     this.isLoadingMore = false,
+    this.isRefreshing = false,
     this.hasMoreContent = true,
     this.nextPageOffset = 0,
   });
@@ -63,6 +64,10 @@ final class ProfileLikedVideosState extends Equatable {
 
   /// Whether more videos are being loaded (pagination)
   final bool isLoadingMore;
+
+  /// Whether a background revalidation is in progress while cached content is
+  /// already on screen. Drives the thin progress bar in the grid.
+  final bool isRefreshing;
 
   /// Whether there are more videos to load
   final bool hasMoreContent;
@@ -90,6 +95,7 @@ final class ProfileLikedVideosState extends Equatable {
     ProfileLikedVideosError? error,
     bool clearError = false,
     bool? isLoadingMore,
+    bool? isRefreshing,
     bool? hasMoreContent,
     int? nextPageOffset,
   }) {
@@ -99,6 +105,7 @@ final class ProfileLikedVideosState extends Equatable {
       likedEventIds: likedEventIds ?? this.likedEventIds,
       error: clearError ? null : (error ?? this.error),
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      isRefreshing: isRefreshing ?? this.isRefreshing,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
       nextPageOffset: nextPageOffset ?? this.nextPageOffset,
     );
@@ -111,6 +118,7 @@ final class ProfileLikedVideosState extends Equatable {
     likedEventIds,
     error,
     isLoadingMore,
+    isRefreshing,
     hasMoreContent,
     nextPageOffset,
   ];

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -3,13 +3,17 @@
 // ABOUTME: (cache-aware relay fetch with SQLite local storage)
 
 import 'dart:async';
+import 'dart:math';
 
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_sdk/aid.dart';
 import 'package:nostr_sdk/event_kind.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -47,8 +51,15 @@ class ProfileRepostedVideosBloc
        _currentUserPubkey = currentUserPubkey,
        _targetUserPubkey = targetUserPubkey,
        super(const ProfileRepostedVideosState()) {
-    on<ProfileRepostedVideosSyncRequested>(_onSyncRequested);
+    on<ProfileRepostedVideosSyncRequested>(
+      _onSyncRequested,
+      transformer: droppable(),
+    );
     on<ProfileRepostedVideosSubscriptionRequested>(_onSubscriptionRequested);
+    on<ProfileRepostedVideosReconcileRequested>(
+      _onReconcileRequested,
+      transformer: sequential(),
+    );
     on<ProfileRepostedVideosLoadMoreRequested>(_onLoadMoreRequested);
   }
 
@@ -65,395 +76,421 @@ class ProfileRepostedVideosBloc
   bool get _isOtherUserProfile =>
       _targetUserPubkey != null && _targetUserPubkey != _currentUserPubkey;
 
-  /// Handle sync request - syncs repost records from repository then loads
-  /// videos.
+  /// Cache key for this profile's reposted-videos snapshot.
   ///
-  /// For own profile: Uses "show cached first, refresh in background" pattern:
-  /// 1. Load cached IDs from local storage (instant)
-  /// 2. Fetch videos for cached IDs and show immediately
-  /// 3. Sync from relay in background, update if new reposts found
+  /// Follows the `${pubkey}:${operation}` convention (RFC #4244) so
+  /// `CacheSync.invalidatePrefix(currentPubkey)` at sign-out clears the
+  /// signed-out user's own-profile entry.
+  String get _cacheKey {
+    final pubkey = _targetUserPubkey ?? _currentUserPubkey;
+    return '$pubkey:profile_reposted_videos';
+  }
+
+  /// Handle sync request using stale-while-revalidate backed by [CacheSync].
   ///
-  /// For other profiles: Fetch from relay (no cache available).
+  /// On reopen the persisted snapshot is deserialized once and served
+  /// immediately; revalidation then only refreshes the reposted-ID list and
+  /// reconciles it against the shown videos (no bulk re-fetch / re-serialize).
   Future<void> _onSyncRequested(
     ProfileRepostedVideosSyncRequested event,
     Emitter<ProfileRepostedVideosState> emit,
   ) async {
-    // Don't re-sync if already syncing
-    if (state.status == ProfileRepostedVideosStatus.syncing) return;
-
-    Log.info(
-      'ProfileRepostedVideosBloc: Starting sync for '
-      '${_isOtherUserProfile ? "other user" : "own profile"}',
-      name: 'ProfileRepostedVideosBloc',
-      category: LogCategory.video,
-    );
-
-    // For other profiles, use the original flow (no cache available)
-    if (_isOtherUserProfile) {
-      await _syncOtherUserReposts(emit);
-      return;
+    if (state.videos.isNotEmpty && !state.isRefreshing) {
+      emit(state.copyWith(isRefreshing: true));
     }
 
-    // For own profile: show cached data first, then refresh in background
-    await _syncOwnProfileReposts(emit);
-  }
-
-  /// Sync reposts for other user's profile (no cache available).
-  Future<void> _syncOtherUserReposts(
-    Emitter<ProfileRepostedVideosState> emit,
-  ) async {
-    emit(state.copyWith(status: ProfileRepostedVideosStatus.syncing));
-
-    try {
-      final addressableIds = await _repostsRepository.fetchUserReposts(
-        _targetUserPubkey!,
-      );
-
-      Log.info(
-        'ProfileRepostedVideosBloc: Fetched ${addressableIds.length} repost '
-        'IDs for other user',
-        name: 'ProfileRepostedVideosBloc',
-        category: LogCategory.video,
-      );
-
-      if (addressableIds.isEmpty) {
-        emit(
-          state.copyWith(
-            status: ProfileRepostedVideosStatus.success,
-            videos: [],
-            repostedAddressableIds: [],
-            hasMoreContent: false,
-            clearError: true,
-          ),
-        );
-        return;
-      }
-
-      emit(
-        state.copyWith(
-          status: ProfileRepostedVideosStatus.loading,
-          repostedAddressableIds: addressableIds,
-        ),
-      );
-
-      final firstPageIds = addressableIds.take(_pageSize).toList();
-      final videos = await _fetchVideos(firstPageIds, cacheResults: true);
-
-      Log.info(
-        'ProfileRepostedVideosBloc: Loaded ${videos.length} videos '
-        '(first page of ${addressableIds.length} total)',
-        name: 'ProfileRepostedVideosBloc',
-        category: LogCategory.video,
-      );
-
+    final cached = await _readCachedSnapshot();
+    if (isClosed) return;
+    if (cached != null && cached.videos.isNotEmpty) {
       emit(
         state.copyWith(
           status: ProfileRepostedVideosStatus.success,
-          videos: videos,
-          hasMoreContent: addressableIds.length > _pageSize,
+          videos: cached.videos,
+          repostedAddressableIds: cached.itemIds,
+          nextPageOffset: cached.nextPageOffset,
+          hasMoreContent: cached.hasMoreContent,
+          isRefreshing: true,
           clearError: true,
         ),
       );
-    } on FetchRepostsFailedException catch (e) {
+    }
+
+    try {
+      if (state.videos.isEmpty) {
+        await _coldLoad(emit);
+      } else {
+        await _warmRevalidate(emit);
+      }
+    } catch (e, stackTrace) {
       Log.error(
-        'ProfileRepostedVideosBloc: Fetch reposts failed - ${e.message}',
+        'ProfileRepostedVideosBloc: Sync failed - $e',
         name: 'ProfileRepostedVideosBloc',
         category: LogCategory.video,
       );
+      addError(e, stackTrace);
+      if (isClosed) return;
+      if (state.videos.isNotEmpty) {
+        emit(state.copyWith(isRefreshing: false));
+        return;
+      }
       emit(
         state.copyWith(
           status: ProfileRepostedVideosStatus.failure,
-          error: ProfileRepostedVideosError.syncFailed,
-        ),
-      );
-    } catch (e) {
-      Log.error(
-        'ProfileRepostedVideosBloc: Failed to load videos - $e',
-        name: 'ProfileRepostedVideosBloc',
-        category: LogCategory.video,
-      );
-      emit(
-        state.copyWith(
-          status: ProfileRepostedVideosStatus.failure,
-          error: ProfileRepostedVideosError.loadFailed,
+          isRefreshing: false,
+          error: _errorFor(e),
         ),
       );
     }
   }
 
-  /// Sync reposts for own profile using "show cached first" pattern.
-  Future<void> _syncOwnProfileReposts(
+  /// Cold path: nothing cached. Resolve the reposted-ID list (own profile
+  /// prefers the instant local list, falling back to the relay) and fetch the
+  /// first page.
+  Future<void> _coldLoad(Emitter<ProfileRepostedVideosState> emit) async {
+    final List<String> addressableIds;
+    if (_isOtherUserProfile) {
+      addressableIds = await _repostsRepository.fetchUserReposts(
+        _targetUserPubkey!,
+      );
+    } else {
+      final localIds = await _repostsRepository
+          .getOrderedRepostedAddressableIds();
+      if (localIds.isNotEmpty) {
+        _scheduleBackgroundRelaySync();
+        addressableIds = localIds;
+      } else {
+        addressableIds =
+            (await _repostsRepository.syncUserReposts()).orderedAddressableIds;
+      }
+    }
+    if (isClosed) return;
+
+    if (addressableIds.isEmpty) {
+      emit(
+        state.copyWith(
+          status: ProfileRepostedVideosStatus.success,
+          videos: [],
+          repostedAddressableIds: [],
+          nextPageOffset: 0,
+          hasMoreContent: false,
+          isRefreshing: false,
+          clearError: true,
+        ),
+      );
+      await _persistSnapshot(_emptySnapshot);
+      return;
+    }
+
+    final firstPageIds = addressableIds.take(_pageSize).toList();
+    final videos = await _fetchVideos(firstPageIds, cacheResults: true);
+    if (isClosed) return;
+
+    final snapshot = ProfileVideoListSnapshot(
+      videos: videos,
+      itemIds: addressableIds,
+      nextPageOffset: firstPageIds.length,
+      hasMoreContent: addressableIds.length > firstPageIds.length,
+    );
+    emit(
+      state.copyWith(
+        status: ProfileRepostedVideosStatus.success,
+        videos: videos,
+        repostedAddressableIds: addressableIds,
+        nextPageOffset: snapshot.nextPageOffset,
+        hasMoreContent: snapshot.hasMoreContent,
+        isRefreshing: false,
+        clearError: true,
+      ),
+    );
+    await _persistSnapshot(snapshot);
+  }
+
+  /// Warm path: cached videos are already on screen. Refresh the reposted-ID
+  /// list against the relay and reconcile it against the shown videos.
+  Future<void> _warmRevalidate(
     Emitter<ProfileRepostedVideosState> emit,
   ) async {
-    try {
-      // Step 1: Get cached IDs from local storage (instant - no relay)
-      final cachedIds = await _repostsRepository
-          .getOrderedRepostedAddressableIds();
+    final List<String> freshIds;
+    if (_isOtherUserProfile) {
+      freshIds = await _repostsRepository.fetchUserReposts(_targetUserPubkey!);
+    } else {
+      freshIds =
+          (await _repostsRepository.syncUserReposts()).orderedAddressableIds;
+    }
+    if (isClosed) return;
 
-      Log.info(
-        'ProfileRepostedVideosBloc: Got ${cachedIds.length} cached repost IDs',
-        name: 'ProfileRepostedVideosBloc',
-        category: LogCategory.video,
-      );
+    if (listEquals(freshIds, state.repostedAddressableIds)) {
+      emit(state.copyWith(isRefreshing: false));
+      return;
+    }
 
-      // If we have cached data, load videos immediately
-      if (cachedIds.isNotEmpty) {
-        emit(
-          state.copyWith(
-            status: ProfileRepostedVideosStatus.loading,
-            repostedAddressableIds: cachedIds,
-          ),
+    final reconciled = await _reconcile(freshIds);
+    if (isClosed) return;
+    emit(
+      state.copyWith(
+        status: ProfileRepostedVideosStatus.success,
+        videos: reconciled.videos,
+        repostedAddressableIds: freshIds,
+        nextPageOffset: reconciled.nextPageOffset,
+        hasMoreContent: reconciled.hasMoreContent,
+        isRefreshing: false,
+        clearError: true,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoListSnapshot(
+        videos: reconciled.videos,
+        itemIds: freshIds,
+        nextPageOffset: reconciled.nextPageOffset,
+        hasMoreContent: reconciled.hasMoreContent,
+      ),
+    );
+  }
+
+  /// Reconciles displayed videos against a fresh [freshIds] list: keeps reposts
+  /// still present, drops the rest, and fetches only the newly-reposted IDs in
+  /// the loaded window. Bounded so it never bulk-fetches.
+  Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
+  _reconcile(List<String> freshIds) async {
+    final byId = <String, VideoEvent>{};
+    for (final video in state.videos) {
+      final id = _computeAddressableId(video);
+      if (id != null) byId[id] = video;
+    }
+    final addedCount = (freshIds.length - state.repostedAddressableIds.length)
+        .clamp(0, freshIds.length);
+    final windowSize =
+        (max(state.nextPageOffset, state.videos.length) + addedCount).clamp(
+          0,
+          freshIds.length,
         );
+    final windowIds = freshIds.take(windowSize).toList();
 
-        // Fetch videos for cached IDs
-        final firstPageIds = cachedIds.take(_pageSize).toList();
-        final videos = await _fetchVideos(firstPageIds, cacheResults: true);
-
-        Log.info(
-          'ProfileRepostedVideosBloc: Loaded ${videos.length} videos from '
-          'cache (first page of ${cachedIds.length} total)',
-          name: 'ProfileRepostedVideosBloc',
-          category: LogCategory.video,
-        );
-
-        emit(
-          state.copyWith(
-            status: ProfileRepostedVideosStatus.success,
-            videos: videos,
-            hasMoreContent: cachedIds.length > _pageSize,
-            clearError: true,
-          ),
-        );
-
-        // Step 2: Sync from relay in background (fire and forget)
-        // The subscription handler will update the list if new reposts are found
-        unawaited(
-          _repostsRepository
-              .syncUserReposts()
-              .then((_) {
-                Log.debug(
-                  'ProfileRepostedVideosBloc: Background relay sync completed',
-                  name: 'ProfileRepostedVideosBloc',
-                  category: LogCategory.video,
-                );
-              })
-              .catchError((e) {
-                Log.warning(
-                  'ProfileRepostedVideosBloc: Background sync failed - $e',
-                  name: 'ProfileRepostedVideosBloc',
-                  category: LogCategory.video,
-                );
-              }),
-        );
-      } else {
-        // No cached data - need to sync from relay (show loading state)
-        emit(state.copyWith(status: ProfileRepostedVideosStatus.syncing));
-
-        final syncResult = await _repostsRepository.syncUserReposts();
-        final addressableIds = syncResult.orderedAddressableIds;
-
-        Log.info(
-          'ProfileRepostedVideosBloc: Synced ${addressableIds.length} repost '
-          'IDs from relay (no cache)',
-          name: 'ProfileRepostedVideosBloc',
-          category: LogCategory.video,
-        );
-
-        if (addressableIds.isEmpty) {
-          emit(
-            state.copyWith(
-              status: ProfileRepostedVideosStatus.success,
-              videos: [],
-              repostedAddressableIds: [],
-              hasMoreContent: false,
-              clearError: true,
-            ),
-          );
-          return;
-        }
-
-        emit(
-          state.copyWith(
-            status: ProfileRepostedVideosStatus.loading,
-            repostedAddressableIds: addressableIds,
-          ),
-        );
-
-        final firstPageIds = addressableIds.take(_pageSize).toList();
-        final videos = await _fetchVideos(firstPageIds, cacheResults: true);
-
-        Log.info(
-          'ProfileRepostedVideosBloc: Loaded ${videos.length} videos '
-          '(first page of ${addressableIds.length} total)',
-          name: 'ProfileRepostedVideosBloc',
-          category: LogCategory.video,
-        );
-
-        emit(
-          state.copyWith(
-            status: ProfileRepostedVideosStatus.success,
-            videos: videos,
-            hasMoreContent: addressableIds.length > _pageSize,
-            clearError: true,
-          ),
-        );
+    final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
+    if (missingIds.isNotEmpty) {
+      for (final video in await _fetchVideos(missingIds, cacheResults: true)) {
+        final id = _computeAddressableId(video);
+        if (id != null) byId[id] = video;
       }
-    } on SyncFailedException catch (e) {
-      Log.error(
-        'ProfileRepostedVideosBloc: Sync failed - ${e.message}',
+    }
+
+    final videos = windowIds
+        .map((id) => byId[id])
+        .whereType<VideoEvent>()
+        .toList();
+    return (
+      videos: videos,
+      nextPageOffset: windowIds.length,
+      hasMoreContent: windowIds.length < freshIds.length,
+    );
+  }
+
+  static const ProfileVideoListSnapshot _emptySnapshot =
+      ProfileVideoListSnapshot(
+        videos: [],
+        itemIds: [],
+        nextPageOffset: 0,
+        hasMoreContent: false,
+      );
+
+  /// Reads and deserializes the persisted snapshot once; `null` on miss or
+  /// failure (cache problems must never break the load).
+  Future<ProfileVideoListSnapshot?> _readCachedSnapshot() async {
+    try {
+      return await CacheSync.read<ProfileVideoListSnapshot>(
+        key: _cacheKey,
+        fromJson: ProfileVideoListSnapshot.fromJson,
+      );
+    } on Object catch (e) {
+      Log.warning(
+        'ProfileRepostedVideosBloc: Failed to read cached snapshot - $e',
         name: 'ProfileRepostedVideosBloc',
         category: LogCategory.video,
       );
-      emit(
-        state.copyWith(
-          status: ProfileRepostedVideosStatus.failure,
-          error: ProfileRepostedVideosError.syncFailed,
-        ),
+      return null;
+    }
+  }
+
+  /// Persists [snapshot] under [_cacheKey] so reopening restores it.
+  Future<void> _persistSnapshot(ProfileVideoListSnapshot snapshot) async {
+    try {
+      await CacheSync.write<ProfileVideoListSnapshot>(
+        key: _cacheKey,
+        value: snapshot,
+        toJson: (s) => s.toJson(),
       );
-    } catch (e) {
-      Log.error(
-        'ProfileRepostedVideosBloc: Failed to load videos - $e',
+    } on Object catch (e) {
+      Log.warning(
+        'ProfileRepostedVideosBloc: Failed to persist snapshot - $e',
         name: 'ProfileRepostedVideosBloc',
         category: LogCategory.video,
-      );
-      emit(
-        state.copyWith(
-          status: ProfileRepostedVideosStatus.failure,
-          error: ProfileRepostedVideosError.loadFailed,
-        ),
       );
     }
   }
 
-  /// Subscribe to reposted IDs changes and update the video list reactively.
+  /// Fire-and-forget relay sync that keeps the in-memory reposted list fresh
+  /// for the live subscription after serving an instant local snapshot.
+  void _scheduleBackgroundRelaySync() {
+    unawaited(
+      _repostsRepository
+          .syncUserReposts()
+          .then((_) {
+            Log.debug(
+              'ProfileRepostedVideosBloc: Background relay sync completed',
+              name: 'ProfileRepostedVideosBloc',
+              category: LogCategory.video,
+            );
+          })
+          .catchError((Object e) {
+            Log.warning(
+              'ProfileRepostedVideosBloc: Background sync failed - $e',
+              name: 'ProfileRepostedVideosBloc',
+              category: LogCategory.video,
+            );
+          }),
+    );
+  }
+
+  ProfileRepostedVideosError _errorFor(Object error) =>
+      error is SyncFailedException || error is FetchRepostsFailedException
+      ? ProfileRepostedVideosError.syncFailed
+      : ProfileRepostedVideosError.loadFailed;
+
+  /// Subscribe to reposted IDs changes and reconcile the video list reactively.
   ///
-  /// Uses emit.forEach to listen to the repository stream and emit state
-  /// changes when reposted IDs change (videos added or removed).
-  ///
-  /// Note: This only works for the current user's own profile, as the
-  /// RepostsRepository only tracks the authenticated user's reposts.
-  /// For other users' profiles, this subscription has no effect.
+  /// Dispatches [ProfileRepostedVideosReconcileRequested] on change so the
+  /// async handler can fetch a newly-reposted clip — `emit.forEach`'s callback
+  /// is synchronous and cannot await. Own profile only.
   Future<void> _onSubscriptionRequested(
     ProfileRepostedVideosSubscriptionRequested event,
     Emitter<ProfileRepostedVideosState> emit,
   ) async {
-    // Only subscribe for own profile - the repository only tracks current
-    // user's reposts, so watching it for other users would show wrong data.
     if (_isOtherUserProfile) return;
 
     await emit.forEach<Set<String>>(
       _repostsRepository.watchRepostedAddressableIds(),
       onData: (repostedIdsSet) {
         final newIds = repostedIdsSet.toList();
-
-        // Skip if IDs haven't changed
-        if (listEquals(newIds, state.repostedAddressableIds)) return state;
-
-        // Skip if we haven't done initial sync yet
-        if (state.status == ProfileRepostedVideosStatus.initial ||
+        if (listEquals(newIds, state.repostedAddressableIds) ||
+            state.status == ProfileRepostedVideosStatus.initial ||
             state.status == ProfileRepostedVideosStatus.syncing) {
           return state;
         }
-
         Log.info(
-          'ProfileRepostedVideosBloc: Reposted IDs changed, updating list',
+          'ProfileRepostedVideosBloc: Reposted IDs changed, reconciling list',
           name: 'ProfileRepostedVideosBloc',
           category: LogCategory.video,
         );
-
-        // If a video was unreposted, remove it from the list immediately
-        if (newIds.length < state.repostedAddressableIds.length) {
-          final removedIds = state.repostedAddressableIds
-              .where((id) => !newIds.contains(id))
-              .toSet();
-          final updatedVideos = state.videos
-              .where((v) => !removedIds.contains(_computeAddressableId(v)))
-              .toList();
-
-          return state.copyWith(
-            repostedAddressableIds: newIds,
-            videos: updatedVideos,
-          );
-        }
-
-        // If a video was reposted, we need to fetch it asynchronously.
-        // For now, just update the IDs - the video will be fetched on next
-        // sync.
-        if (newIds.length > state.repostedAddressableIds.length) {
-          return state.copyWith(repostedAddressableIds: newIds);
-        }
-
+        add(ProfileRepostedVideosReconcileRequested(newIds));
         return state;
       },
     );
   }
 
-  /// Handle load more request - fetches the next page of videos.
-  ///
-  /// Uses [state.videos.length] to determine the offset and fetches
-  /// the next [_pageSize] videos from [state.repostedAddressableIds].
+  /// Reconcile the displayed videos against a fresh reposted-ID list.
+  Future<void> _onReconcileRequested(
+    ProfileRepostedVideosReconcileRequested event,
+    Emitter<ProfileRepostedVideosState> emit,
+  ) async {
+    final freshIds = event.addressableIds;
+    if (listEquals(freshIds, state.repostedAddressableIds)) return;
+
+    try {
+      final reconciled = await _reconcile(freshIds);
+      if (isClosed) return;
+      emit(
+        state.copyWith(
+          status: ProfileRepostedVideosStatus.success,
+          videos: reconciled.videos,
+          repostedAddressableIds: freshIds,
+          nextPageOffset: reconciled.nextPageOffset,
+          hasMoreContent: reconciled.hasMoreContent,
+          clearError: true,
+        ),
+      );
+      await _persistSnapshot(
+        ProfileVideoListSnapshot(
+          videos: reconciled.videos,
+          itemIds: freshIds,
+          nextPageOffset: reconciled.nextPageOffset,
+          hasMoreContent: reconciled.hasMoreContent,
+        ),
+      );
+    } catch (e, stackTrace) {
+      Log.error(
+        'ProfileRepostedVideosBloc: Failed to reconcile reposts - $e',
+        name: 'ProfileRepostedVideosBloc',
+        category: LogCategory.video,
+      );
+      addError(e, stackTrace);
+    }
+  }
+
+  /// Handle load more request - fetches the next page of videos and grows the
+  /// persisted snapshot so reopening restores the full scrolled list.
   Future<void> _onLoadMoreRequested(
     ProfileRepostedVideosLoadMoreRequested event,
     Emitter<ProfileRepostedVideosState> emit,
   ) async {
-    // Skip if not in success state, already loading, or no more content
     if (state.status != ProfileRepostedVideosStatus.success ||
         state.isLoadingMore ||
         !state.hasMoreContent) {
       return;
     }
 
-    final currentCount = state.videos.length;
+    final offset = state.nextPageOffset;
     final totalCount = state.repostedAddressableIds.length;
 
-    // No more to load
-    if (currentCount >= totalCount) {
+    if (offset >= totalCount) {
       emit(state.copyWith(hasMoreContent: false));
       return;
     }
 
-    Log.info(
-      'ProfileRepostedVideosBloc: Loading more videos '
-      '(current: $currentCount, total: $totalCount)',
-      name: 'ProfileRepostedVideosBloc',
-      category: LogCategory.video,
-    );
-
     emit(state.copyWith(isLoadingMore: true));
 
     try {
-      // Get the next page of addressable IDs
       final nextPageIds = state.repostedAddressableIds
-          .skip(currentCount)
+          .skip(offset)
           .take(_pageSize)
           .toList();
+      final newVideos = await _fetchVideos(nextPageIds, cacheResults: true);
 
-      // Fetch videos for the next page
-      final newVideos = await _fetchVideos(nextPageIds);
+      final existingIds = state.videos
+          .map(_computeAddressableId)
+          .whereType<String>()
+          .toSet();
+      final uniqueNewVideos = newVideos.where((v) {
+        final id = _computeAddressableId(v);
+        return id == null || !existingIds.contains(id);
+      }).toList();
 
-      Log.info(
-        'ProfileRepostedVideosBloc: Loaded ${newVideos.length} more videos',
-        name: 'ProfileRepostedVideosBloc',
-        category: LogCategory.video,
-      );
-
-      // Append to existing videos
-      final allVideos = [...state.videos, ...newVideos];
-      final hasMore = allVideos.length < totalCount;
+      final newOffset = offset + nextPageIds.length;
+      final allVideos = [...state.videos, ...uniqueNewVideos];
+      final hasMore = newOffset < totalCount;
 
       emit(
         state.copyWith(
           videos: allVideos,
           isLoadingMore: false,
           hasMoreContent: hasMore,
+          nextPageOffset: newOffset,
         ),
       );
-    } catch (e) {
+      await _persistSnapshot(
+        ProfileVideoListSnapshot(
+          videos: allVideos,
+          itemIds: state.repostedAddressableIds,
+          nextPageOffset: newOffset,
+          hasMoreContent: hasMore,
+        ),
+      );
+    } catch (e, stackTrace) {
       Log.error(
         'ProfileRepostedVideosBloc: Failed to load more videos - $e',
         name: 'ProfileRepostedVideosBloc',
         category: LogCategory.video,
       );
+      addError(e, stackTrace);
       emit(state.copyWith(isLoadingMore: false));
     }
   }

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart
@@ -257,10 +257,12 @@ class ProfileRepostedVideosBloc
       final id = _computeAddressableId(video);
       if (id != null) byId[id] = video;
     }
-    final addedCount = (freshIds.length - state.repostedAddressableIds.length)
-        .clamp(0, freshIds.length);
+    // Anchor on the previous top ID rather than a length delta, so a capped
+    // persisted ID list can't balloon the reconcile window into a full
+    // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
+    final newAtTop = _newItemsAtTop(freshIds);
     final windowSize =
-        (max(state.nextPageOffset, state.videos.length) + addedCount).clamp(
+        (max(state.nextPageOffset, state.videos.length) + newAtTop).clamp(
           0,
           freshIds.length,
         );
@@ -283,6 +285,16 @@ class ProfileRepostedVideosBloc
       nextPageOffset: windowIds.length,
       hasMoreContent: windowIds.length < freshIds.length,
     );
+  }
+
+  /// Number of fresh IDs prepended above the previous top item, located by
+  /// finding the old top ID in [freshIds]. Returns 0 when there is no prior
+  /// list or the old top is gone, so a capped persisted list can never
+  /// balloon the reconcile window into a full re-fetch.
+  int _newItemsAtTop(List<String> freshIds) {
+    if (state.repostedAddressableIds.isEmpty) return 0;
+    final index = freshIds.indexOf(state.repostedAddressableIds.first);
+    return index < 0 ? 0 : index;
   }
 
   static const ProfileVideoListSnapshot _emptySnapshot =
@@ -316,7 +328,12 @@ class ProfileRepostedVideosBloc
     try {
       await CacheSync.write<ProfileVideoListSnapshot>(
         key: _cacheKey,
-        value: snapshot,
+        value: ProfileVideoListSnapshot.capped(
+          videos: snapshot.videos,
+          itemIds: snapshot.itemIds,
+          nextPageOffset: snapshot.nextPageOffset,
+          hasMoreContent: snapshot.hasMoreContent,
+        ),
         toJson: (s) => s.toJson(),
       );
     } on Object catch (e) {

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_event.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_event.dart
@@ -35,3 +35,17 @@ final class ProfileRepostedVideosLoadMoreRequested
     extends ProfileRepostedVideosEvent {
   const ProfileRepostedVideosLoadMoreRequested();
 }
+
+/// Internal: reconcile the displayed videos against a fresh reposted-ID list.
+///
+/// Dispatched from the [RepostsRepository.watchRepostedAddressableIds]
+/// subscription when the repost set changes. Drops unreposted videos and
+/// fetches any newly-reposted IDs in the loaded window so they appear without
+/// re-resolving the whole window.
+final class ProfileRepostedVideosReconcileRequested
+    extends ProfileRepostedVideosEvent {
+  const ProfileRepostedVideosReconcileRequested(this.addressableIds);
+
+  /// The fresh, ordered (most-recent-first) reposted addressable IDs.
+  final List<String> addressableIds;
+}

--- a/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_state.dart
+++ b/mobile/lib/blocs/profile_reposted_videos/profile_reposted_videos_state.dart
@@ -46,7 +46,9 @@ final class ProfileRepostedVideosState extends Equatable {
     this.repostedAddressableIds = const [],
     this.error,
     this.isLoadingMore = false,
+    this.isRefreshing = false,
     this.hasMoreContent = true,
+    this.nextPageOffset = 0,
   });
 
   /// The current loading status
@@ -65,8 +67,15 @@ final class ProfileRepostedVideosState extends Equatable {
   /// Whether more videos are being loaded (pagination)
   final bool isLoadingMore;
 
+  /// Whether a background revalidation is in progress while cached content is
+  /// already on screen. Drives the sticky progress bar in the tab bar.
+  final bool isRefreshing;
+
   /// Whether there are more videos to load
   final bool hasMoreContent;
+
+  /// Offset into [repostedAddressableIds] for the next page fetch.
+  final int nextPageOffset;
 
   /// Whether data has been successfully loaded
   bool get isLoaded => status == ProfileRepostedVideosStatus.success;
@@ -84,7 +93,9 @@ final class ProfileRepostedVideosState extends Equatable {
     ProfileRepostedVideosError? error,
     bool clearError = false,
     bool? isLoadingMore,
+    bool? isRefreshing,
     bool? hasMoreContent,
+    int? nextPageOffset,
   }) {
     return ProfileRepostedVideosState(
       status: status ?? this.status,
@@ -93,7 +104,9 @@ final class ProfileRepostedVideosState extends Equatable {
           repostedAddressableIds ?? this.repostedAddressableIds,
       error: clearError ? null : (error ?? this.error),
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      isRefreshing: isRefreshing ?? this.isRefreshing,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
+      nextPageOffset: nextPageOffset ?? this.nextPageOffset,
     );
   }
 
@@ -104,6 +117,8 @@ final class ProfileRepostedVideosState extends Equatable {
     repostedAddressableIds,
     error,
     isLoadingMore,
+    isRefreshing,
     hasMoreContent,
+    nextPageOffset,
   ];
 }

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -3,10 +3,15 @@
 // ABOUTME: (cache-aware relay fetch with SQLite local storage). Own profile only.
 
 import 'dart:async';
+import 'dart:math';
 
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:equatable/equatable.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/bookmark_service.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -33,10 +38,15 @@ class ProfileSavedVideosBloc
   ProfileSavedVideosBloc({
     required Future<BookmarkService> bookmarkService,
     required VideosRepository videosRepository,
+    required String currentUserPubkey,
   }) : _bookmarkServiceFuture = bookmarkService,
        _videosRepository = videosRepository,
+       _currentUserPubkey = currentUserPubkey,
        super(const ProfileSavedVideosState()) {
-    on<ProfileSavedVideosSyncRequested>(_onSyncRequested);
+    on<ProfileSavedVideosSyncRequested>(
+      _onSyncRequested,
+      transformer: droppable(),
+    );
     on<ProfileSavedVideosLoadMoreRequested>(_onLoadMoreRequested);
   }
 
@@ -45,76 +55,50 @@ class ProfileSavedVideosBloc
   /// build time.
   final Future<BookmarkService> _bookmarkServiceFuture;
   final VideosRepository _videosRepository;
+  final String _currentUserPubkey;
 
-  /// Handle sync request — loads bookmark IDs from [BookmarkService] (which
-  /// already keeps a SharedPreferences-cached list populated on startup and
-  /// reconciles with the relay on initialize) and fetches the first page of
-  /// videos through [VideosRepository].
+  /// Cache key for the saved-videos snapshot (bookmarks are private, so the
+  /// key is scoped to the signed-in user for sign-out invalidation).
+  String get _cacheKey => '$_currentUserPubkey:profile_saved_videos';
+
+  /// Handle sync request using stale-while-revalidate backed by [CacheSync].
+  ///
+  /// On reopen the persisted snapshot is served immediately; revalidation then
+  /// re-reads the (in-memory, SharedPreferences-cached) bookmark list and only
+  /// reconciles it against the shown videos — no bulk re-fetch / re-serialize.
   Future<void> _onSyncRequested(
     ProfileSavedVideosSyncRequested event,
     Emitter<ProfileSavedVideosState> emit,
   ) async {
-    if (state.status == ProfileSavedVideosStatus.syncing) return;
+    if (state.videos.isNotEmpty && !state.isRefreshing) {
+      emit(state.copyWith(isRefreshing: true));
+    }
 
-    emit(state.copyWith(status: ProfileSavedVideosStatus.syncing));
-
-    try {
-      final bookmarkService = await _bookmarkServiceFuture;
-
-      // BookmarkService.globalBookmarks is a List<BookmarkItem>; keep only
-      // event-type entries (type 'e') — hashtag/url/article bookmarks are
-      // not videos.
-      final savedEventIds = bookmarkService.globalBookmarks
-          .where((item) => item.type == 'e')
-          .map((item) => item.id)
-          .toList();
-
-      Log.info(
-        'ProfileSavedVideosBloc: Got ${savedEventIds.length} saved event IDs',
-        name: 'ProfileSavedVideosBloc',
-        category: LogCategory.video,
-      );
-
-      if (savedEventIds.isEmpty) {
-        emit(
-          state.copyWith(
-            status: ProfileSavedVideosStatus.success,
-            videos: [],
-            savedEventIds: [],
-            hasMoreContent: false,
-            nextPageOffset: 0,
-            clearError: true,
-          ),
-        );
-        return;
-      }
-
-      emit(
-        state.copyWith(
-          status: ProfileSavedVideosStatus.loading,
-          savedEventIds: savedEventIds,
-        ),
-      );
-
-      final firstPageIds = savedEventIds.take(_pageSize).toList();
-      final videos = await _fetchVideos(firstPageIds, cacheResults: true);
-
-      Log.info(
-        'ProfileSavedVideosBloc: Loaded ${videos.length} videos '
-        '(first page of ${savedEventIds.length} total)',
-        name: 'ProfileSavedVideosBloc',
-        category: LogCategory.video,
-      );
-
+    final cached = await _readCachedSnapshot();
+    if (isClosed) return;
+    if (cached != null && cached.videos.isNotEmpty) {
       emit(
         state.copyWith(
           status: ProfileSavedVideosStatus.success,
-          videos: videos,
-          hasMoreContent: savedEventIds.length > firstPageIds.length,
-          nextPageOffset: firstPageIds.length,
+          videos: cached.videos,
+          savedEventIds: cached.itemIds,
+          nextPageOffset: cached.nextPageOffset,
+          hasMoreContent: cached.hasMoreContent,
+          isRefreshing: true,
           clearError: true,
         ),
       );
+    }
+
+    try {
+      final freshIds = await _resolveSavedIds();
+      if (isClosed) return;
+
+      if (state.videos.isEmpty) {
+        await _coldLoad(freshIds, emit);
+      } else {
+        await _warmRevalidate(freshIds, emit);
+      }
     } catch (e, stackTrace) {
       Log.error(
         'ProfileSavedVideosBloc: Failed to load saved videos - $e',
@@ -122,11 +106,182 @@ class ProfileSavedVideosBloc
         category: LogCategory.video,
       );
       addError(e, stackTrace);
+      if (isClosed) return;
+      if (state.videos.isNotEmpty) {
+        emit(state.copyWith(isRefreshing: false));
+        return;
+      }
       emit(
         state.copyWith(
           status: ProfileSavedVideosStatus.failure,
+          isRefreshing: false,
           error: ProfileSavedVideosError.loadFailed,
         ),
+      );
+    }
+  }
+
+  /// Reads the event-type bookmark IDs from [BookmarkService]. The service
+  /// keeps a SharedPreferences-cached list and reconciles with the relay on
+  /// initialize, so this read is cheap (no relay round-trip).
+  Future<List<String>> _resolveSavedIds() async {
+    final bookmarkService = await _bookmarkServiceFuture;
+    return bookmarkService.globalBookmarks
+        .where((item) => item.type == 'e')
+        .map((item) => item.id)
+        .toList();
+  }
+
+  /// Cold path: nothing cached. Fetch the first page for [savedEventIds].
+  Future<void> _coldLoad(
+    List<String> savedEventIds,
+    Emitter<ProfileSavedVideosState> emit,
+  ) async {
+    if (savedEventIds.isEmpty) {
+      emit(
+        state.copyWith(
+          status: ProfileSavedVideosStatus.success,
+          videos: [],
+          savedEventIds: [],
+          nextPageOffset: 0,
+          hasMoreContent: false,
+          isRefreshing: false,
+          clearError: true,
+        ),
+      );
+      await _persistSnapshot(_emptySnapshot);
+      return;
+    }
+
+    final firstPageIds = savedEventIds.take(_pageSize).toList();
+    final videos = await _fetchVideos(firstPageIds, cacheResults: true);
+    if (isClosed) return;
+
+    final snapshot = ProfileVideoListSnapshot(
+      videos: videos,
+      itemIds: savedEventIds,
+      nextPageOffset: firstPageIds.length,
+      hasMoreContent: savedEventIds.length > firstPageIds.length,
+    );
+    emit(
+      state.copyWith(
+        status: ProfileSavedVideosStatus.success,
+        videos: videos,
+        savedEventIds: savedEventIds,
+        nextPageOffset: snapshot.nextPageOffset,
+        hasMoreContent: snapshot.hasMoreContent,
+        isRefreshing: false,
+        clearError: true,
+      ),
+    );
+    await _persistSnapshot(snapshot);
+  }
+
+  /// Warm path: cached videos are already on screen. Reconcile against the
+  /// fresh bookmark list (drop unsaved, fetch newly-saved in the window).
+  Future<void> _warmRevalidate(
+    List<String> freshIds,
+    Emitter<ProfileSavedVideosState> emit,
+  ) async {
+    if (listEquals(freshIds, state.savedEventIds)) {
+      emit(state.copyWith(isRefreshing: false));
+      return;
+    }
+
+    final reconciled = await _reconcile(freshIds);
+    if (isClosed) return;
+    emit(
+      state.copyWith(
+        status: ProfileSavedVideosStatus.success,
+        videos: reconciled.videos,
+        savedEventIds: freshIds,
+        nextPageOffset: reconciled.nextPageOffset,
+        hasMoreContent: reconciled.hasMoreContent,
+        isRefreshing: false,
+        clearError: true,
+      ),
+    );
+    await _persistSnapshot(
+      ProfileVideoListSnapshot(
+        videos: reconciled.videos,
+        itemIds: freshIds,
+        nextPageOffset: reconciled.nextPageOffset,
+        hasMoreContent: reconciled.hasMoreContent,
+      ),
+    );
+  }
+
+  /// Reconciles displayed videos against a fresh [freshIds] list: keeps saved
+  /// videos still present, drops the rest, and fetches only the newly-saved
+  /// IDs in the loaded window. Bounded so it never bulk-fetches.
+  Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
+  _reconcile(List<String> freshIds) async {
+    final byId = {for (final video in state.videos) video.id: video};
+    final addedCount = (freshIds.length - state.savedEventIds.length).clamp(
+      0,
+      freshIds.length,
+    );
+    final windowSize =
+        (max(state.nextPageOffset, state.videos.length) + addedCount).clamp(
+          0,
+          freshIds.length,
+        );
+    final windowIds = freshIds.take(windowSize).toList();
+
+    final missingIds = windowIds.where((id) => !byId.containsKey(id)).toList();
+    if (missingIds.isNotEmpty) {
+      for (final video in await _fetchVideos(missingIds, cacheResults: true)) {
+        byId[video.id] = video;
+      }
+    }
+
+    final videos = windowIds
+        .map((id) => byId[id])
+        .whereType<VideoEvent>()
+        .toList();
+    return (
+      videos: videos,
+      nextPageOffset: windowIds.length,
+      hasMoreContent: windowIds.length < freshIds.length,
+    );
+  }
+
+  static const ProfileVideoListSnapshot _emptySnapshot =
+      ProfileVideoListSnapshot(
+        videos: [],
+        itemIds: [],
+        nextPageOffset: 0,
+        hasMoreContent: false,
+      );
+
+  Future<ProfileVideoListSnapshot?> _readCachedSnapshot() async {
+    try {
+      return await CacheSync.read<ProfileVideoListSnapshot>(
+        key: _cacheKey,
+        fromJson: ProfileVideoListSnapshot.fromJson,
+      );
+    } on Object catch (e) {
+      Log.warning(
+        'ProfileSavedVideosBloc: Failed to read cached snapshot - $e',
+        name: 'ProfileSavedVideosBloc',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+  }
+
+  Future<void> _persistSnapshot(ProfileVideoListSnapshot snapshot) async {
+    try {
+      await CacheSync.write<ProfileVideoListSnapshot>(
+        key: _cacheKey,
+        value: snapshot,
+        toJson: (s) => s.toJson(),
+      );
+    } on Object catch (e) {
+      Log.warning(
+        'ProfileSavedVideosBloc: Failed to persist snapshot - $e',
+        name: 'ProfileSavedVideosBloc',
+        category: LogCategory.video,
       );
     }
   }
@@ -170,7 +325,7 @@ class ProfileSavedVideosBloc
           .skip(offset)
           .take(_pageSize)
           .toList();
-      final newVideos = await _fetchVideos(nextPageIds);
+      final newVideos = await _fetchVideos(nextPageIds, cacheResults: true);
 
       Log.info(
         'ProfileSavedVideosBloc: Loaded ${newVideos.length} more videos',
@@ -193,6 +348,14 @@ class ProfileSavedVideosBloc
           isLoadingMore: false,
           hasMoreContent: hasMore,
           nextPageOffset: newOffset,
+        ),
+      );
+      await _persistSnapshot(
+        ProfileVideoListSnapshot(
+          videos: allVideos,
+          itemIds: state.savedEventIds,
+          nextPageOffset: newOffset,
+          hasMoreContent: hasMore,
         ),
       );
     } catch (e, stackTrace) {

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_bloc.dart
@@ -217,12 +217,12 @@ class ProfileSavedVideosBloc
   Future<({List<VideoEvent> videos, int nextPageOffset, bool hasMoreContent})>
   _reconcile(List<String> freshIds) async {
     final byId = {for (final video in state.videos) video.id: video};
-    final addedCount = (freshIds.length - state.savedEventIds.length).clamp(
-      0,
-      freshIds.length,
-    );
+    // Anchor on the previous top ID rather than a length delta, so a capped
+    // persisted ID list can't balloon the reconcile window into a full
+    // re-fetch on reopen (see ProfileLikedVideosBloc for the rationale).
+    final newAtTop = _newItemsAtTop(freshIds);
     final windowSize =
-        (max(state.nextPageOffset, state.videos.length) + addedCount).clamp(
+        (max(state.nextPageOffset, state.videos.length) + newAtTop).clamp(
           0,
           freshIds.length,
         );
@@ -244,6 +244,16 @@ class ProfileSavedVideosBloc
       nextPageOffset: windowIds.length,
       hasMoreContent: windowIds.length < freshIds.length,
     );
+  }
+
+  /// Number of fresh IDs prepended above the previous top item, located by
+  /// finding the old top ID in [freshIds]. Returns 0 when there is no prior
+  /// list or the old top is gone, so a capped persisted list can never
+  /// balloon the reconcile window into a full re-fetch.
+  int _newItemsAtTop(List<String> freshIds) {
+    if (state.savedEventIds.isEmpty) return 0;
+    final index = freshIds.indexOf(state.savedEventIds.first);
+    return index < 0 ? 0 : index;
   }
 
   static const ProfileVideoListSnapshot _emptySnapshot =
@@ -274,7 +284,12 @@ class ProfileSavedVideosBloc
     try {
       await CacheSync.write<ProfileVideoListSnapshot>(
         key: _cacheKey,
-        value: snapshot,
+        value: ProfileVideoListSnapshot.capped(
+          videos: snapshot.videos,
+          itemIds: snapshot.itemIds,
+          nextPageOffset: snapshot.nextPageOffset,
+          hasMoreContent: snapshot.hasMoreContent,
+        ),
         toJson: (s) => s.toJson(),
       );
     } on Object catch (e) {

--- a/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_state.dart
+++ b/mobile/lib/blocs/profile_saved_videos/profile_saved_videos_state.dart
@@ -35,6 +35,7 @@ final class ProfileSavedVideosState extends Equatable {
     this.savedEventIds = const [],
     this.error,
     this.isLoadingMore = false,
+    this.isRefreshing = false,
     this.hasMoreContent = true,
     this.nextPageOffset = 0,
   });
@@ -54,6 +55,10 @@ final class ProfileSavedVideosState extends Equatable {
 
   /// Whether more videos are being loaded (pagination).
   final bool isLoadingMore;
+
+  /// Whether a background revalidation is in progress while cached content is
+  /// already on screen. Drives the sticky progress bar in the tab bar.
+  final bool isRefreshing;
 
   /// Whether there are more videos to load.
   final bool hasMoreContent;
@@ -79,6 +84,7 @@ final class ProfileSavedVideosState extends Equatable {
     ProfileSavedVideosError? error,
     bool clearError = false,
     bool? isLoadingMore,
+    bool? isRefreshing,
     bool? hasMoreContent,
     int? nextPageOffset,
   }) {
@@ -88,6 +94,7 @@ final class ProfileSavedVideosState extends Equatable {
       savedEventIds: savedEventIds ?? this.savedEventIds,
       error: clearError ? null : (error ?? this.error),
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      isRefreshing: isRefreshing ?? this.isRefreshing,
       hasMoreContent: hasMoreContent ?? this.hasMoreContent,
       nextPageOffset: nextPageOffset ?? this.nextPageOffset,
     );
@@ -100,6 +107,7 @@ final class ProfileSavedVideosState extends Equatable {
     savedEventIds,
     error,
     isLoadingMore,
+    isRefreshing,
     hasMoreContent,
     nextPageOffset,
   ];

--- a/mobile/lib/blocs/profile_shared/profile_snapshot_window.dart
+++ b/mobile/lib/blocs/profile_shared/profile_snapshot_window.dart
@@ -1,0 +1,18 @@
+// ABOUTME: Persistence-window policy shared by profile video tab snapshots.
+// ABOUTME: Bounds cache size and (de)serialization cost on reopen.
+
+/// Persistence policy for profile video tab snapshots.
+abstract class ProfileSnapshotWindow {
+  /// Maximum number of items (videos and IDs) persisted in a snapshot.
+  ///
+  /// The live in-memory list is **uncapped** — this only bounds what is
+  /// written to / read from `CacheSync`, so a user with tens of thousands of
+  /// liked/reposted/saved items doesn't serialize a multi-megabyte blob on
+  /// every page load and doesn't jank the UI thread decoding it on reopen.
+  ///
+  /// ~11 screens of a 3-column grid, which comfortably covers an instant
+  /// restore. Pagination past this window re-resolves the full ID list via
+  /// the background revalidation that runs on every reopen, so nothing is
+  /// lost — the rest is simply fetched as the user scrolls.
+  static const int maxItems = 200;
+}

--- a/mobile/lib/blocs/profile_shared/profile_video_cursor_snapshot.dart
+++ b/mobile/lib/blocs/profile_shared/profile_video_cursor_snapshot.dart
@@ -1,0 +1,49 @@
+// ABOUTME: Shared CacheSync payload for cursor-paginated profile video tabs.
+// ABOUTME: Captures the loaded videos + relay cursor so a server-feed tab
+// ABOUTME: (Collabs, …) renders instantly on reopen.
+
+import 'dart:convert';
+
+import 'package:models/models.dart';
+
+/// A point-in-time snapshot of a cursor-paginated profile video tab.
+///
+/// Unlike [ProfileVideoListSnapshot] there is no client-side ID list — the
+/// feed is ordered and paginated by the server via [paginationCursor] (a Unix
+/// timestamp used as the relay `until` bound).
+class ProfileVideoCursorSnapshot {
+  const ProfileVideoCursorSnapshot({
+    required this.videos,
+    required this.paginationCursor,
+    required this.hasMoreContent,
+  });
+
+  /// Deserializes from a JSON string produced by [toJson].
+  factory ProfileVideoCursorSnapshot.fromJson(String json) {
+    final data = jsonDecode(json) as Map<String, dynamic>;
+    final videos = (data['videos'] as List<dynamic>? ?? const [])
+        .map((e) => VideoEvent.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return ProfileVideoCursorSnapshot(
+      videos: videos,
+      paginationCursor: data['paginationCursor'] as int?,
+      hasMoreContent: data['hasMoreContent'] as bool? ?? false,
+    );
+  }
+
+  /// The loaded videos, in feed order.
+  final List<VideoEvent> videos;
+
+  /// Unix timestamp cursor for the next `until` page, or `null` at the end.
+  final int? paginationCursor;
+
+  /// Whether more videos remain beyond the loaded set.
+  final bool hasMoreContent;
+
+  /// Serializes to a JSON string for cache storage.
+  String toJson() => jsonEncode({
+    'videos': videos.map((v) => v.toJson()).toList(),
+    'paginationCursor': paginationCursor,
+    'hasMoreContent': hasMoreContent,
+  });
+}

--- a/mobile/lib/blocs/profile_shared/profile_video_cursor_snapshot.dart
+++ b/mobile/lib/blocs/profile_shared/profile_video_cursor_snapshot.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_shared/profile_snapshot_window.dart';
 
 /// A point-in-time snapshot of a cursor-paginated profile video tab.
 ///
@@ -28,6 +29,33 @@ class ProfileVideoCursorSnapshot {
       videos: videos,
       paginationCursor: data['paginationCursor'] as int?,
       hasMoreContent: data['hasMoreContent'] as bool? ?? false,
+    );
+  }
+
+  /// Builds a snapshot capped to [ProfileSnapshotWindow.maxItems].
+  ///
+  /// Keeps the head of the feed and re-anchors [paginationCursor] to the last
+  /// kept video's timestamp so a load-more after reopen continues right after
+  /// the persisted window rather than skipping the dropped tail. [hasMoreContent]
+  /// is forced `true` whenever videos were dropped.
+  factory ProfileVideoCursorSnapshot.capped({
+    required List<VideoEvent> videos,
+    required int? paginationCursor,
+    required bool hasMoreContent,
+  }) {
+    const max = ProfileSnapshotWindow.maxItems;
+    if (videos.length <= max) {
+      return ProfileVideoCursorSnapshot(
+        videos: videos,
+        paginationCursor: paginationCursor,
+        hasMoreContent: hasMoreContent,
+      );
+    }
+    final keptVideos = videos.sublist(0, max);
+    return ProfileVideoCursorSnapshot(
+      videos: keptVideos,
+      paginationCursor: keptVideos.last.createdAt,
+      hasMoreContent: true,
     );
   }
 

--- a/mobile/lib/blocs/profile_shared/profile_video_list_snapshot.dart
+++ b/mobile/lib/blocs/profile_shared/profile_video_list_snapshot.dart
@@ -5,6 +5,7 @@
 import 'dart:convert';
 
 import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_shared/profile_snapshot_window.dart';
 
 /// A point-in-time snapshot of an ID-list-backed profile video tab.
 ///
@@ -34,6 +35,39 @@ class ProfileVideoListSnapshot {
       itemIds: itemIds,
       nextPageOffset: data['nextPageOffset'] as int? ?? videos.length,
       hasMoreContent: data['hasMoreContent'] as bool? ?? false,
+    );
+  }
+
+  /// Builds a snapshot capped to [ProfileSnapshotWindow.maxItems].
+  ///
+  /// Keeps the **head** of both lists (the most-recent items the user sees
+  /// first on reopen) and clamps [nextPageOffset] into the kept ID range.
+  /// When anything is dropped, [hasMoreContent] is forced `true` so pagination
+  /// (which re-resolves the full ID list via the reopen revalidation) knows
+  /// there is more beyond the persisted window.
+  factory ProfileVideoListSnapshot.capped({
+    required List<VideoEvent> videos,
+    required List<String> itemIds,
+    required int nextPageOffset,
+    required bool hasMoreContent,
+  }) {
+    const max = ProfileSnapshotWindow.maxItems;
+    if (videos.length <= max && itemIds.length <= max) {
+      return ProfileVideoListSnapshot(
+        videos: videos,
+        itemIds: itemIds,
+        nextPageOffset: nextPageOffset,
+        hasMoreContent: hasMoreContent,
+      );
+    }
+    final keptVideos = videos.length > max ? videos.sublist(0, max) : videos;
+    final keptIds = itemIds.length > max ? itemIds.sublist(0, max) : itemIds;
+    return ProfileVideoListSnapshot(
+      videos: keptVideos,
+      itemIds: keptIds,
+      nextPageOffset: nextPageOffset.clamp(0, keptIds.length),
+      hasMoreContent:
+          hasMoreContent || videos.length > max || itemIds.length > max,
     );
   }
 

--- a/mobile/lib/blocs/profile_shared/profile_video_list_snapshot.dart
+++ b/mobile/lib/blocs/profile_shared/profile_video_list_snapshot.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Shared CacheSync payload for ID-list-backed profile video tabs.
+// ABOUTME: Captures the resolved scrolled-through window so a tab (Liked,
+// ABOUTME: Reposts, Saved, …) renders instantly on reopen.
+
+import 'dart:convert';
+
+import 'package:models/models.dart';
+
+/// A point-in-time snapshot of an ID-list-backed profile video tab.
+///
+/// Serialized into `CacheSync` so reopening the tab restores the full
+/// scrolled-through list of videos instantly, then revalidates in the
+/// background. Holds the full ordered [itemIds] (cheap strings — liked event
+/// IDs, reposted addressable IDs, bookmark IDs, …) so pagination and
+/// reconciliation can resume without a fresh relay fetch.
+class ProfileVideoListSnapshot {
+  const ProfileVideoListSnapshot({
+    required this.videos,
+    required this.itemIds,
+    required this.nextPageOffset,
+    required this.hasMoreContent,
+  });
+
+  /// Deserializes from a JSON string produced by [toJson].
+  factory ProfileVideoListSnapshot.fromJson(String json) {
+    final data = jsonDecode(json) as Map<String, dynamic>;
+    final videos = (data['videos'] as List<dynamic>? ?? const [])
+        .map((e) => VideoEvent.fromJson(e as Map<String, dynamic>))
+        .toList();
+    final itemIds = (data['itemIds'] as List<dynamic>? ?? const [])
+        .cast<String>();
+    return ProfileVideoListSnapshot(
+      videos: videos,
+      itemIds: itemIds,
+      nextPageOffset: data['nextPageOffset'] as int? ?? videos.length,
+      hasMoreContent: data['hasMoreContent'] as bool? ?? false,
+    );
+  }
+
+  /// The resolved videos, ordered most-recent-first.
+  final List<VideoEvent> videos;
+
+  /// The full ordered list of item IDs (drives pagination + reconciliation).
+  final List<String> itemIds;
+
+  /// Offset into [itemIds] for the next page fetch.
+  final int nextPageOffset;
+
+  /// Whether more items remain beyond [nextPageOffset].
+  final bool hasMoreContent;
+
+  /// Serializes to a JSON string for cache storage.
+  String toJson() => jsonEncode({
+    'videos': videos.map((v) => v.toJson()).toList(),
+    'itemIds': itemIds,
+    'nextPageOffset': nextPageOffset,
+    'hasMoreContent': hasMoreContent,
+  });
+}

--- a/mobile/lib/mixins/scroll_pagination_mixin.dart
+++ b/mobile/lib/mixins/scroll_pagination_mixin.dart
@@ -54,9 +54,20 @@ mixin ScrollPaginationMixin<T extends StatefulWidget> on State<T> {
   /// ignored.
   FutureOr<void> onLoadMore();
 
-  /// Distance from the bottom edge (in logical pixels) at which loading
+  /// Default distance from the bottom edge (in logical pixels) at which
+  /// loading is triggered.
+  static const double _defaultThreshold = 200;
+
+  /// Distance from the bottom edge (in logical pixels) at which [onLoadMore]
   /// is triggered.
-  static const double _threshold = 200;
+  ///
+  /// Defaults to [_defaultThreshold]. Override with a larger value (for
+  /// example a multiple of the viewport height) to prefetch the next page
+  /// well before the user reaches the bottom, so it is usually ready in time
+  /// and the loading-more indicator is not seen. Called on every scroll tick,
+  /// so keep it cheap.
+  @protected
+  double get paginationLoadMoreThreshold => _defaultThreshold;
 
   Future<void>? _pendingPaginationLoad;
 
@@ -79,8 +90,9 @@ mixin ScrollPaginationMixin<T extends StatefulWidget> on State<T> {
     if (_pendingPaginationLoad != null) return;
     if (!canLoadMore()) return;
 
+    final threshold = paginationLoadMoreThreshold;
     final isNearBottom = paginationScrollController.positions.any(
-      (position) => position.pixels >= position.maxScrollExtent - _threshold,
+      (position) => position.pixels >= position.maxScrollExtent - threshold,
     );
     if (!isNearBottom) {
       return;

--- a/mobile/lib/widgets/profile/profile_cache_load_indicator.dart
+++ b/mobile/lib/widgets/profile/profile_cache_load_indicator.dart
@@ -15,12 +15,16 @@ class ProfileCacheLoadIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const SizedBox(
-      height: height,
-      child: LinearProgressIndicator(
-        minHeight: height,
-        color: VineTheme.primary,
-        backgroundColor: VineTheme.transparent,
+    // Purely decorative background-refresh hint; the cached grid is already
+    // on screen, so keep it out of the semantics tree.
+    return const ExcludeSemantics(
+      child: SizedBox(
+        height: height,
+        child: LinearProgressIndicator(
+          minHeight: height,
+          color: VineTheme.primary,
+          backgroundColor: VineTheme.transparent,
+        ),
       ),
     );
   }

--- a/mobile/lib/widgets/profile/profile_cache_load_indicator.dart
+++ b/mobile/lib/widgets/profile/profile_cache_load_indicator.dart
@@ -1,0 +1,27 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+
+/// Thin revalidation bar shown directly under the profile tab bar while a
+/// cached tab (e.g. Liked) refreshes its data in the background.
+///
+/// Rendered inside the pinned tab bar header so it stays sticky under the
+/// tabs while the grid scrolls. The host controls when it is shown and
+/// reserves [height] in the header extent.
+class ProfileCacheLoadIndicator extends StatelessWidget {
+  const ProfileCacheLoadIndicator({super.key});
+
+  /// Fixed height of the bar in logical pixels.
+  static const double height = 4;
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(
+      height: height,
+      child: LinearProgressIndicator(
+        minHeight: height,
+        color: VineTheme.primary,
+        backgroundColor: VineTheme.transparent,
+      ),
+    );
+  }
+}

--- a/mobile/lib/widgets/profile/profile_collabs_grid.dart
+++ b/mobile/lib/widgets/profile/profile_collabs_grid.dart
@@ -53,6 +53,15 @@ class _ProfileCollabsGridState extends ConsumerState<ProfileCollabsGrid>
   @override
   ScrollController get paginationScrollController => _primaryScrollController!;
 
+  /// Prefetch the next page ~1.5 viewports before the bottom so it is already
+  /// loaded by the time the user scrolls to it.
+  @override
+  double get paginationLoadMoreThreshold {
+    final positions = paginationScrollController.positions;
+    if (positions.isEmpty) return super.paginationLoadMoreThreshold;
+    return positions.first.viewportDimension * 1.5;
+  }
+
   @override
   bool canLoadMore() {
     final bloc = context.read<ProfileCollabVideosBloc>();

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -148,9 +148,26 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     _ => false,
   };
 
-  /// Track the userIdHex the BLoCs were created for.
-  String? _blocsUserIdHex;
-  bool? _blocsIncludeVideoReplies;
+  /// The dependency identities the tab BLoCs were last created for.
+  ///
+  /// The BLoCs capture these at construction (in [build]), so when any of
+  /// them changes identity — profile switch, auth flip, account switch,
+  /// sign-out, or an explicit provider invalidation — the BLoCs must be torn
+  /// down and rebuilt, otherwise they keep operating on a stale signer /
+  /// repository (see `rules/state_management.md`, captured-dependency trap).
+  /// Strings compare by value; repositories don't override `==` so they
+  /// compare by identity, which is exactly the swap signal we need.
+  ({
+    String userIdHex,
+    bool includeVideoReplies,
+    String currentUserPubkey,
+    Object likesRepository,
+    Object repostsRepository,
+    Object videosRepository,
+    Object commentsRepository,
+    Object contentBlocklistRepository,
+  })?
+  _blocsDeps;
 
   /// Track which tabs have been synced (lazy loading).
   bool _likedTabSynced = false;
@@ -291,10 +308,21 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     );
     final currentUserPubkey = nostrService.publicKey;
 
-    // Create BLoCs if not already created, or recreate if userIdHex changed
-    // Store references for refresh capability
-    if (_blocsUserIdHex != widget.userIdHex ||
-        _blocsIncludeVideoReplies != includeVideoReplies) {
+    final blocsDeps = (
+      userIdHex: widget.userIdHex,
+      includeVideoReplies: includeVideoReplies,
+      currentUserPubkey: currentUserPubkey,
+      likesRepository: likesRepository as Object,
+      repostsRepository: repostsRepository as Object,
+      videosRepository: videosRepository as Object,
+      commentsRepository: commentsRepository as Object,
+      contentBlocklistRepository: contentBlocklistRepository as Object,
+    );
+
+    // Create the tab BLoCs on first build, and recreate them whenever any
+    // captured dependency changes identity (profile switch, auth flip,
+    // account switch, sign-out). Store references for refresh capability.
+    if (_blocsDeps != blocsDeps) {
       _likedVideosBloc?.close();
       _repostedVideosBloc?.close();
       _collabVideosBloc?.close();
@@ -384,8 +412,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       );
       // Sync deferred until user views Comments tab
 
-      _blocsUserIdHex = widget.userIdHex;
-      _blocsIncludeVideoReplies = includeVideoReplies;
+      _blocsDeps = blocsDeps;
 
       // Kick off the lazy sync for the currently selected tab. On a fresh
       // mount this will no-op for tab 0 (videos use [widget.videos] and

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Profile grid view with header, stats, action buttons, and tabbed content
 // ABOUTME: Reusable between own profile and others' profile screens
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -19,6 +21,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/profile_tab_index_provider.dart';
 import 'package:openvine/widgets/profile/profile_banner_layer.dart';
+import 'package:openvine/widgets/profile/profile_cache_load_indicator.dart';
 import 'package:openvine/widgets/profile/profile_collabs_grid.dart';
 import 'package:openvine/widgets/profile/profile_comments_grid.dart';
 import 'package:openvine/widgets/profile/profile_header_widget.dart';
@@ -122,6 +125,28 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   ProfileCollabVideosBloc? _collabVideosBloc;
   ProfileSavedVideosBloc? _savedVideosBloc;
   ProfileCommentsBloc? _commentsBloc;
+
+  /// Mirrors each cached tab's `isRefreshing` so the pinned tab bar can show a
+  /// sticky cache-revalidation bar directly under the tabs while that grid
+  /// scrolls (a body overlay would be drawn behind the header).
+  bool _likedRefreshing = false;
+  StreamSubscription<ProfileLikedVideosState>? _likedRefreshSub;
+  bool _repostsRefreshing = false;
+  StreamSubscription<ProfileRepostedVideosState>? _repostsRefreshSub;
+  bool _savedRefreshing = false;
+  StreamSubscription<ProfileSavedVideosState>? _savedRefreshSub;
+  bool _collabsRefreshing = false;
+  StreamSubscription<ProfileCollabVideosState>? _collabsRefreshSub;
+
+  /// Whether the currently-selected tab is revalidating cached content.
+  ///
+  /// The 4th tab (index 3) is Saved on own profiles and Collabs on others.
+  bool get _activeTabRefreshing => switch (_tabController.index) {
+    1 => _likedRefreshing,
+    2 => _repostsRefreshing,
+    3 => widget.isOwnProfile ? _savedRefreshing : _collabsRefreshing,
+    _ => false,
+  };
 
   /// Track the userIdHex the BLoCs were created for.
   String? _blocsUserIdHex;
@@ -237,6 +262,10 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     widget.refreshNotifier?.removeListener(_onRefreshRequested);
     _tabController.removeListener(_onTabChanged);
     _tabController.dispose();
+    _likedRefreshSub?.cancel();
+    _repostsRefreshSub?.cancel();
+    _savedRefreshSub?.cancel();
+    _collabsRefreshSub?.cancel();
     // Close the BLoCs we created
     _likedVideosBloc?.close();
     _repostedVideosBloc?.close();
@@ -290,6 +319,16 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       )..add(const ProfileLikedVideosSubscriptionRequested());
       // Sync deferred until user views Liked tab
 
+      // Mirror the Liked bloc's refreshing flag so the pinned tab bar can
+      // render the sticky revalidation bar.
+      _likedRefreshSub?.cancel();
+      _likedRefreshing = false;
+      _likedRefreshSub = _likedVideosBloc!.stream.listen((likedState) {
+        if (likedState.isRefreshing != _likedRefreshing && mounted) {
+          setState(() => _likedRefreshing = likedState.isRefreshing);
+        }
+      });
+
       _repostedVideosBloc = ProfileRepostedVideosBloc(
         repostsRepository: repostsRepository,
         videosRepository: videosRepository,
@@ -298,19 +337,42 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       )..add(const ProfileRepostedVideosSubscriptionRequested());
       // Sync deferred until user views Reposts tab
 
+      _repostsRefreshSub?.cancel();
+      _repostsRefreshing = false;
+      _repostsRefreshSub = _repostedVideosBloc!.stream.listen((repostsState) {
+        if (repostsState.isRefreshing != _repostsRefreshing && mounted) {
+          setState(() => _repostsRefreshing = repostsState.isRefreshing);
+        }
+      });
+
       // 4th tab: Saved (own profile) or Collabs (other profile).
       // Only create the bloc that will actually be used.
       if (widget.isOwnProfile) {
         _savedVideosBloc = ProfileSavedVideosBloc(
           bookmarkService: ref.read(bookmarkServiceProvider.future),
           videosRepository: videosRepository,
+          currentUserPubkey: currentUserPubkey,
         );
+        _savedRefreshSub?.cancel();
+        _savedRefreshing = false;
+        _savedRefreshSub = _savedVideosBloc!.stream.listen((savedState) {
+          if (savedState.isRefreshing != _savedRefreshing && mounted) {
+            setState(() => _savedRefreshing = savedState.isRefreshing);
+          }
+        });
         _collabVideosBloc = null;
       } else {
         _collabVideosBloc = ProfileCollabVideosBloc(
           videosRepository: videosRepository,
           targetUserPubkey: widget.userIdHex,
         );
+        _collabsRefreshSub?.cancel();
+        _collabsRefreshing = false;
+        _collabsRefreshSub = _collabVideosBloc!.stream.listen((collabsState) {
+          if (collabsState.isRefreshing != _collabsRefreshing && mounted) {
+            setState(() => _collabsRefreshing = collabsState.isRefreshing);
+          }
+        });
         _savedVideosBloc = null;
       }
       // Sync deferred until user views the 4th tab
@@ -431,6 +493,8 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
                 scrollController: widget.scrollController,
                 isOwnProfile: widget.isOwnProfile,
                 headerKey: _headerKey,
+                // Sticky cache-revalidation bar for the active cached tab.
+                isRefreshing: _activeTabRefreshing,
               ),
             ],
             body: tabContent,
@@ -464,12 +528,16 @@ class _ProfileTabBar extends StatefulWidget {
     required this.scrollController,
     required this.isOwnProfile,
     required this.headerKey,
+    required this.isRefreshing,
   });
 
   final TabController controller;
   final ScrollController? scrollController;
   final bool isOwnProfile;
   final GlobalKey headerKey;
+
+  /// Whether to show the sticky cache-revalidation bar under the tabs.
+  final bool isRefreshing;
 
   @override
   State<_ProfileTabBar> createState() => _ProfileTabBarState();
@@ -548,6 +616,7 @@ class _ProfileTabBarState extends State<_ProfileTabBar> {
       pinned: true,
       delegate: _SliverAppBarDelegate(
         topInset: _tabBarTopInset,
+        isRefreshing: widget.isRefreshing,
         TabBar(
           controller: widget.controller,
           indicatorColor: VineTheme.tabIndicatorGreen,
@@ -630,10 +699,17 @@ class _ProfileTab extends StatelessWidget {
 /// the header. The rounded top corners of the tab content viewport are
 /// applied separately, on the body's [ColoredBox] wrapper.
 class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
-  _SliverAppBarDelegate(this._tabBar, {required this.topInset});
+  _SliverAppBarDelegate(
+    this._tabBar, {
+    required this.topInset,
+    required this.isRefreshing,
+  });
 
   final PreferredSizeWidget _tabBar;
   final double topInset;
+
+  /// Whether to overlay the sticky cache-revalidation bar at the bottom edge.
+  final bool isRefreshing;
 
   /// Height of the divider line painted between the tab bar and the tile
   /// grid.
@@ -655,21 +731,37 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     bool overlapsContent,
   ) => DecoratedBox(
     decoration: const BoxDecoration(color: VineTheme.surfaceBackground),
-    child: Column(
+    child: Stack(
+      clipBehavior: .none,
       children: [
-        Padding(
-          padding: EdgeInsets.only(top: topInset),
-          child: _tabBar,
+        Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.only(top: topInset),
+              child: _tabBar,
+            ),
+            const ColoredBox(
+              color: VineTheme.outlineMuted,
+              child: SizedBox(height: _dividerHeight, width: double.infinity),
+            ),
+          ],
         ),
-        const ColoredBox(
-          color: VineTheme.outlineMuted,
-          child: SizedBox(height: _dividerHeight, width: double.infinity),
-        ),
+        // Overlaid on the bottom edge so showing/hiding it never changes the
+        // header extent — the grid below does not jump.
+        if (isRefreshing)
+          const Positioned(
+            left: 0,
+            right: 0,
+            bottom: -4,
+            child: ProfileCacheLoadIndicator(),
+          ),
       ],
     ),
   );
 
   @override
   bool shouldRebuild(_SliverAppBarDelegate oldDelegate) =>
-      topInset != oldDelegate.topInset || _tabBar != oldDelegate._tabBar;
+      topInset != oldDelegate.topInset ||
+      _tabBar != oldDelegate._tabBar ||
+      isRefreshing != oldDelegate.isRefreshing;
 }

--- a/mobile/lib/widgets/profile/profile_liked_grid.dart
+++ b/mobile/lib/widgets/profile/profile_liked_grid.dart
@@ -51,6 +51,16 @@ class _ProfileLikedGridState extends State<ProfileLikedGrid>
   @override
   ScrollController get paginationScrollController => _primaryScrollController!;
 
+  /// Prefetch the next page ~1.5 viewports before the bottom so it is already
+  /// loaded by the time the user scrolls to it — keeping scrolling smooth
+  /// instead of stalling on the loading-more indicator.
+  @override
+  double get paginationLoadMoreThreshold {
+    final positions = paginationScrollController.positions;
+    if (positions.isEmpty) return super.paginationLoadMoreThreshold;
+    return positions.first.viewportDimension * 1.5;
+  }
+
   @override
   bool canLoadMore() {
     final bloc = context.read<ProfileLikedVideosBloc>();
@@ -85,19 +95,25 @@ class _ProfileLikedGridState extends State<ProfileLikedGrid>
   Widget build(BuildContext context) {
     return BlocBuilder<ProfileLikedVideosBloc, ProfileLikedVideosState>(
       builder: (context, state) {
-        if (state.status == ProfileLikedVideosStatus.initial ||
-            state.status == ProfileLikedVideosStatus.syncing ||
-            state.status == ProfileLikedVideosStatus.loading) {
+        final likedVideos = state.videos;
+
+        // Cold open with no cached content yet (initial / syncing / loading):
+        // full-screen spinner. `success` (→ empty state) and `failure`
+        // (→ error screen) are the only settled empty states.
+        if (likedVideos.isEmpty &&
+            state.status != ProfileLikedVideosStatus.success &&
+            state.status != ProfileLikedVideosStatus.failure) {
           return const ProfileTabLoadingState();
         }
 
-        if (state.status == ProfileLikedVideosStatus.failure) {
+        // Only surface the failure screen when there is nothing cached to
+        // show; a failed background refresh keeps the cached grid on screen.
+        if (state.status == ProfileLikedVideosStatus.failure &&
+            likedVideos.isEmpty) {
           return ProfileTabErrorState(
             message: context.l10n.profileErrorLoadingLiked,
           );
         }
-
-        final likedVideos = state.videos;
 
         if (likedVideos.isEmpty) {
           return ProfileTabEmptyState(
@@ -108,6 +124,10 @@ class _ProfileLikedGridState extends State<ProfileLikedGrid>
           );
         }
 
+        // The revalidation bar lives in the pinned tab bar header (see
+        // _SliverAppBarDelegate in profile_grid.dart) so it stays sticky
+        // directly under the tabs while scrolling — a body overlay would be
+        // painted behind the pinned header.
         return CustomScrollView(
           physics: const ClampingScrollPhysics(),
           slivers: [

--- a/mobile/lib/widgets/profile/profile_reposts_grid.dart
+++ b/mobile/lib/widgets/profile/profile_reposts_grid.dart
@@ -51,6 +51,15 @@ class _ProfileRepostsGridState extends State<ProfileRepostsGrid>
   @override
   ScrollController get paginationScrollController => _primaryScrollController!;
 
+  /// Prefetch the next page ~1.5 viewports before the bottom so it is already
+  /// loaded by the time the user scrolls to it.
+  @override
+  double get paginationLoadMoreThreshold {
+    final positions = paginationScrollController.positions;
+    if (positions.isEmpty) return super.paginationLoadMoreThreshold;
+    return positions.first.viewportDimension * 1.5;
+  }
+
   @override
   bool canLoadMore() {
     final bloc = context.read<ProfileRepostedVideosBloc>();

--- a/mobile/lib/widgets/profile/profile_saved_grid.dart
+++ b/mobile/lib/widgets/profile/profile_saved_grid.dart
@@ -46,6 +46,15 @@ class _ProfileSavedGridState extends State<ProfileSavedGrid>
   @override
   ScrollController get paginationScrollController => _primaryScrollController!;
 
+  /// Prefetch the next page ~1.5 viewports before the bottom so it is already
+  /// loaded by the time the user scrolls to it.
+  @override
+  double get paginationLoadMoreThreshold {
+    final positions = paginationScrollController.positions;
+    if (positions.isEmpty) return super.paginationLoadMoreThreshold;
+    return positions.first.viewportDimension * 1.5;
+  }
+
   @override
   bool canLoadMore() {
     final bloc = context.read<ProfileSavedVideosBloc>();

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -689,7 +689,6 @@ class VideoEvent {
       contentWarningLabels: contentWarningLabels,
     );
   }
-
   final String id;
   final String pubkey;
   final int createdAt;

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -689,6 +689,7 @@ class VideoEvent {
       contentWarningLabels: contentWarningLabels,
     );
   }
+
   final String id;
   final String pubkey;
   final int createdAt;

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -292,4 +292,105 @@ void main() {
       },
     );
   });
+
+  group('VideoEvent.fromJson', () {
+    test('round-trips every persisted field through toJson', () {
+      final original = _fullVideo();
+      final restored = VideoEvent.fromJson(
+        jsonDecode(jsonEncode(original.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(restored.id, equals(original.id));
+      expect(restored.pubkey, equals(original.pubkey));
+      expect(restored.createdAt, equals(original.createdAt));
+      expect(restored.content, equals(original.content));
+      expect(restored.timestamp, equals(original.timestamp));
+      expect(restored.title, equals(original.title));
+      expect(restored.videoUrl, equals(original.videoUrl));
+      expect(restored.thumbnailUrl, equals(original.thumbnailUrl));
+      expect(restored.duration, equals(original.duration));
+      expect(restored.dimensions, equals(original.dimensions));
+      expect(restored.mimeType, equals(original.mimeType));
+      expect(restored.sha256, equals(original.sha256));
+      expect(restored.fileSize, equals(original.fileSize));
+      expect(restored.hashtags, equals(original.hashtags));
+      expect(restored.categories, equals(original.categories));
+      expect(restored.publishedAt, equals(original.publishedAt));
+      expect(restored.rawTags, equals(original.rawTags));
+      expect(restored.vineId, equals(original.vineId));
+      expect(restored.group, equals(original.group));
+      expect(restored.altText, equals(original.altText));
+      expect(restored.blurhash, equals(original.blurhash));
+      expect(restored.isRepost, equals(original.isRepost));
+      expect(restored.reposterId, equals(original.reposterId));
+      expect(restored.reposterPubkey, equals(original.reposterPubkey));
+      expect(restored.reposterPubkeys, equals(original.reposterPubkeys));
+      expect(restored.repostedAt, equals(original.repostedAt));
+      expect(restored.isFlaggedContent, equals(original.isFlaggedContent));
+      expect(restored.moderationStatus, equals(original.moderationStatus));
+      expect(restored.originalLoops, equals(original.originalLoops));
+      expect(restored.originalLikes, equals(original.originalLikes));
+      expect(restored.originalComments, equals(original.originalComments));
+      expect(restored.originalReposts, equals(original.originalReposts));
+      expect(
+        restored.expirationTimestamp,
+        equals(original.expirationTimestamp),
+      );
+      expect(restored.audioEventId, equals(original.audioEventId));
+      expect(restored.audioEventRelay, equals(original.audioEventRelay));
+      expect(restored.nostrLikeCount, equals(original.nostrLikeCount));
+      expect(restored.nostrCommentCount, equals(original.nostrCommentCount));
+      expect(restored.nostrRepostCount, equals(original.nostrRepostCount));
+      expect(restored.authorName, equals(original.authorName));
+      expect(restored.authorAvatar, equals(original.authorAvatar));
+      expect(
+        restored.collaboratorPubkeys,
+        equals(original.collaboratorPubkeys),
+      );
+      expect(restored.inspiredByVideo, equals(original.inspiredByVideo));
+      expect(restored.inspiredByNpub, equals(original.inspiredByNpub));
+      expect(restored.textTrackRef, equals(original.textTrackRef));
+      expect(restored.textTrackContent, equals(original.textTrackContent));
+      expect(
+        restored.contentWarningLabels,
+        equals(original.contentWarningLabels),
+      );
+      expect(restored.proofSummary, equals(original.proofSummary));
+    });
+
+    test('round-trips a minimal video with only required fields', () {
+      final minimal = VideoEvent(
+        id: _id,
+        pubkey: _pubkey,
+        createdAt: 1704067200,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(
+          1704067200 * 1000,
+          isUtc: true,
+        ),
+      );
+      final restored = VideoEvent.fromJson(
+        jsonDecode(jsonEncode(minimal.toJson())) as Map<String, dynamic>,
+      );
+
+      expect(restored.id, equals(minimal.id));
+      expect(restored.timestamp, equals(minimal.timestamp));
+      expect(restored.videoUrl, isNull);
+      expect(restored.inspiredByVideo, isNull);
+      expect(restored.proofSummary, isNull);
+      expect(restored.hashtags, isEmpty);
+      expect(restored.isRepost, isFalse);
+    });
+
+    test('defaults internal-only fields omitted from toJson to empty', () {
+      final restored = VideoEvent.fromJson(
+        jsonDecode(jsonEncode(_fullVideo().toJson())) as Map<String, dynamic>,
+      );
+
+      // nostrEventTags and warnLabels are not persisted and default to empty;
+      // moderationLabels IS persisted (a hard content-filter signal).
+      expect(restored.nostrEventTags, isEmpty);
+      expect(restored.warnLabels, isEmpty);
+    });
+  });
 }

--- a/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
@@ -2,17 +2,52 @@
 // ABOUTME: videos. Tests confirmed repository fetch and state management.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_collab_videos/profile_collab_videos_bloc.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_cursor_snapshot.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
+/// In-memory [CacheDao] so the bloc's [CacheSync] reads/writes are isolated
+/// per test without touching disk.
+class _InMemoryCacheDao implements CacheDao {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    _store[key] = payload;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _store.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
 void main() {
   group(ProfileCollabVideosBloc, () {
     late _MockVideosRepository mockVideosRepository;
+    late _InMemoryCacheDao cacheDao;
 
     // 64-character hex pubkeys for testing
     const targetPubkey =
@@ -20,8 +55,10 @@ void main() {
     const authorPubkey =
         'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
-    setUp(() {
+    setUp(() async {
       mockVideosRepository = _MockVideosRepository();
+      cacheDao = _InMemoryCacheDao();
+      await CacheSync.init(dao: cacheDao);
     });
 
     ProfileCollabVideosBloc createBloc() => ProfileCollabVideosBloc(
@@ -268,7 +305,59 @@ void main() {
       );
 
       blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(
-        'does not re-fetch when already loading',
+        'reopen serves cache, then reconciles against the confirmed feed',
+        build: () {
+          // Authoritative confirmed feed now: [new, cached-1] — cached-2 is no
+          // longer confirmed (removed), new was added.
+          when(
+            () => mockVideosRepository.getCollabVideos(
+              taggedPubkey: targetPubkey,
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              createTestVideo(id: 'new', pubkey: authorPubkey),
+              createTestVideo(id: 'cached-1', pubkey: authorPubkey),
+            ],
+          );
+          return createBloc();
+        },
+        setUp: () async {
+          await cacheDao.write(
+            key: '$targetPubkey:profile_collab_videos',
+            payload: ProfileVideoCursorSnapshot(
+              videos: [
+                createTestVideo(id: 'cached-1', pubkey: authorPubkey),
+                createTestVideo(id: 'cached-2', pubkey: authorPubkey),
+              ],
+              paginationCursor: 100,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+        },
+        act: (bloc) => bloc.add(const ProfileCollabVideosFetchRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          // Cached feed served instantly.
+          isA<ProfileCollabVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having((s) => s.videos.map((v) => v.id).toList(), 'cached', [
+                'cached-1',
+                'cached-2',
+              ]),
+          // Fresh page is authoritative: new prepended, the unconfirmed
+          // cached-2 dropped.
+          isA<ProfileCollabVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having((s) => s.videos.map((v) => v.id).toList(), 'reconciled', [
+                'new',
+                'cached-1',
+              ]),
+        ],
+      );
+
+      blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(
+        'droppable: ignores a second fetch while one is in flight',
         build: () {
           when(
             () => mockVideosRepository.getCollabVideos(
@@ -278,11 +367,20 @@ void main() {
           ).thenAnswer((_) async => []);
           return createBloc();
         },
-        seed: () => const ProfileCollabVideosState(
-          status: ProfileCollabVideosStatus.loading,
-        ),
-        act: (bloc) => bloc.add(const ProfileCollabVideosFetchRequested()),
-        expect: () => <ProfileCollabVideosState>[],
+        act: (bloc) {
+          bloc
+            ..add(const ProfileCollabVideosFetchRequested())
+            ..add(const ProfileCollabVideosFetchRequested());
+        },
+        wait: const Duration(milliseconds: 50),
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.getCollabVideos(
+              taggedPubkey: targetPubkey,
+              limit: any(named: 'limit'),
+            ),
+          ).called(1);
+        },
       );
     });
 

--- a/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart
@@ -357,6 +357,58 @@ void main() {
       );
 
       blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(
+        'reopen preserves cached tail after a full first-page overlap',
+        build: () {
+          when(
+            () => mockVideosRepository.getCollabVideos(
+              taggedPubkey: targetPubkey,
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              for (var i = 1; i <= 17; i++)
+                createTestVideo(id: 'cached-$i', pubkey: authorPubkey),
+              createTestVideo(id: 'new-confirmed', pubkey: authorPubkey),
+            ],
+          );
+          return createBloc();
+        },
+        setUp: () async {
+          await cacheDao.write(
+            key: '$targetPubkey:profile_collab_videos',
+            payload: ProfileVideoCursorSnapshot(
+              videos: [
+                for (var i = 1; i <= 17; i++)
+                  createTestVideo(id: 'cached-$i', pubkey: authorPubkey),
+                createTestVideo(id: 'tail-1', pubkey: authorPubkey),
+              ],
+              paginationCursor: 100,
+              hasMoreContent: true,
+            ).toJson(),
+          );
+        },
+        act: (bloc) => bloc.add(const ProfileCollabVideosFetchRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileCollabVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having((s) => s.videos.last.id, 'cached tail', 'tail-1'),
+          isA<ProfileCollabVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'videos',
+                [
+                  for (var i = 1; i <= 17; i++) 'cached-$i',
+                  'new-confirmed',
+                  'tail-1',
+                ],
+              )
+              .having((s) => s.hasMoreContent, 'hasMoreContent', isTrue),
+        ],
+      );
+
+      blocTest<ProfileCollabVideosBloc, ProfileCollabVideosState>(
         'droppable: ignores a second fetch while one is in flight',
         build: () {
           when(

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,6 +12,7 @@ import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
@@ -20,11 +22,44 @@ class _MockVideosRepository extends Mock implements VideosRepository {}
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
 
+/// In-memory [CacheDao] so the bloc's [CacheSync] reads/writes are isolated
+/// per test without touching disk.
+class _InMemoryCacheDao implements CacheDao {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    _store[key] = payload;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _store.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
 void main() {
   group('ProfileLikedVideosBloc', () {
     late _MockLikesRepository mockLikesRepository;
     late _MockVideosRepository mockVideosRepository;
     late _MockContentBlocklistRepository mockBlocklistRepository;
+    late _InMemoryCacheDao cacheDao;
     late StreamController<List<String>> likedIdsController;
     late StreamController<ContentPolicyState> blocklistStateController;
 
@@ -34,10 +69,12 @@ void main() {
     const otherUserPubkey =
         'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
-    setUp(() {
+    setUp(() async {
       mockLikesRepository = _MockLikesRepository();
       mockVideosRepository = _MockVideosRepository();
       mockBlocklistRepository = _MockContentBlocklistRepository();
+      cacheDao = _InMemoryCacheDao();
+      await CacheSync.init(dao: cacheDao);
       likedIdsController = StreamController<List<String>>.broadcast();
       blocklistStateController =
           StreamController<ContentPolicyState>.broadcast();
@@ -160,11 +197,18 @@ void main() {
 
         expect(updated.error, isNull);
       });
+
+      test('copyWith updates isRefreshing', () {
+        const state = ProfileLikedVideosState();
+
+        expect(state.isRefreshing, isFalse);
+        expect(state.copyWith(isRefreshing: true).isRefreshing, isTrue);
+      });
     });
 
     group('ProfileLikedVideosSyncRequested', () {
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
-        'emits [syncing, success] with empty videos when no liked IDs',
+        'emits [success] with empty videos when no liked IDs',
         setUp: () {
           when(
             () => mockLikesRepository.syncUserReactions(),
@@ -172,10 +216,8 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileLikedVideosState(
-            status: ProfileLikedVideosStatus.syncing,
-          ),
           const ProfileLikedVideosState(
             status: ProfileLikedVideosStatus.success,
             hasMoreContent: false,
@@ -184,7 +226,7 @@ void main() {
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
-        'emits [syncing, loading, success] when videos found',
+        'emits [success] with videos when liked videos found',
         setUp: () {
           final video1 = createTestVideo('event1');
           final video2 = createTestVideo('event2');
@@ -207,32 +249,26 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileLikedVideosState(
-            status: ProfileLikedVideosStatus.syncing,
-          ),
-          isA<ProfileLikedVideosState>()
-              .having(
-                (s) => s.status,
-                'status',
-                ProfileLikedVideosStatus.loading,
-              )
-              .having((s) => s.likedEventIds, 'likedEventIds', [
-                'event1',
-                'event2',
-              ]),
           isA<ProfileLikedVideosState>()
               .having(
                 (s) => s.status,
                 'status',
                 ProfileLikedVideosStatus.success,
               )
-              .having((s) => s.videos.length, 'videos count', 2),
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having((s) => s.likedEventIds, 'likedEventIds', [
+                'event1',
+                'event2',
+              ])
+              .having((s) => s.videos.length, 'videos count', 2)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 2),
         ],
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
-        'emits [syncing, failure] when sync fails',
+        'emits [failure] when sync fails and nothing is cached',
         setUp: () {
           when(
             () => mockLikesRepository.syncUserReactions(),
@@ -240,10 +276,8 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileLikedVideosState(
-            status: ProfileLikedVideosStatus.syncing,
-          ),
           const ProfileLikedVideosState(
             status: ProfileLikedVideosStatus.failure,
             error: ProfileLikedVideosError.syncFailed,
@@ -252,21 +286,155 @@ void main() {
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
-        'does not re-sync while already syncing',
-        setUp: () {
-          when(
-            () => mockLikesRepository.syncUserReactions(),
-          ).thenAnswer((_) async => const LikesSyncResult.empty());
+        'serves cached snapshot, then only flips the bar off when unchanged',
+        setUp: () async {
+          await cacheDao.write(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [createTestVideo('a'), createTestVideo('b')],
+              itemIds: const ['a', 'b'],
+              nextPageOffset: 2,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          // Relay reports the same liked set → no change.
+          when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
+            (_) async => const LikesSyncResult(
+              orderedEventIds: ['a', 'b'],
+              eventIdToReactionId: {},
+            ),
+          );
         },
         build: createBloc,
-        seed: () => const ProfileLikedVideosState(
-          status: ProfileLikedVideosStatus.syncing,
-        ),
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
-        expect: () => <ProfileLikedVideosState>[],
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          // Cached snapshot served immediately, revalidation in flight.
+          isA<ProfileLikedVideosState>()
+              .having(
+                (s) => s.status,
+                'status',
+                ProfileLikedVideosStatus.success,
+              )
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'cached videos',
+                ['a', 'b'],
+              ),
+          // Nothing changed → bar off, same videos (no re-fetch).
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'unchanged videos',
+                ['a', 'b'],
+              ),
+        ],
         verify: (_) {
-          verifyNever(() => mockLikesRepository.syncUserReactions());
+          // The whole point of the freeze fix: the loaded window is NOT
+          // re-resolved on revalidation.
+          verifyNever(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          );
         },
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'warm revalidation drops unliked videos without re-fetching',
+        setUp: () async {
+          await cacheDao.write(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [createTestVideo('a'), createTestVideo('b')],
+              itemIds: const ['a', 'b'],
+              nextPageOffset: 2,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          // 'b' was unliked while the tab was away.
+          when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
+            (_) async => const LikesSyncResult(
+              orderedEventIds: ['a'],
+              eventIdToReactionId: {},
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'cached videos',
+                ['a', 'b'],
+              ),
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having(
+                (s) => s.videos.map((v) => v.id).toList(),
+                'reconciled videos',
+                ['a'],
+              )
+              .having((s) => s.likedEventIds, 'likedEventIds', ['a']),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'reopen restores the full scrolled-through list from cache',
+        setUp: () async {
+          final cachedVideos = List.generate(36, (i) => createTestVideo('v$i'));
+          final cachedIds = List.generate(40, (i) => 'v$i');
+          await cacheDao.write(
+            key: '$currentUserPubkey:$otherUserPubkey:profile_liked_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: cachedVideos,
+              itemIds: cachedIds,
+              nextPageOffset: 36,
+              hasMoreContent: true,
+            ).toJson(),
+          );
+          when(
+            () => mockLikesRepository.fetchUserLikes(any()),
+          ).thenAnswer((_) async => cachedIds);
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((invocation) async {
+            final ids = invocation.positionalArguments[0] as List<String>;
+            return ids.map(createTestVideo).toList();
+          });
+        },
+        build: () => createBloc(targetUserPubkey: otherUserPubkey),
+        act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          // Cached emit restores all 36 scrolled videos instantly, not page 1.
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having((s) => s.videos.length, 'cached videos', 36)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 36),
+          // Live emit revalidates the same 36-video window (does not shrink).
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having((s) => s.videos.length, 'revalidated videos', 36)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 36),
+        ],
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
@@ -292,15 +460,8 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileLikedVideosState(
-            status: ProfileLikedVideosStatus.syncing,
-          ),
-          isA<ProfileLikedVideosState>().having(
-            (s) => s.status,
-            'status',
-            ProfileLikedVideosStatus.loading,
-          ),
           isA<ProfileLikedVideosState>()
               .having(
                 (s) => s.status,
@@ -345,15 +506,9 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileLikedVideosState(
-            status: ProfileLikedVideosStatus.syncing,
-          ),
-          isA<ProfileLikedVideosState>().having(
-            (s) => s.status,
-            'status',
-            ProfileLikedVideosStatus.loading,
-          ),
+          // SWR cold load fills a full page through the sparse IDs in one go.
           isA<ProfileLikedVideosState>()
               .having(
                 (s) => s.status,
@@ -428,24 +583,40 @@ void main() {
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
-        'updates likedEventIds when video is liked',
+        'fetches and prepends the video when a new like arrives via stream',
+        setUp: () {
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((_) async => [createTestVideo('event2')]);
+        },
         build: createBloc,
-        seed: () => const ProfileLikedVideosState(
+        seed: () => ProfileLikedVideosState(
           status: ProfileLikedVideosStatus.success,
-          likedEventIds: ['event1'],
+          likedEventIds: const ['event1'],
+          videos: [createTestVideo('event1')],
+          nextPageOffset: 1,
         ),
         act: (bloc) async {
           bloc.add(const ProfileLikedVideosSubscriptionRequested());
           await Future<void>.delayed(const Duration(milliseconds: 50));
+          // event2 liked, prepended (most-recent-first).
           likedIdsController.add(['event2', 'event1']);
         },
         wait: const Duration(milliseconds: 100),
         expect: () => [
-          isA<ProfileLikedVideosState>().having(
-            (s) => s.likedEventIds,
-            'likedEventIds',
-            equals(['event2', 'event1']),
-          ),
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.likedEventIds, 'likedEventIds', [
+                'event2',
+                'event1',
+              ])
+              // The new like is fetched and shown at the top.
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
+                'event2',
+                'event1',
+              ]),
         ],
       );
     });
@@ -475,9 +646,6 @@ void main() {
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
         wait: const Duration(milliseconds: 100),
         expect: () => [
-          const ProfileLikedVideosState(
-            status: ProfileLikedVideosStatus.syncing,
-          ),
           const ProfileLikedVideosState(
             status: ProfileLikedVideosStatus.success,
             hasMoreContent: false,
@@ -515,10 +683,8 @@ void main() {
         },
         build: () => createBloc(targetUserPubkey: currentUserPubkey),
         act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileLikedVideosState(
-            status: ProfileLikedVideosStatus.syncing,
-          ),
           const ProfileLikedVideosState(
             status: ProfileLikedVideosStatus.success,
             hasMoreContent: false,
@@ -565,6 +731,40 @@ void main() {
               .having((s) => s.hasMoreContent, 'hasMoreContent', false)
               .having((s) => s.nextPageOffset, 'nextPageOffset', 3),
         ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'persists the grown list to cache so reopen restores it',
+        setUp: () {
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((_) async => [createTestVideo('event3')]);
+        },
+        build: createBloc,
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          likedEventIds: const ['event1', 'event2', 'event3'],
+          videos: [createTestVideo('event1'), createTestVideo('event2')],
+          nextPageOffset: 2,
+        ),
+        act: (bloc) => bloc.add(const ProfileLikedVideosLoadMoreRequested()),
+        wait: const Duration(milliseconds: 50),
+        verify: (_) async {
+          final cached = await CacheSync.read<ProfileVideoListSnapshot>(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            fromJson: ProfileVideoListSnapshot.fromJson,
+          );
+          expect(cached, isNotNull);
+          expect(cached!.videos.map((v) => v.id).toList(), [
+            'event1',
+            'event2',
+            'event3',
+          ]);
+          expect(cached.nextPageOffset, 3);
+        },
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
@@ -822,7 +1022,15 @@ void main() {
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
-        'shifts nextPageOffset forward when new like is added',
+        'prepends the fetched video and advances offset on a new like',
+        setUp: () {
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((_) async => [createTestVideo('event3')]);
+        },
         build: createBloc,
         seed: () => ProfileLikedVideosState(
           status: ProfileLikedVideosStatus.success,
@@ -840,6 +1048,12 @@ void main() {
         expect: () => [
           isA<ProfileLikedVideosState>()
               .having((s) => s.likedEventIds, 'likedEventIds', [
+                'event3',
+                'event1',
+                'event2',
+              ])
+              // The new like is fetched and shown at the top.
+              .having((s) => s.videos.map((v) => v.id).toList(), 'videos', [
                 'event3',
                 'event1',
                 'event2',
@@ -900,6 +1114,51 @@ void main() {
               .having((s) => s.likedEventIds, 'likedEventIds', ['a', 'b'])
               .having((s) => s.nextPageOffset, 'nextPageOffset', 2),
         ],
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'restores a now-unblocked author by re-resolving the loaded window',
+        setUp: () {
+          // 'a' was filtered out previously; the blocklist no longer filters
+          // it (default filterContent stub returns the input unchanged).
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              videoBy('a', allowedPubkey),
+              videoBy('b', allowedPubkey),
+            ],
+          );
+        },
+        build: createBloc,
+        // Window of 2 IDs, but only 'b' is currently shown ('a' was blocked).
+        seed: () => ProfileLikedVideosState(
+          status: ProfileLikedVideosStatus.success,
+          videos: [videoBy('b', allowedPubkey)],
+          likedEventIds: const ['a', 'b'],
+          nextPageOffset: 2,
+        ),
+        act: (bloc) => bloc.add(const ProfileLikedVideosBlocklistChanged()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          // Re-resolving the window brings 'a' back.
+          isA<ProfileLikedVideosState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'videos',
+            ['a', 'b'],
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.getVideosByIds(
+              any(that: equals(['a', 'b'])),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).called(1);
+        },
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(

--- a/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_liked_videos/profile_liked_videos_bloc_test.dart
@@ -438,6 +438,69 @@ void main() {
       );
 
       blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
+        'reopen of a capped snapshot revalidates without bulk-fetching the '
+        'full liked list',
+        setUp: () async {
+          // Simulates a power user: the persisted window was capped to 50,
+          // but the real liked list is far longer. The cap must not make
+          // reconcile think 250 items were "added" and re-fetch them all.
+          final cachedIds = List.generate(50, (i) => 'v$i');
+          final cachedVideos = cachedIds.map(createTestVideo).toList();
+          await cacheDao.write(
+            key: '$currentUserPubkey:$currentUserPubkey:profile_liked_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: cachedVideos,
+              itemIds: cachedIds,
+              nextPageOffset: 50,
+              hasMoreContent: true,
+            ).toJson(),
+          );
+          // Fresh full list: same top 50, then 250 more.
+          final freshIds = List.generate(300, (i) => 'v$i');
+          when(() => mockLikesRepository.syncUserReactions()).thenAnswer(
+            (_) async => LikesSyncResult(
+              orderedEventIds: freshIds,
+              eventIdToReactionId: const {},
+            ),
+          );
+          when(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer((invocation) async {
+            final ids = invocation.positionalArguments[0] as List<String>;
+            return ids.map(createTestVideo).toList();
+          });
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileLikedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having((s) => s.videos.length, 'cached videos', 50),
+          // Window stays bounded to what was displayed; the full ID list is
+          // restored in memory so pagination can continue past the cap.
+          isA<ProfileLikedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having((s) => s.videos.length, 'revalidated videos', 50)
+              .having((s) => s.likedEventIds.length, 'full id list', 300)
+              .having((s) => s.hasMoreContent, 'hasMoreContent', true),
+        ],
+        verify: (_) {
+          // The reconcile window is the displayed 50, all already cached, so
+          // no video fetch happens — proving no 250-item bulk re-fetch.
+          verifyNever(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          );
+        },
+      );
+
+      blocTest<ProfileLikedVideosBloc, ProfileLikedVideosState>(
         'preserves order of liked event IDs in result',
         setUp: () {
           final video1 = createTestVideo('event1');

--- a/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_reposted_videos/profile_reposted_videos_bloc_test.dart
@@ -5,10 +5,12 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:reposts_repository/reposts_repository.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -16,10 +18,43 @@ class _MockRepostsRepository extends Mock implements RepostsRepository {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
+/// In-memory [CacheDao] so the bloc's [CacheSync] reads/writes are isolated
+/// per test without touching disk.
+class _InMemoryCacheDao implements CacheDao {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    _store[key] = payload;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _store.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
 void main() {
   group('ProfileRepostedVideosBloc', () {
     late _MockRepostsRepository mockRepostsRepository;
     late _MockVideosRepository mockVideosRepository;
+    late _InMemoryCacheDao cacheDao;
     late StreamController<Set<String>> repostedIdsController;
 
     // 64-character hex pubkeys for testing
@@ -28,9 +63,11 @@ void main() {
     const otherUserPubkey =
         'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
-    setUp(() {
+    setUp(() async {
       mockRepostsRepository = _MockRepostsRepository();
       mockVideosRepository = _MockVideosRepository();
+      cacheDao = _InMemoryCacheDao();
+      await CacheSync.init(dao: cacheDao);
       repostedIdsController = StreamController<Set<String>>.broadcast();
 
       // Default stub for watchRepostedAddressableIds
@@ -165,15 +202,24 @@ void main() {
           state.videos,
           const ['34236:abc:123'],
           null,
-          true,
-          false,
+          true, // isLoadingMore
+          false, // isRefreshing
+          false, // hasMoreContent
+          0, // nextPageOffset
         ]);
+      });
+
+      test('copyWith updates isRefreshing', () {
+        const state = ProfileRepostedVideosState();
+
+        expect(state.isRefreshing, isFalse);
+        expect(state.copyWith(isRefreshing: true).isRefreshing, isTrue);
       });
     });
 
     group('ProfileRepostedVideosSyncRequested', () {
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
-        'emits [syncing, success] with empty videos when no reposted IDs',
+        'emits [success] with empty videos when no reposted IDs',
         setUp: () {
           when(
             () => mockRepostsRepository.syncUserReposts(),
@@ -181,10 +227,8 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.syncing,
-          ),
           const ProfileRepostedVideosState(
             status: ProfileRepostedVideosStatus.success,
             hasMoreContent: false,
@@ -193,7 +237,7 @@ void main() {
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
-        'emits [syncing, loading, success] when videos found',
+        'emits [success] with videos when reposts found',
         setUp: () {
           final addressableId1 = createAddressableId(currentUserPubkey, 'd1');
           final addressableId2 = createAddressableId(currentUserPubkey, 'd2');
@@ -226,33 +270,27 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.syncing,
-          ),
-          isA<ProfileRepostedVideosState>()
-              .having(
-                (s) => s.status,
-                'status',
-                ProfileRepostedVideosStatus.loading,
-              )
-              .having(
-                (s) => s.repostedAddressableIds.length,
-                'addressable IDs count',
-                2,
-              ),
           isA<ProfileRepostedVideosState>()
               .having(
                 (s) => s.status,
                 'status',
                 ProfileRepostedVideosStatus.success,
               )
-              .having((s) => s.videos.length, 'videos count', 2),
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having(
+                (s) => s.repostedAddressableIds.length,
+                'addressable IDs count',
+                2,
+              )
+              .having((s) => s.videos.length, 'videos count', 2)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 2),
         ],
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
-        'emits [syncing, failure] when sync fails',
+        'emits [failure] when sync fails and nothing is cached',
         setUp: () {
           when(
             () => mockRepostsRepository.syncUserReposts(),
@@ -260,10 +298,8 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.syncing,
-          ),
           const ProfileRepostedVideosState(
             status: ProfileRepostedVideosStatus.failure,
             error: ProfileRepostedVideosError.syncFailed,
@@ -272,42 +308,98 @@ void main() {
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
-        'emits [syncing, failure] when sync reposts fails',
-        setUp: () {
-          // syncUserReposts throws SyncFailedException, not FetchRepostsFailedException
-          when(
-            () => mockRepostsRepository.syncUserReposts(),
-          ).thenThrow(const SyncFailedException('Network error'));
+        'serves cached snapshot, then only flips the bar off when unchanged',
+        setUp: () async {
+          final id1 = createAddressableId(currentUserPubkey, 'd1');
+          final id2 = createAddressableId(currentUserPubkey, 'd2');
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_reposted_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [
+                createTestVideo(
+                  id: 'e1',
+                  pubkey: currentUserPubkey,
+                  vineId: 'd1',
+                ),
+                createTestVideo(
+                  id: 'e2',
+                  pubkey: currentUserPubkey,
+                  vineId: 'd2',
+                ),
+              ],
+              itemIds: [id1, id2],
+              nextPageOffset: 2,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockRepostsRepository.syncUserReposts()).thenAnswer(
+            (_) async => RepostsSyncResult(
+              orderedAddressableIds: [id1, id2],
+              addressableIdToRepostId: const {},
+            ),
+          );
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.syncing,
-          ),
-          const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.failure,
-            error: ProfileRepostedVideosError.syncFailed,
-          ),
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having((s) => s.videos.length, 'cached videos', 2),
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having((s) => s.videos.length, 'unchanged videos', 2),
         ],
-      );
-
-      blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
-        'does not re-sync while already syncing',
-        setUp: () {
-          when(
-            () => mockRepostsRepository.syncUserReposts(),
-          ).thenAnswer((_) async => const RepostsSyncResult.empty());
-        },
-        build: createBloc,
-        seed: () => const ProfileRepostedVideosState(
-          status: ProfileRepostedVideosStatus.syncing,
-        ),
-        act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
-        expect: () => <ProfileRepostedVideosState>[],
         verify: (_) {
-          verifyNever(() => mockRepostsRepository.syncUserReposts());
+          verifyNever(
+            () => mockVideosRepository.getVideosByAddressableIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          );
         },
+      );
+
+      blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
+        'reopen restores the full scrolled-through list from cache',
+        setUp: () async {
+          final ids = List.generate(
+            40,
+            (i) => createAddressableId(currentUserPubkey, 'd$i'),
+          );
+          final videos = List.generate(
+            36,
+            (i) => createTestVideo(
+              id: 'e$i',
+              pubkey: currentUserPubkey,
+              vineId: 'd$i',
+            ),
+          );
+          await cacheDao.write(
+            key: '$otherUserPubkey:profile_reposted_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: videos,
+              itemIds: ids,
+              nextPageOffset: 36,
+              hasMoreContent: true,
+            ).toJson(),
+          );
+          when(
+            () => mockRepostsRepository.fetchUserReposts(any()),
+          ).thenAnswer((_) async => ids);
+        },
+        build: () => createBloc(targetUserPubkey: otherUserPubkey),
+        act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having((s) => s.videos.length, 'cached videos', 36)
+              .having((s) => s.nextPageOffset, 'nextPageOffset', 36),
+          isA<ProfileRepostedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having((s) => s.videos.length, 'revalidated videos', 36),
+        ],
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
@@ -334,7 +426,6 @@ void main() {
 
           when(() => mockRepostsRepository.syncUserReposts()).thenAnswer(
             (_) async => RepostsSyncResult(
-              // Order: d3, d1, d2 (by recency)
               orderedAddressableIds: [
                 addressableId3,
                 addressableId1,
@@ -343,7 +434,6 @@ void main() {
               addressableIdToRepostId: const {},
             ),
           );
-          // VideosRepository preserves order from input
           when(
             () => mockVideosRepository.getVideosByAddressableIds(
               any(),
@@ -353,15 +443,8 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.syncing,
-          ),
-          isA<ProfileRepostedVideosState>().having(
-            (s) => s.status,
-            'status',
-            ProfileRepostedVideosStatus.loading,
-          ),
           isA<ProfileRepostedVideosState>()
               .having(
                 (s) => s.status,
@@ -446,33 +529,59 @@ void main() {
       );
 
       blocTest<ProfileRepostedVideosBloc, ProfileRepostedVideosState>(
-        'updates repostedAddressableIds when video is reposted',
+        'fetches and prepends the video when a new repost arrives via stream',
+        setUp: () {
+          when(
+            () => mockVideosRepository.getVideosByAddressableIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              createTestVideo(
+                id: 'e2',
+                pubkey: currentUserPubkey,
+                vineId: 'd2',
+              ),
+            ],
+          );
+        },
         build: createBloc,
         seed: () => ProfileRepostedVideosState(
           status: ProfileRepostedVideosStatus.success,
           repostedAddressableIds: [
             createAddressableId(currentUserPubkey, 'd1'),
           ],
+          videos: [
+            createTestVideo(id: 'e1', pubkey: currentUserPubkey, vineId: 'd1'),
+          ],
+          nextPageOffset: 1,
         ),
         act: (bloc) async {
           bloc.add(const ProfileRepostedVideosSubscriptionRequested());
           await Future<void>.delayed(const Duration(milliseconds: 50));
+          // d2 reposted, prepended (most-recent-first).
           repostedIdsController.add({
-            createAddressableId(currentUserPubkey, 'd1'),
             createAddressableId(currentUserPubkey, 'd2'),
+            createAddressableId(currentUserPubkey, 'd1'),
           });
         },
         wait: const Duration(milliseconds: 100),
         expect: () => [
-          // IDs are updated, video will be fetched on next sync
-          isA<ProfileRepostedVideosState>().having(
-            (s) => s.repostedAddressableIds,
-            'repostedAddressableIds',
-            containsAll([
-              createAddressableId(currentUserPubkey, 'd1'),
-              createAddressableId(currentUserPubkey, 'd2'),
-            ]),
-          ),
+          isA<ProfileRepostedVideosState>()
+              .having(
+                (s) => s.repostedAddressableIds,
+                'repostedAddressableIds',
+                containsAll([
+                  createAddressableId(currentUserPubkey, 'd1'),
+                  createAddressableId(currentUserPubkey, 'd2'),
+                ]),
+              )
+              // The new repost is fetched and shown at the top.
+              .having((s) => s.videos.map((v) => v.vineId).toList(), 'videos', [
+                'd2',
+                'd1',
+              ]),
         ],
       );
     });
@@ -521,6 +630,7 @@ void main() {
           repostedAddressableIds: [
             createAddressableId(currentUserPubkey, 'd1'),
           ],
+          nextPageOffset: 1,
         ),
         act: (bloc) => bloc.add(const ProfileRepostedVideosLoadMoreRequested()),
         expect: () => [
@@ -606,9 +716,6 @@ void main() {
         wait: const Duration(milliseconds: 100),
         expect: () => [
           const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.syncing,
-          ),
-          const ProfileRepostedVideosState(
             status: ProfileRepostedVideosStatus.success,
             hasMoreContent: false,
           ),
@@ -647,10 +754,8 @@ void main() {
         },
         build: () => createBloc(targetUserPubkey: currentUserPubkey),
         act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.syncing,
-          ),
           const ProfileRepostedVideosState(
             status: ProfileRepostedVideosStatus.success,
             hasMoreContent: false,
@@ -687,21 +792,8 @@ void main() {
         },
         build: () => createBloc(targetUserPubkey: otherUserPubkey),
         act: (bloc) => bloc.add(const ProfileRepostedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileRepostedVideosState(
-            status: ProfileRepostedVideosStatus.syncing,
-          ),
-          isA<ProfileRepostedVideosState>()
-              .having(
-                (s) => s.status,
-                'status',
-                ProfileRepostedVideosStatus.loading,
-              )
-              .having(
-                (s) => s.repostedAddressableIds.length,
-                'addressable IDs count',
-                1,
-              ),
           isA<ProfileRepostedVideosState>()
               .having(
                 (s) => s.status,

--- a/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
+++ b/mobile/test/blocs/profile_saved_videos/profile_saved_videos_bloc_test.dart
@@ -2,10 +2,12 @@
 // ABOUTME: BookmarkService and paginating through VideosRepository.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 import 'package:openvine/services/bookmark_service.dart';
 import 'package:videos_repository/videos_repository.dart';
 
@@ -13,19 +15,58 @@ class _MockBookmarkService extends Mock implements BookmarkService {}
 
 class _MockVideosRepository extends Mock implements VideosRepository {}
 
+/// In-memory [CacheDao] so the bloc's [CacheSync] reads/writes are isolated
+/// per test without touching disk.
+class _InMemoryCacheDao implements CacheDao {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    _store[key] = payload;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _store.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
 void main() {
   group('ProfileSavedVideosBloc', () {
     late _MockBookmarkService mockBookmarkService;
     late _MockVideosRepository mockVideosRepository;
+    late _InMemoryCacheDao cacheDao;
 
-    setUp(() {
+    const currentUserPubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    setUp(() async {
       mockBookmarkService = _MockBookmarkService();
       mockVideosRepository = _MockVideosRepository();
+      cacheDao = _InMemoryCacheDao();
+      await CacheSync.init(dao: cacheDao);
     });
 
     ProfileSavedVideosBloc createBloc() => ProfileSavedVideosBloc(
       bookmarkService: Future.value(mockBookmarkService),
       videosRepository: mockVideosRepository,
+      currentUserPubkey: currentUserPubkey,
     );
 
     VideoEvent createTestVideo(String id) {
@@ -87,15 +128,52 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ProfileSavedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
         expect: () => [
-          const ProfileSavedVideosState(
-            status: ProfileSavedVideosStatus.syncing,
-          ),
           const ProfileSavedVideosState(
             status: ProfileSavedVideosStatus.success,
             hasMoreContent: false,
           ),
         ],
+      );
+
+      blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(
+        'reopen restores the cached list, then flips the bar off when '
+        'bookmarks are unchanged',
+        setUp: () async {
+          await cacheDao.write(
+            key: '$currentUserPubkey:profile_saved_videos',
+            payload: ProfileVideoListSnapshot(
+              videos: [createTestVideo('video-1'), createTestVideo('video-2')],
+              itemIds: const ['video-1', 'video-2'],
+              nextPageOffset: 2,
+              hasMoreContent: false,
+            ).toJson(),
+          );
+          when(() => mockBookmarkService.globalBookmarks).thenReturn(const [
+            BookmarkItem(type: 'e', id: 'video-1'),
+            BookmarkItem(type: 'e', id: 'video-2'),
+          ]);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ProfileSavedVideosSyncRequested()),
+        wait: const Duration(milliseconds: 50),
+        expect: () => [
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', true)
+              .having((s) => s.videos.length, 'cached videos', 2),
+          isA<ProfileSavedVideosState>()
+              .having((s) => s.isRefreshing, 'isRefreshing', false)
+              .having((s) => s.videos.length, 'unchanged videos', 2),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.getVideosByIds(
+              any(),
+              cacheResults: any(named: 'cacheResults'),
+            ),
+          );
+        },
       );
 
       blocTest<ProfileSavedVideosBloc, ProfileSavedVideosState>(

--- a/mobile/test/blocs/profile_shared/profile_video_cursor_snapshot_test.dart
+++ b/mobile/test/blocs/profile_shared/profile_video_cursor_snapshot_test.dart
@@ -1,0 +1,54 @@
+// ABOUTME: Tests for ProfileVideoCursorSnapshot JSON serialization.
+// ABOUTME: Pins the CacheSync payload round-trip for cursor-paginated tabs.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_cursor_snapshot.dart';
+
+VideoEvent _video(String id) {
+  final now = DateTime.fromMillisecondsSinceEpoch(
+    1704067200 * 1000,
+    isUtc: true,
+  );
+  return VideoEvent(
+    id: id,
+    pubkey: '0' * 64,
+    createdAt: 1704067200,
+    content: '',
+    timestamp: now,
+    title: 'Video $id',
+    thumbnailUrl: 'https://example.com/$id.jpg',
+  );
+}
+
+void main() {
+  group(ProfileVideoCursorSnapshot, () {
+    test('round-trips through toJson/fromJson', () {
+      final snapshot = ProfileVideoCursorSnapshot(
+        videos: [_video('a'), _video('b')],
+        paginationCursor: 1704067200,
+        hasMoreContent: true,
+      );
+
+      final restored = ProfileVideoCursorSnapshot.fromJson(snapshot.toJson());
+
+      expect(restored.videos.map((v) => v.id).toList(), ['a', 'b']);
+      expect(restored.paginationCursor, 1704067200);
+      expect(restored.hasMoreContent, isTrue);
+    });
+
+    test('round-trips a null cursor (end of feed)', () {
+      const snapshot = ProfileVideoCursorSnapshot(
+        videos: [],
+        paginationCursor: null,
+        hasMoreContent: false,
+      );
+
+      final restored = ProfileVideoCursorSnapshot.fromJson(snapshot.toJson());
+
+      expect(restored.videos, isEmpty);
+      expect(restored.paginationCursor, isNull);
+      expect(restored.hasMoreContent, isFalse);
+    });
+  });
+}

--- a/mobile/test/blocs/profile_shared/profile_video_cursor_snapshot_test.dart
+++ b/mobile/test/blocs/profile_shared/profile_video_cursor_snapshot_test.dart
@@ -3,19 +3,19 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_shared/profile_snapshot_window.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_cursor_snapshot.dart';
 
-VideoEvent _video(String id) {
-  final now = DateTime.fromMillisecondsSinceEpoch(
-    1704067200 * 1000,
-    isUtc: true,
-  );
+VideoEvent _video(String id, {int createdAt = 1704067200}) {
   return VideoEvent(
     id: id,
     pubkey: '0' * 64,
-    createdAt: 1704067200,
+    createdAt: createdAt,
     content: '',
-    timestamp: now,
+    timestamp: DateTime.fromMillisecondsSinceEpoch(
+      createdAt * 1000,
+      isUtc: true,
+    ),
     title: 'Video $id',
     thumbnailUrl: 'https://example.com/$id.jpg',
   );
@@ -49,6 +49,47 @@ void main() {
       expect(restored.videos, isEmpty);
       expect(restored.paginationCursor, isNull);
       expect(restored.hasMoreContent, isFalse);
+    });
+
+    group('.capped', () {
+      const max = ProfileSnapshotWindow.maxItems;
+
+      test('returns the videos unchanged when within the window', () {
+        final snapshot = ProfileVideoCursorSnapshot.capped(
+          videos: [_video('a'), _video('b')],
+          paginationCursor: 1704067200,
+          hasMoreContent: false,
+        );
+
+        expect(snapshot.videos.length, 2);
+        expect(snapshot.paginationCursor, 1704067200);
+        expect(snapshot.hasMoreContent, isFalse);
+      });
+
+      test(
+        'truncates to the head and re-anchors the cursor to the last kept '
+        'video',
+        () {
+          // Feed order is most-recent-first → createdAt decreases with index.
+          final videos = List.generate(
+            max + 30,
+            (i) => _video('v$i', createdAt: 2000000000 - i),
+          );
+
+          final snapshot = ProfileVideoCursorSnapshot.capped(
+            videos: videos,
+            paginationCursor: 1000, // stale cursor from the full set's tail
+            hasMoreContent: false,
+          );
+
+          expect(snapshot.videos.length, max);
+          expect(snapshot.videos.last.id, 'v${max - 1}');
+          // Cursor follows the last KEPT video so load-more continues right
+          // after the persisted window rather than skipping the dropped tail.
+          expect(snapshot.paginationCursor, 2000000000 - (max - 1));
+          expect(snapshot.hasMoreContent, isTrue);
+        },
+      );
     });
   });
 }

--- a/mobile/test/blocs/profile_shared/profile_video_list_snapshot_test.dart
+++ b/mobile/test/blocs/profile_shared/profile_video_list_snapshot_test.dart
@@ -1,0 +1,72 @@
+// ABOUTME: Tests for ProfileVideoListSnapshot JSON serialization.
+// ABOUTME: Pins the CacheSync payload round-trip shared by the profile video
+// ABOUTME: tabs (Liked, Reposts, Saved, …).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
+
+VideoEvent _video(String id) {
+  final now = DateTime.fromMillisecondsSinceEpoch(
+    1704067200 * 1000,
+    isUtc: true,
+  );
+  return VideoEvent(
+    id: id,
+    pubkey: '0' * 64,
+    createdAt: 1704067200,
+    content: '',
+    timestamp: now,
+    title: 'Video $id',
+    thumbnailUrl: 'https://example.com/$id.jpg',
+  );
+}
+
+void main() {
+  group(ProfileVideoListSnapshot, () {
+    test('round-trips through toJson/fromJson', () {
+      final snapshot = ProfileVideoListSnapshot(
+        videos: [_video('a'), _video('b')],
+        itemIds: const ['a', 'b', 'c'],
+        nextPageOffset: 2,
+        hasMoreContent: true,
+      );
+
+      final restored = ProfileVideoListSnapshot.fromJson(snapshot.toJson());
+
+      expect(restored.videos.map((v) => v.id).toList(), ['a', 'b']);
+      expect(restored.itemIds, ['a', 'b', 'c']);
+      expect(restored.nextPageOffset, 2);
+      expect(restored.hasMoreContent, isTrue);
+    });
+
+    test('preserves video order', () {
+      final snapshot = ProfileVideoListSnapshot(
+        videos: [_video('c'), _video('a'), _video('b')],
+        itemIds: const ['c', 'a', 'b'],
+        nextPageOffset: 3,
+        hasMoreContent: false,
+      );
+
+      final restored = ProfileVideoListSnapshot.fromJson(snapshot.toJson());
+
+      expect(restored.videos.map((v) => v.id).toList(), ['c', 'a', 'b']);
+    });
+
+    test('round-trips an empty snapshot', () {
+      const snapshot = ProfileVideoListSnapshot(
+        videos: [],
+        itemIds: [],
+        nextPageOffset: 0,
+        hasMoreContent: false,
+      );
+
+      final restored = ProfileVideoListSnapshot.fromJson(snapshot.toJson());
+
+      expect(restored.videos, isEmpty);
+      expect(restored.itemIds, isEmpty);
+      expect(restored.nextPageOffset, 0);
+      expect(restored.hasMoreContent, isFalse);
+    });
+  });
+}

--- a/mobile/test/blocs/profile_shared/profile_video_list_snapshot_test.dart
+++ b/mobile/test/blocs/profile_shared/profile_video_list_snapshot_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_shared/profile_snapshot_window.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_list_snapshot.dart';
 
 VideoEvent _video(String id) {
@@ -67,6 +68,63 @@ void main() {
       expect(restored.itemIds, isEmpty);
       expect(restored.nextPageOffset, 0);
       expect(restored.hasMoreContent, isFalse);
+    });
+
+    group('.capped', () {
+      const max = ProfileSnapshotWindow.maxItems;
+
+      test('returns the lists unchanged when within the window', () {
+        final snapshot = ProfileVideoListSnapshot.capped(
+          videos: [_video('a'), _video('b')],
+          itemIds: const ['a', 'b', 'c'],
+          nextPageOffset: 2,
+          hasMoreContent: false,
+        );
+
+        expect(snapshot.videos.map((v) => v.id).toList(), ['a', 'b']);
+        expect(snapshot.itemIds, ['a', 'b', 'c']);
+        expect(snapshot.nextPageOffset, 2);
+        expect(snapshot.hasMoreContent, isFalse);
+      });
+
+      test(
+        'truncates both lists to the head, clamps the offset, and forces '
+        'hasMoreContent',
+        () {
+          final videos = List.generate(max + 50, (i) => _video('v$i'));
+          final ids = List.generate(max + 500, (i) => 'v$i');
+
+          final snapshot = ProfileVideoListSnapshot.capped(
+            videos: videos,
+            itemIds: ids,
+            nextPageOffset: max + 400,
+            // even with hasMoreContent already false, truncation must flip it
+            hasMoreContent: false,
+          );
+
+          expect(snapshot.videos.length, max);
+          expect(snapshot.videos.first.id, 'v0');
+          expect(snapshot.videos.last.id, 'v${max - 1}');
+          expect(snapshot.itemIds.length, max);
+          expect(snapshot.itemIds.last, 'v${max - 1}');
+          expect(snapshot.nextPageOffset, max);
+          expect(snapshot.hasMoreContent, isTrue);
+        },
+      );
+
+      test('caps a long id list even when the videos fit', () {
+        final snapshot = ProfileVideoListSnapshot.capped(
+          videos: [_video('a'), _video('b')],
+          itemIds: List.generate(max + 1000, (i) => 'id$i'),
+          nextPageOffset: 2,
+          hasMoreContent: false,
+        );
+
+        expect(snapshot.videos.length, 2);
+        expect(snapshot.itemIds.length, max);
+        expect(snapshot.nextPageOffset, 2);
+        expect(snapshot.hasMoreContent, isTrue);
+      });
     });
   });
 }

--- a/mobile/test/mixins/scroll_pagination_mixin_test.dart
+++ b/mobile/test/mixins/scroll_pagination_mixin_test.dart
@@ -59,6 +59,38 @@ void main() {
       },
     );
 
+    testWidgets(
+      'a larger paginationLoadMoreThreshold triggers further from the bottom',
+      (tester) async {
+        var loadMoreCalls = 0;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: _TestWidget(
+              canLoadMore: () => true,
+              onLoadMore: () async => loadMoreCalls++,
+              // Prefetch a full extra screen ahead of the default 200px.
+              loadMoreThreshold: 2000,
+            ),
+          ),
+        );
+
+        final state = tester.state<_TestWidgetState>(find.byType(_TestWidget));
+        final scrollController = state.paginationScrollController;
+
+        // 1000px from the bottom: past the default 200px threshold (no
+        // trigger) but inside the overridden 2000px one (triggers).
+        scrollController.jumpTo(
+          scrollController.position.maxScrollExtent - 1000,
+        );
+        await tester.pump();
+
+        expect(loadMoreCalls, 1);
+      },
+    );
+
     testWidgets('does not trigger when canLoadMore returns false', (
       tester,
     ) async {
@@ -132,10 +164,15 @@ void main() {
 
 /// Test widget that uses [ScrollPaginationMixin].
 class _TestWidget extends StatefulWidget {
-  const _TestWidget({required this.canLoadMore, required this.onLoadMore});
+  const _TestWidget({
+    required this.canLoadMore,
+    required this.onLoadMore,
+    this.loadMoreThreshold,
+  });
 
   final bool Function() canLoadMore;
   final FutureOr<void> Function() onLoadMore;
+  final double? loadMoreThreshold;
 
   @override
   State<_TestWidget> createState() => _TestWidgetState();
@@ -146,6 +183,10 @@ class _TestWidgetState extends State<_TestWidget> with ScrollPaginationMixin {
 
   @override
   ScrollController get paginationScrollController => _scrollController;
+
+  @override
+  double get paginationLoadMoreThreshold =>
+      widget.loadMoreThreshold ?? super.paginationLoadMoreThreshold;
 
   @override
   bool canLoadMore() => widget.canLoadMore();

--- a/mobile/test/widgets/profile/profile_cache_load_indicator_test.dart
+++ b/mobile/test/widgets/profile/profile_cache_load_indicator_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/widgets/profile/profile_cache_load_indicator.dart';
+
+void main() {
+  group(ProfileCacheLoadIndicator, () {
+    testWidgets('renders a linear progress indicator at its fixed height', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: ProfileCacheLoadIndicator()),
+        ),
+      );
+
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+
+      final size = tester.getSize(find.byType(ProfileCacheLoadIndicator));
+      expect(size.height, ProfileCacheLoadIndicator.height);
+    });
+  });
+}

--- a/mobile/test/widgets/profile/profile_liked_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_liked_grid_test.dart
@@ -206,6 +206,26 @@ void main() {
 
         expect(find.byType(BrandedLoadingIndicator), findsOneWidget);
       });
+
+      testWidgets('keeps cached grid on screen while refreshing', (
+        tester,
+      ) async {
+        final videos = _createTestVideos(count: 3);
+        when(() => mockBloc.state).thenReturn(
+          ProfileLikedVideosState(
+            status: ProfileLikedVideosStatus.success,
+            videos: videos,
+            isRefreshing: true,
+          ),
+        );
+
+        await tester.pumpWidget(buildSubject());
+
+        // The grid stays on screen during the background revalidation. The
+        // progress bar itself lives in the pinned tab bar header
+        // (profile_grid.dart), not in the grid body.
+        expect(find.byType(SliverGrid), findsOneWidget);
+      });
     });
 
     group('interactions', () {


### PR DESCRIPTION
Closes #5280

## Description

Reopening a profile tab reloaded its whole list from the relay every time, fast scrolling stalled on "loading more", and freshly-arriving data could briefly jank the UI thread. This backs the profile video tabs with `CacheSync` so each tab's scrolled-through list is restored **instantly** on reopen, then revalidated in the background behind a thin progress bar pinned **under the tab bar**.

Tabs covered: **Liked, Reposts, Saved, Collabs**.

**How it works**
- **Shared snapshot models** persist the resolved window so a reopen renders from cache without a relay round-trip:
  - `ProfileVideoListSnapshot` — ID-list tabs (Liked, Reposts, Saved)
  - `ProfileVideoCursorSnapshot` — cursor-paginated tab (Collabs)
- **Stale-while-revalidate**: the snapshot is served immediately; revalidation only refreshes the ID list (or first page for Collabs) and **reconciles cheaply** — drops removed items and fetches only the genuinely-new ones at the top. The UI thread never re-resolves the whole window (fixes the jank when fresh data arrived).
- **Pagination** prefetches ~1.5 viewports ahead (overridable `ScrollPaginationMixin` threshold) and persists each page, so fast scrolling and re-scrolling no longer stall on "loading more". The Liked tab keeps `main`'s sparse-ID page-filling + blocklist filtering.
- **Sticky bar**: a single revalidation bar in the pinned tab-bar header tracks whichever cached tab is active (a body overlay would be painted behind the pinned header).
- Plumbing: `VideoEvent.fromJson` (already on `main`) is reused; `CacheSync.read`/`write` (already on `main`) drive incremental list growth.



## Out of Scope

- **Comments tab** — intentionally left on the existing path (different data model, cursor-based).
- This branch was rebased onto `main`, which had landed a parallel refactor of the Liked tab (`_fetchVideoPage` sparse-ID page-filling + blocklist-in-fetch). That refactor is integrated into the new SWR paths here; the Liked emit flow is now SWR (no intermediate `syncing`/`loading`), so a few of those tests were updated accordingly.

## Verification

- `flutter analyze lib test integration_test` — clean
- Bloc tests: Liked / Reposts / Saved / Collabs (incl. reopen-restore, reconcile/prepend, droppable, sparse-ID + blocklist) — green
- Shared snapshot tests, profile widget tests, `scroll_pagination_mixin` test — green
- `cache_sync` and `models` package tests — green
- Pre-push hook (analyze + changed-file tests) — green

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧹 Code refactor