### PR TITLE
fix(db): fail closed on cipher bootstrap errors

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -100,6 +100,7 @@ import 'package:openvine/services/startup_performance_service.dart';
 import 'package:openvine/services/video_format_preference.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
+import 'package:openvine/startup/database_bootstrap_failure_app.dart';
 import 'package:openvine/startup/startup_splash_release_controller.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
@@ -1301,25 +1302,31 @@ Future<void> _startOpenVineApp() async {
   // This also forces package:sqlite3 onto the SQLCipher build (Android) and
   // runs the one-time plaintext→encrypted migration, both of which must happen
   // before any sqlite3 open. (#570, finding C2)
-  final dbCipherKey = await resolveStartupDatabaseCipherKey(
-    // resetOnError MUST stay false here: the cipher key is the one secret
-    // whose loss makes the encrypted DB unrecoverable. A transient keystore
-    // read error must throw rather than silently deleting the key and
-    // triggering the §6 key-loss recovery. (#570 C2)
-    resolveCipherKey: () => DatabaseEncryptionBootstrap(
-      secureStorage: const FlutterSecureStorage(
-        aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  final dbCipherKeyResult = await resolveDatabaseBootstrapForAppStart(
+    resolveCipherKey: () => resolveStartupDatabaseCipherKey(
+      // resetOnError MUST stay false here: the cipher key is the one secret
+      // whose loss makes the encrypted DB unrecoverable. A transient keystore
+      // read error must throw rather than silently deleting the key and
+      // triggering the §6 key-loss recovery. (#570 C2)
+      resolveCipherKey: () => DatabaseEncryptionBootstrap(
+        secureStorage: const FlutterSecureStorage(
+          aOptions: AndroidOptions(encryptedSharedPreferences: true),
+        ),
+      ).resolveCipherKey(),
+      // SQLCipher build misconfiguration or secure-storage failures must fail
+      // closed after reporting. Continuing with a null key would open an
+      // existing encrypted DB as plaintext and spam SQLITE_NOTADB.
+      recordError: (error, stack) => CrashReportingService.instance.recordError(
+        error,
+        stack,
+        reason: 'DatabaseEncryptionBootstrap.resolveCipherKey failed',
       ),
-    ).resolveCipherKey(),
-    // SQLCipher build misconfiguration or secure-storage failures must fail
-    // closed after reporting. Continuing with a null key would open an
-    // existing encrypted DB as plaintext and spam SQLITE_NOTADB.
-    recordError: (error, stack) => CrashReportingService.instance.recordError(
-      error,
-      stack,
-      reason: 'DatabaseEncryptionBootstrap.resolveCipherKey failed',
     ),
+    runApp: runApp,
+    removeNativeSplash: FlutterNativeSplash.remove,
   );
+  if (dbCipherKeyResult.didRenderFailureApp) return;
+  final dbCipherKey = dbCipherKeyResult.cipherKey;
 
   // Create ProviderContainer to initialize services BEFORE runApp
   final container = ProviderContainer(

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -117,13 +117,13 @@ class DatabaseEncryptionBootstrap {
   }
 }
 
-/// Resolves the startup DB cipher key and lets startup continue on bootstrap
-/// errors.
+/// Resolves the startup DB cipher key and fails closed on bootstrap errors.
 ///
-/// Startup must not freeze before `runApp` when secure storage or SQLCipher
-/// bootstrap fails. Record the failure and return `null`, matching the pre-#5248
-/// fallback path so the app can still render. Web and intentional plaintext
-/// migration deferrals also return `null` from [resolveCipherKey].
+/// Native app startup must not continue with a `null` cipher key after a
+/// secure-storage or SQLCipher bootstrap failure: an existing encrypted DB
+/// would be opened as plaintext and repeatedly surface SQLITE_NOTADB. Web and
+/// intentional plaintext migration deferrals still return `null` from
+/// [resolveCipherKey].
 Future<String?> resolveStartupDatabaseCipherKey({
   required Future<String?> Function() resolveCipherKey,
   required Future<void> Function(Object error, StackTrace stack) recordError,
@@ -132,7 +132,7 @@ Future<String?> resolveStartupDatabaseCipherKey({
     return await resolveCipherKey();
   } catch (error, stack) {
     await recordError(error, stack);
-    return null;
+    Error.throwWithStackTrace(error, stack);
   }
 }
 

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -131,7 +131,12 @@ Future<String?> resolveStartupDatabaseCipherKey({
   try {
     return await resolveCipherKey();
   } catch (error, stack) {
-    await recordError(error, stack);
+    try {
+      await recordError(error, stack);
+    } catch (_) {
+      // Startup still needs to fail with the bootstrap root cause even if
+      // telemetry is unavailable during early app initialization.
+    }
     Error.throwWithStackTrace(error, stack);
   }
 }

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -1,0 +1,144 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Result of resolving the DB cipher key during app startup.
+class DatabaseBootstrapStartupResult {
+  const DatabaseBootstrapStartupResult._({
+    required this.cipherKey,
+    required this.didRenderFailureApp,
+  });
+
+  const DatabaseBootstrapStartupResult.ready(String? cipherKey)
+    : this._(cipherKey: cipherKey, didRenderFailureApp: false);
+
+  const DatabaseBootstrapStartupResult.failure()
+    : this._(cipherKey: null, didRenderFailureApp: true);
+
+  final String? cipherKey;
+  final bool didRenderFailureApp;
+}
+
+/// Resolves the DB cipher key and renders a visible fail-closed startup screen
+/// when bootstrap cannot complete.
+Future<DatabaseBootstrapStartupResult> resolveDatabaseBootstrapForAppStart({
+  required Future<String?> Function() resolveCipherKey,
+  required void Function(Widget app) runApp,
+  required VoidCallback removeNativeSplash,
+}) async {
+  try {
+    return DatabaseBootstrapStartupResult.ready(await resolveCipherKey());
+  } catch (error, stack) {
+    removeNativeSplash();
+    runApp(DatabaseBootstrapFailureApp(error: error, stack: stack));
+    return const DatabaseBootstrapStartupResult.failure();
+  }
+}
+
+class DatabaseBootstrapFailureApp extends StatelessWidget {
+  const DatabaseBootstrapFailureApp({
+    required this.error,
+    required this.stack,
+    this.onCloseApp = SystemNavigator.pop,
+    super.key,
+  });
+
+  final Object error;
+  final StackTrace stack;
+  final VoidCallback onCloseApp;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        backgroundColor: VineTheme.backgroundColor,
+        body: SafeArea(
+          child: Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 32),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 420),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const DivineIcon(
+                      icon: DivineIconName.warningCircle,
+                      color: VineTheme.accentOrange,
+                      size: 48,
+                    ),
+                    const SizedBox(height: 20),
+                    const Text(
+                      "couldn't unlock your local database",
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: VineTheme.primaryText,
+                        fontSize: 22,
+                        fontWeight: FontWeight.w700,
+                        decoration: TextDecoration.none,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    const Text(
+                      'Restart Divine after unlocking your device. If this '
+                      'keeps happening, update the app or contact support.',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        color: VineTheme.onSurfaceVariant,
+                        fontSize: 14,
+                        height: 1.45,
+                        decoration: TextDecoration.none,
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    DivineButton(
+                      label: 'close Divine',
+                      onPressed: onCloseApp,
+                      type: DivineButtonType.secondary,
+                    ),
+                    if (kDebugMode) ...[
+                      const SizedBox(height: 24),
+                      _DebugErrorDetails(error: error, stack: stack),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DebugErrorDetails extends StatelessWidget {
+  const _DebugErrorDetails({required this.error, required this.stack});
+
+  final Object error;
+  final StackTrace stack;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: VineTheme.cardBackground,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: VineTheme.onSurfaceDisabled),
+      ),
+      child: Text(
+        '$error\n$stack',
+        maxLines: 8,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+          color: VineTheme.error,
+          fontSize: 11,
+          fontFamily: 'monospace',
+          decoration: TextDecoration.none,
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -146,25 +146,24 @@ void main() {
   });
 
   group('resolveStartupDatabaseCipherKey', () {
-    test(
-      'records bootstrap failures and lets startup continue without a key',
-      () async {
-        final error = StateError('secure storage unavailable');
-        Object? recordedError;
-        StackTrace? recordedStack;
+    test('records and rethrows bootstrap failures', () async {
+      final error = StateError('secure storage unavailable');
+      Object? recordedError;
+      StackTrace? recordedStack;
 
-        final key = await resolveStartupDatabaseCipherKey(
+      await expectLater(
+        resolveStartupDatabaseCipherKey(
           resolveCipherKey: () async => throw error,
           recordError: (error, stack) async {
             recordedError = error;
             recordedStack = stack;
           },
-        );
+        ),
+        throwsA(same(error)),
+      );
 
-        expect(key, isNull);
-        expect(recordedError, same(error));
-        expect(recordedStack, isNotNull);
-      },
-    );
+      expect(recordedError, same(error));
+      expect(recordedStack, isNotNull);
+    });
   });
 }

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -165,5 +165,17 @@ void main() {
       expect(recordedError, same(error));
       expect(recordedStack, isNotNull);
     });
+
+    test('rethrows bootstrap root cause when recording fails', () async {
+      final bootstrapError = StateError('secure storage unavailable');
+
+      await expectLater(
+        resolveStartupDatabaseCipherKey(
+          resolveCipherKey: () async => throw bootstrapError,
+          recordError: (_, _) async => throw StateError('crash reporter down'),
+        ),
+        throwsA(same(bootstrapError)),
+      );
+    });
   });
 }

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/startup/database_bootstrap_failure_app.dart';
+
+void main() {
+  group('resolveDatabaseBootstrapForAppStart', () {
+    test('returns the cipher key without rendering failure UI', () async {
+      var removedSplash = false;
+      Widget? renderedApp;
+
+      final result = await resolveDatabaseBootstrapForAppStart(
+        resolveCipherKey: () async => 'a' * 64,
+        removeNativeSplash: () => removedSplash = true,
+        runApp: (app) => renderedApp = app,
+      );
+
+      expect(result.didRenderFailureApp, isFalse);
+      expect(result.cipherKey, equals('a' * 64));
+      expect(removedSplash, isFalse);
+      expect(renderedApp, isNull);
+    });
+
+    test(
+      'renders a visible failure app and removes native splash on error',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        final error = StateError('secure storage unavailable');
+
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async => throw error,
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
+
+        expect(result.didRenderFailureApp, isTrue);
+        expect(result.cipherKey, isNull);
+        expect(removedSplash, isTrue);
+        expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
+      },
+    );
+  });
+
+  group(DatabaseBootstrapFailureApp, () {
+    testWidgets('shows a visible database startup failure screen', (
+      tester,
+    ) async {
+      var closed = false;
+
+      await tester.pumpWidget(
+        DatabaseBootstrapFailureApp(
+          error: StateError('secure storage unavailable'),
+          stack: StackTrace.current,
+          onCloseApp: () => closed = true,
+        ),
+      );
+
+      expect(
+        find.text("couldn't unlock your local database"),
+        findsOneWidget,
+      );
+      expect(find.textContaining('Restart Divine'), findsOneWidget);
+
+      await tester.tap(find.text('close Divine'));
+      expect(closed, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Closes #5301.

## Summary
- restore fail-closed startup handling for database cipher bootstrap failures
- render a visible database startup failure screen and remove the native splash when bootstrap throws before the main app can run
- keep key-loss recovery on the existing path: when secure storage is missing the key but the DB is encrypted, the DB is backed up and recreated under a new generated key
- keep the original bootstrap exception as the root cause even if early error recording is unavailable
- add startup-boundary coverage so bootstrap throws cannot regress into a pre-runApp splash hang

## Root Cause
Database cipher bootstrap runs after the native splash is preserved but before runApp. Rethrowing bootstrap errors is the right fail-closed behavior for encrypted local data, but letting that throw escape _startOpenVineApp prevents any Flutter UI from rendering and leaves the native splash up indefinitely.

## Evidence
- local macOS DB inspection showed the current DB is plaintext/readable and contains real local data, so wiping is not appropriate for readable plaintext DBs
- encrypted DB + missing key is unrecoverable by design; the existing backup-and-recreate path is the correct reset path
- bootstrap exceptions now stop the normal app startup path without opening the database using a null cipher key, while still rendering a visible failure screen

## Tests
- mise exec -- flutter test test/startup/database_bootstrap_failure_app_test.dart test/services/database_encryption_bootstrap_test.dart
- mise exec -- flutter test test/src/database/connection/connection_native_test.dart (from mobile/packages/db_client)
- mise exec -- flutter analyze lib test integration_test
- mise exec -- ./scripts/golden.sh verify
- pre-push hook: analyze + changed-file tests
