### PR TITLE
fix(feed): keep home feed paused behind nested pushed routes

### DIFF
--- a/mobile/lib/providers/home_shell_obscured_provider.dart
+++ b/mobile/lib/providers/home_shell_obscured_provider.dart
@@ -1,0 +1,32 @@
+// ABOUTME: Tracks whether a full-screen route covers the bottom-nav shell.
+// ABOUTME: Driven by AppShell's RouteAware subscription to the root navigator.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Whether a full-screen route (profile, fullscreen video, recorder, …) is
+/// currently pushed on top of the bottom-nav shell on the root navigator.
+///
+/// [AppShell] subscribes to the root `routeObserver` and drives this flag:
+/// `didPushNext` sets it `true`, `didPopNext` sets it `false`. Because the
+/// subscription is keyed on the shell's own route, popping a route that sits
+/// *above another pushed route* (e.g. closing a fullscreen video while a
+/// profile is still open) does not flip it back to `false` — only popping the
+/// route directly above the shell does.
+///
+/// The home feed reads this to know it is offstage behind a pushed screen.
+/// GoRouter's `routeInformationProvider` collapses to the shell location
+/// (`/home`) while popping between pushed routes, so the feed cannot rely on
+/// route reporting alone to tell whether it is actually visible.
+final homeShellObscuredProvider =
+    NotifierProvider<HomeShellObscuredNotifier, bool>(
+      HomeShellObscuredNotifier.new,
+    );
+
+class HomeShellObscuredNotifier extends Notifier<bool> {
+  @override
+  bool build() => false;
+
+  void setObscured({required bool obscured}) {
+    if (state != obscured) state = obscured;
+  }
+}

--- a/mobile/lib/providers/shell_obscured_provider.dart
+++ b/mobile/lib/providers/shell_obscured_provider.dart
@@ -13,6 +13,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// profile is still open) does not flip it back to `false` — only popping the
 /// route directly above the shell does.
 ///
+/// `didPush` resets it to `false` whenever a fresh shell mounts, so a stale
+/// `true` left behind when the shell is removed while covered and re-shown
+/// without a pop event (e.g. sign-out → /welcome → back to home) cannot keep
+/// the feed paused.
+///
 /// The home feed reads this to know it is offstage behind a pushed screen.
 /// GoRouter's `routeInformationProvider` collapses to the shell location
 /// (`/home`) while popping between pushed routes, so the feed cannot rely on

--- a/mobile/lib/providers/shell_obscured_provider.dart
+++ b/mobile/lib/providers/shell_obscured_provider.dart
@@ -17,12 +17,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 /// GoRouter's `routeInformationProvider` collapses to the shell location
 /// (`/home`) while popping between pushed routes, so the feed cannot rely on
 /// route reporting alone to tell whether it is actually visible.
-final homeShellObscuredProvider =
-    NotifierProvider<HomeShellObscuredNotifier, bool>(
-      HomeShellObscuredNotifier.new,
-    );
+final shellObscuredProvider = NotifierProvider<ShellObscuredNotifier, bool>(
+  ShellObscuredNotifier.new,
+);
 
