### PR TITLE
feat(router): cross-fade tab transitions via StatefulShellRoute

### DIFF
--- a/mobile/lib/providers/route_feed_providers.dart
+++ b/mobile/lib/providers/route_feed_providers.dart
@@ -49,6 +49,16 @@ final exploreTabIndexProvider = StateProvider<int>((ref) => 1);
 /// Valid values: 'classics', 'new', 'popular', 'for_you', 'lists', 'apps'
 final forceExploreTabNameProvider = StateProvider<String?>((ref) => null);
 
+/// Index of the currently-active bottom-nav branch
+/// (0 = Home, 1 = Explore, 2 = Inbox, 3 = Profile).
+///
+/// Kept in sync by [AppShell] from the StatefulShellRoute's
+/// `navigationShell.currentIndex` — the authoritative active-tab signal set by
+/// go_router. Backgrounded tab screens (e.g. the home feed) pause off this
+/// rather than the URL-derived pageContext, which can lag on web for
+/// StatefulShellRoute branch switches.
+final activeBranchIndexProvider = StateProvider<int>((ref) => 0);
+
 /// Explore feed state (discovery/all videos)
 /// Returns AsyncValue<VideoFeedState> for route-aware explore screen
 /// Uses tab-specific list when in feed mode, otherwise sorted by loop count

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -258,6 +258,16 @@ bool _isPublicRecorderLocation(String location) =>
 /// tab keep rendering its real content while inactive. [NoTransitionPage]
 /// keeps within-branch navigation (e.g. grid → feed) instant; the *between
 /// tab* cross-fade is done by [AppShellBranchContainer].
