### PR TITLE
feat(profile): cache the Videos tab with stale-while-revalidate

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -253,12 +253,21 @@ class FullscreenFeedBloc
       }
     }
 
+    // Preserve the currently-shown video's position across a reorder/prepend.
+    // Crucially, do NOT latch [initialTargetResolved] here: when an initial
+    // target is still pending (specified but not yet present), preserving a
+    // placeholder/seed video must not mark resolution as done — otherwise a
+    // later emit that finally contains the target can never jump to it. Only
+    // an actual target match (above) or "no target specified" resolves.
     final currentVideo = state.currentVideo;
     final preservedIndex = currentVideo == null
         ? -1
         : indexOfMatchingVideo(videos, currentVideo);
     if (preservedIndex >= 0) {
-      return (index: preservedIndex, initialTargetResolved: true);
+      return (
+        index: preservedIndex,
+        initialTargetResolved: state.initialTargetResolved,
+      );
     }
 
     return (

--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -7,16 +7,17 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
-import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
-import 'package:models/models.dart' hide LogCategory;
+import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_feed/profile_feed_enrichment_merge.dart';
+import 'package:openvine/blocs/profile_feed/profile_video_metadata_cache.dart';
+import 'package:openvine/blocs/profile_feed/profile_video_snapshot_cache.dart';
 import 'package:openvine/blocs/profile_shared/profile_video_offset_snapshot.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:stream_transform/stream_transform.dart';
-import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 part 'profile_feed_event.dart';
@@ -114,14 +115,9 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
   final ContentBlocklistRepository _blocklistRepository;
   final EnrichVideos _enrichVideos;
 
-  /// CacheSync key for this author's persisted Videos-tab window.
-  ///
-  /// Scoped to the author (the persisted videos are the unfiltered public
-  /// feed — blocklist/content filters are re-applied on every emit, so the
-  /// payload is viewer-independent). Follows the `${pubkey}:${operation}`
-  /// convention so sign-out's `invalidatePrefix(currentPubkey)` clears the
-  /// signed-out user's own-profile entry.
-  String get _cacheKey => '$_authorPubkey:profile_videos';
+  /// Best-effort stale-while-revalidate persistence for the Videos tab.
+  late final ProfileVideoSnapshotCache _snapshotCache =
+      ProfileVideoSnapshotCache(_authorPubkey);
 
   /// Accumulated **unfiltered** source list (REST + relay). Not UI state — it's
   /// the source [ProfileFeedFiltersChanged] re-filters in place without a
@@ -130,7 +126,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
 
   /// Backfill cache for engagement counts, used on the Nostr-fallback loadMore
   /// branch where there is no REST hydration.
-  final Map<String, _VideoMetadataCache> _metadataCache = {};
+  final ProfileVideoMetadataCache _metadataCache = ProfileVideoMetadataCache();
 
   /// True while a cold-load fetch is in flight (timer-coupled lifecycle
   /// bookkeeping; the observable result is [ProfileFeedState.isInitialLoad]).
@@ -182,7 +178,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
     // Stale-while-revalidate: a persisted snapshot restores the full
     // scrolled-through window + REST cursor instantly, so reopening a profile
     // does not re-paginate from the relay (#5279 extended to the Videos tab).
-    final cached = await _readCachedSnapshot();
+    final cached = await _snapshotCache.read();
     if (isClosed) return;
     if (cached != null && cached.videos.isNotEmpty) {
       await _restoreFromCache(emit, cached: cached, relaySeed: relaySeed);
@@ -239,7 +235,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
       mergeProfileFeedVideoLists(relaySeed, cached.videos),
     );
     _unfilteredVideos = merged;
-    _cacheVideoMetadata(merged);
+    _metadataCache.cache(merged);
     unawaited(_subscribe());
 
     emit(
@@ -265,6 +261,11 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
   /// pagination cursor so the scrolled-through tail is not dropped and the user
   /// does not re-paginate from the start. Stale cursors self-heal on the next
   /// load-more (an over-shot offset returns empty → `hasMoreContent` flips off).
+  ///
+  /// A `null` restored cursor (Nostr-fallback) is preserved too: even if this
+  /// REST refresh succeeds, pagination stays on the relay `until` path until a
+  /// full refresh re-resolves the offset. That keeps the restored tail intact
+  /// at the cost of one stale-mode pagination, and self-heals on pull-to-refresh.
   Future<void> _revalidateHead(
     Emitter<ProfileFeedState> emit, {
     required List<VideoEvent> relaySeed,
@@ -280,7 +281,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         mergeProfileFeedVideoLists(_unfilteredVideos, result.videos),
       );
       _unfilteredVideos = merged;
-      _cacheVideoMetadata(merged);
+      _metadataCache.cache(merged);
       emit(
         state.copyWith(
           videos: _applyFeedFilters(merged),
@@ -495,7 +496,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         final after = _videoEventService.authorVideos(_authorPubkey).length;
 
         _unfilteredVideos = _withoutTombstones(
-          _applyMetadataCache(
+          _metadataCache.apply(
             _videoEventService
                 .authorVideos(_authorPubkey)
                 .where((v) => !v.isRepost)
@@ -542,7 +543,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         ? mergeProfileFeedVideoLists(_unfilteredVideos, pageVideos)
         : pageVideos;
     _unfilteredVideos = _withoutTombstones(merged);
-    _cacheVideoMetadata(_unfilteredVideos);
+    _metadataCache.cache(_unfilteredVideos);
     final filtered = _applyFeedFilters(_unfilteredVideos);
 
     emit(
@@ -594,10 +595,11 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
     ProfileFeedEnrichmentReady event,
     Emitter<ProfileFeedState> emit,
   ) {
-    _unfilteredVideos = _mergeVideosReplacingCurrentKeys(
+    _unfilteredVideos = mergeProfileFeedEnrichment(
       current: _unfilteredVideos,
       sourceKeys: event.sourceKeys,
       incoming: event.enriched,
+      removeTombstones: _withoutTombstones,
     );
     emit(
       state.copyWith(
@@ -691,7 +693,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         .authorVideos(_authorPubkey)
         .where((v) => !v.isRepost)
         .toList();
-    videos = _applyMetadataCache(videos);
+    videos = _metadataCache.apply(videos);
     return _withoutTombstones(_videoEventService.filterVideoList(videos));
   }
 
@@ -714,146 +716,6 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         .toList();
   }
 
-  void _cacheVideoMetadata(List<VideoEvent> videos) {
-    for (final video in videos) {
-      if (video.originalLoops != null ||
-          video.rawTags['views'] != null ||
-          video.originalLikes != null ||
-          video.originalComments != null ||
-          video.originalReposts != null ||
-          video.nostrLikeCount != null) {
-        _metadataCache[video.id.toLowerCase()] = _VideoMetadataCache(
-          originalLoops: video.originalLoops,
-          views: video.rawTags['views'],
-          originalLikes: video.originalLikes,
-          originalComments: video.originalComments,
-          originalReposts: video.originalReposts,
-          nostrLikeCount: video.nostrLikeCount,
-        );
-      }
-    }
-  }
-
-  List<VideoEvent> _applyMetadataCache(List<VideoEvent> videos) {
-    return videos.map((video) {
-      final cached = _metadataCache[video.id.toLowerCase()];
-      if (cached == null) return video;
-      final currentViews = video.rawTags['views'];
-      final shouldApply =
-          (video.originalLoops == null && cached.originalLoops != null) ||
-          (currentViews == null && cached.views != null) ||
-          (video.originalLikes == null && cached.originalLikes != null) ||
-          (video.originalComments == null && cached.originalComments != null) ||
-          (video.originalReposts == null && cached.originalReposts != null) ||
-          (video.nostrLikeCount == null && cached.nostrLikeCount != null);
-      if (!shouldApply) return video;
-      return video.copyWith(
-        originalLoops: video.originalLoops ?? cached.originalLoops,
-        rawTags: currentViews == null && cached.views != null
-            ? {...video.rawTags, 'views': cached.views!}
-            : video.rawTags,
-        originalLikes: video.originalLikes ?? cached.originalLikes,
-        originalComments: video.originalComments ?? cached.originalComments,
-        originalReposts: video.originalReposts ?? cached.originalReposts,
-        nostrLikeCount: video.nostrLikeCount ?? cached.nostrLikeCount,
-      );
-    }).toList();
-  }
-
-  /// Merges enriched copies over [sourceKeys] against the current list, filling
-  /// missing fields without clobbering relay updates that arrived during the
-  /// enrichment window (#3705).
-  List<VideoEvent> _mergeVideosReplacingCurrentKeys({
-    required List<VideoEvent> current,
-    required Set<String> sourceKeys,
-    required List<VideoEvent> incoming,
-  }) {
-    if (sourceKeys.isEmpty) {
-      return _withoutTombstones(mergeProfileFeedVideoLists(current, incoming));
-    }
-    final currentByKey = {
-      for (final video in current)
-        if (sourceKeys.contains(canonicalProfileFeedVideoKey(video)))
-          canonicalProfileFeedVideoKey(video): video,
-    };
-    final keepFromCurrent = current
-        .where((v) => !sourceKeys.contains(canonicalProfileFeedVideoKey(v)))
-        .toList();
-    final mergedSource = incoming.map((video) {
-      final currentVideo = currentByKey[canonicalProfileFeedVideoKey(video)];
-      return currentVideo == null
-          ? video
-          : _mergeEnrichmentIntoCurrent(currentVideo, video);
-    }).toList();
-    return _withoutTombstones(
-      mergeProfileFeedVideoLists(keepFromCurrent, mergedSource),
-    );
-  }
-
-  VideoEvent _mergeEnrichmentIntoCurrent(
-    VideoEvent current,
-    VideoEvent enriched,
-  ) {
-    return current.copyWith(
-      publishedAt:
-          (current.publishedAt != null && current.publishedAt!.isNotEmpty)
-          ? current.publishedAt
-          : enriched.publishedAt,
-      rawTags: mergeVideoRawTagsPrimaryWins(current.rawTags, enriched.rawTags),
-      contentWarningLabels: current.contentWarningLabels.isNotEmpty
-          ? current.contentWarningLabels
-          : enriched.contentWarningLabels,
-      title: current.title ?? enriched.title,
-      videoUrl: current.videoUrl ?? enriched.videoUrl,
-      thumbnailUrl: current.thumbnailUrl ?? enriched.thumbnailUrl,
-      duration: current.duration ?? enriched.duration,
-      dimensions: current.dimensions ?? enriched.dimensions,
-      mimeType: current.mimeType ?? enriched.mimeType,
-      sha256: current.sha256 ?? enriched.sha256,
-      fileSize: current.fileSize ?? enriched.fileSize,
-      hashtags: current.hashtags.isNotEmpty
-          ? current.hashtags
-          : enriched.hashtags,
-      vineId: current.vineId ?? enriched.vineId,
-      group: current.group ?? enriched.group,
-      altText: current.altText ?? enriched.altText,
-      blurhash: current.blurhash ?? enriched.blurhash,
-      originalLoops: mergeNullableEngagementMax(
-        current.originalLoops,
-        enriched.originalLoops,
-      ),
-      originalLikes: mergeNullableEngagementMax(
-        current.originalLikes,
-        enriched.originalLikes,
-      ),
-      originalComments: mergeNullableEngagementMax(
-        current.originalComments,
-        enriched.originalComments,
-      ),
-      originalReposts: mergeNullableEngagementMax(
-        current.originalReposts,
-        enriched.originalReposts,
-      ),
-      audioEventId: current.audioEventId ?? enriched.audioEventId,
-      audioEventRelay: current.audioEventRelay ?? enriched.audioEventRelay,
-      collaboratorPubkeys: current.collaboratorPubkeys.isNotEmpty
-          ? current.collaboratorPubkeys
-          : enriched.collaboratorPubkeys,
-      inspiredByVideo: current.inspiredByVideo ?? enriched.inspiredByVideo,
-      textTrackRef: current.textTrackRef ?? enriched.textTrackRef,
-      textTrackContent: current.textTrackContent ?? enriched.textTrackContent,
-      nostrEventTags: current.nostrEventTags.isNotEmpty
-          ? current.nostrEventTags
-          : enriched.nostrEventTags,
-      authorName: current.authorName ?? enriched.authorName,
-      authorAvatar: current.authorAvatar ?? enriched.authorAvatar,
-      nostrLikeCount: mergeNullableEngagementMax(
-        current.nostrLikeCount,
-        enriched.nostrLikeCount,
-      ),
-    );
-  }
-
   bool _sameVideoSequence(List<VideoEvent> left, List<VideoEvent> right) {
     if (left.length != right.length) return false;
     for (var i = 0; i < left.length; i++) {
@@ -870,53 +732,14 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
     return true;
   }
 
-  // ---------------------------------------------------------------------------
-  // CacheSync persistence (stale-while-revalidate)
-  // ---------------------------------------------------------------------------
-
-  /// Reads the persisted snapshot once; `null` on miss or failure (a cache
-  /// problem must never break an otherwise-fine cold load).
-  Future<ProfileVideoOffsetSnapshot?> _readCachedSnapshot() async {
-    try {
-      return await CacheSync.read<ProfileVideoOffsetSnapshot>(
-        key: _cacheKey,
-        fromJson: ProfileVideoOffsetSnapshot.fromJson,
-      );
-    } on Object catch (error) {
-      Log.warning(
-        'Failed to read cached profile-videos snapshot - $error',
-        name: 'ProfileFeedCubit',
-        category: LogCategory.video,
-      );
-      return null;
-    }
-  }
-
-  /// Persists the current source window + cursor so a reopen restores it.
-  /// Fire-and-forget: cache writes are best-effort and must never block or
-  /// fail an emit. Capping bounds the serialized payload (see
-  /// [ProfileSnapshotWindow]).
-  void _persistSnapshot() {
-    final snapshot = ProfileVideoOffsetSnapshot.capped(
-      videos: _unfilteredVideos,
-      nextOffset: state.nextOffset,
-      totalVideoCount: state.totalVideoCount,
-      hasMoreContent: state.hasMoreContent,
-    );
-    unawaited(
-      CacheSync.write<ProfileVideoOffsetSnapshot>(
-        key: _cacheKey,
-        value: snapshot,
-        toJson: (s) => s.toJson(),
-      ).catchError((Object error) {
-        Log.warning(
-          'Failed to persist profile-videos snapshot - $error',
-          name: 'ProfileFeedCubit',
-          category: LogCategory.video,
-        );
-      }),
-    );
-  }
+  /// Persists the current source window + cursor via [_snapshotCache] so a
+  /// reopen restores it (stale-while-revalidate).
+  void _persistSnapshot() => _snapshotCache.write(
+    videos: _unfilteredVideos,
+    nextOffset: state.nextOffset,
+    totalVideoCount: state.totalVideoCount,
+    hasMoreContent: state.hasMoreContent,
+  );
 
   @override
   Future<void> close() {
@@ -925,23 +748,4 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
     _initialLoadTimer?.cancel();
     return super.close();
   }
-}
-
-/// Cached engagement metadata used to backfill Nostr-only videos.
-class _VideoMetadataCache {
-  const _VideoMetadataCache({
-    this.originalLoops,
-    this.views,
-    this.originalLikes,
-    this.originalComments,
-    this.originalReposts,
-    this.nostrLikeCount,
-  });
-
-  final int? originalLoops;
-  final String? views;
-  final int? originalLikes;
-  final int? originalComments;
-  final int? originalReposts;
-  final int? nostrLikeCount;
 }

--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -7,13 +7,16 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
-import 'package:models/models.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_video_offset_snapshot.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:stream_transform/stream_transform.dart';
+import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
 part 'profile_feed_event.dart';
@@ -111,6 +114,15 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
   final ContentBlocklistRepository _blocklistRepository;
   final EnrichVideos _enrichVideos;
 
+  /// CacheSync key for this author's persisted Videos-tab window.
+  ///
+  /// Scoped to the author (the persisted videos are the unfiltered public
+  /// feed — blocklist/content filters are re-applied on every emit, so the
+  /// payload is viewer-independent). Follows the `${pubkey}:${operation}`
+  /// convention so sign-out's `invalidatePrefix(currentPubkey)` clears the
+  /// signed-out user's own-profile entry.
+  String get _cacheKey => '$_authorPubkey:profile_videos';
+
   /// Accumulated **unfiltered** source list (REST + relay). Not UI state — it's
   /// the source [ProfileFeedFiltersChanged] re-filters in place without a
   /// re-fetch. Same source-cache category as the injected dependencies.
@@ -166,6 +178,18 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
     emit(state.copyWith(status: ProfileFeedStatus.loading));
 
     final relaySeed = _relayVideosSnapshot();
+
+    // Stale-while-revalidate: a persisted snapshot restores the full
+    // scrolled-through window + REST cursor instantly, so reopening a profile
+    // does not re-paginate from the relay (#5279 extended to the Videos tab).
+    final cached = await _readCachedSnapshot();
+    if (isClosed) return;
+    if (cached != null && cached.videos.isNotEmpty) {
+      await _restoreFromCache(emit, cached: cached, relaySeed: relaySeed);
+      return;
+    }
+
+    // Cold open — no cache to serve.
     if (relaySeed.isEmpty) {
       _beginInitialLoadTracking();
     }
@@ -195,6 +219,83 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
       await _doRefresh(emit, backfillInitialPage: true);
     } else if (!isClosed && result != null) {
       await _backfillInitialRestPage(emit);
+    }
+  }
+
+  /// Serves the persisted snapshot immediately (full window + cursor), then
+  /// revalidates the head in the background.
+  ///
+  /// The cached videos are merged with the current [relaySeed] so any realtime
+  /// data already in [VideoEventService] (e.g. a just-published clip) shows on
+  /// top of the restored window. [ProfileFeedState.nextOffset] /
+  /// [ProfileFeedState.hasMoreContent] come straight from the snapshot so
+  /// scrolling resumes where the user left off.
+  Future<void> _restoreFromCache(
+    Emitter<ProfileFeedState> emit, {
+    required ProfileVideoOffsetSnapshot cached,
+    required List<VideoEvent> relaySeed,
+  }) async {
+    final merged = _withoutTombstones(
+      mergeProfileFeedVideoLists(relaySeed, cached.videos),
+    );
+    _unfilteredVideos = merged;
+    _cacheVideoMetadata(merged);
+    unawaited(_subscribe());
+
+    emit(
+      state.copyWith(
+        status: ProfileFeedStatus.ready,
+        videos: _applyFeedFilters(merged),
+        nextOffset: cached.nextOffset,
+        totalVideoCount: cached.totalVideoCount,
+        hasMoreContent: cached.hasMoreContent,
+        isInitialLoad: false,
+        isRefreshing: true,
+        isFetchingTotalCount: cached.totalVideoCount == null,
+        lastUpdated: DateTime.now(),
+      ),
+    );
+    _persistSnapshot();
+
+    await _revalidateHead(emit, relaySeed: relaySeed);
+  }
+
+  /// Refreshes the head of a cache-restored feed: re-fetches the first REST
+  /// page and merges it into the restored window, **preserving** the restored
+  /// pagination cursor so the scrolled-through tail is not dropped and the user
+  /// does not re-paginate from the start. Stale cursors self-heal on the next
+  /// load-more (an over-shot offset returns empty → `hasMoreContent` flips off).
+  Future<void> _revalidateHead(
+    Emitter<ProfileFeedState> emit, {
+    required List<VideoEvent> relaySeed,
+  }) async {
+    try {
+      final result = await _videosRepository.getAuthorFeed(
+        authorPubkey: _authorPubkey,
+        relaySeed: relaySeed,
+        skipCache: true,
+      );
+      if (isClosed) return;
+      final merged = _withoutTombstones(
+        mergeProfileFeedVideoLists(_unfilteredVideos, result.videos),
+      );
+      _unfilteredVideos = merged;
+      _cacheVideoMetadata(merged);
+      emit(
+        state.copyWith(
+          videos: _applyFeedFilters(merged),
+          totalVideoCount: result.totalCount ?? state.totalVideoCount,
+          isRefreshing: false,
+          isFetchingTotalCount: false,
+          lastUpdated: DateTime.now(),
+        ),
+      );
+      _enrichInBackground();
+      _persistSnapshot();
+    } on Object catch (error, stackTrace) {
+      if (isClosed) return;
+      addError(error, stackTrace);
+      emit(state.copyWith(isRefreshing: false, isFetchingTotalCount: false));
     }
   }
 
@@ -412,6 +513,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
             lastUpdated: DateTime.now(),
           ),
         );
+        _persistSnapshot();
       }
     } on Object catch (error, stackTrace) {
       if (isClosed) return;
@@ -458,6 +560,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         lastUpdated: DateTime.now(),
       ),
     );
+    _persistSnapshot();
   }
 
   // ---------------------------------------------------------------------------
@@ -502,6 +605,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         lastUpdated: DateTime.now(),
       ),
     );
