### PR TITLE
fix(library): truncate library toolbar title to a single line

### DIFF
--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -607,6 +607,8 @@ class _LibraryToolbar extends StatelessWidget {
               child: Text(
                 context.l10n.profileMyLibraryLabel,
                 style: VineTheme.titleMediumFont(),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
             ),
           ),

--- a/mobile/lib/screens/library_screen.dart
+++ b/mobile/lib/screens/library_screen.dart
@@ -471,7 +471,7 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
                   child: Column(
                     children: [
                       if (!widget.selectionMode)
-                        _LibraryToolbar(
+                        LibraryToolbar(
                           isLibrarySelectionMode: isLibrarySelectionMode,
                           canExitSelectionMode: !selectionLockedToCloseOnly,
                           isClipsTabActive: isClipsTabActive,
@@ -559,91 +559,6 @@ class _LibraryViewState extends ConsumerState<_LibraryView>
             ],
           );
         },
-      ),
-    );
-  }
-}
-
-class _LibraryToolbar extends StatelessWidget {
-  const _LibraryToolbar({
-    required this.isLibrarySelectionMode,
-    required this.canExitSelectionMode,
-    required this.isClipsTabActive,
-    required this.onLeadingPressed,
-    required this.onOpenSortMenu,
-    required this.onEnterSelectionMode,
-    required this.onOpenTrash,
-    this.onDeleteSelectedClips,
-  });
-
-  final bool isLibrarySelectionMode;
-  final bool canExitSelectionMode;
-  final bool isClipsTabActive;
-  final VoidCallback onLeadingPressed;
-  final VoidCallback onOpenSortMenu;
-  final VoidCallback onEnterSelectionMode;
-  final VoidCallback onOpenTrash;
-  final VoidCallback? onDeleteSelectedClips;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(16),
-      child: Row(
-        spacing: 8,
-        children: [
-          DivineIconButton(
-            size: .small,
-            type: .secondary,
-            icon: isLibrarySelectionMode ? .x : .caretLeft,
-            semanticLabel: isLibrarySelectionMode && canExitSelectionMode
-                ? context.l10n.commonCancel
-                : null,
-            onPressed: onLeadingPressed,
-          ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Text(
-                context.l10n.profileMyLibraryLabel,
-                style: VineTheme.titleMediumFont(),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-            ),
-          ),
-          if (isClipsTabActive) ...[
-            if (!isLibrarySelectionMode)
-              DivineIconButton(
-                size: .small,
-                type: .secondary,
-                icon: .trash,
-                semanticLabel: context.l10n.libraryTrashEntryLabel,
-                onPressed: onOpenTrash,
-              ),
-            DivineIconButton(
-              size: .small,
-              type: .secondary,
-              icon: .funnelSimple,
-              onPressed: onOpenSortMenu,
-            ),
-            if (!isLibrarySelectionMode)
-              DivineButton(
-                size: .small,
-                type: .secondary,
-                label: context.l10n.librarySelect,
-                onPressed: onEnterSelectionMode,
-              ),
-            if (isLibrarySelectionMode)
-              DivineIconButton(
-                size: .small,
-                type: .error,
-                icon: .trash,
-                semanticLabel: context.l10n.commonDelete,
-                onPressed: onDeleteSelectedClips,
-              ),
-          ],
-        ],
       ),
     );
   }

--- a/mobile/lib/widgets/library/library.dart
+++ b/mobile/lib/widgets/library/library.dart
@@ -4,4 +4,5 @@
 export 'clips_tab.dart';
 export 'drafts_tab.dart';
 export 'empty_library_state.dart';
+export 'library_toolbar.dart';
 export 'sounds_tab.dart';