-class HomeShellObscuredNotifier extends Notifier<bool> {
+class ShellObscuredNotifier extends Notifier<bool> {
   @override
   bool build() => false;
 

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/for_you_provider.dart';
+import 'package:openvine/providers/home_shell_obscured_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/router.dart';
@@ -39,9 +40,46 @@ class AppShell extends ConsumerStatefulWidget {
   ConsumerState<AppShell> createState() => _AppShellState();
 }
 
-class _AppShellState extends ConsumerState<AppShell> {
+class _AppShellState extends ConsumerState<AppShell> with RouteAware {
   int get currentIndex => widget.currentIndex;
   Widget get child => widget.child;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Observe the root navigator so the home feed knows when a full-screen
+    // route (profile, fullscreen video, recorder) covers the shell. The
+    // subscription is keyed on the shell's own route, so didPopNext only fires
+    // when the route directly above the shell is popped — not when a route
+    // above another pushed route closes.
+    final route = ModalRoute.of(context);
+    if (route != null) {
+      routeObserver.subscribe(this, route);
+    }
+  }
+
+  @override
+  void dispose() {
+    routeObserver.unsubscribe(this);
+    super.dispose();
+  }
+
+  void _setShellObscured({required bool obscured}) {
+    // RouteAware callbacks can fire mid-frame; defer the provider write so it
+    // never lands during this shell's own build.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref
+          .read(homeShellObscuredProvider.notifier)
+          .setObscured(obscured: obscured);
+    });
+  }
+
+  @override
+  void didPushNext() => _setShellObscured(obscured: true);
+
+  @override
+  void didPopNext() => _setShellObscured(obscured: false);
 
   String _titleFor(BuildContext context, WidgetRef ref) {
     final l10n = context.l10n;

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -73,6 +73,13 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     });
   }
 
