### PR TITLE
feat(notifications): stale-while-revalidate inbox loading + fix cache retention

### DIFF
--- a/mobile/lib/notifications/bloc/notification_feed_bloc.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_bloc.dart
@@ -32,23 +32,11 @@ class NotificationFeedBloc
        _followRepository = followRepository,
        super(const NotificationFeedState()) {
     on<_SnapshotChanged>(_onSnapshotChanged);
-    on<NotificationFeedStarted>(
-      _onStarted,
-      transformer: droppable(),
-    );
-    on<NotificationFeedLoadMore>(
-      _onLoadMore,
-      transformer: droppable(),
-    );
-    on<NotificationFeedRefreshed>(
-      _onRefreshed,
-      transformer: droppable(),
-    );
+    on<NotificationFeedStarted>(_onStarted, transformer: droppable());
+    on<NotificationFeedLoadMore>(_onLoadMore, transformer: droppable());
+    on<NotificationFeedRefreshed>(_onRefreshed, transformer: droppable());
     on<NotificationFeedItemTapped>(_onItemTapped);
-    on<NotificationFeedFollowBack>(
-      _onFollowBack,
-      transformer: sequential(),
-    );
+    on<NotificationFeedFollowBack>(_onFollowBack, transformer: sequential());
 
     // Project the repository's snapshot stream into BLoC state via a
     // private event so emit() stays inside an event handler.
@@ -110,11 +98,19 @@ class NotificationFeedBloc
     NotificationFeedStarted event,
     Emitter<NotificationFeedState> emit,
   ) async {
-    emit(state.copyWith(status: NotificationFeedStatus.loading));
+    // Stale-while-revalidate: keep any hydrated/cached items rendered and
+    // flag the in-flight refresh so the view shows a thin progress bar
+    // instead of a blanking full-screen spinner.
+    emit(state.copyWith(isRefreshing: true));
 
     try {
       await _notificationRepository.refresh();
-      emit(state.copyWith(status: NotificationFeedStatus.loaded));
+      emit(
+        state.copyWith(
+          status: NotificationFeedStatus.loaded,
+          isRefreshing: false,
+        ),
+      );
       await _markSeenOnOpen();
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
@@ -137,6 +133,7 @@ class NotificationFeedBloc
           status: hasCachedItems
               ? NotificationFeedStatus.loaded
               : NotificationFeedStatus.failure,
+          isRefreshing: false,
           refreshError: true,
         ),
       );
@@ -148,10 +145,7 @@ class NotificationFeedBloc
       // DivineBlocObserver forwards to Crashlytics. Recovery emit
       // mirrors the matrix-NO arm so the UX is preserved.
       addError(
-        Reportable(
-          e,
-          context: NotificationFeedBlocReportableSites.onStarted,
-        ),
+        Reportable(e, context: NotificationFeedBlocReportableSites.onStarted),
         s,
       );
       final hasCachedItems = state.notifications.isNotEmpty;
@@ -160,6 +154,7 @@ class NotificationFeedBloc
           status: hasCachedItems
               ? NotificationFeedStatus.loaded
               : NotificationFeedStatus.failure,
+          isRefreshing: false,
           refreshError: true,
         ),
       );
@@ -223,10 +218,7 @@ class NotificationFeedBloc
     } catch (e, s) {
       // Errors (StateError, TypeError) — matrix-YES invariant.
       addError(
-        Reportable(
-          e,
-          context: NotificationFeedBlocReportableSites.onLoadMore,
-        ),
+        Reportable(e, context: NotificationFeedBlocReportableSites.onLoadMore),
         s,
       );
       emit(state.copyWith(isLoadingMore: false));
@@ -238,9 +230,15 @@ class NotificationFeedBloc
     NotificationFeedRefreshed event,
     Emitter<NotificationFeedState> emit,
   ) async {
+    emit(state.copyWith(isRefreshing: true));
     try {
       await _notificationRepository.refresh();
-      emit(state.copyWith(status: NotificationFeedStatus.loaded));
+      emit(
+        state.copyWith(
+          status: NotificationFeedStatus.loaded,
+          isRefreshing: false,
+        ),
+      );
     } on Exception catch (e, s) {
       // `NotificationRepository.refresh` propagates typed
       // `FunnelcakeException` (4xx/5xx/timeout). Per
@@ -254,6 +252,7 @@ class NotificationFeedBloc
           status: hasCachedItems
               ? NotificationFeedStatus.loaded
               : NotificationFeedStatus.failure,
+          isRefreshing: false,
           refreshError: true,
         ),
       );
@@ -261,10 +260,7 @@ class NotificationFeedBloc
       // Errors (StateError, TypeError) — matrix-YES invariant.
       // Recovery emit mirrors the matrix-NO arm so the UX is preserved.
       addError(
-        Reportable(
-          e,
-          context: NotificationFeedBlocReportableSites.onRefreshed,
-        ),
+        Reportable(e, context: NotificationFeedBlocReportableSites.onRefreshed),
         s,
       );
       final hasCachedItems = state.notifications.isNotEmpty;
@@ -273,6 +269,7 @@ class NotificationFeedBloc
           status: hasCachedItems
               ? NotificationFeedStatus.loaded
               : NotificationFeedStatus.failure,
+          isRefreshing: false,
           refreshError: true,
         ),
       );

--- a/mobile/lib/notifications/bloc/notification_feed_state.dart
+++ b/mobile/lib/notifications/bloc/notification_feed_state.dart
@@ -1,20 +1,23 @@
 // ABOUTME: State for NotificationFeedBloc — tracks notifications list,
-// ABOUTME: loading/pagination status, and unread count.
+// ABOUTME: load/refresh status, and unread count.
 
 part of 'notification_feed_bloc.dart';
 
 /// Status of the notification feed.
+///
+/// "Refresh in flight" is tracked separately via
+/// [NotificationFeedState.isRefreshing] so a background revalidation never
+/// blanks out already-rendered (cached) items — see
+/// [NotificationFeedState] for the stale-while-revalidate contract.
 enum NotificationFeedStatus {
-  /// No data loaded yet.
+  /// No data loaded yet (cold start, before the first emission).
   initial,
-
-  /// Currently loading notifications.
-  loading,
 
   /// Notifications loaded successfully.
   loaded,
 
-  /// An error occurred while loading notifications.
+  /// An error occurred while loading notifications and there is nothing
+  /// cached to fall back to.
   failure,
 }
 
@@ -26,6 +29,7 @@ final class NotificationFeedState extends Equatable {
     this.unreadCount = 0,
     this.hasMore = true,
     this.isLoadingMore = false,
+    this.isRefreshing = false,
     this.refreshError = false,
   });
 
