### PR TITLE
fix(notifications): route video reply targets correctly

### DIFF
--- a/mobile/lib/screens/video_detail_screen.dart
+++ b/mobile/lib/screens/video_detail_screen.dart
@@ -292,7 +292,9 @@ class _VideoDetailScreenState extends ConsumerState<VideoDetailScreen> {
       );
     }
 
-    if (_video == null || videoEventService.shouldHideVideo(_video!)) {
+    if (_video == null ||
+        videoEventService.shouldHideVideo(_video!) ||
+        videoEventService.isVideoEventLocallyDeleted(_video!)) {
       return Scaffold(
         backgroundColor: VineTheme.backgroundColor,
         appBar: _buildExitAppBar(context),

--- a/mobile/lib/services/notification_target_resolver.dart
+++ b/mobile/lib/services/notification_target_resolver.dart
@@ -44,9 +44,12 @@ class NotificationTargetResolver {
       }
     }
 
-    // Fallback: lowercase e tags (NIP-10 style / older events)
-    String? replyId;
-    String? firstEtagId;
+    // Fallback: lowercase e tags (NIP-10 style / older events).
+    //
+    // Reply markers point at the immediate parent, which can be another
+    // comment. Never route to those blindly; only unmarked legacy candidates
+    // are probed below.
+    final legacyCandidates = <String>[];
 
     for (final tag in event.tags) {
       if (tag.length < 2 || tag[0] != 'e') continue;
@@ -54,18 +57,22 @@ class NotificationTargetResolver {
       final candidateId = tag[1];
       if (candidateId.isEmpty) continue;
 
-      firstEtagId ??= candidateId;
-
       final marker = tag.length > 3 ? tag[3] : '';
       if (marker == 'root') {
         return candidateId;
       }
-      if (marker == 'reply') {
-        replyId ??= candidateId;
+      if (marker.isEmpty) {
+        legacyCandidates.add(candidateId);
       }
     }
 
-    return replyId ?? firstEtagId;
+    for (final candidateId in legacyCandidates) {
+      if (await _isResolvableVideoEvent(candidateId)) {
+        return candidateId;
+      }
+    }
+
+    return null;
   }
 
   bool _isVideoAddressableId(String value) {
@@ -74,5 +81,13 @@ class NotificationTargetResolver {
 
     final kind = int.tryParse(parts.first);
     return kind != null && NIP71VideoKinds.isAcceptableVideoKind(kind);
+  }
+
+  Future<bool> _isResolvableVideoEvent(String eventId) async {
+    final cachedVideo = _videoEventService.getVideoById(eventId);
+    if (cachedVideo != null) return true;
+
+    final event = await _nostrService.fetchEventById(eventId);
+    return event != null && NIP71VideoKinds.isAcceptableVideoKind(event.kind);
   }
 }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1531,13 +1531,15 @@ class NotificationRepository {
     final referencedEventId = n.referencedEventId;
     if (referencedEventId != null &&
         referencedEventId.isNotEmpty &&
-        referencedEventId != rootEventId) {
+        referencedEventId != rootEventId &&
+        !n.isReferencedVideo) {
       return true;
     }
 
     final targetCommentId = n.targetCommentId;
     return targetCommentId != null &&
         targetCommentId.isNotEmpty &&
+        !n.isReferencedVideo &&
         n.sourceEventId.isNotEmpty &&
         targetCommentId != n.sourceEventId &&
         targetCommentId != rootEventId;
@@ -1547,15 +1549,21 @@ class NotificationRepository {
   ///
   /// New staging Funnelcake payloads for NIP-22 comments can omit
   /// `referenced_event_id` while including `root_event_id`. For comments, the
-  /// root ID is the video we want to open and group on.
+  /// root ID is the video we want to open and group on unless the referenced
+  /// event is itself a video, which happens for comments on video replies.
   static String? _videoAnchorEventId(
     NotificationKind kind,
     RelayNotification n,
   ) {
-    if (kind == NotificationKind.comment &&
-        n.rootEventId != null &&
-        n.rootEventId!.isNotEmpty) {
-      return n.rootEventId;
+    if (kind == NotificationKind.comment) {
+      if (n.isReferencedVideo &&
+          n.referencedEventId != null &&
+          n.referencedEventId!.isNotEmpty) {
+        return n.referencedEventId;
+      }
+      if (n.rootEventId != null && n.rootEventId!.isNotEmpty) {
+        return n.rootEventId;
+      }
     }
     return n.referencedEventId;
   }

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -955,6 +955,41 @@ void main() {
         expect(item.videoEventId, equals('video_root'));
       });
 
+      test(
+        'comment on a video reply anchors to the referenced video, not root',
+        () async {
+          stubNotifications([
+            makeNotification(
+              id: 'c-reply-video',
+              sourcePubkey: 'pub_a',
+              sourceKind: 1111,
+              notificationType: 'comment',
+              sourceEventId: 'comment_event_id',
+              referencedEventId: 'reply_video_event',
+              rootEventId: 'thread_root_event',
+              targetCommentId: 'reply_video_event',
+              referencedDTag: 'reply-video-dtag',
+              content: 'comment on a video reply',
+            ),
+          ]);
+          stubProfiles({'pub_a': makeProfile('pub_a', displayName: 'Alice')});
+
+          final page = await repository.getNotifications();
+
+          expect(page.items, hasLength(1));
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.comment));
+          expect(item.videoEventId, equals('reply_video_event'));
+          expect(
+            item.videoAddressableId,
+            equals(
+              '${NIP71VideoKinds.addressableShortVideo}:'
+              '$userPubkey:reply-video-dtag',
+            ),
+          );
+        },
+      );
+
       test('grouped video notifications leave addressable id null when neither '
           'VideoStats nor the payload carries a usable d-tag', () async {
         stubNotifications([
@@ -1397,6 +1432,7 @@ void main() {
             notificationType: 'reply',
             sourceKind: 1111,
             sourceEventId: 'reply_event_id',
+            isReferencedVideo: false,
             referencedEventId: 'parent_comment_id',
             rootEventId: 'someone_else_video_id',
             targetCommentId: 'parent_comment_id',
@@ -1417,6 +1453,7 @@ void main() {
             notificationType: 'comment',
             sourceKind: 1111,
             sourceEventId: 'reply_event_id',
+            isReferencedVideo: false,
             referencedEventId: 'parent_comment_id',
             rootEventId: 'someone_else_video_id',
             targetCommentId: 'parent_comment_id',

--- a/mobile/test/screens/video_detail_screen_test.dart
+++ b/mobile/test/screens/video_detail_screen_test.dart
@@ -84,6 +84,9 @@ void main() {
       when(
         () => mockVideoEventService.shouldHideVideo(any()),
       ).thenReturn(false);
+      when(
+        () => mockVideoEventService.isVideoEventLocallyDeleted(any()),
+      ).thenReturn(false);
     });
 
     tearDown(() async {
@@ -559,6 +562,31 @@ void main() {
         ).thenReturn(true);
 
         await tester.pumpWidget(buildSubject(videoId: 'hidden_video_id'));
+        await tester.pump();
+
+        expect(find.text('Video not found'), findsOneWidget);
+        expect(find.bySemanticsLabel('Close video player'), findsOneWidget);
+      });
+
+      testWidgets('renders exit button when video was locally deleted', (
+        tester,
+      ) async {
+        final video = createTestVideoEvent(
+          id: 'deleted_video_id',
+          pubkey: 'deleted_pubkey',
+          title: 'Deleted Video',
+        );
+
+        when(
+          () => mockVideosRepository.fetchVideoWithStatsForRouteId(
+            'deleted_video_id',
+          ),
+        ).thenAnswer((_) async => video);
+        when(
+          () => mockVideoEventService.isVideoEventLocallyDeleted(video),
+        ).thenReturn(true);
+
+        await tester.pumpWidget(buildSubject(videoId: 'deleted_video_id'));
         await tester.pump();
 
         expect(find.text('Video not found'), findsOneWidget);

--- a/mobile/test/services/notification_target_resolver_test.dart
+++ b/mobile/test/services/notification_target_resolver_test.dart
@@ -180,6 +180,81 @@ void main() {
       },
     );
 
+    test(
+      'does not route lowercase reply e-tags to parent comment ids',
+      () async {
+        when(
+          () => videoEventService.getVideoById('comment_reply_only'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('comment_reply_only')).thenAnswer(
+          (_) async => Event('e' * 64, 1111, const [
+            ['e', 'parent_comment_1', '', 'reply'],
+          ], 'nested reply'),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget('comment_reply_only');
+
+        expect(resolved, isNull);
+        verifyNever(() => videoEventService.getVideoById('parent_comment_1'));
+        verifyNever(() => nostrClient.fetchEventById('parent_comment_1'));
+      },
+    );
+
+    test(
+      'rejects unmarked legacy e-tag candidates that resolve to comments',
+      () async {
+        when(
+          () => videoEventService.getVideoById('comment_with_parent_only'),
+        ).thenReturn(null);
+        when(
+          () => nostrClient.fetchEventById('comment_with_parent_only'),
+        ).thenAnswer(
+          (_) async => Event('e' * 64, 1111, const [
+            ['e', 'parent_comment_1'],
+          ], 'legacy nested reply'),
+        );
+        when(
+          () => videoEventService.getVideoById('parent_comment_1'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('parent_comment_1')).thenAnswer(
+          (_) async => Event('f' * 64, 1111, const [], 'parent comment'),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget(
+              'comment_with_parent_only',
+            );
+
+        expect(resolved, isNull);
+      },
+    );
+
+    test(
+      'keeps legacy unmarked e-tag fallback when candidate is a video',
+      () async {
+        when(
+          () => videoEventService.getVideoById('legacy_comment'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('legacy_comment')).thenAnswer(
+          (_) async => Event('e' * 64, 1111, const [
+            ['e', 'legacy_video_1'],
+          ], 'legacy top-level comment'),
+        );
+        when(
+          () => videoEventService.getVideoById('legacy_video_1'),
+        ).thenReturn(null);
+        when(() => nostrClient.fetchEventById('legacy_video_1')).thenAnswer(
+          (_) async => Event('f' * 64, 22, const [], 'legacy video'),
+        );
+
+        final resolved = await resolver
+            .resolveVideoEventIdFromNotificationTarget('legacy_comment');
+
+        expect(resolved, equals('legacy_video_1'));
+      },
+    );
+
     test('returns null when no resolvable video tags exist', () async {
       when(() => videoEventService.getVideoById('comment_2')).thenReturn(null);
       when(() => nostrClient.fetchEventById('comment_2')).thenAnswer(


### PR DESCRIPTION
## Summary

- Route comment notifications on video replies to the referenced reply video instead of blindly preferring the thread root event.
- Stop notification target resolution from falling back to lowercase reply `e` tags that can point at parent comments instead of videos.
- Keep legacy unmarked `e` fallback only when the candidate resolves to an acceptable video event.
- Treat locally deleted video events as hidden in the video detail route.

## Root Cause

#5290 combines two paths:

1. Comment notifications for video replies can include both a `referencedEventId` for the reply video and a `rootEventId` for the wider thread. Mobile always preferred `rootEventId` for comment notifications, which can route to the wrong/non-video target.
2. The resolver's final fallback returned lowercase `e` reply/first tags without proving they were videos, so nested comment targets could become video route ids and fail as "video not found".

The backend-owned deleted-video notification generation is tracked separately in divinevideo/divine-funnelcake#546. This PR adds mobile-side unavailable handling for locally deleted events but does not pretend the app can stop Funnelcake from emitting future tombstoned-content notifications.

## Validation

- `mise exec -- flutter test test/src/notification_repository_test.dart` from `mobile/packages/notification_repository`
- `mise exec -- flutter test test/services/notification_target_resolver_test.dart`
- `mise exec -- flutter test test/screens/video_detail_screen_test.dart`
- `mise exec -- flutter test test/notifications/view/notifications_view_test.dart`
- `mise exec -- flutter analyze`
- pre-push hook analyzer + changed-file tests

Closes #5290
