### PR TITLE
fix(startup): continue after DB cipher bootstrap failure

### DIFF
--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -117,13 +117,13 @@ class DatabaseEncryptionBootstrap {
   }
 }
 
-/// Resolves the startup DB cipher key and fails closed on bootstrap errors.
+/// Resolves the startup DB cipher key and lets startup continue on bootstrap
+/// errors.
 ///
-/// Native app startup must not continue with a `null` cipher key after a
-/// secure-storage or SQLCipher bootstrap failure: an existing encrypted DB
-/// would be opened as plaintext and repeatedly surface SQLITE_NOTADB. Web and
-/// intentional plaintext migration deferrals still return `null` from
-/// [resolveCipherKey].
+/// Startup must not freeze before `runApp` when secure storage or SQLCipher
+/// bootstrap fails. Record the failure and return `null`, matching the pre-#5248
+/// fallback path so the app can still render. Web and intentional plaintext
+/// migration deferrals also return `null` from [resolveCipherKey].
 Future<String?> resolveStartupDatabaseCipherKey({
   required Future<String?> Function() resolveCipherKey,
   required Future<void> Function(Object error, StackTrace stack) recordError,
@@ -132,7 +132,7 @@ Future<String?> resolveStartupDatabaseCipherKey({
     return await resolveCipherKey();
   } catch (error, stack) {
     await recordError(error, stack);
-    Error.throwWithStackTrace(error, stack);
+    return null;
   }
 }
 

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -146,24 +146,25 @@ void main() {
   });
 
   group('resolveStartupDatabaseCipherKey', () {
-    test('records and rethrows bootstrap failures', () async {
-      final error = StateError('secure storage unavailable');
-      Object? recordedError;
-      StackTrace? recordedStack;
+    test(
+      'records bootstrap failures and lets startup continue without a key',
+      () async {
+        final error = StateError('secure storage unavailable');
+        Object? recordedError;
+        StackTrace? recordedStack;
 
-      await expectLater(
-        resolveStartupDatabaseCipherKey(
+        final key = await resolveStartupDatabaseCipherKey(
           resolveCipherKey: () async => throw error,
           recordError: (error, stack) async {
             recordedError = error;
             recordedStack = stack;
           },
-        ),
-        throwsA(same(error)),
-      );
+        );
 
-      expect(recordedError, same(error));
-      expect(recordedStack, isNotNull);
-    });
+        expect(key, isNull);
+        expect(recordedError, same(error));
+        expect(recordedStack, isNotNull);
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #5288

## Summary
- restore the pre-#5248 startup fallback when DB cipher-key bootstrap throws
- keep recording the secure-storage / SQLCipher bootstrap failure for Crashlytics
- return `null` for the startup DB cipher key so `runApp` still happens instead of freezing on the native splash

Fixes the launch hang from #5257 without adding a user-facing recovery decision screen.

## Verification
- RED: `flutter test test/services/database_encryption_bootstrap_test.dart` failed while `resolveStartupDatabaseCipherKey` still rethrew
- `flutter test test/services/database_encryption_bootstrap_test.dart`
- `flutter test test/services/database_encryption_bootstrap_test.dart test/startup/startup_splash_release_controller_test.dart test/startup/app_first_frame_startup_test.dart`
- `dart analyze lib/services/database_encryption_bootstrap.dart test/services/database_encryption_bootstrap_test.dart`
- `flutter analyze`
- pre-push hook: analyzer + changed-file DB bootstrap test