### PR TITLE
fix(upload): preserve drafts after failed publish

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -84,8 +82,7 @@ class BackgroundPublishBloc
         ),
       );
 
-      // Draft is no longer needed after successful publish
-      unawaited(_draftStorageService.deleteDraft(event.draft.id));
+      await _deletePublishedDrafts(event.draft);
     } else {
       // Update the upload with the result
       final updatedUploads = state.uploads.map((upload) {
@@ -97,14 +94,11 @@ class BackgroundPublishBloc
 
       emit(state.copyWith(uploads: updatedUploads));
 
-      // Persist failed status in the database
       final errorMessage = result is PublishError ? result.userMessage : null;
-      unawaited(
-        _draftStorageService.updatePublishStatus(
-          draftId: event.draft.id,
-          status: PublishStatus.failed,
-          publishError: errorMessage,
-        ),
+      await _persistPublishStatus(
+        draftId: event.draft.id,
+        status: PublishStatus.failed,
+        publishError: errorMessage,
       );
     }
   }
@@ -137,21 +131,28 @@ class BackgroundPublishBloc
     emit(state.copyWith(uploads: updatedUploads));
   }
 
-  void _onBackgroundPublishVanished(
+  Future<void> _onBackgroundPublishVanished(
     BackgroundPublishVanished event,
     Emitter<BackgroundPublishState> emit,
-  ) {
+  ) async {
+    final uploadToVanish = state.uploads.cast<BackgroundUpload?>().firstWhere(
+      (upload) => upload!.draft.id == event.draftId,
+      orElse: () => null,
+    );
     final remainingUploads = state.uploads.where((upload) {
       return upload.draft.id != event.draftId;
     }).toList();
     emit(state.copyWith(uploads: remainingUploads));
 
-    // Reset to draft so resumePendingPublishes won't re-surface it
-    unawaited(
-      _draftStorageService.updatePublishStatus(
-        draftId: event.draftId,
-        status: PublishStatus.draft,
-      ),
+    final vanishedDraft = uploadToVanish?.draft;
+    if (vanishedDraft?.sourceDraftId != null) {
+      await _deleteDraft(vanishedDraft!.id);
+      return;
+    }
+
+    await _persistPublishStatus(
+      draftId: event.draftId,
+      status: PublishStatus.draft,
     );
   }
 
@@ -207,5 +208,50 @@ class BackgroundPublishBloc
       progress: 0,
     );
     emit(state.copyWith(uploads: [...state.uploads, failedUpload]));
+  }
+
+  Future<void> _deletePublishedDrafts(DivineVideoDraft publishedDraft) async {
+    await _deleteDraft(publishedDraft.id);
+
+    final sourceDraftId = publishedDraft.sourceDraftId;
+    if (sourceDraftId != null && sourceDraftId != publishedDraft.id) {
+      await _deleteDraft(sourceDraftId);
+    }
+  }
+
+  Future<void> _deleteDraft(String draftId) async {
+    try {
+      await _draftStorageService.deleteDraft(draftId);
+    } catch (error, stackTrace) {
+      Log.error(
+        'Failed to delete publish draft $draftId: $error',
+        category: LogCategory.video,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      addError(error, stackTrace);
+    }
+  }
+
+  Future<void> _persistPublishStatus({
+    required String draftId,
+    required PublishStatus status,
+    String? publishError,
+  }) async {
+    try {
+      await _draftStorageService.updatePublishStatus(
+        draftId: draftId,
+        status: status,
+        publishError: publishError,
+      );
+    } catch (error, stackTrace) {
+      Log.error(
+        'Failed to persist publish status for draft $draftId: $error',
+        category: LogCategory.video,
+        error: error,
+        stackTrace: stackTrace,
+      );
+      addError(error, stackTrace);
+    }
   }
 }

--- a/mobile/lib/models/divine_video_draft.dart
+++ b/mobile/lib/models/divine_video_draft.dart
@@ -31,6 +31,7 @@ class DivineVideoDraft {
     required this.publishStatus,
     required this.publishAttempts,
     this.publishError,
+    this.sourceDraftId,
     this.allowAudioReuse = false,
     this.expireTime,
     this.proofManifestJson,
@@ -163,6 +164,7 @@ class DivineVideoDraft {
       allowAudioReuse: json['allowAudioReuse'] as bool? ?? false,
       publishError: json['publishError'] as String?,
       publishAttempts: json['publishAttempts'] as int? ?? 0,
+      sourceDraftId: json['sourceDraftId'] as String?,
       proofManifestJson: json['proofManifestJson'] as String?,
       editorStateHistory:
           (json['editorStateHistory'] as Map<String, dynamic>?) ?? const {},
@@ -238,6 +240,7 @@ class DivineVideoDraft {
   final PublishStatus publishStatus;
   final String? proofManifestJson;
   final String? publishError;
+  final String? sourceDraftId;
   final int publishAttempts;
   final bool allowAudioReuse;
 
@@ -314,6 +317,8 @@ class DivineVideoDraft {
     PublishStatus? publishStatus,
     String? publishError,
     bool clearPublishError = false,
+    String? sourceDraftId,
+    bool clearSourceDraftId = false,
     Duration? expireTime,
     bool? allowAudioReuse,
     int? publishAttempts,
@@ -351,6 +356,9 @@ class DivineVideoDraft {
     publishError: clearPublishError
         ? null
         : (publishError ?? this.publishError),
+    sourceDraftId: clearSourceDraftId
+        ? null
+        : (sourceDraftId ?? this.sourceDraftId),
     publishAttempts: publishAttempts ?? this.publishAttempts,
     proofManifestJson: clearProofManifestJson
         ? null
@@ -397,6 +405,7 @@ class DivineVideoDraft {
     'allowAudioReuse': allowAudioReuse,
     'publishStatus': publishStatus.name,
     'publishError': publishError,
+    if (sourceDraftId != null) 'sourceDraftId': sourceDraftId,
     'publishAttempts': publishAttempts,
     'proofManifestJson': proofManifestJson,
     if (editorStateHistory.isNotEmpty) 'editorStateHistory': editorStateHistory,

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -238,12 +238,14 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
           final videoFile = File(videoPath);
           if (!videoFile.existsSync()) {
             Log.warning(
-              '🗑️ Deleting draft ${draft.id} - video file no longer exists: $videoPath',
+              '⚠️ Pending publish draft ${draft.id} references missing video file: $videoPath',
               name: 'VideoPublishNotifier',
               category: LogCategory.video,
             );
-            await _draftService.deleteDraft(draft.id);
-            continue;
+            if (draft.sourceDraftId != null) {
+              await _draftService.deleteDraft(draft.id);
+              continue;
+            }
           }
         } catch (e) {
           Log.warning(
@@ -251,9 +253,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
             name: 'VideoPublishNotifier',
             category: LogCategory.video,
           );
-          // Delete draft if we can't verify the video
-          await _draftService.deleteDraft(draft.id);
-          continue;
+          if (draft.sourceDraftId != null) {
+            await _draftService.deleteDraft(draft.id);
+            continue;
+          }
         }
       }
 
@@ -394,6 +397,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         proofManifestJson: proofManifestJson,
         publishStatus: PublishStatus.publishing,
         clearPublishError: true,
+        sourceDraftId: draft.sourceDraftId ?? draft.id,
         publishAttempts: draft.publishAttempts + 1,
       );
 
@@ -403,16 +407,6 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         category: .video,
       );
       await _draftService.saveDraft(publishDraft);
-
-      // Delete the original draft since we now have the publish draft
-      if (!draft.id.startsWith(VideoEditorConstants.publishPrefixId)) {
-        Log.debug(
-          '🗑️ Deleting original draft: ${draft.id}',
-          name: 'VideoPublishNotifier',
-          category: .video,
-        );
-        await _draftService.deleteDraft(draft.id);
-      }
 
       Log.info(
         '📤 Uploading video',

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -111,6 +111,7 @@ void main() {
 
       setUp(() {
         when(() => draft.id).thenReturn(draftId);
+        when(() => draft.sourceDraftId).thenReturn(null);
       });
 
       group('when the upload is a success', () {
@@ -179,6 +180,54 @@ void main() {
                 status: PublishStatus.failed,
                 publishError: 'ops',
               ),
+            ).called(1);
+          },
+        );
+      });
+
+      group('when a transient publish copy succeeds', () {
+        final publishDraft = _MockVineDraft();
+
+        const publishDraftId = 'draft_publish_1';
+        const sourceDraftId = 'draft_1';
+
+        setUp(() {
+          when(() => publishDraft.id).thenReturn(publishDraftId);
+          when(() => publishDraft.sourceDraftId).thenReturn(sourceDraftId);
+        });
+
+        blocTest(
+          'deletes the publish copy and the source draft',
+          build: () => BackgroundPublishBloc(
+            videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+            draftStorageService: mockDraftStorageService,
+          ),
+          act: (bloc) => bloc.add(
+            BackgroundPublishRequested(
+              draft: publishDraft,
+              publishmentProcess: Future.value(const PublishSuccess()),
+            ),
+          ),
+          expect: () => [
+            BackgroundPublishState(
+              uploads: [
+                BackgroundUpload(
+                  draft: publishDraft,
+                  result: null,
+                  progress: 0,
+                ),
+              ],
+            ),
+            const BackgroundPublishState(
+              recentlySucceededIds: {publishDraftId},
+            ),
+          ],
+          verify: (_) {
+            verify(
+              () => mockDraftStorageService.deleteDraft(publishDraftId),
+            ).called(1);
+            verify(
+              () => mockDraftStorageService.deleteDraft(sourceDraftId),
             ).called(1);
           },
         );
@@ -257,6 +306,7 @@ void main() {
 
       setUp(() {
         when(() => draft.id).thenReturn(draftId);
+        when(() => draft.sourceDraftId).thenReturn(null);
       });
 
       blocTest(
@@ -353,12 +403,14 @@ void main() {
     });
 
     group('BackgroundPublishVanished', () {
-      final draft = _MockVineDraft();
+      late _MockVineDraft draft;
 
       const draftId = '1';
 
       setUp(() {
+        draft = _MockVineDraft();
         when(() => draft.id).thenReturn(draftId);
+        when(() => draft.sourceDraftId).thenReturn(null);
       });
       blocTest(
         'removes the background upload and resets status to draft',
@@ -400,6 +452,34 @@ void main() {
           // recentlySucceededIds must be empty — Vanished is not a publish
           // success and must never trigger a success snackbar.
           expect(bloc.state.recentlySucceededIds, isEmpty);
+        },
+      );
+
+      blocTest(
+        'deletes a transient publish copy instead of mutating the source draft',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+          draftStorageService: mockDraftStorageService,
+        ),
+        setUp: () {
+          when(() => draft.sourceDraftId).thenReturn('draft_source');
+        },
+        seed: () => BackgroundPublishState(
+          uploads: [
+            BackgroundUpload(draft: draft, result: null, progress: 1.0),
+          ],
+        ),
+        act: (bloc) => bloc.add(BackgroundPublishVanished(draftId: draftId)),
+        expect: () => [const BackgroundPublishState()],
+        verify: (_) {
+          verify(() => mockDraftStorageService.deleteDraft(draftId)).called(1);
+          verifyNever(
+            () => mockDraftStorageService.updatePublishStatus(
+              draftId: any(named: 'draftId'),
+              status: any(named: 'status'),
+              publishError: any(named: 'publishError'),
+            ),
+          );
         },
       );
     });
@@ -473,6 +553,7 @@ void main() {
         draft = _MockVineDraft();
         mockPublishService = _MockVideoPublishService();
         when(() => draft.id).thenReturn(draftId);
+        when(() => draft.sourceDraftId).thenReturn(null);
       });
 
       blocTest<BackgroundPublishBloc, BackgroundPublishState>(

--- a/mobile/test/models/divine_video_draft_copy_with_test.dart
+++ b/mobile/test/models/divine_video_draft_copy_with_test.dart
@@ -150,6 +150,33 @@ void main() {
       });
     });
 
+    group('copyWith clearSourceDraftId', () {
+      test('clears sourceDraftId when clearSourceDraftId is true', () {
+        final draft = _createDraft().copyWith(
+          sourceDraftId: 'draft_source',
+          skipUpdateLastModified: true,
+        );
+
+        final cleared = draft.copyWith(
+          clearSourceDraftId: true,
+          skipUpdateLastModified: true,
+        );
+
+        expect(cleared.sourceDraftId, isNull);
+      });
+
+      test('preserves sourceDraftId when clearSourceDraftId is false', () {
+        final draft = _createDraft().copyWith(
+          sourceDraftId: 'draft_source',
+          skipUpdateLastModified: true,
+        );
+
+        final preserved = draft.copyWith(skipUpdateLastModified: true);
+
+        expect(preserved.sourceDraftId, equals('draft_source'));
+      });
+    });
+
     group('copyWith clearProofManifestJson', () {
       test('clears proofManifestJson when flag is true', () {
         final draft = _createDraft();
@@ -192,6 +219,19 @@ void main() {
 
         expect(json.containsKey('selectedSound'), isFalse);
       });
+    });
+
+    test('persists sourceDraftId through JSON', () {
+      final draft = _createDraft().copyWith(
+        sourceDraftId: 'draft_source',
+        skipUpdateLastModified: true,
+      );
+
+      final json = draft.toJson();
+      final restored = DivineVideoDraft.fromJson(json, '/tmp');
+
+      expect(json['sourceDraftId'], equals('draft_source'));
+      expect(restored.sourceDraftId, equals('draft_source'));
     });
   });
 }

