### PR TITLE
fix(settings): hide blocked content filter categories

### DIFF
--- a/mobile/lib/blocs/content_filters/content_filters_state.dart
+++ b/mobile/lib/blocs/content_filters/content_filters_state.dart
@@ -11,8 +11,9 @@ enum ContentFiltersStatus { loading, ready }
 /// State for [ContentFiltersCubit].
 ///
 /// [preferences] is read once from `ContentFilterService` on load (replacing
-/// the pre-migration per-row imperative reads in `build`). Adult categories are
-/// locked in the UI when [isAgeVerified] is false.
+/// the pre-migration per-row imperative reads in `build`). The state also owns
+/// whether a label is locked in the UI so widgets only render state and
+/// dispatch actions.
 class ContentFiltersState extends Equatable {
   const ContentFiltersState({
     this.status = ContentFiltersStatus.loading,
@@ -27,6 +28,12 @@ class ContentFiltersState extends Equatable {
   /// Preference for [label], defaulting to "show" until loaded.
   ContentFilterPreference preferenceFor(ContentLabel label) =>
       preferences[label] ?? ContentFilterPreference.show;
+
+  /// Whether [label] should be locked in the UI.
+  bool isLabelLocked(ContentLabel label) =>
+      ContentFilterService.alwaysFilteredCategories.contains(label) ||
+      (!isAgeVerified &&
+          ContentFilterService.ageRestrictedCategories.contains(label));
 
   ContentFiltersState copyWith({
     ContentFiltersStatus? status,

--- a/mobile/lib/screens/content_filters_screen.dart
+++ b/mobile/lib/screens/content_filters_screen.dart
@@ -90,25 +90,18 @@ class ContentFiltersView extends StatelessWidget {
                     title: context.l10n.contentFiltersAdultContent,
                     labels: _adultLabels,
                     state: state,
-                    locked: !state.isAgeVerified,
                     onChanged: cubit.setPreference,
                   ),
                   _CategoryGroup(
                     title: context.l10n.contentFiltersSubstances,
                     labels: _substanceLabels,
                     state: state,
-                    lockedLabels: !state.isAgeVerified
-                        ? ContentFilterService.ageRestrictedCategories
-                        : const {},
                     onChanged: cubit.setPreference,
                   ),
                   _CategoryGroup(
                     title: context.l10n.contentFiltersOther,
                     labels: _otherLabels,
                     state: state,
-                    lockedLabels: !state.isAgeVerified
-                        ? ContentFilterService.ageRestrictedCategories
-                        : const {},
                     onChanged: cubit.setPreference,
                   ),
                 ],
@@ -162,15 +155,11 @@ class _CategoryGroup extends StatelessWidget {
     required this.labels,
     required this.state,
     required this.onChanged,
-    this.locked = false,
-    this.lockedLabels = const {},
   });
 
   final String title;
   final List<ContentLabel> labels;
   final ContentFiltersState state;
-  final bool locked;
-  final Set<ContentLabel> lockedLabels;
   final Future<void> Function(
     ContentLabel label,
     ContentFilterPreference preference,
@@ -187,7 +176,7 @@ class _CategoryGroup extends StatelessWidget {
           (label) => _ContentFilterRow(
             label: label,
             preference: state.preferenceFor(label),
-            locked: locked || lockedLabels.contains(label),
+            locked: state.isLabelLocked(label),
             onChanged: (preference) {
               onChanged(label, preference);
             },

--- a/mobile/lib/screens/content_filters_screen.dart
+++ b/mobile/lib/screens/content_filters_screen.dart
@@ -46,31 +46,17 @@ class ContentFiltersView extends StatelessWidget {
   static const List<ContentLabel> _adultLabels = [
     ContentLabel.nudity,
     ContentLabel.sexual,
-    ContentLabel.porn,
-  ];
-
-  static const List<ContentLabel> _violenceLabels = [
-    ContentLabel.graphicMedia,
-    ContentLabel.violence,
-    ContentLabel.selfHarm,
   ];
 
   static const List<ContentLabel> _substanceLabels = [
-    ContentLabel.drugs,
     ContentLabel.alcohol,
     ContentLabel.tobacco,
-    ContentLabel.gambling,
   ];
 
   static const List<ContentLabel> _otherLabels = [
     ContentLabel.profanity,
-    ContentLabel.hate,
-    ContentLabel.harassment,
     ContentLabel.flashingLights,
-    ContentLabel.aiGenerated,
-    ContentLabel.deepfake,
-    ContentLabel.spam,
-    ContentLabel.scam,
+    ContentLabel.gambling,
     ContentLabel.spoiler,
     ContentLabel.misleading,
   ];
@@ -108,21 +94,21 @@ class ContentFiltersView extends StatelessWidget {
                     onChanged: cubit.setPreference,
                   ),
                   _CategoryGroup(
-                    title: context.l10n.contentFiltersViolenceGore,
-                    labels: _violenceLabels,
-                    state: state,
-                    onChanged: cubit.setPreference,
-                  ),
-                  _CategoryGroup(
                     title: context.l10n.contentFiltersSubstances,
                     labels: _substanceLabels,
                     state: state,
+                    lockedLabels: !state.isAgeVerified
+                        ? ContentFilterService.ageRestrictedCategories
+                        : const {},
                     onChanged: cubit.setPreference,
                   ),
                   _CategoryGroup(
                     title: context.l10n.contentFiltersOther,
                     labels: _otherLabels,
                     state: state,
+                    lockedLabels: !state.isAgeVerified
+                        ? ContentFilterService.ageRestrictedCategories
+                        : const {},
                     onChanged: cubit.setPreference,
                   ),
                 ],
@@ -177,12 +163,14 @@ class _CategoryGroup extends StatelessWidget {
     required this.state,
     required this.onChanged,
     this.locked = false,
+    this.lockedLabels = const {},
   });
 
   final String title;
   final List<ContentLabel> labels;
   final ContentFiltersState state;
   final bool locked;
+  final Set<ContentLabel> lockedLabels;
   final Future<void> Function(
     ContentLabel label,
     ContentFilterPreference preference,
@@ -199,7 +187,7 @@ class _CategoryGroup extends StatelessWidget {
           (label) => _ContentFilterRow(
             label: label,
             preference: state.preferenceFor(label),
-            locked: locked,
+            locked: locked || lockedLabels.contains(label),
             onChanged: (preference) {
               onChanged(label, preference);
             },
@@ -248,6 +236,7 @@ class _ContentFilterRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
+      key: ValueKey('content-filter-${label.value}'),
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
       child: Row(
         children: [

--- a/mobile/lib/services/content_filter_service.dart
+++ b/mobile/lib/services/content_filter_service.dart
@@ -185,11 +185,13 @@ class ContentFilterService extends ChangeNotifier {
         await _save();
         notifyListeners();
       }
-      Log.warning(
-        'Cannot set always-filtered category $label to $preference',
-        name: 'ContentFilterService',
-        category: LogCategory.system,
-      );
+      if (preference != ContentFilterPreference.hide) {
+        Log.warning(
+          'Cannot set always-filtered category $label to $preference',
+          name: 'ContentFilterService',
+          category: LogCategory.system,
+        );
+      }
       return;
     }
 

--- a/mobile/lib/services/content_filter_service.dart
+++ b/mobile/lib/services/content_filter_service.dart
@@ -23,9 +23,11 @@ enum ContentFilterPreference {
 
 /// Service that manages per-category content filter preferences.
 ///
-/// Each [ContentLabel] can be independently set to [ContentFilterPreference]
-/// (show, warn, or hide). Adult content categories are locked to [hide]
-/// unless the user has verified they are 18+.
+/// Visible [ContentLabel] categories can be independently set to
+/// [ContentFilterPreference] (show, warn, or hide). Categories in
+/// [ageRestrictedCategories] are locked to [hide] unless the user has verified
+/// they are 18+. Categories in [alwaysFilteredCategories] are always locked to
+/// [hide].
 ///
 /// Persists preferences in SharedPreferences as a JSON map.
 class ContentFilterService extends ChangeNotifier {
@@ -46,31 +48,54 @@ class ContentFilterService extends ChangeNotifier {
     ContentLabel.porn,
   };
 
+  /// Visible categories locked to hide unless the user is age-verified.
+  static const Set<ContentLabel> ageRestrictedCategories = {
+    ...adultCategories,
+    ContentLabel.alcohol,
+    ContentLabel.tobacco,
+    ContentLabel.profanity,
+    ContentLabel.gambling,
+  };
+
+  /// Categories that Divine always filters out and does not expose as toggles.
+  static const Set<ContentLabel> alwaysFilteredCategories = {
+    ContentLabel.graphicMedia,
+    ContentLabel.violence,
+    ContentLabel.selfHarm,
+    ContentLabel.porn,
+    ContentLabel.drugs,
+    ContentLabel.hate,
+    ContentLabel.harassment,
+    ContentLabel.aiGenerated,
+    ContentLabel.deepfake,
+    ContentLabel.spam,
+    ContentLabel.scam,
+  };
+
   /// Default preferences for each category.
   static const Map<ContentLabel, ContentFilterPreference> _defaults = {
-    // Adult content — hide by default
-    ContentLabel.nudity: ContentFilterPreference.hide,
-    ContentLabel.sexual: ContentFilterPreference.hide,
+    // Visible adult content starts at warn when the age gate is unlocked.
+    ContentLabel.nudity: ContentFilterPreference.warn,
+    ContentLabel.sexual: ContentFilterPreference.warn,
+    // Always-filtered categories are not user-configurable.
+    ContentLabel.graphicMedia: ContentFilterPreference.hide,
+    ContentLabel.violence: ContentFilterPreference.hide,
+    ContentLabel.selfHarm: ContentFilterPreference.hide,
     ContentLabel.porn: ContentFilterPreference.hide,
-    // Violence — warn by default
-    ContentLabel.graphicMedia: ContentFilterPreference.warn,
-    ContentLabel.violence: ContentFilterPreference.warn,
-    ContentLabel.selfHarm: ContentFilterPreference.warn,
-    // Substances — show by default
-    ContentLabel.drugs: ContentFilterPreference.show,
-    ContentLabel.alcohol: ContentFilterPreference.show,
-    ContentLabel.tobacco: ContentFilterPreference.show,
-    ContentLabel.gambling: ContentFilterPreference.show,
-    // Other — show by default
-    ContentLabel.profanity: ContentFilterPreference.show,
-    ContentLabel.hate: ContentFilterPreference.warn,
-    ContentLabel.harassment: ContentFilterPreference.warn,
-    ContentLabel.flashingLights: ContentFilterPreference.warn,
-    ContentLabel.aiGenerated: ContentFilterPreference.show,
-    ContentLabel.deepfake: ContentFilterPreference.warn,
+    ContentLabel.drugs: ContentFilterPreference.hide,
+    ContentLabel.hate: ContentFilterPreference.hide,
+    ContentLabel.harassment: ContentFilterPreference.hide,
+    ContentLabel.aiGenerated: ContentFilterPreference.hide,
+    ContentLabel.deepfake: ContentFilterPreference.hide,
     ContentLabel.spam: ContentFilterPreference.hide,
     ContentLabel.scam: ContentFilterPreference.hide,
-    ContentLabel.spoiler: ContentFilterPreference.show,
+    // Visible non-adult categories start at warn.
+    ContentLabel.alcohol: ContentFilterPreference.warn,
+    ContentLabel.tobacco: ContentFilterPreference.warn,
+    ContentLabel.gambling: ContentFilterPreference.warn,
+    ContentLabel.profanity: ContentFilterPreference.warn,
+    ContentLabel.flashingLights: ContentFilterPreference.warn,
+    ContentLabel.spoiler: ContentFilterPreference.warn,
     ContentLabel.misleading: ContentFilterPreference.warn,
   };
 
@@ -105,6 +130,9 @@ class ContentFilterService extends ChangeNotifier {
         if (label == ContentLabel.other) continue;
         _preferences.putIfAbsent(label, () => _defaultFor(label));
       }
+      if (_enforceAlwaysFilteredCategories()) {
+        await _save();
+      }
 
       _initialized = true;
 
@@ -124,14 +152,18 @@ class ContentFilterService extends ChangeNotifier {
         if (label == ContentLabel.other) continue;
         _preferences.putIfAbsent(label, () => _defaultFor(label));
       }
+      _enforceAlwaysFilteredCategories();
       _initialized = true;
     }
   }
 
   /// Get the preference for a specific content label.
   ContentFilterPreference getPreference(ContentLabel label) {
-    // Adult categories are locked to hide if not age-verified
-    if (adultCategories.contains(label) &&
+    if (alwaysFilteredCategories.contains(label)) {
+      return ContentFilterPreference.hide;
+    }
+    // Age-restricted categories are locked to hide if not age-verified.
+    if (ageRestrictedCategories.contains(label) &&
         !ageVerificationService.isAdultContentVerified) {
       return ContentFilterPreference.hide;
     }
@@ -140,18 +172,33 @@ class ContentFilterService extends ChangeNotifier {
 
   /// Set the preference for a specific content label.
   ///
-  /// Adult categories cannot be set to anything other than [hide]
+  /// Age-restricted categories cannot be set to anything other than [hide]
   /// unless the user is age-verified.
   Future<void> setPreference(
     ContentLabel label,
     ContentFilterPreference preference,
   ) async {
-    // Enforce age gate for adult categories
-    if (adultCategories.contains(label) &&
+    if (alwaysFilteredCategories.contains(label)) {
+      final changed = _preferences[label] != ContentFilterPreference.hide;
+      _preferences[label] = ContentFilterPreference.hide;
+      if (changed) {
+        await _save();
+        notifyListeners();
+      }
+      Log.warning(
+        'Cannot set always-filtered category $label to $preference',
+        name: 'ContentFilterService',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
+    // Enforce age gate for restricted categories.
+    if (ageRestrictedCategories.contains(label) &&
         !ageVerificationService.isAdultContentVerified &&
         preference != ContentFilterPreference.hide) {
       Log.warning(
-        'Cannot set adult category $label to $preference without age '
+        'Cannot set age-restricted category $label to $preference without age '
         'verification',
         name: 'ContentFilterService',
         category: LogCategory.system,
@@ -221,7 +268,7 @@ class ContentFilterService extends ChangeNotifier {
   ///
   /// Called when the user un-checks age verification.
   Future<void> lockAdultCategories() async {
-    for (final label in adultCategories) {
+    for (final label in ageRestrictedCategories) {
       _preferences[label] = ContentFilterPreference.hide;
     }
     await _save();
@@ -239,7 +286,8 @@ class ContentFilterService extends ChangeNotifier {
   /// prompt the first time they play a given adult video — a safe default
   /// that can be overridden per-category in Content Filters.
   Future<void> unlockAdultCategories() async {
-    for (final label in adultCategories) {
+    for (final label in ageRestrictedCategories) {
+      if (alwaysFilteredCategories.contains(label)) continue;
       if ((_preferences[label] ?? _defaultFor(label)) ==
           ContentFilterPreference.hide) {
         _preferences[label] = ContentFilterPreference.warn;
@@ -331,6 +379,17 @@ class ContentFilterService extends ChangeNotifier {
   /// Get the default preference for a given label.
   static ContentFilterPreference _defaultFor(ContentLabel label) {
     return _defaults[label] ?? ContentFilterPreference.show;
+  }
+
+  bool _enforceAlwaysFilteredCategories() {
+    var changed = false;
+    for (final label in alwaysFilteredCategories) {
+      if (_preferences[label] != ContentFilterPreference.hide) {
+        _preferences[label] = ContentFilterPreference.hide;
+        changed = true;
+      }
+    }
+    return changed;
   }
 
   /// Parse a preference from its string name.

--- a/mobile/test/blocs/content_filters/content_filters_cubit_test.dart
+++ b/mobile/test/blocs/content_filters/content_filters_cubit_test.dart
@@ -49,7 +49,7 @@ void main() {
       setUp: () {
         when(() => ageService.isAdultContentVerified).thenReturn(true);
         when(
-          () => filterService.getPreference(ContentLabel.violence),
+          () => filterService.getPreference(ContentLabel.flashingLights),
         ).thenReturn(ContentFilterPreference.hide);
       },
       build: buildCubit,
@@ -60,8 +60,8 @@ void main() {
             .having((s) => s.status, 'status', ContentFiltersStatus.ready)
             .having((s) => s.isAgeVerified, 'isAgeVerified', true)
             .having(
-              (s) => s.preferenceFor(ContentLabel.violence),
-              'violence',
+              (s) => s.preferenceFor(ContentLabel.flashingLights),
+              'flashingLights',
               ContentFilterPreference.hide,
             )
             .having(
@@ -88,25 +88,25 @@ void main() {
       ),
       setUp: () {
         when(
-          () => filterService.getPreference(ContentLabel.violence),
+          () => filterService.getPreference(ContentLabel.flashingLights),
         ).thenReturn(ContentFilterPreference.hide);
       },
       build: buildCubit,
       act: (cubit) => cubit.setPreference(
-        ContentLabel.violence,
+        ContentLabel.flashingLights,
         ContentFilterPreference.hide,
       ),
       expect: () => [
         isA<ContentFiltersState>().having(
-          (s) => s.preferenceFor(ContentLabel.violence),
-          'violence',
+          (s) => s.preferenceFor(ContentLabel.flashingLights),
+          'flashingLights',
           ContentFilterPreference.hide,
         ),
       ],
       verify: (_) {
         verify(
           () => filterService.setPreference(
-            ContentLabel.violence,
+            ContentLabel.flashingLights,
             ContentFilterPreference.hide,
           ),
         ).called(1);

--- a/mobile/test/blocs/content_filters/content_filters_cubit_test.dart
+++ b/mobile/test/blocs/content_filters/content_filters_cubit_test.dart
@@ -21,6 +21,37 @@ void main() {
     registerFallbackValue(ContentFilterPreference.show);
   });
 
+  group(ContentFiltersState, () {
+    test('locks always-filtered labels regardless of age verification', () {
+      expect(
+        const ContentFiltersState(
+          isAgeVerified: true,
+        ).isLabelLocked(ContentLabel.porn),
+        isTrue,
+      );
+    });
+
+    test('locks age-restricted labels only until age verified', () {
+      expect(
+        const ContentFiltersState().isLabelLocked(ContentLabel.gambling),
+        isTrue,
+      );
+      expect(
+        const ContentFiltersState(
+          isAgeVerified: true,
+        ).isLabelLocked(ContentLabel.gambling),
+        isFalse,
+      );
+    });
+
+    test('does not lock unrestricted visible labels', () {
+      expect(
+        const ContentFiltersState().isLabelLocked(ContentLabel.flashingLights),
+        isFalse,
+      );
+    });
+  });
+
   group(ContentFiltersCubit, () {
     late _MockContentFilterService filterService;
     late _MockAgeVerificationService ageService;

--- a/mobile/test/screens/content_filters_screen_test.dart
+++ b/mobile/test/screens/content_filters_screen_test.dart
@@ -60,23 +60,50 @@ void main() {
 
       final l10n = l10nOf(tester);
       expect(find.text(l10n.contentFiltersAdultContent), findsOneWidget);
-      expect(find.text(l10n.contentFiltersViolenceGore), findsOneWidget);
+      expect(find.text(l10n.contentFiltersViolenceGore), findsNothing);
       expect(find.text(l10n.contentFiltersSubstances), findsOneWidget);
+      expect(find.text(l10n.contentFiltersOther), findsOneWidget);
     });
 
-    testWidgets('renders the full supported Other label set', (tester) async {
+    testWidgets('hides categories that are always filtered out', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
 
       final l10n = l10nOf(tester);
-      await tester.scrollUntilVisible(
-        find.text(l10n.contentLabelDeepfake),
-        200,
-      );
+      expect(find.text(l10n.contentLabelPornography), findsNothing);
+      expect(find.text(l10n.contentLabelGraphicMedia), findsNothing);
+      expect(find.text(l10n.contentLabelViolence), findsNothing);
+      expect(find.text(l10n.contentLabelSelfHarm), findsNothing);
+      expect(find.text(l10n.contentLabelDrugUse), findsNothing);
+      expect(find.text(l10n.contentLabelHateSpeech), findsNothing);
+      expect(find.text(l10n.contentLabelHarassment), findsNothing);
+      expect(find.text(l10n.contentLabelAiGenerated), findsNothing);
+      expect(find.text(l10n.contentLabelDeepfake), findsNothing);
+      expect(find.text(l10n.contentLabelSpam), findsNothing);
+      expect(find.text(l10n.contentLabelScam), findsNothing);
+    });
+
+    testWidgets('moves gambling under Other while substances stay visible', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
       await tester.pumpAndSettle();
-      expect(find.text(l10n.contentLabelDeepfake), findsOneWidget);
-      expect(find.text(l10n.contentLabelSpam), findsOneWidget);
-      expect(find.text(l10n.contentLabelScam), findsOneWidget);
+
+      final l10n = l10nOf(tester);
+      expect(find.text(l10n.contentLabelAlcohol), findsOneWidget);
+      expect(find.text(l10n.contentLabelTobacco), findsOneWidget);
+
+      await tester.scrollUntilVisible(find.text(l10n.contentLabelGambling), 80);
+      await tester.pumpAndSettle();
+
+      expect(find.text(l10n.contentFiltersOther), findsOneWidget);
+      expect(find.text(l10n.contentLabelGambling), findsOneWidget);
+      expect(
+        tester.getTopLeft(find.text(l10n.contentFiltersOther)).dy,
+        lessThan(tester.getTopLeft(find.text(l10n.contentLabelGambling)).dy),
+      );
     });
 
     testWidgets('shows the age-gate banner when not verified', (tester) async {
@@ -88,6 +115,47 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets(
+      'locks alcohol tobacco profanity and gambling when not verified',
+      (tester) async {
+        when(
+          () => filterService.getPreference(ContentLabel.alcohol),
+        ).thenReturn(ContentFilterPreference.hide);
+        when(
+          () => filterService.getPreference(ContentLabel.tobacco),
+        ).thenReturn(ContentFilterPreference.hide);
+        when(
+          () => filterService.getPreference(ContentLabel.profanity),
+        ).thenReturn(ContentFilterPreference.hide);
+        when(
+          () => filterService.getPreference(ContentLabel.gambling),
+        ).thenReturn(ContentFilterPreference.hide);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        Future<void> tapShowFor(ContentLabel label) async {
+          final row = find.byKey(ValueKey('content-filter-${label.value}'));
+          await tester.scrollUntilVisible(row, 80);
+          await tester.pumpAndSettle();
+          await tester.tap(
+            find.descendant(
+              of: row,
+              matching: find.text(l10nOf(tester).contentFiltersShow),
+            ),
+          );
+          await tester.pump();
+        }
+
+        await tapShowFor(ContentLabel.alcohol);
+        await tapShowFor(ContentLabel.tobacco);
+        await tapShowFor(ContentLabel.profanity);
+        await tapShowFor(ContentLabel.gambling);
+
+        verifyNever(() => filterService.setPreference(any(), any()));
+      },
+    );
 
     testWidgets('hides the age-gate banner when verified', (tester) async {
       when(() => ageService.isAdultContentVerified).thenReturn(true);

--- a/mobile/test/services/content_filter_service_test.dart
+++ b/mobile/test/services/content_filter_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/services/age_verification_service.dart';
@@ -26,25 +28,25 @@ void main() {
         );
         expect(
           service.getPreference(ContentLabel.violence),
-          equals(ContentFilterPreference.warn),
+          equals(ContentFilterPreference.hide),
         );
         expect(
-          service.getPreference(ContentLabel.drugs),
-          equals(ContentFilterPreference.show),
+          service.getPreference(ContentLabel.alcohol),
+          equals(ContentFilterPreference.hide),
         );
       });
 
       test('only initializes once', () async {
         await service.initialize();
         await service.setPreference(
-          ContentLabel.drugs,
-          ContentFilterPreference.warn,
+          ContentLabel.flashingLights,
+          ContentFilterPreference.show,
         );
         await service.initialize(); // Should not reset
 
         expect(
-          service.getPreference(ContentLabel.drugs),
-          equals(ContentFilterPreference.warn),
+          service.getPreference(ContentLabel.flashingLights),
+          equals(ContentFilterPreference.show),
         );
       });
     });
@@ -62,34 +64,40 @@ void main() {
         }
       });
 
-      test('violence categories default to warn', () async {
+      test('always-filtered categories default to hide', () async {
         await service.initialize();
 
-        expect(
-          service.getPreference(ContentLabel.graphicMedia),
-          equals(ContentFilterPreference.warn),
-        );
-        expect(
-          service.getPreference(ContentLabel.violence),
-          equals(ContentFilterPreference.warn),
-        );
-        expect(
-          service.getPreference(ContentLabel.selfHarm),
-          equals(ContentFilterPreference.warn),
-        );
+        for (final label in ContentFilterService.alwaysFilteredCategories) {
+          expect(
+            service.getPreference(label),
+            equals(ContentFilterPreference.hide),
+            reason: '${label.displayName} should always filter out',
+          );
+        }
       });
 
-      test('substance categories default to show', () async {
+      test('visible categories default to warn', () async {
         await service.initialize();
+        await ageService.initialize();
+        await ageService.setAdultContentVerified(true);
 
-        expect(
-          service.getPreference(ContentLabel.drugs),
-          equals(ContentFilterPreference.show),
-        );
-        expect(
-          service.getPreference(ContentLabel.alcohol),
-          equals(ContentFilterPreference.show),
-        );
+        for (final label in [
+          ContentLabel.nudity,
+          ContentLabel.sexual,
+          ContentLabel.alcohol,
+          ContentLabel.tobacco,
+          ContentLabel.gambling,
+          ContentLabel.profanity,
+          ContentLabel.flashingLights,
+          ContentLabel.spoiler,
+          ContentLabel.misleading,
+        ]) {
+          expect(
+            service.getPreference(label),
+            equals(ContentFilterPreference.warn),
+            reason: '${label.displayName} should default to warn',
+          );
+        }
       });
     });
 
@@ -98,12 +106,30 @@ void main() {
         await service.initialize();
 
         await service.setPreference(
-          ContentLabel.violence,
+          ContentLabel.flashingLights,
           ContentFilterPreference.hide,
         );
 
         expect(
-          service.getPreference(ContentLabel.violence),
+          service.getPreference(ContentLabel.flashingLights),
+          equals(ContentFilterPreference.hide),
+        );
+      });
+
+      test('cannot change always-filtered categories away from hide', () async {
+        await service.initialize();
+
+        await service.setPreference(
+          ContentLabel.porn,
+          ContentFilterPreference.show,
+        );
+
+        expect(
+          service.getPreference(ContentLabel.porn),
+          equals(ContentFilterPreference.hide),
+        );
+        expect(
+          service.allPreferences[ContentLabel.porn],
           equals(ContentFilterPreference.hide),
         );
       });
@@ -111,7 +137,7 @@ void main() {
       test('persists preference across instances', () async {
         await service.initialize();
         await service.setPreference(
-          ContentLabel.profanity,
+          ContentLabel.flashingLights,
           ContentFilterPreference.warn,
         );
 
@@ -122,7 +148,7 @@ void main() {
         await newService.initialize();
 
         expect(
-          newService.getPreference(ContentLabel.profanity),
+          newService.getPreference(ContentLabel.flashingLights),
           equals(ContentFilterPreference.warn),
         );
       });
@@ -184,17 +210,46 @@ void main() {
         );
       });
 
-      test('non-adult categories not affected by age gate', () async {
+      test(
+        'locks alcohol tobacco profanity and gambling when not age verified',
+        () async {
+          await ageService.initialize();
+          await service.initialize();
+
+          for (final label in [
+            ContentLabel.alcohol,
+            ContentLabel.tobacco,
+            ContentLabel.profanity,
+            ContentLabel.gambling,
+          ]) {
+            expect(
+              service.getPreference(label),
+              equals(ContentFilterPreference.hide),
+              reason: '${label.displayName} should be hidden until verified',
+            );
+
+            await service.setPreference(label, ContentFilterPreference.show);
+
+            expect(
+              service.getPreference(label),
+              equals(ContentFilterPreference.hide),
+              reason: '${label.displayName} should reject unverified changes',
+            );
+          }
+        },
+      );
+
+      test('visible non-adult categories not affected by age gate', () async {
         await ageService.initialize();
         await service.initialize();
 
         await service.setPreference(
-          ContentLabel.violence,
+          ContentLabel.flashingLights,
           ContentFilterPreference.show,
         );
 
         expect(
-          service.getPreference(ContentLabel.violence),
+          service.getPreference(ContentLabel.flashingLights),
           equals(ContentFilterPreference.show),
         );
       });
@@ -218,38 +273,40 @@ void main() {
       test('returns most restrictive preference', () async {
         await service.initialize();
 
-        // drugs=show, violence=warn -> should return warn
-        final result = service.getPreferenceForLabels(['drugs', 'violence']);
+        // flashing-lights=warn, misleading=warn -> should return warn
+        final result = service.getPreferenceForLabels([
+          'flashing-lights',
+          'misleading',
+        ]);
         expect(result, equals(ContentFilterPreference.warn));
       });
 
       test('returns hide when any label is hide', () async {
         await service.initialize();
 
-        // drugs=show, nudity=hide -> should return hide
-        final result = service.getPreferenceForLabels(['drugs', 'nudity']);
+        // alcohol=hide while unverified, nudity=hide -> should return hide
+        final result = service.getPreferenceForLabels(['alcohol', 'nudity']);
         expect(result, equals(ContentFilterPreference.hide));
       });
 
-      test('respects user preference for ai-generated labels', () async {
-        await service.initialize();
+      test(
+        'always-filtered labels return hide regardless of stored value',
+        () async {
+          await service.initialize();
 
-        // Default is show
-        final defaultResult = service.getPreferenceForLabels(['ai-generated']);
-        expect(defaultResult, equals(ContentFilterPreference.show));
+          await service.setPreference(
+            ContentLabel.aiGenerated,
+            ContentFilterPreference.warn,
+          );
 
-        // User can change to warn or hide
-        await service.setPreference(
-          ContentLabel.aiGenerated,
-          ContentFilterPreference.warn,
-        );
-        final warnResult = service.getPreferenceForLabels(['ai-generated']);
-        expect(warnResult, equals(ContentFilterPreference.warn));
-      });
+          final result = service.getPreferenceForLabels(['ai-generated']);
+          expect(result, equals(ContentFilterPreference.hide));
+        },
+      );
     });
 
     group('lockAdultCategories', () {
-      test('resets all adult categories to hide', () async {
+      test('resets all age-restricted categories to hide', () async {
         await ageService.initialize();
         await ageService.setAdultContentVerified(true);
         await service.initialize();
@@ -263,11 +320,19 @@ void main() {
           ContentLabel.sexual,
           ContentFilterPreference.warn,
         );
+        await service.setPreference(
+          ContentLabel.alcohol,
+          ContentFilterPreference.show,
+        );
+        await service.setPreference(
+          ContentLabel.gambling,
+          ContentFilterPreference.warn,
+        );
 
         // Lock them back
         await service.lockAdultCategories();
 
-        for (final label in ContentFilterService.adultCategories) {
+        for (final label in ContentFilterService.ageRestrictedCategories) {
           expect(
             service.getPreference(label),
             equals(ContentFilterPreference.hide),
@@ -278,28 +343,60 @@ void main() {
     });
 
     group('unlockAdultCategories', () {
-      test('promotes hide categories to warn on first unlock', () async {
+      test(
+        'visible adult categories default to warn after verification',
+        () async {
+          await ageService.initialize();
+          await ageService.setAdultContentVerified(true);
+          await service.initialize();
+
+          for (final label in [
+            ContentLabel.nudity,
+            ContentLabel.sexual,
+            ContentLabel.alcohol,
+            ContentLabel.tobacco,
+            ContentLabel.profanity,
+            ContentLabel.gambling,
+          ]) {
+            expect(
+              service.getPreference(label),
+              equals(ContentFilterPreference.warn),
+              reason: '${label.displayName} should default to warn',
+            );
+          }
+          expect(
+            service.getPreference(ContentLabel.porn),
+            equals(ContentFilterPreference.hide),
+          );
+        },
+      );
+
+      test('promotes locked visible adult categories back to warn', () async {
         await ageService.initialize();
         await ageService.setAdultContentVerified(true);
         await service.initialize();
 
-        // All adult categories start at hide (default)
-        for (final label in ContentFilterService.adultCategories) {
-          expect(
-            service.getPreference(label),
-            equals(ContentFilterPreference.hide),
-          );
-        }
-
+        await service.lockAdultCategories();
         await service.unlockAdultCategories();
 
-        for (final label in ContentFilterService.adultCategories) {
+        for (final label in [
+          ContentLabel.nudity,
+          ContentLabel.sexual,
+          ContentLabel.alcohol,
+          ContentLabel.tobacco,
+          ContentLabel.profanity,
+          ContentLabel.gambling,
+        ]) {
           expect(
             service.getPreference(label),
             equals(ContentFilterPreference.warn),
             reason: '${label.displayName} should be promoted from hide to warn',
           );
         }
+        expect(
+          service.getPreference(ContentLabel.porn),
+          equals(ContentFilterPreference.hide),
+        );
       });
 
       test('does not overwrite an existing warn preference', () async {
@@ -358,14 +455,15 @@ void main() {
           service.getPreference(ContentLabel.nudity),
           equals(ContentFilterPreference.show),
         );
-        // sexual and porn were hide — must be promoted to warn
+        // sexual was hide, so it is promoted to warn. Pornography remains
+        // locked to hide because it is always filtered out.
         expect(
           service.getPreference(ContentLabel.sexual),
           equals(ContentFilterPreference.warn),
         );
         expect(
           service.getPreference(ContentLabel.porn),
-          equals(ContentFilterPreference.warn),
+          equals(ContentFilterPreference.hide),
         );
       });
 
@@ -385,13 +483,24 @@ void main() {
 
         // age-verified so the gate is lifted; persisted warn should be visible
         await newAgeService.setAdultContentVerified(true);
-        for (final label in ContentFilterService.adultCategories) {
+        for (final label in [
+          ContentLabel.nudity,
+          ContentLabel.sexual,
+          ContentLabel.alcohol,
+          ContentLabel.tobacco,
+          ContentLabel.profanity,
+          ContentLabel.gambling,
+        ]) {
           expect(
             newService.getPreference(label),
             equals(ContentFilterPreference.warn),
             reason: '${label.displayName} should survive restart',
           );
         }
+        expect(
+          newService.getPreference(ContentLabel.porn),
+          equals(ContentFilterPreference.hide),
+        );
       });
 
       test(
@@ -424,20 +533,26 @@ void main() {
         );
       });
 
-      test('returns show when all adult categories are set to show', () async {
-        await ageService.initialize();
-        await ageService.setAdultContentVerified(true);
-        await service.initialize();
+      test(
+        'returns warn when visible adult categories are set to show',
+        () async {
+          await ageService.initialize();
+          await ageService.setAdultContentVerified(true);
+          await service.initialize();
 
-        for (final label in ContentFilterService.adultCategories) {
-          await service.setPreference(label, ContentFilterPreference.show);
-        }
+          for (final label in [
+            ContentLabel.nudity,
+            ContentLabel.sexual,
+          ]) {
+            await service.setPreference(label, ContentFilterPreference.show);
+          }
 
-        expect(
-          service.adultPlaybackPreference,
-          equals(ContentFilterPreference.show),
-        );
-      });
+          expect(
+            service.adultPlaybackPreference,
+            equals(ContentFilterPreference.warn),
+          );
+        },
+      );
 
       test(
         'returns warn when adult categories have mixed preferences',
@@ -481,9 +596,62 @@ void main() {
           throwsUnsupportedError,
         );
       });
+
+      test('reports always-filtered categories as hide', () async {
+        await service.initialize();
+
+        for (final label in ContentFilterService.alwaysFilteredCategories) {
+          expect(
+            service.allPreferences[label],
+            equals(ContentFilterPreference.hide),
+            reason: '${label.displayName} should be stored as hide',
+          );
+        }
+      });
     });
 
     group('migration from old preferences', () {
+      test(
+        'overwrites stale stored preferences for always-filtered categories',
+        () async {
+          SharedPreferences.setMockInitialValues({
+            'content_filter_prefs':
+                '{"drugs":"show","violence":"warn","ai-generated":"show",'
+                '"porn":"show"}',
+          });
+
+          final migrationService = ContentFilterService(
+            ageVerificationService: ageService,
+          );
+          await migrationService.initialize();
+
+          for (final label in [
+            ContentLabel.drugs,
+            ContentLabel.violence,
+            ContentLabel.aiGenerated,
+            ContentLabel.porn,
+          ]) {
+            expect(
+              migrationService.getPreference(label),
+              equals(ContentFilterPreference.hide),
+            );
+            expect(
+              migrationService.allPreferences[label],
+              equals(ContentFilterPreference.hide),
+            );
+          }
+
+          final prefs = await SharedPreferences.getInstance();
+          final persisted =
+              jsonDecode(prefs.getString('content_filter_prefs')!)
+                  as Map<String, dynamic>;
+          expect(persisted['drugs'], equals('hide'));
+          expect(persisted['violence'], equals('hide'));
+          expect(persisted['ai-generated'], equals('hide'));
+          expect(persisted['porn'], equals('hide'));
+        },
+      );
+
       test('migrates alwaysShow to show for adult categories', () async {
         SharedPreferences.setMockInitialValues({
           // Legacy playback preference "alwaysShow" = index 0
@@ -525,13 +693,20 @@ void main() {
         );
         await restartedService.initialize();
 
-        for (final label in ContentFilterService.adultCategories) {
+        for (final label in [
+          ContentLabel.nudity,
+          ContentLabel.sexual,
+        ]) {
           expect(
             restartedService.getPreference(label),
             equals(ContentFilterPreference.show),
             reason: '${label.displayName} should survive restart',
           );
         }
+        expect(
+          restartedService.getPreference(ContentLabel.porn),
+          equals(ContentFilterPreference.hide),
+        );
       });
 
       test(
@@ -562,7 +737,7 @@ void main() {
           );
           expect(
             migrationService.getPreference(ContentLabel.porn),
-            equals(ContentFilterPreference.show),
+            equals(ContentFilterPreference.hide),
           );
           expect(
             migrationService.getPreference(ContentLabel.violence),

--- a/mobile/test/services/nsfw_content_filter_test.dart
+++ b/mobile/test/services/nsfw_content_filter_test.dart
@@ -138,46 +138,43 @@ void main() {
         expect(filter(video), isTrue);
       });
 
-      test('returns false for video with violence label (warn by default)', () {
+      test('returns true for video with violence label', () {
         final filter = createNsfwFilter(
           contentFilterService,
           moderationLabelService: moderationLabelService,
         );
         final video = _createVideo(contentWarningLabels: ['violence']);
 
-        expect(filter(video), isFalse);
+        expect(filter(video), isTrue);
       });
 
-      test('returns false for video with drugs label (show by default)', () {
+      test('returns true for video with drugs label', () {
         final filter = createNsfwFilter(
           contentFilterService,
           moderationLabelService: moderationLabelService,
         );
         final video = _createVideo(contentWarningLabels: ['drugs']);
 
-        expect(filter(video), isFalse);
+        expect(filter(video), isTrue);
       });
 
-      test(
-        'still hides a video whose moderationLabels survived a cache '
-        'round-trip',
-        () {
-          final filter = createNsfwFilter(
-            contentFilterService,
-            moderationLabelService: moderationLabelService,
-          );
-          // The home-feed cache stores videos via toJson and rehydrates them
-          // via fromJson on cold start. The ML "hide" signal must survive that
-          // trip, otherwise a moderated video slips past the filter while the
-          // cached window is served.
-          final original = _createVideo(moderationLabels: ['nudity']);
-          final cached = VideoEvent.fromJson(original.toJson());
+      test('still hides a video whose moderationLabels survived a cache '
+          'round-trip', () {
+        final filter = createNsfwFilter(
+          contentFilterService,
+          moderationLabelService: moderationLabelService,
+        );
+        // The home-feed cache stores videos via toJson and rehydrates them
+        // via fromJson on cold start. The ML "hide" signal must survive that
+        // trip, otherwise a moderated video slips past the filter while the
+        // cached window is served.
+        final original = _createVideo(moderationLabels: ['nudity']);
+        final cached = VideoEvent.fromJson(original.toJson());
 
-          expect(filter(original), isTrue);
-          expect(cached.moderationLabels, equals(['nudity']));
-          expect(filter(cached), isTrue);
-        },
-      );
+        expect(filter(original), isTrue);
+        expect(cached.moderationLabels, equals(['nudity']));
+        expect(filter(cached), isTrue);
+      });
     });
 
     group('NSFW hashtag detection', () {
@@ -242,8 +239,9 @@ void main() {
           contentFilterService,
           moderationLabelService: moderationLabelService,
         );
-        // 'drugs' is recognized and defaults to show
-        final video = _createVideo(contentWarningLabels: ['drugs']);
+        // 'flashing-lights' is recognized and defaults to warn, which does
+        // not hide.
+        final video = _createVideo(contentWarningLabels: ['flashing-lights']);
 
         expect(filter(video), isFalse);
       });
@@ -270,9 +268,9 @@ void main() {
         },
       );
 
-      test('returns true for violence when user sets to hide', () async {
+      test('returns true for flashing lights when user sets to hide', () async {
         await contentFilterService.setPreference(
-          ContentLabel.violence,
+          ContentLabel.flashingLights,
           ContentFilterPreference.hide,
         );
 
@@ -280,7 +278,7 @@ void main() {
           contentFilterService,
           moderationLabelService: moderationLabelService,
         );
-        final video = _createVideo(contentWarningLabels: ['violence']);
+        final video = _createVideo(contentWarningLabels: ['flashing-lights']);
 
         expect(filter(video), isTrue);
       });
@@ -292,19 +290,21 @@ void main() {
           contentFilterService,
           moderationLabelService: moderationLabelService,
         );
-        // drugs=show, nudity=hide → most restrictive wins → hide
-        final video = _createVideo(contentWarningLabels: ['drugs', 'nudity']);
+        // alcohol=hide while unverified, nudity=hide -> hide wins
+        final video = _createVideo(contentWarningLabels: ['alcohol', 'nudity']);
 
         expect(filter(video), isTrue);
       });
 
-      test('returns false when all labels map to warn or show', () {
+      test('returns false when all labels map to warn', () {
         final filter = createNsfwFilter(
           contentFilterService,
           moderationLabelService: moderationLabelService,
         );
-        // drugs=show, violence=warn → most restrictive is warn, not hide
-        final video = _createVideo(contentWarningLabels: ['drugs', 'violence']);
+        // flashing-lights=warn, misleading=warn -> most restrictive is warn.
+        final video = _createVideo(
+          contentWarningLabels: ['flashing-lights', 'misleading'],
+        );
 
         expect(filter(video), isFalse);
       });
@@ -321,7 +321,7 @@ void main() {
             hashtags: ['nsfw'],
           );
 
-          // Should still filter (nudity=hide), no double-add issues
+          // Should still filter because nudity is age-gated to hide.
           expect(filter(video), isTrue);
         },
       );
@@ -417,13 +417,13 @@ void main() {
       test('unknown label hides the video even if the user preferenced the '
           'known label as show', () async {
         // Simulate an age-verified user who has explicitly opted in to
-        // seeing violence. Without the unknown-label short-circuit, a
-        // video labeled ['violence', 'unknown-x'] would pass through
+        // seeing alcohol content. Without the unknown-label short-circuit, a
+        // video labeled ['alcohol', 'unknown-x'] would pass through
         // because the combined preference resolves to show.
         await ageService.initialize();
         await ageService.setAdultContentVerified(true);
         await contentFilterService.setPreference(
-          ContentLabel.violence,
+          ContentLabel.alcohol,
           ContentFilterPreference.show,
         );
 
@@ -432,7 +432,7 @@ void main() {
           moderationLabelService: moderationLabelService,
         );
         final video = _createVideo(
-          moderationLabels: const ['violence', 'unknown-x'],
+          moderationLabels: const ['alcohol', 'unknown-x'],
         );
 
         // The unknown label must force-hide regardless of user preference.
@@ -463,7 +463,7 @@ void main() {
       test('returns trusted hash-based warn labels', () async {
         await seedModerationLabels([
           ['L', 'content-warning'],
-          ['l', 'violence', 'content-warning'],
+          ['l', 'flashing-lights', 'content-warning'],
           ['x', 'trusted-warning-hash'],
         ]);
 
@@ -473,7 +473,7 @@ void main() {
         );
         final labels = resolver(_createVideo(sha256: 'trusted-warning-hash'));
 
-        expect(labels, equals(['violence']));
+        expect(labels, equals(['flashing-lights']));
       });
     });
   });

--- a/mobile/test/services/video_event_service_content_filter_test.dart
+++ b/mobile/test/services/video_event_service_content_filter_test.dart
@@ -124,24 +124,24 @@ void main() {
       () async {
         await seedModerationLabels([
           ['L', 'content-warning'],
-          ['l', 'violence', 'content-warning'],
-          ['x', 'sha-violence'],
+          ['l', 'flashing-lights', 'content-warning'],
+          ['x', 'sha-flashing-lights'],
         ]);
 
         final result = videoEventService.filterVideoList([
-          _createVideo(id: 'video-2', sha256: 'sha-violence'),
+          _createVideo(id: 'video-2', sha256: 'sha-flashing-lights'),
         ]);
 
         expect(result, hasLength(1));
         expect(result.single.contentWarningLabels, isEmpty);
-        expect(result.single.warnLabels, equals(['violence']));
+        expect(result.single.warnLabels, equals(['flashing-lights']));
       },
     );
 
     test('applies trusted addressable labels to replaceable videos', () async {
       await seedModerationLabels([
         ['L', 'content-warning'],
-        ['l', 'graphic-media', 'content-warning'],
+        ['l', 'flashing-lights', 'content-warning'],
         ['a', '34236:creator_pubkey_hex:replaceable-video-d-tag'],
       ]);
 
@@ -155,7 +155,7 @@ void main() {
 
       expect(result, hasLength(1));
       expect(result.single.contentWarningLabels, isEmpty);
-      expect(result.single.warnLabels, equals(['graphic-media']));
+      expect(result.single.warnLabels, equals(['flashing-lights']));
     });
   });
 }


### PR DESCRIPTION
## Summary
- force the issue-requested hidden labels to Filter out in ContentFilterService, so feed filtering cannot be bypassed by hiding settings UI
- always filter out and hide these categories from Content Settings: Graphic Media, Violence, Self-Harm, Pornography, Drug Use, Hate Speech, Harassment, AI-Generated, Deepfake, Spam, and Scam
- lock Nudity, Sexual Content, Alcohol, Tobacco/Smoking, Profanity, and Gambling to Filter out until the user is age-verified
- remove the empty Violence & Gore group, remove unavailable toggles, and move Gambling from Substances to Other
- default every remaining visible, unlocked content-filter category to Warn
- keep Pornography locked to Filter out even after age verification, which means the aggregate adult playback preference cannot resolve looser than Warn while Pornography is part of the adult category set
- migrate stale stored preferences for always-filtered labels back to Hide and update regression coverage across settings UI, cubit state, service defaults/migration/persistence, feed filtering, age-gate behavior, and trusted-label warn flows

## Behavior Notes
- Filter out labels are enforced by ContentFilterService#getPreference and getPreferenceForLabels, which feed nsfw_content_filter.dart and trusted label filtering in video_event_service.dart.
- Warn labels are still surfaced through createNsfwWarnLabels and the feed overlay path; the existing feed overlay tests were rerun to verify warned videos still block autoplay until View Anyway is tapped.
- User setting changes are saved immediately through ContentFiltersCubit#setPreference -> ContentFilterService#setPreference -> SharedPreferences, so closing the filters screen does not require an explicit save action and settings persist across service instances.

## Verification
- mise exec flutter@3.44.0 -- flutter analyze
- mise exec flutter@3.44.0 -- flutter test test/services/content_filter_service_test.dart test/screens/content_filters_screen_test.dart test/blocs/content_filters/content_filters_cubit_test.dart test/services/nsfw_content_filter_test.dart test/services/video_event_service_content_filter_test.dart test/widgets/video_feed_item/content_warning_helpers_test.dart test/widgets/video_feed_item/feed_videos_test.dart test/blocs/safety_settings/safety_settings_cubit_test.dart test/screens/safety_settings_screen_test.dart test/screens/settings/settings_taxonomy_test.dart test/services/media_auth_interceptor_preference_test.dart
- Pre-push hook reran analyzer plus changed-file tests successfully before push
- GitHub checks passed: Format, Generated Files, Analyze, Tests, Mobile CI, VGV Tag Gate, Web Preview, semantic PR, linked issue, CLA, and mergeability

Closes #5302