+///
+/// Scoping caveat: only a *direct* `ref.watch(pageContextProvider)` from a
+/// widget in this subtree observes the branch-local override. A root-level
+/// provider that derives from [pageContextProvider] (e.g.
+/// [activeRouteTypeProvider], [activeVideoIdProvider],
+/// [videoControllerAutoCleanupProvider]) is instantiated in the root container
+/// and therefore always reads the *global* route — by design, since playback
+/// gating must follow the genuinely-active tab. Any new provider that reads
+/// [pageContextProvider] inherits this global behaviour even when consumed
+/// inside a branch; reach for the scoped value only via a direct widget read.
 Page<void> _branchPage(GoRouterState state, Widget child) {
   return NoTransitionPage<void>(
     key: state.pageKey,

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -246,6 +246,34 @@ List<String> stringListRouteExtra(Object? extra) {
 bool _isPublicRecorderLocation(String location) =>
     location == VideoRecorderScreen.path;
 
+/// Builds a [StatefulShellBranch] page whose subtree sees its *own* route's
+/// [RouteContext] via a scoped [pageContextProvider], rather than the
+/// globally-active route's.
+///
+/// `StatefulShellRoute` keeps every branch mounted, but the tab screens gate
+/// their content on the global [pageContextProvider] (they render a
+/// placeholder when its type doesn't match). Without this scope an inactive
+/// branch would see the active tab's context and blank out — breaking both
+/// state preservation and the live cross-fade. Scoping per branch makes each
+/// tab keep rendering its real content while inactive. [NoTransitionPage]
+/// keeps within-branch navigation (e.g. grid → feed) instant; the *between
+/// tab* cross-fade is done by [AppShellBranchContainer].
+Page<void> _branchPage(GoRouterState state, Widget child) {
+  return NoTransitionPage<void>(
+    key: state.pageKey,
+    child: ProviderScope(
+      overrides: [
+        pageContextProvider.overrideWith(
+          (ref) => Stream<RouteContext>.value(
+            parseRoute(state.uri.toString()),
+          ),
+        ),
+      ],
+      child: child,
+    ),
+  );
+}
+
 final goRouterProvider = Provider<GoRouter>((ref) {
   // Use ref.read to avoid recreating the router on auth state changes
   final authService = ref.read(authServiceProvider);
@@ -463,216 +491,135 @@ final goRouterProvider = Provider<GoRouter>((ref) {
         name: VideoRecorderScreen.routeName,
         builder: (_, _) => const VideoRecorderRoute(),
       ),
-      // Shell owns the shared scaffold and bottom navigation. Individual tab
-      // route state that must survive a child swap is restored explicitly from
-      // route params or tab-position providers.
-      ShellRoute(
-        builder: (context, state, child) {
-          final location = state.uri.toString();
-          final current = tabIndexFromLocation(location);
-          return AppShell(currentIndex: current, child: child);
-        },
-        routes: [
-          // HOME tab subtree
-          GoRoute(
-            path: VideoFeedPage.pathWithIndex,
-            name: VideoFeedPage.routeName,
-            pageBuilder: (ctx, st) {
-              final initialIndex = homeInitialIndexFromPathParameters(
-                st.pathParameters,
-              );
-              return NoTransitionPage(
-                key: st.pageKey,
-                child: Navigator(
-                  key: NavigatorKeys.home,
-                  onGenerateRoute: (r) => MaterialPageRoute(
-                    builder: (_) => VideoFeedPage(initialIndex: initialIndex),
-                    settings: const RouteSettings(
-                      name: VideoFeedPage.routeName,
+      // Bottom-nav tabs live in a StatefulShellRoute so every tab keeps its
+      // own Navigator (and state) alive while inactive — that is what lets the
+      // tab switch cross-fade between two live tabs (see AppShellBranchContainer).
+      //
+      // Each branch screen reads the *globally-active* route via
+      // pageContextProvider and renders a placeholder when it doesn't match.
+      // Because all branches stay mounted, [_branchPage] scopes
+      // pageContextProvider per branch so each tab sees *its own* route context
+      // (not the active tab's) and keeps rendering real content while inactive.
+      StatefulShellRoute(
+        builder: (context, state, navigationShell) => AppShell(
+          currentIndex: navigationShell.currentIndex,
+          child: navigationShell,
+        ),
+        navigatorContainerBuilder: (context, navigationShell, children) =>
+            AppShellBranchContainer(
+              currentIndex: navigationShell.currentIndex,
+              children: children,
+            ),
+        branches: [
+          // HOME tab
+          StatefulShellBranch(
+            navigatorKey: NavigatorKeys.home,
+            initialLocation: VideoFeedPage.pathForIndex(0),
+            routes: [
+              GoRoute(
+                path: VideoFeedPage.pathWithIndex,
+                name: VideoFeedPage.routeName,
+                pageBuilder: (ctx, st) => _branchPage(
+                  st,
+                  VideoFeedPage(
+                    initialIndex: homeInitialIndexFromPathParameters(
+                      st.pathParameters,
                     ),
                   ),
                 ),
-              );
-            },
+              ),
+            ],
           ),
 
-          // EXPLORE tab - grid mode (no index)
-          GoRoute(
-            path: ExploreScreen.path,
-            name: ExploreScreen.routeName,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.exploreGrid,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const ExploreScreen(),
-                  settings: const RouteSettings(name: ExploreScreen.routeName),
-                ),
+          // EXPLORE tab (grid + tab-by-name + feed)
+          StatefulShellBranch(
+            navigatorKey: NavigatorKeys.explore,
+            initialLocation: ExploreScreen.path,
+            routes: [
+              GoRoute(
+                path: ExploreScreen.path,
+                name: ExploreScreen.routeName,
+                pageBuilder: (ctx, st) =>
+                    _branchPage(st, const ExploreScreen()),
               ),
-            ),
+              GoRoute(
+                path: ExploreScreen.pathTabSubpath,
+                pageBuilder: (ctx, st) {
+                  final tabName = ExploreScreen.tabNameFromPathParameter(
+                    st.pathParameters['name'],
+                  );
+                  if (tabName == null) {
+                    return _branchPage(
+                      st,
+                      RouteErrorScreen(message: ctx.l10n.routeUnknownPath),
+                    );
+                  }
+                  return _branchPage(
+                    st,
+                    ExploreScreen(initialTabName: tabName),
+                  );
+                },
+              ),
+              GoRoute(
+                path: ExploreScreen.pathWithIndex,
+                pageBuilder: (ctx, st) =>
+                    _branchPage(st, const ExploreScreen()),
+              ),
+            ],
           ),
 
-          // EXPLORE tab - select a specific tab by name (grid mode)
-          GoRoute(
-            path: ExploreScreen.pathTabSubpath,
-            pageBuilder: (ctx, st) {
-              final tabName = ExploreScreen.tabNameFromPathParameter(
-                st.pathParameters['name'],
-              );
-              if (tabName == null) {
-                return NoTransitionPage(
-                  key: st.pageKey,
-                  child: RouteErrorScreen(message: ctx.l10n.routeUnknownPath),
-                );
-              }
-              return NoTransitionPage(
-                key: st.pageKey,
-                child: Navigator(
-                  key: NavigatorKeys.exploreGrid,
-                  onGenerateRoute: (r) => MaterialPageRoute(
-                    builder: (_) => ExploreScreen(initialTabName: tabName),
-                    settings: const RouteSettings(
-                      name: ExploreScreen.routeName,
-                    ),
-                  ),
-                ),
-              );
-            },
+          // INBOX tab (inbox + notifications share tab position 2)
+          StatefulShellBranch(
+            navigatorKey: NavigatorKeys.inbox,
+            initialLocation: InboxPage.path,
+            routes: [
+              GoRoute(
+                path: NotificationsPage.pathWithIndex,
+                name: NotificationsPage.routeName,
+                pageBuilder: (ctx, st) =>
+                    _branchPage(st, const NotificationsPage()),
+              ),
+              GoRoute(
+                path: InboxPage.path,
+                name: InboxPage.routeName,
+                pageBuilder: (ctx, st) => _branchPage(st, const InboxPage()),
+              ),
+            ],
           ),
 
-          // EXPLORE tab - feed mode (with video index)
-          GoRoute(
-            path: ExploreScreen.pathWithIndex,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.exploreFeed,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const ExploreScreen(),
-                  settings: const RouteSettings(name: ExploreScreen.routeName),
-                ),
+          // PROFILE tab (own profile grid/feed + liked-videos)
+          StatefulShellBranch(
+            navigatorKey: NavigatorKeys.profile,
+            initialLocation: ProfileScreenRouter.path,
+            routes: [
+              GoRoute(
+                path: ProfileScreenRouter.path,
+                name: ProfileScreenRouter.routeName,
+                pageBuilder: (ctx, st) =>
+                    _branchPage(st, const ProfileScreenRouter()),
               ),
-            ),
-          ),
-
-          // NOTIFICATIONS tab subtree
-          GoRoute(
-            path: NotificationsPage.pathWithIndex,
-            name: NotificationsPage.routeName,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.notifications,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const NotificationsPage(),
-                  settings: const RouteSettings(
-                    name: NotificationsPage.routeName,
-                  ),
-                ),
+              GoRoute(
+                path: ProfileScreenRouter.pathWithNpub,
+                pageBuilder: (ctx, st) =>
+                    _branchPage(st, const ProfileScreenRouter()),
               ),
-            ),
-          ),
-
-          // INBOX tab (Messages + Notifications combined)
-          GoRoute(
-            path: InboxPage.path,
-            name: InboxPage.routeName,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.inbox,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const InboxPage(),
-                  settings: const RouteSettings(name: InboxPage.routeName),
-                ),
+              GoRoute(
+                path: ProfileScreenRouter.pathWithIndex,
+                pageBuilder: (ctx, st) =>
+                    _branchPage(st, const ProfileScreenRouter()),
               ),
-            ),
-          ),
-
-          // PROFILE tab subtree - grid mode (no index)
-          GoRoute(
-            path: ProfileScreenRouter.path,
-            name: ProfileScreenRouter.routeName,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.profileGrid,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const ProfileScreenRouter(),
-                  settings: const RouteSettings(
-                    name: ProfileScreenRouter.routeName,
-                  ),
-                ),
+              GoRoute(
+                path: LikedVideosScreenRouter.path,
+                name: LikedVideosScreenRouter.routeName,
+                pageBuilder: (ctx, st) =>
+                    _branchPage(st, const LikedVideosScreenRouter()),
               ),
-            ),
-          ),
-
-          // PROFILE tab subtree - grid mode (with npub)
-          GoRoute(
-            path: ProfileScreenRouter.pathWithNpub,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.profileGrid,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const ProfileScreenRouter(),
-                  settings: const RouteSettings(
-                    name: ProfileScreenRouter.routeName,
-                  ),
-                ),
+              GoRoute(
+                path: LikedVideosScreenRouter.pathWithIndex,
+                pageBuilder: (ctx, st) =>
+                    _branchPage(st, const LikedVideosScreenRouter()),
               ),
-            ),
-          ),
-          // PROFILE tab subtree - feed mode (with video index)
-          GoRoute(
-            path: ProfileScreenRouter.pathWithIndex,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.profileFeed,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const ProfileScreenRouter(),
-                  settings: const RouteSettings(
-                    name: ProfileScreenRouter.routeName,
-                  ),
-                ),
-              ),
-            ),
-          ),
-
-          // LIKED VIDEOS route - grid mode (no index)
-          GoRoute(
-            path: LikedVideosScreenRouter.path,
-            name: LikedVideosScreenRouter.routeName,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.likedVideosGrid,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const LikedVideosScreenRouter(),
-                  settings: const RouteSettings(
-                    name: LikedVideosScreenRouter.routeName,
-                  ),
-                ),
-              ),
-            ),
-          ),
-
-          // LIKED VIDEOS route - feed mode (with video index)
-          GoRoute(
-            path: LikedVideosScreenRouter.pathWithIndex,
-            pageBuilder: (ctx, st) => NoTransitionPage(
-              key: st.pageKey,
-              child: Navigator(
-                key: NavigatorKeys.likedVideosFeed,
-                onGenerateRoute: (r) => MaterialPageRoute(
-                  builder: (_) => const LikedVideosScreenRouter(),
-                  settings: const RouteSettings(
-                    name: LikedVideosScreenRouter.routeName,
-                  ),
-                ),
-              ),
-            ),
+            ],
           ),
         ],
       ),

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -274,9 +274,7 @@ Page<void> _branchPage(GoRouterState state, Widget child) {
     child: ProviderScope(
       overrides: [
         pageContextProvider.overrideWith(
-          (ref) => Stream<RouteContext>.value(
-            parseRoute(state.uri.toString()),
-          ),
+          (ref) => Stream<RouteContext>.value(parseRoute(state.uri.path)),
         ),
       ],
       child: child,
@@ -1423,77 +1421,4 @@ List<NavigatorObserver> _buildRouterObservers() {
   ];
 
   return observers;
-}
-
-/// Maps URL location to bottom nav tab index.
-///
-/// Returns the tab index for tab routes:
-/// - 0: Home
-/// - 1: Explore (also for hashtag routes)
-/// - 2: Notifications
-/// - 3: Profile (also for liked-videos)
-///
-/// Returns -1 for non-tab routes (like search, settings, edit-profile)
-/// to hide the bottom navigation bar.
-int tabIndexFromLocation(String loc) {
-  final uri = Uri.parse(loc);
-  final first = uri.pathSegments.isEmpty ? '' : uri.pathSegments.first;
-  switch (first) {
-    case 'home':
-      return 0;
-    case 'explore':
-      return 1;
-    case 'notifications':
-    case 'inbox':
-      return 2; // Inbox replaces notifications in the same tab position
-    case 'profile':
-    case 'liked-videos':
-      return 3; // Liked videos keeps profile tab active
-    case 'search':
-    case 'badges':
-    case 'apps':
-    case 'invites':
-    case 'settings':
-    case 'relay-settings':
-    case 'relay-diagnostic':
-    case 'blossom-settings':
-    case 'notification-settings':
-    case 'key-management':
-    case 'safety-settings':
-    case 'content-filters':
-    case 'content-preferences':
-    case 'app-language':
-    case 'support-center':
-    case 'legal':
-    case 'nostr-settings':
-    case 'bluesky-settings':
-    case 'developer-options':
-    case 'edit-profile':
-    case 'setup-profile':
-    case 'import-key':
-    case 'nostr-connect':
-    case 'welcome':
-    case 'video-recorder':
-    case 'video-editor':
-    case 'video-metadata':
-    case 'clip-manager':
-    case 'drafts':
-    case 'followers':
-    case 'following':
-    case 'video-feed':
-    case 'profile-view':
-    case 'sound':
-    case 'list':
-    case 'discover-lists':
-    case 'people-lists':
-    case 'people-list-members':
-    case 'people-list-add-people':
-    case 'people-list-create':
-    case 'creator-analytics':
-    case 'hashtag':
-    case 'categories':
-      return -1; // Non-tab routes - no bottom nav (outside shell)
-    default:
-      return 0; // fallback to home
-  }
 }

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -262,8 +262,8 @@ bool _isPublicRecorderLocation(String location) =>
 /// Scoping caveat: only a *direct* `ref.watch(pageContextProvider)` from a
 /// widget in this subtree observes the branch-local override. A root-level
 /// provider that derives from [pageContextProvider] (e.g.
-/// [activeRouteTypeProvider], [activeVideoIdProvider],
-/// [videoControllerAutoCleanupProvider]) is instantiated in the root container
+/// [activeVideoIdProvider], [videoControllerAutoCleanupProvider]) is
+/// instantiated in the root container
 /// and therefore always reads the *global* route — by design, since playback
 /// gating must follow the genuinely-active tab. Any new provider that reads
 /// [pageContextProvider] inherits this global behaviour even when consumed

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -30,6 +30,17 @@ import 'package:openvine/widgets/vine_bottom_nav.dart';
 import 'package:pointer_interceptor/pointer_interceptor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+/// Duration of the cross-fade applied when switching between bottom-nav tabs.
+/// Kept short so tab switches stay snappy.
+const Duration _kTabFadeDuration = Duration(milliseconds: 120);
+
+/// Shell chrome (app bar + bottom nav) wrapped around the [StatefulShellRoute]
+/// branch container.
+///
+/// [child] is the `StatefulNavigationShell` (rendered via
+/// [AppShellBranchContainer]); [currentIndex] is its active branch. AppShell
+/// itself no longer animates the tab switch — the cross-fade lives in
+/// [AppShellBranchContainer], which keeps every branch alive.
 class AppShell extends ConsumerStatefulWidget {
   const AppShell({required this.child, required this.currentIndex, super.key});
 
@@ -268,21 +279,17 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
     // Watch page context to determine if back button should show and if on search route
     final pageCtxAsync = ref.watch(pageContextProvider);
 
-    // Check if on own profile grid view - if so, let ProfileScreenRouter render its own scaffold
+    // Own profile grid renders its own scrollable header (avatar + stats), so
+    // AppShell suppresses its app bar for it — like home / inbox / explore grid.
     final isOwnProfileGrid = pageCtxAsync.maybeWhen(
       data: (ctx) {
         if (ctx.type != RouteType.profile) return false;
-        if (ctx.videoIndex != null) return false; // Video mode uses shell
+        if (ctx.videoIndex != null) return false; // Video mode uses the app bar
         final currentNpub = ref.read(authServiceProvider).currentNpub;
         return ctx.npub == 'me' || ctx.npub == currentNpub;
       },
       orElse: () => false,
     );
-
-    // Own profile grid uses its own scaffold - just return the child
-    if (isOwnProfileGrid) {
-      return child;
-    }
 
     // Inbox manages its own header (segmented toggle replaces app bar)
     final isInbox = pageCtxAsync.maybeWhen(
@@ -329,7 +336,8 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
       // instead of the standard AppBar, for full-screen video UX.
       // Inbox uses its own segmented toggle header.
       // Explore grid manages its own header (search bar + tabs).
-      appBar: currentIndex == 0 || isInbox || isExploreGrid
+      // Own profile grid renders its own scrollable header.
+      appBar: currentIndex == 0 || isInbox || isExploreGrid || isOwnProfileGrid
           ? null
           : DiVineAppBar(
               titleWidget: _buildTappableTitle(context, ref, title),
@@ -419,7 +427,6 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
             )
           : child,
       // Bottom nav visible for all shell routes (search, tabs, etc.).
-      // For search (currentIndex=-1), no tab is highlighted.
       // PointerInterceptor ensures the bottom nav receives taps on web
       // even when HTML platform views (video elements) overlap the area.
       //
@@ -435,6 +442,50 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Cross-fades between the [StatefulShellRoute] branch navigators.
+///
+/// Every branch stays mounted (state preserved); the active branch is fully
+/// opaque and interactive, the others sit at opacity 0 with their tickers
+/// paused and pointer events ignored. On a tab switch the outgoing branch
+/// fades out while the incoming one fades in — a true cross-fade between two
+/// live tabs. Within-tab navigation never reaches here (those are
+/// [NoTransitionPage]s inside a single branch).
+class AppShellBranchContainer extends StatelessWidget {
+  const AppShellBranchContainer({
+    required this.currentIndex,
+    required this.children,
+    super.key,
+  });
+
+  /// Index (in [children]) of the branch navigator to display.
+  final int currentIndex;
+
+  /// The branch navigators, one per [StatefulShellBranch], kept alive.
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
+    final duration = MediaQuery.disableAnimationsOf(context)
+        ? Duration.zero
+        : _kTabFadeDuration;
+    return Stack(
+      fit: StackFit.expand,
+      children: List.generate(children.length, (index) {
+        final isActive = index == currentIndex;
+        return AnimatedOpacity(
+          opacity: isActive ? 1 : 0,
+          duration: duration,
+          curve: Curves.easeInOut,
+          child: IgnorePointer(
+            ignoring: !isActive,
+            child: TickerMode(enabled: isActive, child: children[index]),
+          ),
+        );
+      }),
     );
   }
 }

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -253,6 +253,19 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
   Widget build(BuildContext context) {
     final title = _titleFor(context, ref);
 
+    // Publish the authoritative active branch (navigationShell.currentIndex)
+    // so backgrounded tab screens can pause off it. Deferred to a post-frame
+    // callback because a provider must not be mutated during build. This is
+    // the platform-agnostic source — the URL-derived pageContext can lag on
+    // web for StatefulShellRoute branch switches, which left the home feed
+    // playing on other tabs there.
+    final activeIndex = currentIndex;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final notifier = ref.read(activeBranchIndexProvider.notifier);
+      if (notifier.state != activeIndex) notifier.state = activeIndex;
+    });
+
     // Initialize auto-cleanup provider to ensure only one video plays at a time
     ref.watch(videoControllerAutoCleanupProvider);
 

--- a/mobile/lib/router/app_shell.dart
+++ b/mobile/lib/router/app_shell.dart
@@ -418,14 +418,15 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
                     }
                   : null,
             ),
-      body: currentIndex == 0
-          ? Column(
-              children: [
-                Expanded(child: child),
-                const UpdateBanner(),
-              ],
-            )
-          : child,
+      // Keep the branch container in the same slot regardless of tab so
+      // switching to/from home never reparents it (which would relayout all
+      // four kept-alive branches). The UpdateBanner only shows on home.
+      body: Column(
+        children: [
+          Expanded(child: child),
+          if (currentIndex == 0) const UpdateBanner(),
+        ],
+      ),
       // Bottom nav visible for all shell routes (search, tabs, etc.).
       // PointerInterceptor ensures the bottom nav receives taps on web
       // even when HTML platform views (video elements) overlap the area.
@@ -450,10 +451,14 @@ class _AppShellState extends ConsumerState<AppShell> with RouteAware {
 ///
 /// Every branch stays mounted (state preserved); the active branch is fully
 /// opaque and interactive, the others sit at opacity 0 with their tickers
-/// paused and pointer events ignored. On a tab switch the outgoing branch
-/// fades out while the incoming one fades in — a true cross-fade between two
-/// live tabs. Within-tab navigation never reaches here (those are
-/// [NoTransitionPage]s inside a single branch).
+/// paused, pointer events ignored, and — crucially — excluded from the
+/// semantics and focus trees. `Opacity`/`IgnorePointer` alone do not hide a
+/// subtree from screen readers or focus traversal, so without
+/// [ExcludeSemantics]/[ExcludeFocus] the three hidden tabs would still be
+/// announced and focusable. On a tab switch the outgoing branch fades out
+/// while the incoming one fades in — a true cross-fade between two live tabs.
+/// Within-tab navigation never reaches here (those are [NoTransitionPage]s
+/// inside a single branch).
 class AppShellBranchContainer extends StatelessWidget {
   const AppShellBranchContainer({
     required this.currentIndex,
@@ -480,9 +485,15 @@ class AppShellBranchContainer extends StatelessWidget {
           opacity: isActive ? 1 : 0,
           duration: duration,
           curve: Curves.easeInOut,
-          child: IgnorePointer(
-            ignoring: !isActive,
-            child: TickerMode(enabled: isActive, child: children[index]),
+          child: ExcludeSemantics(
+            excluding: !isActive,
+            child: ExcludeFocus(
+              excluding: !isActive,
+              child: IgnorePointer(
+                ignoring: !isActive,
+                child: TickerMode(enabled: isActive, child: children[index]),
+              ),
+            ),
           ),
         );
       }),

--- a/mobile/lib/router/navigator_keys.dart
+++ b/mobile/lib/router/navigator_keys.dart
@@ -1,54 +1,27 @@
-// ABOUTME: Navigator keys for per-tab state preservation
-// ABOUTME: Each tab has its own navigator key to maintain independent navigation stacks
+// ABOUTME: Navigator keys for the root navigator and the four shell branches
+// ABOUTME: Each bottom-nav tab is a StatefulShellBranch with its own navigator
 
 import 'package:flutter/widgets.dart';
 
-/// Navigator keys for per-tab state preservation in the app shell.
+/// Navigator keys for the app's root navigator and the four bottom-nav
+/// branches of the [StatefulShellRoute].
 ///
-/// Each key maintains a separate navigation stack, allowing tabs to preserve
-/// their state when switching between them.
+/// Each branch key identifies the [Navigator] built for that tab. Because
+/// `StatefulShellRoute` keeps every branch's navigator alive, these keys let
+/// each tab preserve its own navigation stack and state while inactive.
 class NavigatorKeys {
   /// Root navigator key for the entire app.
   static final root = GlobalKey<NavigatorState>(debugLabel: 'root');
 
-  /// Home tab navigator key.
+  /// Home tab branch navigator key.
   static final home = GlobalKey<NavigatorState>(debugLabel: 'home');
 
-  /// Explore tab navigator key for grid mode (no video index).
-  static final exploreGrid = GlobalKey<NavigatorState>(
-    debugLabel: 'explore-grid',
-  );
+  /// Explore tab branch navigator key (grid + feed routes).
+  static final explore = GlobalKey<NavigatorState>(debugLabel: 'explore');
 
-  /// Explore tab navigator key for feed mode (with video index).
-  static final exploreFeed = GlobalKey<NavigatorState>(
-    debugLabel: 'explore-feed',
-  );
-
-  /// Notifications tab navigator key.
-  static final notifications = GlobalKey<NavigatorState>(
-    debugLabel: 'notifications',
-  );
-
-  /// Inbox tab navigator key (Messages + Notifications).
+  /// Inbox tab branch navigator key (inbox + notifications routes).
   static final inbox = GlobalKey<NavigatorState>(debugLabel: 'inbox');
 
-  /// Profile tab navigator key for grid mode (no video index).
-  static final profileGrid = GlobalKey<NavigatorState>(
-    debugLabel: 'profile-grid',
-  );
-
-  /// Profile tab navigator key for feed mode (with video index).
-  static final profileFeed = GlobalKey<NavigatorState>(
-    debugLabel: 'profile-feed',
-  );
-
-  /// Liked videos navigator key for grid mode (no video index).
-  static final likedVideosGrid = GlobalKey<NavigatorState>(
-    debugLabel: 'liked-videos-grid',
-  );
-
-  /// Liked videos navigator key for feed mode (with video index).
-  static final likedVideosFeed = GlobalKey<NavigatorState>(
-    debugLabel: 'liked-videos-feed',
-  );
+  /// Profile tab branch navigator key (profile + liked-videos routes).
+  static final profile = GlobalKey<NavigatorState>(debugLabel: 'profile');
 }

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -715,3 +715,18 @@ final pageContextProvider = StreamProvider<RouteContext>((ref) async* {
     yield ctx;
   }
 });
+
+/// The globally-active route type — the tab actually on screen — independent
+/// of the per-branch [pageContextProvider] scope.
+///
+/// Inside a `StatefulShellRoute` branch, [pageContextProvider] is scoped to
+/// that branch's own route (so a kept-alive inactive branch keeps rendering
+/// its real content). A branch screen that must instead know "is *my* tab the
+/// active one?" — e.g. the home feed pausing playback when backgrounded —
+/// reads this provider, which derives from the un-scoped router location and
+/// therefore always reflects the real active tab.
+final activeRouteTypeProvider = StreamProvider<RouteType>((ref) async* {
+  await for (final loc in ref.watch(routerLocationStreamProvider)) {
+    yield parseRoute(loc).type;
+  }
+});

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -725,15 +725,3 @@ final pageContextProvider = StreamProvider<RouteContext>((ref) async* {
 /// active one?" — e.g. the home feed pausing playback when backgrounded —
 /// reads this provider, which derives from the un-scoped router location and
 /// therefore always reflects the real active tab.
-final activeRouteTypeProvider = Provider<RouteType?>((ref) {
-  // Derives from pageContextProvider rather than re-listening
-  // routerLocationStreamProvider directly (that stream is single-subscription
-  // and already consumed by pageContextProvider — a second listener throws and
-  // silently left the home feed playing on other tabs).
-  //
-  // Crucially this provider is NOT overridden per StatefulShellRoute branch (only
-  // pageContextProvider is), so Riverpod instantiates it in the root container
-  // and it always reads the *root* (global) pageContext — the genuinely active
-  // tab — even when read from inside a branch whose pageContext is scoped.
-  return ref.watch(pageContextProvider).asData?.value.type;
-});

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -725,8 +725,15 @@ final pageContextProvider = StreamProvider<RouteContext>((ref) async* {
 /// active one?" — e.g. the home feed pausing playback when backgrounded —
 /// reads this provider, which derives from the un-scoped router location and
 /// therefore always reflects the real active tab.
-final activeRouteTypeProvider = StreamProvider<RouteType>((ref) async* {
-  await for (final loc in ref.watch(routerLocationStreamProvider)) {
-    yield parseRoute(loc).type;
-  }
+final activeRouteTypeProvider = Provider<RouteType?>((ref) {
+  // Derives from pageContextProvider rather than re-listening
+  // routerLocationStreamProvider directly (that stream is single-subscription
+  // and already consumed by pageContextProvider — a second listener throws and
+  // silently left the home feed playing on other tabs).
+  //
+  // Crucially this provider is NOT overridden per StatefulShellRoute branch (only
+  // pageContextProvider is), so Riverpod instantiates it in the root container
+  // and it always reads the *root* (global) pageContext — the genuinely active
+  // tab — even when read from inside a branch whose pageContext is scoped.
+  return ref.watch(pageContextProvider).asData?.value.type;
 });

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -185,7 +185,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     if (!mounted) return;
     // Global active tab — not the branch-scoped pageContextProvider, which is
     // pinned to "home" inside the home branch and never reports leaving it.
-    final routeType = ref.read(activeRouteTypeProvider).asData?.value;
+    final routeType = ref.read(activeRouteTypeProvider);
     // Hold the current state until the route context resolves.
     if (routeType == null) return;
 

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -183,7 +183,9 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// open. See the listeners in [build] for the rationale.
   void _syncFeedActive() {
     if (!mounted) return;
-    final routeType = ref.read(pageContextProvider).asData?.value.type;
+    // Global active tab — not the branch-scoped pageContextProvider, which is
+    // pinned to "home" inside the home branch and never reports leaving it.
+    final routeType = ref.read(activeRouteTypeProvider).asData?.value;
     // Hold the current state until the route context resolves.
     if (routeType == null) return;
 
@@ -205,15 +207,15 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     // pushed routes keep this widget mounted, so playback must follow these
     // signals instead of assuming disposal handles every transition.
     //
-    // GoRouter's routeInformationProvider collapses to the shell location
-    // ("/home") while popping between pushed routes (e.g. profile → fullscreen
-    // video → pop back to profile), so the route type alone cannot tell whether
-    // the feed is actually visible. [shellObscuredProvider] — driven by
-    // AppShell's RouteAware subscription to the root navigator — supplies that
-    // missing signal: it stays true until the route directly above the shell is
-    // popped, so closing the video while the profile is still open keeps the
-    // feed paused, while a genuine return to home resumes it.
-    ref.listen(pageContextProvider, (_, _) => _syncFeedActive());
+    // Uses activeRouteTypeProvider (the *global* active tab), NOT
+    // pageContextProvider: inside the StatefulShellRoute home branch the latter
+    // is scoped to "home" and never flips when the tab is backgrounded, so it
+    // would leave the feed playing on other tabs. [shellObscuredProvider] —
+    // driven by AppShell's RouteAware subscription to the root navigator —
+    // covers the orthogonal case where a full-screen route covers the shell
+    // (e.g. profile → fullscreen video → pop back to profile), which the route
+    // type alone cannot detect.
+    ref.listen(activeRouteTypeProvider, (_, _) => _syncFeedActive());
     ref.listen(shellObscuredProvider, (_, _) => _syncFeedActive());
     ref.listen(overlayVisibilityProvider, (_, _) => _syncFeedActive());
 

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -11,6 +11,7 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
+import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
@@ -183,13 +184,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
   /// open. See the listeners in [build] for the rationale.
   void _syncFeedActive() {
     if (!mounted) return;
-    // Global active tab — not the branch-scoped pageContextProvider, which is
-    // pinned to "home" inside the home branch and never reports leaving it.
-    final routeType = ref.read(activeRouteTypeProvider);
-    // Hold the current state until the route context resolves.
-    if (routeType == null) return;
-
-    final isHomeRoute = routeType == RouteType.home;
+    // Home is the first bottom-nav branch (index 0). Use the authoritative
+    // active-branch index (set by AppShell from navigationShell) rather than
+    // the URL-derived route: the latter can lag on web for StatefulShellRoute
+    // branch switches, which left the feed playing on other tabs there.
+    final isHomeRoute = ref.read(activeBranchIndexProvider) == 0;
     final isObscured = ref.read(shellObscuredProvider);
     final hasOverlay = ref.read(overlayVisibilityProvider).hasVisibleOverlay;
 
@@ -207,15 +206,16 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
     // pushed routes keep this widget mounted, so playback must follow these
     // signals instead of assuming disposal handles every transition.
     //
-    // Uses activeRouteTypeProvider (the *global* active tab), NOT
-    // pageContextProvider: inside the StatefulShellRoute home branch the latter
-    // is scoped to "home" and never flips when the tab is backgrounded, so it
-    // would leave the feed playing on other tabs. [shellObscuredProvider] —
-    // driven by AppShell's RouteAware subscription to the root navigator —
-    // covers the orthogonal case where a full-screen route covers the shell
-    // (e.g. profile → fullscreen video → pop back to profile), which the route
-    // type alone cannot detect.
-    ref.listen(activeRouteTypeProvider, (_, _) => _syncFeedActive());
+    // Uses activeBranchIndexProvider (the authoritative active tab from
+    // navigationShell), NOT pageContextProvider: inside the StatefulShellRoute
+    // home branch the latter is scoped to "home" and never flips when the tab
+    // is backgrounded, and the URL-derived route can lag on web — both would
+    // leave the feed playing on other tabs. [shellObscuredProvider] — driven by
+    // AppShell's RouteAware subscription to the root navigator — covers the
+    // orthogonal case where a full-screen route covers the shell (e.g. profile
+    // → fullscreen video → pop back to profile), which the active tab alone
+    // cannot detect.
+    ref.listen(activeBranchIndexProvider, (_, _) => _syncFeedActive());
     ref.listen(shellObscuredProvider, (_, _) => _syncFeedActive());
     ref.listen(overlayVisibilityProvider, (_, _) => _syncFeedActive());
 

--- a/mobile/lib/screens/profile_screen_router.dart
+++ b/mobile/lib/screens/profile_screen_router.dart
@@ -28,7 +28,6 @@ import 'package:openvine/widgets/profile/blocked_user_screen.dart';
 import 'package:openvine/widgets/profile/profile_grid.dart';
 import 'package:openvine/widgets/profile/profile_loading_view.dart';
 import 'package:openvine/widgets/profile/profile_video_feed_view.dart';
-import 'package:openvine/widgets/vine_bottom_nav.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -308,10 +307,11 @@ class _ProfileScaffold extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // No bottom nav here — the enclosing AppShell provides the shared
+    // VineBottomNav for every tab (own-profile no longer bypasses the shell).
     return Scaffold(
       backgroundColor: VineTheme.surfaceBackground,
       body: body,
-      bottomNavigationBar: const VineBottomNav(currentIndex: 3),
     );
   }
 }

--- a/mobile/test/router/app_shell_tab_fade_test.dart
+++ b/mobile/test/router/app_shell_tab_fade_test.dart
@@ -1,0 +1,130 @@
+// ABOUTME: Tests AppShellBranchContainer — the cross-fade between shell tabs
+// ABOUTME: All branches stay alive; switching cross-fades; reduced motion snaps
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/router.dart';
+
+const _keys = [
+  ValueKey<String>('branch-0'),
+  ValueKey<String>('branch-1'),
+  ValueKey<String>('branch-2'),
+  ValueKey<String>('branch-3'),
+];
+
+Widget _buildSubject(ValueListenable<int> currentIndex, {bool reduce = false}) {
+  return MaterialApp(
+    home: MediaQuery(
+      data: MediaQueryData(disableAnimations: reduce),
+      child: ValueListenableBuilder<int>(
+        valueListenable: currentIndex,
+        builder: (context, index, _) => AppShellBranchContainer(
+          currentIndex: index,
+          children: [
+            for (final key in _keys) ColoredBox(key: key, color: Colors.black),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+/// Rendered opacity of the branch [key] (read off the [FadeTransition] that
+/// [AnimatedOpacity] builds internally).
+double _opacityOf(WidgetTester tester, Key key) {
+  // `.first` = the closest FadeTransition (the one AnimatedOpacity builds);
+  // the MaterialApp page transition adds another higher up.
+  final fade = tester.widget<FadeTransition>(
+    find
+        .ancestor(of: find.byKey(key), matching: find.byType(FadeTransition))
+        .first,
+  );
+  return fade.opacity.value;
+}
+
+void main() {
+  group(AppShellBranchContainer, () {
+    testWidgets('keeps every branch mounted, only the active one opaque', (
+      tester,
+    ) async {
+      final index = ValueNotifier<int>(0);
+      addTearDown(index.dispose);
+
+      await tester.pumpWidget(_buildSubject(index));
+      await tester.pumpAndSettle();
+
+      for (final key in _keys) {
+        expect(find.byKey(key), findsOneWidget); // all alive
+      }
+      expect(_opacityOf(tester, _keys[0]), 1.0);
+      expect(_opacityOf(tester, _keys[1]), 0.0);
+      expect(_opacityOf(tester, _keys[3]), 0.0);
+    });
+
+    testWidgets('cross-fades the outgoing and incoming branches on switch', (
+      tester,
+    ) async {
+      final index = ValueNotifier<int>(0);
+      addTearDown(index.dispose);
+
+      await tester.pumpWidget(_buildSubject(index));
+      await tester.pumpAndSettle();
+
+      index.value = 1;
+      await tester.pump(); // start the implicit animations
+      await tester.pump(const Duration(milliseconds: 40)); // mid (< fade dur)
+
+      expect(tester.hasRunningAnimations, isTrue);
+      final outgoing = _opacityOf(tester, _keys[0]);
+      final incoming = _opacityOf(tester, _keys[1]);
+      expect(outgoing, greaterThan(0.0));
+      expect(outgoing, lessThan(1.0));
+      expect(incoming, greaterThan(0.0));
+      expect(incoming, lessThan(1.0));
+
+      await tester.pumpAndSettle();
+      expect(_opacityOf(tester, _keys[0]), 0.0);
+      expect(_opacityOf(tester, _keys[1]), 1.0);
+      // Branches are never torn down across the switch.
+      expect(find.byKey(_keys[0]), findsOneWidget);
+    });
+
+    testWidgets('cross-fades between two non-home tabs', (tester) async {
+      final index = ValueNotifier<int>(1);
+      addTearDown(index.dispose);
+
+      await tester.pumpWidget(_buildSubject(index));
+      await tester.pumpAndSettle();
+
+      index.value = 2;
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 40)); // mid (< fade dur)
+
+      expect(_opacityOf(tester, _keys[1]), greaterThan(0.0));
+      expect(_opacityOf(tester, _keys[1]), lessThan(1.0));
+      expect(_opacityOf(tester, _keys[2]), greaterThan(0.0));
+      expect(_opacityOf(tester, _keys[2]), lessThan(1.0));
+
+      await tester.pumpAndSettle();
+      expect(_opacityOf(tester, _keys[2]), 1.0);
+    });
+
+    testWidgets('reduced motion snaps without a running animation', (
+      tester,
+    ) async {
+      final index = ValueNotifier<int>(0);
+      addTearDown(index.dispose);
+
+      await tester.pumpWidget(_buildSubject(index, reduce: true));
+      await tester.pumpAndSettle();
+
+      index.value = 2;
+      await tester.pump();
+
+      expect(tester.hasRunningAnimations, isFalse);
+      expect(_opacityOf(tester, _keys[0]), 0.0);
+      expect(_opacityOf(tester, _keys[2]), 1.0);
+    });
+  });
+}

--- a/mobile/test/router/app_shell_tab_fade_test.dart
+++ b/mobile/test/router/app_shell_tab_fade_test.dart
@@ -43,6 +43,32 @@ double _opacityOf(WidgetTester tester, Key key) {
   return fade.opacity.value;
 }
 
+/// Whether branch [key] is excluded from the semantics tree, read off the
+/// [ExcludeSemantics] that [AppShellBranchContainer] wraps each branch in.
+///
+/// Asserting the wrapper's `excluding` flag rather than querying the compiled
+/// semantics tree avoids `find.bySemanticsLabel`, which reads cached
+/// `debugSemantics` that goes stale when a subtree is dynamically excluded.
+bool _semanticsExcluded(WidgetTester tester, Key key) => tester
+    .widget<ExcludeSemantics>(
+      find
+          .ancestor(
+            of: find.byKey(key),
+            matching: find.byType(ExcludeSemantics),
+          )
+          .first,
+    )
+    .excluding;
+
+/// Whether branch [key] is excluded from focus traversal.
+bool _focusExcluded(WidgetTester tester, Key key) => tester
+    .widget<ExcludeFocus>(
+      find
+          .ancestor(of: find.byKey(key), matching: find.byType(ExcludeFocus))
+          .first,
+    )
+    .excluding;
+
 void main() {
   group(AppShellBranchContainer, () {
     testWidgets('keeps every branch mounted, only the active one opaque', (
@@ -125,6 +151,35 @@ void main() {
       expect(tester.hasRunningAnimations, isFalse);
       expect(_opacityOf(tester, _keys[0]), 0.0);
       expect(_opacityOf(tester, _keys[2]), 1.0);
+    });
+
+    testWidgets('excludes inactive branches from semantics and focus', (
+      tester,
+    ) async {
+      final index = ValueNotifier<int>(0);
+      addTearDown(index.dispose);
+
+      await tester.pumpWidget(_buildSubject(index));
+      await tester.pumpAndSettle();
+
+      // The active branch stays in the semantics/focus trees; the three
+      // opacity-0 branches are excluded so screen readers and focus traversal
+      // skip them (Opacity/IgnorePointer alone do not hide them).
+      expect(_semanticsExcluded(tester, _keys[0]), isFalse);
+      expect(_focusExcluded(tester, _keys[0]), isFalse);
+      for (final key in [_keys[1], _keys[2], _keys[3]]) {
+        expect(_semanticsExcluded(tester, key), isTrue);
+        expect(_focusExcluded(tester, key), isTrue);
+      }
+
+      index.value = 2;
+      await tester.pumpAndSettle();
+
+      // Exclusion follows the active branch after a switch.
+      expect(_semanticsExcluded(tester, _keys[2]), isFalse);
+      expect(_focusExcluded(tester, _keys[2]), isFalse);
+      expect(_semanticsExcluded(tester, _keys[0]), isTrue);
+      expect(_focusExcluded(tester, _keys[0]), isTrue);
     });
   });
 }

--- a/mobile/test/router/branch_scoped_context_test.dart
+++ b/mobile/test/router/branch_scoped_context_test.dart
@@ -31,7 +31,7 @@ class _Probe extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     // Scoped: this branch's own route. Global: the actually-active tab.
     final scoped = ref.watch(pageContextProvider).asData?.value.type;
-    final active = ref.watch(activeRouteTypeProvider).asData?.value;
+    final active = ref.watch(activeRouteTypeProvider);
     return Text(
       '$label scoped=${scoped?.name ?? 'none'} active=${active?.name ?? 'none'}',
       textDirection: TextDirection.ltr,
@@ -76,6 +76,49 @@ GoRouter _buildRouter() => GoRouter(
 );
 
 void main() {
+  // Regression: activeRouteTypeProvider must not add a second listener to the
+  // single-subscription routerLocationStreamProvider (already consumed by the
+  // global pageContextProvider). If it does, the second listen throws and the
+  // home feed silently keeps playing on other tabs.
+  testWidgets('global pageContext and activeRouteType coexist', (tester) async {
+    final router = GoRouter(
+      initialLocation: '/home/0',
+      routes: [
+        GoRoute(
+          path: '/home/:index',
+          builder: (_, _) => const SizedBox.shrink(),
+        ),
+        GoRoute(path: '/explore', builder: (_, _) => const SizedBox.shrink()),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    RouteType? ctxType;
+    RouteType? activeType;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [goRouterProvider.overrideWithValue(router)],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (context, child) => Consumer(
+            builder: (context, ref, _) {
+              // Both global providers read at once — the broken version makes
+              // the second one throw "Stream already listened".
+              ctxType = ref.watch(pageContextProvider).asData?.value.type;
+              activeType = ref.watch(activeRouteTypeProvider);
+              return child!;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(ctxType, RouteType.home);
+    expect(activeType, RouteType.home);
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets(
     'inactive branch keeps its scoped context; active type stays global',
     (tester) async {
@@ -84,8 +127,9 @@ void main() {
 
       await tester.pumpWidget(
         ProviderScope(
-          // activeRouteTypeProvider derives from goRouterProvider, so point it
-          // at the test router.
+          // pageContextProvider (which activeRouteTypeProvider derives from)
+          // resolves the router location via goRouterProvider, so point it at
+          // the test router.
           overrides: [goRouterProvider.overrideWithValue(router)],
           child: MaterialApp.router(routerConfig: router),
         ),

--- a/mobile/test/router/branch_scoped_context_test.dart
+++ b/mobile/test/router/branch_scoped_context_test.dart
@@ -1,0 +1,112 @@
+// ABOUTME: Proves each StatefulShellRoute branch sees its own scoped pageContext
+// ABOUTME: while activeRouteTypeProvider stays global (so feeds can pause)
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/router/router.dart';
+
+/// Mirrors `_branchPage` in app_router.dart: scopes [pageContextProvider] to
+/// this branch's own route so it doesn't read the globally-active route.
+Page<void> _scopedPage(GoRouterState st, Widget child) =>
+    NoTransitionPage<void>(
+      key: st.pageKey,
+      child: ProviderScope(
+        overrides: [
+          pageContextProvider.overrideWith(
+            (ref) => Stream<RouteContext>.value(parseRoute(st.uri.toString())),
+          ),
+        ],
+        child: child,
+      ),
+    );
+
+class _Probe extends ConsumerWidget {
+  const _Probe(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Scoped: this branch's own route. Global: the actually-active tab.
+    final scoped = ref.watch(pageContextProvider).asData?.value.type;
+    final active = ref.watch(activeRouteTypeProvider).asData?.value;
+    return Text(
+      '$label scoped=${scoped?.name ?? 'none'} active=${active?.name ?? 'none'}',
+      textDirection: TextDirection.ltr,
+    );
+  }
+}
+
+GoRouter _buildRouter() => GoRouter(
+  initialLocation: '/home/0',
+  routes: [
+    StatefulShellRoute(
+      builder: (context, state, shell) => shell,
+      navigatorContainerBuilder: (context, shell, children) =>
+          AppShellBranchContainer(
+            currentIndex: shell.currentIndex,
+            children: children,
+          ),
+      branches: [
+        StatefulShellBranch(
+          initialLocation: '/home/0',
+          routes: [
+            GoRoute(
+              path: '/home/:index',
+              pageBuilder: (context, state) =>
+                  _scopedPage(state, const _Probe('home')),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          initialLocation: '/explore',
+          routes: [
+            GoRoute(
+              path: '/explore',
+              pageBuilder: (context, state) =>
+                  _scopedPage(state, const _Probe('explore')),
+            ),
+          ],
+        ),
+      ],
+    ),
+  ],
+);
+
+void main() {
+  testWidgets(
+    'inactive branch keeps its scoped context; active type stays global',
+    (tester) async {
+      final router = _buildRouter();
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          // activeRouteTypeProvider derives from goRouterProvider, so point it
+          // at the test router.
+          overrides: [goRouterProvider.overrideWithValue(router)],
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // On home: home branch sees its own route AND is the active tab.
+      expect(find.text('home scoped=home active=home'), findsOneWidget);
+
+      router.go('/explore');
+      await tester.pumpAndSettle();
+
+      // Active branch: its own route, and it is the active tab.
+      expect(
+        find.text('explore scoped=explore active=explore'),
+        findsOneWidget,
+      );
+      // Kept-alive home branch: still renders its OWN content (scoped=home) so
+      // the cross-fade has something to dissolve, but knows it is NOT the
+      // active tab (active=explore) — which is what lets the home feed pause.
+      expect(find.text('home scoped=home active=explore'), findsOneWidget);
+    },
+  );
+}

--- a/mobile/test/router/branch_scoped_context_test.dart
+++ b/mobile/test/router/branch_scoped_context_test.dart
@@ -15,7 +15,7 @@ Page<void> _scopedPage(GoRouterState st, Widget child) =>
       child: ProviderScope(
         overrides: [
           pageContextProvider.overrideWith(
-            (ref) => Stream<RouteContext>.value(parseRoute(st.uri.toString())),
+            (ref) => Stream<RouteContext>.value(parseRoute(st.uri.path)),
           ),
         ],
         child: child,
@@ -96,5 +96,62 @@ void main() {
     // NOT blank to the active 'explore' route) — that is what gives the
     // cross-fade two live tabs to dissolve between.
     expect(find.text('home scoped=home'), findsOneWidget);
+  });
+
+  testWidgets('branch-scoped pageContext ignores query parameters', (
+    tester,
+  ) async {
+    RouteContext? captured;
+    final router = GoRouter(
+      initialLocation:
+          '/profile/npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqlz5yt?utm_source=test',
+      routes: [
+        StatefulShellRoute(
+          builder: (context, state, shell) => shell,
+          navigatorContainerBuilder: (context, shell, children) =>
+              AppShellBranchContainer(
+                currentIndex: shell.currentIndex,
+                children: children,
+              ),
+          branches: [
+            StatefulShellBranch(
+              initialLocation: '/profile/me',
+              routes: [
+                GoRoute(
+                  path: '/profile/:npub',
+                  pageBuilder: (context, state) => _scopedPage(
+                    state,
+                    Consumer(
+                      builder: (context, ref, _) {
+                        final ctx = ref
+                            .watch(pageContextProvider)
+                            .asData
+                            ?.value;
+                        if (ctx != null) captured = ctx;
+                        return const SizedBox();
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(child: MaterialApp.router(routerConfig: router)),
+    );
+    await tester.pumpAndSettle();
+
+    final ctx = captured;
+    expect(ctx, isNotNull);
+    expect(ctx!.type, RouteType.profile);
+    expect(
+      ctx.npub,
+      'npub1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqlz5yt',
+    );
   });
 }

--- a/mobile/test/router/branch_scoped_context_test.dart
+++ b/mobile/test/router/branch_scoped_context_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Proves each StatefulShellRoute branch sees its own scoped pageContext
-// ABOUTME: while activeRouteTypeProvider stays global (so feeds can pause)
+// ABOUTME: so a kept-alive inactive branch keeps rendering its real content
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -29,11 +29,9 @@ class _Probe extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // Scoped: this branch's own route. Global: the actually-active tab.
     final scoped = ref.watch(pageContextProvider).asData?.value.type;
-    final active = ref.watch(activeRouteTypeProvider);
     return Text(
-      '$label scoped=${scoped?.name ?? 'none'} active=${active?.name ?? 'none'}',
+      '$label scoped=${scoped?.name ?? 'none'}',
       textDirection: TextDirection.ltr,
     );
   }
@@ -76,81 +74,27 @@ GoRouter _buildRouter() => GoRouter(
 );
 
 void main() {
-  // Regression: activeRouteTypeProvider must not add a second listener to the
-  // single-subscription routerLocationStreamProvider (already consumed by the
-  // global pageContextProvider). If it does, the second listen throws and the
-  // home feed silently keeps playing on other tabs.
-  testWidgets('global pageContext and activeRouteType coexist', (tester) async {
-    final router = GoRouter(
-      initialLocation: '/home/0',
-      routes: [
-        GoRoute(
-          path: '/home/:index',
-          builder: (_, _) => const SizedBox.shrink(),
-        ),
-        GoRoute(path: '/explore', builder: (_, _) => const SizedBox.shrink()),
-      ],
-    );
+  testWidgets('an inactive branch keeps its own scoped pageContext', (
+    tester,
+  ) async {
+    final router = _buildRouter();
     addTearDown(router.dispose);
 
-    RouteType? ctxType;
-    RouteType? activeType;
     await tester.pumpWidget(
-      ProviderScope(
-        overrides: [goRouterProvider.overrideWithValue(router)],
-        child: MaterialApp.router(
-          routerConfig: router,
-          builder: (context, child) => Consumer(
-            builder: (context, ref, _) {
-              // Both global providers read at once — the broken version makes
-              // the second one throw "Stream already listened".
-              ctxType = ref.watch(pageContextProvider).asData?.value.type;
-              activeType = ref.watch(activeRouteTypeProvider);
-              return child!;
-            },
-          ),
-        ),
-      ),
+      ProviderScope(child: MaterialApp.router(routerConfig: router)),
     );
     await tester.pumpAndSettle();
 
-    expect(ctxType, RouteType.home);
-    expect(activeType, RouteType.home);
-    expect(tester.takeException(), isNull);
+    expect(find.text('home scoped=home'), findsOneWidget);
+
+    router.go('/explore');
+    await tester.pumpAndSettle();
+
+    // The newly active branch shows its own context...
+    expect(find.text('explore scoped=explore'), findsOneWidget);
+    // ...and the kept-alive home branch STILL renders its OWN content (it did
+    // NOT blank to the active 'explore' route) — that is what gives the
+    // cross-fade two live tabs to dissolve between.
+    expect(find.text('home scoped=home'), findsOneWidget);
   });
-
-  testWidgets(
-    'inactive branch keeps its scoped context; active type stays global',
-    (tester) async {
-      final router = _buildRouter();
-      addTearDown(router.dispose);
-
-      await tester.pumpWidget(
-        ProviderScope(
-          // pageContextProvider (which activeRouteTypeProvider derives from)
-          // resolves the router location via goRouterProvider, so point it at
-          // the test router.
-          overrides: [goRouterProvider.overrideWithValue(router)],
-          child: MaterialApp.router(routerConfig: router),
-        ),
-      );
-      await tester.pumpAndSettle();
-
-      // On home: home branch sees its own route AND is the active tab.
-      expect(find.text('home scoped=home active=home'), findsOneWidget);
-
-      router.go('/explore');
-      await tester.pumpAndSettle();
-
-      // Active branch: its own route, and it is the active tab.
-      expect(
-        find.text('explore scoped=explore active=explore'),
-        findsOneWidget,
-      );
-      // Kept-alive home branch: still renders its OWN content (scoped=home) so
-      // the cross-fade has something to dissolve, but knows it is NOT the
-      // active tab (active=explore) — which is what lets the home feed pause.
-      expect(find.text('home scoped=home active=explore'), findsOneWidget);
-    },
-  );
 }

--- a/mobile/test/router/category_route_test.dart
+++ b/mobile/test/router/category_route_test.dart
@@ -20,15 +20,5 @@ void main() {
       expect(context.categoryName, 'animals');
       expect(context.videoIndex, isNull);
     });
-
-    test(
-      'tabIndexFromLocation hides bottom nav for category gallery routes',
-      () {
-        expect(
-          tabIndexFromLocation(CategoryGalleryScreen.locationFor('animals')),
-          -1,
-        );
-      },
-    );
   });
 }

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -108,10 +108,6 @@ void main() {
         expect(context.type, RouteType.invites);
       });
 
-      test('${InvitesScreen.path} is treated as a non-tab route', () {
-        expect(tabIndexFromLocation(InvitesScreen.path), -1);
-      });
-
       test('${BadgesScreen.path} parses to RouteType.badges', () {
         final context = parseRoute(BadgesScreen.path);
         expect(context.type, RouteType.badges);
@@ -122,25 +118,15 @@ void main() {
         expect(path, BadgesScreen.path);
       });
 
-      test('${BadgesScreen.path} is treated as a non-tab route', () {
-        expect(tabIndexFromLocation(BadgesScreen.path), -1);
+      test('${NostrSettingsScreen.path} parses to RouteType.nostrSettings', () {
+        final context = parseRoute(NostrSettingsScreen.path);
+        expect(context.type, RouteType.nostrSettings);
       });
 
-      test(
-        '${NostrSettingsScreen.path} parses to RouteType.nostrSettings',
-        () {
-          final context = parseRoute(NostrSettingsScreen.path);
-          expect(context.type, RouteType.nostrSettings);
-        },
-      );
-
-      test(
-        '${Nip05SettingsScreen.path} parses to RouteType.nip05Settings',
-        () {
-          final context = parseRoute(Nip05SettingsScreen.path);
-          expect(context.type, RouteType.nip05Settings);
-        },
-      );
+      test('${Nip05SettingsScreen.path} parses to RouteType.nip05Settings', () {
+        final context = parseRoute(Nip05SettingsScreen.path);
+        expect(context.type, RouteType.nip05Settings);
+      });
 
       test(
         '${Nip05SettingsScreen.path} round-trips through buildRoute(parseRoute())',
@@ -206,22 +192,6 @@ void main() {
         );
         expect(path, AppDetailScreen.pathForSlug('primal'));
       });
-    });
-
-    group('Apps routes hide the bottom nav', () {
-      test('${AppsDirectoryScreen.path} is treated as a non-tab route', () {
-        expect(tabIndexFromLocation(AppsDirectoryScreen.path), -1);
-      });
-
-      test(
-        '${AppDetailScreen.pathForSlug('primal')} is treated as a non-tab route',
-        () {
-          expect(
-            tabIndexFromLocation(AppDetailScreen.pathForSlug('primal')),
-            -1,
-          );
-        },
-      );
     });
 
     group('Tab routes parse correctly', () {
@@ -359,15 +329,12 @@ void main() {
         },
       );
 
-      test(
-        '/people-lists/list%3A123/add-people parses to '
-        'RouteType.peopleListAddPeople',
-        () {
-          final context = parseRoute('/people-lists/list%3A123/add-people');
-          expect(context.type, RouteType.peopleListAddPeople);
-          expect(context.listId, 'list:123');
-        },
-      );
+      test('/people-lists/list%3A123/add-people parses to '
+          'RouteType.peopleListAddPeople', () {
+        final context = parseRoute('/people-lists/list%3A123/add-people');
+        expect(context.type, RouteType.peopleListAddPeople);
+        expect(context.listId, 'list:123');
+      });
     });
 
     group('Standalone routes parse correctly', () {

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/explore/explore_screen.dart';
@@ -605,26 +606,30 @@ void main() {
         ).read(shellObscuredProvider.notifier).setObscured(obscured: obscured);
       }
 
+      // Drives the authoritative active tab (0 = Home) the home feed pauses on.
+      void setBranchIndex(WidgetTester tester, int index) {
+        containerOf(tester).read(activeBranchIndexProvider.notifier).state =
+            index;
+      }
+
       testWidgets(
-        'stays paused when GoRouter falsely reports "home" while a route still '
-        'covers the shell',
+        'stays paused while a route covers the shell, even on the home tab',
         (tester) async {
-          final controller = await pumpFeed(tester);
+          await pumpFeed(tester);
 
           // Feed starts active on the home tab.
-          controller.add('/home/0');
           await tester.pump();
           expect(feedVideos(tester).isActive, isTrue);
 
-          // Open a profile (full-screen route covers the shell): feed pauses.
+          // A full-screen route covers the shell: feed pauses.
           setObscured(tester, obscured: true);
           await tester.pump();
           expect(feedVideos(tester).isActive, isFalse);
 
-          // Closing a fullscreen video opened from the profile pops back to the
-          // profile, where GoRouter emits the shell location "/home". The
-          // profile still covers the shell, so the feed must NOT resume.
-          controller.add('/home/0');
+          // Home is still the active branch (e.g. a fullscreen video opened
+          // from the profile is popped back to the still-covering profile), but
+          // the shell stays covered, so the feed must NOT resume.
+          setBranchIndex(tester, 0);
           await tester.pump();
           expect(feedVideos(tester).isActive, isFalse);
 
@@ -635,8 +640,7 @@ void main() {
       testWidgets(
         'resumes only once the shell is no longer covered',
         (tester) async {
-          final controller = await pumpFeed(tester);
-          controller.add('/home/0');
+          await pumpFeed(tester);
           await tester.pump();
           expect(feedVideos(tester).isActive, isTrue);
 
@@ -645,8 +649,8 @@ void main() {
           await tester.pump();
           expect(feedVideos(tester).isActive, isFalse);
 
-          // Profile closed (shell revealed) while the route reports home:
-          // the feed resumes.
+          // Profile closed (shell revealed) while home is still the active
+          // branch: the feed resumes.
           setObscured(tester, obscured: false);
           await tester.pump();
           expect(feedVideos(tester).isActive, isTrue);
@@ -655,19 +659,18 @@ void main() {
         },
       );
 
-      testWidgets('pauses on a non-home route and resumes back on home', (
+      testWidgets('pauses on a non-home tab and resumes back on home', (
         tester,
       ) async {
-        final controller = await pumpFeed(tester);
-        controller.add('/home/0');
+        await pumpFeed(tester);
         await tester.pump();
         expect(feedVideos(tester).isActive, isTrue);
 
-        controller.add('/explore');
+        setBranchIndex(tester, 1); // Explore
         await tester.pump();
         expect(feedVideos(tester).isActive, isFalse);
 
-        controller.add('/home/0');
+        setBranchIndex(tester, 0); // back to Home
         await tester.pump();
         expect(feedVideos(tester).isActive, isTrue);
 


### PR DESCRIPTION
Closes #5316

## Description

Migrates the bottom-nav shell from `ShellRoute` to `StatefulShellRoute` so all four tabs (Home, Explore, Inbox, Profile) stay alive and tab switches cross-fade between live branch contents instead of rebuilding or fading a stale snapshot.

Key pieces:
- `StatefulShellRoute` with four branch navigators, one per bottom-nav tab.
- Per-branch `pageContextProvider` scope in `_branchPage`, so kept-alive inactive branches continue rendering their own route context.
- `AppShellBranchContainer` cross-fades active/inactive branches while disabling pointer, focus, semantics, and tickers for inactive branches; reduced motion snaps to zero duration.
- `activeBranchIndexProvider` drives home feed playback pause/resume from the authoritative `navigationShell.currentIndex`, while `shellObscuredProvider` still handles full-screen routes covering the shell.
- Profile and app shell ownership is simplified so the shell owns the shared bottom nav for all tab routes.
- Review follow-up: branch-scoped route parsing now uses `state.uri.path` so query-bearing deep links do not contaminate `RouteContext`, and the orphaned old `tabIndexFromLocation` helper/tests were removed.

## Linked Issue

Closes #5316.

## Example after every tab was open

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/21d0fe31-a9e0-4ce9-b0a1-91a4dd5da680" width="300" controls></video> | <video src="https://github.com/user-attachments/assets/ba35f508-1bbc-49fd-a370-9e2d42f8c2b8" width="300" controls></video> |

## Out of Scope

- Memory tradeoff: keeping all four tabs alive holds the branch trees after first visit. Inactive branches are not interactive, semantic, focused, or ticking.
- No broader `parseRoute` query normalization in this PR; this fix is limited to the new branch-scoped call site to avoid changing global route-normalization query behavior.

## Verification

- `mise exec -- flutter test test/router/app_shell_tab_fade_test.dart test/router/branch_scoped_context_test.dart test/router/route_coverage_test.dart test/router/category_route_test.dart`
- `mise exec -- flutter analyze lib test integration_test`
- `mise exec -- flutter test test/screens/feed/video_feed_page_test.dart`
- Pre-push hook: merge-conflict check against main, analyze, and changed-file tests all passed.

## Type of Change

- [x] Feature
- [x] Bug fix / review follow-up
