### PR TITLE
fix(db): recover stale encrypted cache keys

### DIFF
--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -30,6 +30,7 @@ class DatabaseEncryptionBootstrap {
     Future<CipherMigrationOutcome> Function(String rawKeyHex)? migrate,
     Future<void> Function()? deleteDatabase,
     Future<void> Function()? onDatabaseReset,
+    Future<bool> Function(String rawKeyHex)? canOpenEncryptedDatabase,
   }) : _secureStorage = secureStorage,
        _ensureRuntime = ensureRuntime ?? ensureSqlCipherRuntime,
        _isCipherAvailable = isCipherAvailable ?? isSqlCipherAvailable,
@@ -37,13 +38,17 @@ class DatabaseEncryptionBootstrap {
            migrate ??
            ((rawKeyHex) => migratePlaintextToEncrypted(rawKeyHex: rawKeyHex)),
        _deleteDatabase = deleteDatabase ?? backUpAndRemoveSharedDatabase,
-       _onDatabaseReset = onDatabaseReset;
+       _onDatabaseReset = onDatabaseReset,
+       _canOpenEncryptedDatabase =
+           canOpenEncryptedDatabase ??
+           ((rawKeyHex) => encryptedDatabaseOpensWithKey(rawKeyHex: rawKeyHex));
 
   final FlutterSecureStorage _secureStorage;
   final Future<void> Function() _ensureRuntime;
   final bool Function() _isCipherAvailable;
   final Future<CipherMigrationOutcome> Function(String rawKeyHex) _migrate;
   final Future<void> Function() _deleteDatabase;
+  final Future<bool> Function(String rawKeyHex) _canOpenEncryptedDatabase;
 
   /// Invoked after the key-loss recreate wipes the Drift DB, so callers can
   /// clear local state that lives OUTSIDE the database (e.g. the DM sync
@@ -88,38 +93,18 @@ class DatabaseEncryptionBootstrap {
         return key;
       case CipherMigrationOutcome.alreadyEncrypted:
         if (wasGenerated) {
-          // Key-loss recovery (#570 §6): the keystore was cleared but an
-          // encrypted database remains. It is cryptographically unrecoverable,
-          // so it is backed up (not hard-deleted) and recreated under the
-          // freshly generated key. Local-only data is preserved in the backup;
-          // DMs resync from relays. Accepted tradeoff for the rare
-          // keystore-reset case — pending product signoff on the user-facing
-          // notice.
-          Log.warning(
-            'Cipher key was missing but an encrypted database exists '
-            '(keystore reset). Backing up the unrecoverable database and '
-            'recreating under a new key.',
-            name: _logName,
+          return _recoverUnusableEncryptedDatabase(key, reason: 'missing');
+        }
+        if (!await _canOpenEncryptedDatabase(key)) {
+          final replacementKey = generateCipherKeyHex();
+          await _secureStorage.write(
+            key: dbCipherKeyStorageKey,
+            value: replacementKey,
           );
-          await _deleteDatabase();
-          // The Drift DB is now empty but SharedPreferences survives, so the
-          // DM sync cursors / `historyDrainComplete` flag would make the next
-          // inbox open skip the full re-drain and strand recovered chats under
-          // "Message requests". Clear DM sync state so recovery re-runs against
-          // the fresh DB. See #5304.
-          //
-          // Best-effort: a SharedPreferences IO failure here only re-strands
-          // requests (itself healed by the drain-version bump) and must not
-          // escalate into a hard cipher-key-resolution failure now that the DB
-          // has already been recreated.
-          try {
-            await _onDatabaseReset?.call();
-          } on Object catch (e) {
-            Log.warning(
-              'Post-recreate DM sync-state reset failed (non-fatal): $e',
-              name: _logName,
-            );
-          }
+          return _recoverUnusableEncryptedDatabase(
+            replacementKey,
+            reason: 'stale',
+          );
         }
         return key;
       case CipherMigrationOutcome.failed:
@@ -141,6 +126,41 @@ class DatabaseEncryptionBootstrap {
     final key = generateCipherKeyHex();
     await _secureStorage.write(key: dbCipherKeyStorageKey, value: key);
     return (key, true);
+  }
+
+  Future<String> _recoverUnusableEncryptedDatabase(
+    String key, {
+    required String reason,
+  }) async {
+    // Key-loss recovery (#570 §6): the keystore was cleared, or it contains a
+    // valid-looking key that no longer opens the encrypted DB. Either way the
+    // DB is cryptographically unrecoverable, so it is backed up (not
+    // hard-deleted) and recreated under the current key. Local-only data is
+    // preserved in the backup; DMs resync from relays.
+    Log.warning(
+      'Encrypted database is unrecoverable ($reason cipher key). Backing it '
+      'up and recreating under a new key.',
+      name: _logName,
+    );
+    await _deleteDatabase();
+    // The Drift DB is now empty but SharedPreferences survives, so the DM sync
+    // cursors / `historyDrainComplete` flag would make the next inbox open skip
+    // the full re-drain and strand recovered chats under "Message requests".
+    // Clear DM sync state so recovery re-runs against the fresh DB. See #5304.
+    //
+    // Best-effort: a SharedPreferences IO failure here only re-strands requests
+    // (itself healed by the drain-version bump) and must not escalate into a
+    // hard cipher-key-resolution failure now that the DB has already been
+    // recreated.
+    try {
+      await _onDatabaseReset?.call();
+    } on Object catch (e) {
+      Log.warning(
+        'Post-recreate DM sync-state reset failed (non-fatal): $e',
+        name: _logName,
+      );
+    }
+    return key;
   }
 }
 

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -67,6 +67,35 @@ QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
   });
 }
 
