### PR TITLE
fix(publish): repair video upload publish failures

### DIFF
--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -97,6 +97,20 @@ class EnvironmentConfig {
     return url;
   }
 
+  /// Get REST event publish base URL.
+  ///
+  /// NIP-98 signs the exact publish URL. The events endpoint validates against
+  /// the relay HTTP origin, not the production FunnelCake API host.
+  String get eventPublishBaseUrl {
+    final url = relayUrl;
+    if (url.startsWith('wss://')) {
+      return url.replaceFirst('wss://', 'https://');
+    } else if (url.startsWith('ws://')) {
+      return url.replaceFirst('ws://', 'http://');
+    }
+    return url;
+  }
+
   /// Base URL for the Divine identity verification service
   /// (verifyer.divine.video). Single host across all environments — the
   /// service is not part of local_stack.

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -169,10 +169,10 @@ VideoEventPublisher videoEventPublisher(Ref ref) {
   final profileStatsDao = ref.watch(databaseProvider).profileStatsDao;
   final savedSoundsService = ref.watch(savedSoundsServiceProvider);
 
-  // REST-first publish: POST the signed event to {apiBaseUrl}/api/events with
+  // REST-first publish: POST the signed event to {eventPublishBaseUrl}/api/events with
   // NIP-98 auth, falling back to the WebSocket relay pool on transient
-  // failures. apiBaseUrl resolves to https://api.divine.video (production) and
-  // https://relay.staging.divine.video (staging).
+  // failures. NIP-98 validates the exact URL, so event publish uses the relay
+  // HTTP origin rather than production's FunnelCake API host.
   final environmentConfig = ref.watch(currentEnvironmentProvider);
   final nip98AuthService = ref.watch(nip98AuthServiceProvider);
   final eventApiHttpClient = http.Client();
@@ -180,7 +180,7 @@ VideoEventPublisher videoEventPublisher(Ref ref) {
   final eventApiClient = EventApiClient(
     httpClient: eventApiHttpClient,
     nip98AuthService: nip98AuthService,
-    apiBaseUrl: () => environmentConfig.apiBaseUrl,
+    apiBaseUrl: () => environmentConfig.eventPublishBaseUrl,
   );
 
   return VideoEventPublisher(

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -375,7 +375,7 @@ final class VideoEventPublisherProvider
 }
 
 String _$videoEventPublisherHash() =>
-    r'262237ee460d29c871f62af6e0fce9c88508a02b';
+    r'efa59c22d7b675684e4c3f7d203768fc2df5eefc';
 
 /// View event publisher for kind 22236 ephemeral analytics events
 ///

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -17,6 +17,7 @@ import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/circuit_breaker_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
+import 'package:openvine/services/upload_publishability.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/async_utils.dart';
 import 'package:path/path.dart' as path;
@@ -251,21 +252,10 @@ class UploadManager {
 
   bool _isVisibleToCurrentOwner(PendingUpload upload) {
     if (!_scopeUploadsToCurrentUser) return true;
-
     final currentPubkey = _currentNostrPubkey;
-    if (currentPubkey == null || currentPubkey.isEmpty) {
-      return false;
-    }
-
-    return upload.nostrPubkey == currentPubkey;
-  }
-
-  bool _isPublishableReadyUpload(PendingUpload upload) {
-    if (upload.status != UploadStatus.readyToPublish) return false;
-    return upload.videoId != null &&
-        upload.videoId!.isNotEmpty &&
-        _isHttpUrl(upload.cdnUrl) &&
-        _isHttpUrl(upload.thumbnailPath);
+    return currentPubkey != null &&
+        currentPubkey.isNotEmpty &&
+        upload.nostrPubkey == currentPubkey;
   }
 
   /// Get uploads by status
@@ -309,7 +299,7 @@ class UploadManager {
       if (upload.status == UploadStatus.pending) continue;
       if (upload.status == UploadStatus.paused) continue;
       if (upload.status == UploadStatus.readyToPublish &&
-          !_isPublishableReadyUpload(upload)) {
+          !readyUploadIsPublishable(upload)) {
         continue;
       }
       if (upload.status == UploadStatus.failed &&
@@ -1998,10 +1988,8 @@ class UploadManager {
     var fixedCount = 0;
 
     for (final upload in uploads) {
-      // Fix uploads that are ready to publish but missing required data
-      // These should be moved back to failed status so user can retry
       if (upload.status == UploadStatus.readyToPublish &&
-          !_isPublishableReadyUpload(upload)) {
+          !readyUploadIsPublishable(upload)) {
         Log.error(
           'Fixing stuck upload: ${upload.id} (missing publishable video data) - moving to failed',
           name: 'UploadManager',

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -260,6 +260,14 @@ class UploadManager {
     return upload.nostrPubkey == currentPubkey;
   }
 
+  bool _isPublishableReadyUpload(PendingUpload upload) {
+    if (upload.status != UploadStatus.readyToPublish) return false;
+    return upload.videoId != null &&
+        upload.videoId!.isNotEmpty &&
+        _isHttpUrl(upload.cdnUrl) &&
+        _isHttpUrl(upload.thumbnailPath);
+  }
+
   /// Get uploads by status
   List<PendingUpload> getUploadsByStatus(UploadStatus status) =>
       pendingUploads.where((upload) => upload.status == status).toList();
@@ -300,6 +308,10 @@ class UploadManager {
       if (upload.status == UploadStatus.published) continue;
       if (upload.status == UploadStatus.pending) continue;
       if (upload.status == UploadStatus.paused) continue;
+      if (upload.status == UploadStatus.readyToPublish &&
+          !_isPublishableReadyUpload(upload)) {
+        continue;
+      }
       if (upload.status == UploadStatus.failed &&
           upload.resumableSession == null) {
         continue;
@@ -1989,9 +2001,9 @@ class UploadManager {
       // Fix uploads that are ready to publish but missing required data
       // These should be moved back to failed status so user can retry
       if (upload.status == UploadStatus.readyToPublish &&
-          (upload.videoId == null || upload.cdnUrl == null)) {
+          !_isPublishableReadyUpload(upload)) {
         Log.error(
-          'Fixing stuck upload: ${upload.id} (missing videoId/cdnUrl) - moving to failed',
+          'Fixing stuck upload: ${upload.id} (missing publishable video data) - moving to failed',
           name: 'UploadManager',
           category: LogCategory.video,
         );

--- a/mobile/lib/services/upload_publishability.dart
+++ b/mobile/lib/services/upload_publishability.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Helper predicates for deciding whether persisted upload state can publish
+// ABOUTME: Keeps upload-state validation out of the already oversized UploadManager
+
+import 'package:openvine/models/pending_upload.dart';
+
+bool readyUploadIsPublishable(PendingUpload upload) =>
+    upload.status == UploadStatus.readyToPublish &&
+    upload.videoId != null &&
+    upload.videoId!.isNotEmpty &&
+    _isHttpUrl(upload.cdnUrl) &&
+    _isHttpUrl(upload.thumbnailPath);
+
+bool _isHttpUrl(String? url) {
+  final value = url?.trim();
+  if (value == null || value.isEmpty) return false;
+  final uri = Uri.tryParse(value);
+  if (uri == null || uri.host.isEmpty) return false;
+  return uri.scheme == 'http' || uri.scheme == 'https';
+}

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -498,8 +498,7 @@ class VideoEventPublisher {
   ///    published and stop (avoids re-publishing a previously accepted
   ///    event whose `OK` was lost).
   /// 2. Up to 3 attempts of `POST /api/events`. A 200 acceptance is
-  ///    published; a 401/403/422 is a non-retryable failure; a transient
-  ///    REST failure falls back to a WebSocket `publishEvent`
+  ///    published; any REST failure falls back to a WebSocket `publishEvent`
   ///    (fire-and-forget, not `publishEventAwaitOk`).
   /// 3. Before each retry, re-check relay presence so a false-negative
   ///    WebSocket `OK` does not produce a duplicate publish.
@@ -597,8 +596,8 @@ class VideoEventPublisher {
     return _EventPublishOutcome.transientFailure;
   }
 
-  /// One publish attempt: REST first, WebSocket fire-and-forget on transient
-  /// REST failure.
+  /// One publish attempt: REST first, WebSocket fire-and-forget on any REST
+  /// failure.
   Future<_EventPublishOutcome> _publishViaRestThenWebSocket(
     EventApiClient apiClient,
     Event event,
@@ -608,12 +607,13 @@ class VideoEventPublisher {
       case EventApiAccepted():
         return _EventPublishOutcome.published;
       case EventApiRejected(:final statusCode, :final reason):
-        Log.error(
-          '❌ REST publish rejected ($statusCode) for ${event.id}: $reason',
+        Log.warning(
+          '⚠️ REST publish rejected ($statusCode) for ${event.id}: $reason; '
+          'falling back to WebSocket fire-and-forget',
           name: 'VideoEventPublisher',
           category: LogCategory.video,
         );
-        return _EventPublishOutcome.permanentlyRejected;
+        return _publishViaWebSocketFireAndForget(event);
       case EventApiTransientFailure(:final reason):
         Log.warning(
           '⚠️ REST publish transient failure for ${event.id} ($reason); '

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -75,6 +75,15 @@ void main() {
       });
     });
 
+    group('eventPublishBaseUrl', () {
+      test('production uses relay.divine.video for NIP-98 event publish', () {
+        const config = EnvironmentConfig(
+          environment: AppEnvironment.production,
+        );
+        expect(config.eventPublishBaseUrl, 'https://relay.divine.video');
+      });
+    });
+
     test('blossomUrl is same for all environments', () {
       const poc = EnvironmentConfig(environment: AppEnvironment.poc);
       const staging = EnvironmentConfig(environment: AppEnvironment.staging);

--- a/mobile/test/services/upload_manager_resumable_upload_test.dart
+++ b/mobile/test/services/upload_manager_resumable_upload_test.dart
@@ -700,12 +700,18 @@ void main() {
       expect(result!.id, equals(upload.id));
     });
 
-    test('returns upload in readyToPublish status', () async {
-      final upload = PendingUpload.create(
-        localVideoPath: videoFile.path,
-        nostrPubkey: 'test-pubkey',
-        title: 'Ready video',
-      ).copyWith(status: UploadStatus.readyToPublish);
+    test('returns publishable readyToPublish upload', () async {
+      final upload =
+          PendingUpload.create(
+            localVideoPath: videoFile.path,
+            nostrPubkey: 'test-pubkey',
+            title: 'Ready video',
+          ).copyWith(
+            status: UploadStatus.readyToPublish,
+            videoId: 'ready-video',
+            cdnUrl: 'https://media.divine.video/ready-video',
+            thumbnailPath: 'https://media.divine.video/ready-video-thumb.jpg',
+          );
 
       final box = Hive.box<PendingUpload>('pending_uploads');
       await box.put(upload.id, upload);
@@ -714,6 +720,50 @@ void main() {
       expect(result, isNotNull);
       expect(result!.status, equals(UploadStatus.readyToPublish));
     });
+
+    test('skips readyToPublish upload without an HTTP thumbnail', () async {
+      final upload =
+          PendingUpload.create(
+            localVideoPath: videoFile.path,
+            nostrPubkey: 'test-pubkey',
+            title: 'Ready video without thumbnail',
+          ).copyWith(
+            status: UploadStatus.readyToPublish,
+            videoId: 'ready-video-no-thumb',
+            cdnUrl: 'https://media.divine.video/ready-video-no-thumb',
+          );
+
+      final box = Hive.box<PendingUpload>('pending_uploads');
+      await box.put(upload.id, upload);
+
+      final result = uploadManager.findReusableUpload(videoFile.path);
+      expect(result, isNull);
+    });
+
+    test(
+      'cleanup moves readyToPublish upload without thumbnail to failed',
+      () async {
+        final upload =
+            PendingUpload.create(
+              localVideoPath: videoFile.path,
+              nostrPubkey: 'test-pubkey',
+              title: 'Stale ready video',
+            ).copyWith(
+              status: UploadStatus.readyToPublish,
+              videoId: 'stale-ready-video',
+              cdnUrl: 'https://media.divine.video/stale-ready-video',
+            );
+
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        await box.put(upload.id, upload);
+
+        await uploadManager.cleanupProblematicUploads();
+
+        final cleanedUpload = uploadManager.getUpload(upload.id);
+        expect(cleanedUpload, isNotNull);
+        expect(cleanedUpload!.status, equals(UploadStatus.failed));
+      },
+    );
 
     test(
       'returns failed upload only when it has a resumable session',

--- a/mobile/test/services/upload_publishability_test.dart
+++ b/mobile/test/services/upload_publishability_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/upload_publishability.dart';
+
+void main() {
+  group('readyUploadIsPublishable', () {
+    test('accepts ready uploads with video id and HTTP media URLs', () {
+      final upload = _upload();
+
+      expect(readyUploadIsPublishable(upload), isTrue);
+    });
+
+    test('rejects uploads that are not ready to publish', () {
+      final upload = _upload(status: UploadStatus.uploading);
+
+      expect(readyUploadIsPublishable(upload), isFalse);
+    });
+
+    test('rejects ready uploads without a video id', () {
+      final upload = _upload(videoId: '');
+
+      expect(readyUploadIsPublishable(upload), isFalse);
+    });
+
+    test('rejects ready uploads without an HTTP CDN URL', () {
+      final upload = _upload(cdnUrl: '/tmp/local-video.mp4');
+
+      expect(readyUploadIsPublishable(upload), isFalse);
+    });
+
+    test('rejects ready uploads without an HTTP thumbnail URL', () {
+      final upload = _upload(thumbnailPath: '/tmp/local-thumbnail.jpg');
+
+      expect(readyUploadIsPublishable(upload), isFalse);
+    });
+  });
+}
+
+PendingUpload _upload({
+  UploadStatus status = UploadStatus.readyToPublish,
+  String? videoId = 'video-123',
+  String? cdnUrl = 'https://media.divine.video/video-123',
+  String? thumbnailPath = 'https://media.divine.video/thumb-123',
+}) {
+  return PendingUpload(
+    id: 'upload-123',
+    localVideoPath: '/tmp/video.mp4',
+    nostrPubkey: 'npub-test',
+    status: status,
+    createdAt: DateTime(2026),
+    videoId: videoId,
+    cdnUrl: cdnUrl,
+    thumbnailPath: thumbnailPath,
+  );
+}

--- a/mobile/test/services/video_event_publisher_rest_publish_test.dart
+++ b/mobile/test/services/video_event_publisher_rest_publish_test.dart
@@ -198,22 +198,23 @@ void main() {
       },
     );
 
-    test('REST 401/403/422 fails without WebSocket fallback', () async {
+    test('REST rejection falls back to WebSocket send success', () async {
       final signedEvent = createSignedEvent();
       stubSigning(signedEvent);
       stubRest(const EventApiRejected(statusCode: 422, reason: 'bad event'));
+      stubWebSocket(PublishSuccess(event: signedEvent));
 
       final result = await publisher.publishDirectUpload(createUpload());
 
-      expect(result, isFalse);
-      verifyNever(() => mockNostrClient.publishEvent(any()));
-      verifyNever(
+      expect(result, isTrue);
+      verify(() => mockNostrClient.publishEvent(signedEvent)).called(1);
+      verify(
         () => mockUploadManager.updateUploadStatus(
-          any(),
+          'test-upload-id',
           UploadStatus.published,
-          nostrEventId: any(named: 'nostrEventId'),
+          nostrEventId: signedEvent.id,
         ),
-      );
+      ).called(1);
     });
 
     test('retry reuses the original signed event id (no re-sign)', () async {


### PR DESCRIPTION
## Summary
- sign REST event publishes against the relay HTTP origin so NIP-98 URL validation matches production (`https://relay.divine.video/api/events`)
- still fall back to WebSocket publish for any REST failure, including REST rejection responses
- keep Funnelcake REST on `api.divine.video` by adding a separate `eventPublishBaseUrl`
- skip persisted `readyToPublish` uploads missing publishable thumbnail data and mark stale records failed during cleanup so retry can rebuild state

## Log evidence
- media upload succeeded for `88dafbf909c55b42087398b0e19267a1c21b054bf4625dc9b4f7b2bd2680ad94`
- thumbnail upload succeeded for `661304b9921d927bfa599c5a3312b7dbbc53da5601f8d3d33a6320f8396e488a`
- REST event publish failed with `401`: server expected `https://relay.divine.video/api/events`, client signed `https://api.divine.video/api/events`

## Verification
- `flutter test test/models/environment_config_test.dart test/services/event_api_client_test.dart test/services/video_event_publisher_rest_publish_test.dart test/services/upload_manager_resumable_upload_test.dart`
- `flutter analyze`
- `mise exec -- dart run build_runner build --delete-conflicting-outputs`
- pre-push hook analyzer, generated-file check, and changed-file tests