+  // Resets the flag whenever a fresh shell mounts. Without this, a stale
+  // `true` survives when the shell is removed while covered and later
+  // re-shown without a pop event reaching it (e.g. sign-out navigates to
+  // /welcome, then the user returns home) — the home feed would stay paused.
+  @override
+  void didPush() => _setShellObscured(obscured: false);
+
   @override
   void didPushNext() => _setShellObscured(obscured: true);
 

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -15,8 +15,8 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/classic_vines_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/for_you_provider.dart';
-import 'package:openvine/providers/home_shell_obscured_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
+import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
@@ -69,9 +69,7 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     // never lands during this shell's own build.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      ref
-          .read(homeShellObscuredProvider.notifier)
-          .setObscured(obscured: obscured);
+      ref.read(shellObscuredProvider.notifier).setObscured(obscured: obscured);
     });
   }
 

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -152,11 +152,6 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   }
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-  }
-
-  @override
   void dispose() {
     _pagePosition.dispose();
     unawaited(_autoAdvanceCubit.close());

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -9,6 +9,7 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/home_shell_obscured_provider.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
@@ -103,15 +104,10 @@ class VideoFeedView extends ConsumerStatefulWidget {
 
 class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     with WidgetsBindingObserver {
-  /// Whether the home tab is currently active.
-  ///
-  /// Used to prevent overlay-close from resuming playback when the user
-  /// has navigated away to another tab (e.g. Search).
-  bool _isOnHomeTab = true;
-
   /// Tracks whether the new native player feed should be active.
   ///
-  /// Drives [FeedVideos] pause/resume on tab switches and overlay open/close.
+  /// Drives [FeedVideos] pause/resume on tab switches, route pushes, and
+  /// overlay open/close. Kept in sync by [_syncFeedActive].
   bool _isNewFeedActive = true;
 
   /// Guards so startup milestones fire only once.
@@ -182,57 +178,50 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
 
   void _resumeAutoAdvanceAfterSwipe() => _autoAdvanceCubit.resumeAfterSwipe();
 
+  /// Recomputes whether the home feed should be playing and updates
+  /// [_isNewFeedActive] if it changed. The feed is active only when the home
+  /// route is current, nothing is pushed over the shell, and no overlay is
+  /// open. See the listeners in [build] for the rationale.
+  void _syncFeedActive() {
+    if (!mounted) return;
+    final routeType = ref.read(pageContextProvider).asData?.value.type;
+    // Hold the current state until the route context resolves.
+    if (routeType == null) return;
+
+    final isHomeRoute = routeType == RouteType.home;
+    final isObscured = ref.read(homeShellObscuredProvider);
+    final hasOverlay = ref.read(overlayVisibilityProvider).hasVisibleOverlay;
+
+    final shouldBeActive = isHomeRoute && !isObscured && !hasOverlay;
+    if (shouldBeActive == _isNewFeedActive) return;
+    setState(() => _isNewFeedActive = shouldBeActive);
+  }
+
   @override
   Widget build(BuildContext context) {
-    // Pause/resume when navigating away from/back to home tab. Some pushed
-    // routes keep this widget mounted, so playback must follow route context
-    // instead of assuming disposal handles every transition.
-    ref.listen(pageContextProvider, (_, next) {
-      final routeType = next.asData?.value.type;
-      if (routeType == null) return;
-
-      final isHome = routeType == RouteType.home;
-      if (isHome == _isOnHomeTab) return;
-      _isOnHomeTab = isHome;
-
-      // Don't resume when GoRouter falsely reports "home" while a pushed
-      // overlay (e.g. video recorder) is still open. This happens because
-      // GoRouter's routeInformationProvider can emit the shell-route
-      // location when popping between pushed routes (recorder → editor →
-      // pop back to recorder). The overlay listener handles resume when
-      // the overlay actually closes.
-      if (isHome && ref.read(overlayVisibilityProvider).hasVisibleOverlay) {
-        return;
-      }
-
-      setState(() => _isNewFeedActive = isHome);
-    });
+    // The home feed plays only while it is the visible top-level screen: the
+    // home route is current, no full-screen route covers the shell, and no
+    // overlay (page/bottom sheet) is open. Each signal lives in its own
+    // provider, so re-evaluate playback whenever any of them changes. Some
+    // pushed routes keep this widget mounted, so playback must follow these
+    // signals instead of assuming disposal handles every transition.
+    //
+    // GoRouter's routeInformationProvider collapses to the shell location
+    // ("/home") while popping between pushed routes (e.g. profile → fullscreen
+    // video → pop back to profile), so the route type alone cannot tell whether
+    // the feed is actually visible. [homeShellObscuredProvider] — driven by
+    // AppShell's RouteAware subscription to the root navigator — supplies that
+    // missing signal: it stays true until the route directly above the shell is
+    // popped, so closing the video while the profile is still open keeps the
+    // feed paused, while a genuine return to home resumes it.
+    ref.listen(pageContextProvider, (_, _) => _syncFeedActive());
+    ref.listen(homeShellObscuredProvider, (_, _) => _syncFeedActive());
+    ref.listen(overlayVisibilityProvider, (_, _) => _syncFeedActive());
 
     // Refresh feed when blocklist changes (block from profile, DM, or relay).
     ref.listen(blocklistVersionProvider, (previous, current) {
       if (previous != null && current > previous) {
         context.read<VideoFeedBloc>().add(const VideoFeedBlocklistChanged());
-      }
-    });
-
-    // Pause/resume for overlays (drawer, pages, bottom sheets), but only when
-    // on the home tab. Without this guard, closing an overlay while on
-    // another tab would incorrectly resume the home feed audio.
-    //
-    // Bottom sheets retain the current player for instant resume.
-    // Pages/drawer release all players to free memory.
-    ref.listen(overlayVisibilityProvider, (previous, current) {
-      if (!_isOnHomeTab) return;
-
-      final hadOverlay = previous?.hasVisibleOverlay ?? false;
-      final hasOverlay = current.hasVisibleOverlay;
-
-      if (hasOverlay && !hadOverlay) {
-        // Overlay opened - pause with retention based on overlay type
-        setState(() => _isNewFeedActive = false);
-      } else if (!hasOverlay && hadOverlay) {
-        // All overlays closed - resume playback
-        setState(() => _isNewFeedActive = true);
       }
     });
 

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -9,9 +9,9 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/providers/home_shell_obscured_provider.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
@@ -140,6 +140,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     _currentIndex = widget.initialIndex < 0 ? 0 : widget.initialIndex;
     _pagePosition = ValueNotifier<double>(_currentIndex.toDouble());
     WidgetsBinding.instance.addObserver(this);
+    // Seed playback from the current signals once mounted, in case this view is
+    // first built on a non-home route (e.g. a deep link) where no later change
+    // fires the [build] listeners. Deferred so the providers can resolve.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _syncFeedActive());
   }
 
   int _clampIndexForItemCount(int index, int itemCount) {
@@ -189,7 +193,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     if (routeType == null) return;
 
     final isHomeRoute = routeType == RouteType.home;
-    final isObscured = ref.read(homeShellObscuredProvider);
+    final isObscured = ref.read(shellObscuredProvider);
     final hasOverlay = ref.read(overlayVisibilityProvider).hasVisibleOverlay;
 
     final shouldBeActive = isHomeRoute && !isObscured && !hasOverlay;
@@ -209,13 +213,13 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     // GoRouter's routeInformationProvider collapses to the shell location
     // ("/home") while popping between pushed routes (e.g. profile → fullscreen
     // video → pop back to profile), so the route type alone cannot tell whether
-    // the feed is actually visible. [homeShellObscuredProvider] — driven by
+    // the feed is actually visible. [shellObscuredProvider] — driven by
     // AppShell's RouteAware subscription to the root navigator — supplies that
     // missing signal: it stays true until the route directly above the shell is
     // popped, so closing the video while the profile is still open keeps the
     // feed paused, while a genuine return to home resumes it.
     ref.listen(pageContextProvider, (_, _) => _syncFeedActive());
-    ref.listen(homeShellObscuredProvider, (_, _) => _syncFeedActive());
+    ref.listen(shellObscuredProvider, (_, _) => _syncFeedActive());
     ref.listen(overlayVisibilityProvider, (_, _) => _syncFeedActive());
 
     // Refresh feed when blocklist changes (block from profile, DM, or relay).

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -1,0 +1,150 @@
+// ABOUTME: Verifies AppShell drives homeShellObscuredProvider via RouteAware.
+// ABOUTME: A route directly above the shell flips it; nested routes do not.
+
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/app_update/app_update.dart';
+import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
+import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/environment_config.dart';
+import 'package:openvine/providers/active_video_provider.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/environment_provider.dart';
+import 'package:openvine/providers/home_shell_obscured_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockDmUnreadCountCubit extends MockCubit<int>
+    implements DmUnreadCountCubit {}
+
+class _MockNotificationBadgeCubit extends MockCubit<int>
+    implements NotificationBadgeCubit {}
+
+class _MockAppUpdateBloc extends MockBloc<AppUpdateEvent, AppUpdateState>
+    implements AppUpdateBloc {}
+
+Widget _buildSubject({
+  required _MockAuthService mockAuthService,
+  required SharedPreferences sharedPreferences,
+}) {
+  final dmCubit = _MockDmUnreadCountCubit();
+  when(() => dmCubit.state).thenReturn(0);
+
+  final notifBadgeCubit = _MockNotificationBadgeCubit();
+  when(() => notifBadgeCubit.state).thenReturn(0);
+
+  final appUpdateBloc = _MockAppUpdateBloc();
+  when(() => appUpdateBloc.state).thenReturn(const AppUpdateState());
+
+  return MultiBlocProvider(
+    providers: [
+      BlocProvider<DmUnreadCountCubit>.value(value: dmCubit),
+      BlocProvider<NotificationBadgeCubit>.value(value: notifBadgeCubit),
+      BlocProvider<AppUpdateBloc>.value(value: appUpdateBloc),
+    ],
+    child: ProviderScope(
+      overrides: [
+        pageContextProvider.overrideWith(
+          (ref) => Stream.value(const RouteContext(type: RouteType.home)),
+        ),
+        videoControllerAutoCleanupProvider.overrideWithValue(null),
+        relayStatisticsBridgeProvider.overrideWithValue(null),
+        relaySetChangeBridgeProvider.overrideWithValue(null),
+        zendeskIdentitySyncProvider.overrideWithValue(null),
+        pushNotificationSyncProvider.overrideWithValue(null),
+        blocklistSyncBridgeProvider.overrideWithValue(null),
+        authServiceProvider.overrideWithValue(mockAuthService),
+        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+        currentEnvironmentProvider.overrideWithValue(
+          EnvironmentConfig.production,
+        ),
+      ],
+      child: MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        // The shell subscribes to this observer to learn when a full-screen
+        // route covers it.
+        navigatorObservers: [routeObserver],
+        home: const AppShell(currentIndex: 0, child: SizedBox.shrink()),
+      ),
+    ),
+  );
+}
+
+void main() {
+  late _MockAuthService mockAuthService;
+  late SharedPreferences sharedPreferences;
+
+  setUp(() async {
+    mockAuthService = _MockAuthService();
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
+    when(() => mockAuthService.currentNpub).thenReturn(null);
+    when(() => mockAuthService.isAuthenticated).thenReturn(false);
+    when(() => mockAuthService.authState).thenReturn(AuthState.unauthenticated);
+
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    sharedPreferences = await SharedPreferences.getInstance();
+  });
+
+  testWidgets(
+    'homeShellObscuredProvider only flips for the route directly above the '
+    'shell',
+    (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          mockAuthService: mockAuthService,
+          sharedPreferences: sharedPreferences,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(AppShell)),
+      );
+      final navigator = Navigator.of(tester.element(find.byType(AppShell)));
+
+      // Nothing pushed yet.
+      expect(container.read(homeShellObscuredProvider), isFalse);
+
+      // Push a profile over the shell → obscured.
+      unawaited(
+        navigator.push(
+          MaterialPageRoute<void>(builder: (_) => const SizedBox.shrink()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(container.read(homeShellObscuredProvider), isTrue);
+
+      // Push a fullscreen video over the profile → still obscured (the shell's
+      // RouteAware does not fire for a push above the profile).
+      unawaited(
+        navigator.push(
+          MaterialPageRoute<void>(builder: (_) => const SizedBox.shrink()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(container.read(homeShellObscuredProvider), isTrue);
+
+      // Close the video → back to the profile. The shell is still covered.
+      navigator.pop();
+      await tester.pumpAndSettle();
+      expect(container.read(homeShellObscuredProvider), isTrue);
+
+      // Close the profile → shell revealed.
+      navigator.pop();
+      await tester.pumpAndSettle();
+      expect(container.read(homeShellObscuredProvider), isFalse);
+    },
+  );
+}

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -21,6 +21,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -34,10 +35,25 @@ class _MockNotificationBadgeCubit extends MockCubit<int>
 class _MockAppUpdateBloc extends MockBloc<AppUpdateEvent, AppUpdateState>
     implements AppUpdateBloc {}
 
-Widget _buildSubject({
+List<Override> _overrides({
   required _MockAuthService mockAuthService,
   required SharedPreferences sharedPreferences,
-}) {
+}) => [
+  pageContextProvider.overrideWith(
+    (ref) => Stream.value(const RouteContext(type: RouteType.home)),
+  ),
+  videoControllerAutoCleanupProvider.overrideWithValue(null),
+  relayStatisticsBridgeProvider.overrideWithValue(null),
+  relaySetChangeBridgeProvider.overrideWithValue(null),
+  zendeskIdentitySyncProvider.overrideWithValue(null),
+  pushNotificationSyncProvider.overrideWithValue(null),
+  blocklistSyncBridgeProvider.overrideWithValue(null),
+  authServiceProvider.overrideWithValue(mockAuthService),
+  sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+  currentEnvironmentProvider.overrideWithValue(EnvironmentConfig.production),
+];
+
+Widget _wrapWithBlocs(Widget child) {
   final dmCubit = _MockDmUnreadCountCubit();
   when(() => dmCubit.state).thenReturn(0);
 
@@ -53,34 +69,31 @@ Widget _buildSubject({
       BlocProvider<NotificationBadgeCubit>.value(value: notifBadgeCubit),
       BlocProvider<AppUpdateBloc>.value(value: appUpdateBloc),
     ],
-    child: ProviderScope(
-      overrides: [
-        pageContextProvider.overrideWith(
-          (ref) => Stream.value(const RouteContext(type: RouteType.home)),
-        ),
-        videoControllerAutoCleanupProvider.overrideWithValue(null),
-        relayStatisticsBridgeProvider.overrideWithValue(null),
-        relaySetChangeBridgeProvider.overrideWithValue(null),
-        zendeskIdentitySyncProvider.overrideWithValue(null),
-        pushNotificationSyncProvider.overrideWithValue(null),
-        blocklistSyncBridgeProvider.overrideWithValue(null),
-        authServiceProvider.overrideWithValue(mockAuthService),
-        sharedPreferencesProvider.overrideWithValue(sharedPreferences),
-        currentEnvironmentProvider.overrideWithValue(
-          EnvironmentConfig.production,
-        ),
-      ],
-      child: MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        // The shell subscribes to this observer to learn when a full-screen
-        // route covers it.
-        navigatorObservers: [routeObserver],
-        home: const AppShell(currentIndex: 0, child: SizedBox.shrink()),
-      ),
-    ),
+    child: child,
   );
 }
+
+// The shell subscribes to [routeObserver] to learn when a full-screen route
+// covers it, so the test app must register it on the navigator.
+Widget _appShellMaterialApp() => MaterialApp(
+  localizationsDelegates: AppLocalizations.localizationsDelegates,
+  supportedLocales: AppLocalizations.supportedLocales,
+  navigatorObservers: [routeObserver],
+  home: const AppShell(currentIndex: 0, child: SizedBox.shrink()),
+);
+
+Widget _buildSubject({
+  required _MockAuthService mockAuthService,
+  required SharedPreferences sharedPreferences,
+}) => _wrapWithBlocs(
+  ProviderScope(
+    overrides: _overrides(
+      mockAuthService: mockAuthService,
+      sharedPreferences: sharedPreferences,
+    ),
+    child: _appShellMaterialApp(),
+  ),
+);
 
 void main() {
   late _MockAuthService mockAuthService;
@@ -144,6 +157,41 @@ void main() {
       // Close the profile → shell revealed.
       navigator.pop();
       await tester.pumpAndSettle();
+      expect(container.read(shellObscuredProvider), isFalse);
+    },
+  );
+
+  testWidgets(
+    'a freshly mounted shell clears a stale obscured flag from a removed shell',
+    (tester) async {
+      final container = ProviderContainer(
+        overrides: _overrides(
+          mockAuthService: mockAuthService,
+          sharedPreferences: sharedPreferences,
+        ),
+      );
+      addTearDown(container.dispose);
+
+      // Residue of a shell torn down while a route still covered it: sign-out
+      // navigates away (e.g. to /welcome) without a pop event reaching the
+      // shell, so didPopNext never fires and the flag stays true.
+      container
+          .read(shellObscuredProvider.notifier)
+          .setObscured(obscured: true);
+      expect(container.read(shellObscuredProvider), isTrue);
+
+      await tester.pumpWidget(
+        _wrapWithBlocs(
+          UncontrolledProviderScope(
+            container: container,
+            child: _appShellMaterialApp(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // didPush fires once as the fresh shell subscribes, clearing the flag so
+      // the home feed can resume.
       expect(container.read(shellObscuredProvider), isFalse);
     },
   );

--- a/mobile/test/router/app_shell_obscured_test.dart
+++ b/mobile/test/router/app_shell_obscured_test.dart
@@ -1,4 +1,4 @@
-// ABOUTME: Verifies AppShell drives homeShellObscuredProvider via RouteAware.
+// ABOUTME: Verifies AppShell drives shellObscuredProvider via RouteAware.
 // ABOUTME: A route directly above the shell flips it; nested routes do not.
 
 import 'dart:async';
@@ -17,8 +17,8 @@ import 'package:openvine/models/environment_config.dart';
 import 'package:openvine/providers/active_video_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
-import 'package:openvine/providers/home_shell_obscured_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -98,7 +98,7 @@ void main() {
   });
 
   testWidgets(
-    'homeShellObscuredProvider only flips for the route directly above the '
+    'shellObscuredProvider only flips for the route directly above the '
     'shell',
     (tester) async {
       await tester.pumpWidget(
@@ -115,7 +115,7 @@ void main() {
       final navigator = Navigator.of(tester.element(find.byType(AppShell)));
 
       // Nothing pushed yet.
-      expect(container.read(homeShellObscuredProvider), isFalse);
+      expect(container.read(shellObscuredProvider), isFalse);
 
       // Push a profile over the shell → obscured.
       unawaited(
@@ -124,7 +124,7 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      expect(container.read(homeShellObscuredProvider), isTrue);
+      expect(container.read(shellObscuredProvider), isTrue);
 
       // Push a fullscreen video over the profile → still obscured (the shell's
       // RouteAware does not fire for a push above the profile).
@@ -134,17 +134,17 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
-      expect(container.read(homeShellObscuredProvider), isTrue);
+      expect(container.read(shellObscuredProvider), isTrue);
 
       // Close the video → back to the profile. The shell is still covered.
       navigator.pop();
       await tester.pumpAndSettle();
-      expect(container.read(homeShellObscuredProvider), isTrue);
+      expect(container.read(shellObscuredProvider), isTrue);
 
       // Close the profile → shell revealed.
       navigator.pop();
       await tester.pumpAndSettle();
-      expect(container.read(homeShellObscuredProvider), isFalse);
+      expect(container.read(shellObscuredProvider), isFalse);
     },
   );
 }

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Verifies that overlay visibility and tab switches pause/resume the
 // ABOUTME: native video feed
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -15,6 +17,7 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/home_shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
@@ -539,6 +542,137 @@ void main() {
       verify(
         () => videoFeedBloc.add(const VideoFeedRefreshRequested()),
       ).called(1);
+    });
+
+    group('home feed playback follows the visible route', () {
+      FeedVideos feedVideos(WidgetTester tester) => tester.widget<FeedVideos>(
+        find.byType(FeedVideos, skipOffstage: false),
+      );
+
+      Future<StreamController<String>> pumpFeed(WidgetTester tester) async {
+        final controller = StreamController<String>.broadcast();
+        addTearDown(controller.close);
+
+        final video = createTestVideoEvent();
+        final state = VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          videos: [video],
+        );
+        when(() => videoFeedBloc.state).thenReturn(state);
+        whenListen(
+          videoFeedBloc,
+          const Stream<VideoFeedBlocState>.empty(),
+          initialState: state,
+        );
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            additionalOverrides: [
+              routerLocationStreamProvider.overrideWith(
+                (_) => controller.stream,
+              ),
+            ],
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoFeedBloc>.value(value: videoFeedBloc),
+                BlocProvider<VideoPlaybackStatusCubit>(
+                  create: (_) => VideoPlaybackStatusCubit(),
+                ),
+                BlocProvider<VideoVolumeCubit>.value(value: videoVolumeCubit),
+              ],
+              child: const VideoFeedView(),
+            ),
+          ),
+        );
+        await tester.pump();
+        return controller;
+      }
+
+      Future<void> drainAndDispose(WidgetTester tester) async {
+        await tester.pump(const Duration(seconds: 3));
+        await tester.pumpWidget(const SizedBox());
+        await tester.pump();
+      }
+
+      ProviderContainer containerOf(WidgetTester tester) =>
+          ProviderScope.containerOf(
+            tester.element(find.byType(VideoFeedView, skipOffstage: false)),
+          );
+
+      void setObscured(WidgetTester tester, {required bool obscured}) {
+        containerOf(tester)
+            .read(homeShellObscuredProvider.notifier)
+            .setObscured(obscured: obscured);
+      }
+
+      testWidgets(
+        'stays paused when GoRouter falsely reports "home" while a route still '
+        'covers the shell',
+        (tester) async {
+          final controller = await pumpFeed(tester);
+
+          // Feed starts active on the home tab.
+          controller.add('/home/0');
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isTrue);
+
+          // Open a profile (full-screen route covers the shell): feed pauses.
+          setObscured(tester, obscured: true);
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isFalse);
+
+          // Closing a fullscreen video opened from the profile pops back to the
+          // profile, where GoRouter emits the shell location "/home". The
+          // profile still covers the shell, so the feed must NOT resume.
+          controller.add('/home/0');
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isFalse);
+
+          await drainAndDispose(tester);
+        },
+      );
+
+      testWidgets(
+        'resumes only once the shell is no longer covered',
+        (tester) async {
+          final controller = await pumpFeed(tester);
+          controller.add('/home/0');
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isTrue);
+
+          // Profile pushed over the shell pauses the feed.
+          setObscured(tester, obscured: true);
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isFalse);
+
+          // Profile closed (shell revealed) while the route reports home:
+          // the feed resumes.
+          setObscured(tester, obscured: false);
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isTrue);
+
+          await drainAndDispose(tester);
+        },
+      );
+
+      testWidgets('pauses on a non-home route and resumes back on home', (
+        tester,
+      ) async {
+        final controller = await pumpFeed(tester);
+        controller.add('/home/0');
+        await tester.pump();
+        expect(feedVideos(tester).isActive, isTrue);
+
+        controller.add('/explore');
+        await tester.pump();
+        expect(feedVideos(tester).isActive, isFalse);
+
+        controller.add('/home/0');
+        await tester.pump();
+        expect(feedVideos(tester).isActive, isTrue);
+
+        await drainAndDispose(tester);
+      });
     });
   });
 }

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -17,7 +17,7 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/home_shell_obscured_provider.dart';
+import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
@@ -600,9 +600,9 @@ void main() {
           );
 
       void setObscured(WidgetTester tester, {required bool obscured}) {
-        containerOf(tester)
-            .read(homeShellObscuredProvider.notifier)
-            .setObscured(obscured: obscured);
+        containerOf(
+          tester,
+        ).read(shellObscuredProvider.notifier).setObscured(obscured: obscured);
       }
 
       testWidgets(


### PR DESCRIPTION
Closes #5310

## Description

Closing a fullscreen video opened from a user profile resumed the home feed playback behind the still-open profile. Audio could play while the user was still looking at the profile.

Root cause: GoRouter route information can report the shell location (`/home`) while popping between routes pushed on top of the shell, for example `profile -> fullscreen video -> pop back to profile`. The home feed treated that spurious `/home` report as a genuine return home and resumed.

Fix:
- Add `shellObscuredProvider`, driven by an `AppShell` `RouteAware` subscription to the root navigator. Because the subscription is keyed on the shell route, `didPopNext` fires only when the route directly above the shell is popped. Closing a video above a profile does not reveal the shell; closing the profile does.
- Reset the app-scoped shell-obscured flag when a fresh shell mounts so replace-style auth/navigation flows cannot leave the home feed paused by stale state.
- Make `VideoFeedView` derive playback from combined visibility signals: `home route && !shellObscured && !overlay`, re-evaluated when any of those signals changes.
- Remove an adjacent empty `didChangeDependencies` override while touching the feed view.

This also keeps the previous recorder/editor pause behavior robust because feed playback no longer depends on route location alone during stacked-route pops.

## Out of Scope

None.

## Verification

- `mise exec -- flutter test test/router/app_shell_obscured_test.dart test/screens/feed/video_feed_page_test.dart`
- `mise exec -- flutter analyze lib/providers/shell_obscured_provider.dart lib/router/app_shell.dart lib/screens/feed/video_feed_page.dart test/router/app_shell_obscured_test.dart test/screens/feed/video_feed_page_test.dart`

New tests:
- `app_shell_obscured_test.dart`: shell-obscured state flips only for the route directly above the shell, and a fresh shell clears stale obscured state.
- `video_feed_page_test.dart`: home feed stays paused on a spurious `/home` report while the shell is still obscured, resumes once the shell is revealed, and pauses/resumes across non-home routes.

Manual verification from the author: profile -> open video -> close video keeps the home feed paused; closing the profile resumes it.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore