### PR TITLE
fix(inbox): keep compose FAB from covering the last conversation tile

### DIFF
--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -194,10 +194,12 @@ const double _kTabSlideFraction = 0.06;
 /// Inset of the compose FAB from the bottom-right of the Messages pane.
 const double _kFabInset = 16;
 
-/// Bottom padding reserved on the conversation list so the FAB (56pt tall,
-/// inset [_kFabInset] from the bottom) never covers the last conversation
-/// tile when scrolled to the end. Equals the FAB's footprint plus a margin.
-const double _kConversationListBottomInset = _kFabInset + 56 + _kFabInset;
+/// Bottom padding reserved on the conversation list so the compose FAB
+/// ([InboxFab], inset [_kFabInset] from the bottom) never covers the last
+/// conversation tile when scrolled to the end. Equals the FAB's footprint
+/// plus a margin, so it tracks [InboxFab.size] automatically.
+const double _kConversationListBottomInset =
+    _kFabInset + InboxFab.size + _kFabInset;
 
 /// Material shared-axis transition between the two inbox tabs: a short
 /// horizontal slide combined with an overlapping cross-fade.

--- a/mobile/lib/screens/inbox/inbox_view.dart
+++ b/mobile/lib/screens/inbox/inbox_view.dart
@@ -191,6 +191,14 @@ class _InboxViewState extends ConsumerState<InboxView>
 /// pane width — the subtle shared-axis slide.
 const double _kTabSlideFraction = 0.06;
 
+/// Inset of the compose FAB from the bottom-right of the Messages pane.
+const double _kFabInset = 16;
+
+/// Bottom padding reserved on the conversation list so the FAB (56pt tall,
+/// inset [_kFabInset] from the bottom) never covers the last conversation
+/// tile when scrolled to the end. Equals the FAB's footprint plus a margin.
+const double _kConversationListBottomInset = _kFabInset + 56 + _kFabInset;
+
 /// Material shared-axis transition between the two inbox tabs: a short
 /// horizontal slide combined with an overlapping cross-fade.
 ///
@@ -366,8 +374,8 @@ class _MessagesContent extends ConsumerWidget {
           ),
           // FAB positioned bottom-right
           PositionedDirectional(
-            end: 16,
-            bottom: 16,
+            end: _kFabInset,
+            bottom: _kFabInset,
             child: InboxFab(onPressed: () => _onNewConversation(context, ref)),
           ),
         ],