@@ -53,6 +57,15 @@ final class NotificationFeedState extends Equatable {
 
   /// Whether a load-more operation is in progress.
   final bool isLoadingMore;
+
+  /// Whether a first-page network refresh is currently in flight.
+  ///
+  /// This is the stale-while-revalidate signal: when cached items are
+  /// already on screen, the view keeps rendering them and shows a thin
+  /// `LinearProgressIndicator` instead of a blanking full-screen spinner.
+  /// The full-screen spinner is reserved for the cold-start case where
+  /// there is nothing cached to show yet.
+  final bool isRefreshing;
 
   /// Whether the most recent first-page refresh failed.
   ///
@@ -84,6 +97,7 @@ final class NotificationFeedState extends Equatable {
     int? unreadCount,
     bool? hasMore,
     bool? isLoadingMore,
+    bool? isRefreshing,
     bool? refreshError,
   }) {
     return NotificationFeedState(
@@ -92,6 +106,7 @@ final class NotificationFeedState extends Equatable {
       unreadCount: unreadCount ?? this.unreadCount,
       hasMore: hasMore ?? this.hasMore,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+      isRefreshing: isRefreshing ?? this.isRefreshing,
       refreshError: refreshError ?? this.refreshError,
     );
   }
@@ -103,6 +118,7 @@ final class NotificationFeedState extends Equatable {
     unreadCount,
     hasMore,
     isLoadingMore,
+    isRefreshing,
     refreshError,
   ];
 }

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -111,39 +111,55 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           }
 
           // Cached or freshly-loaded items present → render the list
-          // even while the first-page refresh is still in flight. The
-          // inline refresh-error banner handles the soft-failure
-          // affordance via `state.refreshError`.
+          // immediately (stale-while-revalidate). A thin revalidation bar
+          // overlays the top while a network refresh is in flight, so a
+          // background refresh never blanks the cached list. The inline
+          // refresh-error banner handles the soft-failure affordance via
+          // `state.refreshError`.
           if (visible.isNotEmpty) {
-            return RefreshIndicator(
-              color: VineTheme.onPrimary,
-              backgroundColor: VineTheme.vineGreen,
-              onRefresh: () async {
-                context.read<NotificationFeedBloc>().add(
-                  const NotificationFeedRefreshed(),
-                );
-              },
-              child: _NotificationList(
-                notifications: visible,
-                isLoadingMore: state.isLoadingMore,
-                hasMore: state.hasMore,
-                scrollController: _scrollController,
-                showRefreshErrorBanner: state.refreshError,
-                onRetryRefresh: () => context.read<NotificationFeedBloc>().add(
-                  const NotificationFeedRefreshed(),
+            return Stack(
+              children: [
+                RefreshIndicator(
+                  color: VineTheme.onPrimary,
+                  backgroundColor: VineTheme.vineGreen,
+                  onRefresh: () async {
+                    context.read<NotificationFeedBloc>().add(
+                      const NotificationFeedRefreshed(),
+                    );
+                  },
+                  child: _NotificationList(
+                    notifications: visible,
+                    isLoadingMore: state.isLoadingMore,
+                    hasMore: state.hasMore,
+                    scrollController: _scrollController,
+                    showRefreshErrorBanner: state.refreshError,
+                    onRetryRefresh: () => context
+                        .read<NotificationFeedBloc>()
+                        .add(const NotificationFeedRefreshed()),
+                    onItemTap: (notification) =>
+                        _onItemTap(context, notification),
+                    onProfileTap: (pubkey) =>
+                        _navigateToProfile(context, pubkey),
+                    onFollowBack: (pubkey) => context
+                        .read<NotificationFeedBloc>()
+                        .add(NotificationFeedFollowBack(pubkey)),
+                  ),
                 ),
-                onItemTap: (notification) => _onItemTap(context, notification),
-                onProfileTap: (pubkey) => _navigateToProfile(context, pubkey),
-                onFollowBack: (pubkey) => context
-                    .read<NotificationFeedBloc>()
-                    .add(NotificationFeedFollowBack(pubkey)),
-              ),
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  child: _RevalidationBar(visible: state.isRefreshing),
+                ),
+              ],
             );
           }
 
-          // Empty + still loading → full-screen spinner.
+          // Empty + still loading → full-screen spinner. This is the only
+          // remaining full-screen spinner: it fires solely on a cold start
+          // with nothing cached to show.
           if (state.status == NotificationFeedStatus.initial ||
-              state.status == NotificationFeedStatus.loading) {
+              state.isRefreshing) {
             return const Center(
               child: CircularProgressIndicator(color: VineTheme.vineGreen),
             );
@@ -329,6 +345,52 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
 // ---------------------------------------------------------------------------
 // Private sub-widgets
 // ---------------------------------------------------------------------------
+
+/// Thin background-refresh bar overlaid at the top of the cached list while
+/// a network revalidation is in flight (stale-while-revalidate).
+///
+/// Fades and slides (size) in/out as [visible] toggles so the bar never
+/// pops abruptly. Purely decorative — the cached list is already on screen —
+/// so it stays out of the semantics tree. Mirrors `ProfileCacheLoadIndicator`.
+class _RevalidationBar extends StatelessWidget {
+  const _RevalidationBar({required this.visible});
+
+  /// Whether a network revalidation is currently in flight.
+  final bool visible;
+
+  static const double _height = 4;
+  static const _transitionDuration = Duration(milliseconds: 250);
+
+  @override
+  Widget build(BuildContext context) {
+    // Honour the reduced-motion preference — collapse the animation to an
+    // instant swap rather than dropping the affordance entirely.
+    final duration = MediaQuery.disableAnimationsOf(context)
+        ? Duration.zero
+        : _transitionDuration;
+
+    return ExcludeSemantics(
+      child: AnimatedSwitcher(
+        duration: duration,
+        transitionBuilder: (child, animation) => SizeTransition(
+          sizeFactor: animation,
+          child: FadeTransition(opacity: animation, child: child),
+        ),
+        child: visible
+            ? const SizedBox(
+                key: ValueKey('revalidation-bar'),
+                height: _height,
+                child: LinearProgressIndicator(
+                  minHeight: _height,
+                  color: VineTheme.vineGreen,
+                  backgroundColor: VineTheme.transparent,
+                ),
+              )
+            : const SizedBox(key: ValueKey('revalidation-bar-hidden')),
+      ),
+    );
+  }
+}
 
 class _ScrollableEmptyState extends StatelessWidget {
   const _ScrollableEmptyState();

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -158,27 +158,41 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
           // Empty + cold start → full-screen spinner. This is the only
           // remaining full-screen spinner, gated on the `initial` status
           // alone: once the feed has loaded, an empty inbox keeps its empty
-          // state during a manual refresh instead of blinking back to a
-          // spinner — the refresh affordance lives in the RefreshIndicator,
-          // not a full-screen takeover. Cold start keeps `status == initial`
-          // until the first refresh resolves, so this still covers the
-          // empty-cache launch.
+          // state during a manual refresh (with the thin revalidation bar as
+          // the non-blocking in-flight affordance) instead of blinking back
+          // to a spinner. Cold start keeps `status == initial` until the
+          // first refresh resolves, so this still covers the empty-cache
+          // launch.
           if (state.status == NotificationFeedStatus.initial) {
             return const Center(
               child: CircularProgressIndicator(color: VineTheme.vineGreen),
             );
           }
 
-          // Empty + loaded → empty state with pull-to-refresh.
-          return RefreshIndicator(
-            color: VineTheme.onPrimary,
-            backgroundColor: VineTheme.vineGreen,
-            onRefresh: () async {
-              context.read<NotificationFeedBloc>().add(
-                const NotificationFeedRefreshed(),
-              );
-            },
-            child: const _ScrollableEmptyState(),
+          // Empty + loaded → empty state with pull-to-refresh. The
+          // revalidation bar overlays the top while a refresh is in flight so
+          // a slow or hanging refresh keeps a visible non-blocking affordance:
+          // the empty state has no RefreshIndicator spinner of its own once
+          // `onRefresh` returns.
+          return Stack(
+            children: [
+              RefreshIndicator(
+                color: VineTheme.onPrimary,
+                backgroundColor: VineTheme.vineGreen,
+                onRefresh: () async {
+                  context.read<NotificationFeedBloc>().add(
+                    const NotificationFeedRefreshed(),
+                  );
+                },
+                child: const _ScrollableEmptyState(),
+              ),
+              Positioned(
+                top: 0,
+                left: 0,
+                right: 0,
+                child: _RevalidationBar(visible: state.isRefreshing),
+              ),
+            ],
           );
         },
       ),

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -155,11 +155,15 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
             );
           }
 