+/// Returns whether the shared encrypted database opens with [rawKeyHex].
+///
+/// This is a startup guard for the app layer: a valid-looking key can remain
+/// in secure storage while the database file belongs to a different key
+/// (backup/restore drift, partial reinstall, manual sandbox surgery). In that
+/// case the DB is just as unrecoverable as a missing key and should be backed
+/// up/recreated before the first Drift provider touches it.
+Future<bool> encryptedDatabaseOpensWithKey({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  _rawKeyLiteral(rawKeyHex);
+
+  final dbPath = databasePath ?? await getSharedDatabasePath();
+  if (!File(dbPath).existsSync()) return true;
+
+  Database? db;
+  try {
+    db = sqlite3.open(dbPath);
+    applyCipherKey(db, rawKeyHex);
+    return true;
+  } on SqliteException catch (e) {
+    if (e.resultCode == _sqliteNotADb) return false;
+    rethrow;
+  } finally {
+    db?.dispose();
+  }
+}
+
 /// Keys [rawDb] with [rawKeyHex] and verifies SQLCipher is actually active.
 ///
 /// `PRAGMA key` must be the first statement on the connection. On plain

--- a/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_stub.dart
@@ -18,6 +18,14 @@ QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
   throw UnsupportedError('No database implementation found for this platform');
 }
 
+/// Stub implementation - will be replaced by conditional imports
+Future<bool> encryptedDatabaseOpensWithKey({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  throw UnsupportedError('No database implementation found for this platform');
+}
+
 /// Outcome of [migratePlaintextToEncrypted]. Mirrors the native enum so app
 /// code that switches on it compiles when only the stub is available.
 enum CipherMigrationOutcome {

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -31,6 +31,16 @@ QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
   );
 }
 
+/// Web never opens SQLCipher databases; startup skips DB encryption there.
+Future<bool> encryptedDatabaseOpensWithKey({
+  required String rawKeyHex,
+  String? databasePath,
+}) async {
+  throw UnsupportedError(
+    'SQLCipher at-rest encryption is not supported on web',
+  );
+}
+
 /// No-op on web (key-loss recovery is native-only). Never reached at runtime.
 Future<void> backUpAndRemoveSharedDatabase() async {}
 

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -44,6 +44,7 @@ void main() {
       required void Function() onDelete,
       bool cipherAvailable = true,
       void Function()? onReset,
+      bool Function(String rawKeyHex)? canOpenEncryptedDatabase,
     }) {
       return DatabaseEncryptionBootstrap(
         secureStorage: storage,
@@ -52,6 +53,9 @@ void main() {
         migrate: (_) async => outcome,
         deleteDatabase: () async => onDelete(),
         onDatabaseReset: onReset == null ? null : () async => onReset(),
+        canOpenEncryptedDatabase: canOpenEncryptedDatabase == null
+            ? null
+            : (rawKeyHex) async => canOpenEncryptedDatabase(rawKeyHex),
       );
     }
 
@@ -123,6 +127,32 @@ void main() {
       expect(key, matches(RegExp(r'^[0-9a-f]{64}$')));
       expect(deleted, isTrue);
     });
+
+    test(
+      'backs up DB and rotates key when stored key no longer opens it',
+      () async {
+        const staleKey =
+            '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+        store[dbCipherKeyStorageKey] = staleKey;
+        var deleted = false;
+        var reset = false;
+
+        final bootstrap = buildBootstrap(
+          outcome: CipherMigrationOutcome.alreadyEncrypted,
+          onDelete: () => deleted = true,
+          onReset: () => reset = true,
+          canOpenEncryptedDatabase: (rawKeyHex) => rawKeyHex != staleKey,
+        );
+
+        final key = await bootstrap.resolveCipherKey();
+
+        expect(key, matches(RegExp(r'^[0-9a-f]{64}$')));
+        expect(key, isNot(equals(staleKey)));
+        expect(store[dbCipherKeyStorageKey], equals(key));
+        expect(deleted, isTrue);
+        expect(reset, isTrue);
+      },
+    );
 
     test(
       'clears DM sync state on key loss so the inbox re-drains (#5304)',


### PR DESCRIPTION
Closes #5327

## Summary
- verify that an existing stored SQLCipher key can actually open the encrypted local database before trusting it
- when the stored key is stale or wrong, rotate the secure-storage key and reuse the existing backup/remove recovery path for the unreadable cache DB
- keep transient or indeterminate SQLite/secure-storage failures fail-closed instead of deleting data on ambiguous errors

## Root Cause
Missing or malformed key material already generated a fresh key and reset the unreadable encrypted cache DB. The hole was a stale key: FlutterSecureStorage could contain a valid-looking 64-hex value that was not the key for the current encrypted DB. Bootstrap treated that as intact key material, then the first encrypted DB open failed and startup showed the fatal local database screen.

## Verification
- flutter test test/services/database_encryption_bootstrap_test.dart
- flutter test test/services/database_encryption_bootstrap_test.dart test/startup/database_bootstrap_failure_app_test.dart
- flutter analyze lib/services/database_encryption_bootstrap.dart test/services/database_encryption_bootstrap_test.dart packages/db_client/lib/src/database/connection/connection_native.dart packages/db_client/lib/src/database/connection/connection_web.dart packages/db_client/lib/src/database/connection/connection_stub.dart
- cd packages/db_client && dart analyze lib/src/database/connection/connection_native.dart lib/src/database/connection/connection_web.dart lib/src/database/connection/connection_stub.dart
- git diff --check