--- a/mobile/test/models/divine_video_draft_has_been_edited_test.dart
+++ b/mobile/test/models/divine_video_draft_has_been_edited_test.dart
@@ -121,40 +121,37 @@ void main() {
         expect(draft.hasBeenEdited, isTrue);
       });
 
-      test(
-        'returns true when editorStateHistory contains a widget layer with '
-        'exportConfigs.id (sticker)',
-        () {
-          // Regression guard: hasEditorStateEdits parses the history with a
-          // dummy widgetLoader so saved drafts containing sticker layers can
-          // be rehydrated. Without the loader, WidgetLayer.fromMap asserts
-          // when exportConfigs.id is set.
-          final draft = _minimalDraft().copyWith(
-            editorStateHistory: const {
-              'position': 0,
-              'history': [
-                {
-                  'layers': [
-                    {
-                      'x': 0,
-                      'y': 0,
-                      'rotation': 0,
-                      'scale': 1,
-                      'flipX': false,
-                      'flipY': false,
-                      'type': 'widget',
-                      'exportConfigs': {'id': 'sticker-1'},
-                    },
-                  ],
-                },
-              ],
-            },
-            skipUpdateLastModified: true,
-          );
+      test('returns true when editorStateHistory contains a widget layer with '
+          'exportConfigs.id (sticker)', () {
+        // Regression guard: hasEditorStateEdits parses the history with a
+        // dummy widgetLoader so saved drafts containing sticker layers can
+        // be rehydrated. Without the loader, WidgetLayer.fromMap asserts
+        // when exportConfigs.id is set.
+        final draft = _minimalDraft().copyWith(
+          editorStateHistory: const {
+            'position': 0,
+            'history': [
+              {
+                'layers': [
+                  {
+                    'x': 0,
+                    'y': 0,
+                    'rotation': 0,
+                    'scale': 1,
+                    'flipX': false,
+                    'flipY': false,
+                    'type': 'widget',
+                    'exportConfigs': {'id': 'sticker-1'},
+                  },
+                ],
+              },
+            ],
+          },
+          skipUpdateLastModified: true,
+        );
 
-          expect(draft.hasBeenEdited, isTrue);
-        },
-      );
+        expect(draft.hasBeenEdited, isTrue);
+      });
 
       test('returns false when draft has editorEditingParameters only', () {
         final draft = _minimalDraft().copyWith(
@@ -279,6 +276,7 @@ void main() {
           publishStatus: PublishStatus.draft,
           publishAttempts: 1,
           publishError: 'err',
+          sourceDraftId: 'draft_source',
           expireTime: const Duration(days: 1),
           proofManifestJson: '{}',
           editorStateHistory: const {'k': 'v'},
@@ -328,6 +326,7 @@ void main() {
           'publishStatus', // lifecycle status
           'publishAttempts', // lifecycle counter
           'publishError', // transient error
+          'sourceDraftId', // publish-copy bookkeeping, not user content
           'proofManifestJson', // auto-generated, not a user edit
           'editorEditingParameters', // editor internals, not user-facing edit
           'allowAudioReuse', // publishing option, not edit indicator


### PR DESCRIPTION
## Summary

- keep the user's original draft until publish success instead of deleting it before upload completes
- persist a source draft id on transient publish copies so retries and recovery can clean up the right records
- make failed/dismissed transient uploads delete only the publish copy while leaving captions, tags, and metadata on the source draft
- await durable publish-status cleanup in the background publish bloc and add regression coverage for the new lifecycle

## Root cause

The publish flow created a hidden draft_publish_* copy, then deleted the visible source draft before upload success. If upload failed or the app restarted before the transient copy was made visible again, the drafts library could appear to lose the user's captions, tags, and post metadata.

## Validation

- mise exec flutter@3.44.0 -- flutter analyze
- mise exec flutter@3.44.0 -- flutter test test/blocs/background_publish_bloc/background_publish_bloc_test.dart test/models/divine_video_draft_copy_with_test.dart test/models/divine_video_draft_has_been_edited_test.dart
- pre-push hook: analyzer plus changed-file tests, including test/providers/video_publish_provider_test.dart

Closes #5289