--- a/mobile/lib/widgets/library/library_toolbar.dart
+++ b/mobile/lib/widgets/library/library_toolbar.dart
@@ -1,0 +1,92 @@
+// ABOUTME: Toolbar for the library screen with navigation and clip actions
+// ABOUTME: Keeps library header actions separate from LibraryScreen wiring
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+class LibraryToolbar extends StatelessWidget {
+  const LibraryToolbar({
+    required this.isLibrarySelectionMode,
+    required this.canExitSelectionMode,
+    required this.isClipsTabActive,
+    required this.onLeadingPressed,
+    required this.onOpenSortMenu,
+    required this.onEnterSelectionMode,
+    required this.onOpenTrash,
+    this.onDeleteSelectedClips,
+    super.key,
+  });
+
+  final bool isLibrarySelectionMode;
+  final bool canExitSelectionMode;
+  final bool isClipsTabActive;
+  final VoidCallback onLeadingPressed;
+  final VoidCallback onOpenSortMenu;
+  final VoidCallback onEnterSelectionMode;
+  final VoidCallback onOpenTrash;
+  final VoidCallback? onDeleteSelectedClips;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        spacing: 8,
+        children: [
+          DivineIconButton(
+            size: .small,
+            type: .secondary,
+            icon: isLibrarySelectionMode ? .x : .caretLeft,
+            semanticLabel: isLibrarySelectionMode && canExitSelectionMode
+                ? context.l10n.commonCancel
+                : null,
+            onPressed: onLeadingPressed,
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: Text(
+                context.l10n.profileMyLibraryLabel,
+                style: VineTheme.titleMediumFont(),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ),
+          if (isClipsTabActive) ...[
+            if (!isLibrarySelectionMode)
+              DivineIconButton(
+                size: .small,
+                type: .secondary,
+                icon: .trash,
+                semanticLabel: context.l10n.libraryTrashEntryLabel,
+                onPressed: onOpenTrash,
+              ),
+            DivineIconButton(
+              size: .small,
+              type: .secondary,
+              icon: .funnelSimple,
+              onPressed: onOpenSortMenu,
+            ),
+            if (!isLibrarySelectionMode)
+              DivineButton(
+                size: .small,
+                type: .secondary,
+                label: context.l10n.librarySelect,
+                onPressed: onEnterSelectionMode,
+              ),
+            if (isLibrarySelectionMode)
+              DivineIconButton(
+                size: .small,
+                type: .error,
+                icon: .trash,
+                semanticLabel: context.l10n.commonDelete,
+                onPressed: onDeleteSelectedClips,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -101,20 +101,6 @@ void main() {
         expect(find.text(en.libraryTabClips), findsOneWidget);
       });
 
-      testWidgets('toolbar title is limited to a single line with ellipsis', (
-        tester,
-      ) async {
-        await tester.pumpWidget(buildWidget());
-        await tester.pump();
-
-        final titleFinder = find.text(en.profileMyLibraryLabel);
-        expect(titleFinder, findsOneWidget);
-
-        final title = tester.widget<Text>(titleFinder);
-        expect(title.maxLines, equals(1));
-        expect(title.overflow, equals(TextOverflow.ellipsis));
-      });
-
       testWidgets('$DraftsTab initially (first tab)', (tester) async {
         await tester.pumpWidget(buildWidget());
         await tester.pumpAndSettle();

--- a/mobile/test/screens/library_screen_test.dart
+++ b/mobile/test/screens/library_screen_test.dart
@@ -101,6 +101,20 @@ void main() {
         expect(find.text(en.libraryTabClips), findsOneWidget);
       });
 
+      testWidgets('toolbar title is limited to a single line with ellipsis', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pump();
+
+        final titleFinder = find.text(en.profileMyLibraryLabel);
+        expect(titleFinder, findsOneWidget);
+
+        final title = tester.widget<Text>(titleFinder);
+        expect(title.maxLines, equals(1));
+        expect(title.overflow, equals(TextOverflow.ellipsis));
+      });
+
       testWidgets('$DraftsTab initially (first tab)', (tester) async {
         await tester.pumpWidget(buildWidget());
         await tester.pumpAndSettle();

--- a/mobile/test/widgets/library/library_toolbar_test.dart
+++ b/mobile/test/widgets/library/library_toolbar_test.dart
@@ -1,0 +1,174 @@
+// ABOUTME: Tests for LibraryToolbar widget
+// ABOUTME: Covers title truncation, conditional actions, and button callbacks
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/widgets/library/library_toolbar.dart';
+
+void main() {
+  final en = AppLocalizationsEn();
+
+  group(LibraryToolbar, () {
+    Finder iconButton(DivineIconName icon) => find.byWidgetPredicate(
+      (widget) => widget is DivineIconButton && widget.icon == icon,
+    );
+
+    Widget buildWidget({
+      bool isLibrarySelectionMode = false,
+      bool canExitSelectionMode = true,
+      bool isClipsTabActive = true,
+      VoidCallback? onLeadingPressed,
+      VoidCallback? onOpenSortMenu,
+      VoidCallback? onEnterSelectionMode,
+      VoidCallback? onOpenTrash,
+      VoidCallback? onDeleteSelectedClips,
+    }) {
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        theme: VineTheme.theme,
+        home: Scaffold(
+          body: LibraryToolbar(
+            isLibrarySelectionMode: isLibrarySelectionMode,
+            canExitSelectionMode: canExitSelectionMode,
+            isClipsTabActive: isClipsTabActive,
+            onLeadingPressed: onLeadingPressed ?? () {},
+            onOpenSortMenu: onOpenSortMenu ?? () {},
+            onEnterSelectionMode: onEnterSelectionMode ?? () {},
+            onOpenTrash: onOpenTrash ?? () {},
+            onDeleteSelectedClips: onDeleteSelectedClips,
+          ),
+        ),
+      );
+    }
+
+    group('renders', () {
+      testWidgets('displays the library title', (tester) async {
+        await tester.pumpWidget(buildWidget());
+
+        expect(find.text(en.profileMyLibraryLabel), findsOneWidget);
+      });
+
+      testWidgets('title is limited to a single line with ellipsis', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+
+        final title = tester.widget<Text>(
+          find.text(en.profileMyLibraryLabel),
+        );
+        expect(title.maxLines, equals(1));
+        expect(title.overflow, equals(TextOverflow.ellipsis));
+      });
+
+      testWidgets('shows back leading icon outside selection mode', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+
+        expect(iconButton(DivineIconName.caretLeft), findsOneWidget);
+        expect(iconButton(DivineIconName.x), findsNothing);
+      });
+
+      testWidgets('shows close leading icon in selection mode', (tester) async {
+        await tester.pumpWidget(buildWidget(isLibrarySelectionMode: true));
+
+        expect(iconButton(DivineIconName.x), findsOneWidget);
+        expect(iconButton(DivineIconName.caretLeft), findsNothing);
+        expect(find.bySemanticsLabel(en.commonCancel), findsOneWidget);
+      });
+
+      testWidgets('hides clip actions when clips tab is inactive', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(isClipsTabActive: false));
+
+        expect(find.text(en.librarySelect), findsNothing);
+        expect(iconButton(DivineIconName.funnelSimple), findsNothing);
+        expect(iconButton(DivineIconName.trash), findsNothing);
+      });
+
+      testWidgets('shows clip actions when clips tab is active', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+
+        expect(find.text(en.librarySelect), findsOneWidget);
+        expect(iconButton(DivineIconName.funnelSimple), findsOneWidget);
+        expect(
+          find.bySemanticsLabel(en.libraryTrashEntryLabel),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('swaps Select for delete in selection mode', (tester) async {
+        await tester.pumpWidget(buildWidget(isLibrarySelectionMode: true));
+
+        expect(find.text(en.librarySelect), findsNothing);
+        expect(find.bySemanticsLabel(en.commonDelete), findsOneWidget);
+      });
+    });
+
+    group('interactions', () {
+      testWidgets('leading button triggers onLeadingPressed', (tester) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(onLeadingPressed: () => pressed = true),
+        );
+
+        await tester.tap(iconButton(DivineIconName.caretLeft));
+        expect(pressed, isTrue);
+      });
+
+      testWidgets('sort button triggers onOpenSortMenu', (tester) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(onOpenSortMenu: () => pressed = true),
+        );
+
+        await tester.tap(iconButton(DivineIconName.funnelSimple));
+        expect(pressed, isTrue);
+      });
+
+      testWidgets('Select button triggers onEnterSelectionMode', (
+        tester,
+      ) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(onEnterSelectionMode: () => pressed = true),
+        );
+
+        await tester.tap(find.text(en.librarySelect));
+        expect(pressed, isTrue);
+      });
+
+      testWidgets('trash button triggers onOpenTrash', (tester) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(onOpenTrash: () => pressed = true),
+        );
+
+        await tester.tap(iconButton(DivineIconName.trash));
+        expect(pressed, isTrue);
+      });
+
+      testWidgets('delete button triggers onDeleteSelectedClips', (
+        tester,
+      ) async {
+        var pressed = false;
+        await tester.pumpWidget(
+          buildWidget(
+            isLibrarySelectionMode: true,
+            onDeleteSelectedClips: () => pressed = true,
+          ),
+        );
+
+        await tester.tap(iconButton(DivineIconName.trash));
+        expect(pressed, isTrue);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes #5321

## Description

Fixes the library header title and tidies up the toolbar:

- **Title truncation** — the library toolbar title sat in an `Expanded`
  with no `maxLines`/`overflow`, so a longer localized title could wrap to
  two lines and unbalance the header row. It is now constrained to a single
  line with an ellipsis (`maxLines: 1`, `overflow: TextOverflow.ellipsis`),
  matching the shared `DiVineAppBar` title behavior.
- **Toolbar extraction** — the inline `_LibraryToolbar` is extracted into a
  reusable `LibraryToolbar` widget under `lib/widgets/library/`, keeping the
  header actions separate from `LibraryScreen` wiring.
- **Dedicated tests** — `LibraryToolbar` now has its own test file
  (`test/widgets/library/library_toolbar_test.dart`), mirroring its sibling
  library widgets: title truncation, conditional clip actions, the leading
  icon swap in selection mode, and every button callback.

**Related Issue:** 

| Before | After |
| ------ | ------ |
|        <img width="945" height="2048" alt="Before" src="https://github.com/user-attachments/assets/20aa0b7f-a904-45e9-ab77-d23fddadd5bd" />   |          <img width="945" height="2048" alt="After" src="https://github.com/user-attachments/assets/3c55c5c2-c9d2-4c16-8639-cd5bf996fbc7" />   |

## Out of Scope

None.

## Verification

- `flutter analyze` on the changed lib/test files — no issues
- `flutter test test/widgets/library/library_toolbar_test.dart test/screens/library_screen_test.dart` — all pass

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor