### PR TITLE
style(design-system): migrate the DiscoverLists subscribe toggle to DivineIcon (#4803)

### DIFF
--- a/mobile/lib/screens/discover_lists_screen.dart
+++ b/mobile/lib/screens/discover_lists_screen.dart
@@ -611,9 +611,14 @@ class _DiscoverListsScreenState extends ConsumerState<DiscoverListsScreen>
                           borderRadius: BorderRadius.circular(20),
                         ),
                       ),
-                      child: Icon(
-                        isSubscribed ? Icons.check : Icons.add,
+                      child: DivineIcon(
+                        icon: isSubscribed
+                            ? DivineIconName.check
+                            : DivineIconName.plus,
                         size: 20,
+                        color: isSubscribed
+                            ? VineTheme.vineGreen
+                            : VineTheme.backgroundColor,
                       ),
                     ),
                   ),

--- a/mobile/scripts/baseline/raw_icons.txt
+++ b/mobile/scripts/baseline/raw_icons.txt
@@ -13,7 +13,7 @@ lib/screens/comments/comments_screen.dart	3
 lib/screens/comments/widgets/comments_empty_state.dart	1
 lib/screens/creator_analytics_screen.dart	9
 lib/screens/curated_list_feed_screen.dart	2
-lib/screens/discover_lists_screen.dart	4
+lib/screens/discover_lists_screen.dart	2
 lib/screens/feed/video_feed_page.dart	1
 lib/screens/followers/my_followers_screen.dart	1
 lib/screens/followers/others_followers_screen.dart	1


### PR DESCRIPTION
## Description

Continues the `Icons.* → DivineIcon` migration (#4803, under maintainability epic #4339). After #5233 shipped the clean-tier slice + the raw-`Icons.*` ratchet, I re-classified the remaining residue **by structural context** (not just glyph availability). The takeaway: the "clean-glyph" tokens left are almost all **structurally blocked or unreachable**, not ship-now —

- **Shared `IconData` param helpers** fed both clean and non-clean glyphs, so the param can't move to `DivineIconName` without breaking the non-clean callers (`_buildActionTile`, `_KpiCard`, `_SupportTile`, `_buildInteractionItem`).
- **`switch`-returns-`IconData`** / **mixed ternaries** with a non-clean arm (`_DeliveryStatusIndicator`, `video_processing_status_widget`, `relay_diagnostic`, …).
- **Orphaned/dead widgets** — `GlobalUploadIndicator`, `VideoExploreTile`/`ProofModeBadgeRow`, and `BadgeExplanationModal` are no longer instantiated anywhere in `lib`, so any swap there can't be verified on-device.

That leaves exactly one callsite that is independently swappable, glyph-exact, **and** reachable on a real device: the **DiscoverLists subscribe/unsubscribe toggle**.

| File | Swap | Color source |
| --- | --- | --- |
| `discover_lists_screen.dart` | `add` → `plus` (subscribe), `check` → `check` (subscribed) | button `foregroundColor` (`vineGreen` subscribed / `backgroundColor` not) |

`DivineIcon` ignores `IconTheme`, so the swap carries an explicit `color:` matching the button's dynamic `foregroundColor` and preserves the explicit `size: 20`. Ratchet baseline shrinks **221 → 219**.

## 📱 How to test on a real device

> The change is a single icon-only button on the **Discover Lists** screen. Goal: confirm the new Phosphor glyphs render with the right color/size and the subscribe toggle still works.

**Setup**
1. Build & run on a physical device (or simulator), signed into an account.

**Navigate to the surface**
2. Open the **Explore** tab → switch to the **Lists** sub-tab.
3. Tap the **“Discover Lists”** button at the top → the Discover Lists screen opens (route `/discover-lists`).
4. You need at least one public list in the feed. If empty, have another account publish a curated list, or use a populated environment.

**Verify the unsubscribed state**
5. Find a list you are **not** subscribed to. Its trailing 40×40 button is **solid green** with a **`+` (plus)** glyph.
6. Confirm the `+` is the **Phosphor `plus`** (thin, rounded strokes), tinted the dark background color, centered, ~20px — **not** invisible, black, or clipped.

**Verify the toggle + subscribed state**
7. Tap the button. It should toggle to **subscribed**: card-background fill, **green border**, and a **`✓` (check)** glyph tinted **vineGreen**.
8. Confirm the `✓` is the **Phosphor `check`** glyph at the same size, clearly visible against the dark fill.
9. Tap again → it returns to the green **`+`** state. The underlying subscribe/unsubscribe action still fires (the list’s subscription state persists on refresh).

**Regression check**
10. Compare against `main`: the layout, button size, colors, and tap behavior are unchanged — **only the glyph style** changes (Material → Phosphor). Nothing should look smaller/larger or off-center.

*(Divine is dark-mode only, so no light-theme pass is needed. The glyphs are vector SVGs — no system-text-scaling impact.)*

## Out of Scope

- The structurally-blocked clean glyphs (shared helpers / switches / mixed ternaries) — gated on the approx design ruling and #4833.
- **APPROX** tokens (`error`×16 → `warningCircle`, shield/clock families) → design ruling (@NotThatKindOfDrLiz).
- **NONE** tokens (cloud family, `radio_button_*`, `video_library`, …) → new SVG assets via #4833 (open, unassigned).
- The clean glyphs inside **orphaned widgets** (`upload_progress_indicator` pause/play, `proofmode_badge_row` + `badge_explanation_modal` search) — left raw rather than modifying unmounted code. Whether those widgets should be **deleted** is a separate dead-code cleanup, worth a follow-up.

## Verification

- `flutter analyze` (changed file) → No issues found
- `dart format` → clean
- `flutter test test/screens/discover_lists_screen_test.dart` → pass (no `byIcon`/`byType(Icon)` assertions affected)
- `flutter test test/tools/raw_icons_ceiling_test.dart` → 9 pass; ratchet green at **60 files / 219**

## Type of Change

- [x] 🧹 Code refactor

Relates to #4803, #4339