@@ -539,6 +547,7 @@ class _ConversationListState extends ConsumerState<_ConversationList>
 
     return ListView.builder(
       controller: _scrollController,
+      padding: const EdgeInsets.only(bottom: _kConversationListBottomInset),
       itemCount: conversations.length + bannerOffset + (hasMore ? 1 : 0),
       itemBuilder: (context, index) {
         if (hasRequests && index == 0) {

--- a/mobile/lib/screens/inbox/widgets/inbox_fab.dart
+++ b/mobile/lib/screens/inbox/widgets/inbox_fab.dart
@@ -13,13 +13,18 @@ class InboxFab extends StatelessWidget {
 
   final VoidCallback onPressed;
 
+  /// Diameter of the circular FAB. Single source of truth — layouts that
+  /// reserve space for the FAB (e.g. the conversation list bottom inset)
+  /// derive from this rather than re-hardcoding the value.
+  static const double size = 56;
+
   static const double _borderRadius = 24;
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      width: 56,
-      height: 56,
+      width: size,
+      height: size,
       child: GestureDetector(
         onTap: onPressed,
         child: DecoratedBox(

--- a/mobile/lib/screens/inbox/widgets/inbox_fab.dart
+++ b/mobile/lib/screens/inbox/widgets/inbox_fab.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 /// Green FAB for starting a new conversation.
 ///
-/// 56x56 circle with `primary` background and a `+` icon.
+/// A [size]×[size] circle with `primary` background and a `+` icon.
 /// Positioned by the parent layout (typically bottom-right).
 class InboxFab extends StatelessWidget {
   const InboxFab({required this.onPressed, super.key});

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -3,6 +3,7 @@
 // ABOUTME: empty, loaded), and tab switching between messages and notifications.
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
@@ -25,6 +26,7 @@ import 'package:openvine/screens/inbox/message_requests/widgets/message_requests
 import 'package:openvine/screens/inbox/widgets/conversation_tile.dart';
 import 'package:openvine/screens/inbox/widgets/following_bar.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_empty_state.dart';
+import 'package:openvine/screens/inbox/widgets/inbox_fab.dart';
 import 'package:openvine/screens/inbox/widgets/inbox_segmented_toggle.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
 
@@ -299,23 +301,26 @@ void main() {
       });
 
       testWidgets(
-        'reserves bottom padding on the conversation list so the FAB does '
-        'not cover the last tile',
+        'keeps the last conversation tile clear of the FAB when scrolled '
+        'to the end',
         (tester) async {
-          final conversation = DmConversation(
-            id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
-            participantPubkeys: const [currentPubkey, otherPubkey],
-            isGroup: false,
-            createdAt: nowUnix,
-            lastMessageContent: 'Hello',
-            lastMessageTimestamp: nowUnix,
+          final conversations = List.generate(
+            30,
+            (index) => DmConversation(
+              id: 'conv$index',
+              participantPubkeys: const [currentPubkey, otherPubkey],
+              isGroup: false,
+              createdAt: nowUnix - index,
+              lastMessageContent: 'Hello $index',
+              lastMessageTimestamp: nowUnix - index,
+            ),
           );
 
           await tester.pumpWidget(
             buildSubject(
               state: ConversationListState(
                 status: ConversationListStatus.loaded,
-                conversations: [conversation],
+                conversations: conversations,
                 hasMore: false,
               ),
             ),
@@ -326,16 +331,28 @@ void main() {
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 350));
 
-          final listView = tester.widget<ListView>(
-            find.ancestor(
-              of: find.byType(ConversationTile),
-              matching: find.byType(ListView),
-            ),
-          );
-          final padding = listView.padding! as EdgeInsets;
-          // FAB is 56pt tall and inset 16pt from the bottom, so the list must
-          // reserve at least that much to keep the last tile fully visible.
-          expect(padding.bottom, greaterThanOrEqualTo(56 + 16));
+          // Scroll the conversation list to its very end so the last tile is
+          // pinned against the reserved bottom inset.
+          final position = tester
+              .state<ScrollableState>(
+                find.ancestor(
+                  of: find.byType(ConversationTile).first,
+                  matching: find.byType(Scrollable),
+                ),
+              )
+              .position;
+          position.jumpTo(position.maxScrollExtent);
+          await tester.pump();
+
+          // The bottom edge of the last visible tile must sit at or above the
+          // FAB's top edge — i.e. the FAB never overlaps the last tile.
+          final lastTileBottom = tester
+              .widgetList<ConversationTile>(find.byType(ConversationTile))
+              .map((tile) => tester.getRect(find.byWidget(tile)).bottom)
+              .reduce(math.max);
+          final fabTop = tester.getRect(find.byType(InboxFab)).top;
+
+          expect(lastTileBottom, lessThanOrEqualTo(fabTop));
         },
       );
 

--- a/mobile/test/screens/inbox/inbox_view_test.dart
+++ b/mobile/test/screens/inbox/inbox_view_test.dart
@@ -299,6 +299,47 @@ void main() {
       });
 
       testWidgets(
+        'reserves bottom padding on the conversation list so the FAB does '
+        'not cover the last tile',
+        (tester) async {
+          final conversation = DmConversation(
+            id: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+            participantPubkeys: const [currentPubkey, otherPubkey],
+            isGroup: false,
+            createdAt: nowUnix,
+            lastMessageContent: 'Hello',
+            lastMessageTimestamp: nowUnix,
+          );
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: ConversationListState(
+                status: ConversationListStatus.loaded,
+                conversations: [conversation],
+                hasMore: false,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          await tester.tap(find.text('Messages'));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 350));
+
+          final listView = tester.widget<ListView>(
+            find.ancestor(
+              of: find.byType(ConversationTile),
+              matching: find.byType(ListView),
+            ),
+          );
+          final padding = listView.padding! as EdgeInsets;
+          // FAB is 56pt tall and inset 16pt from the bottom, so the list must
+          // reserve at least that much to keep the last tile fully visible.
+          expect(padding.bottom, greaterThanOrEqualTo(56 + 16));
+        },
+      );
+
+      testWidgets(
         'excludes inactive mounted pane from semantics after tab switch',
         (tester) async {
           final semantics = tester.ensureSemantics();


### PR DESCRIPTION
Closes #5314

## Summary

The compose FAB (`InboxFab`) overlays the conversation list inside a `Stack` at `bottom: 16`. The `ListView.builder` had no bottom padding, so when scrolled to the end the last `ConversationTile` sat underneath the 56pt-tall FAB and was partially hidden.

This reserves bottom padding on the conversation list equal to the FAB's footprint (FAB height 56 + 16pt inset top and bottom = 88), so the last tile always clears the FAB. The 16pt FAB inset is now shared via a `_kFabInset` constant so the position and the reserved padding can't drift apart.

| Before | After |
| ------ | ------ |
|   <img width="322" alt="image" src="https://github.com/user-attachments/assets/f194a5fd-ac22-4fd9-beea-0808f3f20273" />    |       <img width="322" alt="image" src="https://github.com/user-attachments/assets/d00e6882-2e80-4aa0-9187-32e2ba037f38" />  |

## Changes

- `inbox_view.dart`: add `_kFabInset` and `_kConversationListBottomInset` constants; apply `padding: EdgeInsets.only(bottom: _kConversationListBottomInset)` to the conversation `ListView.builder`; use `_kFabInset` for the FAB's `PositionedDirectional`.
- `inbox_view_test.dart`: add a widget test asserting the conversation list reserves enough bottom padding to clear the FAB.

## Test plan

- [x] `flutter analyze lib/screens/inbox/inbox_view.dart` — no issues
- [x] `flutter test test/screens/inbox/inbox_view_test.dart` — 19/19 pass