### PR TITLE
fix(profile): preserve tapped history video

### DIFF
--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -14,6 +14,7 @@ import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/utils/video_identity.dart';
 import 'package:rxdart/rxdart.dart';
+import 'package:videos_repository/videos_repository.dart';
 
 /// Fullscreen video feed view for profile screens.
 ///
@@ -119,17 +120,13 @@ class _ProfileFullscreenContentState extends State<_ProfileFullscreenContent> {
     super.initState();
     _cubit = context.read<ProfileFeedCubit>();
 
-    // Prefer the live cubit list, falling back to the tapped seed list until
-    // the cubit resolves. `startWith` guarantees the first list reaches the
-    // FullscreenFeedBloc before it subscribes.
-    List<VideoEvent> effective(ProfileFeedState state) =>
-        state.videos.isNotEmpty ? state.videos : widget.seedVideos;
-
     final initialState = _cubit.state;
-    _initialIndex = _resolveInitialIndex(effective(initialState));
+    _initialIndex = _resolveInitialIndex(_effectiveVideos(initialState));
 
     _feedRepository = StreamFeedRepository(
-      videos: _cubit.stream.map(effective).startWith(effective(initialState)),
+      videos: _cubit.stream
+          .map(_effectiveVideos)
+          .startWith(_effectiveVideos(initialState)),
       hasMore: _cubit.stream
           .map((state) => state.hasMoreContent)
           .startWith(initialState.hasMoreContent),
@@ -137,21 +134,42 @@ class _ProfileFullscreenContentState extends State<_ProfileFullscreenContent> {
     );
   }
 
+  List<VideoEvent> _effectiveVideos(ProfileFeedState state) {
+    final liveVideos = state.videos;
+    final seedVideos = widget.seedVideos;
+    if (liveVideos.isEmpty) return seedVideos;
+    if (seedVideos.isEmpty || !_seedContainsInitialTarget()) return liveVideos;
+    if (_containsInitialTarget(liveVideos)) return liveVideos;
+
+    return mergeProfileFeedVideoLists(liveVideos, seedVideos);
+  }
+
   int _resolveInitialIndex(List<VideoEvent> videos) {
     if (videos.isEmpty) return 0;
 
+    final resolved = _indexOfInitialTarget(videos);
+    if (resolved >= 0) return resolved;
+
+    return widget.videoIndex.clamp(0, videos.length - 1);
+  }
+
+  bool _seedContainsInitialTarget() =>
+      _containsInitialTarget(widget.seedVideos);
+
+  bool _containsInitialTarget(List<VideoEvent> videos) =>
+      _indexOfInitialTarget(videos) >= 0;
+
+  int _indexOfInitialTarget(List<VideoEvent> videos) {
     final initialVideoId = widget.initialVideoId;
     final initialStableId = widget.initialStableId;
     if (initialVideoId != null || initialStableId != null) {
-      final resolved = indexOfVideoIdentity(
+      return indexOfVideoIdentity(
         videos,
         videoId: initialVideoId,
         stableId: initialStableId,
       );
-      if (resolved >= 0) return resolved;
     }
-
-    return widget.videoIndex.clamp(0, videos.length - 1);
+    return -1;
   }
 
   @override

--- a/mobile/lib/widgets/profile/profile_video_feed_view.dart
+++ b/mobile/lib/widgets/profile/profile_video_feed_view.dart
@@ -114,11 +114,13 @@ class _ProfileFullscreenContentState extends State<_ProfileFullscreenContent> {
   late final ProfileFeedCubit _cubit;
   late final FeedRepository _feedRepository;
   late final int _initialIndex;
+  late final bool _seedContainsInitialTarget;
 
   @override
   void initState() {
     super.initState();
     _cubit = context.read<ProfileFeedCubit>();
+    _seedContainsInitialTarget = _containsInitialTarget(widget.seedVideos);
 
     final initialState = _cubit.state;
     _initialIndex = _resolveInitialIndex(_effectiveVideos(initialState));
@@ -134,11 +136,17 @@ class _ProfileFullscreenContentState extends State<_ProfileFullscreenContent> {
     );
   }
 
+  // Adapts the scoped live cubit feed to the launch seed while the new cubit
+  // catches up to the tapped video from the profile grid.
   List<VideoEvent> _effectiveVideos(ProfileFeedState state) {
     final liveVideos = state.videos;
     final seedVideos = widget.seedVideos;
     if (liveVideos.isEmpty) return seedVideos;
-    if (seedVideos.isEmpty || !_seedContainsInitialTarget()) return liveVideos;
+    if (seedVideos.isEmpty || !_seedContainsInitialTarget) return liveVideos;
+
+    // Once live paging reaches the tapped target, the cubit-owned list is
+    // authoritative again; seed-only items can drop until live paging reaches
+    // them through the normal profile feed path.
     if (_containsInitialTarget(liveVideos)) return liveVideos;
 
     return mergeProfileFeedVideoLists(liveVideos, seedVideos);
@@ -152,9 +160,6 @@ class _ProfileFullscreenContentState extends State<_ProfileFullscreenContent> {
 
     return widget.videoIndex.clamp(0, videos.length - 1);
   }
-
-  bool _seedContainsInitialTarget() =>
-      _containsInitialTarget(widget.seedVideos);
 
   bool _containsInitialTarget(List<VideoEvent> videos) =>
       _indexOfInitialTarget(videos) >= 0;

--- a/mobile/test/widgets/profile/profile_video_feed_view_test.dart
+++ b/mobile/test/widgets/profile/profile_video_feed_view_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -40,11 +41,7 @@ class _FakeVideoEvent extends Fake implements VideoEvent {}
 const _profilePubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
-VideoEvent _video(
-  String id, {
-  required int createdAt,
-  String? stableId,
-}) {
+VideoEvent _video(String id, {required int createdAt, String? stableId}) {
   return VideoEvent(
     id: id,
     pubkey: _profilePubkey,
@@ -99,6 +96,9 @@ void main() {
       when(
         () => blocklistRepository.shouldFilterFromFeeds(any()),
       ).thenReturn(false);
+      when(
+        () => blocklistRepository.currentState,
+      ).thenReturn(ContentPolicyState.empty());
     });
 
     testWidgets(
@@ -173,6 +173,87 @@ void main() {
         expect(fullscreenBloc.state.videos, seedVideos);
         expect(fullscreenBloc.state.currentIndex, 1);
         expect(fullscreenBloc.state.currentVideo?.id, target.id);
+      },
+    );
+
+    testWidgets(
+      'keeps the tapped seed video when the live profile page is shorter',
+      (tester) async {
+        const targetStableId = 'stable-target';
+        final seedVideos = [
+          _video('seed-0', createdAt: 6000),
+          _video('seed-1', createdAt: 5000),
+          _video('seed-2', createdAt: 4000),
+          _video('seed-3', createdAt: 3000),
+          _video('target-video', createdAt: 2000, stableId: targetStableId),
+          _video('seed-5', createdAt: 1000),
+        ];
+        final liveFirstPage = [
+          _video('live-0', createdAt: 8000),
+          _video('live-1', createdAt: 7000),
+        ];
+
+        when(
+          () => videosRepository.getAuthorFeed(
+            authorPubkey: any(named: 'authorPubkey'),
+            offset: any(named: 'offset'),
+            relaySeed: any(named: 'relaySeed'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer(
+          (_) async => AuthorFeedResult(
+            authorPubkey: _profilePubkey,
+            videos: liveFirstPage,
+            hasMore: true,
+            nextOffset: liveFirstPage.length,
+          ),
+        );
+
+        await tester.pumpWidget(
+          testProviderScope(
+            additionalOverrides: [
+              videosRepositoryProvider.overrideWithValue(videosRepository),
+              videoEventServiceProvider.overrideWithValue(videoEventService),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                blocklistRepository,
+              ),
+            ],
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: BlocProvider(
+                create: (_) => VideoVolumeCubit(
+                  sharedPreferences: createMockSharedPreferences(),
+                  systemVolumeListener: _FakeSystemVolumeListener(),
+                ),
+                child: ProfileVideoFeedView(
+                  npub: 'npub1profile',
+                  userIdHex: _profilePubkey,
+                  videoIndex: 4,
+                  videos: seedVideos,
+                  initialVideoId: 'target-video',
+                  initialStableId: targetStableId,
+                  contextTitleOverride: 'Profile',
+                  onPageChanged: (_) {},
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.runAsync(() async {
+          await Future<void>.delayed(Duration.zero);
+        });
+
+        final contentContext = tester.element(
+          find.byType(FullscreenFeedContent),
+        );
+        final fullscreenBloc = contentContext.read<FullscreenFeedBloc>();
+
+        expect(fullscreenBloc.state.status, FullscreenFeedStatus.ready);
+        expect(fullscreenBloc.state.videos, containsAll(seedVideos));
+        expect(fullscreenBloc.state.videos, containsAll(liveFirstPage));
+        expect(fullscreenBloc.state.currentVideo?.id, 'target-video');
       },
     );
   });

--- a/mobile/test/widgets/profile/profile_video_feed_view_test.dart
+++ b/mobile/test/widgets/profile/profile_video_feed_view_test.dart
@@ -101,6 +101,53 @@ void main() {
       ).thenReturn(ContentPolicyState.empty());
     });
 
+    Future<FullscreenFeedBloc> pumpProfileVideoFeed(
+      WidgetTester tester, {
+      required List<VideoEvent> seedVideos,
+      required int videoIndex,
+      required String? initialVideoId,
+      required String? initialStableId,
+    }) async {
+      await tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: [
+            videosRepositoryProvider.overrideWithValue(videosRepository),
+            videoEventServiceProvider.overrideWithValue(videoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              blocklistRepository,
+            ),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: BlocProvider(
+              create: (_) => VideoVolumeCubit(
+                sharedPreferences: createMockSharedPreferences(),
+                systemVolumeListener: _FakeSystemVolumeListener(),
+              ),
+              child: ProfileVideoFeedView(
+                npub: 'npub1profile',
+                userIdHex: _profilePubkey,
+                videoIndex: videoIndex,
+                videos: seedVideos,
+                initialVideoId: initialVideoId,
+                initialStableId: initialStableId,
+                contextTitleOverride: 'Profile',
+                onPageChanged: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.runAsync(() async {
+        await Future<void>.delayed(Duration.zero);
+      });
+
+      final contentContext = tester.element(find.byType(FullscreenFeedContent));
+      return contentContext.read<FullscreenFeedBloc>();
+    }
+
     testWidgets(
       'seeds fullscreen with the tapped video before live profile videos load',
       (tester) async {
@@ -128,46 +175,13 @@ void main() {
           ),
         );
 
-        await tester.pumpWidget(
-          testProviderScope(
-            additionalOverrides: [
-              videosRepositoryProvider.overrideWithValue(videosRepository),
-              videoEventServiceProvider.overrideWithValue(videoEventService),
-              contentBlocklistRepositoryProvider.overrideWithValue(
-                blocklistRepository,
-              ),
-            ],
-            child: MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: BlocProvider(
-                create: (_) => VideoVolumeCubit(
-                  sharedPreferences: createMockSharedPreferences(),
-                  systemVolumeListener: _FakeSystemVolumeListener(),
-                ),
-                child: ProfileVideoFeedView(
-                  npub: 'npub1profile',
-                  userIdHex: _profilePubkey,
-                  videoIndex: 0,
-                  videos: seedVideos,
-                  initialVideoId: target.id,
-                  initialStableId: targetStableId,
-                  contextTitleOverride: 'Profile',
-                  onPageChanged: (_) {},
-                ),
-              ),
-            ),
-          ),
+        final fullscreenBloc = await pumpProfileVideoFeed(
+          tester,
+          seedVideos: seedVideos,
+          videoIndex: 0,
+          initialVideoId: target.id,
+          initialStableId: targetStableId,
         );
-
-        await tester.runAsync(() async {
-          await Future<void>.delayed(Duration.zero);
-        });
-
-        final contentContext = tester.element(
-          find.byType(FullscreenFeedContent),
-        );
-        final fullscreenBloc = contentContext.read<FullscreenFeedBloc>();
 
         expect(fullscreenBloc.state.status, FullscreenFeedStatus.ready);
         expect(fullscreenBloc.state.videos, seedVideos);
@@ -209,51 +223,180 @@ void main() {
           ),
         );
 
-        await tester.pumpWidget(
-          testProviderScope(
-            additionalOverrides: [
-              videosRepositoryProvider.overrideWithValue(videosRepository),
-              videoEventServiceProvider.overrideWithValue(videoEventService),
-              contentBlocklistRepositoryProvider.overrideWithValue(
-                blocklistRepository,
-              ),
-            ],
-            child: MaterialApp(
-              localizationsDelegates: AppLocalizations.localizationsDelegates,
-              supportedLocales: AppLocalizations.supportedLocales,
-              home: BlocProvider(
-                create: (_) => VideoVolumeCubit(
-                  sharedPreferences: createMockSharedPreferences(),
-                  systemVolumeListener: _FakeSystemVolumeListener(),
-                ),
-                child: ProfileVideoFeedView(
-                  npub: 'npub1profile',
-                  userIdHex: _profilePubkey,
-                  videoIndex: 4,
-                  videos: seedVideos,
-                  initialVideoId: 'target-video',
-                  initialStableId: targetStableId,
-                  contextTitleOverride: 'Profile',
-                  onPageChanged: (_) {},
-                ),
-              ),
-            ),
-          ),
+        final fullscreenBloc = await pumpProfileVideoFeed(
+          tester,
+          seedVideos: seedVideos,
+          videoIndex: 4,
+          initialVideoId: 'target-video',
+          initialStableId: targetStableId,
         );
-
-        await tester.runAsync(() async {
-          await Future<void>.delayed(Duration.zero);
-        });
-
-        final contentContext = tester.element(
-          find.byType(FullscreenFeedContent),
-        );
-        final fullscreenBloc = contentContext.read<FullscreenFeedBloc>();
 
         expect(fullscreenBloc.state.status, FullscreenFeedStatus.ready);
         expect(fullscreenBloc.state.videos, containsAll(seedVideos));
         expect(fullscreenBloc.state.videos, containsAll(liveFirstPage));
         expect(fullscreenBloc.state.currentVideo?.id, 'target-video');
+      },
+    );
+
+    testWidgets(
+      'switches back to the live profile page once load-more finds the target',
+      (tester) async {
+        const targetStableId = 'stable-target';
+        final seedOnly = _video('seed-only', createdAt: 1000);
+        final seedVideos = [
+          _video('seed-0', createdAt: 6000),
+          _video('seed-1', createdAt: 5000),
+          _video('target-video', createdAt: 2000, stableId: targetStableId),
+          seedOnly,
+        ];
+        final liveFirstPage = List.generate(
+          50,
+          (index) => _video('live-$index', createdAt: 8000 - index),
+        );
+        final liveSecondPage = [
+          _video('target-video', createdAt: 2000, stableId: targetStableId),
+        ];
+
+        when(
+          () => videosRepository.getAuthorFeed(
+            authorPubkey: any(named: 'authorPubkey'),
+            offset: any(named: 'offset'),
+            relaySeed: any(named: 'relaySeed'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer(
+          (_) async => AuthorFeedResult(
+            authorPubkey: _profilePubkey,
+            videos: liveFirstPage,
+            hasMore: true,
+            nextOffset: liveFirstPage.length,
+          ),
+        );
+        when(
+          () => videosRepository.getAuthorFeed(
+            authorPubkey: any(named: 'authorPubkey'),
+            offset: liveFirstPage.length,
+          ),
+        ).thenAnswer(
+          (_) async => AuthorFeedResult(
+            authorPubkey: _profilePubkey,
+            videos: liveSecondPage,
+            hasMore: false,
+          ),
+        );
+
+        final fullscreenBloc = await pumpProfileVideoFeed(
+          tester,
+          seedVideos: seedVideos,
+          videoIndex: 2,
+          initialVideoId: 'target-video',
+          initialStableId: targetStableId,
+        );
+
+        expect(fullscreenBloc.state.videos, contains(seedOnly));
+        expect(fullscreenBloc.state.currentVideo?.id, 'target-video');
+
+        fullscreenBloc.add(const FullscreenFeedLoadMoreRequested());
+        await tester.runAsync(() async {
+          await Future<void>.delayed(Duration.zero);
+        });
+
+        expect(fullscreenBloc.state.videos, containsAll(liveFirstPage));
+        expect(fullscreenBloc.state.videos, containsAll(liveSecondPage));
+        expect(fullscreenBloc.state.videos, isNot(contains(seedOnly)));
+        expect(fullscreenBloc.state.currentVideo?.id, 'target-video');
+      },
+    );
+
+    testWidgets(
+      'uses live profile videos when the seed lacks the tapped target',
+      (tester) async {
+        const targetStableId = 'stable-target';
+        final seedOnly = _video('seed-only', createdAt: 1000);
+        final liveTarget = _video(
+          'target-video',
+          createdAt: 2000,
+          stableId: targetStableId,
+        );
+        final liveVideos = [
+          _video('live-0', createdAt: 3000),
+          liveTarget,
+        ];
+
+        when(
+          () => videosRepository.getAuthorFeed(
+            authorPubkey: any(named: 'authorPubkey'),
+            offset: any(named: 'offset'),
+            relaySeed: any(named: 'relaySeed'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer(
+          (_) async => AuthorFeedResult(
+            authorPubkey: _profilePubkey,
+            videos: liveVideos,
+            hasMore: false,
+          ),
+        );
+
+        final fullscreenBloc = await pumpProfileVideoFeed(
+          tester,
+          seedVideos: [seedOnly],
+          videoIndex: 0,
+          initialVideoId: liveTarget.id,
+          initialStableId: targetStableId,
+        );
+
+        expect(fullscreenBloc.state.videos, liveVideos);
+        expect(fullscreenBloc.state.videos, isNot(contains(seedOnly)));
+        expect(fullscreenBloc.state.currentVideo?.id, liveTarget.id);
+      },
+    );
+
+    testWidgets(
+      'uses live profile videos when the live page already has the target',
+      (tester) async {
+        const targetStableId = 'stable-target';
+        final seedOnly = _video('seed-only', createdAt: 1000);
+        final liveTarget = _video(
+          'target-video',
+          createdAt: 2000,
+          stableId: targetStableId,
+        );
+        final liveVideos = [
+          _video('live-0', createdAt: 3000),
+          liveTarget,
+        ];
+        final seedVideos = [
+          seedOnly,
+          _video('target-video', createdAt: 2000, stableId: targetStableId),
+        ];
+
+        when(
+          () => videosRepository.getAuthorFeed(
+            authorPubkey: any(named: 'authorPubkey'),
+            offset: any(named: 'offset'),
+            relaySeed: any(named: 'relaySeed'),
+            skipCache: any(named: 'skipCache'),
+          ),
+        ).thenAnswer(
+          (_) async => AuthorFeedResult(
+            authorPubkey: _profilePubkey,
+            videos: liveVideos,
+            hasMore: false,
+          ),
+        );
+
+        final fullscreenBloc = await pumpProfileVideoFeed(
+          tester,
+          seedVideos: seedVideos,
+          videoIndex: 1,
+          initialVideoId: liveTarget.id,
+          initialStableId: targetStableId,
+        );
+
+        expect(fullscreenBloc.state.videos, liveVideos);
+        expect(fullscreenBloc.state.videos, isNot(contains(seedOnly)));
+        expect(fullscreenBloc.state.currentVideo?.id, liveTarget.id);
       },
     );
   });


### PR DESCRIPTION
## Summary

Fixes #5234.

Profile fullscreen playback now preserves the tapped launch video when the newly-mounted profile feed cubit emits a shorter first live page that does not yet include that older item. The profile fullscreen adapter merges the launch seed with the live page only while the live page would otherwise drop the tapped initial identity, using the existing profile feed merge policy instead of ad hoc list/index handling.

The merge stays in this fullscreen adapter because the adapter already owns the scoped `StreamFeedRepository` handoff between the launch seed and the freshly-mounted `ProfileFeedCubit`; moving that handoff into `ProfileFeedCubit` or a repository wrapper would widen this targeted bug fix.

## Root Cause

When a user tapped an older loaded profile video, the grid passed the accumulated seed list and tapped video identity into the fullscreen route. The fullscreen route mounts its own `ProfileFeedCubit`; when that fresh cubit emitted its first non-empty page, the adapter replaced the seed with that shorter live page. For deep history videos, the tapped event was absent from the shorter page, so fullscreen clamped/preserved the wrong index and opened a different video.

## User Impact

Tapping older videos from profile history should now open the selected video consistently, including videos loaded by scrolling beyond the first page.

## Validation

- `mise exec -- flutter test test/widgets/profile/profile_video_feed_view_test.dart`
- `mise exec -- flutter test test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart test/widgets/profile/profile_video_feed_view_test.dart`
- `mise exec -- flutter analyze`
- Pre-push hook: analyzer and changed-file tests passed