+    _persistSnapshot();
   }
 
   // ---------------------------------------------------------------------------
@@ -532,6 +636,7 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
         lastUpdated: DateTime.now(),
       ),
     );
+    _persistSnapshot();
   }
 
   void _onFiltersChanged(
@@ -763,6 +868,54 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
       if (l.nostrLikeCount != r.nostrLikeCount) return false;
     }
     return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // CacheSync persistence (stale-while-revalidate)
+  // ---------------------------------------------------------------------------
+
+  /// Reads the persisted snapshot once; `null` on miss or failure (a cache
+  /// problem must never break an otherwise-fine cold load).
+  Future<ProfileVideoOffsetSnapshot?> _readCachedSnapshot() async {
+    try {
+      return await CacheSync.read<ProfileVideoOffsetSnapshot>(
+        key: _cacheKey,
+        fromJson: ProfileVideoOffsetSnapshot.fromJson,
+      );
+    } on Object catch (error) {
+      Log.warning(
+        'Failed to read cached profile-videos snapshot - $error',
+        name: 'ProfileFeedCubit',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+  }
+
+  /// Persists the current source window + cursor so a reopen restores it.
+  /// Fire-and-forget: cache writes are best-effort and must never block or
+  /// fail an emit. Capping bounds the serialized payload (see
+  /// [ProfileSnapshotWindow]).
+  void _persistSnapshot() {
+    final snapshot = ProfileVideoOffsetSnapshot.capped(
+      videos: _unfilteredVideos,
+      nextOffset: state.nextOffset,
+      totalVideoCount: state.totalVideoCount,
+      hasMoreContent: state.hasMoreContent,
+    );
+    unawaited(
+      CacheSync.write<ProfileVideoOffsetSnapshot>(
+        key: _cacheKey,
+        value: snapshot,
+        toJson: (s) => s.toJson(),
+      ).catchError((Object error) {
+        Log.warning(
+          'Failed to persist profile-videos snapshot - $error',
+          name: 'ProfileFeedCubit',
+          category: LogCategory.video,
+        );
+      }),
+    );
   }
 
   @override

--- a/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_cubit.dart
@@ -109,6 +109,12 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
   @visibleForTesting
   static Duration relaySnapshotAudit = const Duration(milliseconds: 250);
 
+  /// Debounce window for persisting the Videos-tab snapshot. The snapshot
+  /// contains full [VideoEvent] payloads, so serializing it on every emit during
+  /// relay/enrichment bursts is unnecessary main-isolate work.
+  @visibleForTesting
+  static Duration snapshotPersistDebounce = const Duration(milliseconds: 250);
+
   final String _authorPubkey;
   final VideosRepository _videosRepository;
   final VideoEventService _videoEventService;
@@ -132,6 +138,8 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
   /// bookkeeping; the observable result is [ProfileFeedState.isInitialLoad]).
   bool _initialLoadPending = false;
   Timer? _initialLoadTimer;
+  Timer? _snapshotPersistTimer;
+  ProfileVideoOffsetSnapshot? _pendingSnapshot;
 
   VoidCallback? _removeChangeListener;
   VoidCallback? _unregisterUpdate;
@@ -734,18 +742,32 @@ class ProfileFeedCubit extends Bloc<ProfileFeedEvent, ProfileFeedState> {
 
   /// Persists the current source window + cursor via [_snapshotCache] so a
   /// reopen restores it (stale-while-revalidate).
-  void _persistSnapshot() => _snapshotCache.write(
-    videos: _unfilteredVideos,
-    nextOffset: state.nextOffset,
-    totalVideoCount: state.totalVideoCount,
-    hasMoreContent: state.hasMoreContent,
-  );
+  void _persistSnapshot() {
+    _pendingSnapshot = ProfileVideoOffsetSnapshot.capped(
+      videos: _unfilteredVideos,
+      nextOffset: state.nextOffset,
+      totalVideoCount: state.totalVideoCount,
+      hasMoreContent: state.hasMoreContent,
+    );
+    if (_snapshotPersistTimer?.isActive ?? false) return;
+    _snapshotPersistTimer = Timer(snapshotPersistDebounce, _flushSnapshot);
+  }
+
+  void _flushSnapshot() {
+    final snapshot = _pendingSnapshot;
+    _pendingSnapshot = null;
+    _snapshotPersistTimer?.cancel();
+    _snapshotPersistTimer = null;
+    if (snapshot == null || isClosed) return;
+    _snapshotCache.writeSnapshot(snapshot);
+  }
 
   @override
   Future<void> close() {
     _removeChangeListener?.call();
     _unregisterUpdate?.call();
     _initialLoadTimer?.cancel();
+    _flushSnapshot();
     return super.close();
   }
 }

--- a/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
@@ -1,0 +1,105 @@
+// ABOUTME: Nostr-enrichment merge policy for the profile/author feed (#3705).
+// ABOUTME: Fills missing fields on the current videos from their enriched Nostr
+// ABOUTME: copies without clobbering relay updates that arrived meanwhile.
+
+import 'package:models/models.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+/// Merges enriched copies over [sourceKeys] against [current], filling missing
+/// fields without clobbering relay updates that arrived during the enrichment
+/// window (#3705).
+///
+/// [removeTombstones] drops NIP-09-deleted events; it is injected because
+/// tombstone state is a session-scoped, `VideoEventService`-owned concern that
+/// this Flutter-free merge must not depend on directly.
+List<VideoEvent> mergeProfileFeedEnrichment({
+  required List<VideoEvent> current,
+  required Set<String> sourceKeys,
+  required List<VideoEvent> incoming,
+  required List<VideoEvent> Function(List<VideoEvent>) removeTombstones,
+}) {
+  if (sourceKeys.isEmpty) {
+    return removeTombstones(mergeProfileFeedVideoLists(current, incoming));
+  }
+  final currentByKey = {
+    for (final video in current)
+      if (sourceKeys.contains(canonicalProfileFeedVideoKey(video)))
+        canonicalProfileFeedVideoKey(video): video,
+  };
+  final keepFromCurrent = current
+      .where((v) => !sourceKeys.contains(canonicalProfileFeedVideoKey(v)))
+      .toList();
+  final mergedSource = incoming.map((video) {
+    final currentVideo = currentByKey[canonicalProfileFeedVideoKey(video)];
+    return currentVideo == null
+        ? video
+        : _mergeEnrichmentIntoCurrent(currentVideo, video);
+  }).toList();
+  return removeTombstones(
+    mergeProfileFeedVideoLists(keepFromCurrent, mergedSource),
+  );
+}
+
+VideoEvent _mergeEnrichmentIntoCurrent(
+  VideoEvent current,
+  VideoEvent enriched,
+) {
+  return current.copyWith(
+    publishedAt:
+        (current.publishedAt != null && current.publishedAt!.isNotEmpty)
+        ? current.publishedAt
+        : enriched.publishedAt,
+    rawTags: mergeVideoRawTagsPrimaryWins(current.rawTags, enriched.rawTags),
+    contentWarningLabels: current.contentWarningLabels.isNotEmpty
+        ? current.contentWarningLabels
+        : enriched.contentWarningLabels,
+    title: current.title ?? enriched.title,
+    videoUrl: current.videoUrl ?? enriched.videoUrl,
+    thumbnailUrl: current.thumbnailUrl ?? enriched.thumbnailUrl,
+    duration: current.duration ?? enriched.duration,
+    dimensions: current.dimensions ?? enriched.dimensions,
+    mimeType: current.mimeType ?? enriched.mimeType,
+    sha256: current.sha256 ?? enriched.sha256,
+    fileSize: current.fileSize ?? enriched.fileSize,
+    hashtags: current.hashtags.isNotEmpty
+        ? current.hashtags
+        : enriched.hashtags,
+    vineId: current.vineId ?? enriched.vineId,
+    group: current.group ?? enriched.group,
+    altText: current.altText ?? enriched.altText,
+    blurhash: current.blurhash ?? enriched.blurhash,
+    originalLoops: mergeNullableEngagementMax(
+      current.originalLoops,
+      enriched.originalLoops,
+    ),
+    originalLikes: mergeNullableEngagementMax(
+      current.originalLikes,
+      enriched.originalLikes,
+    ),
+    originalComments: mergeNullableEngagementMax(
+      current.originalComments,
+      enriched.originalComments,
+    ),
+    originalReposts: mergeNullableEngagementMax(
+      current.originalReposts,
+      enriched.originalReposts,
+    ),
+    audioEventId: current.audioEventId ?? enriched.audioEventId,
+    audioEventRelay: current.audioEventRelay ?? enriched.audioEventRelay,
+    collaboratorPubkeys: current.collaboratorPubkeys.isNotEmpty
+        ? current.collaboratorPubkeys
+        : enriched.collaboratorPubkeys,
+    inspiredByVideo: current.inspiredByVideo ?? enriched.inspiredByVideo,
+    textTrackRef: current.textTrackRef ?? enriched.textTrackRef,
+    textTrackContent: current.textTrackContent ?? enriched.textTrackContent,
+    nostrEventTags: current.nostrEventTags.isNotEmpty
+        ? current.nostrEventTags
+        : enriched.nostrEventTags,
+    authorName: current.authorName ?? enriched.authorName,
+    authorAvatar: current.authorAvatar ?? enriched.authorAvatar,
+    nostrLikeCount: mergeNullableEngagementMax(
+      current.nostrLikeCount,
+      enriched.nostrLikeCount,
+    ),
+  );
+}

--- a/mobile/lib/blocs/profile_feed/profile_video_metadata_cache.dart
+++ b/mobile/lib/blocs/profile_feed/profile_video_metadata_cache.dart
@@ -1,0 +1,80 @@
+// ABOUTME: Engagement-count backfill cache for the profile/author feed.
+// ABOUTME: Holds REST-sourced metadata (loops, views, likes, …) so Nostr-only
+// ABOUTME: videos on the load-more fallback path keep their counts.
+
+import 'package:models/models.dart';
+
+/// Backfill cache for engagement counts, used on the Nostr-fallback loadMore
+/// branch where there is no REST hydration.
+class ProfileVideoMetadataCache {
+  final Map<String, _MetadataEntry> _entries = {};
+
+  /// Records the engagement metadata of any [videos] that carry it, keyed by
+  /// lowercased event id.
+  void cache(List<VideoEvent> videos) {
+    for (final video in videos) {
+      if (video.originalLoops != null ||
+          video.rawTags['views'] != null ||
+          video.originalLikes != null ||
+          video.originalComments != null ||
+          video.originalReposts != null ||
+          video.nostrLikeCount != null) {
+        _entries[video.id.toLowerCase()] = _MetadataEntry(
+          originalLoops: video.originalLoops,
+          views: video.rawTags['views'],
+          originalLikes: video.originalLikes,
+          originalComments: video.originalComments,
+          originalReposts: video.originalReposts,
+          nostrLikeCount: video.nostrLikeCount,
+        );
+      }
+    }
+  }
+
+  /// Backfills missing engagement counts on [videos] from prior hydration,
+  /// leaving any field that already has a value untouched.
+  List<VideoEvent> apply(List<VideoEvent> videos) {
+    return videos.map((video) {
+      final cached = _entries[video.id.toLowerCase()];
+      if (cached == null) return video;
+      final currentViews = video.rawTags['views'];
+      final shouldApply =
+          (video.originalLoops == null && cached.originalLoops != null) ||
+          (currentViews == null && cached.views != null) ||
+          (video.originalLikes == null && cached.originalLikes != null) ||
+          (video.originalComments == null && cached.originalComments != null) ||
+          (video.originalReposts == null && cached.originalReposts != null) ||
+          (video.nostrLikeCount == null && cached.nostrLikeCount != null);
+      if (!shouldApply) return video;
+      return video.copyWith(
+        originalLoops: video.originalLoops ?? cached.originalLoops,
+        rawTags: currentViews == null && cached.views != null
+            ? {...video.rawTags, 'views': cached.views!}
+            : video.rawTags,
+        originalLikes: video.originalLikes ?? cached.originalLikes,
+        originalComments: video.originalComments ?? cached.originalComments,
+        originalReposts: video.originalReposts ?? cached.originalReposts,
+        nostrLikeCount: video.nostrLikeCount ?? cached.nostrLikeCount,
+      );
+    }).toList();
+  }
+}
+
+/// Cached engagement metadata used to backfill Nostr-only videos.
+class _MetadataEntry {
+  const _MetadataEntry({
+    this.originalLoops,
+    this.views,
+    this.originalLikes,
+    this.originalComments,
+    this.originalReposts,
+    this.nostrLikeCount,
+  });
+
+  final int? originalLoops;
+  final String? views;
+  final int? originalLikes;
+  final int? originalComments;
+  final int? originalReposts;
+  final int? nostrLikeCount;
+}

--- a/mobile/lib/blocs/profile_feed/profile_video_snapshot_cache.dart
+++ b/mobile/lib/blocs/profile_feed/profile_video_snapshot_cache.dart
@@ -51,13 +51,18 @@ class ProfileVideoSnapshotCache {
     required int? nextOffset,
     required int? totalVideoCount,
     required bool hasMoreContent,
-  }) {
-    final snapshot = ProfileVideoOffsetSnapshot.capped(
+  }) => writeSnapshot(
+    ProfileVideoOffsetSnapshot.capped(
       videos: videos,
       nextOffset: nextOffset,
       totalVideoCount: totalVideoCount,
       hasMoreContent: hasMoreContent,
-    );
+    ),
+  );
+
+  /// Persists a pre-built snapshot. Used when callers coalesce writes and keep
+  /// the latest capped payload outside this helper.
+  void writeSnapshot(ProfileVideoOffsetSnapshot snapshot) {
     unawaited(
       CacheSync.write<ProfileVideoOffsetSnapshot>(
         key: _key,

--- a/mobile/lib/blocs/profile_feed/profile_video_snapshot_cache.dart
+++ b/mobile/lib/blocs/profile_feed/profile_video_snapshot_cache.dart
@@ -1,0 +1,75 @@
+// ABOUTME: CacheSync I/O for the profile Videos tab's offset snapshot.
+// ABOUTME: Best-effort read/write — a cache failure must never break a load or
+// ABOUTME: block an emit (stale-while-revalidate, #5279 extended to Videos).
+
+import 'dart:async';
+
+import 'package:cache_sync/cache_sync.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/profile_shared/profile_video_offset_snapshot.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Reads and writes the persisted Videos-tab window for one author via
+/// [CacheSync].
+class ProfileVideoSnapshotCache {
+  ProfileVideoSnapshotCache(this._authorPubkey);
+
+  final String _authorPubkey;
+
+  /// Scoped to the author: the persisted videos are the unfiltered public feed
+  /// (blocklist/content filters are re-applied on every emit, so the payload is
+  /// viewer-independent). Follows the `${pubkey}:${operation}` convention so
+  /// sign-out's `invalidatePrefix(currentPubkey)` clears the signed-out user's
+  /// own-profile entry.
+  String get _key => '$_authorPubkey:profile_videos';
+
+  /// Reads the persisted snapshot once; `null` on miss or failure (a cache
+  /// problem must never break an otherwise-fine cold load).
+  Future<ProfileVideoOffsetSnapshot?> read() async {
+    try {
+      return await CacheSync.read<ProfileVideoOffsetSnapshot>(
+        key: _key,
+        fromJson: ProfileVideoOffsetSnapshot.fromJson,
+      );
+    } on Object catch (error) {
+      Log.warning(
+        'Failed to read cached profile-videos snapshot - $error',
+        name: 'ProfileVideoSnapshotCache',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+  }
+
+  /// Persists the current source window + cursor (capped to
+  /// [ProfileSnapshotWindow]) so a reopen restores it.
+  ///
+  /// Fire-and-forget: cache writes are best-effort and must never block or fail
+  /// an emit. Capping bounds the serialized payload.
+  void write({
+    required List<VideoEvent> videos,
+    required int? nextOffset,
+    required int? totalVideoCount,
+    required bool hasMoreContent,
+  }) {
+    final snapshot = ProfileVideoOffsetSnapshot.capped(
+      videos: videos,
+      nextOffset: nextOffset,
+      totalVideoCount: totalVideoCount,
+      hasMoreContent: hasMoreContent,
+    );
+    unawaited(
+      CacheSync.write<ProfileVideoOffsetSnapshot>(
+        key: _key,
+        value: snapshot,
+        toJson: (s) => s.toJson(),
+      ).catchError((Object error) {
+        Log.warning(
+          'Failed to persist profile-videos snapshot - $error',
+          name: 'ProfileVideoSnapshotCache',
+          category: LogCategory.video,
+        );
+      }),
+    );
+  }
+}

--- a/mobile/lib/blocs/profile_shared/profile_video_offset_snapshot.dart
+++ b/mobile/lib/blocs/profile_shared/profile_video_offset_snapshot.dart
@@ -1,0 +1,98 @@
+// ABOUTME: Shared CacheSync payload for the offset-paginated profile Videos tab.
+// ABOUTME: Captures the resolved scrolled-through window + REST offset cursor so
+// ABOUTME: the main author feed renders instantly on reopen, then revalidates.
+
+import 'dart:convert';
+
+import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_shared/profile_snapshot_window.dart';
+
+/// A point-in-time snapshot of the offset-paginated profile Videos tab.
+///
+/// Unlike [ProfileVideoListSnapshot] there is no client-side ID list — the
+/// author feed is paginated by an **absolute REST offset** ([nextOffset], the
+/// position into the author's newest-first feed for the next page). A `null`
+/// offset means the feed is in Nostr-fallback pagination (REST unavailable);
+/// load-more then resumes from the oldest restored video's timestamp.
+///
+/// Holds the resolved videos (unfiltered source — blocklist/content filters are
+/// re-applied on every emit) so reopening restores the full scrolled window
+/// without a relay round-trip.
+class ProfileVideoOffsetSnapshot {
+  const ProfileVideoOffsetSnapshot({
+    required this.videos,
+    required this.nextOffset,
+    required this.totalVideoCount,
+    required this.hasMoreContent,
+  });
+
+  /// Deserializes from a JSON string produced by [toJson].
+  factory ProfileVideoOffsetSnapshot.fromJson(String json) {
+    final data = jsonDecode(json) as Map<String, dynamic>;
+    final videos = (data['videos'] as List<dynamic>? ?? const [])
+        .map((e) => VideoEvent.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return ProfileVideoOffsetSnapshot(
+      videos: videos,
+      nextOffset: data['nextOffset'] as int?,
+      totalVideoCount: data['totalVideoCount'] as int?,
+      hasMoreContent: data['hasMoreContent'] as bool? ?? false,
+    );
+  }
+
+  /// Builds a snapshot capped to [ProfileSnapshotWindow.maxItems].
+  ///
+  /// Keeps the **head** of the feed (the newest videos the user sees first on
+  /// reopen) and clamps [nextOffset] into the kept range so a load-more after
+  /// reopen resumes REST pagination at the boundary of the persisted window
+  /// rather than skipping the dropped tail. When videos are dropped,
+  /// [hasMoreContent] is forced `true`.
+  ///
+  /// Because the kept window and the REST feed are both newest-first, resuming
+  /// at the clamped offset re-fetches (and dedupes) at most the boundary page —
+  /// it never leaves a gap. A `null` [nextOffset] (Nostr-fallback) is preserved
+  /// and load-more resumes from the oldest restored video's timestamp.
+  factory ProfileVideoOffsetSnapshot.capped({
+    required List<VideoEvent> videos,
+    required int? nextOffset,
+    required int? totalVideoCount,
+    required bool hasMoreContent,
+  }) {
+    const max = ProfileSnapshotWindow.maxItems;
+    if (videos.length <= max) {
+      return ProfileVideoOffsetSnapshot(
+        videos: videos,
+        nextOffset: nextOffset,
+        totalVideoCount: totalVideoCount,
+        hasMoreContent: hasMoreContent,
+      );
+    }
+    final keptVideos = videos.sublist(0, max);
+    return ProfileVideoOffsetSnapshot(
+      videos: keptVideos,
+      nextOffset: nextOffset?.clamp(0, keptVideos.length),
+      totalVideoCount: totalVideoCount,
+      hasMoreContent: true,
+    );
+  }
+
+  /// The resolved videos, ordered newest-first (unfiltered source).
+  final List<VideoEvent> videos;
+
+  /// Absolute REST offset for the next page, or `null` in Nostr-fallback mode.
+  final int? nextOffset;
+
+  /// Total videos for this author (from the REST `X-Total-Count` header).
+  final int? totalVideoCount;
+
+  /// Whether more videos remain beyond the loaded window.
+  final bool hasMoreContent;
+
+  /// Serializes to a JSON string for cache storage.
+  String toJson() => jsonEncode({
+    'videos': videos.map((v) => v.toJson()).toList(),
+    'nextOffset': nextOffset,
+    'totalVideoCount': totalVideoCount,
+    'hasMoreContent': hasMoreContent,
+  });
+}

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -11,6 +11,7 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/others_followers/others_followers_bloc.dart';
 import 'package:openvine/blocs/profile_collab_videos/profile_collab_videos_bloc.dart';
 import 'package:openvine/blocs/profile_comments/profile_comments_bloc.dart';
+import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
 import 'package:openvine/blocs/profile_liked_videos/profile_liked_videos_bloc.dart';
 import 'package:openvine/blocs/profile_reposted_videos/profile_reposted_videos_bloc.dart';
 import 'package:openvine/blocs/profile_saved_videos/profile_saved_videos_bloc.dart';
@@ -143,13 +144,17 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   /// Resolved by tab [ProfileTabKind] rather than raw index: the own profile's
   /// tab order differs from other profiles' (Collabs is inserted at index 1 on
   /// the own profile, per #5213), so a fixed index would track the wrong tab.
-  bool get _activeTabRefreshing => switch (_tabKinds[_tabController.index]) {
-    ProfileTabKind.liked => _likedRefreshing,
-    ProfileTabKind.reposts => _repostsRefreshing,
-    ProfileTabKind.collabs => _collabsRefreshing,
-    ProfileTabKind.saved => _savedRefreshing,
-    ProfileTabKind.videos || ProfileTabKind.comments => false,
-  };
+  /// Videos reads the [ProfileFeedCubit]'s refreshing flag, passed in from
+  /// [build] because that cubit is provided by the ancestor `ProfileFeedScope`.
+  bool _activeTabRefreshing(bool videosRefreshing) =>
+      switch (_tabKinds[_tabController.index]) {
+        ProfileTabKind.videos => videosRefreshing,
+        ProfileTabKind.liked => _likedRefreshing,
+        ProfileTabKind.reposts => _repostsRefreshing,
+        ProfileTabKind.collabs => _collabsRefreshing,
+        ProfileTabKind.saved => _savedRefreshing,
+        ProfileTabKind.comments => false,
+      };
 
   /// The dependency identities the tab BLoCs were last created for.
   ///
@@ -392,6 +397,13 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     );
     final currentUserPubkey = nostrService.publicKey;
 
+    // The Videos tab's BLoC is provided by the ancestor `ProfileFeedScope`, so
+    // its revalidation flag is read here (rather than via a stored stream
+    // subscription like the tabs created below) to drive the sticky bar.
+    final videosRefreshing = context.select<ProfileFeedCubit, bool>(
+      (cubit) => cubit.state.isRefreshing,
+    );
+
     final blocsDeps = (
       userIdHex: widget.userIdHex,
       isOwnProfile: widget.isOwnProfile,
@@ -581,7 +593,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
                 tabs: [for (final kind in _tabKinds) _tabPresentationFor(kind)],
                 headerKey: _headerKey,
                 // Sticky cache-revalidation bar for the active cached tab.
-                isRefreshing: _activeTabRefreshing,
+                isRefreshing: _activeTabRefreshing(videosRefreshing),
               ),
             ],
             body: tabContent,

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -501,6 +501,55 @@ void main() {
       );
 
       blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'duplicate placeholder emits do not block resolving a later target',
+        build: () => createBloc(
+          initialVideoId: 'target-video',
+          initialStableId: 'stable-target-video',
+        ),
+        act: (bloc) async {
+          final placeholder = createTestVideo('placeholder-video');
+          final target = createTestVideo(
+            'target-video',
+            rawTags: const {'d': 'stable-target-video'},
+          );
+
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          // Two identical placeholder emits before the target arrives. The
+          // second one previously latched initialTargetResolved via the
+          // preserve branch, which then blocked the real target from ever
+          // being resolved (regression behind #5306's profile feed cache).
+          videosController.add([placeholder]);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([placeholder]);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([createTestVideo('newer-video'), target]);
+        },
+        wait: const Duration(milliseconds: 250),
+        expect: () => [
+          isA<FullscreenFeedState>()
+              .having(
+                (s) => s.currentVideo?.id,
+                'currentVideo',
+                'placeholder-video',
+              )
+              .having(
+                (s) => s.initialTargetResolved,
+                'initialTargetResolved',
+                false,
+              ),
+          isA<FullscreenFeedState>()
+              .having((s) => s.currentIndex, 'currentIndex', 1)
+              .having((s) => s.currentVideo?.id, 'currentVideo', 'target-video')
+              .having(
+                (s) => s.initialTargetResolved,
+                'initialTargetResolved',
+                true,
+              ),
+        ],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
         'cancels previous subscription when started again',
         build: createBloc,
         act: (bloc) async {

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -316,6 +316,66 @@ void main() {
         expect(persisted.nextOffset, 2);
         expect(persisted.hasMoreContent, isFalse);
       });
+
+      test(
+        'revalidation failure keeps the restored window (offline reopen)',
+        () async {
+          await seedSnapshot(
+            ProfileVideoOffsetSnapshot(
+              videos: [
+                _video('v1', createdAt: 5000),
+                _video('v2', createdAt: 4000),
+              ],
+              nextOffset: 120,
+              totalVideoCount: 200,
+              hasMoreContent: true,
+            ),
+          );
+          // Head revalidation fails (e.g. offline); the restored window must
+          // survive and the cursor must not be reset.
+          h.stubAuthorFeedThrows(Exception('offline'));
+
+          final cubit = h.build();
+          addTearDown(cubit.close);
+          await pumpEventQueue();
+
+          expect(cubit.state.status, ProfileFeedStatus.ready);
+          expect(cubit.state.videos.map((v) => v.id), ['v1', 'v2']);
+          expect(cubit.state.nextOffset, 120);
+          expect(cubit.state.hasMoreContent, isTrue);
+          expect(cubit.state.isRefreshing, isFalse);
+        },
+      );
+
+      test('Nostr-fallback loadMore persists the grown window', () async {
+        // No snapshot seeded -> cold load into Nostr-fallback mode (a null
+        // REST offset), then a relay-backed load-more.
+        h.stubAuthorFeed(
+          _result(
+            [_video('a', createdAt: 3000)],
+            totalCount: 50,
+            hasMore: true,
+          ),
+        );
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue(times: 3);
+        expect(cubit.state.nextOffset, isNull);
+
+        when(() => h.ves.authorVideos(_author)).thenReturn([
+          _video('a', createdAt: 3000),
+          _video('b', createdAt: 2000),
+        ]);
+        cubit.add(const ProfileFeedLoadMoreRequested());
+        await pumpEventQueue(times: 3);
+
+        expect(cubit.state.videos.map((v) => v.id), containsAll(['a', 'b']));
+
+        final persisted = await readSnapshot();
+        expect(persisted, isNotNull);
+        expect(persisted!.videos.map((v) => v.id), containsAll(['a', 'b']));
+        expect(persisted.nextOffset, isNull);
+      });
     });
 
     test('cold load: REST success -> ready with envelope', () async {

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -187,11 +187,20 @@ void main() {
   group('ProfileFeedCubit', () {
     late _Harness h;
     late _InMemoryCacheDao cacheDao;
+    late Duration originalSnapshotPersistDebounce;
 
     setUp(() async {
+      originalSnapshotPersistDebounce =
+          ProfileFeedCubit.snapshotPersistDebounce;
+      ProfileFeedCubit.snapshotPersistDebounce = Duration.zero;
       h = _Harness();
       cacheDao = _InMemoryCacheDao();
       await CacheSync.init(dao: cacheDao);
+    });
+
+    tearDown(() {
+      ProfileFeedCubit.snapshotPersistDebounce =
+          originalSnapshotPersistDebounce;
     });
 
     Future<ProfileFeedCubit> buildReady(AuthorFeedResult result) async {
@@ -217,53 +226,50 @@ void main() {
         );
 
     group('CacheSync stale-while-revalidate', () {
-      test(
-        'reopen restores the persisted window + cursor instantly, then '
-        'revalidates the head without clobbering the cursor',
-        () async {
-          await seedSnapshot(
-            ProfileVideoOffsetSnapshot(
-              videos: [
-                _video('v1', createdAt: 5000),
-                _video('v2', createdAt: 4000),
-                _video('v3', createdAt: 3000),
-              ],
-              nextOffset: 150,
-              totalVideoCount: 300,
-              hasMoreContent: true,
-            ),
-          );
-          // Head revalidation returns the freshest first page (no new clips).
-          h.stubAuthorFeed(
-            _result(
-              [_video('v1', createdAt: 5000)],
-              totalCount: 300,
-              nextOffset: 50,
-              hasMore: true,
-            ),
-          );
+      test('reopen restores the persisted window + cursor instantly, then '
+          'revalidates the head without clobbering the cursor', () async {
+        await seedSnapshot(
+          ProfileVideoOffsetSnapshot(
+            videos: [
+              _video('v1', createdAt: 5000),
+              _video('v2', createdAt: 4000),
+              _video('v3', createdAt: 3000),
+            ],
+            nextOffset: 150,
+            totalVideoCount: 300,
+            hasMoreContent: true,
+          ),
+        );
+        // Head revalidation returns the freshest first page (no new clips).
+        h.stubAuthorFeed(
+          _result(
+            [_video('v1', createdAt: 5000)],
+            totalCount: 300,
+            nextOffset: 50,
+            hasMore: true,
+          ),
+        );
 
-          final cubit = h.build();
-          addTearDown(cubit.close);
-          await pumpEventQueue();
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue();
 
-          expect(cubit.state.status, ProfileFeedStatus.ready);
-          expect(cubit.state.videos.map((v) => v.id), ['v1', 'v2', 'v3']);
-          // Cursor comes from the snapshot, NOT the head refresh's offset (50).
-          expect(cubit.state.nextOffset, 150);
-          expect(cubit.state.hasMoreContent, isTrue);
-          expect(cubit.state.totalVideoCount, 300);
-          expect(cubit.state.isInitialLoad, isFalse);
-          expect(cubit.state.isRefreshing, isFalse);
-          verify(
-            () => h.repo.getAuthorFeed(
-              authorPubkey: _author,
-              relaySeed: any(named: 'relaySeed'),
-              skipCache: true,
-            ),
-          ).called(1);
-        },
-      );
+        expect(cubit.state.status, ProfileFeedStatus.ready);
+        expect(cubit.state.videos.map((v) => v.id), ['v1', 'v2', 'v3']);
+        // Cursor comes from the snapshot, NOT the head refresh's offset (50).
+        expect(cubit.state.nextOffset, 150);
+        expect(cubit.state.hasMoreContent, isTrue);
+        expect(cubit.state.totalVideoCount, 300);
+        expect(cubit.state.isInitialLoad, isFalse);
+        expect(cubit.state.isRefreshing, isFalse);
+        verify(
+          () => h.repo.getAuthorFeed(
+            authorPubkey: _author,
+            relaySeed: any(named: 'relaySeed'),
+            skipCache: true,
+          ),
+        ).called(1);
+      });
 
       test('cold load persists the resolved window', () async {
         h.stubAuthorFeed(
@@ -635,9 +641,7 @@ void main() {
       () async {
         final originalAudit = ProfileFeedCubit.relaySnapshotAudit;
         ProfileFeedCubit.relaySnapshotAudit = const Duration(milliseconds: 20);
-        addTearDown(
-          () => ProfileFeedCubit.relaySnapshotAudit = originalAudit,
-        );
+        addTearDown(() => ProfileFeedCubit.relaySnapshotAudit = originalAudit);
 
         // Cold load: first page, more available.
         final cubit = await buildReady(
@@ -782,9 +786,7 @@ void main() {
       () async {
         final originalAudit = ProfileFeedCubit.relaySnapshotAudit;
         ProfileFeedCubit.relaySnapshotAudit = const Duration(milliseconds: 20);
-        addTearDown(
-          () => ProfileFeedCubit.relaySnapshotAudit = originalAudit,
-        );
+        addTearDown(() => ProfileFeedCubit.relaySnapshotAudit = originalAudit);
 
         final cubit = await buildReady(_result([_video('a')]));
         addTearDown(cubit.close);
@@ -813,9 +815,7 @@ void main() {
       () async {
         final originalAudit = ProfileFeedCubit.relaySnapshotAudit;
         ProfileFeedCubit.relaySnapshotAudit = const Duration(milliseconds: 20);
-        addTearDown(
-          () => ProfileFeedCubit.relaySnapshotAudit = originalAudit,
-        );
+        addTearDown(() => ProfileFeedCubit.relaySnapshotAudit = originalAudit);
 
         final cubit = await buildReady(_result(const []));
         addTearDown(cubit.close);

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -4,12 +4,14 @@
 
 import 'dart:async';
 
+import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_offset_snapshot.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/services/video_event_service.dart';
 import 'package:videos_repository/videos_repository.dart';
@@ -20,6 +22,38 @@ class _MockVideoEventService extends Mock implements VideoEventService {}
 
 class _MockContentBlocklistRepository extends Mock
     implements ContentBlocklistRepository {}
+
+/// In-memory [CacheDao] so the cubit's [CacheSync] reads/writes are isolated
+/// per test without touching disk.
+class _InMemoryCacheDao implements CacheDao {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    _store[key] = payload;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _store.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
 
 const _author =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -152,8 +186,13 @@ void main() {
 
   group('ProfileFeedCubit', () {
     late _Harness h;
+    late _InMemoryCacheDao cacheDao;
 
-    setUp(() => h = _Harness());
+    setUp(() async {
+      h = _Harness();
+      cacheDao = _InMemoryCacheDao();
+      await CacheSync.init(dao: cacheDao);
+    });
 
     Future<ProfileFeedCubit> buildReady(AuthorFeedResult result) async {
       h.stubAuthorFeed(result);
@@ -161,6 +200,123 @@ void main() {
       await pumpEventQueue();
       return cubit;
     }
+
+    const cacheKey = '$_author:profile_videos';
+
+    Future<void> seedSnapshot(ProfileVideoOffsetSnapshot snapshot) =>
+        CacheSync.write<ProfileVideoOffsetSnapshot>(
+          key: cacheKey,
+          value: snapshot,
+          toJson: (s) => s.toJson(),
+        );
+
+    Future<ProfileVideoOffsetSnapshot?> readSnapshot() =>
+        CacheSync.read<ProfileVideoOffsetSnapshot>(
+          key: cacheKey,
+          fromJson: ProfileVideoOffsetSnapshot.fromJson,
+        );
+
+    group('CacheSync stale-while-revalidate', () {
+      test(
+        'reopen restores the persisted window + cursor instantly, then '
+        'revalidates the head without clobbering the cursor',
+        () async {
+          await seedSnapshot(
+            ProfileVideoOffsetSnapshot(
+              videos: [
+                _video('v1', createdAt: 5000),
+                _video('v2', createdAt: 4000),
+                _video('v3', createdAt: 3000),
+              ],
+              nextOffset: 150,
+              totalVideoCount: 300,
+              hasMoreContent: true,
+            ),
+          );
+          // Head revalidation returns the freshest first page (no new clips).
+          h.stubAuthorFeed(
+            _result(
+              [_video('v1', createdAt: 5000)],
+              totalCount: 300,
+              nextOffset: 50,
+              hasMore: true,
+            ),
+          );
+
+          final cubit = h.build();
+          addTearDown(cubit.close);
+          await pumpEventQueue();
+
+          expect(cubit.state.status, ProfileFeedStatus.ready);
+          expect(cubit.state.videos.map((v) => v.id), ['v1', 'v2', 'v3']);
+          // Cursor comes from the snapshot, NOT the head refresh's offset (50).
+          expect(cubit.state.nextOffset, 150);
+          expect(cubit.state.hasMoreContent, isTrue);
+          expect(cubit.state.totalVideoCount, 300);
+          expect(cubit.state.isInitialLoad, isFalse);
+          expect(cubit.state.isRefreshing, isFalse);
+          verify(
+            () => h.repo.getAuthorFeed(
+              authorPubkey: _author,
+              relaySeed: any(named: 'relaySeed'),
+              skipCache: true,
+            ),
+          ).called(1);
+        },
+      );
+
+      test('cold load persists the resolved window', () async {
+        h.stubAuthorFeed(
+          _result(
+            [_video('a', createdAt: 5000), _video('b', createdAt: 4000)],
+            totalCount: 2,
+            hasMore: false,
+          ),
+        );
+
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue(times: 3);
+
+        final persisted = await readSnapshot();
+        expect(persisted, isNotNull);
+        expect(persisted!.videos.map((v) => v.id), ['a', 'b']);
+        expect(persisted.totalVideoCount, 2);
+        expect(persisted.hasMoreContent, isFalse);
+      });
+
+      test('REST load-more grows the persisted window', () async {
+        h.stubAuthorFeedSequence([
+          _result(
+            [_video('a', createdAt: 5000)],
+            totalCount: 1,
+            nextOffset: 1,
+            hasMore: true,
+          ),
+          _result(
+            [_video('b', createdAt: 4000)],
+            totalCount: 2,
+            nextOffset: 2,
+            hasMore: false,
+          ),
+        ]);
+
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue(times: 3);
+
+        cubit.add(const ProfileFeedLoadMoreRequested());
+        await pumpEventQueue(times: 3);
+
+        expect(cubit.state.videos.map((v) => v.id), ['a', 'b']);
+        expect(cubit.state.nextOffset, 2);
+
+        final persisted = await readSnapshot();
+        expect(persisted!.videos.map((v) => v.id), ['a', 'b']);
+        expect(persisted.nextOffset, 2);
+        expect(persisted.hasMoreContent, isFalse);
+      });
+    });
 
     test('cold load: REST success -> ready with envelope', () async {
       final cubit = await buildReady(

--- a/mobile/test/blocs/profile_shared/profile_video_offset_snapshot_test.dart
+++ b/mobile/test/blocs/profile_shared/profile_video_offset_snapshot_test.dart
@@ -1,0 +1,112 @@
+// ABOUTME: Tests for ProfileVideoOffsetSnapshot JSON serialization.
+// ABOUTME: Pins the CacheSync payload round-trip for the offset-paginated
+// ABOUTME: Videos tab, plus the head-cap / offset-clamp policy.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_shared/profile_snapshot_window.dart';
+import 'package:openvine/blocs/profile_shared/profile_video_offset_snapshot.dart';
+
+VideoEvent _video(String id, {int createdAt = 1704067200}) {
+  return VideoEvent(
+    id: id,
+    pubkey: '0' * 64,
+    createdAt: createdAt,
+    content: '',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(
+      createdAt * 1000,
+      isUtc: true,
+    ),
+    title: 'Video $id',
+    thumbnailUrl: 'https://example.com/$id.jpg',
+  );
+}
+
+void main() {
+  group(ProfileVideoOffsetSnapshot, () {
+    test('round-trips through toJson/fromJson', () {
+      final snapshot = ProfileVideoOffsetSnapshot(
+        videos: [_video('a'), _video('b')],
+        nextOffset: 50,
+        totalVideoCount: 120,
+        hasMoreContent: true,
+      );
+
+      final restored = ProfileVideoOffsetSnapshot.fromJson(snapshot.toJson());
+
+      expect(restored.videos.map((v) => v.id).toList(), ['a', 'b']);
+      expect(restored.nextOffset, 50);
+      expect(restored.totalVideoCount, 120);
+      expect(restored.hasMoreContent, isTrue);
+    });
+
+    test('round-trips a null offset (Nostr-fallback) and null total', () {
+      const snapshot = ProfileVideoOffsetSnapshot(
+        videos: [],
+        nextOffset: null,
+        totalVideoCount: null,
+        hasMoreContent: false,
+      );
+
+      final restored = ProfileVideoOffsetSnapshot.fromJson(snapshot.toJson());
+
+      expect(restored.videos, isEmpty);
+      expect(restored.nextOffset, isNull);
+      expect(restored.totalVideoCount, isNull);
+      expect(restored.hasMoreContent, isFalse);
+    });
+
+    group('.capped', () {
+      const max = ProfileSnapshotWindow.maxItems;
+
+      test('returns the videos unchanged when within the window', () {
+        final snapshot = ProfileVideoOffsetSnapshot.capped(
+          videos: [_video('a'), _video('b')],
+          nextOffset: 2,
+          totalVideoCount: 2,
+          hasMoreContent: false,
+        );
+
+        expect(snapshot.videos.length, 2);
+        expect(snapshot.nextOffset, 2);
+        expect(snapshot.totalVideoCount, 2);
+        expect(snapshot.hasMoreContent, isFalse);
+      });
+
+      test('truncates to the head and clamps the offset into the kept range', () {
+        final videos = List.generate(max + 30, (i) => _video('v$i'));
+
+        final snapshot = ProfileVideoOffsetSnapshot.capped(
+          videos: videos,
+          nextOffset: max + 30, // offset of the full (uncapped) tail
+          totalVideoCount: 500,
+          hasMoreContent: false,
+        );
+
+        expect(snapshot.videos.length, max);
+        expect(snapshot.videos.last.id, 'v${max - 1}');
+        // Resumes REST pagination at the boundary of the persisted window so a
+        // load-more after reopen re-fetches the boundary page (deduped) rather
+        // than skipping the dropped tail.
+        expect(snapshot.nextOffset, max);
+        expect(snapshot.totalVideoCount, 500);
+        expect(snapshot.hasMoreContent, isTrue);
+      });
+
+      test('preserves a null offset when truncating (Nostr-fallback)', () {
+        final videos = List.generate(max + 5, (i) => _video('v$i'));
+
+        final snapshot = ProfileVideoOffsetSnapshot.capped(
+          videos: videos,
+          nextOffset: null,
+          totalVideoCount: null,
+          hasMoreContent: false,
+        );
+
+        expect(snapshot.videos.length, max);
+        expect(snapshot.nextOffset, isNull);
+        expect(snapshot.hasMoreContent, isTrue);
+      });
+    });
+  });
+}

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -1,3 +1,4 @@
+import 'package:bloc_test/bloc_test.dart';
 import 'package:comments_repository/comments_repository.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
@@ -8,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
+import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
@@ -31,6 +33,9 @@ class _MockContentBlocklistRepository extends Mock
 
 class _MockBookmarkService extends Mock implements BookmarkService {}
 
+class _MockProfileFeedCubit extends MockBloc<ProfileFeedEvent, ProfileFeedState>
+    implements ProfileFeedCubit {}
+
 void main() {
   const userIdHex =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -42,6 +47,7 @@ void main() {
     late _MockCommentsRepository commentsRepository;
     late _MockContentBlocklistRepository blocklistRepository;
     late _MockBookmarkService bookmarkService;
+    late _MockProfileFeedCubit profileFeedCubit;
     late MockNostrClient nostrClient;
 
     setUp(() {
@@ -51,6 +57,7 @@ void main() {
       commentsRepository = _MockCommentsRepository();
       blocklistRepository = _MockContentBlocklistRepository();
       bookmarkService = _MockBookmarkService();
+      profileFeedCubit = _MockProfileFeedCubit();
       nostrClient = createMockNostrService();
 
       when(() => nostrClient.publicKey).thenReturn(userIdHex);
@@ -70,17 +77,27 @@ void main() {
       when(() => blocklistRepository.hasMutedUs(any())).thenReturn(false);
       when(() => blocklistRepository.hasBlockedUs(any())).thenReturn(false);
       when(() => bookmarkService.globalBookmarks).thenReturn(const []);
+      whenListen(
+        profileFeedCubit,
+        const Stream<ProfileFeedState>.empty(),
+        initialState: const ProfileFeedState(status: ProfileFeedStatus.ready),
+      );
     });
 
     Widget buildSubject({required bool isOwnProfile}) {
       return testMaterialApp(
         theme: VineTheme.theme,
         home: Scaffold(
-          body: BlocProvider<MyProfileBloc>(
-            create: (_) => MyProfileBloc(
-              profileRepository: createMockProfileRepository(),
-              pubkey: userIdHex,
-            ),
+          body: MultiBlocProvider(
+            providers: [
+              BlocProvider<MyProfileBloc>(
+                create: (_) => MyProfileBloc(
+                  profileRepository: createMockProfileRepository(),
+                  pubkey: userIdHex,
+                ),
+              ),
+              BlocProvider<ProfileFeedCubit>.value(value: profileFeedCubit),
+            ],
             child: ProfileGridView(
               key: const ValueKey('profile-grid'),
               userIdHex: userIdHex,

--- a/mobile/test/widgets/profile/profile_video_feed_view_test.dart
+++ b/mobile/test/widgets/profile/profile_video_feed_view_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cache_sync/cache_sync.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:content_policy/content_policy.dart';
 import 'package:flutter/material.dart';
@@ -38,6 +39,41 @@ class _FakeSystemVolumeListener implements SystemVolumeListener {
 
 class _FakeVideoEvent extends Fake implements VideoEvent {}
 
+/// In-memory [CacheDao] so the [ProfileFeedCubit]'s [CacheSync] reads/writes
+/// are isolated per test. Without it, the shared global [CacheSync] (which
+/// other test files initialize) leaks one test's persisted snapshot into the
+/// next under the same author key — only visible under `very_good test
+/// --optimization`, which runs every test file in a single isolate.
+class _InMemoryCacheDao implements CacheDao {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write({
+    required String key,
+    required String payload,
+    Duration? ttl,
+  }) async {
+    _store[key] = payload;
+  }
+
+  @override
+  Future<void> delete(String key) async => _store.remove(key);
+
+  @override
+  Future<void> deletePrefix(String prefix) async =>
+      _store.removeWhere((key, _) => key.startsWith(prefix));
+
+  @override
+  Future<int> totalPayloadBytes() async =>
+      _store.values.fold<int>(0, (sum, v) => sum + v.length);
+
+  @override
+  Future<void> evictOldest(int bytesToFree) async {}
+}
+
 const _profilePubkey =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
@@ -65,7 +101,11 @@ void main() {
       registerFallbackValue(_FakeVideoEvent());
     });
 
-    setUp(() {
+    setUp(() async {
+      // Fresh per-test cache so the ProfileFeedCubit's snapshot persistence
+      // can't leak across tests in the shared --optimization isolate.
+      await CacheSync.init(dao: _InMemoryCacheDao());
+
       videosRepository = _MockVideosRepository();
       videoEventService = _MockVideoEventService();
       blocklistRepository = _MockContentBlocklistRepository();


### PR DESCRIPTION
Closes #5306

## Description

Reopening a profile reloaded its **Videos** tab from the relay every time. The author-feed `InMemoryFeedCache` only persisted the *first* REST page (offset == null) and only in memory, so the scrolled-through window was lost on reopen and re-scrolling stalled on "loading more". #5279 fixed this for Liked / Reposts / Saved / Collabs with `CacheSync`; the main Videos tab was explicitly out of scope there. This PR extends the same stale-while-revalidate pattern to the Videos tab.

**How it works**
- **`ProfileVideoOffsetSnapshot`** (new shared model) persists the resolved scrolled-through window plus the **absolute REST offset cursor** (`nextOffset`, `totalVideoCount`, `hasMoreContent`). It is the offset-paginated sibling of `ProfileVideoListSnapshot` (ID-list) and `ProfileVideoCursorSnapshot` (timestamp cursor), capped to `ProfileSnapshotWindow.maxItems` (200).
- **Instant restore**: `ProfileFeedCubit._onStarted` reads the snapshot and serves the full window + cursor immediately (merged with the current relay seed), so scrolling resumes where the user left off - no relay round-trip.
- **Head revalidation**: only the first REST page is re-fetched (`skipCache: true`) and merged into the restored window, **preserving** the restored cursor so the tail is not dropped and the user does not re-paginate. Stale cursors self-heal on the next load-more (an over-shot offset returns empty -> `hasMoreContent` flips off).
- **Persistence** is capped + best-effort + coalesced: rapid page / relay-snapshot / enrichment / load-more emits keep only the latest pending snapshot and write once per debounce window, with a final flush on cubit close. The snapshot stores the **unfiltered** source, so blocklist/content filters keep re-applying on every emit.
- **Sticky bar**: the thin revalidation bar under the tabs now also covers the Videos tab, resolved through `ProfileTabKind` so the own-profile 6-tab order from #5213/#5284 is preserved.

Cache key is `${authorPubkey}:profile_videos` - the payload is the unfiltered public author feed (viewer-independent), and the prefix keeps sign-out's `invalidatePrefix(currentPubkey)` clearing the signed-out user's own-profile entry.

## Out of Scope

- The unrelated `Package.resolved` SPM-cache churn is intentionally not included (per `ios_build_troubleshooting.md`).

## Verification

- `mise exec -- flutter test test/blocs/profile_feed/profile_feed_cubit_test.dart test/blocs/profile_shared/profile_video_offset_snapshot_test.dart test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart test/widgets/profile/profile_grid_test.dart test/widgets/profile/profile_video_feed_view_test.dart test/widgets/profile/profile_tab_kind_test.dart`
- `mise exec -- flutter analyze`
- `mise exec -- dart format --set-exit-if-changed lib/blocs/profile_feed/profile_feed_cubit.dart lib/blocs/profile_feed/profile_video_snapshot_cache.dart lib/widgets/profile/profile_grid.dart lib/widgets/profile/profile_tab_bar.dart test/blocs/profile_feed/profile_feed_cubit_test.dart test/widgets/profile/profile_grid_test.dart`
- Pre-push hook: merge-conflict check, analyze, and changed-file tests all passed

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