-          // Empty + still loading → full-screen spinner. This is the only
-          // remaining full-screen spinner: it fires solely on a cold start
-          // with nothing cached to show.
-          if (state.status == NotificationFeedStatus.initial ||
-              state.isRefreshing) {
+          // Empty + cold start → full-screen spinner. This is the only
+          // remaining full-screen spinner, gated on the `initial` status
+          // alone: once the feed has loaded, an empty inbox keeps its empty
+          // state during a manual refresh instead of blinking back to a
+          // spinner — the refresh affordance lives in the RefreshIndicator,
+          // not a full-screen takeover. Cold start keeps `status == initial`
+          // until the first refresh resolves, so this still covers the
+          // empty-cache launch.
+          if (state.status == NotificationFeedStatus.initial) {
             return const Center(
               child: CircularProgressIndicator(color: VineTheme.vineGreen),
             );

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -671,7 +671,7 @@ class AppDatabase extends _$AppDatabase {
   /// - Expired Nostr events (based on expire_at timestamp, including NULL)
   /// - Expired profile stats (older than 5 minutes)
   /// - Expired hashtag stats (older than 1 hour)
-  /// - Old notifications (older than 7 days)
+  /// - Notification cache rows written more than 7 days ago
   ///
   /// Returns a [CleanupResult] with counts of deleted records.
   Future<CleanupResult> runStartupCleanup() async {
@@ -684,13 +684,14 @@ class AppDatabase extends _$AppDatabase {
     // Delete expired hashtag stats (1 hour expiry)
     final expiredHashtagStatsDeleted = await hashtagStatsDao.deleteExpired();
 
-    // Delete old notifications (7 day retention)
-    final notificationCutoff =
-        DateTime.now()
-            .subtract(const Duration(days: _notificationRetentionDays))
-            .millisecondsSinceEpoch ~/
-        1000;
-    final oldNotificationsDeleted = await notificationsDao.deleteOlderThan(
+    // Delete notification cache rows written more than 7 days ago. Retention
+    // is keyed on when the row was cached, not the notification's own age, so
+    // still-current notifications about older events survive to hydrate the
+    // next cold start.
+    final notificationCutoff = DateTime.now().subtract(
+      const Duration(days: _notificationRetentionDays),
+    );
+    final oldNotificationsDeleted = await notificationsDao.deleteCachedBefore(
       notificationCutoff,
     );
 

--- a/mobile/packages/db_client/lib/src/database/daos/notifications_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/notifications_dao.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Data Access Object for notification persistence operations.
-// ABOUTME: Provides CRUD with timestamp-based cleanup.
+// ABOUTME: Provides CRUD with cache-age-based cleanup.
 
 import 'package:db_client/db_client.dart';
 import 'package:drift/drift.dart';
@@ -79,11 +79,18 @@ class NotificationsDao extends DatabaseAccessor<AppDatabase>
     return (delete(notifications)..where((t) => t.id.equals(id))).go();
   }
 
-  /// Delete notifications older than a timestamp
-  Future<int> deleteOlderThan(int timestamp) {
+  /// Deletes cache rows last written before [cutoff].
+  ///
+  /// Retention is keyed on `cachedAt` (when the row was written through),
+  /// not the notification's own `timestamp` (its `createdAt`). The cache is
+  /// a write-through snapshot of the latest first page (see [replaceAll]);
+  /// pruning by content age would wipe still-current notifications that
+  /// merely describe events older than the retention window, defeating
+  /// cold-start hydration.
+  Future<int> deleteCachedBefore(DateTime cutoff) {
     return (delete(
       notifications,
-    )..where((t) => t.timestamp.isSmallerThan(Variable(timestamp)))).go();
+    )..where((t) => t.cachedAt.isSmallerThanValue(cutoff))).go();
   }
 
   /// Watch all notifications (reactive stream)

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -134,33 +134,45 @@ void main() {
         expect(result.expiredHashtagStatsDeleted, equals(1));
       });
 
-      test('deletes old notifications', () async {
+      test('deletes notifications cached more than 7 days ago', () async {
         final dao = database.notificationsDao;
 
-        // Insert notification from 8 days ago (older than 7 day retention)
-        final oldTimestamp = nowUnix() - (8 * 24 * 60 * 60);
-        await dao.upsertNotification(
-          id: 'old_notification',
-          type: 'like',
-          fromPubkey: testPubkey,
-          timestamp: oldTimestamp,
-        );
+        // Cached 8 days ago (older than the 7-day cache retention) → deleted.
+        await database
+            .into(database.notifications)
+            .insert(
+              NotificationsCompanion.insert(
+                id: 'stale_cache',
+                type: 'like',
+                fromPubkey: testPubkey,
+                timestamp: nowUnix(),
+                cachedAt: DateTime.now().subtract(const Duration(days: 8)),
+              ),
+            );
 
-        // Insert recent notification
-        await dao.upsertNotification(
-          id: 'recent_notification',
-          type: 'like',
-          fromPubkey: testPubkey,
-          timestamp: nowUnix(),
-        );
+        // Freshly cached but describing an 8-day-old event → must survive.
+        // Retention keys on cachedAt, not the notification's content age, so
+        // a still-current notification about an old event still hydrates the
+        // next cold start.
+        await database
+            .into(database.notifications)
+            .insert(
+              NotificationsCompanion.insert(
+                id: 'fresh_cache_old_content',
+                type: 'like',
+                fromPubkey: testPubkey,
+                timestamp: nowUnix() - (8 * 24 * 60 * 60),
+                cachedAt: DateTime.now(),
+              ),
+            );
 
         // Run cleanup
         final result = await database.runStartupCleanup();
 
-        // Old notification should be deleted
+        // Only the stale cache row should be deleted.
         final notifications = await dao.getAllNotifications();
         expect(notifications.length, equals(1));
-        expect(notifications.first.id, equals('recent_notification'));
+        expect(notifications.first.id, equals('fresh_cache_old_content'));
 
         expect(result.oldNotificationsDeleted, equals(1));
       });

--- a/mobile/packages/db_client/test/src/database/daos/notifications_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/notifications_dao_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Unit tests for NotificationsDao with read status and cleanup
 // ABOUTME: operations. Tests upsertNotification, getAllNotifications,
-// ABOUTME: markAsRead, deleteOlderThan.
+// ABOUTME: markAsRead, deleteCachedBefore.
 
 import 'dart:io';
 
@@ -330,38 +330,64 @@ void main() {
       });
     });
 
-    group('deleteOlderThan', () {
-      test('deletes notifications older than timestamp', () async {
-        await dao.upsertNotification(
-          id: 'notif_old',
-          type: 'like',
-          fromPubkey: testPubkey,
-          timestamp: 1700000000,
+    group('deleteCachedBefore', () {
+      test(
+        'deletes rows cached before the cutoff but keeps a freshly cached row '
+        'even when its content is old',
+        () async {
+          // Stale cache row (cached 8 days ago) → deleted.
+          await database
+              .into(database.notifications)
+              .insert(
+                NotificationsCompanion.insert(
+                  id: 'notif_stale_cache',
+                  type: 'like',
+                  fromPubkey: testPubkey,
+                  timestamp: 1700000000,
+                  cachedAt: DateTime.now().subtract(const Duration(days: 8)),
+                ),
+              );
+          // Freshly cached row describing an old event → survives. This is the
+          // regression: retention keys on cachedAt, not the content timestamp.
+          await database
+              .into(database.notifications)
+              .insert(
+                NotificationsCompanion.insert(
+                  id: 'notif_fresh_cache',
+                  type: 'follow',
+                  fromPubkey: testPubkey,
+                  timestamp: 1700000000,
+                  cachedAt: DateTime.now(),
+                ),
+              );
+
+          final deleted = await dao.deleteCachedBefore(
+            DateTime.now().subtract(const Duration(days: 7)),
+          );
+
+          expect(deleted, equals(1));
+          final results = await dao.getAllNotifications();
+          expect(results, hasLength(1));
+          expect(results.first.id, equals('notif_fresh_cache'));
+        },
+      );
+
+      test('keeps all when none were cached before the cutoff', () async {
+        await database
+            .into(database.notifications)
+            .insert(
+              NotificationsCompanion.insert(
+                id: 'notif_1',
+                type: 'like',
+                fromPubkey: testPubkey,
+                timestamp: 1700000000,
+                cachedAt: DateTime.now(),
+              ),
+            );
+
+        final deleted = await dao.deleteCachedBefore(
+          DateTime.now().subtract(const Duration(days: 7)),
         );
-        await dao.upsertNotification(
-          id: 'notif_new',
-          type: 'follow',
-          fromPubkey: testPubkey,
-          timestamp: 1700000002,
-        );
-
-        final deleted = await dao.deleteOlderThan(1700000001);
-
-        expect(deleted, equals(1));
-        final results = await dao.getAllNotifications();
-        expect(results, hasLength(1));
-        expect(results.first.id, equals('notif_new'));
-      });
-
-      test('keeps all when none are older', () async {
-        await dao.upsertNotification(
-          id: 'notif_1',
-          type: 'like',
-          fromPubkey: testPubkey,
-          timestamp: 1700000000,
-        );
-
-        final deleted = await dao.deleteOlderThan(1699999999);
 
         expect(deleted, equals(0));
         final results = await dao.getAllNotifications();

--- a/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
+++ b/mobile/test/notifications/bloc/notification_feed_bloc_test.dart
@@ -29,10 +29,7 @@ const _bobPubkey =
 const _videoEventId =
     '1111111111111111111111111111111111111111111111111111111111111111';
 
-ActorInfo _actor({
-  String pubkey = _alicePubkey,
-  String displayName = 'Alice',
-}) {
+ActorInfo _actor({String pubkey = _alicePubkey, String displayName = 'Alice'}) {
   return ActorInfo(pubkey: pubkey, displayName: displayName);
 }
 
@@ -89,18 +86,16 @@ void main() {
       when(
         () => mockNotificationRepo.watchSnapshot(),
       ).thenAnswer((_) => snapshotController.stream);
-      when(() => mockNotificationRepo.refresh()).thenAnswer(
-        (_) async => NotificationPage.empty,
-      );
-      when(() => mockNotificationRepo.loadNextPage()).thenAnswer(
-        (_) async => NotificationPage.empty,
-      );
+      when(
+        () => mockNotificationRepo.refresh(),
+      ).thenAnswer((_) async => NotificationPage.empty);
+      when(
+        () => mockNotificationRepo.loadNextPage(),
+      ).thenAnswer((_) async => NotificationPage.empty);
       when(
         () => mockNotificationRepo.markAsRead(any()),
       ).thenAnswer((_) async {});
-      when(
-        () => mockNotificationRepo.markAllAsRead(),
-      ).thenAnswer((_) async {});
+      when(() => mockNotificationRepo.markAllAsRead()).thenAnswer((_) async {});
       when(() => mockNotificationRepo.resetPaginationDepth()).thenReturn(null);
     });
 
@@ -152,10 +147,7 @@ void main() {
         build: createBloc,
         act: (_) async {
           snapshotController.add(
-            NotificationPage(
-              items: [_actorNotif()],
-              unreadCount: 1,
-            ),
+            NotificationPage(items: [_actorNotif()], unreadCount: 1),
           );
           await Future<void>.delayed(Duration.zero);
         },
@@ -195,11 +187,12 @@ void main() {
 
     group('NotificationFeedStarted', () {
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'emits loading then loaded; refreshes then marks seen on open (#4708)',
+        'emits refreshing then loaded; refreshes then marks seen on open '
+        '(#4708)',
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
-          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(isRefreshing: true),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
@@ -223,7 +216,7 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
-          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(isRefreshing: true),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         errors: () => [isA<Exception>()],
@@ -244,7 +237,7 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
-          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(isRefreshing: true),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         errors: () => [
@@ -254,11 +247,7 @@ void main() {
                 'context',
                 NotificationFeedBlocReportableSites.markSeenOnOpen,
               )
-              .having(
-                (r) => r.unwrap(),
-                'unwrap',
-                isA<StateError>(),
-              ),
+              .having((r) => r.unwrap(), 'unwrap', isA<StateError>()),
         ],
         verify: (_) {
           verify(() => mockNotificationRepo.refresh()).called(1);
@@ -276,7 +265,7 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
-          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(isRefreshing: true),
           NotificationFeedState(
             status: NotificationFeedStatus.failure,
             refreshError: true,
@@ -295,7 +284,7 @@ void main() {
         },
         build: createBloc,
         seed: () => NotificationFeedState(
-          status: NotificationFeedStatus.loading,
+          isRefreshing: true,
           notifications: [
             ActorNotification(
               id: 'cached_1',
@@ -310,10 +299,10 @@ void main() {
         ),
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
-          // The bloc's first emit (loading) deduplicates against the seed
-          // (already loading), so only the post-catch `loaded` state is
-          // surfaced. The cached row is preserved and `refreshError` flips
-          // so the view renders the inline banner instead of the full
+          // The bloc's first emit (isRefreshing: true) deduplicates against
+          // the seed (already refreshing), so only the post-catch `loaded`
+          // state is surfaced. The cached row is preserved and `refreshError`
+          // flips so the view renders the inline banner instead of the full
           // failure screen.
           NotificationFeedState(
             status: NotificationFeedStatus.loaded,
@@ -345,7 +334,7 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedStarted()),
         expect: () => [
-          NotificationFeedState(status: NotificationFeedStatus.loading),
+          NotificationFeedState(isRefreshing: true),
           NotificationFeedState(
             status: NotificationFeedStatus.failure,
             refreshError: true,
@@ -464,13 +453,16 @@ void main() {
 
     group('NotificationFeedRefreshed', () {
       blocTest<NotificationFeedBloc, NotificationFeedState>(
-        'calls refresh and emits loaded',
+        'emits refreshing then loaded',
         build: createBloc,
-        seed: () => NotificationFeedState(
-          status: NotificationFeedStatus.failure,
-        ),
+        seed: () =>
+            NotificationFeedState(status: NotificationFeedStatus.failure),
         act: (bloc) => bloc.add(NotificationFeedRefreshed()),
         expect: () => [
+          NotificationFeedState(
+            status: NotificationFeedStatus.failure,
+            isRefreshing: true,
+          ),
           NotificationFeedState(status: NotificationFeedStatus.loaded),
         ],
         verify: (_) {
@@ -492,6 +484,7 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedRefreshed()),
         expect: () => [
+          NotificationFeedState(isRefreshing: true),
           NotificationFeedState(
             status: NotificationFeedStatus.failure,
             refreshError: true,
@@ -525,6 +518,24 @@ void main() {
         ),
         act: (bloc) => bloc.add(NotificationFeedRefreshed()),
         expect: () => [
+          // Cached row stays on screen while the refresh runs (the thin
+          // revalidation bar shows in the view), then `refreshError` flips
+          // so the inline banner replaces the bar on the terminal emit.
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              ActorNotification(
+                id: 'cached_1',
+                type: NotificationKind.follow,
+                actor: const ActorInfo(
+                  pubkey: 'pubkey_cached',
+                  displayName: 'Loading…',
+                ),
+                timestamp: DateTime(2026),
+              ),
+            ],
+            isRefreshing: true,
+          ),
           NotificationFeedState(
             status: NotificationFeedStatus.loaded,
             notifications: [
@@ -555,6 +566,7 @@ void main() {
         build: createBloc,
         act: (bloc) => bloc.add(NotificationFeedRefreshed()),
         expect: () => [
+          NotificationFeedState(isRefreshing: true),
           NotificationFeedState(
             status: NotificationFeedStatus.failure,
             refreshError: true,

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -183,33 +183,93 @@ void main() {
       testWidgets('renders loading indicator when notifications is empty', (
         tester,
       ) async {
-        when(() => mockBloc.state).thenReturn(
-          NotificationFeedState(status: NotificationFeedStatus.loading),
-        );
+        when(
+          () => mockBloc.state,
+        ).thenReturn(NotificationFeedState(isRefreshing: true));
 
         await _pumpView(tester, mockBloc);
 
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
       });
 
+      testWidgets('renders cached list (not full-screen spinner) when hydrated '
+          'notifications are present and refresh is still in flight', (
+        tester,
+      ) async {
+        // Cold-start path: repository emits hydrated cache; bloc is
+        // still refreshing because `refresh()` has not returned yet.
+        // The view must surface the cached rows under the active tab
+        // instead of masking them behind a full-screen spinner.
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            isRefreshing: true,
+            notifications: [
+              ActorNotification(
+                id: 'cached_1',
+                type: NotificationKind.follow,
+                actor: ActorInfo(
+                  pubkey: 'cached_actor',
+                  displayName: 'Loading…',
+                ),
+                timestamp: DateTime(2026),
+              ),
+            ],
+          ),
+        );
+
+        await _pumpView(tester, mockBloc);
+
+        expect(find.byType(NotificationListItem), findsOneWidget);
+        // No full-screen spinner — the inner ListView never renders
+        // a CircularProgressIndicator unless `isLoadingMore` is true.
+        expect(
+          find.descendant(
+            of: find.byType(NotificationsView),
+            matching: find.byType(CircularProgressIndicator),
+          ),
+          findsNothing,
+        );
+      });
+
+      testWidgets('shows the thin revalidation bar over cached items while '
+          'isRefreshing is true', (tester) async {
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            isRefreshing: true,
+            notifications: [
+              ActorNotification(
+                id: 'cached_1',
+                type: NotificationKind.follow,
+                actor: ActorInfo(
+                  pubkey: 'cached_actor',
+                  displayName: 'Loading…',
+                ),
+                timestamp: DateTime(2026),
+              ),
+            ],
+          ),
+        );
+
+        await _pumpView(tester, mockBloc);
+
+        expect(find.byType(NotificationListItem), findsOneWidget);
+        expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      });
+
       testWidgets(
-        'renders cached list (not full-screen spinner) when hydrated '
-        'notifications are present and refresh is still in flight',
+        'hides the revalidation bar once the refresh settles (loaded, not '
+        'refreshing)',
         (tester) async {
-          // Cold-start path: repository emits hydrated cache; bloc is
-          // still in `loading` because `refresh()` has not returned yet.
-          // The view must surface the cached rows under the active tab
-          // instead of masking them behind a full-screen spinner.
           when(() => mockBloc.state).thenReturn(
             NotificationFeedState(
-              status: NotificationFeedStatus.loading,
+              status: NotificationFeedStatus.loaded,
               notifications: [
                 ActorNotification(
                   id: 'cached_1',
                   type: NotificationKind.follow,
                   actor: ActorInfo(
                     pubkey: 'cached_actor',
-                    displayName: 'Loading…',
+                    displayName: 'Alice',
                   ),
                   timestamp: DateTime(2026),
                 ),
@@ -220,15 +280,7 @@ void main() {
           await _pumpView(tester, mockBloc);
 
           expect(find.byType(NotificationListItem), findsOneWidget);
-          // No full-screen spinner — the inner ListView never renders
-          // a CircularProgressIndicator unless `isLoadingMore` is true.
-          expect(
-            find.descendant(
-              of: find.byType(NotificationsView),
-              matching: find.byType(CircularProgressIndicator),
-            ),
-            findsNothing,
-          );
+          expect(find.byType(LinearProgressIndicator), findsNothing);
         },
       );
 
@@ -454,78 +506,70 @@ void main() {
         expect(result.videoDetailRoutes.single.extra?.autoOpenComments, isTrue);
       });
 
-      testWidgets(
-        'reply tap resolves target comment to root video and opens '
-        'comments thread',
-        (tester) async {
-          final videoService = _MockVideoEventService();
-          final nostrClient = _MockNostrClient();
-          final videosRepository = _MockVideosRepository();
-          const parentCommentId = 'parent_comment_id';
-          const rootVideoEventId = 'reply_root_video';
+      testWidgets('reply tap resolves target comment to root video and opens '
+          'comments thread', (tester) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        const parentCommentId = 'parent_comment_id';
+        const rootVideoEventId = 'reply_root_video';
 
-          when(
-            () => videoService.getVideoById(parentCommentId),
-          ).thenReturn(null);
-          when(() => nostrClient.fetchEventById(parentCommentId)).thenAnswer((
-            _,
-          ) async {
-            final event = Event(
-              'a' * 64,
-              1111,
-              const [
-                ['E', rootVideoEventId],
-              ],
-              'parent comment text',
-              createdAt: 1700000000,
-            );
-            event.id = parentCommentId;
-            return event;
-          });
+        when(() => videoService.getVideoById(parentCommentId)).thenReturn(null);
+        when(() => nostrClient.fetchEventById(parentCommentId)).thenAnswer((
+          _,
+        ) async {
+          final event = Event(
+            'a' * 64,
+            1111,
+            const [
+              ['E', rootVideoEventId],
+            ],
+            'parent comment text',
+            createdAt: 1700000000,
+          );
+          event.id = parentCommentId;
+          return event;
+        });
 
-          when(() => mockBloc.state).thenReturn(
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              notifications: [
-                ActorNotification(
-                  id: 'r1',
-                  type: NotificationKind.reply,
-                  actor: ActorInfo(pubkey: 'replier', displayName: 'Bob'),
-                  timestamp: DateTime(2026),
-                  targetEventId: parentCommentId,
-                ),
-              ],
-            ),
-          );
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              ActorNotification(
+                id: 'r1',
+                type: NotificationKind.reply,
+                actor: ActorInfo(pubkey: 'replier', displayName: 'Bob'),
+                timestamp: DateTime(2026),
+                targetEventId: parentCommentId,
+              ),
+            ],
+          ),
+        );
 
-          final result = await _pumpRoutedViewFull(
-            tester,
-            mockBloc,
-            videoEventService: videoService,
-            nostrClient: nostrClient,
-            videosRepository: videosRepository,
-          );
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
 
-          await tester.tap(find.byType(NotificationListItem).first);
-          await tester.pumpAndSettle();
+        await tester.tap(find.byType(NotificationListItem).first);
+        await tester.pumpAndSettle();
 
-          verify(() => nostrClient.fetchEventById(parentCommentId)).called(1);
-          verifyNever(
-            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
-          );
-          expect(result.videoArgs, isEmpty);
-          expect(result.videoDetailRoutes, hasLength(1));
-          expect(result.videoDetailRoutes.single.videoId, rootVideoEventId);
-          expect(
-            result.videoDetailRoutes.single.extra?.autoOpenComments,
-            isTrue,
-          );
-          expect(
-            result.videoDetailRoutes.single.extra?.fallbackVideoIds,
-            isEmpty,
-          );
-        },
-      );
+        verify(() => nostrClient.fetchEventById(parentCommentId)).called(1);
+        verifyNever(
+          () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+        );
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, hasLength(1));
+        expect(result.videoDetailRoutes.single.videoId, rootVideoEventId);
+        expect(result.videoDetailRoutes.single.extra?.autoOpenComments, isTrue);
+        expect(
+          result.videoDetailRoutes.single.extra?.fallbackVideoIds,
+          isEmpty,
+        );
+      });
 
       testWidgets(
         'reply tap waits for root video resolution before pushing video route',
@@ -742,67 +786,63 @@ void main() {
     // -----------------------------------------------------------------------
 
     group('tap routing — like', () {
-      testWidgets(
-        'like tap opens the target video with autoOpenComments:false '
-        'using the stable addressable id through the durable video route',
-        (tester) async {
-          final videoService = _MockVideoEventService();
-          final nostrClient = _MockNostrClient();
-          final videosRepository = _MockVideosRepository();
-          const addressableId =
-              '34236:'
-              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-              ':vine-like';
+      testWidgets('like tap opens the target video with autoOpenComments:false '
+          'using the stable addressable id through the durable video route', (
+        tester,
+      ) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        const addressableId =
+            '34236:'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            ':vine-like';
 
-          when(() => mockBloc.state).thenReturn(
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              notifications: [
-                VideoNotification(
-                  id: 'like-1',
-                  type: NotificationKind.like,
-                  videoEventId: 'liked_video_event',
-                  videoAddressableId: addressableId,
-                  actors: const [
-                    ActorInfo(pubkey: 'liker_pubkey', displayName: 'Alice'),
-                  ],
-                  totalCount: 1,
-                  timestamp: DateTime(2026),
-                ),
-              ],
-            ),
-          );
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              VideoNotification(
+                id: 'like-1',
+                type: NotificationKind.like,
+                videoEventId: 'liked_video_event',
+                videoAddressableId: addressableId,
+                actors: const [
+                  ActorInfo(pubkey: 'liker_pubkey', displayName: 'Alice'),
+                ],
+                totalCount: 1,
+                timestamp: DateTime(2026),
+              ),
+            ],
+          ),
+        );
 
-          final result = await _pumpRoutedViewFull(
-            tester,
-            mockBloc,
-            videoEventService: videoService,
-            nostrClient: nostrClient,
-            videosRepository: videosRepository,
-          );
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
 
-          await tester.tap(find.byType(NotificationListItem).first);
-          await tester.pumpAndSettle();
+        await tester.tap(find.byType(NotificationListItem).first);
+        await tester.pumpAndSettle();
 
-          verifyNever(
-            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
-          );
-          expect(result.videoArgs, isEmpty);
-          expect(result.videoDetailRoutes, hasLength(1));
-          expect(
-            result.videoDetailRoutes.single.videoId,
-            equals(addressableId),
-          );
-          expect(
-            result.videoDetailRoutes.single.extra?.autoOpenComments,
-            isFalse,
-          );
-          expect(
-            result.videoDetailRoutes.single.extra?.fallbackVideoIds,
-            equals(['liked_video_event']),
-          );
-        },
-      );
+        verifyNever(
+          () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+        );
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, hasLength(1));
+        expect(result.videoDetailRoutes.single.videoId, equals(addressableId));
+        expect(
+          result.videoDetailRoutes.single.extra?.autoOpenComments,
+          isFalse,
+        );
+        expect(
+          result.videoDetailRoutes.single.extra?.fallbackVideoIds,
+          equals(['liked_video_event']),
+        );
+      });
 
       testWidgets(
         'like tap falls back to raw eventId when no addressable id is set',
@@ -921,127 +961,111 @@ void main() {
     });
 
     group('tap routing — follow', () {
-      testWidgets(
-        'follow tap navigates to the actor profile',
-        (tester) async {
-          final videoService = _MockVideoEventService();
-          final nostrClient = _MockNostrClient();
-          final videosRepository = _MockVideosRepository();
-          // A real 64-char hex pubkey so encodePubKey produces a valid npub.
-          final followerPubkey = 'a' * 64;
+      testWidgets('follow tap navigates to the actor profile', (tester) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        // A real 64-char hex pubkey so encodePubKey produces a valid npub.
+        final followerPubkey = 'a' * 64;
 
-          when(() => mockBloc.state).thenReturn(
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              notifications: [
-                ActorNotification(
-                  id: 'follow-1',
-                  type: NotificationKind.follow,
-                  actor: ActorInfo(
-                    pubkey: followerPubkey,
-                    displayName: 'Dave',
-                  ),
-                  timestamp: DateTime(2026),
-                ),
-              ],
-            ),
-          );
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              ActorNotification(
+                id: 'follow-1',
+                type: NotificationKind.follow,
+                actor: ActorInfo(pubkey: followerPubkey, displayName: 'Dave'),
+                timestamp: DateTime(2026),
+              ),
+            ],
+          ),
+        );
 
-          final result = await _pumpRoutedViewFull(
-            tester,
-            mockBloc,
-            videoEventService: videoService,
-            nostrClient: nostrClient,
-            videosRepository: videosRepository,
-          );
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
 
-          await tester.tap(find.byType(NotificationListItem).first);
-          await tester.pumpAndSettle();
+        await tester.tap(find.byType(NotificationListItem).first);
+        await tester.pumpAndSettle();
 
-          expect(result.videoArgs, isEmpty);
-          expect(result.profileNpubs, hasLength(1));
-          // npub must be the bech32 encoding of followerPubkey.
-          expect(result.profileNpubs.single, startsWith('npub'));
-        },
-      );
+        expect(result.videoArgs, isEmpty);
+        expect(result.profileNpubs, hasLength(1));
+        // npub must be the bech32 encoding of followerPubkey.
+        expect(result.profileNpubs.single, startsWith('npub'));
+      });
     });
 
     group('tap routing — mention', () {
-      testWidgets(
-        'mention tap resolves the mention event to the root video '
-        'and opens with autoOpenComments:true',
-        (tester) async {
-          final videoService = _MockVideoEventService();
-          final nostrClient = _MockNostrClient();
-          final videosRepository = _MockVideosRepository();
-          const mentionEventId = 'mention_kind1_event';
-          const rootVideoEventId = 'mention_root_video';
+      testWidgets('mention tap resolves the mention event to the root video '
+          'and opens with autoOpenComments:true', (tester) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        const mentionEventId = 'mention_kind1_event';
+        const rootVideoEventId = 'mention_root_video';
 
-          // The mention event is a kind-1 with an uppercase E tag pointing
-          // to the root video — the same resolver path used for replies.
-          when(
-            () => videoService.getVideoById(mentionEventId),
-          ).thenReturn(null);
-          when(
-            () => nostrClient.fetchEventById(mentionEventId),
-          ).thenAnswer((_) async {
-            final event = Event(
-              'c' * 64,
-              1,
-              const [
-                ['E', rootVideoEventId],
-              ],
-              'hey @user great video',
-              createdAt: 1700000000,
-            );
-            event.id = mentionEventId;
-            return event;
-          });
+        // The mention event is a kind-1 with an uppercase E tag pointing
+        // to the root video — the same resolver path used for replies.
+        when(() => videoService.getVideoById(mentionEventId)).thenReturn(null);
+        when(() => nostrClient.fetchEventById(mentionEventId)).thenAnswer((
+          _,
+        ) async {
+          final event = Event(
+            'c' * 64,
+            1,
+            const [
+              ['E', rootVideoEventId],
+            ],
+            'hey @user great video',
+            createdAt: 1700000000,
+          );
+          event.id = mentionEventId;
+          return event;
+        });
 
-          when(() => mockBloc.state).thenReturn(
-            NotificationFeedState(
-              status: NotificationFeedStatus.loaded,
-              notifications: [
-                ActorNotification(
-                  id: 'mention-1',
-                  type: NotificationKind.mention,
-                  actor: ActorInfo(
-                    pubkey: 'mentioner_pubkey',
-                    displayName: 'Eve',
-                  ),
-                  timestamp: DateTime(2026),
-                  targetEventId: mentionEventId,
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              ActorNotification(
+                id: 'mention-1',
+                type: NotificationKind.mention,
+                actor: ActorInfo(
+                  pubkey: 'mentioner_pubkey',
+                  displayName: 'Eve',
                 ),
-              ],
-            ),
-          );
+                timestamp: DateTime(2026),
+                targetEventId: mentionEventId,
+              ),
+            ],
+          ),
+        );
 
-          final result = await _pumpRoutedViewFull(
-            tester,
-            mockBloc,
-            videoEventService: videoService,
-            nostrClient: nostrClient,
-            videosRepository: videosRepository,
-          );
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
 
-          await tester.tap(find.byType(NotificationListItem).first);
-          await tester.pumpAndSettle();
+        await tester.tap(find.byType(NotificationListItem).first);
+        await tester.pumpAndSettle();
 
-          verify(
-            () => nostrClient.fetchEventById(mentionEventId),
-          ).called(1);
-          verifyNever(
-            () => videosRepository.fetchVideoWithStatsForRouteId(any()),
-          );
-          expect(result.videoArgs, isEmpty);
-          expect(result.videoDetailRoutes, hasLength(1));
-          expect(result.videoDetailRoutes.single.videoId, rootVideoEventId);
-          expect(
-            result.videoDetailRoutes.single.extra?.autoOpenComments,
-            isTrue,
-          );
-        },
-      );
+        verify(() => nostrClient.fetchEventById(mentionEventId)).called(1);
+        verifyNever(
+          () => videosRepository.fetchVideoWithStatsForRouteId(any()),
+        );
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, hasLength(1));
+        expect(result.videoDetailRoutes.single.videoId, rootVideoEventId);
+        expect(result.videoDetailRoutes.single.extra?.autoOpenComments, isTrue);
+      });
 
       testWidgets(
         'mention tap falls back to actor profile when resolver cannot '
@@ -1057,9 +1081,9 @@ void main() {
           when(
             () => videoService.getVideoById(mentionEventId),
           ).thenReturn(null);
-          when(
-            () => nostrClient.fetchEventById(mentionEventId),
-          ).thenAnswer((_) async {
+          when(() => nostrClient.fetchEventById(mentionEventId)).thenAnswer((
+            _,
+          ) async {
             final event = Event(
               'd' * 64,
               1,

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -354,6 +354,23 @@ void main() {
 
         expect(find.byType(NotificationEmptyState), findsOneWidget);
       });
+
+      testWidgets('keeps the empty state (no full-screen spinner) while a '
+          'manual refresh is in flight on an already-loaded empty inbox', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            isRefreshing: true,
+          ),
+        );
+
+        await _pumpView(tester, mockBloc);
+
+        expect(find.byType(NotificationEmptyState), findsOneWidget);
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+      });
     });
 
     group('loaded with notifications', () {

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -355,10 +355,9 @@ void main() {
         expect(find.byType(NotificationEmptyState), findsOneWidget);
       });
 
-      testWidgets('keeps the empty state (no full-screen spinner) while a '
-          'manual refresh is in flight on an already-loaded empty inbox', (
-        tester,
-      ) async {
+      testWidgets('keeps the empty state and shows the thin revalidation bar '
+          '(no full-screen spinner) while a manual refresh is in flight on an '
+          'already-loaded empty inbox', (tester) async {
         when(() => mockBloc.state).thenReturn(
           NotificationFeedState(
             status: NotificationFeedStatus.loaded,
@@ -369,7 +368,22 @@ void main() {
         await _pumpView(tester, mockBloc);
 
         expect(find.byType(NotificationEmptyState), findsOneWidget);
+        // Non-blocking in-flight affordance over the empty state, never a
+        // full-screen spinner.
         expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      });
+
+      testWidgets('hides the revalidation bar on a settled empty inbox '
+          '(loaded, not refreshing)', (tester) async {
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(status: NotificationFeedStatus.loaded),
+        );
+
+        await _pumpView(tester, mockBloc);
+
+        expect(find.byType(NotificationEmptyState), findsOneWidget);
+        expect(find.byType(LinearProgressIndicator), findsNothing);
       });
     });
 


### PR DESCRIPTION
Closes #5308

## Description

Opening the notifications inbox always showed a full-screen loading spinner for ~1–2s, even though a persistent SQLite cache already exists. Two issues combined:

**1. Cache wiped on every cold start (root cause).** `runStartupCleanup` pruned cached notifications by their *content* timestamp (`createdAt`) with a 7‑day window. The write-through stores that content timestamp, so an account whose recent notifications are all older than 7 days had its inbox cache wiped on every launch — hydration always found 0 rows and the inbox spun until the network responded. Fixed by keying retention on `cachedAt` (when the row was written) instead. The cache is already size-bounded by `replaceAll`, so content-age pruning was both obsolete and actively defeating cold-start hydration.

**2. No stale-while-revalidate display.** The bloc emitted a `loading` status that drove a full-screen spinner whenever the in-memory list was empty. Replaced with an explicit `isRefreshing` flag: cached items render immediately and a thin `LinearProgressIndicator` shows while the network refresh is in flight. The full-screen spinner now fires only on a true cold start with an empty cache. The revalidation bar fades + sizes in/out via `AnimatedSwitcher` and honours reduced-motion. Mirrors the profile tabs' SWR pattern (`ProfileCacheLoadIndicator`).

**Related Issue:** None

## Out of Scope

- Decoupling the notifications cache from the signer-readiness gate (`notificationRepositoryProvider == null` during early auth). Until the repository exists the cache can't render, so the very first cold start after a fresh launch can still briefly show the page-level spinner. This is a larger provider/lifecycle change, deferred.

## Verification

- `flutter analyze` (lib/notifications, packages/db_client, packages/notification_repository): no issues
- `dart format`: clean
- Tests (all green):
  - `notification_repository` package (108)
  - `db_client`: `notifications_dao_test` + `app_database_test` — incl. a new `deleteCachedBefore` regression asserting a freshly-cached row describing an 8‑day‑old event survives cleanup
  - mobile: `notification_feed_bloc_test`, `notifications_view_test` (incl. revalidation-bar visible/hidden), `notification_pages_repo_swap_test`
- Manual: open inbox → cached list renders instantly with an animated revalidation bar that fades out when fresh data lands; empty cache → full-screen spinner; offline + cache → inline refresh-error banner.

Note: `notifications_view_test.dart` shows a large diff because the file was stale-formatted under an older formatter — touching it makes the pinned `dart format` normalise the whole file. The logical change is small.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
