### PR TITLE
fix(db): force SQLCipher runtime on iOS

### DIFF
--- a/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -752,6 +752,11 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.15;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SQLCipher,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1004,6 +1009,11 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.15;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SQLCipher,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -1034,6 +1044,11 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.15;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					SQLCipher,
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,14 +28,6 @@
       }
     },
     {
-      "identity" : "csqlite",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/simolus3/CSQLite.git",
-      "state" : {
-        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
-      }
-    },
-    {
       "identity" : "dkcamera",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zhangao0086/DKCamera",

--- a/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -28,14 +28,6 @@
       }
     },
     {
-      "identity" : "csqlite",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/simolus3/CSQLite.git",
-      "state" : {
-        "revision" : "ae972b235e8b3c5af6d8f4e5bf18c800bdddb27e"
-      }
-    },
-    {
       "identity" : "dkcamera",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zhangao0086/DKCamera",

--- a/mobile/lib/database/sqlcipher_runtime_io.dart
+++ b/mobile/lib/database/sqlcipher_runtime_io.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Native SQLCipher runtime bootstrap (Android lib override + availability probe).
 // ABOUTME: Forces package:sqlite3 to load libsqlcipher.so on Android before first use.
 
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:sqlcipher_flutter_libs/sqlcipher_flutter_libs.dart';
@@ -11,13 +12,21 @@ import 'package:sqlite3/sqlite3.dart';
 ///
 /// Android ships a plain `libsqlite3.so`, so `package:sqlite3` must be told to
 /// load `libsqlcipher.so` instead — before ANY sqlite3 call and before drift
-/// spawns its background isolate. iOS/macOS link the SQLCipher pod
-/// automatically when it is the only sqlite3 provider, so no override is
-/// needed there (the runtime [isSqlCipherAvailable] probe is the safety net).
+/// spawns its background isolate.
+///
+/// iOS/macOS can also link plain sqlite3 through unrelated dependencies
+/// (Firebase Messaging is explicitly called out by `sqlcipher_flutter_libs`).
+/// CocoaPods links SQLCipher into the app process, so force package:sqlite3 to
+/// resolve process symbols instead of opening sqlite3.framework or stale
+/// CSQLite.framework pins first.
 Future<void> ensureSqlCipherRuntime() async {
   if (Platform.isAndroid) {
     await applyWorkaroundToOpenSqlCipherOnOldAndroidVersions();
     open.overrideFor(OperatingSystem.android, openCipherOnAndroid);
+  } else if (Platform.isIOS || Platform.isMacOS) {
+    open.overrideFor(open.os!, () {
+      return DynamicLibrary.process();
+    });
   }
 }
 

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1303,6 +1303,9 @@ Future<void> _startOpenVineApp() async {
   // This also forces package:sqlite3 onto the SQLCipher build (Android) and
   // runs the one-time plaintext→encrypted migration, both of which must happen
   // before any sqlite3 open. (#570, finding C2)
+  const dbCipherSecureStorage = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  );
   final dbCipherKeyResult = await resolveDatabaseBootstrapForAppStart(
     resolveCipherKey: () => resolveStartupDatabaseCipherKey(
       // resetOnError MUST stay false here: the cipher key is the one secret
@@ -1310,9 +1313,7 @@ Future<void> _startOpenVineApp() async {
       // read error must throw rather than silently deleting the key and
       // triggering the §6 key-loss recovery. (#570 C2)
       resolveCipherKey: () => DatabaseEncryptionBootstrap(
-        secureStorage: const FlutterSecureStorage(
-          aOptions: AndroidOptions(encryptedSharedPreferences: true),
-        ),
+        secureStorage: dbCipherSecureStorage,
         // On the key-loss recreate the Drift DB is wiped but SharedPreferences
         // survives; clear the DM sync state so the next inbox open runs a full
         // re-drain instead of skipping it as "already complete" (which had
@@ -1328,6 +1329,12 @@ Future<void> _startOpenVineApp() async {
         reason: 'DatabaseEncryptionBootstrap.resolveCipherKey failed',
       ),
     ),
+    repairLocalDatabaseCache: (error, stack) => resetEncryptedDatabaseCache(
+      secureStorage: dbCipherSecureStorage,
+      onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
+    ),
+    shouldRepairLocalDatabaseCache: (error) =>
+        error is! SqlCipherUnavailableError,
     runApp: runApp,
     removeNativeSplash: FlutterNativeSplash.remove,
   );

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1306,6 +1306,20 @@ Future<void> _startOpenVineApp() async {
   const dbCipherSecureStorage = FlutterSecureStorage(
     aOptions: AndroidOptions(encryptedSharedPreferences: true),
   );
+  var didRecordDatabaseBootstrapFailure = false;
+  Future<void> recordDatabaseBootstrapFailure(
+    Object error,
+    StackTrace stack,
+  ) async {
+    if (didRecordDatabaseBootstrapFailure) return;
+    didRecordDatabaseBootstrapFailure = true;
+    await CrashReportingService.instance.recordError(
+      error,
+      stack,
+      reason: 'DatabaseEncryptionBootstrap.resolveCipherKey failed',
+    );
+  }
+
   final dbCipherKeyResult = await resolveDatabaseBootstrapForAppStart(
     resolveCipherKey: () => resolveStartupDatabaseCipherKey(
       // resetOnError MUST stay false here: the cipher key is the one secret
@@ -1323,18 +1337,14 @@ Future<void> _startOpenVineApp() async {
       // SQLCipher build misconfiguration or secure-storage failures must fail
       // closed after reporting. Continuing with a null key would open an
       // existing encrypted DB as plaintext and spam SQLITE_NOTADB.
-      recordError: (error, stack) => CrashReportingService.instance.recordError(
-        error,
-        stack,
-        reason: 'DatabaseEncryptionBootstrap.resolveCipherKey failed',
-      ),
+      recordError: recordDatabaseBootstrapFailure,
     ),
     repairLocalDatabaseCache: (error, stack) => resetEncryptedDatabaseCache(
       secureStorage: dbCipherSecureStorage,
       onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
     ),
-    shouldRepairLocalDatabaseCache: (error) =>
-        error is! SqlCipherUnavailableError,
+    shouldRepairLocalDatabaseCache:
+        shouldRepairLocalDatabaseCacheAfterBootstrapError,
     runApp: runApp,
     removeNativeSplash: FlutterNativeSplash.remove,
   );

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -7,6 +7,7 @@ import 'package:db_client/db_client.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:openvine/database/sqlcipher_runtime.dart';
+import 'package:sqlite3/sqlite3.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Secure-storage key for the at-rest DB cipher key. Versioned so a future
@@ -139,23 +140,7 @@ class DatabaseEncryptionBootstrap {
       name: _logName,
     );
     await _deleteDatabase();
-    // The Drift DB is now empty but SharedPreferences survives, so the DM sync
-    // cursors / `historyDrainComplete` flag would make the next inbox open skip
-    // the full re-drain and strand recovered chats under "Message requests".
-    // Clear DM sync state so recovery re-runs against the fresh DB. See #5304.
-    //
-    // Best-effort: a SharedPreferences IO failure here only re-strands requests
-    // (itself healed by the drain-version bump) and must not escalate into a
-    // hard cipher-key-resolution failure now that the DB has already been
-    // recreated.
-    try {
-      await _onDatabaseReset?.call();
-    } on Object catch (e) {
-      Log.warning(
-        'Post-recreate DM sync-state reset failed (non-fatal): $e',
-        name: _logName,
-      );
-    }
+    await _runPostDatabaseReset(_onDatabaseReset);
     return key;
   }
 }
@@ -196,6 +181,29 @@ Future<String?> resolveStartupDatabaseCipherKey({
 bool _isValidCipherKey(String value) =>
     RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(value);
 
+const _sqliteCorrupt = 11;
+const _sqliteNotADb = 26;
+
+/// Returns whether a startup bootstrap failure is safe to repair by backing up
+/// the local encrypted DB cache and retrying once.
+///
+/// Keep this as an allowlist. Secure-storage, SQLCipher linkage, and other
+/// transient startup failures must fail closed because deleting or rotating the
+/// DB cipher key can make an otherwise recoverable encrypted DB unusable.
+bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
+  if (error is SqlCipherUnavailableError) return false;
+  if (error is SqliteException) {
+    return error.resultCode == _sqliteNotADb ||
+        error.resultCode == _sqliteCorrupt;
+  }
+
+  final message = error.toString();
+  return message.contains('SQLITE_NOTADB') ||
+      message.contains('SQLITE_CORRUPT') ||
+      message.contains('database disk image is malformed') ||
+      message.contains('file is not a database');
+}
+
 /// Backs up the encrypted local database cache and removes only its DB cipher
 /// key so the next bootstrap creates a fresh encrypted cache.
 Future<void> resetEncryptedDatabaseCache({
@@ -205,6 +213,20 @@ Future<void> resetEncryptedDatabaseCache({
 }) async {
   await (deleteDatabase ?? backUpAndRemoveSharedDatabase)();
   await secureStorage.delete(key: dbCipherKeyStorageKey);
+  await _runPostDatabaseReset(onDatabaseReset);
+}
+
+Future<void> _runPostDatabaseReset(
+  Future<void> Function()? onDatabaseReset,
+) async {
+  // The Drift DB is now empty but SharedPreferences survives, so the DM sync
+  // cursors / `historyDrainComplete` flag would make the next inbox open skip
+  // the full re-drain and strand recovered chats under "Message requests".
+  // Clear DM sync state so recovery re-runs against the fresh DB. See #5304.
+  //
+  // Best-effort: a SharedPreferences IO failure here only re-strands requests
+  // (itself healed by the drain-version bump) and must not escalate into a hard
+  // cipher-key-resolution failure now that the DB has already been recreated.
   try {
     await onDatabaseReset?.call();
   } on Object catch (e) {

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -7,7 +7,6 @@ import 'package:db_client/db_client.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:openvine/database/sqlcipher_runtime.dart';
-import 'package:sqlite3/sqlite3.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Secure-storage key for the at-rest DB cipher key. Versioned so a future
@@ -192,13 +191,11 @@ const _sqliteNotADb = 26;
 /// DB cipher key can make an otherwise recoverable encrypted DB unusable.
 bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
   if (error is SqlCipherUnavailableError) return false;
-  if (error is SqliteException) {
-    return error.resultCode == _sqliteNotADb ||
-        error.resultCode == _sqliteCorrupt;
-  }
 
   final message = error.toString();
-  return message.contains('SQLITE_NOTADB') ||
+  return message.contains('SqliteException($_sqliteNotADb)') ||
+      message.contains('SqliteException($_sqliteCorrupt)') ||
+      message.contains('SQLITE_NOTADB') ||
       message.contains('SQLITE_CORRUPT') ||
       message.contains('database disk image is malformed') ||
       message.contains('file is not a database');

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -76,11 +76,7 @@ class DatabaseEncryptionBootstrap {
 
     await _ensureRuntime();
     if (!_isCipherAvailable()) {
-      throw StateError(
-        'SQLCipher is not linked; refusing to start with an unencrypted local '
-        'database. Verify sqlcipher_flutter_libs replaced sqlite3_flutter_libs '
-        'and that no dependency links plain sqlite3.',
-      );
+      throw SqlCipherUnavailableError();
     }
 
     final (key, wasGenerated) = await _readOrCreateKey();
@@ -164,6 +160,15 @@ class DatabaseEncryptionBootstrap {
   }
 }
 
+class SqlCipherUnavailableError extends StateError {
+  SqlCipherUnavailableError()
+    : super(
+        'SQLCipher is not linked; refusing to start with an unencrypted local '
+        'database. Verify sqlcipher_flutter_libs replaced sqlite3_flutter_libs '
+        'and that no dependency links plain sqlite3.',
+      );
+}
+
 /// Resolves the startup DB cipher key and fails closed on bootstrap errors.
 ///
 /// Native app startup must not continue with a `null` cipher key after a
@@ -190,6 +195,25 @@ Future<String?> resolveStartupDatabaseCipherKey({
 
 bool _isValidCipherKey(String value) =>
     RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(value);
+
+/// Backs up the encrypted local database cache and removes only its DB cipher
+/// key so the next bootstrap creates a fresh encrypted cache.
+Future<void> resetEncryptedDatabaseCache({
+  required FlutterSecureStorage secureStorage,
+  Future<void> Function()? deleteDatabase,
+  Future<void> Function()? onDatabaseReset,
+}) async {
+  await (deleteDatabase ?? backUpAndRemoveSharedDatabase)();
+  await secureStorage.delete(key: dbCipherKeyStorageKey);
+  try {
+    await onDatabaseReset?.call();
+  } on Object catch (e) {
+    Log.warning(
+      'Post-recreate DM sync-state reset failed (non-fatal): $e',
+      name: DatabaseEncryptionBootstrap._logName,
+    );
+  }
+}
 
 /// Generates a 64-character hex (raw 32-byte) cipher key from a CSPRNG.
 ///

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -26,10 +26,23 @@ Future<DatabaseBootstrapStartupResult> resolveDatabaseBootstrapForAppStart({
   required Future<String?> Function() resolveCipherKey,
   required void Function(Widget app) runApp,
   required VoidCallback removeNativeSplash,
+  Future<void> Function(Object error, StackTrace stack)?
+  repairLocalDatabaseCache,
+  bool Function(Object error)? shouldRepairLocalDatabaseCache,
 }) async {
   try {
     return DatabaseBootstrapStartupResult.ready(await resolveCipherKey());
   } catch (error, stack) {
+    final shouldRepair = shouldRepairLocalDatabaseCache?.call(error) ?? true;
+    if (repairLocalDatabaseCache != null && shouldRepair) {
+      try {
+        await repairLocalDatabaseCache(error, stack);
+        return DatabaseBootstrapStartupResult.ready(await resolveCipherKey());
+      } catch (_) {
+        // Fall through to the final fail-closed UI below. The initial
+        // bootstrap failure has already been recorded by the resolver.
+      }
+    }
     removeNativeSplash();
     runApp(DatabaseBootstrapFailureApp(error: error, stack: stack));
     return const DatabaseBootstrapStartupResult.failure();
@@ -91,6 +104,17 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
                         decoration: TextDecoration.none,
                       ),
                     ),
+                    const SizedBox(height: 12),
+                    Text(
+                      'Diagnostic: ${databaseBootstrapDiagnosticCode(error)}',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        color: VineTheme.onSurfaceVariant,
+                        fontSize: 12,
+                        height: 1.35,
+                        decoration: TextDecoration.none,
+                      ),
+                    ),
                     const SizedBox(height: 24),
                     DivineButton(
                       label: 'close Divine',
@@ -110,6 +134,20 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
       ),
     );
   }
+}
+
+String databaseBootstrapDiagnosticCode(Object error) {
+  final message = error.toString();
+  if (message.contains('SQLCipher is not linked')) {
+    return 'db-sqlcipher-unavailable';
+  }
+  if (message.contains('secure storage')) {
+    return 'db-secure-storage';
+  }
+  if (message.contains('SQLITE_NOTADB') || message.contains('not a database')) {
+    return 'db-cipher-mismatch';
+  }
+  return 'db-bootstrap-failed';
 }
 
 class _DebugErrorDetails extends StatelessWidget {

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -2,6 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:openvine/services/database_encryption_bootstrap.dart';
 
 /// Result of resolving the DB cipher key during app startup.
 class DatabaseBootstrapStartupResult {
@@ -33,7 +34,7 @@ Future<DatabaseBootstrapStartupResult> resolveDatabaseBootstrapForAppStart({
   try {
     return DatabaseBootstrapStartupResult.ready(await resolveCipherKey());
   } catch (error, stack) {
-    final shouldRepair = shouldRepairLocalDatabaseCache?.call(error) ?? true;
+    final shouldRepair = shouldRepairLocalDatabaseCache?.call(error) ?? false;
     if (repairLocalDatabaseCache != null && shouldRepair) {
       try {
         await repairLocalDatabaseCache(error, stack);
@@ -137,6 +138,10 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
 }
 
 String databaseBootstrapDiagnosticCode(Object error) {
+  if (error is SqlCipherUnavailableError) {
+    return 'db-sqlcipher-unavailable';
+  }
+
   final message = error.toString();
   if (message.contains('SQLCipher is not linked')) {
     return 'db-sqlcipher-unavailable';

--- a/mobile/test/ios/ios_sqlcipher_linkage_test.dart
+++ b/mobile/test/ios/ios_sqlcipher_linkage_test.dart
@@ -1,0 +1,55 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Runner force-links SQLCipher for every app build configuration', () {
+    final project = File(
+      'ios/Runner.xcodeproj/project.pbxproj',
+    ).readAsStringSync();
+
+    for (final config in ['Debug', 'Profile', 'Release']) {
+      final block = _configBlocks(project, config).where(
+        (block) =>
+            block.contains('PRODUCT_BUNDLE_IDENTIFIER = co.openvine.app;'),
+      );
+
+      expect(
+        block,
+        hasLength(1),
+        reason: '$config Runner config must exist exactly once',
+      );
+      final runnerConfig = block.single;
+      expect(runnerConfig, contains('OTHER_LDFLAGS = ('));
+      expect(runnerConfig, contains(r'"$(inherited)"'));
+      expect(runnerConfig, contains('"-framework"'));
+      expect(runnerConfig, contains('SQLCipher'));
+    }
+  });
+
+  test('tracked SwiftPM lockfiles do not pin plain CSQLite', () {
+    for (final path in [
+      'ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved',
+      'ios/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved',
+    ]) {
+      final packageResolved = File(path).readAsStringSync();
+      expect(packageResolved, isNot(contains('simolus3/CSQLite')));
+      expect(packageResolved, isNot(contains('"identity" : "csqlite"')));
+    }
+  });
+}
+
+List<String> _configBlocks(String project, String config) {
+  final blocks = <String>[];
+  final marker = '/* $config */ = {';
+  final endMarker = 'name = $config;';
+  var offset = 0;
+  while (true) {
+    final start = project.indexOf(marker, offset);
+    if (start == -1) return blocks;
+    final end = project.indexOf(endMarker, start);
+    if (end == -1) return blocks;
+    blocks.add(project.substring(start, end + endMarker.length));
+    offset = end + endMarker.length;
+  }
+}

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -37,6 +37,11 @@ void main() {
         store[inv.namedArguments[#key] as String] =
             inv.namedArguments[#value] as String;
       });
+      when(
+        () => storage.delete(key: any(named: 'key')),
+      ).thenAnswer((inv) async {
+        store.remove(inv.namedArguments[#key] as String);
+      });
     });
 
     DatabaseEncryptionBootstrap buildBootstrap({
@@ -66,7 +71,10 @@ void main() {
         onDelete: () {},
       );
 
-      expect(bootstrap.resolveCipherKey(), throwsStateError);
+      expect(
+        bootstrap.resolveCipherKey(),
+        throwsA(isA<SqlCipherUnavailableError>()),
+      );
     });
 
     test(
@@ -243,6 +251,44 @@ void main() {
       expect(key, matches(RegExp(r'^[0-9a-f]{64}$')));
       expect(store[dbCipherKeyStorageKey], equals(key));
     });
+  });
+
+  group('resetEncryptedDatabaseCache', () {
+    late _MockSecureStorage storage;
+    late Map<String, String> store;
+
+    setUp(() {
+      storage = _MockSecureStorage();
+      store = <String, String>{
+        dbCipherKeyStorageKey:
+            '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99',
+        'auth_key': 'must-stay',
+      };
+      when(
+        () => storage.delete(key: any(named: 'key')),
+      ).thenAnswer((inv) async {
+        store.remove(inv.namedArguments[#key] as String);
+      });
+    });
+
+    test(
+      'backs up DB, deletes only DB cipher key, and clears reset state',
+      () async {
+        var deleted = false;
+        var reset = false;
+
+        await resetEncryptedDatabaseCache(
+          secureStorage: storage,
+          deleteDatabase: () async => deleted = true,
+          onDatabaseReset: () async => reset = true,
+        );
+
+        expect(deleted, isTrue);
+        expect(store, isNot(contains(dbCipherKeyStorageKey)));
+        expect(store['auth_key'], equals('must-stay'));
+        expect(reset, isTrue);
+      },
+    );
   });
 
   group('resolveStartupDatabaseCipherKey', () {

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -39,6 +39,97 @@ void main() {
         expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
       },
     );
+
+    test(
+      'repairs local database cache and retries before rendering failure UI',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        var attempts = 0;
+        var repaired = false;
+        final error = StateError('database bootstrap failed');
+
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async {
+            attempts += 1;
+            if (attempts == 1) throw error;
+            return 'b' * 64;
+          },
+          repairLocalDatabaseCache: (error, stack) async {
+            repaired = true;
+          },
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
+
+        expect(result.didRenderFailureApp, isFalse);
+        expect(result.cipherKey, equals('b' * 64));
+        expect(attempts, equals(2));
+        expect(repaired, isTrue);
+        expect(removedSplash, isFalse);
+        expect(renderedApp, isNull);
+      },
+    );
+
+    test(
+      'renders failure UI only after automatic repair retry fails',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        var attempts = 0;
+        var repaired = false;
+
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async {
+            attempts += 1;
+            throw StateError('database bootstrap failed $attempts');
+          },
+          repairLocalDatabaseCache: (error, stack) async {
+            repaired = true;
+          },
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
+
+        expect(result.didRenderFailureApp, isTrue);
+        expect(result.cipherKey, isNull);
+        expect(attempts, equals(2));
+        expect(repaired, isTrue);
+        expect(removedSplash, isTrue);
+        expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
+      },
+    );
+
+    test(
+      'does not repair when the bootstrap error is not repairable',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        var attempts = 0;
+        var repaired = false;
+        final error = StateError('SQLCipher is not linked');
+
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async {
+            attempts += 1;
+            throw error;
+          },
+          repairLocalDatabaseCache: (error, stack) async {
+            repaired = true;
+          },
+          shouldRepairLocalDatabaseCache: (_) => false,
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
+
+        expect(result.didRenderFailureApp, isTrue);
+        expect(result.cipherKey, isNull);
+        expect(attempts, equals(1));
+        expect(repaired, isFalse);
+        expect(removedSplash, isTrue);
+        expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
+      },
+    );
   });
 
   group(DatabaseBootstrapFailureApp, () {
@@ -60,9 +151,19 @@ void main() {
         findsOneWidget,
       );
       expect(find.textContaining('Restart Divine'), findsOneWidget);
+      expect(find.textContaining('Diagnostic:'), findsOneWidget);
 
       await tester.tap(find.text('close Divine'));
       expect(closed, isTrue);
+    });
+
+    test('classifies SQLCipher link failures for release diagnostics', () {
+      expect(
+        databaseBootstrapDiagnosticCode(
+          StateError('SQLCipher is not linked'),
+        ),
+        equals('db-sqlcipher-unavailable'),
+      );
     });
   });
 }

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/startup/database_bootstrap_failure_app.dart';
+import 'package:sqlite3/sqlite3.dart';
 
 void main() {
   group('resolveDatabaseBootstrapForAppStart', () {
@@ -58,6 +60,7 @@ void main() {
           repairLocalDatabaseCache: (error, stack) async {
             repaired = true;
           },
+          shouldRepairLocalDatabaseCache: (_) => true,
           removeNativeSplash: () => removedSplash = true,
           runApp: (app) => renderedApp = app,
         );
@@ -87,6 +90,7 @@ void main() {
           repairLocalDatabaseCache: (error, stack) async {
             repaired = true;
           },
+          shouldRepairLocalDatabaseCache: (_) => true,
           removeNativeSplash: () => removedSplash = true,
           runApp: (app) => renderedApp = app,
         );
@@ -130,6 +134,100 @@ void main() {
         expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
       },
     );
+
+    test(
+      'does not implicitly repair when no repair predicate is provided',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        var attempts = 0;
+        var repaired = false;
+        final error = SqliteException(26, 'file is not a database');
+
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async {
+            attempts += 1;
+            throw error;
+          },
+          repairLocalDatabaseCache: (error, stack) async {
+            repaired = true;
+          },
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
+
+        expect(result.didRenderFailureApp, isTrue);
+        expect(attempts, equals(1));
+        expect(repaired, isFalse);
+        expect(removedSplash, isTrue);
+        expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
+      },
+    );
+
+    test(
+      'does not repair secure-storage failures',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        var attempts = 0;
+        var repaired = false;
+        final error = StateError('secure storage unavailable before unlock');
+
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async {
+            attempts += 1;
+            throw error;
+          },
+          repairLocalDatabaseCache: (error, stack) async {
+            repaired = true;
+          },
+          shouldRepairLocalDatabaseCache:
+              shouldRepairLocalDatabaseCacheAfterBootstrapError,
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
+
+        expect(result.didRenderFailureApp, isTrue);
+        expect(attempts, equals(1));
+        expect(repaired, isFalse);
+        expect(removedSplash, isTrue);
+        expect(renderedApp, isA<DatabaseBootstrapFailureApp>());
+      },
+    );
+
+    test(
+      'repairs allowlisted sqlite corruption failures',
+      () async {
+        var removedSplash = false;
+        Widget? renderedApp;
+        var attempts = 0;
+        var repaired = false;
+
+        final result = await resolveDatabaseBootstrapForAppStart(
+          resolveCipherKey: () async {
+            attempts += 1;
+            if (attempts == 1) {
+              throw SqliteException(26, 'file is not a database');
+            }
+            return 'c' * 64;
+          },
+          repairLocalDatabaseCache: (error, stack) async {
+            repaired = true;
+          },
+          shouldRepairLocalDatabaseCache:
+              shouldRepairLocalDatabaseCacheAfterBootstrapError,
+          removeNativeSplash: () => removedSplash = true,
+          runApp: (app) => renderedApp = app,
+        );
+
+        expect(result.didRenderFailureApp, isFalse);
+        expect(result.cipherKey, equals('c' * 64));
+        expect(attempts, equals(2));
+        expect(repaired, isTrue);
+        expect(removedSplash, isFalse);
+        expect(renderedApp, isNull);
+      },
+    );
   });
 
   group(DatabaseBootstrapFailureApp, () {
@@ -160,9 +258,41 @@ void main() {
     test('classifies SQLCipher link failures for release diagnostics', () {
       expect(
         databaseBootstrapDiagnosticCode(
-          StateError('SQLCipher is not linked'),
+          SqlCipherUnavailableError(),
         ),
         equals('db-sqlcipher-unavailable'),
+      );
+    });
+  });
+
+  group('shouldRepairLocalDatabaseCacheAfterBootstrapError', () {
+    test('allowlists sqlite not-a-database and corruption errors', () {
+      expect(
+        shouldRepairLocalDatabaseCacheAfterBootstrapError(
+          SqliteException(26, 'file is not a database'),
+        ),
+        isTrue,
+      );
+      expect(
+        shouldRepairLocalDatabaseCacheAfterBootstrapError(
+          SqliteException(11, 'database disk image is malformed'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('excludes SQLCipher linkage and secure-storage failures', () {
+      expect(
+        shouldRepairLocalDatabaseCacheAfterBootstrapError(
+          SqlCipherUnavailableError(),
+        ),
+        isFalse,
+      );
+      expect(
+        shouldRepairLocalDatabaseCacheAfterBootstrapError(
+          StateError('secure storage unavailable before unlock'),
+        ),
+        isFalse,
       );
     });
   });


### PR DESCRIPTION
Closes #5329

## Summary
- force iOS/macOS sqlite3 loading to resolve SQLCipher from the app process and force-link SQLCipher in Runner configs
- remove stale CSQLite SwiftPM pins so plain SQLite cannot win the runtime loader path
- keep automatic encrypted-cache repair for allowlisted SQLite cache corruption / `SQLITE_NOTADB` failures only
- keep SQLCipher-link and secure-storage bootstrap failures fail-closed so transient keychain errors cannot wipe or rotate the DB cipher key
- deduplicate post-reset DM sync cleanup and avoid recording the same bootstrap failure twice during the one retry
- keep the repair classifier web-safe so preview builds do not import native sqlite FFI declarations
- show a release-safe database bootstrap diagnostic code and add CI guard tests for iOS SQLCipher linkage regressions

## Root cause
Crashlytics for `1.0.15+751` showed `SQLCipher is not linked`, not a stale or missing DB key. Wiping the local DB cannot fix that class of failure. iOS had the SQLCipher pod present, but the runtime could still resolve plain SQLite through stale `simolus3/CSQLite` SwiftPM pins / sqlite3.framework / other dependencies. The existing runtime probe correctly failed closed instead of opening an unencrypted database.

The follow-up commit also fixes the review-blocking repair policy bug: the first version repaired on every bootstrap error except SQLCipher-unavailable, which could destructively back up/remove the local DB after a transient secure-storage read failure. Repair is now an allowlist, and secure-storage failures explicitly do not repair.

## Verification
- `flutter analyze lib/database/sqlcipher_runtime_io.dart lib/startup/database_bootstrap_failure_app.dart lib/services/database_encryption_bootstrap.dart lib/main.dart test/startup/database_bootstrap_failure_app_test.dart test/services/database_encryption_bootstrap_test.dart test/ios/ios_sqlcipher_linkage_test.dart`
- `flutter test test/startup/database_bootstrap_failure_app_test.dart test/services/database_encryption_bootstrap_test.dart test/ios/ios_sqlcipher_linkage_test.dart`
- `flutter test test/startup/database_bootstrap_failure_app_test.dart`
- `flutter build web --release --tree-shake-icons --optimization-level=4 --pwa-strategy=none --dart-define=BACKEND_URL=https://api.divine.video --dart-define=MEDIA_API_URL=https://api.openvine.co --dart-define=ENVIRONMENT=production --dart-define=GH_ACTIONS_PR_PREVIEW=true --no-source-maps`
- pre-push hook analyzer + changed-file tests
- earlier PR verification: `flutter build ios --release --no-codesign`; built `Runner.app/Runner` contains `_sqlite3_key_v2`, `_sqlite3_rekey_v2`, `_sqlite3_open`, and `_sqlcipher*` symbols
