### PR TITLE
feat(db): migrate encryption to SQLite3MultipleCiphers

### DIFF
--- a/mobile/docs/sqlcipher_at_rest_plan.md
+++ b/mobile/docs/sqlcipher_at_rest_plan.md
@@ -1,119 +1,124 @@
-# SQLCipher at-rest encryption for the local DB (#570, finding C2)
+# SQLite3MultipleCiphers at-rest encryption for the local DB (#570, finding C2)
 
-Status: **device-QA gated before merge.** The full Dart implementation, the
-native dependency swap, and unit tests for every host-testable property are
-committed. What remains before merge is **on-device validation** (the encrypted
-open, the in-place migration, and the iOS/macOS build configuration) — none of
-it can be exercised in CI, which links plain sqlite3 and on which
-`PRAGMA cipher_version` is empty. See the device-QA checklist at the bottom.
+Status: **device-QA gated before merge.** The Dart implementation, dependency
+swap, host tests, and local host probes are in this PR. The final gate is a real
+iOS device and real Android device with a pre-existing encrypted database.
 
 ## Why
 
-DMs (and the rest of the shared `divine_db.db`: drafts, pending uploads,
-pending actions, outgoing DMs, reactions, reposts, notifications, bookmarks,
-NIP-05 verifications) are stored **plaintext at rest** today. For a moderation
-account holding reports about users, plaintext-at-rest is materially more
-sensitive. Decision (#570): encrypt at rest before the T&S moderation launch.
+`divine_db.db` stores user data that includes drafts, pending uploads/actions,
+reactions, reposts, notifications, bookmarks, NIP-05 state, and DMs. That file
+must be encrypted at rest on native platforms. Web / IndexedDB remains out of
+scope until the OPFS encryption work.
 
-## What is NOT in scope
+## Dependency shape
 
-- **Web / IndexedDB** (`connection_web.dart`): SQLCipher is native-only. Web
-  at-rest encryption is deferred behind the OPFS migration (#373). The app
-  guards encryption with `kIsWeb`; the web connection variants throw
-  `UnsupportedError` and are never reached.
-- **Backend D1 retention**: the backend stores DMs plaintext indefinitely in
-  `dm_log` — a separate data-minimization item (tracked as #570 Decision 8).
-- **The `cache_sync.db` cache**: it shares the SQLCipher runtime but is opened
-  unkeyed (plaintext), which SQLCipher supports. Only `divine_db.db` is keyed.
+- `drift` is on the 2.34 line and `sqlite3` is on the 3.3 line.
+- `sqlcipher_flutter_libs` is removed. The 0.7 line is an EOL no-op for sqlite3
+  3.x, and the old Android `open.overrideFor` / SQLCipher workaround is gone.
+- `sqlite3_flutter_libs` and `drift_flutter` must stay out of the app. Extra
+  native SQLite providers can make plain SQLite win.
+- `pubspec.yaml` selects SQLite3MultipleCiphers through the sqlite3 hook:
 
-## Committed in this PR (host-verified)
+```yaml
+hooks:
+  user_defines:
+    sqlite3:
+      source: sqlite3mc
+```
 
-### Dependency swap — `mobile/pubspec.yaml`
-- `sqlite3_flutter_libs ^0.5.40` → **`sqlcipher_flutter_libs ^0.6.8`**. The two
-  cannot coexist (both ship a native sqlite3 that collides on iOS/macOS). 0.6.x
-  is the SQLCipher build for the sqlite3 2.x family; **0.7.0+ is an EOL no-op**.
-- Removed **`drift_flutter`** — it was unused (db_client opens `NativeDatabase`
-  directly) and transitively pulled `sqlite3_flutter_libs` back in,
-  reintroducing the collision.
-- Added **`sqlite3`** as a direct dep so the Android library override
-  (`package:sqlite3/open.dart`) is referenceable.
+`package:sqlite3` 3.3.3 publishes prebuilt sqlite3mc assets for Android, iOS,
+iOS simulator, macOS, Linux, Windows, and wasm. Local hook output confirmed the
+workspace pubspec define is read and the host build loads `libsqlite3mc.dylib`.
 
-### db_client (`connection_native.dart` + web/stub variants)
-- `formatCipherKeyPragma(rawKeyHex)` — builds the raw-key `PRAGMA key`. **The
-  thrown `ArgumentError` never embeds the key** (fixes the #4945 review finding).
-- `applyCipherKey(db, rawKeyHex)` — keys the connection and **fails closed**:
-  if `PRAGMA cipher_version` is empty (SQLCipher not linked) it throws rather
-  than silently writing plaintext.
-- `openEncryptedConnection({rawKeyHex})` — keyed `NativeDatabase` for the app
-  to inject the key into (db_client never reads the keystore).
-- `migratePlaintextToEncrypted({rawKeyHex})` — one-time in-place rekey via
-  `sqlcipher_export`, **safe by construction**: writes a side file, verifies it
-  (key opens it; table/row counts match the source) before swapping, renames
-  the plaintext original to a backup rather than deleting it, and leaves the
-  source intact on any failure (retries next launch). Copies `user_version`
-  (drift's schema version) explicitly, which `sqlcipher_export` does not.
-  Wipe-and-resync is rejected: `divine_db.db` holds local-only data that cannot
-  be re-fetched.
-- `backUpAndRemoveSharedDatabase()` — used by the §6 key-loss recovery.
+## Key and open sequence
 
-### App layer
-- `lib/database/sqlcipher_runtime.dart` (+ `_io` / `_stub`) — conditional-import
-  glue: on Android, `applyWorkaroundToOpenSqlCipherOnOldAndroidVersions()` +
-  `open.overrideFor(OperatingSystem.android, openCipherOnAndroid)`; a runtime
-  `isSqlCipherAvailable()` probe. No-op on web (no dart:ffi).
-- `lib/services/database_encryption_bootstrap.dart` — reads/generates a 32-byte
-  CSPRNG key in `flutter_secure_storage` (`db.cipher.key.v1`, 64 hex; never
-  logged), forces the SQLCipher runtime, runs the migration, and resolves the
-  key for the database provider. Throws if SQLCipher is not linked.
-- `lib/providers/db_cipher_key_provider.dart` — `Provider<String?>` (null
-  default → plaintext for web/tests), overridden in `main.dart`.
-- `lib/providers/database_provider.dart` — opens an encrypted connection when a
-  key is present, else the default connection.
-- `lib/main.dart` — resolves the key before the `ProviderContainer`; on failure
-  reports to Crashlytics and degrades to plaintext (the device-QA gate prevents
-  an unencrypted build from shipping).
+The app stores a 32-byte CSPRNG key in `flutter_secure_storage` under
+`db.cipher.key.v1`, represented as 64 lower-case hex characters. db_client never
+reads secure storage; the app bootstrap resolves the key and injects it.
 
-### §6 key-loss behavior (implemented; pending product signoff)
-If the keystore is cleared (OS reset / restore without keychain migration), the
-cipher key is gone and the encrypted DB is cryptographically unrecoverable. The
-bootstrap detects this (freshly generated key + an existing encrypted DB),
-**backs up the unrecoverable DB and recreates it under a new key** — DMs resync
-from relays; other local-only data is preserved in the backup but unavailable
-to the app without the lost key. This is the only possible recovery for an
-unrecoverable DB, but the user-facing notice / exact UX **needs product
-signoff** before merge.
+Every keyed native open runs these statements before any database use:
 
-## Device-QA-gated (NOT committed — must be done on real devices)
+```sql
+PRAGMA cipher = 'sqlcipher';
+PRAGMA legacy = 4;
+PRAGMA key = "x'<64 hex chars>'";
+```
 
-### iOS / macOS build configuration
-- On Apple platforms `package:sqlite3` resolves to the SQLCipher pod **only
-  when it is the sole sqlite3 provider** (now true after dropping
-  `sqlite3_flutter_libs`). If a future pod links plain sqlite3, `PRAGMA key`
-  silently no-ops. Mitigations to apply and verify on device:
-  - Add `-framework SQLCipher` to **Other Linker Flags** in the Runner target,
-    and ensure no `libsqlite3.dylib`/`.tbd` sits in *Link Binary With
-    Libraries*.
-  - A Podfile `post_install` that defines `SQLITE_HAS_CODEC=1` across pod build
-    configurations (mirror the SQLCipher podspec) if any pod is found linking
-    plain sqlite3.
-- App Store **export compliance**: AES-256 at rest is standard crypto. Set
-  `ITSAppUsesNonExemptEncryption` in `Info.plist` and confirm the exemption
-  with the compliance owner.
+The raw-key form skips PBKDF2, which is correct for a random 32-byte key and
+preserves compatibility with databases previously written by SQLCipher. The key
+must never appear in logs, exceptions, Crashlytics, analytics, or test output.
 
-These are intentionally not committed half-validated; the committed runtime
-`cipher_version` fail-closed check is the safety net regardless of build config.
+Fail-closed remains mandatory. The runtime and connection probes use
+`PRAGMA cipher`; upstream SQLite returns no rows, while SQLite3MultipleCiphers
+returns the active cipher. If MC is not active, startup refuses to open the local
+database instead of silently writing plaintext.
 
-## Device-QA checklist (must pass before merge)
-- [ ] iOS / Android / macOS build + launch with `sqlcipher_flutter_libs`.
-- [ ] Fresh install: DB is created encrypted; `PRAGMA cipher_version` is
-      non-empty; the file is not readable by plain `sqlite3`.
-- [ ] Upgrade from a populated **plaintext** DB: migration runs once, all
-      tables + row counts preserved, app fully functional, plaintext backup
-      present until the first successful keyed open, then cleaned.
-- [ ] Force-kill mid-migration → next launch recovers (plaintext intact,
-      retried), no data loss.
-- [ ] Key-loss path (clear keystore): DB is backed up + recreated, DMs resync,
-      app does not brick. (Confirm the §6 UX with product first.)
-- [ ] No measurable regression on cold-start DB open on a low-end device
-      (SQLCipher adds ~5–15%).
-- [ ] Key never appears in logs / Crashlytics / analytics.
+## Plaintext-to-encrypted migration
+
+`sqlcipher_export()` is not available under SQLite3MultipleCiphers, so the old
+migration path is replaced with a safe side-file flow:
+
+1. Classify the existing `divine_db.db` by opening it unkeyed. Only
+   `SQLITE_NOTADB` is treated as already encrypted; transient read failures stay
+   indeterminate and retry later.
+2. For populated plaintext DBs, copy the source to
+   `divine_db.db.sqlcipher_migrating` with `VACUUM INTO`.
+3. Open the side file, select `cipher='sqlcipher'` + `legacy=4`, then
+   `PRAGMA rekey = "x'<key>'"`.
+4. Verify the encrypted copy opens with the raw key and that `user_version` plus
+   all user-table row counts match the plaintext source.
+5. Rename the plaintext source to a `.pre_cipher_migration_backup*` file and
+   promote the verified encrypted artifact into place.
+
+On any failure, the plaintext source is left intact and migration retries next
+launch. After a later successful keyed open, old pre-cipher plaintext backups are
+deleted so plaintext does not remain at rest.
+
+## Key-loss recovery
+
+If secure storage loses `db.cipher.key.v1` while an encrypted DB remains, the old
+DB is cryptographically unrecoverable. The bootstrap backs up the unreadable DB
+and creates a fresh encrypted DB under the new key. This is data-preserving in
+the only possible way: the old bytes are retained for forensic/manual recovery,
+but the app cannot unlock them without the lost key.
+
+## Cache database
+
+Only `divine_db.db` is keyed. `cache_sync.db` remains opened unkeyed. MC supports
+plaintext databases, and the cache contains replaceable local cache state.
+
+## Host verification
+
+Host tests now cover the properties that used to be device-only:
+
+- raw-key MC file-backed open succeeds with `cipher='sqlcipher'` + `legacy=4`;
+- the encrypted file is not readable as plaintext SQLite;
+- populated plaintext DB migration preserves `user_version` and row counts;
+- malformed keys and keying failures do not leak the raw key;
+- bootstrap key generation, reuse, key-loss backup, and fail-closed behavior.
+
+Local probes also confirmed keyed in-memory MC databases are unsupported, so
+tests use file-backed DBs.
+
+## Device-QA checklist
+
+- [ ] Real iOS device: existing SQLCipher-encrypted `divine_db.db` opens through
+      the MC compatibility path with no data loss.
+- [ ] Real Android device: existing SQLCipher-encrypted `divine_db.db` opens
+      through the MC compatibility path with no data loss.
+- [ ] Fresh iOS install creates an encrypted DB and plain `sqlite3` cannot read
+      the file.
+- [ ] Fresh Android install creates an encrypted DB and plain `sqlite3` cannot
+      read the file.
+- [ ] Legacy populated plaintext DB migrates once, preserves row counts and
+      `user_version`, then removes pre-cipher plaintext backups after a keyed
+      open.
+- [ ] Force-kill during migration resumes without data loss.
+- [ ] Clear secure storage / simulate key loss: app backs up the unreadable DB,
+      creates a new encrypted DB, and does not brick.
+- [ ] Key material is absent from logs, Crashlytics, analytics, and thrown error
+      strings.
+
+Record device, OS version, build number, and exact result for each item before
+merging.

--- a/mobile/lib/database/sqlcipher_runtime.dart
+++ b/mobile/lib/database/sqlcipher_runtime.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Platform-conditional SQLCipher native-runtime bootstrap.
-// ABOUTME: Native applies the Android lib override + probes availability; web is a no-op.
+// ABOUTME: Platform-conditional SQLite3MultipleCiphers runtime bootstrap.
+// ABOUTME: Native probes sqlite3mc availability; web is a no-op.
 
 export 'sqlcipher_runtime_stub.dart'
     if (dart.library.io) 'sqlcipher_runtime_io.dart';

--- a/mobile/lib/database/sqlcipher_runtime_io.dart
+++ b/mobile/lib/database/sqlcipher_runtime_io.dart
@@ -1,46 +1,27 @@
-// ABOUTME: Native SQLCipher runtime bootstrap (Android lib override + availability probe).
-// ABOUTME: Forces package:sqlite3 to load libsqlcipher.so on Android before first use.
+// ABOUTME: Native SQLite3MultipleCiphers runtime availability probe.
+// ABOUTME: sqlite3 3.x loads the selected native SQLite build through hooks.
 
-import 'dart:ffi';
-import 'dart:io';
-
-import 'package:sqlcipher_flutter_libs/sqlcipher_flutter_libs.dart';
-import 'package:sqlite3/open.dart';
 import 'package:sqlite3/sqlite3.dart';
 
-/// Forces `package:sqlite3` to load the SQLCipher native library.
+/// Ensures `package:sqlite3` has initialized its hook-selected native library.
 ///
-/// Android ships a plain `libsqlite3.so`, so `package:sqlite3` must be told to
-/// load `libsqlcipher.so` instead — before ANY sqlite3 call and before drift
-/// spawns its background isolate.
-///
-/// iOS/macOS can also link plain sqlite3 through unrelated dependencies
-/// (Firebase Messaging is explicitly called out by `sqlcipher_flutter_libs`).
-/// CocoaPods links SQLCipher into the app process, so force package:sqlite3 to
-/// resolve process symbols instead of opening sqlite3.framework or stale
-/// CSQLite.framework pins first.
-Future<void> ensureSqlCipherRuntime() async {
-  if (Platform.isAndroid) {
-    await applyWorkaroundToOpenSqlCipherOnOldAndroidVersions();
-    open.overrideFor(OperatingSystem.android, openCipherOnAndroid);
-  } else if (Platform.isIOS || Platform.isMacOS) {
-    open.overrideFor(open.os!, () {
-      return DynamicLibrary.process();
-    });
-  }
-}
+/// sqlite3 3.x uses build hooks for Android/iOS/macOS/Linux/Windows native
+/// assets, so the legacy sqlcipher_flutter_libs Android workaround and
+/// `open.overrideFor` path are intentionally gone.
+Future<void> ensureSqlCipherRuntime() async {}
 
-/// Probes whether SQLCipher is actually the linked library by opening an
-/// in-memory database and checking the SQLCipher-only `cipher_version` pragma
-/// (empty on plain SQLite). Guards against the iOS failure mode where the
-/// system sqlite3 is linked and `PRAGMA key` silently no-ops.
+/// Probes whether SQLite3MultipleCiphers is the active SQLite implementation.
+///
+/// Upstream SQLite returns no rows for `PRAGMA cipher`; MC returns at least the
+/// currently selected cipher. This is the fail-closed guard before the app can
+/// open or migrate an encrypted local database.
 bool isSqlCipherAvailable() {
   final db = sqlite3.openInMemory();
   try {
-    return db.select('PRAGMA cipher_version;').isNotEmpty;
+    return db.select('PRAGMA cipher;').isNotEmpty;
   } on SqliteException {
     return false;
   } finally {
-    db.dispose();
+    db.close();
   }
 }

--- a/mobile/lib/database/sqlcipher_runtime_stub.dart
+++ b/mobile/lib/database/sqlcipher_runtime_stub.dart
@@ -1,8 +1,9 @@
-// ABOUTME: No-op SQLCipher runtime for platforms without dart:ffi (web).
-// ABOUTME: SQLCipher is native-only; web at-rest encryption is out of scope (#373).
+// ABOUTME: No-op SQLite3MultipleCiphers runtime for platforms without dart:ffi (web).
+// ABOUTME: Native at-rest encryption is out of scope on web (#373).
 
-/// Ensures `package:sqlite3` loads the SQLCipher build. No-op on web.
+/// Ensures `package:sqlite3` loads the sqlite3mc build. No-op on web.
 Future<void> ensureSqlCipherRuntime() async {}
 
-/// Whether SQLCipher is the active SQLite library. Always `false` on web.
+/// Whether SQLite3MultipleCiphers is the active SQLite library. Always `false`
+/// on web.
 bool isSqlCipherAvailable() => false;

--- a/mobile/lib/features/feature_flags/providers/feature_flag_providers.g.dart
+++ b/mobile/lib/features/feature_flags/providers/feature_flag_providers.g.dart
@@ -11,7 +11,7 @@ part of 'feature_flag_providers.dart';
 /// Build configuration provider
 
 @ProviderFor(buildConfiguration)
-const buildConfigurationProvider = BuildConfigurationProvider._();
+final buildConfigurationProvider = BuildConfigurationProvider._();
 
 /// Build configuration provider
 
@@ -24,7 +24,7 @@ final class BuildConfigurationProvider
         >
     with $Provider<BuildConfiguration> {
   /// Build configuration provider
-  const BuildConfigurationProvider._()
+  BuildConfigurationProvider._()
     : super(
         from: null,
         argument: null,
@@ -64,7 +64,7 @@ String _$buildConfigurationHash() =>
 /// Feature flag service provider — kept alive so flag state survives navigation
 
 @ProviderFor(featureFlagService)
-const featureFlagServiceProvider = FeatureFlagServiceProvider._();
+final featureFlagServiceProvider = FeatureFlagServiceProvider._();
 
 /// Feature flag service provider — kept alive so flag state survives navigation
 
@@ -77,7 +77,7 @@ final class FeatureFlagServiceProvider
         >
     with $Provider<FeatureFlagService> {
   /// Feature flag service provider — kept alive so flag state survives navigation
-  const FeatureFlagServiceProvider._()
+  FeatureFlagServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -117,7 +117,7 @@ String _$featureFlagServiceHash() =>
 /// Feature flag state provider (reactive to service changes)
 
 @ProviderFor(featureFlagState)
-const featureFlagStateProvider = FeatureFlagStateProvider._();
+final featureFlagStateProvider = FeatureFlagStateProvider._();
 
 /// Feature flag state provider (reactive to service changes)
 
@@ -130,7 +130,7 @@ final class FeatureFlagStateProvider
         >
     with $Provider<Map<FeatureFlag, bool>> {
   /// Feature flag state provider (reactive to service changes)
-  const FeatureFlagStateProvider._()
+  FeatureFlagStateProvider._()
     : super(
         from: null,
         argument: null,
@@ -169,7 +169,7 @@ String _$featureFlagStateHash() => r'bf39490bff4b6cb74fd70fff0c499635669fef8d';
 /// Individual feature flag check provider family
 
 @ProviderFor(isFeatureEnabled)
-const isFeatureEnabledProvider = IsFeatureEnabledFamily._();
+final isFeatureEnabledProvider = IsFeatureEnabledFamily._();
 
 /// Individual feature flag check provider family
 
@@ -177,7 +177,7 @@ final class IsFeatureEnabledProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Individual feature flag check provider family
-  const IsFeatureEnabledProvider._({
+  IsFeatureEnabledProvider._({
     required IsFeatureEnabledFamily super.from,
     required FeatureFlag super.argument,
   }) : super(
@@ -234,7 +234,7 @@ String _$isFeatureEnabledHash() => r'706cae00a5cf7bf715bcb31deb6840a98727e80e';
 
 final class IsFeatureEnabledFamily extends $Family
     with $FunctionalFamilyOverride<bool, FeatureFlag> {
-  const IsFeatureEnabledFamily._()
+  IsFeatureEnabledFamily._()
     : super(
         retry: null,
         name: r'isFeatureEnabledProvider',

--- a/mobile/lib/hive_registrar.g.dart
+++ b/mobile/lib/hive_registrar.g.dart
@@ -2,7 +2,7 @@
 // Do not modify
 // Check in to version control
 
-import 'package:hive_ce/hive.dart';
+import 'package:hive_ce/hive_ce.dart';
 import 'package:openvine/models/pending_upload.dart';
 
 extension HiveRegistrar on HiveInterface {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1299,10 +1299,10 @@ Future<void> _startOpenVineApp() async {
   final packageInfo = await PackageInfo.fromPlatform();
 
   // Resolve the at-rest database cipher key before the container so the
-  // database provider opens an encrypted SQLCipher connection on first use.
-  // This also forces package:sqlite3 onto the SQLCipher build (Android) and
-  // runs the one-time plaintext→encrypted migration, both of which must happen
-  // before any sqlite3 open. (#570, finding C2)
+  // database provider opens an encrypted SQLite3MultipleCiphers connection on
+  // first use. This also verifies package:sqlite3 loaded the sqlite3mc hook
+  // build and runs the one-time plaintext→encrypted migration, both of which
+  // must happen before any Drift database open. (#570, finding C2)
   const dbCipherSecureStorage = FlutterSecureStorage(
     aOptions: AndroidOptions(encryptedSharedPreferences: true),
   );
@@ -1334,9 +1334,9 @@ Future<void> _startOpenVineApp() async {
         // left recovered chats stranded under "Message requests"). See #5304.
         onDatabaseReset: () => DmSyncState(sharedPreferences).clearAll(),
       ).resolveCipherKey(),
-      // SQLCipher build misconfiguration or secure-storage failures must fail
-      // closed after reporting. Continuing with a null key would open an
-      // existing encrypted DB as plaintext and spam SQLITE_NOTADB.
+      // SQLite3MultipleCiphers build misconfiguration or secure-storage
+      // failures must fail closed after reporting. Continuing with a null key
+      // would open an existing encrypted DB as plaintext and spam SQLITE_NOTADB.
       recordError: recordDatabaseBootstrapFailure,
     ),
     repairLocalDatabaseCache: (error, stack) => resetEncryptedDatabaseCache(

--- a/mobile/lib/providers/app_foreground_provider.g.dart
+++ b/mobile/lib/providers/app_foreground_provider.g.dart
@@ -11,13 +11,13 @@ part of 'app_foreground_provider.dart';
 /// State notifier for tracking app foreground/background state
 
 @ProviderFor(AppForeground)
-const appForegroundProvider = AppForegroundProvider._();
+final appForegroundProvider = AppForegroundProvider._();
 
 /// State notifier for tracking app foreground/background state
 final class AppForegroundProvider
     extends $NotifierProvider<AppForeground, bool> {
   /// State notifier for tracking app foreground/background state
-  const AppForegroundProvider._()
+  AppForegroundProvider._()
     : super(
         from: null,
         argument: null,
@@ -52,8 +52,7 @@ abstract class _$AppForeground extends $Notifier<bool> {
   bool build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<bool, bool>;
     final element =
         ref.element
@@ -63,6 +62,6 @@ abstract class _$AppForeground extends $Notifier<bool> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -11,7 +11,7 @@ part of 'auth_providers.dart';
 /// Secure key storage service (foundational service)
 
 @ProviderFor(secureKeyStorage)
-const secureKeyStorageProvider = SecureKeyStorageProvider._();
+final secureKeyStorageProvider = SecureKeyStorageProvider._();
 
 /// Secure key storage service (foundational service)
 
@@ -24,7 +24,7 @@ final class SecureKeyStorageProvider
         >
     with $Provider<SecureKeyStorage> {
   /// Secure key storage service (foundational service)
-  const SecureKeyStorageProvider._()
+  SecureKeyStorageProvider._()
     : super(
         from: null,
         argument: null,
@@ -60,12 +60,12 @@ final class SecureKeyStorageProvider
 String _$secureKeyStorageHash() => r'853547d439994307884d2f47f3d9769daa0a1e96';
 
 @ProviderFor(oauthConfig)
-const oauthConfigProvider = OauthConfigProvider._();
+final oauthConfigProvider = OauthConfigProvider._();
 
 final class OauthConfigProvider
     extends $FunctionalProvider<OAuthConfig, OAuthConfig, OAuthConfig>
     with $Provider<OAuthConfig> {
-  const OauthConfigProvider._()
+  OauthConfigProvider._()
     : super(
         from: null,
         argument: null,
@@ -101,7 +101,7 @@ final class OauthConfigProvider
 String _$oauthConfigHash() => r'2078bce919b9216a65dedc105d471568ba510a52';
 
 @ProviderFor(flutterSecureStorage)
-const flutterSecureStorageProvider = FlutterSecureStorageProvider._();
+final flutterSecureStorageProvider = FlutterSecureStorageProvider._();
 
 final class FlutterSecureStorageProvider
     extends
@@ -111,7 +111,7 @@ final class FlutterSecureStorageProvider
           FlutterSecureStorage
         >
     with $Provider<FlutterSecureStorage> {
-  const FlutterSecureStorageProvider._()
+  FlutterSecureStorageProvider._()
     : super(
         from: null,
         argument: null,
@@ -149,7 +149,7 @@ String _$flutterSecureStorageHash() =>
     r'4d4ab3d09f7188871974df552778d4799beabcd8';
 
 @ProviderFor(secureKeycastStorage)
-const secureKeycastStorageProvider = SecureKeycastStorageProvider._();
+final secureKeycastStorageProvider = SecureKeycastStorageProvider._();
 
 final class SecureKeycastStorageProvider
     extends
@@ -159,7 +159,7 @@ final class SecureKeycastStorageProvider
           SecureKeycastStorage
         >
     with $Provider<SecureKeycastStorage> {
-  const SecureKeycastStorageProvider._()
+  SecureKeycastStorageProvider._()
     : super(
         from: null,
         argument: null,
@@ -197,7 +197,7 @@ String _$secureKeycastStorageHash() =>
     r'c57c0ec02e36cd1a0cc8b850c450af2eb4c496b3';
 
 @ProviderFor(pendingVerificationService)
-const pendingVerificationServiceProvider =
+final pendingVerificationServiceProvider =
     PendingVerificationServiceProvider._();
 
 final class PendingVerificationServiceProvider
@@ -208,7 +208,7 @@ final class PendingVerificationServiceProvider
           PendingVerificationService
         >
     with $Provider<PendingVerificationService> {
-  const PendingVerificationServiceProvider._()
+  PendingVerificationServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -246,12 +246,12 @@ String _$pendingVerificationServiceHash() =>
     r'9b524b7d7fd20c98b2e0942e9ea6358419dc9dd4';
 
 @ProviderFor(oauthClient)
-const oauthClientProvider = OauthClientProvider._();
+final oauthClientProvider = OauthClientProvider._();
 
 final class OauthClientProvider
     extends $FunctionalProvider<KeycastOAuth, KeycastOAuth, KeycastOAuth>
     with $Provider<KeycastOAuth> {
-  const OauthClientProvider._()
+  OauthClientProvider._()
     : super(
         from: null,
         argument: null,
@@ -287,7 +287,7 @@ final class OauthClientProvider
 String _$oauthClientHash() => r'0cc53348fbc3c769c81e52dd200c0efc6c20de3c';
 
 @ProviderFor(passwordResetListener)
-const passwordResetListenerProvider = PasswordResetListenerProvider._();
+final passwordResetListenerProvider = PasswordResetListenerProvider._();
 
 final class PasswordResetListenerProvider
     extends
@@ -297,7 +297,7 @@ final class PasswordResetListenerProvider
           PasswordResetListener
         >
     with $Provider<PasswordResetListener> {
-  const PasswordResetListenerProvider._()
+  PasswordResetListenerProvider._()
     : super(
         from: null,
         argument: null,
@@ -335,7 +335,7 @@ String _$passwordResetListenerHash() =>
     r'3fe0dd6870cd754567aaaf53b5b74f439f232ad4';
 
 @ProviderFor(emailVerificationListener)
-const emailVerificationListenerProvider = EmailVerificationListenerProvider._();
+final emailVerificationListenerProvider = EmailVerificationListenerProvider._();
 
 final class EmailVerificationListenerProvider
     extends
@@ -345,7 +345,7 @@ final class EmailVerificationListenerProvider
           EmailVerificationListener
         >
     with $Provider<EmailVerificationListener> {
-  const EmailVerificationListenerProvider._()
+  EmailVerificationListenerProvider._()
     : super(
         from: null,
         argument: null,
@@ -385,7 +385,7 @@ String _$emailVerificationListenerHash() =>
 /// Web authentication service (for web platform only)
 
 @ProviderFor(webAuthService)
-const webAuthServiceProvider = WebAuthServiceProvider._();
+final webAuthServiceProvider = WebAuthServiceProvider._();
 
 /// Web authentication service (for web platform only)
 
@@ -393,7 +393,7 @@ final class WebAuthServiceProvider
     extends $FunctionalProvider<WebAuthService, WebAuthService, WebAuthService>
     with $Provider<WebAuthService> {
   /// Web authentication service (for web platform only)
-  const WebAuthServiceProvider._()
+  WebAuthServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -431,7 +431,7 @@ String _$webAuthServiceHash() => r'53411c0f6a62bb9b59f90a0d7fc738a553a0b575';
 /// Nostr key manager for cryptographic operations
 
 @ProviderFor(nostrKeyManager)
-const nostrKeyManagerProvider = NostrKeyManagerProvider._();
+final nostrKeyManagerProvider = NostrKeyManagerProvider._();
 
 /// Nostr key manager for cryptographic operations
 
@@ -440,7 +440,7 @@ final class NostrKeyManagerProvider
         $FunctionalProvider<NostrKeyManager, NostrKeyManager, NostrKeyManager>
     with $Provider<NostrKeyManager> {
   /// Nostr key manager for cryptographic operations
-  const NostrKeyManagerProvider._()
+  NostrKeyManagerProvider._()
     : super(
         from: null,
         argument: null,
@@ -478,7 +478,7 @@ String _$nostrKeyManagerHash() => r'a0d67b6d79af5ecdc42bc6616542249200a24b64';
 /// Authentication service
 
 @ProviderFor(authService)
-const authServiceProvider = AuthServiceProvider._();
+final authServiceProvider = AuthServiceProvider._();
 
 /// Authentication service
 
@@ -486,7 +486,7 @@ final class AuthServiceProvider
     extends $FunctionalProvider<AuthService, AuthService, AuthService>
     with $Provider<AuthService> {
   /// Authentication service
-  const AuthServiceProvider._()
+  AuthServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -526,7 +526,7 @@ String _$authServiceHash() => r'5ed8b2e4f69b956cef94207839973aa1f676df4c';
 /// to get automatic rebuilds when authentication state changes.
 
 @ProviderFor(currentAuthState)
-const currentAuthStateProvider = CurrentAuthStateProvider._();
+final currentAuthStateProvider = CurrentAuthStateProvider._();
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly
@@ -538,7 +538,7 @@ final class CurrentAuthStateProvider
   /// Provider that returns current auth state and rebuilds when it changes.
   /// Widgets should watch this instead of authService.authState directly
   /// to get automatic rebuilds when authentication state changes.
-  const CurrentAuthStateProvider._()
+  CurrentAuthStateProvider._()
     : super(
         from: null,
         argument: null,
@@ -579,7 +579,7 @@ String _$currentAuthStateHash() => r'41c987ffc8f661555bab3ebec9078180411f66eb';
 /// [AuthService.authRpcCapability] directly.
 
 @ProviderFor(currentAuthRpcCapability)
-const currentAuthRpcCapabilityProvider = CurrentAuthRpcCapabilityProvider._();
+final currentAuthRpcCapabilityProvider = CurrentAuthRpcCapabilityProvider._();
 
 /// Provider that returns current RPC capability and rebuilds on changes.
 ///
@@ -598,7 +598,7 @@ final class CurrentAuthRpcCapabilityProvider
   ///
   /// Widgets and repositories should watch this instead of polling
   /// [AuthService.authRpcCapability] directly.
-  const CurrentAuthRpcCapabilityProvider._()
+  CurrentAuthRpcCapabilityProvider._()
     : super(
         from: null,
         argument: null,
@@ -640,7 +640,7 @@ String _$currentAuthRpcCapabilityHash() =>
 /// Invalidate this provider after sign-in or sign-out to refresh the list.
 
 @ProviderFor(knownAccounts)
-const knownAccountsProvider = KnownAccountsProvider._();
+final knownAccountsProvider = KnownAccountsProvider._();
 
 /// Provider that fetches the list of known accounts from the auth service.
 ///
@@ -659,7 +659,7 @@ final class KnownAccountsProvider
   /// Provider that fetches the list of known accounts from the auth service.
   ///
   /// Invalidate this provider after sign-in or sign-out to refresh the list.
-  const KnownAccountsProvider._()
+  KnownAccountsProvider._()
     : super(
         from: null,
         argument: null,
@@ -691,7 +691,7 @@ String _$knownAccountsHash() => r'8e9753265420cf092af04aa07686c98cdaa8eb1e';
 /// Watch this provider at app startup to keep Zendesk identity in sync with auth
 
 @ProviderFor(zendeskIdentitySync)
-const zendeskIdentitySyncProvider = ZendeskIdentitySyncProvider._();
+final zendeskIdentitySyncProvider = ZendeskIdentitySyncProvider._();
 
 /// Provider that sets Zendesk user identity when auth state changes
 /// Watch this provider at app startup to keep Zendesk identity in sync with auth
@@ -701,7 +701,7 @@ final class ZendeskIdentitySyncProvider
     with $Provider<void> {
   /// Provider that sets Zendesk user identity when auth state changes
   /// Watch this provider at app startup to keep Zendesk identity in sync with auth
-  const ZendeskIdentitySyncProvider._()
+  ZendeskIdentitySyncProvider._()
     : super(
         from: null,
         argument: null,
@@ -741,7 +741,7 @@ String _$zendeskIdentitySyncHash() =>
 /// verifier base URL. Stateless — every call hits the network.
 
 @ProviderFor(verifierClient)
-const verifierClientProvider = VerifierClientProvider._();
+final verifierClientProvider = VerifierClientProvider._();
 
 /// Provider for [VerifierClient] pointed at the current environment's
 /// verifier base URL. Stateless — every call hits the network.
@@ -751,7 +751,7 @@ final class VerifierClientProvider
     with $Provider<VerifierClient> {
   /// Provider for [VerifierClient] pointed at the current environment's
   /// verifier base URL. Stateless — every call hits the network.
-  const VerifierClientProvider._()
+  VerifierClientProvider._()
     : super(
         from: null,
         argument: null,
@@ -790,7 +790,7 @@ String _$verifierClientHash() => r'1d6966c5483814cd7fa203e7e9e198dc5c9c232d';
 /// with NIP-39 i tag parsing.
 
 @ProviderFor(identityClaimsRepository)
-const identityClaimsRepositoryProvider = IdentityClaimsRepositoryProvider._();
+final identityClaimsRepositoryProvider = IdentityClaimsRepositoryProvider._();
 
 /// Provider for [IdentityClaimsRepository] composing the verifier client
 /// with NIP-39 i tag parsing.
@@ -805,7 +805,7 @@ final class IdentityClaimsRepositoryProvider
     with $Provider<IdentityClaimsRepository> {
   /// Provider for [IdentityClaimsRepository] composing the verifier client
   /// with NIP-39 i tag parsing.
-  const IdentityClaimsRepositoryProvider._()
+  IdentityClaimsRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -845,7 +845,7 @@ String _$identityClaimsRepositoryHash() =>
 /// NIP-98 authentication service
 
 @ProviderFor(nip98AuthService)
-const nip98AuthServiceProvider = Nip98AuthServiceProvider._();
+final nip98AuthServiceProvider = Nip98AuthServiceProvider._();
 
 /// NIP-98 authentication service
 
@@ -858,7 +858,7 @@ final class Nip98AuthServiceProvider
         >
     with $Provider<Nip98AuthService> {
   /// NIP-98 authentication service
-  const Nip98AuthServiceProvider._()
+  Nip98AuthServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -896,7 +896,7 @@ String _$nip98AuthServiceHash() => r'cfc2e0a65e1dbd9c559886929257fa66a7afb1c6';
 /// Account Deletion Service for NIP-62 Request to Vanish
 
 @ProviderFor(accountDeletionService)
-const accountDeletionServiceProvider = AccountDeletionServiceProvider._();
+final accountDeletionServiceProvider = AccountDeletionServiceProvider._();
 
 /// Account Deletion Service for NIP-62 Request to Vanish
 
@@ -909,7 +909,7 @@ final class AccountDeletionServiceProvider
         >
     with $Provider<AccountDeletionService> {
   /// Account Deletion Service for NIP-62 Request to Vanish
-  const AccountDeletionServiceProvider._()
+  AccountDeletionServiceProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/classic_vines_provider.g.dart
+++ b/mobile/lib/providers/classic_vines_provider.g.dart
@@ -17,7 +17,7 @@ part of 'classic_vines_provider.dart';
 /// transient failures and empty pages.
 
 @ProviderFor(ClassicVinesFeed)
-const classicVinesFeedProvider = ClassicVinesFeedProvider._();
+final classicVinesFeedProvider = ClassicVinesFeedProvider._();
 
 /// ClassicVines feed provider - shows pre-2017 Vine archive sorted by loops
 ///
@@ -35,7 +35,7 @@ final class ClassicVinesFeedProvider
   ///
   /// Pull-to-refresh selects a fresh random slice of classics while retrying
   /// transient failures and empty pages.
-  const ClassicVinesFeedProvider._()
+  ClassicVinesFeedProvider._()
     : super(
         from: null,
         argument: null,
@@ -68,8 +68,7 @@ abstract class _$ClassicVinesFeed extends $AsyncNotifier<VideoFeedState> {
   FutureOr<VideoFeedState> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<VideoFeedState>, VideoFeedState>;
     final element =
         ref.element
@@ -79,14 +78,14 @@ abstract class _$ClassicVinesFeed extends $AsyncNotifier<VideoFeedState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 /// Provider to check if classic vines feed is loading
 
 @ProviderFor(classicVinesFeedLoading)
-const classicVinesFeedLoadingProvider = ClassicVinesFeedLoadingProvider._();
+final classicVinesFeedLoadingProvider = ClassicVinesFeedLoadingProvider._();
 
 /// Provider to check if classic vines feed is loading
 
@@ -94,7 +93,7 @@ final class ClassicVinesFeedLoadingProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider to check if classic vines feed is loading
-  const ClassicVinesFeedLoadingProvider._()
+  ClassicVinesFeedLoadingProvider._()
     : super(
         from: null,
         argument: null,
@@ -133,7 +132,7 @@ String _$classicVinesFeedLoadingHash() =>
 /// Provider to get current classic vines feed video count
 
 @ProviderFor(classicVinesFeedCount)
-const classicVinesFeedCountProvider = ClassicVinesFeedCountProvider._();
+final classicVinesFeedCountProvider = ClassicVinesFeedCountProvider._();
 
 /// Provider to get current classic vines feed video count
 
@@ -141,7 +140,7 @@ final class ClassicVinesFeedCountProvider
     extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   /// Provider to get current classic vines feed video count
-  const ClassicVinesFeedCountProvider._()
+  ClassicVinesFeedCountProvider._()
     : super(
         from: null,
         argument: null,
@@ -183,7 +182,7 @@ String _$classicVinesFeedCountHash() =>
 /// Classic vines require Funnelcake REST API to be available.
 
 @ProviderFor(classicVinesAvailable)
-const classicVinesAvailableProvider = ClassicVinesAvailableProvider._();
+final classicVinesAvailableProvider = ClassicVinesAvailableProvider._();
 
 /// Provider to check if classic vines are available
 ///
@@ -197,7 +196,7 @@ final class ClassicVinesAvailableProvider
   ///
   /// Delegates to the centralized funnelcakeAvailableProvider.
   /// Classic vines require Funnelcake REST API to be available.
-  const ClassicVinesAvailableProvider._()
+  ClassicVinesAvailableProvider._()
     : super(
         from: null,
         argument: null,
@@ -231,7 +230,7 @@ String _$classicVinesAvailableHash() =>
 /// Also triggers profile prefetching for Viners without avatars.
 
 @ProviderFor(topClassicViners)
-const topClassicVinersProvider = TopClassicVinersProvider._();
+final topClassicVinersProvider = TopClassicVinersProvider._();
 
 /// Provider for top classic Viners derived from classic videos
 ///
@@ -252,7 +251,7 @@ final class TopClassicVinersProvider
   ///
   /// Aggregates videos by pubkey and sorts by total loop count.
   /// Also triggers profile prefetching for Viners without avatars.
-  const TopClassicVinersProvider._()
+  TopClassicVinersProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/curation_providers.g.dart
+++ b/mobile/lib/providers/curation_providers.g.dart
@@ -11,7 +11,7 @@ part of 'curation_providers.dart';
 /// Provider for FunnelcakeApiClient (typed client for Funnelcake REST API)
 
 @ProviderFor(funnelcakeApiClient)
-const funnelcakeApiClientProvider = FunnelcakeApiClientProvider._();
+final funnelcakeApiClientProvider = FunnelcakeApiClientProvider._();
 
 /// Provider for FunnelcakeApiClient (typed client for Funnelcake REST API)
 
@@ -24,7 +24,7 @@ final class FunnelcakeApiClientProvider
         >
     with $Provider<FunnelcakeApiClient> {
   /// Provider for FunnelcakeApiClient (typed client for Funnelcake REST API)
-  const FunnelcakeApiClientProvider._()
+  FunnelcakeApiClientProvider._()
     : super(
         from: null,
         argument: null,
@@ -70,7 +70,7 @@ String _$funnelcakeApiClientHash() =>
 /// `client.isAvailable` directly.
 
 @ProviderFor(FunnelcakeAvailable)
-const funnelcakeAvailableProvider = FunnelcakeAvailableProvider._();
+final funnelcakeAvailableProvider = FunnelcakeAvailableProvider._();
 
 /// Single source of truth for Funnelcake REST API availability.
 ///
@@ -88,7 +88,7 @@ final class FunnelcakeAvailableProvider
   ///
   /// All feed providers should watch this instead of checking
   /// `client.isAvailable` directly.
-  const FunnelcakeAvailableProvider._()
+  FunnelcakeAvailableProvider._()
     : super(
         from: null,
         argument: null,
@@ -122,8 +122,7 @@ abstract class _$FunnelcakeAvailable extends $AsyncNotifier<bool> {
   FutureOr<bool> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<bool>, bool>;
     final element =
         ref.element
@@ -133,7 +132,7 @@ abstract class _$FunnelcakeAvailable extends $AsyncNotifier<bool> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -141,7 +140,7 @@ abstract class _$FunnelcakeAvailable extends $AsyncNotifier<bool> {
 /// keepAlive ensures provider persists across tab navigation
 
 @ProviderFor(Curation)
-const curationProvider = CurationProvider._();
+final curationProvider = CurationProvider._();
 
 /// Main curation provider that manages curated content sets
 /// keepAlive ensures provider persists across tab navigation
@@ -149,7 +148,7 @@ final class CurationProvider
     extends $NotifierProvider<Curation, CurationState> {
   /// Main curation provider that manages curated content sets
   /// keepAlive ensures provider persists across tab navigation
-  const CurationProvider._()
+  CurationProvider._()
     : super(
         from: null,
         argument: null,
@@ -185,8 +184,7 @@ abstract class _$Curation extends $Notifier<CurationState> {
   CurationState build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<CurationState, CurationState>;
     final element =
         ref.element
@@ -196,14 +194,14 @@ abstract class _$Curation extends $Notifier<CurationState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 /// Provider to check if curation is loading
 
 @ProviderFor(curationLoading)
-const curationLoadingProvider = CurationLoadingProvider._();
+final curationLoadingProvider = CurationLoadingProvider._();
 
 /// Provider to check if curation is loading
 
@@ -211,7 +209,7 @@ final class CurationLoadingProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider to check if curation is loading
-  const CurationLoadingProvider._()
+  CurationLoadingProvider._()
     : super(
         from: null,
         argument: null,
@@ -249,7 +247,7 @@ String _$curationLoadingHash() => r'e1a04d9f8d90870d340665613c0938b356085039';
 /// Provider to get editor's picks
 
 @ProviderFor(editorsPicks)
-const editorsPicksProvider = EditorsPicksProvider._();
+final editorsPicksProvider = EditorsPicksProvider._();
 
 /// Provider to get editor's picks
 
@@ -262,7 +260,7 @@ final class EditorsPicksProvider
         >
     with $Provider<List<VideoEvent>> {
   /// Provider to get editor's picks
-  const EditorsPicksProvider._()
+  EditorsPicksProvider._()
     : super(
         from: null,
         argument: null,
@@ -300,13 +298,13 @@ String _$editorsPicksHash() => r'47f6f4c73a8e2f6f8aafa718986c063feb530d08';
 /// Provider for analytics-based trending videos with cursor pagination
 
 @ProviderFor(AnalyticsTrending)
-const analyticsTrendingProvider = AnalyticsTrendingProvider._();
+final analyticsTrendingProvider = AnalyticsTrendingProvider._();
 
 /// Provider for analytics-based trending videos with cursor pagination
 final class AnalyticsTrendingProvider
     extends $NotifierProvider<AnalyticsTrending, List<VideoEvent>> {
   /// Provider for analytics-based trending videos with cursor pagination
-  const AnalyticsTrendingProvider._()
+  AnalyticsTrendingProvider._()
     : super(
         from: null,
         argument: null,
@@ -341,8 +339,7 @@ abstract class _$AnalyticsTrending extends $Notifier<List<VideoEvent>> {
   List<VideoEvent> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<List<VideoEvent>, List<VideoEvent>>;
     final element =
         ref.element
@@ -352,20 +349,20 @@ abstract class _$AnalyticsTrending extends $Notifier<List<VideoEvent>> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 /// Provider for analytics-based popular videos
 
 @ProviderFor(AnalyticsPopular)
-const analyticsPopularProvider = AnalyticsPopularProvider._();
+final analyticsPopularProvider = AnalyticsPopularProvider._();
 
 /// Provider for analytics-based popular videos
 final class AnalyticsPopularProvider
     extends $NotifierProvider<AnalyticsPopular, List<VideoEvent>> {
   /// Provider for analytics-based popular videos
-  const AnalyticsPopularProvider._()
+  AnalyticsPopularProvider._()
     : super(
         from: null,
         argument: null,
@@ -400,8 +397,7 @@ abstract class _$AnalyticsPopular extends $Notifier<List<VideoEvent>> {
   List<VideoEvent> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<List<VideoEvent>, List<VideoEvent>>;
     final element =
         ref.element
@@ -411,20 +407,20 @@ abstract class _$AnalyticsPopular extends $Notifier<List<VideoEvent>> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 /// Provider for trending hashtags
 
 @ProviderFor(TrendingHashtags)
-const trendingHashtagsProvider = TrendingHashtagsProvider._();
+final trendingHashtagsProvider = TrendingHashtagsProvider._();
 
 /// Provider for trending hashtags
 final class TrendingHashtagsProvider
     extends $AsyncNotifierProvider<TrendingHashtags, List<TrendingHashtag>> {
   /// Provider for trending hashtags
-  const TrendingHashtagsProvider._()
+  TrendingHashtagsProvider._()
     : super(
         from: null,
         argument: null,
@@ -452,8 +448,7 @@ abstract class _$TrendingHashtags
   FutureOr<List<TrendingHashtag>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref =
         this.ref
             as $Ref<AsyncValue<List<TrendingHashtag>>, List<TrendingHashtag>>;
@@ -468,6 +463,6 @@ abstract class _$TrendingHashtags
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/database_provider.dart
+++ b/mobile/lib/providers/database_provider.dart
@@ -9,7 +9,7 @@ part 'database_provider.g.dart';
 @Riverpod(keepAlive: true) // Singleton - lives for app lifetime
 AppDatabase database(Ref ref) {
   // When a cipher key is present (resolved at startup by
-  // DatabaseEncryptionBootstrap), open an at-rest-encrypted SQLCipher
+  // DatabaseEncryptionBootstrap), open an at-rest-encrypted native
   // connection; otherwise (web, tests, or a deferred migration) open the
   // default connection. (#570, finding C2)
   final cipherKey = ref.watch(dbCipherKeyProvider);

--- a/mobile/lib/providers/database_provider.g.dart
+++ b/mobile/lib/providers/database_provider.g.dart
@@ -10,12 +10,12 @@ part of 'database_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(database)
-const databaseProvider = DatabaseProvider._();
+final databaseProvider = DatabaseProvider._();
 
 final class DatabaseProvider
     extends $FunctionalProvider<AppDatabase, AppDatabase, AppDatabase>
     with $Provider<AppDatabase> {
-  const DatabaseProvider._()
+  DatabaseProvider._()
     : super(
         from: null,
         argument: null,
@@ -54,7 +54,7 @@ String _$databaseHash() => r'8a6f9ab3f9be46444941c5c472f4f76e12a75ba1';
 /// Enables optimistic caching of Nostr events in the local database.
 
 @ProviderFor(appDbClient)
-const appDbClientProvider = AppDbClientProvider._();
+final appDbClientProvider = AppDbClientProvider._();
 
 /// AppDbClient wrapping the database for NostrClient integration.
 /// Enables optimistic caching of Nostr events in the local database.
@@ -64,7 +64,7 @@ final class AppDbClientProvider
     with $Provider<AppDbClient> {
   /// AppDbClient wrapping the database for NostrClient integration.
   /// Enables optimistic caching of Nostr events in the local database.
-  const AppDbClientProvider._()
+  AppDbClientProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/db_cipher_key_provider.dart
+++ b/mobile/lib/providers/db_cipher_key_provider.dart
@@ -3,7 +3,7 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// The 64-hex (raw 32-byte) SQLCipher key for the local database, or `null`
+/// The 64-hex (raw 32-byte) cipher key for the local database, or `null`
 /// when the database should open unencrypted.
 ///
 /// `null` is the default so tests and web fall back to a plaintext connection.

--- a/mobile/lib/providers/deep_link_provider.g.dart
+++ b/mobile/lib/providers/deep_link_provider.g.dart
@@ -12,7 +12,7 @@ part of 'deep_link_provider.dart';
 /// Note: Does NOT auto-initialize - caller must call initialize() after setting up listeners
 
 @ProviderFor(deepLinkService)
-const deepLinkServiceProvider = DeepLinkServiceProvider._();
+final deepLinkServiceProvider = DeepLinkServiceProvider._();
 
 /// Provider for the deep link service
 /// Note: Does NOT auto-initialize - caller must call initialize() after setting up listeners
@@ -23,7 +23,7 @@ final class DeepLinkServiceProvider
     with $Provider<DeepLinkService> {
   /// Provider for the deep link service
   /// Note: Does NOT auto-initialize - caller must call initialize() after setting up listeners
-  const DeepLinkServiceProvider._()
+  DeepLinkServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -61,7 +61,7 @@ String _$deepLinkServiceHash() => r'09d157627be000ddb4b5ef34307797ed3c7745ca';
 /// Stream provider for incoming deep links
 
 @ProviderFor(deepLinks)
-const deepLinksProvider = DeepLinksProvider._();
+final deepLinksProvider = DeepLinksProvider._();
 
 /// Stream provider for incoming deep links
 
@@ -70,7 +70,7 @@ final class DeepLinksProvider
         $FunctionalProvider<AsyncValue<DeepLink>, DeepLink, Stream<DeepLink>>
     with $FutureModifier<DeepLink>, $StreamProvider<DeepLink> {
   /// Stream provider for incoming deep links
-  const DeepLinksProvider._()
+  DeepLinksProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/developer_mode_tap_provider.g.dart
+++ b/mobile/lib/providers/developer_mode_tap_provider.g.dart
@@ -10,11 +10,11 @@ part of 'developer_mode_tap_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(DeveloperModeTapCounter)
-const developerModeTapCounterProvider = DeveloperModeTapCounterProvider._();
+final developerModeTapCounterProvider = DeveloperModeTapCounterProvider._();
 
 final class DeveloperModeTapCounterProvider
     extends $NotifierProvider<DeveloperModeTapCounter, int> {
-  const DeveloperModeTapCounterProvider._()
+  DeveloperModeTapCounterProvider._()
     : super(
         from: null,
         argument: null,
@@ -48,8 +48,7 @@ abstract class _$DeveloperModeTapCounter extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -59,6 +58,6 @@ abstract class _$DeveloperModeTapCounter extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/environment_provider.g.dart
+++ b/mobile/lib/providers/environment_provider.g.dart
@@ -11,7 +11,7 @@ part of 'environment_provider.dart';
 /// Provider for the environment service singleton
 
 @ProviderFor(environmentService)
-const environmentServiceProvider = EnvironmentServiceProvider._();
+final environmentServiceProvider = EnvironmentServiceProvider._();
 
 /// Provider for the environment service singleton
 
@@ -24,7 +24,7 @@ final class EnvironmentServiceProvider
         >
     with $Provider<EnvironmentService> {
   /// Provider for the environment service singleton
-  const EnvironmentServiceProvider._()
+  EnvironmentServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -64,7 +64,7 @@ String _$environmentServiceHash() =>
 /// Provider for current environment config (reactive)
 
 @ProviderFor(currentEnvironment)
-const currentEnvironmentProvider = CurrentEnvironmentProvider._();
+final currentEnvironmentProvider = CurrentEnvironmentProvider._();
 
 /// Provider for current environment config (reactive)
 
@@ -77,7 +77,7 @@ final class CurrentEnvironmentProvider
         >
     with $Provider<EnvironmentConfig> {
   /// Provider for current environment config (reactive)
-  const CurrentEnvironmentProvider._()
+  CurrentEnvironmentProvider._()
     : super(
         from: null,
         argument: null,
@@ -117,7 +117,7 @@ String _$currentEnvironmentHash() =>
 /// Provider for developer mode enabled state
 
 @ProviderFor(isDeveloperModeEnabled)
-const isDeveloperModeEnabledProvider = IsDeveloperModeEnabledProvider._();
+final isDeveloperModeEnabledProvider = IsDeveloperModeEnabledProvider._();
 
 /// Provider for developer mode enabled state
 
@@ -125,7 +125,7 @@ final class IsDeveloperModeEnabledProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider for developer mode enabled state
-  const IsDeveloperModeEnabledProvider._()
+  IsDeveloperModeEnabledProvider._()
     : super(
         from: null,
         argument: null,
@@ -164,7 +164,7 @@ String _$isDeveloperModeEnabledHash() =>
 /// Provider to check if showing environment indicator
 
 @ProviderFor(showEnvironmentIndicator)
-const showEnvironmentIndicatorProvider = ShowEnvironmentIndicatorProvider._();
+final showEnvironmentIndicatorProvider = ShowEnvironmentIndicatorProvider._();
 
 /// Provider to check if showing environment indicator
 
@@ -172,7 +172,7 @@ final class ShowEnvironmentIndicatorProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider to check if showing environment indicator
-  const ShowEnvironmentIndicatorProvider._()
+  ShowEnvironmentIndicatorProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/feed_repository_provider.g.dart
+++ b/mobile/lib/providers/feed_repository_provider.g.dart
@@ -14,7 +14,7 @@ part of 'feed_repository_provider.dart';
 /// whichever widget opened the route — the core fix in issue #3383.
 
 @ProviderFor(feedRepository)
-const feedRepositoryProvider = FeedRepositoryProvider._();
+final feedRepositoryProvider = FeedRepositoryProvider._();
 
 /// The app-wide [FeedRepository].
 ///
@@ -28,7 +28,7 @@ final class FeedRepositoryProvider
   ///
   /// keepAlive so the fullscreen feed it backs is decoupled from the lifetime of
   /// whichever widget opened the route — the core fix in issue #3383.
-  const FeedRepositoryProvider._()
+  FeedRepositoryProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/for_you_provider.g.dart
+++ b/mobile/lib/providers/for_you_provider.g.dart
@@ -15,7 +15,7 @@ part of 'for_you_provider.dart';
 /// Currently only enabled on staging environment for testing.
 
 @ProviderFor(ForYouFeed)
-const forYouFeedProvider = ForYouFeedProvider._();
+final forYouFeedProvider = ForYouFeedProvider._();
 
 /// For You recommendations feed provider - ML-powered personalized videos
 ///
@@ -29,7 +29,7 @@ final class ForYouFeedProvider
   /// Uses Gorse-based recommendations from Funnelcake REST API.
   /// Falls back to popular videos when personalization isn't available.
   /// Currently only enabled on staging environment for testing.
-  const ForYouFeedProvider._()
+  ForYouFeedProvider._()
     : super(
         from: null,
         argument: null,
@@ -60,8 +60,7 @@ abstract class _$ForYouFeed extends $AsyncNotifier<VideoFeedState> {
   FutureOr<VideoFeedState> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<VideoFeedState>, VideoFeedState>;
     final element =
         ref.element
@@ -71,7 +70,7 @@ abstract class _$ForYouFeed extends $AsyncNotifier<VideoFeedState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -80,7 +79,7 @@ abstract class _$ForYouFeed extends $AsyncNotifier<VideoFeedState> {
 /// Available when Funnelcake REST API is available (has recommendations endpoint).
 
 @ProviderFor(forYouAvailable)
-const forYouAvailableProvider = ForYouAvailableProvider._();
+final forYouAvailableProvider = ForYouAvailableProvider._();
 
 /// Provider to check if For You tab should be visible
 ///
@@ -92,7 +91,7 @@ final class ForYouAvailableProvider
   /// Provider to check if For You tab should be visible
   ///
   /// Available when Funnelcake REST API is available (has recommendations endpoint).
-  const ForYouAvailableProvider._()
+  ForYouAvailableProvider._()
     : super(
         from: null,
         argument: null,
@@ -130,7 +129,7 @@ String _$forYouAvailableHash() => r'406ca7b70240fe02deb1c61f455f256440e40cd2';
 /// Provider to check if For You feed is loading
 
 @ProviderFor(forYouFeedLoading)
-const forYouFeedLoadingProvider = ForYouFeedLoadingProvider._();
+final forYouFeedLoadingProvider = ForYouFeedLoadingProvider._();
 
 /// Provider to check if For You feed is loading
 
@@ -138,7 +137,7 @@ final class ForYouFeedLoadingProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider to check if For You feed is loading
-  const ForYouFeedLoadingProvider._()
+  ForYouFeedLoadingProvider._()
     : super(
         from: null,
         argument: null,
@@ -176,14 +175,14 @@ String _$forYouFeedLoadingHash() => r'9eea3cee5284c8fd12b7a15e734079db6ba63d09';
 /// Provider to get current For You feed video count
 
 @ProviderFor(forYouFeedCount)
-const forYouFeedCountProvider = ForYouFeedCountProvider._();
+final forYouFeedCountProvider = ForYouFeedCountProvider._();
 
 /// Provider to get current For You feed video count
 
 final class ForYouFeedCountProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   /// Provider to get current For You feed video count
-  const ForYouFeedCountProvider._()
+  ForYouFeedCountProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/individual_video_providers.g.dart
+++ b/mobile/lib/providers/individual_video_providers.g.dart
@@ -12,7 +12,7 @@ part of 'individual_video_providers.dart';
 /// Each video gets its own controller instance
 
 @ProviderFor(individualVideoController)
-const individualVideoControllerProvider = IndividualVideoControllerFamily._();
+final individualVideoControllerProvider = IndividualVideoControllerFamily._();
 
 /// Provider for individual video controllers with autoDispose
 /// Each video gets its own controller instance
@@ -27,7 +27,7 @@ final class IndividualVideoControllerProvider
     with $Provider<VideoPlayerController> {
   /// Provider for individual video controllers with autoDispose
   /// Each video gets its own controller instance
-  const IndividualVideoControllerProvider._({
+  IndividualVideoControllerProvider._({
     required IndividualVideoControllerFamily super.from,
     required VideoControllerParams super.argument,
   }) : super(
@@ -92,7 +92,7 @@ final class IndividualVideoControllerFamily extends $Family
           VideoPlayerController,
           VideoControllerParams
         > {
-  const IndividualVideoControllerFamily._()
+  IndividualVideoControllerFamily._()
     : super(
         retry: null,
         name: r'individualVideoControllerProvider',
@@ -114,7 +114,7 @@ final class IndividualVideoControllerFamily extends $Family
 /// Provider for video loading state
 
 @ProviderFor(videoLoadingState)
-const videoLoadingStateProvider = VideoLoadingStateFamily._();
+final videoLoadingStateProvider = VideoLoadingStateFamily._();
 
 /// Provider for video loading state
 
@@ -127,7 +127,7 @@ final class VideoLoadingStateProvider
         >
     with $Provider<VideoLoadingState> {
   /// Provider for video loading state
-  const VideoLoadingStateProvider._({
+  VideoLoadingStateProvider._({
     required VideoLoadingStateFamily super.from,
     required VideoControllerParams super.argument,
   }) : super(
@@ -185,7 +185,7 @@ String _$videoLoadingStateHash() => r'22f741beecbea8885fcd115ef3047a2fa2eb5e0d';
 
 final class VideoLoadingStateFamily extends $Family
     with $FunctionalFamilyOverride<VideoLoadingState, VideoControllerParams> {
-  const VideoLoadingStateFamily._()
+  VideoLoadingStateFamily._()
     : super(
         retry: null,
         name: r'videoLoadingStateProvider',

--- a/mobile/lib/providers/list_providers.g.dart
+++ b/mobile/lib/providers/list_providers.g.dart
@@ -16,7 +16,7 @@ part of 'list_providers.dart';
 /// - no user is currently authenticated (no owner pubkey to scope by).
 
 @ProviderFor(userLists)
-const userListsProvider = UserListsProvider._();
+final userListsProvider = UserListsProvider._();
 
 /// Provider for all user lists (NIP-51 kind 30000 people lists).
 ///
@@ -39,7 +39,7 @@ final class UserListsProvider
   /// every local mutation. Emits an empty list when:
   /// - the [FeatureFlag.curatedLists] feature flag is disabled, or
   /// - no user is currently authenticated (no owner pubkey to scope by).
-  const UserListsProvider._()
+  UserListsProvider._()
     : super(
         from: null,
         argument: null,
@@ -70,7 +70,7 @@ String _$userListsHash() => r'6e9c114c2c52d95c433c3eb6c7093c446f5dc6b9';
 /// Provider for all curated video lists (kind 30005)
 
 @ProviderFor(curatedLists)
-const curatedListsProvider = CuratedListsProvider._();
+final curatedListsProvider = CuratedListsProvider._();
 
 /// Provider for all curated video lists (kind 30005)
 
@@ -85,7 +85,7 @@ final class CuratedListsProvider
         $FutureModifier<List<CuratedList>>,
         $FutureProvider<List<CuratedList>> {
   /// Provider for all curated video lists (kind 30005)
-  const CuratedListsProvider._()
+  CuratedListsProvider._()
     : super(
         from: null,
         argument: null,
@@ -116,7 +116,7 @@ String _$curatedListsHash() => r'74de3f9b86d5444e78e7f2c797370ca75f29f9f5';
 /// Combined provider for both types of lists
 
 @ProviderFor(allLists)
-const allListsProvider = AllListsProvider._();
+final allListsProvider = AllListsProvider._();
 
 /// Combined provider for both types of lists
 
@@ -137,7 +137,7 @@ final class AllListsProvider
           ({List<CuratedList> curatedLists, List<UserList> userLists})
         > {
   /// Combined provider for both types of lists
-  const AllListsProvider._()
+  AllListsProvider._()
     : super(
         from: null,
         argument: null,
@@ -172,7 +172,7 @@ String _$allListsHash() => r'8d7c4fb84d445151d5bb84764da34cedf4e7e8a6';
 /// This persists the lists so they're not lost when leaving/returning to screen
 
 @ProviderFor(DiscoveredLists)
-const discoveredListsProvider = DiscoveredListsProvider._();
+final discoveredListsProvider = DiscoveredListsProvider._();
 
 /// Provider that caches discovered public lists across navigation
 /// This persists the lists so they're not lost when leaving/returning to screen
@@ -180,7 +180,7 @@ final class DiscoveredListsProvider
     extends $NotifierProvider<DiscoveredLists, DiscoveredListsState> {
   /// Provider that caches discovered public lists across navigation
   /// This persists the lists so they're not lost when leaving/returning to screen
-  const DiscoveredListsProvider._()
+  DiscoveredListsProvider._()
     : super(
         from: null,
         argument: null,
@@ -216,8 +216,7 @@ abstract class _$DiscoveredLists extends $Notifier<DiscoveredListsState> {
   DiscoveredListsState build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<DiscoveredListsState, DiscoveredListsState>;
     final element =
         ref.element
@@ -227,14 +226,14 @@ abstract class _$DiscoveredLists extends $Notifier<DiscoveredListsState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 /// Provider for videos in a specific curated list
 
 @ProviderFor(curatedListVideos)
-const curatedListVideosProvider = CuratedListVideosFamily._();
+final curatedListVideosProvider = CuratedListVideosFamily._();
 
 /// Provider for videos in a specific curated list
 
@@ -247,7 +246,7 @@ final class CuratedListVideosProvider
         >
     with $FutureModifier<List<String>>, $FutureProvider<List<String>> {
   /// Provider for videos in a specific curated list
-  const CuratedListVideosProvider._({
+  CuratedListVideosProvider._({
     required CuratedListVideosFamily super.from,
     required String super.argument,
   }) : super(
@@ -297,7 +296,7 @@ String _$curatedListVideosHash() => r'ce7db4b5ea59279d88325cdc9e928dc5a89a92b0';
 
 final class CuratedListVideosFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<String>>, String> {
-  const CuratedListVideosFamily._()
+  CuratedListVideosFamily._()
     : super(
         retry: null,
         name: r'curatedListVideosProvider',
@@ -318,7 +317,7 @@ final class CuratedListVideosFamily extends $Family
 /// Provider for videos from all members of a user list
 
 @ProviderFor(userListMemberVideos)
-const userListMemberVideosProvider = UserListMemberVideosFamily._();
+final userListMemberVideosProvider = UserListMemberVideosFamily._();
 
 /// Provider for videos from all members of a user list
 
@@ -331,7 +330,7 @@ final class UserListMemberVideosProvider
         >
     with $FutureModifier<List<VideoEvent>>, $StreamProvider<List<VideoEvent>> {
   /// Provider for videos from all members of a user list
-  const UserListMemberVideosProvider._({
+  UserListMemberVideosProvider._({
     required UserListMemberVideosFamily super.from,
     required List<String> super.argument,
   }) : super(
@@ -382,7 +381,7 @@ String _$userListMemberVideosHash() =>
 
 final class UserListMemberVideosFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<VideoEvent>>, List<String>> {
-  const UserListMemberVideosFamily._()
+  UserListMemberVideosFamily._()
     : super(
         retry: null,
         name: r'userListMemberVideosProvider',
@@ -405,7 +404,7 @@ final class UserListMemberVideosFamily extends $Family
 /// on each new result. This enables progressive UI updates via Riverpod.
 
 @ProviderFor(publicListsContainingVideo)
-const publicListsContainingVideoProvider = PublicListsContainingVideoFamily._();
+final publicListsContainingVideoProvider = PublicListsContainingVideoFamily._();
 
 /// Provider that streams public lists containing a specific video
 /// Accumulates results as they arrive from Nostr relays, yielding updated list
@@ -424,7 +423,7 @@ final class PublicListsContainingVideoProvider
   /// Provider that streams public lists containing a specific video
   /// Accumulates results as they arrive from Nostr relays, yielding updated list
   /// on each new result. This enables progressive UI updates via Riverpod.
-  const PublicListsContainingVideoProvider._({
+  PublicListsContainingVideoProvider._({
     required PublicListsContainingVideoFamily super.from,
     required String super.argument,
   }) : super(
@@ -478,7 +477,7 @@ String _$publicListsContainingVideoHash() =>
 
 final class PublicListsContainingVideoFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<CuratedList>>, String> {
-  const PublicListsContainingVideoFamily._()
+  PublicListsContainingVideoFamily._()
     : super(
         retry: null,
         name: r'publicListsContainingVideoProvider',
@@ -502,7 +501,7 @@ final class PublicListsContainingVideoFamily extends $Family
 /// Streams videos as they are fetched from cache or relays
 
 @ProviderFor(curatedListVideoEvents)
-const curatedListVideoEventsProvider = CuratedListVideoEventsFamily._();
+final curatedListVideoEventsProvider = CuratedListVideoEventsFamily._();
 
 /// Provider that fetches actual VideoEvent objects for a curated list
 /// Streams videos as they are fetched from cache or relays
@@ -517,7 +516,7 @@ final class CuratedListVideoEventsProvider
     with $FutureModifier<List<VideoEvent>>, $StreamProvider<List<VideoEvent>> {
   /// Provider that fetches actual VideoEvent objects for a curated list
   /// Streams videos as they are fetched from cache or relays
-  const CuratedListVideoEventsProvider._({
+  CuratedListVideoEventsProvider._({
     required CuratedListVideoEventsFamily super.from,
     required String super.argument,
   }) : super(
@@ -570,7 +569,7 @@ String _$curatedListVideoEventsHash() =>
 
 final class CuratedListVideoEventsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<VideoEvent>>, String> {
-  const CuratedListVideoEventsFamily._()
+  CuratedListVideoEventsFamily._()
     : super(
         retry: null,
         name: r'curatedListVideoEventsProvider',
@@ -593,7 +592,7 @@ final class CuratedListVideoEventsFamily extends $Family
 /// Use this for discovered lists that aren't in local storage
 
 @ProviderFor(videoEventsByIds)
-const videoEventsByIdsProvider = VideoEventsByIdsFamily._();
+final videoEventsByIdsProvider = VideoEventsByIdsFamily._();
 
 /// Provider that fetches VideoEvent objects directly from a list of video IDs
 /// Use this for discovered lists that aren't in local storage
@@ -608,7 +607,7 @@ final class VideoEventsByIdsProvider
     with $FutureModifier<List<VideoEvent>>, $StreamProvider<List<VideoEvent>> {
   /// Provider that fetches VideoEvent objects directly from a list of video IDs
   /// Use this for discovered lists that aren't in local storage
-  const VideoEventsByIdsProvider._({
+  VideoEventsByIdsProvider._({
     required VideoEventsByIdsFamily super.from,
     required List<String> super.argument,
   }) : super(
@@ -659,7 +658,7 @@ String _$videoEventsByIdsHash() => r'e6a653a18021cfbf8221af6045f7f20a93841622';
 
 final class VideoEventsByIdsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<List<VideoEvent>>, List<String>> {
-  const VideoEventsByIdsFamily._()
+  VideoEventsByIdsFamily._()
     : super(
         retry: null,
         name: r'videoEventsByIdsProvider',

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -10,7 +10,7 @@ part of 'moderation_providers.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(contentPolicyEngine)
-const contentPolicyEngineProvider = ContentPolicyEngineProvider._();
+final contentPolicyEngineProvider = ContentPolicyEngineProvider._();
 
 final class ContentPolicyEngineProvider
     extends
@@ -20,7 +20,7 @@ final class ContentPolicyEngineProvider
           ContentPolicyEngine
         >
     with $Provider<ContentPolicyEngine> {
-  const ContentPolicyEngineProvider._()
+  ContentPolicyEngineProvider._()
     : super(
         from: null,
         argument: null,
@@ -69,7 +69,7 @@ String _$contentPolicyEngineHash() =>
 /// the current user.
 
 @ProviderFor(canTargetUser)
-const canTargetUserProvider = CanTargetUserFamily._();
+final canTargetUserProvider = CanTargetUserFamily._();
 
 /// Whether the UI may offer interactions that target [pubkey] —
 /// follow, DM, reply, mention, share-to, tag.
@@ -94,7 +94,7 @@ final class CanTargetUserProvider extends $FunctionalProvider<bool, bool, bool>
   /// Consults [ContentPolicyEngine.canTarget]: the affordance is hidden when
   /// the target's published kind 30000 d=block or kind 10000 mute list names
   /// the current user.
-  const CanTargetUserProvider._({
+  CanTargetUserProvider._({
     required CanTargetUserFamily super.from,
     required String super.argument,
   }) : super(
@@ -160,7 +160,7 @@ String _$canTargetUserHash() => r'96f7718c9d61620ad1b239a7a553df858165007e';
 
 final class CanTargetUserFamily extends $Family
     with $FunctionalFamilyOverride<bool, String> {
-  const CanTargetUserFamily._()
+  CanTargetUserFamily._()
     : super(
         retry: null,
         name: r'canTargetUserProvider',
@@ -192,7 +192,7 @@ final class CanTargetUserFamily extends $Family
 /// even when widgets that watch it dispose and rebuild
 
 @ProviderFor(ageVerificationService)
-const ageVerificationServiceProvider = AgeVerificationServiceProvider._();
+final ageVerificationServiceProvider = AgeVerificationServiceProvider._();
 
 /// Age verification service for content creation restrictions
 /// keepAlive ensures the service persists and maintains in-memory verification state
@@ -209,7 +209,7 @@ final class AgeVerificationServiceProvider
   /// Age verification service for content creation restrictions
   /// keepAlive ensures the service persists and maintains in-memory verification state
   /// even when widgets that watch it dispose and rebuild
-  const AgeVerificationServiceProvider._()
+  AgeVerificationServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -250,7 +250,7 @@ String _$ageVerificationServiceHash() =>
 /// keepAlive ensures preferences persist and are consistent across the app.
 
 @ProviderFor(contentFilterService)
-const contentFilterServiceProvider = ContentFilterServiceProvider._();
+final contentFilterServiceProvider = ContentFilterServiceProvider._();
 
 /// Content filter service for per-category Show/Warn/Hide preferences.
 /// keepAlive ensures preferences persist and are consistent across the app.
@@ -265,7 +265,7 @@ final class ContentFilterServiceProvider
     with $Provider<ContentFilterService> {
   /// Content filter service for per-category Show/Warn/Hide preferences.
   /// keepAlive ensures preferences persist and are consistent across the app.
-  const ContentFilterServiceProvider._()
+  ContentFilterServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -306,7 +306,7 @@ String _$contentFilterServiceHash() =>
 /// to rebuild when the user changes a Show/Warn/Hide setting.
 
 @ProviderFor(contentFilterVersion)
-const contentFilterVersionProvider = ContentFilterVersionProvider._();
+final contentFilterVersionProvider = ContentFilterVersionProvider._();
 
 /// Tracks content filter preference changes. Feed providers watch this
 /// to rebuild when the user changes a Show/Warn/Hide setting.
@@ -316,7 +316,7 @@ final class ContentFilterVersionProvider
     with $Provider<int> {
   /// Tracks content filter preference changes. Feed providers watch this
   /// to rebuild when the user changes a Show/Warn/Hide setting.
-  const ContentFilterVersionProvider._()
+  ContentFilterVersionProvider._()
     : super(
         from: null,
         argument: null,
@@ -355,7 +355,7 @@ String _$contentFilterVersionHash() =>
 /// Account label service for self-labeling content (NIP-32 Kind 1985).
 
 @ProviderFor(accountLabelService)
-const accountLabelServiceProvider = AccountLabelServiceProvider._();
+final accountLabelServiceProvider = AccountLabelServiceProvider._();
 
 /// Account label service for self-labeling content (NIP-32 Kind 1985).
 
@@ -368,7 +368,7 @@ final class AccountLabelServiceProvider
         >
     with $Provider<AccountLabelService> {
   /// Account label service for self-labeling content (NIP-32 Kind 1985).
-  const AccountLabelServiceProvider._()
+  AccountLabelServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -408,7 +408,7 @@ String _$accountLabelServiceHash() =>
 /// Moderation label service for subscribing to Kind 1985 labeler events.
 
 @ProviderFor(moderationLabelService)
-const moderationLabelServiceProvider = ModerationLabelServiceProvider._();
+final moderationLabelServiceProvider = ModerationLabelServiceProvider._();
 
 /// Moderation label service for subscribing to Kind 1985 labeler events.
 
@@ -421,7 +421,7 @@ final class ModerationLabelServiceProvider
         >
     with $Provider<ModerationLabelService> {
   /// Moderation label service for subscribing to Kind 1985 labeler events.
-  const ModerationLabelServiceProvider._()
+  ModerationLabelServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -470,7 +470,7 @@ String _$moderationLabelServiceHash() =>
 /// from the relay are never delivered to new instances.
 
 @ProviderFor(contentBlocklistRepository)
-const contentBlocklistRepositoryProvider =
+final contentBlocklistRepositoryProvider =
     ContentBlocklistRepositoryProvider._();
 
 /// Content blocklist service for filtering unwanted content from feeds
@@ -502,7 +502,7 @@ final class ContentBlocklistRepositoryProvider
   /// [syncBlockListsInBackground] survives widget rebuilds. Without it the
   /// provider auto-disposes, the subscription is lost, and blocks restored
   /// from the relay are never delivered to new instances.
-  const ContentBlocklistRepositoryProvider._()
+  ContentBlocklistRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -543,7 +543,7 @@ String _$contentBlocklistRepositoryHash() =>
 /// Widgets watching this will rebuild when block/unblock actions occur.
 
 @ProviderFor(BlocklistVersion)
-const blocklistVersionProvider = BlocklistVersionProvider._();
+final blocklistVersionProvider = BlocklistVersionProvider._();
 
 /// Version counter to trigger rebuilds when blocklist changes.
 /// Widgets watching this will rebuild when block/unblock actions occur.
@@ -551,7 +551,7 @@ final class BlocklistVersionProvider
     extends $NotifierProvider<BlocklistVersion, int> {
   /// Version counter to trigger rebuilds when blocklist changes.
   /// Widgets watching this will rebuild when block/unblock actions occur.
-  const BlocklistVersionProvider._()
+  BlocklistVersionProvider._()
     : super(
         from: null,
         argument: null,
@@ -587,8 +587,7 @@ abstract class _$BlocklistVersion extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -598,7 +597,7 @@ abstract class _$BlocklistVersion extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -614,7 +613,7 @@ abstract class _$BlocklistVersion extends $Notifier<int> {
 /// `_blockListSyncStarted`) so duplicate calls are no-ops.
 
 @ProviderFor(blocklistSyncBridge)
-const blocklistSyncBridgeProvider = BlocklistSyncBridgeProvider._();
+final blocklistSyncBridgeProvider = BlocklistSyncBridgeProvider._();
 
 /// Bridge that starts blocklist sync when the Nostr session becomes ready.
 ///
@@ -640,7 +639,7 @@ final class BlocklistSyncBridgeProvider
   ///
   /// Both sync methods have internal guards (`_mutualMuteSyncStarted`,
   /// `_blockListSyncStarted`) so duplicate calls are no-ops.
-  const BlocklistSyncBridgeProvider._()
+  BlocklistSyncBridgeProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/new_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.g.dart
@@ -14,7 +14,7 @@ part of 'new_videos_feed_provider.dart';
 /// New Videos tab does not share the popular/trending source.
 
 @ProviderFor(NewVideosFeed)
-const newVideosFeedProvider = NewVideosFeedProvider._();
+final newVideosFeedProvider = NewVideosFeedProvider._();
 
 /// New Videos feed provider - shows newest videos first.
 ///
@@ -26,7 +26,7 @@ final class NewVideosFeedProvider
   ///
   /// Delegates video fetching to [VideosRepository.getNewVideos] so the Explore
   /// New Videos tab does not share the popular/trending source.
-  const NewVideosFeedProvider._()
+  NewVideosFeedProvider._()
     : super(
         from: null,
         argument: null,
@@ -56,8 +56,7 @@ abstract class _$NewVideosFeed extends $AsyncNotifier<VideoFeedState> {
   FutureOr<VideoFeedState> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<VideoFeedState>, VideoFeedState>;
     final element =
         ref.element
@@ -67,6 +66,6 @@ abstract class _$NewVideosFeed extends $AsyncNotifier<VideoFeedState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/nip05_verification_provider.g.dart
+++ b/mobile/lib/providers/nip05_verification_provider.g.dart
@@ -11,7 +11,7 @@ part of 'nip05_verification_provider.dart';
 /// Provider for the NIP-05 verification service singleton
 
 @ProviderFor(nip05VerificationService)
-const nip05VerificationServiceProvider = Nip05VerificationServiceProvider._();
+final nip05VerificationServiceProvider = Nip05VerificationServiceProvider._();
 
 /// Provider for the NIP-05 verification service singleton
 
@@ -24,7 +24,7 @@ final class Nip05VerificationServiceProvider
         >
     with $Provider<Nip05VerificationService> {
   /// Provider for the NIP-05 verification service singleton
-  const Nip05VerificationServiceProvider._()
+  Nip05VerificationServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -78,7 +78,7 @@ String _$nip05VerificationServiceHash() =>
 /// ```
 
 @ProviderFor(nip05Verification)
-const nip05VerificationProvider = Nip05VerificationFamily._();
+final nip05VerificationProvider = Nip05VerificationFamily._();
 
 /// Provider that returns the NIP-05 verification status for a pubkey.
 ///
@@ -121,7 +121,7 @@ final class Nip05VerificationProvider
   ///   _ => false,
   /// };
   /// ```
-  const Nip05VerificationProvider._({
+  Nip05VerificationProvider._({
     required Nip05VerificationFamily super.from,
     required String super.argument,
   }) : super(
@@ -185,7 +185,7 @@ String _$nip05VerificationHash() => r'fdd40ea0ffdab1324c0114909a431e3f0e7abcd4';
 
 final class Nip05VerificationFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<Nip05VerificationStatus>, String> {
-  const Nip05VerificationFamily._()
+  Nip05VerificationFamily._()
     : super(
         retry: null,
         name: r'nip05VerificationProvider',
@@ -223,7 +223,7 @@ final class Nip05VerificationFamily extends $Family
 /// status changes (e.g., after a fresh verification completes).
 
 @ProviderFor(nip05VerificationStream)
-const nip05VerificationStreamProvider = Nip05VerificationStreamFamily._();
+final nip05VerificationStreamProvider = Nip05VerificationStreamFamily._();
 
 /// Stream provider for reactive NIP-05 verification updates.
 ///
@@ -244,7 +244,7 @@ final class Nip05VerificationStreamProvider
   ///
   /// Use this when you need to reactively update UI when verification
   /// status changes (e.g., after a fresh verification completes).
-  const Nip05VerificationStreamProvider._({
+  Nip05VerificationStreamProvider._({
     required Nip05VerificationStreamFamily super.from,
     required String super.argument,
   }) : super(
@@ -299,7 +299,7 @@ String _$nip05VerificationStreamHash() =>
 
 final class Nip05VerificationStreamFamily extends $Family
     with $FunctionalFamilyOverride<Stream<Nip05VerificationStatus>, String> {
-  const Nip05VerificationStreamFamily._()
+  Nip05VerificationStreamFamily._()
     : super(
         retry: null,
         name: r'nip05VerificationStreamProvider',

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -13,7 +13,7 @@ part of 'nostr_client_provider.dart';
 /// code path. Production builds use this provider transparently.
 
 @ProviderFor(nostrClientFactory)
-const nostrClientFactoryProvider = NostrClientFactoryProvider._();
+final nostrClientFactoryProvider = NostrClientFactoryProvider._();
 
 /// Indirection layer over [NostrServiceFactory.create] so tests can
 /// substitute a fake factory without touching the real relay/network
@@ -30,7 +30,7 @@ final class NostrClientFactoryProvider
   /// Indirection layer over [NostrServiceFactory.create] so tests can
   /// substitute a fake factory without touching the real relay/network
   /// code path. Production builds use this provider transparently.
-  const NostrClientFactoryProvider._()
+  NostrClientFactoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -72,7 +72,7 @@ String _$nostrClientFactoryHash() =>
 /// when the keyContainer changes (e.g., user signs out and signs in with different keys)
 
 @ProviderFor(NostrService)
-const nostrServiceProvider = NostrServiceProvider._();
+final nostrServiceProvider = NostrServiceProvider._();
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client
@@ -82,7 +82,7 @@ final class NostrServiceProvider
   /// Core Nostr service via NostrClient for relay communication
   /// Uses a Notifier to react to auth state changes and recreate the client
   /// when the keyContainer changes (e.g., user signs out and signs in with different keys)
-  const NostrServiceProvider._()
+  NostrServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -119,8 +119,7 @@ abstract class _$NostrService extends $Notifier<NostrClient> {
   NostrClient build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<NostrClient, NostrClient>;
     final element =
         ref.element
@@ -130,6 +129,6 @@ abstract class _$NostrService extends $Notifier<NostrClient> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/notifications_providers.g.dart
+++ b/mobile/lib/providers/notifications_providers.g.dart
@@ -15,7 +15,7 @@ part of 'notifications_providers.dart';
 /// outgoing-session cleanup runs before signers and callbacks are cleared.
 
 @ProviderFor(pushNotificationSync)
-const pushNotificationSyncProvider = PushNotificationSyncProvider._();
+final pushNotificationSyncProvider = PushNotificationSyncProvider._();
 
 /// Bridges Nostr session readiness to push notification registration.
 ///
@@ -31,7 +31,7 @@ final class PushNotificationSyncProvider
   /// Registers FCM token only after the signer-backed Nostr client is ready.
   /// Deregisters the last ready client through AuthService's pre-teardown hook so
   /// outgoing-session cleanup runs before signers and callbacks are cleared.
-  const PushNotificationSyncProvider._()
+  PushNotificationSyncProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/overlay_visibility_provider.g.dart
+++ b/mobile/lib/providers/overlay_visibility_provider.g.dart
@@ -11,13 +11,13 @@ part of 'overlay_visibility_provider.dart';
 /// Notifier for managing overlay visibility state
 
 @ProviderFor(OverlayVisibility)
-const overlayVisibilityProvider = OverlayVisibilityProvider._();
+final overlayVisibilityProvider = OverlayVisibilityProvider._();
 
 /// Notifier for managing overlay visibility state
 final class OverlayVisibilityProvider
     extends $NotifierProvider<OverlayVisibility, OverlayVisibilityState> {
   /// Notifier for managing overlay visibility state
-  const OverlayVisibilityProvider._()
+  OverlayVisibilityProvider._()
     : super(
         from: null,
         argument: null,
@@ -52,8 +52,7 @@ abstract class _$OverlayVisibility extends $Notifier<OverlayVisibilityState> {
   OverlayVisibilityState build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<OverlayVisibilityState, OverlayVisibilityState>;
     final element =
@@ -64,6 +63,6 @@ abstract class _$OverlayVisibility extends $Notifier<OverlayVisibilityState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/permissions_providers.dart
+++ b/mobile/lib/providers/permissions_providers.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Permission / geo-blocking / gallery-save providers split from
 // ABOUTME: app_providers.dart
 
+import 'package:flutter_riverpod/flutter_riverpod.dart' show Provider;
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/services/geo_blocking_service.dart';
 import 'package:permissions_service/permissions_service.dart';
@@ -15,10 +16,10 @@ GeoBlockingService geoBlockingService(Ref ref) {
 }
 
 /// Permissions service for checking and requesting OS permissions
-@riverpod
-PermissionsService permissionsService(Ref ref) {
-  return const PermissionHandlerPermissionsService();
-}
+final permissionsServiceProvider = Provider<PermissionsService>(
+  (_) => const PermissionHandlerPermissionsService(),
+  name: 'permissionsServiceProvider',
+);
 
 /// Gallery save service for saving videos to device camera roll
 @riverpod

--- a/mobile/lib/providers/permissions_providers.g.dart
+++ b/mobile/lib/providers/permissions_providers.g.dart
@@ -11,7 +11,7 @@ part of 'permissions_providers.dart';
 /// Geo-blocking service for regional compliance
 
 @ProviderFor(geoBlockingService)
-const geoBlockingServiceProvider = GeoBlockingServiceProvider._();
+final geoBlockingServiceProvider = GeoBlockingServiceProvider._();
 
 /// Geo-blocking service for regional compliance
 
@@ -24,7 +24,7 @@ final class GeoBlockingServiceProvider
         >
     with $Provider<GeoBlockingService> {
   /// Geo-blocking service for regional compliance
-  const GeoBlockingServiceProvider._()
+  GeoBlockingServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -61,63 +61,10 @@ final class GeoBlockingServiceProvider
 String _$geoBlockingServiceHash() =>
     r'0475466204746fb8b4c6dd614847e3853d360d12';
 
-/// Permissions service for checking and requesting OS permissions
-
-@ProviderFor(permissionsService)
-const permissionsServiceProvider = PermissionsServiceProvider._();
-
-/// Permissions service for checking and requesting OS permissions
-
-final class PermissionsServiceProvider
-    extends
-        $FunctionalProvider<
-          PermissionsService,
-          PermissionsService,
-          PermissionsService
-        >
-    with $Provider<PermissionsService> {
-  /// Permissions service for checking and requesting OS permissions
-  const PermissionsServiceProvider._()
-    : super(
-        from: null,
-        argument: null,
-        retry: null,
-        name: r'permissionsServiceProvider',
-        isAutoDispose: true,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
-
-  @override
-  String debugGetCreateSourceHash() => _$permissionsServiceHash();
-
-  @$internal
-  @override
-  $ProviderElement<PermissionsService> $createElement(
-    $ProviderPointer pointer,
-  ) => $ProviderElement(pointer);
-
-  @override
-  PermissionsService create(Ref ref) {
-    return permissionsService(ref);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(PermissionsService value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<PermissionsService>(value),
-    );
-  }
-}
-
-String _$permissionsServiceHash() =>
-    r'7212219b8e720fe0fcd19ae7e9313e2c5c5be1d5';
-
 /// Gallery save service for saving videos to device camera roll
 
 @ProviderFor(gallerySaveService)
-const gallerySaveServiceProvider = GallerySaveServiceProvider._();
+final gallerySaveServiceProvider = GallerySaveServiceProvider._();
 
 /// Gallery save service for saving videos to device camera roll
 
@@ -130,7 +77,7 @@ final class GallerySaveServiceProvider
         >
     with $Provider<GallerySaveService> {
   /// Gallery save service for saving videos to device camera roll
-  const GallerySaveServiceProvider._()
+  GallerySaveServiceProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/popular_now_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.g.dart
@@ -20,7 +20,7 @@ part of 'popular_now_feed_provider.dart';
 /// - appReady gate becomes true (triggers rebuild to start subscription)
 
 @ProviderFor(PopularNowFeed)
-const popularNowFeedProvider = PopularNowFeedProvider._();
+final popularNowFeedProvider = PopularNowFeedProvider._();
 
 /// PopularNow feed provider - shows newest videos (sorted by creation time)
 ///
@@ -44,7 +44,7 @@ final class PopularNowFeedProvider
   /// - User pulls to refresh
   /// - VideoEventService updates with new videos
   /// - appReady gate becomes true (triggers rebuild to start subscription)
-  const PopularNowFeedProvider._()
+  PopularNowFeedProvider._()
     : super(
         from: null,
         argument: null,
@@ -80,8 +80,7 @@ abstract class _$PopularNowFeed extends $AsyncNotifier<VideoFeedState> {
   FutureOr<VideoFeedState> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<VideoFeedState>, VideoFeedState>;
     final element =
         ref.element
@@ -91,14 +90,14 @@ abstract class _$PopularNowFeed extends $AsyncNotifier<VideoFeedState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 /// Provider to check if popularNow feed is loading
 
 @ProviderFor(popularNowFeedLoading)
-const popularNowFeedLoadingProvider = PopularNowFeedLoadingProvider._();
+final popularNowFeedLoadingProvider = PopularNowFeedLoadingProvider._();
 
 /// Provider to check if popularNow feed is loading
 
@@ -106,7 +105,7 @@ final class PopularNowFeedLoadingProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider to check if popularNow feed is loading
-  const PopularNowFeedLoadingProvider._()
+  PopularNowFeedLoadingProvider._()
     : super(
         from: null,
         argument: null,
@@ -145,7 +144,7 @@ String _$popularNowFeedLoadingHash() =>
 /// Provider to get current popularNow feed video count
 
 @ProviderFor(popularNowFeedCount)
-const popularNowFeedCountProvider = PopularNowFeedCountProvider._();
+final popularNowFeedCountProvider = PopularNowFeedCountProvider._();
 
 /// Provider to get current popularNow feed video count
 
@@ -153,7 +152,7 @@ final class PopularNowFeedCountProvider
     extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   /// Provider to get current popularNow feed video count
-  const PopularNowFeedCountProvider._()
+  PopularNowFeedCountProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -19,7 +19,7 @@ part of 'popular_videos_feed_provider.dart';
 /// - Content filter preferences change
 
 @ProviderFor(PopularVideosFeed)
-const popularVideosFeedProvider = PopularVideosFeedProvider._();
+final popularVideosFeedProvider = PopularVideosFeedProvider._();
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///
@@ -41,7 +41,7 @@ final class PopularVideosFeedProvider
   /// - Pull to refresh
   /// - appReady gate becomes true
   /// - Content filter preferences change
-  const PopularVideosFeedProvider._()
+  PopularVideosFeedProvider._()
     : super(
         from: null,
         argument: null,
@@ -76,8 +76,7 @@ abstract class _$PopularVideosFeed extends $AsyncNotifier<VideoFeedState> {
   FutureOr<VideoFeedState> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<VideoFeedState>, VideoFeedState>;
     final element =
         ref.element
@@ -87,6 +86,6 @@ abstract class _$PopularVideosFeed extends $AsyncNotifier<VideoFeedState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/preferences_providers.g.dart
+++ b/mobile/lib/providers/preferences_providers.g.dart
@@ -12,7 +12,7 @@ part of 'preferences_providers.dart';
 /// for reuse by default. keepAlive ensures setting persists across widget rebuilds.
 
 @ProviderFor(audioSharingPreferenceService)
-const audioSharingPreferenceServiceProvider =
+final audioSharingPreferenceServiceProvider =
     AudioSharingPreferenceServiceProvider._();
 
 /// Audio sharing preference service for managing whether audio is available
@@ -28,7 +28,7 @@ final class AudioSharingPreferenceServiceProvider
     with $Provider<AudioSharingPreferenceService> {
   /// Audio sharing preference service for managing whether audio is available
   /// for reuse by default. keepAlive ensures setting persists across widget rebuilds.
-  const AudioSharingPreferenceServiceProvider._()
+  AudioSharingPreferenceServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -71,7 +71,7 @@ String _$audioSharingPreferenceServiceHash() =>
 /// for recording on macOS. keepAlive ensures preference persists.
 
 @ProviderFor(audioDevicePreferenceService)
-const audioDevicePreferenceServiceProvider =
+final audioDevicePreferenceServiceProvider =
     AudioDevicePreferenceServiceProvider._();
 
 /// Audio device preference service for managing the preferred input device
@@ -87,7 +87,7 @@ final class AudioDevicePreferenceServiceProvider
     with $Provider<AudioDevicePreferenceService> {
   /// Audio device preference service for managing the preferred input device
   /// for recording on macOS. keepAlive ensures preference persists.
-  const AudioDevicePreferenceServiceProvider._()
+  AudioDevicePreferenceServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -129,7 +129,7 @@ String _$audioDevicePreferenceServiceHash() =>
 /// keepAlive ensures setting persists across widget rebuilds.
 
 @ProviderFor(languagePreferenceService)
-const languagePreferenceServiceProvider = LanguagePreferenceServiceProvider._();
+final languagePreferenceServiceProvider = LanguagePreferenceServiceProvider._();
 
 /// Language preference service for managing the user's preferred content
 /// language. Used for NIP-32 self-labeling on published video events.
@@ -146,7 +146,7 @@ final class LanguagePreferenceServiceProvider
   /// Language preference service for managing the user's preferred content
   /// language. Used for NIP-32 self-labeling on published video events.
   /// keepAlive ensures setting persists across widget rebuilds.
-  const LanguagePreferenceServiceProvider._()
+  LanguagePreferenceServiceProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/profile_reposts_provider.g.dart
+++ b/mobile/lib/providers/profile_reposts_provider.g.dart
@@ -17,7 +17,7 @@ part of 'profile_reposts_provider.dart';
 /// This is independent from profileFeedProvider which only returns originals.
 
 @ProviderFor(profileReposts)
-const profileRepostsProvider = ProfileRepostsFamily._();
+final profileRepostsProvider = ProfileRepostsFamily._();
 
 /// Provider that returns only the videos a user has reposted
 ///
@@ -42,7 +42,7 @@ final class ProfileRepostsProvider
   /// - reposterPubkey == userIdHex
   ///
   /// This is independent from profileFeedProvider which only returns originals.
-  const ProfileRepostsProvider._({
+  ProfileRepostsProvider._({
     required ProfileRepostsFamily super.from,
     required String super.argument,
   }) : super(
@@ -98,7 +98,7 @@ String _$profileRepostsHash() => r'6cd7fc7f3b63b4066befc65f6692b2ec1428d130';
 
 final class ProfileRepostsFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<VideoEvent>>, String> {
-  const ProfileRepostsFamily._()
+  ProfileRepostsFamily._()
     : super(
         retry: null,
         name: r'profileRepostsProvider',

--- a/mobile/lib/providers/readiness_gate_providers.g.dart
+++ b/mobile/lib/providers/readiness_gate_providers.g.dart
@@ -11,14 +11,14 @@ part of 'readiness_gate_providers.dart';
 /// Provider that combines all readiness gates to determine if app is ready for subscriptions
 
 @ProviderFor(appReady)
-const appReadyProvider = AppReadyProvider._();
+final appReadyProvider = AppReadyProvider._();
 
 /// Provider that combines all readiness gates to determine if app is ready for subscriptions
 
 final class AppReadyProvider extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider that combines all readiness gates to determine if app is ready for subscriptions
-  const AppReadyProvider._()
+  AppReadyProvider._()
     : super(
         from: null,
         argument: null,
@@ -56,7 +56,7 @@ String _$appReadyHash() => r'e5ade29720db0ff896154f0423b80168cdce97c8';
 /// Provider that checks if the discovery/explore tab is currently active
 
 @ProviderFor(isDiscoveryTabActive)
-const isDiscoveryTabActiveProvider = IsDiscoveryTabActiveProvider._();
+final isDiscoveryTabActiveProvider = IsDiscoveryTabActiveProvider._();
 
 /// Provider that checks if the discovery/explore tab is currently active
 
@@ -64,7 +64,7 @@ final class IsDiscoveryTabActiveProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider that checks if the discovery/explore tab is currently active
-  const IsDiscoveryTabActiveProvider._()
+  IsDiscoveryTabActiveProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/relay_providers.g.dart
+++ b/mobile/lib/providers/relay_providers.g.dart
@@ -11,7 +11,7 @@ part of 'relay_providers.dart';
 /// Connection status service for monitoring network connectivity
 
 @ProviderFor(connectionStatusService)
-const connectionStatusServiceProvider = ConnectionStatusServiceProvider._();
+final connectionStatusServiceProvider = ConnectionStatusServiceProvider._();
 
 /// Connection status service for monitoring network connectivity
 
@@ -24,7 +24,7 @@ final class ConnectionStatusServiceProvider
         >
     with $Provider<ConnectionStatusService> {
   /// Connection status service for monitoring network connectivity
-  const ConnectionStatusServiceProvider._()
+  ConnectionStatusServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -64,7 +64,7 @@ String _$connectionStatusServiceHash() =>
 /// Relay capability service for detecting NIP-11 Divine extensions
 
 @ProviderFor(relayCapabilityService)
-const relayCapabilityServiceProvider = RelayCapabilityServiceProvider._();
+final relayCapabilityServiceProvider = RelayCapabilityServiceProvider._();
 
 /// Relay capability service for detecting NIP-11 Divine extensions
 
@@ -77,7 +77,7 @@ final class RelayCapabilityServiceProvider
         >
     with $Provider<RelayCapabilityService> {
   /// Relay capability service for detecting NIP-11 Divine extensions
-  const RelayCapabilityServiceProvider._()
+  RelayCapabilityServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -117,7 +117,7 @@ String _$relayCapabilityServiceHash() =>
 /// Relay statistics service for tracking per-relay metrics
 
 @ProviderFor(relayStatisticsService)
-const relayStatisticsServiceProvider = RelayStatisticsServiceProvider._();
+final relayStatisticsServiceProvider = RelayStatisticsServiceProvider._();
 
 /// Relay statistics service for tracking per-relay metrics
 
@@ -130,7 +130,7 @@ final class RelayStatisticsServiceProvider
         >
     with $Provider<RelayStatisticsService> {
   /// Relay statistics service for tracking per-relay metrics
-  const RelayStatisticsServiceProvider._()
+  RelayStatisticsServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -171,7 +171,7 @@ String _$relayStatisticsServiceHash() =>
 /// Use this provider when you need UI to rebuild when statistics change
 
 @ProviderFor(relayStatisticsStream)
-const relayStatisticsStreamProvider = RelayStatisticsStreamProvider._();
+final relayStatisticsStreamProvider = RelayStatisticsStreamProvider._();
 
 /// Stream provider for reactive relay statistics updates
 /// Use this provider when you need UI to rebuild when statistics change
@@ -188,7 +188,7 @@ final class RelayStatisticsStreamProvider
         $StreamProvider<Map<String, RelayStatistics>> {
   /// Stream provider for reactive relay statistics updates
   /// Use this provider when you need UI to rebuild when statistics change
-  const RelayStatisticsStreamProvider._()
+  RelayStatisticsStreamProvider._()
     : super(
         from: null,
         argument: null,
@@ -227,7 +227,7 @@ String _$relayStatisticsStreamHash() =>
 /// Must be watched at app level to activate the bridge.
 
 @ProviderFor(relayStatisticsBridge)
-const relayStatisticsBridgeProvider = RelayStatisticsBridgeProvider._();
+final relayStatisticsBridgeProvider = RelayStatisticsBridgeProvider._();
 
 /// Bridge provider that connects NostrClient relay status updates to
 /// RelayStatisticsService.
@@ -249,7 +249,7 @@ final class RelayStatisticsBridgeProvider
   /// errors) so each relay displays its own real statistics.
   ///
   /// Must be watched at app level to activate the bridge.
-  const RelayStatisticsBridgeProvider._()
+  RelayStatisticsBridgeProvider._()
     : super(
         from: null,
         argument: null,
@@ -291,7 +291,7 @@ String _$relayStatisticsBridgeHash() =>
 /// Only reacts to set membership changes, not connection state flapping.
 
 @ProviderFor(relaySetChangeBridge)
-const relaySetChangeBridgeProvider = RelaySetChangeBridgeProvider._();
+final relaySetChangeBridgeProvider = RelaySetChangeBridgeProvider._();
 
 /// Bridge provider that detects when the configured relay set changes
 /// (relays added or removed) and triggers a full feed reset+resubscribe.
@@ -305,7 +305,7 @@ final class RelaySetChangeBridgeProvider
   /// (relays added or removed) and triggers a full feed reset+resubscribe.
   /// Debounces for 2 seconds to collapse rapid add/remove operations.
   /// Only reacts to set membership changes, not connection state flapping.
-  const RelaySetChangeBridgeProvider._()
+  RelaySetChangeBridgeProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -15,7 +15,7 @@ part of 'repository_providers.dart';
 /// feed display. The full FollowRepository will update this when ready.
 
 @ProviderFor(cachedFollowingList)
-const cachedFollowingListProvider = CachedFollowingListProvider._();
+final cachedFollowingListProvider = CachedFollowingListProvider._();
 
 /// Cached following list loaded directly from SharedPreferences.
 ///
@@ -31,7 +31,7 @@ final class CachedFollowingListProvider
   /// Available immediately after authentication (no NostrClient needed).
   /// This provides the follow list from the previous session for instant
   /// feed display. The full FollowRepository will update this when ready.
-  const CachedFollowingListProvider._()
+  CachedFollowingListProvider._()
     : super(
         from: null,
         argument: null,
@@ -78,7 +78,7 @@ String _$cachedFollowingListHash() =>
 /// - PersonalEventCacheService (for caching contact list events)
 
 @ProviderFor(followRepository)
-const followRepositoryProvider = FollowRepositoryProvider._();
+final followRepositoryProvider = FollowRepositoryProvider._();
 
 /// Provider for FollowRepository instance
 ///
@@ -107,7 +107,7 @@ final class FollowRepositoryProvider
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)
   /// - PersonalEventCacheService (for caching contact list events)
-  const FollowRepositoryProvider._()
+  FollowRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -150,7 +150,7 @@ String _$followRepositoryHash() => r'fb0dd5265e3906366876638e6a2026d1b672e8c9';
 /// until the repository owns its own persistence (Phase 1b).
 
 @ProviderFor(curatedListRepository)
-const curatedListRepositoryProvider = CuratedListRepositoryProvider._();
+final curatedListRepositoryProvider = CuratedListRepositoryProvider._();
 
 /// Provider for [CuratedListRepository] instance.
 ///
@@ -173,7 +173,7 @@ final class CuratedListRepositoryProvider
   /// [BehaviorSubject] stream for reactive BLoC subscription. Data is
   /// bridged from the legacy [CuratedListService] via [setSubscribedLists]
   /// until the repository owns its own persistence (Phase 1b).
-  const CuratedListRepositoryProvider._()
+  CuratedListRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -215,7 +215,7 @@ String _$curatedListRepositoryHash() =>
 /// Creates a HashtagRepository for searching hashtags via the Funnelcake API.
 
 @ProviderFor(hashtagRepository)
-const hashtagRepositoryProvider = HashtagRepositoryProvider._();
+final hashtagRepositoryProvider = HashtagRepositoryProvider._();
 
 /// Provider for HashtagRepository instance.
 ///
@@ -232,7 +232,7 @@ final class HashtagRepositoryProvider
   /// Provider for HashtagRepository instance.
   ///
   /// Creates a HashtagRepository for searching hashtags via the Funnelcake API.
-  const HashtagRepositoryProvider._()
+  HashtagRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -273,7 +273,7 @@ String _$hashtagRepositoryHash() => r'fe5341fcbbd62c6418fd00154f9ea24112476251';
 /// Keep-alive so the categories cache survives tab and screen transitions.
 
 @ProviderFor(categoriesRepository)
-const categoriesRepositoryProvider = CategoriesRepositoryProvider._();
+final categoriesRepositoryProvider = CategoriesRepositoryProvider._();
 
 /// Provider for CategoriesRepository instance.
 ///
@@ -290,7 +290,7 @@ final class CategoriesRepositoryProvider
   /// Provider for CategoriesRepository instance.
   ///
   /// Keep-alive so the categories cache survives tab and screen transitions.
-  const CategoriesRepositoryProvider._()
+  CategoriesRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -337,7 +337,7 @@ String _$categoriesRepositoryHash() =>
 /// - FunnelcakeApiClient for fast REST-based profile search
 
 @ProviderFor(profileRepository)
-const profileRepositoryProvider = ProfileRepositoryProvider._();
+final profileRepositoryProvider = ProfileRepositoryProvider._();
 
 /// Provider for ProfileRepository instance
 ///
@@ -364,7 +364,7 @@ final class ProfileRepositoryProvider
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)
   /// - FunnelcakeApiClient for fast REST-based profile search
-  const ProfileRepositoryProvider._()
+  ProfileRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -403,7 +403,7 @@ String _$profileRepositoryHash() => r'387526a9d5084ffca862ce5ea06c3c568b9f653c';
 /// Curation Service - manages NIP-51 video curation sets
 
 @ProviderFor(curationRepository)
-const curationRepositoryProvider = CurationRepositoryProvider._();
+final curationRepositoryProvider = CurationRepositoryProvider._();
 
 /// Curation Service - manages NIP-51 video curation sets
 
@@ -416,7 +416,7 @@ final class CurationRepositoryProvider
         >
     with $Provider<CurationRepository> {
   /// Curation Service - manages NIP-51 video curation sets
-  const CurationRepositoryProvider._()
+  CurationRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -456,13 +456,13 @@ String _$curationRepositoryHash() =>
 /// Lists state notifier - manages curated lists state
 
 @ProviderFor(CuratedListsState)
-const curatedListsStateProvider = CuratedListsStateProvider._();
+final curatedListsStateProvider = CuratedListsStateProvider._();
 
 /// Lists state notifier - manages curated lists state
 final class CuratedListsStateProvider
     extends $AsyncNotifierProvider<CuratedListsState, List<CuratedList>> {
   /// Lists state notifier - manages curated lists state
-  const CuratedListsStateProvider._()
+  CuratedListsStateProvider._()
     : super(
         from: null,
         argument: null,
@@ -489,8 +489,7 @@ abstract class _$CuratedListsState extends $AsyncNotifier<List<CuratedList>> {
   FutureOr<List<CuratedList>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<List<CuratedList>>, List<CuratedList>>;
     final element =
@@ -501,7 +500,7 @@ abstract class _$CuratedListsState extends $AsyncNotifier<List<CuratedList>> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -513,7 +512,7 @@ abstract class _$CuratedListsState extends $AsyncNotifier<List<CuratedList>> {
 /// itself has no Flutter dependencies; this provider owns all UI glue.
 
 @ProviderFor(peopleListsRepository)
-const peopleListsRepositoryProvider = PeopleListsRepositoryProvider._();
+final peopleListsRepositoryProvider = PeopleListsRepositoryProvider._();
 
 /// Repository for NIP-51 kind 30000 people lists.
 ///
@@ -536,7 +535,7 @@ final class PeopleListsRepositoryProvider
   /// [PeopleListsRepositoryImpl] backed by a [LocalPeopleListsCache] that opens
   /// a lazily-created `hive_ce` box named [_peopleListsBoxName]. The repository
   /// itself has no Flutter dependencies; this provider owns all UI glue.
-  const PeopleListsRepositoryProvider._()
+  PeopleListsRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -576,7 +575,7 @@ String _$peopleListsRepositoryHash() =>
 /// Bookmark service for NIP-51 bookmarks
 
 @ProviderFor(bookmarkService)
-const bookmarkServiceProvider = BookmarkServiceProvider._();
+final bookmarkServiceProvider = BookmarkServiceProvider._();
 
 /// Bookmark service for NIP-51 bookmarks
 
@@ -589,7 +588,7 @@ final class BookmarkServiceProvider
         >
     with $FutureModifier<BookmarkService>, $FutureProvider<BookmarkService> {
   /// Bookmark service for NIP-51 bookmarks
-  const BookmarkServiceProvider._()
+  BookmarkServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -642,7 +641,7 @@ String _$bookmarkServiceHash() => r'2430aa71f0c433b0c192fb434b3777877eb41a49';
 /// Read operations return cached/empty data; write operations check keys.
 
 @ProviderFor(dmReactionsRepository)
-const dmReactionsRepositoryProvider = DmReactionsRepositoryProvider._();
+final dmReactionsRepositoryProvider = DmReactionsRepositoryProvider._();
 
 /// Provider for NIP-17 DM repository.
 ///
@@ -699,7 +698,7 @@ final class DmReactionsRepositoryProvider
   ///
   /// Non-nullable: the repository works without keys at construction time.
   /// Read operations return cached/empty data; write operations check keys.
-  const DmReactionsRepositoryProvider._()
+  DmReactionsRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -737,12 +736,12 @@ String _$dmReactionsRepositoryHash() =>
     r'6ef28a0c4a76c2ece84048f04c0b8962a1f1ab48';
 
 @ProviderFor(dmRepository)
-const dmRepositoryProvider = DmRepositoryProvider._();
+final dmRepositoryProvider = DmRepositoryProvider._();
 
 final class DmRepositoryProvider
     extends $FunctionalProvider<DmRepository, DmRepository, DmRepository>
     with $Provider<DmRepository> {
-  const DmRepositoryProvider._()
+  DmRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -787,7 +786,7 @@ String _$dmRepositoryHash() => r'db555e77673032bf3d1c10788e9b448c363e81e0';
 /// - NostrClient from nostrServiceProvider (for relay communication)
 
 @ProviderFor(commentsRepository)
-const commentsRepositoryProvider = CommentsRepositoryProvider._();
+final commentsRepositoryProvider = CommentsRepositoryProvider._();
 
 /// Provider for CommentsRepository instance
 ///
@@ -814,7 +813,7 @@ final class CommentsRepositoryProvider
   ///
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)
-  const CommentsRepositoryProvider._()
+  CommentsRepositoryProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/seen_videos_notifier.g.dart
+++ b/mobile/lib/providers/seen_videos_notifier.g.dart
@@ -11,13 +11,13 @@ part of 'seen_videos_notifier.dart';
 /// Notifier for managing seen videos state reactively
 
 @ProviderFor(SeenVideosNotifier)
-const seenVideosProvider = SeenVideosNotifierProvider._();
+final seenVideosProvider = SeenVideosNotifierProvider._();
 
 /// Notifier for managing seen videos state reactively
 final class SeenVideosNotifierProvider
     extends $NotifierProvider<SeenVideosNotifier, SeenVideosState> {
   /// Notifier for managing seen videos state reactively
-  const SeenVideosNotifierProvider._()
+  SeenVideosNotifierProvider._()
     : super(
         from: null,
         argument: null,
@@ -53,8 +53,7 @@ abstract class _$SeenVideosNotifier extends $Notifier<SeenVideosState> {
   SeenVideosState build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<SeenVideosState, SeenVideosState>;
     final element =
         ref.element
@@ -64,6 +63,6 @@ abstract class _$SeenVideosNotifier extends $Notifier<SeenVideosState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -12,7 +12,7 @@ part of 'social_providers.dart';
 /// Returns null when not authenticated (no userPubkey available)
 
 @ProviderFor(pendingActionService)
-const pendingActionServiceProvider = PendingActionServiceProvider._();
+final pendingActionServiceProvider = PendingActionServiceProvider._();
 
 /// Pending action service for offline sync of social actions
 /// Returns null when not authenticated (no userPubkey available)
@@ -27,7 +27,7 @@ final class PendingActionServiceProvider
     with $Provider<PendingActionService?> {
   /// Pending action service for offline sync of social actions
   /// Returns null when not authenticated (no userPubkey available)
-  const PendingActionServiceProvider._()
+  PendingActionServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -81,7 +81,7 @@ String _$pendingActionServiceHash() =>
 /// catching `StateError` in every sweep pass.
 
 @ProviderFor(outgoingDmRetryService)
-const outgoingDmRetryServiceProvider = OutgoingDmRetryServiceProvider._();
+final outgoingDmRetryServiceProvider = OutgoingDmRetryServiceProvider._();
 
 /// Auto-sweep service for the durable `outgoing_dms` queue.
 ///
@@ -122,7 +122,7 @@ final class OutgoingDmRetryServiceProvider
   /// session is not ready — the underlying [DmRepository.recoverSelfWrap]
   /// requires `setCredentials` to have run, and gating here is cleaner than
   /// catching `StateError` in every sweep pass.
-  const OutgoingDmRetryServiceProvider._()
+  OutgoingDmRetryServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -162,7 +162,7 @@ String _$outgoingDmRetryServiceHash() =>
 /// Auto-sweep service for the durable `pending_view_events` queue.
 
 @ProviderFor(viewEventRetryService)
-const viewEventRetryServiceProvider = ViewEventRetryServiceProvider._();
+final viewEventRetryServiceProvider = ViewEventRetryServiceProvider._();
 
 /// Auto-sweep service for the durable `pending_view_events` queue.
 
@@ -175,7 +175,7 @@ final class ViewEventRetryServiceProvider
         >
     with $Provider<ViewEventRetryService?> {
   /// Auto-sweep service for the durable `pending_view_events` queue.
-  const ViewEventRetryServiceProvider._()
+  ViewEventRetryServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -217,7 +217,7 @@ String _$viewEventRetryServiceHash() =>
 /// Publishes Kind 22236 ephemeral Nostr view events via [ViewEventPublisher].
 
 @ProviderFor(analyticsService)
-const analyticsServiceProvider = AnalyticsServiceProvider._();
+final analyticsServiceProvider = AnalyticsServiceProvider._();
 
 /// Analytics service with opt-out support.
 ///
@@ -234,7 +234,7 @@ final class AnalyticsServiceProvider
   /// Analytics service with opt-out support.
   ///
   /// Publishes Kind 22236 ephemeral Nostr view events via [ViewEventPublisher].
-  const AnalyticsServiceProvider._()
+  AnalyticsServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -272,7 +272,7 @@ String _$analyticsServiceHash() => r'afdabdf0b1d7c769d7b1219062de928f17d34633';
 /// Hashtag cache service for persistent hashtag storage
 
 @ProviderFor(hashtagCacheService)
-const hashtagCacheServiceProvider = HashtagCacheServiceProvider._();
+final hashtagCacheServiceProvider = HashtagCacheServiceProvider._();
 
 /// Hashtag cache service for persistent hashtag storage
 
@@ -285,7 +285,7 @@ final class HashtagCacheServiceProvider
         >
     with $Provider<HashtagCacheService> {
   /// Hashtag cache service for persistent hashtag storage
-  const HashtagCacheServiceProvider._()
+  HashtagCacheServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -325,7 +325,7 @@ String _$hashtagCacheServiceHash() =>
 /// Draft storage service for persisting vine drafts
 
 @ProviderFor(draftStorageService)
-const draftStorageServiceProvider = DraftStorageServiceProvider._();
+final draftStorageServiceProvider = DraftStorageServiceProvider._();
 
 /// Draft storage service for persisting vine drafts
 
@@ -338,7 +338,7 @@ final class DraftStorageServiceProvider
         >
     with $Provider<DraftStorageService> {
   /// Draft storage service for persisting vine drafts
-  const DraftStorageServiceProvider._()
+  DraftStorageServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -378,7 +378,7 @@ String _$draftStorageServiceHash() =>
 /// Clip library service for persisting individual video clips
 
 @ProviderFor(clipLibraryService)
-const clipLibraryServiceProvider = ClipLibraryServiceProvider._();
+final clipLibraryServiceProvider = ClipLibraryServiceProvider._();
 
 /// Clip library service for persisting individual video clips
 
@@ -391,7 +391,7 @@ final class ClipLibraryServiceProvider
         >
     with $Provider<ClipLibraryService> {
   /// Clip library service for persisting individual video clips
-  const ClipLibraryServiceProvider._()
+  ClipLibraryServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -432,7 +432,7 @@ String _$clipLibraryServiceHash() =>
 /// Prevents data leakage between different Nostr accounts
 
 @ProviderFor(userDataCleanupService)
-const userDataCleanupServiceProvider = UserDataCleanupServiceProvider._();
+final userDataCleanupServiceProvider = UserDataCleanupServiceProvider._();
 
 /// User data cleanup service for handling identity changes
 /// Prevents data leakage between different Nostr accounts
@@ -447,7 +447,7 @@ final class UserDataCleanupServiceProvider
     with $Provider<UserDataCleanupService> {
   /// User data cleanup service for handling identity changes
   /// Prevents data leakage between different Nostr accounts
-  const UserDataCleanupServiceProvider._()
+  UserDataCleanupServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -487,7 +487,7 @@ String _$userDataCleanupServiceHash() =>
 /// Hashtag service depends on Video event service and cache service
 
 @ProviderFor(hashtagService)
-const hashtagServiceProvider = HashtagServiceProvider._();
+final hashtagServiceProvider = HashtagServiceProvider._();
 
 /// Hashtag service depends on Video event service and cache service
 
@@ -495,7 +495,7 @@ final class HashtagServiceProvider
     extends $FunctionalProvider<HashtagService, HashtagService, HashtagService>
     with $Provider<HashtagService> {
   /// Hashtag service depends on Video event service and cache service
-  const HashtagServiceProvider._()
+  HashtagServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -535,7 +535,7 @@ String _$hashtagServiceHash() => r'5cd38d3c2e8d78a6f7b74a72b650d79e28938fe4';
 /// Follower count stats have moved to [FollowRepository].
 
 @ProviderFor(socialService)
-const socialServiceProvider = SocialServiceProvider._();
+final socialServiceProvider = SocialServiceProvider._();
 
 /// Social service for follow sets (NIP-51 Kind 30000).
 ///
@@ -547,7 +547,7 @@ final class SocialServiceProvider
   /// Social service for follow sets (NIP-51 Kind 30000).
   ///
   /// Follower count stats have moved to [FollowRepository].
-  const SocialServiceProvider._()
+  SocialServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -585,7 +585,7 @@ String _$socialServiceHash() => r'025a0d7f80743f11d040e4867c012397282404b3';
 /// Content reporting service for NIP-56 compliance
 
 @ProviderFor(contentReportingService)
-const contentReportingServiceProvider = ContentReportingServiceProvider._();
+final contentReportingServiceProvider = ContentReportingServiceProvider._();
 
 /// Content reporting service for NIP-56 compliance
 
@@ -600,7 +600,7 @@ final class ContentReportingServiceProvider
         $FutureModifier<ContentReportingService>,
         $FutureProvider<ContentReportingService> {
   /// Content reporting service for NIP-56 compliance
-  const ContentReportingServiceProvider._()
+  ContentReportingServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -632,7 +632,7 @@ String _$contentReportingServiceHash() =>
 /// Content deletion service for NIP-09 delete events
 
 @ProviderFor(contentDeletionService)
-const contentDeletionServiceProvider = ContentDeletionServiceProvider._();
+final contentDeletionServiceProvider = ContentDeletionServiceProvider._();
 
 /// Content deletion service for NIP-09 delete events
 
@@ -647,7 +647,7 @@ final class ContentDeletionServiceProvider
         $FutureModifier<ContentDeletionService>,
         $FutureProvider<ContentDeletionService> {
   /// Content deletion service for NIP-09 delete events
-  const ContentDeletionServiceProvider._()
+  ContentDeletionServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -679,7 +679,7 @@ String _$contentDeletionServiceHash() =>
 /// Bug report service for collecting diagnostics and sending encrypted reports
 
 @ProviderFor(bugReportService)
-const bugReportServiceProvider = BugReportServiceProvider._();
+final bugReportServiceProvider = BugReportServiceProvider._();
 
 /// Bug report service for collecting diagnostics and sending encrypted reports
 
@@ -692,7 +692,7 @@ final class BugReportServiceProvider
         >
     with $Provider<BugReportService> {
   /// Bug report service for collecting diagnostics and sending encrypted reports
-  const BugReportServiceProvider._()
+  BugReportServiceProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/sound_picker_provider.g.dart
+++ b/mobile/lib/providers/sound_picker_provider.g.dart
@@ -10,11 +10,11 @@ part of 'sound_picker_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(SoundPicker)
-const soundPickerProvider = SoundPickerProvider._();
+final soundPickerProvider = SoundPickerProvider._();
 
 final class SoundPickerProvider
     extends $NotifierProvider<SoundPicker, SoundPickerState> {
-  const SoundPickerProvider._()
+  SoundPickerProvider._()
     : super(
         from: null,
         argument: null,
@@ -47,8 +47,7 @@ abstract class _$SoundPicker extends $Notifier<SoundPickerState> {
   SoundPickerState build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<SoundPickerState, SoundPickerState>;
     final element =
         ref.element
@@ -58,6 +57,6 @@ abstract class _$SoundPicker extends $Notifier<SoundPickerState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/sounds_providers.g.dart
+++ b/mobile/lib/providers/sounds_providers.g.dart
@@ -24,7 +24,7 @@ part of 'sounds_providers.dart';
 /// ```
 
 @ProviderFor(soundsRepository)
-const soundsRepositoryProvider = SoundsRepositoryProvider._();
+final soundsRepositoryProvider = SoundsRepositoryProvider._();
 
 /// Provider for SoundsRepository singleton.
 ///
@@ -63,7 +63,7 @@ final class SoundsRepositoryProvider
   /// final repository = ref.watch(soundsRepositoryProvider);
   /// final sounds = await repository.fetchTrendingSounds();
   /// ```
-  const SoundsRepositoryProvider._()
+  SoundsRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -114,7 +114,7 @@ String _$soundsRepositoryHash() => r'd60c97024c6ebb820c3b5e67c8aeb3934df22888';
 /// ```
 
 @ProviderFor(TrendingSounds)
-const trendingSoundsProvider = TrendingSoundsProvider._();
+final trendingSoundsProvider = TrendingSoundsProvider._();
 
 /// Async provider for trending sounds.
 ///
@@ -146,7 +146,7 @@ final class TrendingSoundsProvider
   ///   error: (e, s) => ErrorWidget(message: e.toString()),
   /// );
   /// ```
-  const TrendingSoundsProvider._()
+  TrendingSoundsProvider._()
     : super(
         from: null,
         argument: null,
@@ -186,8 +186,7 @@ abstract class _$TrendingSounds extends $AsyncNotifier<List<AudioEvent>> {
   FutureOr<List<AudioEvent>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<List<AudioEvent>>, List<AudioEvent>>;
     final element =
@@ -198,7 +197,7 @@ abstract class _$TrendingSounds extends $AsyncNotifier<List<AudioEvent>> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -218,7 +217,7 @@ abstract class _$TrendingSounds extends $AsyncNotifier<List<AudioEvent>> {
 /// ```
 
 @ProviderFor(soundById)
-const soundByIdProvider = SoundByIdFamily._();
+final soundByIdProvider = SoundByIdFamily._();
 
 /// Family provider to fetch a single sound by event ID.
 ///
@@ -257,7 +256,7 @@ final class SoundByIdProvider
   ///   error: (e, s) => ErrorWidget(message: e.toString()),
   /// );
   /// ```
-  const SoundByIdProvider._({
+  SoundByIdProvider._({
     required SoundByIdFamily super.from,
     required String super.argument,
   }) : super(
@@ -320,7 +319,7 @@ String _$soundByIdHash() => r'78312c13305ba58abbc71565853a0c1fb67725b9';
 
 final class SoundByIdFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<AudioEvent?>, String> {
-  const SoundByIdFamily._()
+  SoundByIdFamily._()
     : super(
         retry: null,
         name: r'soundByIdProvider',
@@ -362,7 +361,7 @@ final class SoundByIdFamily extends $Family
 /// ```
 
 @ProviderFor(soundsByCreator)
-const soundsByCreatorProvider = SoundsByCreatorFamily._();
+final soundsByCreatorProvider = SoundsByCreatorFamily._();
 
 /// Family provider for sounds by creator pubkey.
 ///
@@ -391,7 +390,7 @@ final class SoundsByCreatorProvider
   /// ```dart
   /// final creatorSoundsAsync = ref.watch(soundsByCreatorProvider(pubkey));
   /// ```
-  const SoundsByCreatorProvider._({
+  SoundsByCreatorProvider._({
     required SoundsByCreatorFamily super.from,
     required String super.argument,
   }) : super(
@@ -449,7 +448,7 @@ String _$soundsByCreatorHash() => r'87b7969dedb7a2e2b2ab6ef4eb1bf9d7796bde36';
 
 final class SoundsByCreatorFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<AudioEvent>>, String> {
-  const SoundsByCreatorFamily._()
+  SoundsByCreatorFamily._()
     : super(
         retry: null,
         name: r'soundsByCreatorProvider',
@@ -487,7 +486,7 @@ final class SoundsByCreatorFamily extends $Family
 /// ```
 
 @ProviderFor(soundUsageCount)
-const soundUsageCountProvider = SoundUsageCountFamily._();
+final soundUsageCountProvider = SoundUsageCountFamily._();
 
 /// Family provider for video usage count of a specific sound.
 ///
@@ -513,7 +512,7 @@ final class SoundUsageCountProvider
   /// final countAsync = ref.watch(soundUsageCountProvider('audio-event-id'));
   /// final count = countAsync.valueOrNull ?? 0;
   /// ```
-  const SoundUsageCountProvider._({
+  SoundUsageCountProvider._({
     required SoundUsageCountFamily super.from,
     required String super.argument,
   }) : super(
@@ -571,7 +570,7 @@ String _$soundUsageCountHash() => r'0006d93e606657fae006e7309d2f8cb8e1c0140d';
 
 final class SoundUsageCountFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<int>, String> {
-  const SoundUsageCountFamily._()
+  SoundUsageCountFamily._()
     : super(
         retry: null,
         name: r'soundUsageCountProvider',
@@ -620,7 +619,7 @@ final class SoundUsageCountFamily extends $Family
 /// ```
 
 @ProviderFor(SelectedSound)
-const selectedSoundProvider = SelectedSoundProvider._();
+final selectedSoundProvider = SelectedSoundProvider._();
 
 /// State provider for the currently selected sound.
 ///
@@ -664,7 +663,7 @@ final class SelectedSoundProvider
   /// // Clear selection
   /// ref.read(selectedSoundProvider.notifier).state = null;
   /// ```
-  const SelectedSoundProvider._()
+  SelectedSoundProvider._()
     : super(
         from: null,
         argument: null,
@@ -718,8 +717,7 @@ abstract class _$SelectedSound extends $Notifier<AudioEvent?> {
   AudioEvent? build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AudioEvent?, AudioEvent?>;
     final element =
         ref.element
@@ -729,7 +727,7 @@ abstract class _$SelectedSound extends $Notifier<AudioEvent?> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
@@ -749,7 +747,7 @@ abstract class _$SelectedSound extends $Notifier<AudioEvent?> {
 /// ```
 
 @ProviderFor(soundsStream)
-const soundsStreamProvider = SoundsStreamProvider._();
+final soundsStreamProvider = SoundsStreamProvider._();
 
 /// Stream provider for reactive sounds list updates.
 ///
@@ -788,7 +786,7 @@ final class SoundsStreamProvider
   ///   error: (e, s) => ErrorWidget(message: e.toString()),
   /// );
   /// ```
-  const SoundsStreamProvider._()
+  SoundsStreamProvider._()
     : super(
         from: null,
         argument: null,
@@ -832,7 +830,7 @@ String _$soundsStreamHash() => r'56ff68952009171af0f64e7beab9978232fc3cb4';
 /// ```
 
 @ProviderFor(videosUsingSound)
-const videosUsingSoundProvider = VideosUsingSoundFamily._();
+final videosUsingSoundProvider = VideosUsingSoundFamily._();
 
 /// Family provider to fetch videos that use a specific sound.
 ///
@@ -871,7 +869,7 @@ final class VideosUsingSoundProvider
   ///   error: (e, s) => ErrorWidget(message: e.toString()),
   /// );
   /// ```
-  const VideosUsingSoundProvider._({
+  VideosUsingSoundProvider._({
     required VideosUsingSoundFamily super.from,
     required String super.argument,
   }) : super(
@@ -934,7 +932,7 @@ String _$videosUsingSoundHash() => r'f84cd3226592bd070cb9a0f1028e0b72cec47bed';
 
 final class VideosUsingSoundFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<List<String>>, String> {
-  const VideosUsingSoundFamily._()
+  VideosUsingSoundFamily._()
     : super(
         retry: null,
         name: r'videosUsingSoundProvider',

--- a/mobile/lib/providers/subtitle_providers.g.dart
+++ b/mobile/lib/providers/subtitle_providers.g.dart
@@ -21,7 +21,7 @@ part of 'subtitle_providers.dart';
 /// 4. Otherwise returns an empty list (no subtitles available).
 
 @ProviderFor(subtitleCues)
-const subtitleCuesProvider = SubtitleCuesFamily._();
+final subtitleCuesProvider = SubtitleCuesFamily._();
 
 /// Fetches subtitle cues for a video, using the fastest available path.
 ///
@@ -56,7 +56,7 @@ final class SubtitleCuesProvider
   ///    `39307:<pubkey>:subtitles:<d-tag>`), query the relay for the subtitle
   ///    event and parse its content.
   /// 4. Otherwise returns an empty list (no subtitles available).
-  const SubtitleCuesProvider._({
+  SubtitleCuesProvider._({
     required SubtitleCuesFamily super.from,
     required ({
       String videoId,
@@ -144,7 +144,7 @@ final class SubtitleCuesFamily extends $Family
             String? sha256,
           })
         > {
-  const SubtitleCuesFamily._()
+  SubtitleCuesFamily._()
     : super(
         retry: null,
         name: r'subtitleCuesProvider',
@@ -191,7 +191,7 @@ final class SubtitleCuesFamily extends $Family
 /// applies to all videos.
 
 @ProviderFor(SubtitleVisibility)
-const subtitleVisibilityProvider = SubtitleVisibilityProvider._();
+final subtitleVisibilityProvider = SubtitleVisibilityProvider._();
 
 /// Tracks global subtitle visibility (CC on/off).
 ///
@@ -205,7 +205,7 @@ final class SubtitleVisibilityProvider
   /// When enabled, subtitles are shown on all videos that have them.
   /// This acts as an app-wide preference - toggling on one video
   /// applies to all videos.
-  const SubtitleVisibilityProvider._()
+  SubtitleVisibilityProvider._()
     : super(
         from: null,
         argument: null,
@@ -245,8 +245,7 @@ abstract class _$SubtitleVisibility extends $Notifier<bool> {
   bool build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<bool, bool>;
     final element =
         ref.element
@@ -256,6 +255,6 @@ abstract class _$SubtitleVisibility extends $Notifier<bool> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/tab_visibility_provider.g.dart
+++ b/mobile/lib/providers/tab_visibility_provider.g.dart
@@ -10,11 +10,11 @@ part of 'tab_visibility_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(TabVisibility)
-const tabVisibilityProvider = TabVisibilityProvider._();
+final tabVisibilityProvider = TabVisibilityProvider._();
 
 final class TabVisibilityProvider
     extends $NotifierProvider<TabVisibility, int> {
-  const TabVisibilityProvider._()
+  TabVisibilityProvider._()
     : super(
         from: null,
         argument: null,
@@ -47,8 +47,7 @@ abstract class _$TabVisibility extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -58,17 +57,17 @@ abstract class _$TabVisibility extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 @ProviderFor(isFeedTabActive)
-const isFeedTabActiveProvider = IsFeedTabActiveProvider._();
+final isFeedTabActiveProvider = IsFeedTabActiveProvider._();
 
 final class IsFeedTabActiveProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
-  const IsFeedTabActiveProvider._()
+  IsFeedTabActiveProvider._()
     : super(
         from: null,
         argument: null,
@@ -104,12 +103,12 @@ final class IsFeedTabActiveProvider
 String _$isFeedTabActiveHash() => r'f2e318a0f603f13a04f40d7db6232115994b4e7f';
 
 @ProviderFor(isExploreTabActive)
-const isExploreTabActiveProvider = IsExploreTabActiveProvider._();
+final isExploreTabActiveProvider = IsExploreTabActiveProvider._();
 
 final class IsExploreTabActiveProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
-  const IsExploreTabActiveProvider._()
+  IsExploreTabActiveProvider._()
     : super(
         from: null,
         argument: null,
@@ -146,12 +145,12 @@ String _$isExploreTabActiveHash() =>
     r'd040595e2acc4ef80312d6f174a269eac14f1062';
 
 @ProviderFor(isProfileTabActive)
-const isProfileTabActiveProvider = IsProfileTabActiveProvider._();
+final isProfileTabActiveProvider = IsProfileTabActiveProvider._();
 
 final class IsProfileTabActiveProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
-  const IsProfileTabActiveProvider._()
+  IsProfileTabActiveProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/upload_media_providers.g.dart
+++ b/mobile/lib/providers/upload_media_providers.g.dart
@@ -11,7 +11,7 @@ part of 'upload_media_providers.dart';
 /// Blossom BUD-01 authentication service for age-restricted content
 
 @ProviderFor(blossomAuthService)
-const blossomAuthServiceProvider = BlossomAuthServiceProvider._();
+final blossomAuthServiceProvider = BlossomAuthServiceProvider._();
 
 /// Blossom BUD-01 authentication service for age-restricted content
 
@@ -24,7 +24,7 @@ final class BlossomAuthServiceProvider
         >
     with $Provider<BlossomAuthService> {
   /// Blossom BUD-01 authentication service for age-restricted content
-  const BlossomAuthServiceProvider._()
+  BlossomAuthServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -64,7 +64,7 @@ String _$blossomAuthServiceHash() =>
 /// Media authentication interceptor for handling 401 unauthorized responses
 
 @ProviderFor(mediaAuthInterceptor)
-const mediaAuthInterceptorProvider = MediaAuthInterceptorProvider._();
+final mediaAuthInterceptorProvider = MediaAuthInterceptorProvider._();
 
 /// Media authentication interceptor for handling 401 unauthorized responses
 
@@ -77,7 +77,7 @@ final class MediaAuthInterceptorProvider
         >
     with $Provider<MediaAuthInterceptor> {
   /// Media authentication interceptor for handling 401 unauthorized responses
-  const MediaAuthInterceptorProvider._()
+  MediaAuthInterceptorProvider._()
     : super(
         from: null,
         argument: null,
@@ -117,7 +117,7 @@ String _$mediaAuthInterceptorHash() =>
 /// Blossom upload service (uses user-configured Blossom server)
 
 @ProviderFor(blossomUploadService)
-const blossomUploadServiceProvider = BlossomUploadServiceProvider._();
+final blossomUploadServiceProvider = BlossomUploadServiceProvider._();
 
 /// Blossom upload service (uses user-configured Blossom server)
 
@@ -130,7 +130,7 @@ final class BlossomUploadServiceProvider
         >
     with $Provider<BlossomUploadService> {
   /// Blossom upload service (uses user-configured Blossom server)
-  const BlossomUploadServiceProvider._()
+  BlossomUploadServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -170,7 +170,7 @@ String _$blossomUploadServiceHash() =>
 /// Upload manager uses only Blossom upload service
 
 @ProviderFor(uploadManager)
-const uploadManagerProvider = UploadManagerProvider._();
+final uploadManagerProvider = UploadManagerProvider._();
 
 /// Upload manager uses only Blossom upload service
 
@@ -178,7 +178,7 @@ final class UploadManagerProvider
     extends $FunctionalProvider<UploadManager, UploadManager, UploadManager>
     with $Provider<UploadManager> {
   /// Upload manager uses only Blossom upload service
-  const UploadManagerProvider._()
+  UploadManagerProvider._()
     : super(
         from: null,
         argument: null,
@@ -216,7 +216,7 @@ String _$uploadManagerHash() => r'9cfb9aeca47922785af40243c40b4fc2d5f63608';
 /// API service depends on auth service
 
 @ProviderFor(apiService)
-const apiServiceProvider = ApiServiceProvider._();
+final apiServiceProvider = ApiServiceProvider._();
 
 /// API service depends on auth service
 
@@ -224,7 +224,7 @@ final class ApiServiceProvider
     extends $FunctionalProvider<ApiService, ApiService, ApiService>
     with $Provider<ApiService> {
   /// API service depends on auth service
-  const ApiServiceProvider._()
+  ApiServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -262,7 +262,7 @@ String _$apiServiceHash() => r'a114c5e161b816881b395a10c90d043ef94c8de7';
 /// Crosspost API client for Bluesky toggle settings
 
 @ProviderFor(crosspostApiClient)
-const crosspostApiClientProvider = CrosspostApiClientProvider._();
+final crosspostApiClientProvider = CrosspostApiClientProvider._();
 
 /// Crosspost API client for Bluesky toggle settings
 
@@ -275,7 +275,7 @@ final class CrosspostApiClientProvider
         >
     with $Provider<CrosspostApiClient> {
   /// Crosspost API client for Bluesky toggle settings
-  const CrosspostApiClientProvider._()
+  CrosspostApiClientProvider._()
     : super(
         from: null,
         argument: null,
@@ -319,7 +319,7 @@ String _$crosspostApiClientHash() =>
 /// Uses keepAlive to persist across the session (not auto-disposed).
 
 @ProviderFor(audioPlaybackService)
-const audioPlaybackServiceProvider = AudioPlaybackServiceProvider._();
+final audioPlaybackServiceProvider = AudioPlaybackServiceProvider._();
 
 /// Audio playback service for sound playback during recording and preview
 ///
@@ -340,7 +340,7 @@ final class AudioPlaybackServiceProvider
   /// Used by SoundsScreen to preview sounds and by camera screen
   /// for lip-sync recording. Handles audio loading, play/pause, and cleanup.
   /// Uses keepAlive to persist across the session (not auto-disposed).
-  const AudioPlaybackServiceProvider._()
+  AudioPlaybackServiceProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/user_profile_providers.g.dart
+++ b/mobile/lib/providers/user_profile_providers.g.dart
@@ -19,7 +19,7 @@ part of 'user_profile_providers.dart';
 /// FutureProvider, so widget code changes are minimal.
 
 @ProviderFor(userProfileReactive)
-const userProfileReactiveProvider = UserProfileReactiveFamily._();
+final userProfileReactiveProvider = UserProfileReactiveFamily._();
 
 /// Reactive profile provider backed by Drift's watchProfile stream.
 ///
@@ -48,7 +48,7 @@ final class UserProfileReactiveProvider
   ///
   /// Consumers get `AsyncValue<UserProfile?>` — same API as the old
   /// FutureProvider, so widget code changes are minimal.
-  const UserProfileReactiveProvider._({
+  UserProfileReactiveProvider._({
     required UserProfileReactiveFamily super.from,
     required String super.argument,
   }) : super(
@@ -107,7 +107,7 @@ String _$userProfileReactiveHash() =>
 
 final class UserProfileReactiveFamily extends $Family
     with $FunctionalFamilyOverride<Stream<UserProfile?>, String> {
-  const UserProfileReactiveFamily._()
+  UserProfileReactiveFamily._()
     : super(
         retry: null,
         name: r'userProfileReactiveProvider',
@@ -139,7 +139,7 @@ final class UserProfileReactiveFamily extends $Family
 /// rather than a reactive stream.
 
 @ProviderFor(fetchUserProfile)
-const fetchUserProfileProvider = FetchUserProfileFamily._();
+final fetchUserProfileProvider = FetchUserProfileFamily._();
 
 /// One-shot provider: returns cached profile or fetches fresh.
 ///
@@ -158,7 +158,7 @@ final class FetchUserProfileProvider
   ///
   /// Use this when you need a single read (e.g., building a share sheet)
   /// rather than a reactive stream.
-  const FetchUserProfileProvider._({
+  FetchUserProfileProvider._({
     required FetchUserProfileFamily super.from,
     required String super.argument,
   }) : super(
@@ -211,7 +211,7 @@ String _$fetchUserProfileHash() => r'b5565d7d2d026d79ff21286d42511b8aee085d4d';
 
 final class FetchUserProfileFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<UserProfile?>, String> {
-  const FetchUserProfileFamily._()
+  FetchUserProfileFamily._()
     : super(
         retry: null,
         name: r'fetchUserProfileProvider',

--- a/mobile/lib/providers/video_clip_import_provider.g.dart
+++ b/mobile/lib/providers/video_clip_import_provider.g.dart
@@ -10,7 +10,7 @@ part of 'video_clip_import_provider.dart';
 // ignore_for_file: type=lint, type=warning
 
 @ProviderFor(videoClipImportService)
-const videoClipImportServiceProvider = VideoClipImportServiceProvider._();
+final videoClipImportServiceProvider = VideoClipImportServiceProvider._();
 
 final class VideoClipImportServiceProvider
     extends
@@ -20,7 +20,7 @@ final class VideoClipImportServiceProvider
           VideoClipImportService
         >
     with $Provider<VideoClipImportService> {
-  const VideoClipImportServiceProvider._()
+  VideoClipImportServiceProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/video_events_providers.g.dart
+++ b/mobile/lib/providers/video_events_providers.g.dart
@@ -11,7 +11,7 @@ part of 'video_events_providers.dart';
 /// Provider for NostrClient instance (Video Events specific)
 
 @ProviderFor(videoEventsNostrService)
-const videoEventsNostrServiceProvider = VideoEventsNostrServiceProvider._();
+final videoEventsNostrServiceProvider = VideoEventsNostrServiceProvider._();
 
 /// Provider for NostrClient instance (Video Events specific)
 
@@ -19,7 +19,7 @@ final class VideoEventsNostrServiceProvider
     extends $FunctionalProvider<NostrClient, NostrClient, NostrClient>
     with $Provider<NostrClient> {
   /// Provider for NostrClient instance (Video Events specific)
-  const VideoEventsNostrServiceProvider._()
+  VideoEventsNostrServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -58,7 +58,7 @@ String _$videoEventsNostrServiceHash() =>
 /// Provider for SubscriptionManager instance (Video Events specific)
 
 @ProviderFor(videoEventsSubscriptionManager)
-const videoEventsSubscriptionManagerProvider =
+final videoEventsSubscriptionManagerProvider =
     VideoEventsSubscriptionManagerProvider._();
 
 /// Provider for SubscriptionManager instance (Video Events specific)
@@ -72,7 +72,7 @@ final class VideoEventsSubscriptionManagerProvider
         >
     with $Provider<SubscriptionManager> {
   /// Provider for SubscriptionManager instance (Video Events specific)
-  const VideoEventsSubscriptionManagerProvider._()
+  VideoEventsSubscriptionManagerProvider._()
     : super(
         from: null,
         argument: null,
@@ -112,13 +112,13 @@ String _$videoEventsSubscriptionManagerHash() =>
 /// Stream provider for video events from Nostr
 
 @ProviderFor(VideoEvents)
-const videoEventsProvider = VideoEventsProvider._();
+final videoEventsProvider = VideoEventsProvider._();
 
 /// Stream provider for video events from Nostr
 final class VideoEventsProvider
     extends $StreamNotifierProvider<VideoEvents, List<VideoEvent>> {
   /// Stream provider for video events from Nostr
-  const VideoEventsProvider._()
+  VideoEventsProvider._()
     : super(
         from: null,
         argument: null,
@@ -145,8 +145,7 @@ abstract class _$VideoEvents extends $StreamNotifier<List<VideoEvent>> {
   Stream<List<VideoEvent>> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref =
         this.ref as $Ref<AsyncValue<List<VideoEvent>>, List<VideoEvent>>;
     final element =
@@ -157,14 +156,14 @@ abstract class _$VideoEvents extends $StreamNotifier<List<VideoEvent>> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 /// Provider to check if video events are loading
 
 @ProviderFor(videoEventsLoading)
-const videoEventsLoadingProvider = VideoEventsLoadingProvider._();
+final videoEventsLoadingProvider = VideoEventsLoadingProvider._();
 
 /// Provider to check if video events are loading
 
@@ -172,7 +171,7 @@ final class VideoEventsLoadingProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider to check if video events are loading
-  const VideoEventsLoadingProvider._()
+  VideoEventsLoadingProvider._()
     : super(
         from: null,
         argument: null,
@@ -211,14 +210,14 @@ String _$videoEventsLoadingHash() =>
 /// Provider to get video event count
 
 @ProviderFor(videoEventCount)
-const videoEventCountProvider = VideoEventCountProvider._();
+final videoEventCountProvider = VideoEventCountProvider._();
 
 /// Provider to get video event count
 
 final class VideoEventCountProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   /// Provider to get video event count
-  const VideoEventCountProvider._()
+  VideoEventCountProvider._()
     : super(
         from: null,
         argument: null,
@@ -256,13 +255,13 @@ String _$videoEventCountHash() => r'a46a7c75e516aa2022464dfb9a2ce1988729e413';
 /// State provider for buffered video count
 
 @ProviderFor(BufferedVideoCount)
-const bufferedVideoCountProvider = BufferedVideoCountProvider._();
+final bufferedVideoCountProvider = BufferedVideoCountProvider._();
 
 /// State provider for buffered video count
 final class BufferedVideoCountProvider
     extends $NotifierProvider<BufferedVideoCount, int> {
   /// State provider for buffered video count
-  const BufferedVideoCountProvider._()
+  BufferedVideoCountProvider._()
     : super(
         from: null,
         argument: null,
@@ -298,8 +297,7 @@ abstract class _$BufferedVideoCount extends $Notifier<int> {
   int build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<int, int>;
     final element =
         ref.element
@@ -309,6 +307,6 @@ abstract class _$BufferedVideoCount extends $Notifier<int> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }

--- a/mobile/lib/providers/video_feed_provider.g.dart
+++ b/mobile/lib/providers/video_feed_provider.g.dart
@@ -11,13 +11,13 @@ part of 'video_feed_provider.dart';
 /// Simple discovery video feed provider
 
 @ProviderFor(VideoFeed)
-const videoFeedProvider = VideoFeedProvider._();
+final videoFeedProvider = VideoFeedProvider._();
 
 /// Simple discovery video feed provider
 final class VideoFeedProvider
     extends $AsyncNotifierProvider<VideoFeed, VideoFeedState> {
   /// Simple discovery video feed provider
-  const VideoFeedProvider._()
+  VideoFeedProvider._()
     : super(
         from: null,
         argument: null,
@@ -44,8 +44,7 @@ abstract class _$VideoFeed extends $AsyncNotifier<VideoFeedState> {
   FutureOr<VideoFeedState> build();
   @$mustCallSuper
   @override
-  void runBuild() {
-    final created = build();
+  WhenComplete runBuild() {
     final ref = this.ref as $Ref<AsyncValue<VideoFeedState>, VideoFeedState>;
     final element =
         ref.element
@@ -55,14 +54,14 @@ abstract class _$VideoFeed extends $AsyncNotifier<VideoFeedState> {
               Object?,
               Object?
             >;
-    element.handleValue(ref, created);
+    return element.handleCreate(ref, build);
   }
 }
 
 /// Provider to check if video feed is loading
 
 @ProviderFor(videoFeedLoading)
-const videoFeedLoadingProvider = VideoFeedLoadingProvider._();
+final videoFeedLoadingProvider = VideoFeedLoadingProvider._();
 
 /// Provider to check if video feed is loading
 
@@ -70,7 +69,7 @@ final class VideoFeedLoadingProvider
     extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider to check if video feed is loading
-  const VideoFeedLoadingProvider._()
+  VideoFeedLoadingProvider._()
     : super(
         from: null,
         argument: null,
@@ -108,14 +107,14 @@ String _$videoFeedLoadingHash() => r'055850405fbf52cb95fa8a6d62b431fc5b5aed2a';
 /// Provider to get current video count
 
 @ProviderFor(videoFeedCount)
-const videoFeedCountProvider = VideoFeedCountProvider._();
+final videoFeedCountProvider = VideoFeedCountProvider._();
 
 /// Provider to get current video count
 
 final class VideoFeedCountProvider extends $FunctionalProvider<int, int, int>
     with $Provider<int> {
   /// Provider to get current video count
-  const VideoFeedCountProvider._()
+  VideoFeedCountProvider._()
     : super(
         from: null,
         argument: null,
@@ -153,14 +152,14 @@ String _$videoFeedCountHash() => r'de3d7d4c6f880e868a4a0c490b3c4df125040195';
 /// Provider to check if we have videos
 
 @ProviderFor(hasVideos)
-const hasVideosProvider = HasVideosProvider._();
+final hasVideosProvider = HasVideosProvider._();
 
 /// Provider to check if we have videos
 
 final class HasVideosProvider extends $FunctionalProvider<bool, bool, bool>
     with $Provider<bool> {
   /// Provider to check if we have videos
-  const HasVideosProvider._()
+  HasVideosProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:flutter_riverpod/flutter_riverpod.dart' show Provider;
 import 'package:http/http.dart' as http;
 import 'package:likes_repository/likes_repository.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
@@ -522,7 +523,11 @@ LikesRepository likesRepository(Ref ref) {
 /// Uses:
 /// - NostrClient from nostrServiceProvider (for relay communication)
 /// - PersonalRepostsDao from databaseProvider (for local storage)
-@Riverpod(keepAlive: true)
+final repostsRepositoryProvider = Provider<RepostsRepository>(
+  repostsRepository,
+  name: 'repostsRepositoryProvider',
+);
+
 RepostsRepository repostsRepository(Ref ref) {
   final authService = ref.watch(authServiceProvider);
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -11,7 +11,7 @@ part of 'video_providers.dart';
 /// Video filter builder for constructing relay-aware filters with server-side sorting
 
 @ProviderFor(videoFilterBuilder)
-const videoFilterBuilderProvider = VideoFilterBuilderProvider._();
+final videoFilterBuilderProvider = VideoFilterBuilderProvider._();
 
 /// Video filter builder for constructing relay-aware filters with server-side sorting
 
@@ -24,7 +24,7 @@ final class VideoFilterBuilderProvider
         >
     with $Provider<VideoFilterBuilder> {
   /// Video filter builder for constructing relay-aware filters with server-side sorting
-  const VideoFilterBuilderProvider._()
+  VideoFilterBuilderProvider._()
     : super(
         from: null,
         argument: null,
@@ -64,7 +64,7 @@ String _$videoFilterBuilderHash() =>
 /// Video visibility manager for controlling video playback based on visibility
 
 @ProviderFor(videoVisibilityManager)
-const videoVisibilityManagerProvider = VideoVisibilityManagerProvider._();
+final videoVisibilityManagerProvider = VideoVisibilityManagerProvider._();
 
 /// Video visibility manager for controlling video playback based on visibility
 
@@ -77,7 +77,7 @@ final class VideoVisibilityManagerProvider
         >
     with $Provider<VideoVisibilityManager> {
   /// Video visibility manager for controlling video playback based on visibility
-  const VideoVisibilityManagerProvider._()
+  VideoVisibilityManagerProvider._()
     : super(
         from: null,
         argument: null,
@@ -117,7 +117,7 @@ String _$videoVisibilityManagerHash() =>
 /// Personal event cache service for ALL user's own events
 
 @ProviderFor(personalEventCacheService)
-const personalEventCacheServiceProvider = PersonalEventCacheServiceProvider._();
+final personalEventCacheServiceProvider = PersonalEventCacheServiceProvider._();
 
 /// Personal event cache service for ALL user's own events
 
@@ -130,7 +130,7 @@ final class PersonalEventCacheServiceProvider
         >
     with $Provider<PersonalEventCacheService> {
   /// Personal event cache service for ALL user's own events
-  const PersonalEventCacheServiceProvider._()
+  PersonalEventCacheServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -170,7 +170,7 @@ String _$personalEventCacheServiceHash() =>
 /// Seen videos service for tracking viewed content
 
 @ProviderFor(seenVideosService)
-const seenVideosServiceProvider = SeenVideosServiceProvider._();
+final seenVideosServiceProvider = SeenVideosServiceProvider._();
 
 /// Seen videos service for tracking viewed content
 
@@ -183,7 +183,7 @@ final class SeenVideosServiceProvider
         >
     with $Provider<SeenVideosService> {
   /// Seen videos service for tracking viewed content
-  const SeenVideosServiceProvider._()
+  SeenVideosServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -222,7 +222,7 @@ String _$seenVideosServiceHash() => r'74099bd4d859b446a3fc0cf1a7f416756a104e43';
 /// Subscription manager for centralized subscription management
 
 @ProviderFor(subscriptionManager)
-const subscriptionManagerProvider = SubscriptionManagerProvider._();
+final subscriptionManagerProvider = SubscriptionManagerProvider._();
 
 /// Subscription manager for centralized subscription management
 
@@ -235,7 +235,7 @@ final class SubscriptionManagerProvider
         >
     with $Provider<SubscriptionManager> {
   /// Subscription manager for centralized subscription management
-  const SubscriptionManagerProvider._()
+  SubscriptionManagerProvider._()
     : super(
         from: null,
         argument: null,
@@ -275,7 +275,7 @@ String _$subscriptionManagerHash() =>
 /// Video event service depends on Nostr, SeenVideos, Blocklist, AgeVerification, and SubscriptionManager
 
 @ProviderFor(videoEventService)
-const videoEventServiceProvider = VideoEventServiceProvider._();
+final videoEventServiceProvider = VideoEventServiceProvider._();
 
 /// Video event service depends on Nostr, SeenVideos, Blocklist, AgeVerification, and SubscriptionManager
 
@@ -288,7 +288,7 @@ final class VideoEventServiceProvider
         >
     with $Provider<VideoEventService> {
   /// Video event service depends on Nostr, SeenVideos, Blocklist, AgeVerification, and SubscriptionManager
-  const VideoEventServiceProvider._()
+  VideoEventServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -327,7 +327,7 @@ String _$videoEventServiceHash() => r'85ef90976750b306638eca4df08291e7c5e2cb54';
 /// Video event publisher for publishing video events to Nostr relays
 
 @ProviderFor(videoEventPublisher)
-const videoEventPublisherProvider = VideoEventPublisherProvider._();
+final videoEventPublisherProvider = VideoEventPublisherProvider._();
 
 /// Video event publisher for publishing video events to Nostr relays
 
@@ -340,7 +340,7 @@ final class VideoEventPublisherProvider
         >
     with $Provider<VideoEventPublisher> {
   /// Video event publisher for publishing video events to Nostr relays
-  const VideoEventPublisherProvider._()
+  VideoEventPublisherProvider._()
     : super(
         from: null,
         argument: null,
@@ -383,7 +383,7 @@ String _$videoEventPublisherHash() =>
 /// and enable creator analytics and recommendation systems.
 
 @ProviderFor(viewEventPublisher)
-const viewEventPublisherProvider = ViewEventPublisherProvider._();
+final viewEventPublisherProvider = ViewEventPublisherProvider._();
 
 /// View event publisher for kind 22236 ephemeral analytics events
 ///
@@ -402,7 +402,7 @@ final class ViewEventPublisherProvider
   ///
   /// Publishes video view events to track watch time, traffic sources,
   /// and enable creator analytics and recommendation systems.
-  const ViewEventPublisherProvider._()
+  ViewEventPublisherProvider._()
     : super(
         from: null,
         argument: null,
@@ -443,7 +443,7 @@ String _$viewEventPublisherHash() =>
 /// Depends on CuratedListService which is async, so watch the state provider
 
 @ProviderFor(subscribedListVideoCache)
-const subscribedListVideoCacheProvider = SubscribedListVideoCacheProvider._();
+final subscribedListVideoCacheProvider = SubscribedListVideoCacheProvider._();
 
 /// Subscribed list video cache for merging subscribed list videos into home feed
 /// Depends on CuratedListService which is async, so watch the state provider
@@ -458,7 +458,7 @@ final class SubscribedListVideoCacheProvider
     with $Provider<SubscribedListVideoCache?> {
   /// Subscribed list video cache for merging subscribed list videos into home feed
   /// Depends on CuratedListService which is async, so watch the state provider
-  const SubscribedListVideoCacheProvider._()
+  SubscribedListVideoCacheProvider._()
     : super(
         from: null,
         argument: null,
@@ -501,7 +501,7 @@ String _$subscribedListVideoCacheHash() =>
 /// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
 
 @ProviderFor(videoSharingService)
-const videoSharingServiceProvider = VideoSharingServiceProvider._();
+final videoSharingServiceProvider = VideoSharingServiceProvider._();
 
 /// Video sharing service
 ///
@@ -520,7 +520,7 @@ final class VideoSharingServiceProvider
   ///
   /// When a [DmRepository] is available the service sends videos via NIP-17
   /// encrypted DMs (NIP-17). Otherwise falls back to NIP-04 kind 4.
-  const VideoSharingServiceProvider._()
+  VideoSharingServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -561,7 +561,7 @@ String _$videoSharingServiceHash() =>
 /// in-memory → personal cache → relay fallback. See [VideoEventResolver].
 
 @ProviderFor(videoEventResolver)
-const videoEventResolverProvider = VideoEventResolverProvider._();
+final videoEventResolverProvider = VideoEventResolverProvider._();
 
 /// Unified resolver for fetching a [VideoEvent] by its event id, with
 /// in-memory → personal cache → relay fallback. See [VideoEventResolver].
@@ -576,7 +576,7 @@ final class VideoEventResolverProvider
     with $Provider<VideoEventResolver> {
   /// Unified resolver for fetching a [VideoEvent] by its event id, with
   /// in-memory → personal cache → relay fallback. See [VideoEventResolver].
-  const VideoEventResolverProvider._()
+  VideoEventResolverProvider._()
     : super(
         from: null,
         argument: null,
@@ -616,7 +616,7 @@ String _$videoEventResolverHash() =>
 /// Service that orchestrates the video-metadata-edit republish flow.
 
 @ProviderFor(videoMetadataUpdateService)
-const videoMetadataUpdateServiceProvider =
+final videoMetadataUpdateServiceProvider =
     VideoMetadataUpdateServiceProvider._();
 
 /// Service that orchestrates the video-metadata-edit republish flow.
@@ -630,7 +630,7 @@ final class VideoMetadataUpdateServiceProvider
         >
     with $Provider<VideoMetadataUpdateService> {
   /// Service that orchestrates the video-metadata-edit republish flow.
-  const VideoMetadataUpdateServiceProvider._()
+  VideoMetadataUpdateServiceProvider._()
     : super(
         from: null,
         argument: null,
@@ -670,7 +670,7 @@ String _$videoMetadataUpdateServiceHash() =>
 /// Broken video tracker service for filtering non-functional videos
 
 @ProviderFor(brokenVideoTracker)
-const brokenVideoTrackerProvider = BrokenVideoTrackerProvider._();
+final brokenVideoTrackerProvider = BrokenVideoTrackerProvider._();
 
 /// Broken video tracker service for filtering non-functional videos
 
@@ -685,7 +685,7 @@ final class BrokenVideoTrackerProvider
         $FutureModifier<BrokenVideoTracker>,
         $FutureProvider<BrokenVideoTracker> {
   /// Broken video tracker service for filtering non-functional videos
-  const BrokenVideoTrackerProvider._()
+  BrokenVideoTrackerProvider._()
     : super(
         from: null,
         argument: null,
@@ -723,7 +723,7 @@ String _$brokenVideoTrackerHash() =>
 /// - NostrEventsDao from databaseProvider (for SQLite storage)
 
 @ProviderFor(videoLocalStorage)
-const videoLocalStorageProvider = VideoLocalStorageProvider._();
+final videoLocalStorageProvider = VideoLocalStorageProvider._();
 
 /// Provider for VideoLocalStorage instance (SQLite-backed)
 ///
@@ -748,7 +748,7 @@ final class VideoLocalStorageProvider
   ///
   /// Uses:
   /// - NostrEventsDao from databaseProvider (for SQLite storage)
-  const VideoLocalStorageProvider._()
+  VideoLocalStorageProvider._()
     : super(
         from: null,
         argument: null,
@@ -802,7 +802,7 @@ String _$videoLocalStorageHash() => r'0be44203ec8edf59105a013aae374c07637a3ba0';
 /// - FunnelcakeApiClient for trending/popular video sorting
 
 @ProviderFor(videosRepository)
-const videosRepositoryProvider = VideosRepositoryProvider._();
+final videosRepositoryProvider = VideosRepositoryProvider._();
 
 /// Provider for VideosRepository instance
 ///
@@ -845,7 +845,7 @@ final class VideosRepositoryProvider
   /// - ContentBlocklistRepository for filtering blocked/muted users
   /// - ContentFilterService for filtering NSFW content based on user preferences
   /// - FunnelcakeApiClient for trending/popular video sorting
-  const VideosRepositoryProvider._()
+  VideosRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -890,7 +890,7 @@ String _$videosRepositoryHash() => r'e4ef1b585f6dc5a957af569cd01f750e60ba5838';
 /// - PersonalReactionsDao from databaseProvider (for local storage)
 
 @ProviderFor(likesRepository)
-const likesRepositoryProvider = LikesRepositoryProvider._();
+final likesRepositoryProvider = LikesRepositoryProvider._();
 
 /// Provider for LikesRepository instance
 ///
@@ -913,7 +913,7 @@ final class LikesRepositoryProvider
   /// Uses:
   /// - NostrClient from nostrServiceProvider (for relay communication)
   /// - PersonalReactionsDao from databaseProvider (for local storage)
-  const LikesRepositoryProvider._()
+  LikesRepositoryProvider._()
     : super(
         from: null,
         argument: null,
@@ -947,76 +947,3 @@ final class LikesRepositoryProvider
 }
 
 String _$likesRepositoryHash() => r'fc6229af119fdde9c92deaa2280f26e3ce3bfb00';
-
-/// Provider for RepostsRepository instance
-///
-/// Creates a RepostsRepository for managing user reposts (Kind 16 generic
-/// reposts).
-///
-/// Uses:
-/// - NostrClient from nostrServiceProvider (for relay communication)
-/// - PersonalRepostsDao from databaseProvider (for local storage)
-
-@ProviderFor(repostsRepository)
-const repostsRepositoryProvider = RepostsRepositoryProvider._();
-
-/// Provider for RepostsRepository instance
-///
-/// Creates a RepostsRepository for managing user reposts (Kind 16 generic
-/// reposts).
-///
-/// Uses:
-/// - NostrClient from nostrServiceProvider (for relay communication)
-/// - PersonalRepostsDao from databaseProvider (for local storage)
-
-final class RepostsRepositoryProvider
-    extends
-        $FunctionalProvider<
-          RepostsRepository,
-          RepostsRepository,
-          RepostsRepository
-        >
-    with $Provider<RepostsRepository> {
-  /// Provider for RepostsRepository instance
-  ///
-  /// Creates a RepostsRepository for managing user reposts (Kind 16 generic
-  /// reposts).
-  ///
-  /// Uses:
-  /// - NostrClient from nostrServiceProvider (for relay communication)
-  /// - PersonalRepostsDao from databaseProvider (for local storage)
-  const RepostsRepositoryProvider._()
-    : super(
-        from: null,
-        argument: null,
-        retry: null,
-        name: r'repostsRepositoryProvider',
-        isAutoDispose: false,
-        dependencies: null,
-        $allTransitiveDependencies: null,
-      );
-
-  @override
-  String debugGetCreateSourceHash() => _$repostsRepositoryHash();
-
-  @$internal
-  @override
-  $ProviderElement<RepostsRepository> $createElement(
-    $ProviderPointer pointer,
-  ) => $ProviderElement(pointer);
-
-  @override
-  RepostsRepository create(Ref ref) {
-    return repostsRepository(ref);
-  }
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(RepostsRepository value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<RepostsRepository>(value),
-    );
-  }
-}
-
-String _$repostsRepositoryHash() => r'4d3840d9b241111ec4c7e95830e08932048eba31';

--- a/mobile/lib/providers/watermark_download_provider.g.dart
+++ b/mobile/lib/providers/watermark_download_provider.g.dart
@@ -11,7 +11,7 @@ part of 'watermark_download_provider.dart';
 /// Provides a [WatermarkDownloadService] with injected dependencies.
 
 @ProviderFor(watermarkDownloadService)
-const watermarkDownloadServiceProvider = WatermarkDownloadServiceProvider._();
+final watermarkDownloadServiceProvider = WatermarkDownloadServiceProvider._();
 
 /// Provides a [WatermarkDownloadService] with injected dependencies.
 
@@ -24,7 +24,7 @@ final class WatermarkDownloadServiceProvider
         >
     with $Provider<WatermarkDownloadService> {
   /// Provides a [WatermarkDownloadService] with injected dependencies.
-  const WatermarkDownloadServiceProvider._()
+  WatermarkDownloadServiceProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/services/database_encryption_bootstrap.dart
+++ b/mobile/lib/services/database_encryption_bootstrap.dart
@@ -14,14 +14,14 @@ import 'package:unified_logger/unified_logger.dart';
 @visibleForTesting
 const dbCipherKeyStorageKey = 'db.cipher.key.v1';
 
-/// Resolves the SQLCipher key for the local database before the first
+/// Resolves the SQLite3MultipleCiphers key for the local database before the first
 /// `AppDatabase` open and performs the one-time plaintext→encrypted migration.
 ///
 /// db_client stays keystore-free: this app-layer service reads/generates the
 /// key from [FlutterSecureStorage] and injects it via `db_cipher_key_provider`.
-/// Native runtime hooks (the Android library override, the cipher-availability
-/// probe, the migration, the key-loss backup/recreate path) are injected so
-/// the orchestration is unit-testable on the host VM, which links plain sqlite3.
+/// Native runtime hooks (the cipher-availability probe, the migration, the
+/// key-loss backup/recreate path) are injected so the orchestration is
+/// unit-testable.
 class DatabaseEncryptionBootstrap {
   DatabaseEncryptionBootstrap({
     required FlutterSecureStorage secureStorage,
@@ -62,13 +62,13 @@ class DatabaseEncryptionBootstrap {
   /// Resolves the cipher key for the database provider, or `null` when the
   /// database should open unencrypted.
   ///
-  /// Returns `null` for web (SQLCipher is native-only, #373) and when a
+  /// Returns `null` for web (native DB encryption is out of scope, #373) and when a
   /// populated plaintext database could not be migrated this launch (the
   /// migration left it intact and retries on the next launch).
   ///
-  /// Throws [StateError] when SQLCipher is not the linked SQLite library — a
-  /// build misconfiguration that must fail loudly rather than silently ship an
-  /// unencrypted database.
+  /// Throws [StateError] when SQLite3MultipleCiphers is not the active SQLite
+  /// build — a build misconfiguration that must fail loudly rather than
+  /// silently ship an unencrypted database.
   ///
   /// Must run before the first `AppDatabase` open.
   Future<String?> resolveCipherKey() async {
@@ -76,7 +76,7 @@ class DatabaseEncryptionBootstrap {
 
     await _ensureRuntime();
     if (!_isCipherAvailable()) {
-      throw SqlCipherUnavailableError();
+      throw DatabaseCipherUnavailableError();
     }
 
     final (key, wasGenerated) = await _readOrCreateKey();
@@ -144,19 +144,19 @@ class DatabaseEncryptionBootstrap {
   }
 }
 
-class SqlCipherUnavailableError extends StateError {
-  SqlCipherUnavailableError()
+class DatabaseCipherUnavailableError extends StateError {
+  DatabaseCipherUnavailableError()
     : super(
-        'SQLCipher is not linked; refusing to start with an unencrypted local '
-        'database. Verify sqlcipher_flutter_libs replaced sqlite3_flutter_libs '
-        'and that no dependency links plain sqlite3.',
+        'SQLite3MultipleCiphers is not active; refusing to start with an '
+        'unencrypted local database. Verify package:sqlite3 hooks select '
+        'sqlite3mc and no dependency links plain sqlite3.',
       );
 }
 
 /// Resolves the startup DB cipher key and fails closed on bootstrap errors.
 ///
 /// Native app startup must not continue with a `null` cipher key after a
-/// secure-storage or SQLCipher bootstrap failure: an existing encrypted DB
+/// secure-storage or cipher bootstrap failure: an existing encrypted DB
 /// would be opened as plaintext and repeatedly surface SQLITE_NOTADB. Web and
 /// intentional plaintext migration deferrals still return `null` from
 /// [resolveCipherKey].
@@ -186,11 +186,12 @@ const _sqliteNotADb = 26;
 /// Returns whether a startup bootstrap failure is safe to repair by backing up
 /// the local encrypted DB cache and retrying once.
 ///
-/// Keep this as an allowlist. Secure-storage, SQLCipher linkage, and other
-/// transient startup failures must fail closed because deleting or rotating the
-/// DB cipher key can make an otherwise recoverable encrypted DB unusable.
+/// Keep this as an allowlist. Secure-storage, SQLite3MultipleCiphers linkage,
+/// and other transient startup failures must fail closed because deleting or
+/// rotating the DB cipher key can make an otherwise recoverable encrypted DB
+/// unusable.
 bool shouldRepairLocalDatabaseCacheAfterBootstrapError(Object error) {
-  if (error is SqlCipherUnavailableError) return false;
+  if (error is DatabaseCipherUnavailableError) return false;
 
   final message = error.toString();
   return message.contains('SqliteException($_sqliteNotADb)') ||

--- a/mobile/lib/services/openvine_media_cache.g.dart
+++ b/mobile/lib/services/openvine_media_cache.g.dart
@@ -14,7 +14,7 @@ part of 'openvine_media_cache.dart';
 /// The underlying singleton is initialized in main.dart before Riverpod.
 
 @ProviderFor(mediaCache)
-const mediaCacheProvider = MediaCacheProvider._();
+final mediaCacheProvider = MediaCacheProvider._();
 
 /// Provider exposing the media cache singleton for dependency injection.
 ///
@@ -33,7 +33,7 @@ final class MediaCacheProvider
   ///
   /// Use this in Riverpod contexts for testability - can be overridden in tests.
   /// The underlying singleton is initialized in main.dart before Riverpod.
-  const MediaCacheProvider._()
+  MediaCacheProvider._()
     : super(
         from: null,
         argument: null,

--- a/mobile/lib/startup/database_bootstrap_failure_app.dart
+++ b/mobile/lib/startup/database_bootstrap_failure_app.dart
@@ -138,13 +138,14 @@ class DatabaseBootstrapFailureApp extends StatelessWidget {
 }
 
 String databaseBootstrapDiagnosticCode(Object error) {
-  if (error is SqlCipherUnavailableError) {
-    return 'db-sqlcipher-unavailable';
+  if (error is DatabaseCipherUnavailableError) {
+    return 'db-cipher-unavailable';
   }
 
   final message = error.toString();
-  if (message.contains('SQLCipher is not linked')) {
-    return 'db-sqlcipher-unavailable';
+  if (message.contains('SQLCipher is not linked') ||
+      message.contains('SQLite3MultipleCiphers is not active')) {
+    return 'db-cipher-unavailable';
   }
   if (message.contains('secure storage')) {
     return 'db-secure-storage';

--- a/mobile/lib/state/user_profile_state.freezed.dart
+++ b/mobile/lib/state/user_profile_state.freezed.dart
@@ -15,12 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$UserProfileState {
 
-// Pending profile requests
- Set<String> get pendingRequests;// Missing profiles to avoid spam
- Set<String> get knownMissingProfiles; Map<String, DateTime> get missingProfileRetryAfter;// Batch fetching state
- Set<String> get pendingBatchPubkeys;// Loading and error state
- bool get isLoading; bool get isInitialized; String? get error;// Stats
- int get totalProfilesRequested;
+ Set<String> get pendingRequests; Set<String> get knownMissingProfiles; Map<String, DateTime> get missingProfileRetryAfter; Set<String> get pendingBatchPubkeys; bool get isLoading; bool get isInitialized; String? get error; int get totalProfilesRequested;
 /// Create a copy of UserProfileState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -218,18 +213,14 @@ class _UserProfileState extends UserProfileState {
   const _UserProfileState({final  Set<String> pendingRequests = const {}, final  Set<String> knownMissingProfiles = const {}, final  Map<String, DateTime> missingProfileRetryAfter = const {}, final  Set<String> pendingBatchPubkeys = const {}, this.isLoading = false, this.isInitialized = false, this.error, this.totalProfilesRequested = 0}): _pendingRequests = pendingRequests,_knownMissingProfiles = knownMissingProfiles,_missingProfileRetryAfter = missingProfileRetryAfter,_pendingBatchPubkeys = pendingBatchPubkeys,super._();
   factory _UserProfileState.fromJson(Map<String, dynamic> json) => _$UserProfileStateFromJson(json);
 
-// Pending profile requests
  final  Set<String> _pendingRequests;
-// Pending profile requests
 @override@JsonKey() Set<String> get pendingRequests {
   if (_pendingRequests is EqualUnmodifiableSetView) return _pendingRequests;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableSetView(_pendingRequests);
 }
 
-// Missing profiles to avoid spam
  final  Set<String> _knownMissingProfiles;
-// Missing profiles to avoid spam
 @override@JsonKey() Set<String> get knownMissingProfiles {
   if (_knownMissingProfiles is EqualUnmodifiableSetView) return _knownMissingProfiles;
   // ignore: implicit_dynamic_type
@@ -243,20 +234,16 @@ class _UserProfileState extends UserProfileState {
   return EqualUnmodifiableMapView(_missingProfileRetryAfter);
 }
 
-// Batch fetching state
  final  Set<String> _pendingBatchPubkeys;
-// Batch fetching state
 @override@JsonKey() Set<String> get pendingBatchPubkeys {
   if (_pendingBatchPubkeys is EqualUnmodifiableSetView) return _pendingBatchPubkeys;
   // ignore: implicit_dynamic_type
   return EqualUnmodifiableSetView(_pendingBatchPubkeys);
 }
 
-// Loading and error state
 @override@JsonKey() final  bool isLoading;
 @override@JsonKey() final  bool isInitialized;
 @override final  String? error;
-// Stats
 @override@JsonKey() final  int totalProfilesRequested;
 
 /// Create a copy of UserProfileState

--- a/mobile/packages/cache_sync/pubspec.yaml
+++ b/mobile/packages/cache_sync/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ^3.41.1
 
 dependencies:
-  drift: ^2.31.0
+  drift: ^2.34.0
   flutter:
     sdk: flutter
   meta: ^1.16.0
@@ -17,10 +17,10 @@ dependencies:
   path_provider: ^2.1.5
 
 dev_dependencies:
-  build_runner: ^2.10.5
-  drift_dev: ^2.31.0
+  build_runner: ^2.15.0
+  drift_dev: ^2.34.0
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
-  sqlite3: ^2.9.4
+  sqlite3: ^3.3.3
   very_good_analysis: ^10.2.0

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -30,22 +30,21 @@ bool get _isFlutterTestProcess =>
     Platform.executable.contains('flutter_tester');
 
 // ---------------------------------------------------------------------------
-// SQLCipher at-rest encryption (#570, finding C2).
+// SQLite3MultipleCiphers at-rest encryption (#570, finding C2).
 //
 // db_client stays low-level: it never reads the platform keystore. The app
 // layer resolves the 64-hex (raw 32-byte) cipher key and injects it here. The
-// real encrypted open + the in-place rekey migration require the SQLCipher
-// native library and must be validated on real devices — the host test VM
-// links plain sqlite3, on which `PRAGMA cipher_version` is empty (the
-// fail-closed guard below throws there). See
+// real encrypted open + the plaintext→encrypted migration require the
+// sqlite3mc native build selected by package:sqlite3 hooks. See
 // `mobile/docs/sqlcipher_at_rest_plan.md`.
 // ---------------------------------------------------------------------------
 
 /// Opens an at-rest-encrypted database connection for native platforms.
 ///
-/// [rawKeyHex] is a 64-character hex (raw 32-byte) SQLCipher key supplied by
+/// [rawKeyHex] is a 64-character hex (raw 32-byte) cipher key supplied by
 /// the app layer. The key is applied in [applyCipherKey], which **fails
-/// closed**: if SQLCipher is not the linked SQLite library the open throws
+/// closed**: if SQLite3MultipleCiphers is not the active SQLite build the open
+/// throws
 /// rather than silently writing plaintext.
 ///
 /// Throws [ArgumentError] if [rawKeyHex] is malformed (the error never embeds
@@ -92,32 +91,34 @@ Future<bool> encryptedDatabaseOpensWithKey({
     if (e.resultCode == _sqliteNotADb) return false;
     rethrow;
   } finally {
-    db?.dispose();
+    db?.close();
   }
 }
 
-/// Keys [rawDb] with [rawKeyHex] and verifies SQLCipher is actually active.
+/// Keys [rawDb] with [rawKeyHex] and verifies SQLite3MultipleCiphers is active.
 ///
-/// `PRAGMA key` must be the first statement on the connection. On plain
-/// SQLite the pragma is an unknown no-op and `PRAGMA cipher_version` returns
-/// no rows — meaning the database would be **unencrypted**. We refuse to open
-/// in that case (fail closed) instead of silently storing plaintext.
+/// The cipher selection pragmas and `PRAGMA key` must run before any real
+/// database use. On plain SQLite these pragmas are unknown no-ops and
+/// `PRAGMA cipher` returns no rows — meaning the database would be
+/// **unencrypted**. We refuse to open in that case (fail closed) instead of
+/// silently storing plaintext.
 @visibleForTesting
 void applyCipherKey(CommonDatabase rawDb, String rawKeyHex) {
+  _rawKeyLiteral(rawKeyHex);
+  _applySqlCipherCompatibility(rawDb);
   try {
     rawDb.execute(formatCipherKeyPragma(rawKeyHex));
   } on SqliteException {
     // Never rethrow the original: SqliteException.toString() appends the
     // causing statement, which is the `PRAGMA key` containing the raw key.
-    throw StateError('Failed to apply the SQLCipher key.');
+    throw StateError('Failed to apply the local database cipher key.');
   }
 
-  final cipherVersion = rawDb.select('PRAGMA cipher_version;');
-  if (cipherVersion.isEmpty) {
+  if (!_isMultipleCiphersAvailable(rawDb)) {
     throw StateError(
-      'SQLCipher is not the active SQLite library; refusing to open the '
-      'database unencrypted. Ensure sqlcipher_flutter_libs is linked and no '
-      'other dependency links plain sqlite3.',
+      'SQLite3MultipleCiphers is not the active SQLite library; refusing to '
+      'open the database unencrypted. Ensure package:sqlite3 hooks select '
+      'sqlite3mc and no dependency links plain sqlite3.',
     );
   }
 
@@ -126,6 +127,15 @@ void applyCipherKey(CommonDatabase rawDb, String rawKeyHex) {
   // so a wrong key fails deterministically at open time.
   rawDb.execute('SELECT count(*) FROM sqlite_master;');
 }
+
+void _applySqlCipherCompatibility(CommonDatabase rawDb) {
+  rawDb
+    ..execute("PRAGMA cipher = 'sqlcipher';")
+    ..execute('PRAGMA legacy = 4;');
+}
+
+bool _isMultipleCiphersAvailable(CommonDatabase rawDb) =>
+    rawDb.select('PRAGMA cipher;').isNotEmpty;
 
 /// Builds the SQLCipher `PRAGMA key` statement for a **raw** 32-byte key.
 ///
@@ -141,14 +151,14 @@ void applyCipherKey(CommonDatabase rawDb, String rawKeyHex) {
 String formatCipherKeyPragma(String rawKeyHex) =>
     'PRAGMA key = ${_rawKeyLiteral(rawKeyHex)};';
 
-/// Returns the SQLCipher raw-key literal (`"x'<hex>'"`) for use in
-/// `PRAGMA key` and `ATTACH ... KEY` clauses. Inlining the validated hex is
+/// Returns the SQLCipher-compatible raw-key literal (`"x'<hex>'"`) for use in
+/// `PRAGMA key` and `PRAGMA rekey` clauses. Inlining the validated hex is
 /// injection-safe because the value is constrained to `[0-9a-fA-F]{64}`.
 String _rawKeyLiteral(String rawKeyHex) {
   if (!RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(rawKeyHex)) {
     throw ArgumentError(
       'rawKeyHex must be exactly 64 hex characters '
-      '(a raw 32-byte SQLCipher key)',
+      '(a raw 32-byte database cipher key)',
     );
   }
   return '"x\'$rawKeyHex\'"';
@@ -175,21 +185,20 @@ enum CipherMigrationOutcome {
 }
 
 /// One-time in-place rekey of the existing **plaintext** `divine_db.db` into a
-/// SQLCipher-encrypted database, using `sqlcipher_export`.
+/// SQLite3MultipleCiphers-encrypted database.
 ///
-/// Safe by construction: the encrypted copy is written to a side file and
-/// verified (key opens it; table/row counts match the source) **before** the
-/// plaintext original is swapped out, and the original is renamed to a backup
-/// rather than deleted. On any failure the plaintext database is left exactly
-/// as it was so the app keeps working and the migration retries next launch.
+/// Safe by construction: a plaintext side-file copy is encrypted and verified
+/// (key opens it; table/row counts match the source) **before** the plaintext
+/// original is swapped out, and the original is renamed to a backup rather
+/// than deleted. On any failure the plaintext database is left exactly as it
+/// was so the app keeps working and the migration retries next launch.
 ///
 /// Wipe-and-resync is intentionally rejected: `divine_db.db` is shared with
 /// drafts, pending uploads/actions, reactions, reposts, etc., which cannot be
 /// re-fetched. See `mobile/docs/sqlcipher_at_rest_plan.md`.
 ///
-/// Requires the SQLCipher native library; returns
-/// [CipherMigrationOutcome.failed] when it is not linked (e.g. the host test
-/// VM), leaving the source intact.
+/// Requires SQLite3MultipleCiphers; returns [CipherMigrationOutcome.failed]
+/// when it is not linked, leaving the source intact.
 Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
   required String rawKeyHex,
   String? databasePath,
@@ -265,7 +274,7 @@ _DbClassification _classifyDatabase(String dbPath) {
   } on SqliteException catch (e) {
     return _encryptedOrIndeterminate(e);
   } finally {
-    db.dispose();
+    db.close();
   }
 }
 
@@ -284,39 +293,33 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
 
   Database source;
   try {
-    // The source must be opened UNKEYED — sqlcipher_export reads plaintext and
-    // writes the keyed copy through the ATTACH ... KEY clause.
+    // The source must be opened UNKEYED. It remains untouched until a verified
+    // encrypted side-file is ready to promote.
     source = sqlite3.open(dbPath);
   } on SqliteException {
     return CipherMigrationOutcome.failed;
   }
 
   try {
-    if (source.select('PRAGMA cipher_version;').isEmpty) {
-      // SQLCipher not linked — cannot encrypt. Leave plaintext intact.
+    if (!_isMultipleCiphersAvailable(source)) {
+      // SQLite3MultipleCiphers not linked — cannot encrypt. Leave plaintext
+      // intact.
       return CipherMigrationOutcome.failed;
     }
-    // sqlcipher_export does NOT copy user_version, which drift uses as its
-    // schema version; copy it explicitly or drift re-runs every migration on
-    // the encrypted copy. PRAGMA's RHS cannot be a subquery, so read the int
-    // and inline it (an int literal is injection-safe).
-    final userVersion =
-        source.select('PRAGMA main.user_version;').first['user_version']
-            as int? ??
-        0;
-    source
-      ..execute(
-        'ATTACH DATABASE ? AS encrypted KEY ${_rawKeyLiteral(rawKeyHex)};',
-        [encryptedPath],
-      )
-      ..execute("SELECT sqlcipher_export('encrypted');")
-      ..execute('PRAGMA encrypted.user_version = $userVersion;')
-      ..execute('DETACH DATABASE encrypted;');
+    source.execute('VACUUM INTO ?;', [encryptedPath]);
   } on SqliteException {
     _deleteDatabaseAndSidecars(encryptedPath);
     return CipherMigrationOutcome.failed;
   } finally {
-    source.dispose();
+    source.close();
+  }
+
+  if (!_encryptPlaintextMigrationArtifact(
+    encryptedPath: encryptedPath,
+    rawKeyHex: rawKeyHex,
+  )) {
+    _deleteDatabaseAndSidecars(encryptedPath);
+    return CipherMigrationOutcome.failed;
   }
 
   if (!_encryptedCopyMatchesSource(
@@ -343,6 +346,25 @@ CipherMigrationOutcome _rekeyPlaintextInPlace({
   return CipherMigrationOutcome.migrated;
 }
 
+bool _encryptPlaintextMigrationArtifact({
+  required String encryptedPath,
+  required String rawKeyHex,
+}) {
+  Database? db;
+  try {
+    db = sqlite3.open(encryptedPath);
+    _applySqlCipherCompatibility(db);
+    db
+      ..execute('PRAGMA rekey = ${_rawKeyLiteral(rawKeyHex)};')
+      ..execute('SELECT count(*) FROM sqlite_master;');
+    return true;
+  } on SqliteException {
+    return false;
+  } finally {
+    db?.close();
+  }
+}
+
 /// Promotes the verified encrypted migration artifact into the canonical DB
 /// path, carrying WAL/SHM sidecars with it.
 @visibleForTesting
@@ -365,9 +387,8 @@ bool _encryptedCopyMatchesSource({
   Database? encrypted;
   Database? plaintext;
   try {
-    encrypted = sqlite3.open(encryptedPath)
-      ..execute(formatCipherKeyPragma(rawKeyHex));
-    if (encrypted.select('PRAGMA cipher_version;').isEmpty) return false;
+    encrypted = sqlite3.open(encryptedPath);
+    applyCipherKey(encrypted, rawKeyHex);
 
     plaintext = sqlite3.open(plaintextPath, mode: OpenMode.readOnly);
 
@@ -380,8 +401,8 @@ bool _encryptedCopyMatchesSource({
   } on SqliteException {
     return false;
   } finally {
-    encrypted?.dispose();
-    plaintext?.dispose();
+    encrypted?.close();
+    plaintext?.close();
   }
 }
 
@@ -409,7 +430,7 @@ Future<void> backUpAndRemoveSharedDatabase() async {
   _moveSidecars(fromPath: dbPath, toPath: backupPath);
 }
 
-/// Removes plaintext backups left by a successful plaintext→SQLCipher
+/// Removes plaintext backups left by a successful plaintext→encrypted
 /// migration once the encrypted database has opened with its key.
 ///
 /// The migration keeps the plaintext source as
@@ -699,7 +720,7 @@ bool _databaseHasActionableLocalOnlyData(String dbPath) {
   } on SqliteException {
     return true;
   } finally {
-    db.dispose();
+    db.close();
   }
 }
 

--- a/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_web.dart
@@ -20,24 +20,25 @@ Future<String> getSharedDatabasePath() async {
   return 'divine_db'; // IndexedDB database name
 }
 
-/// SQLCipher is native-only; at-rest encryption is unsupported on web.
+/// Native at-rest encryption is unsupported on web.
 ///
 /// Web at-rest encryption is deferred behind the OPFS migration (#373). The
 /// app guards encryption with `kIsWeb`, so this is never reached at runtime —
 /// it exists only so app code compiles for web. See the native variant.
 QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
   throw UnsupportedError(
-    'SQLCipher at-rest encryption is not supported on web',
+    'Native at-rest encryption is not supported on web',
   );
 }
 
-/// Web never opens SQLCipher databases; startup skips DB encryption there.
+/// Web never opens native encrypted databases; startup skips DB encryption
+/// there.
 Future<bool> encryptedDatabaseOpensWithKey({
   required String rawKeyHex,
   String? databasePath,
 }) async {
   throw UnsupportedError(
-    'SQLCipher at-rest encryption is not supported on web',
+    'Native at-rest encryption is not supported on web',
   );
 }
 
@@ -54,13 +55,13 @@ enum CipherMigrationOutcome {
   failed,
 }
 
-/// SQLCipher is native-only; the plaintext→encrypted migration does not apply
-/// on web. Never reached at runtime (guarded by `kIsWeb` in the app).
+/// Native plaintext→encrypted migration does not apply on web. Never reached
+/// at runtime (guarded by `kIsWeb` in the app).
 Future<CipherMigrationOutcome> migratePlaintextToEncrypted({
   required String rawKeyHex,
   String? databasePath,
 }) async {
   throw UnsupportedError(
-    'SQLCipher at-rest encryption is not supported on web',
+    'Native at-rest encryption is not supported on web',
   );
 }

--- a/mobile/packages/db_client/pubspec.yaml
+++ b/mobile/packages/db_client/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  drift: ^2.29.0
+  drift: ^2.34.0
   flutter:
     sdk: flutter
   meta: ^1.16.0
@@ -20,11 +20,11 @@ dependencies:
     path: ../nostr_sdk
   path: ^1.9.1
   path_provider: ^2.1.5
-  sqlite3: ^2.7.6
+  sqlite3: ^3.3.3
 
 dev_dependencies:
-  build_runner: ^2.7.1
-  drift_dev: ^2.29.0
+  build_runner: ^2.15.0
+  drift_dev: ^2.34.0
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -461,18 +461,61 @@ void main() {
     const validKey =
         '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
 
-    test('fails closed when SQLCipher is not the linked library', () {
-      // The host test VM links plain sqlite3, on which PRAGMA cipher_version
-      // returns no rows. The connection must refuse rather than silently
-      // storing plaintext.
-      final db = sqlite3.openInMemory();
-      addTearDown(db.dispose);
-      expect(() => applyCipherKey(db, validKey), throwsStateError);
+    test(
+      'opens a file-backed SQLite3MultipleCiphers database with a raw key',
+      () {
+        final tempRoot = Directory.systemTemp.createTempSync(
+          'db_client_apply_mc_key_test_',
+        );
+        addTearDown(() {
+          if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+        });
+        final dbPath = p.join(tempRoot.path, 'encrypted.db');
+
+        final db = sqlite3.open(dbPath);
+        applyCipherKey(db, validKey);
+        db
+          ..execute('CREATE TABLE secrets (value TEXT NOT NULL);')
+          ..execute("INSERT INTO secrets (value) VALUES ('kept');")
+          ..close();
+
+        final reopened = sqlite3.open(dbPath);
+        addTearDown(reopened.close);
+        applyCipherKey(reopened, validKey);
+        expect(
+          reopened.select('SELECT value FROM secrets;').first['value'],
+          equals('kept'),
+        );
+      },
+    );
+
+    test('encrypted raw-key database is not readable as plaintext', () {
+      final tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_plaintext_rejects_mc_key_test_',
+      );
+      addTearDown(() {
+        if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+      });
+      final dbPath = p.join(tempRoot.path, 'encrypted.db');
+
+      final encrypted = sqlite3.open(dbPath);
+      applyCipherKey(encrypted, validKey);
+      encrypted
+        ..execute('CREATE TABLE secrets (value TEXT NOT NULL);')
+        ..execute("INSERT INTO secrets (value) VALUES ('kept');")
+        ..close();
+
+      final plaintext = sqlite3.open(dbPath, mode: OpenMode.readOnly);
+      addTearDown(plaintext.close);
+      expect(
+        () => plaintext.select('SELECT count(*) FROM sqlite_master;'),
+        throwsA(isA<SqliteException>()),
+      );
     });
 
     test('rejects a malformed key before touching the database', () {
       final db = sqlite3.openInMemory();
-      addTearDown(db.dispose);
+      addTearDown(db.close);
       expect(() => applyCipherKey(db, 'not-a-key'), throwsArgumentError);
     });
 
@@ -480,16 +523,21 @@ void main() {
       // SqliteException.toString() appends the causing statement, which is the
       // PRAGMA key containing the raw key. applyCipherKey must convert that to
       // a key-free error before it can escape to Crashlytics.
+      final keyPragma = formatCipherKeyPragma(validKey);
       final leaky = SqliteException(
-        26,
-        'file is not a database',
-        null,
-        formatCipherKeyPragma(validKey), // causing statement embeds the key
+        extendedResultCode: 26,
+        message: 'file is not a database',
+        causingStatement: keyPragma, // causing statement embeds the key
       );
       expect(leaky.toString(), contains(validKey)); // the source really leaks
 
       final db = _MockCipherDb();
-      when(() => db.execute(any())).thenThrow(leaky);
+      when(() => db.execute(any())).thenAnswer((invocation) {
+        final sql = invocation.positionalArguments.first as String;
+        if (sql == keyPragma) {
+          throw leaky;
+        }
+      });
 
       expect(
         () => applyCipherKey(db, validKey),
@@ -554,7 +602,7 @@ void main() {
 
     test('removes an empty plaintext database so a fresh encrypted one is '
         'created on first open', () async {
-      sqlite3.open(dbPath).dispose(); // empty database, no user tables
+      sqlite3.open(dbPath).close(); // empty database, no user tables
       expect(File(dbPath).existsSync(), isTrue);
 
       final outcome = await migratePlaintextToEncrypted(
@@ -578,21 +626,31 @@ void main() {
       );
     });
 
-    test('fails safely and preserves a populated plaintext DB when SQLCipher '
-        'is not linked', () async {
-      _createSqliteDatabase(dbPath, draftCount: 3);
+    test(
+      'migrates a populated plaintext DB to encrypted raw-key storage',
+      () async {
+        _createSqliteDatabase(dbPath, draftCount: 3);
 
-      final outcome = await migratePlaintextToEncrypted(
-        rawKeyHex: validKey,
-        databasePath: dbPath,
-      );
+        final outcome = await migratePlaintextToEncrypted(
+          rawKeyHex: validKey,
+          databasePath: dbPath,
+        );
 
-      // No cipher library on the host VM, so the rekey cannot complete — the
-      // plaintext source must stay intact for retry on the next launch.
-      expect(outcome, equals(CipherMigrationOutcome.failed));
-      expect(File(dbPath).existsSync(), isTrue);
-      expect(_draftCount(dbPath), equals(3));
-    });
+        expect(outcome, equals(CipherMigrationOutcome.migrated));
+        expect(File(dbPath).existsSync(), isTrue);
+        final encrypted = sqlite3.open(dbPath);
+        addTearDown(encrypted.close);
+        applyCipherKey(encrypted, validKey);
+        expect(_draftCountFromOpenDb(encrypted), equals(3));
+
+        final plaintext = sqlite3.open(dbPath, mode: OpenMode.readOnly);
+        addTearDown(plaintext.close);
+        expect(
+          () => plaintext.select('SELECT count(*) FROM sqlite_master;'),
+          throwsA(isA<SqliteException>()),
+        );
+      },
+    );
 
     test('rejects a malformed key', () async {
       _createSqliteDatabase(dbPath, draftCount: 1);
@@ -759,19 +817,21 @@ void _createSqliteDatabase(
       ]);
     }
   } finally {
-    db.dispose();
+    db.close();
   }
 }
 
 int _draftCount(String path) {
   final db = sqlite3.open(path);
   try {
-    return db.select('SELECT COUNT(*) AS count FROM drafts').first['count']
-        as int;
+    return _draftCountFromOpenDb(db);
   } finally {
-    db.dispose();
+    db.close();
   }
 }
+
+int _draftCountFromOpenDb(Database db) =>
+    db.select('SELECT COUNT(*) AS count FROM drafts').first['count'] as int;
 
 int _eventCount(String path) {
   final db = sqlite3.open(path);
@@ -779,7 +839,7 @@ int _eventCount(String path) {
     return db.select('SELECT COUNT(*) AS count FROM event').first['count']
         as int;
   } finally {
-    db.dispose();
+    db.close();
   }
 }
 
@@ -793,7 +853,7 @@ int _tableCount(String path, String table) {
     return db.select('SELECT COUNT(*) AS count FROM $table').first['count']
         as int;
   } finally {
-    db.dispose();
+    db.close();
   }
 }
 

--- a/mobile/packages/models/pubspec.yaml
+++ b/mobile/packages/models/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   unique_names_generator: ^3.0.0
 
 dev_dependencies:
-  build_runner: ^2.10.4
+  build_runner: ^2.15.0
   json_serializable: ^6.9.4
   mocktail: ^1.0.4
   test: ^1.26.3

--- a/mobile/packages/nostr_sdk/pubspec.yaml
+++ b/mobile/packages/nostr_sdk/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   http: ^1.4.0
   http_parser: ^4.1.2
 dependency_overrides:
-  meta: ^1.16.0
+  meta: ^1.18.0
 
 dev_dependencies:
   flutter_test:

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
+      sha256: a49d6cf99e8d8e7a8e93668d09ced0bbdb954d0b4fccc2f5f9241c6b87fad95c
       url: "https://pub.dev"
     source: hosted
-    version: "91.0.0"
+    version: "99.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -29,26 +29,18 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: a40a0cee526a7e1f387c6847bd8a5ccbf510a75952ef8a28338e989558072cb0
+      sha256: "663efa951fb8a45e06f491223a604c93820598f20e6a99c25617a1576065e8b7"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
+    version: "12.1.0"
   analyzer_buffer:
     dependency: transitive
     description:
       name: analyzer_buffer
-      sha256: aba2f75e63b3135fd1efaa8b6abefe1aa6e41b6bd9806221620fa48f98156033
+      sha256: "445b77e2054fa3e8c8a8ef1b5e9e6b23bb8028fffd34b5e60eaef315b7750674"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.11"
-  analyzer_plugin:
-    dependency: transitive
-    description:
-      name: analyzer_plugin
-      sha256: "08cfefa90b4f4dd3b447bda831cecf644029f9f8e22820f6ee310213ebe2dd53"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.13.10"
+    version: "0.3.3"
   android_content_provider:
     dependency: transitive
     description:
@@ -228,18 +220,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: c1668065e9ba04752570ad7e038288559d1e2ca5c6d0131c0f5f55e39e777413
+      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.6"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   build_daemon:
     dependency: transitive
     description:
@@ -252,10 +244,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b4d854962a32fd9f8efc0b76f98214790b833af8b2e9b2df6bfc927c0415a072
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.5"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -472,30 +464,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
-  custom_lint_core:
-    dependency: transitive
-    description:
-      name: custom_lint_core
-      sha256: "85b339346154d5646952d44d682965dfe9e12cae5febd706f0db3aa5010d6423"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.8.1"
-  custom_lint_visitor:
-    dependency: transitive
-    description:
-      name: custom_lint_visitor
-      sha256: "91f2a81e9f0abb4b9f3bb529f78b6227ce6050300d1ae5b1e2c69c66c7a566d8"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0+8.4.0"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: a4c1ccfee44c7e75ed80484071a5c142a385345e658fd8bd7c4b5c97e7198f98
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.8"
   dbus:
     dependency: transitive
     description:
@@ -580,18 +556,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   equatable:
     dependency: "direct main"
     description:
@@ -923,10 +899,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "9e2d6907f12cc7d23a846847615941bddee8709bf2bfd274acdf5e80bcf22fde"
+      sha256: "9255e1e3ad6e38906a1b4f8287678f95f378744c5b46b1985588543f3f19046e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.3.2"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -1029,10 +1005,10 @@ packages:
     dependency: "direct dev"
     description:
       name: freezed
-      sha256: "13065f10e135263a4f5a4391b79a8efc5fb8106f8dd555a9e49b750b45393d77"
+      sha256: "8599ba37236328ff6f97269ecce875d251a367eb2929c9bbf9b811b2ce56c74e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.6-dev.1"
   freezed_annotation:
     dependency: "direct main"
     description:
@@ -1138,10 +1114,10 @@ packages:
     dependency: "direct dev"
     description:
       name: hive_ce_generator
-      sha256: b19ac263cb37529513508ba47352c41e6de72ba879952898d9c18c9c8a955921
+      sha256: "69800cb5e9bde43d457d24d38c20f458cf95b122c25ba04cfe9519578f31548d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.2"
   hooks:
     dependency: transitive
     description:
@@ -1311,18 +1287,18 @@ packages:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: c5b2ee75210a0f263c6c7b9eeea80553dbae96ea1bf57f02484e806a3ffdffa3
+      sha256: ffcd10cde35a93b2abbbcc26bd9971f4ca93763e8abe78d855e3c4177797e501
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.2"
+    version: "6.14.0"
   just_audio:
     dependency: transitive
     description:
@@ -1485,13 +1461,13 @@ packages:
     source: hosted
     version: "7.3.0"
   meta:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.3"
   mime:
     dependency: transitive
     description:
@@ -1928,34 +1904,34 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: c406de02bff19d920b832bddfb8283548bfa05ce41c59afba57ce643e116aa59
+      sha256: "17100416c51db7810c71a7bb2c34d1f881faa0074fd452afb0c4db6f8f126c76"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.3.2"
   riverpod_analyzer_utils:
     dependency: transitive
     description:
       name: riverpod_analyzer_utils
-      sha256: a0f68adb078b790faa3c655110a017f9a7b7b079a57bbd40f540e80dce5fcd29
+      sha256: "3e275138862ccc22ed61444a1f9a840f753094c367f28f4123f50289cd204d68"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0-dev.7"
+    version: "1.0.0-dev.10"
   riverpod_annotation:
     dependency: "direct main"
     description:
       name: riverpod_annotation
-      sha256: "7230014155777fc31ba3351bc2cb5a3b5717b11bfafe52b1553cb47d385f8897"
+      sha256: "674dbb26e2db3d9253166faf4758c796af14146b8fbcf5e7102bc8a04cd359b8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "4.0.3"
   riverpod_generator:
     dependency: "direct dev"
     description:
       name: riverpod_generator
-      sha256: "49894543a42cf7a9954fc4e7366b6d3cb2e6ec0fa07775f660afcdd92d097702"
+      sha256: "54d790c3fee1ae281c448801bfdbfaa9fd961a9d3998494e0fcd9ee32184d7eb"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "4.0.4"
   rxdart:
     dependency: "direct main"
     description:
@@ -2149,18 +2125,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "07b277b67e0096c45196cbddddf2d8c6ffc49342e88bf31d460ce04605ddac75"
+      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.2.3"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
+      sha256: "4227d54ceefd0bb8ca4c8fcb96e1719dc53f1ee1b6e2ca9d7a6069da160e4eae"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.8"
+    version: "1.3.12"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -2241,30 +2217,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
-  sqlcipher_flutter_libs:
-    dependency: "direct main"
-    description:
-      name: sqlcipher_flutter_libs
-      sha256: dd1fcc74d5baf3c36ad53e2652b2d06c9f8747494a3ccde0076e88b159dfe622
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.8"
   sqlite3:
     dependency: "direct main"
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.3.3"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.43.1"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -99,7 +99,7 @@ dependencies:
 
   # State management
   flutter_riverpod: ^3.0.0
-  riverpod_annotation: ^3.0.0
+  riverpod_annotation: ^4.0.3
   flutter_bloc: ^9.0.0
   bloc_concurrency: ^0.3.0
   freezed_annotation: ^3.0.0
@@ -290,17 +290,13 @@ dependencies:
   package_info_plus: ^9.0.0
   uuid: ^4.5.1
   app_links: ^6.4.1
-  drift: ^2.29.0
-  # SQLCipher at-rest encryption for the local DB (#570, finding C2). Replaces
-  # sqlite3_flutter_libs (the two cannot coexist — both ship a native sqlite3
-  # and collide on iOS/macOS). 0.6.x is the SQLCipher build for the sqlite3 2.x
-  # family; 0.7.0+ is an EOL no-op. sqlite3 is a direct dep so the Android
-  # native-library override (package:sqlite3/open.dart) is referenceable.
-  # drift_flutter was removed: it is unused (db_client opens NativeDatabase
-  # directly) and it transitively pulled sqlite3_flutter_libs back in,
-  # reintroducing the collision.
-  sqlcipher_flutter_libs: ^0.6.8
-  sqlite3: ^2.7.6
+  drift: ^2.34.0
+  # At-rest encryption for the local DB (#570, finding C2) uses
+  # SQLite3MultipleCiphers through package:sqlite3 build hooks. Do not add
+  # sqlcipher_flutter_libs, sqlite3_flutter_libs, or drift_flutter here: sqlite3
+  # 3.x bundles the selected native SQLite implementation through hooks, and
+  # extra Flutter-specific native SQLite providers can make plain SQLite win.
+  sqlite3: ^3.3.3
   video_player_web_hls: ^1.3.0
   firebase_performance: ^0.11.1+4
   firebase_messaging: ^16.1.1
@@ -318,6 +314,7 @@ dependencies:
   app_device_integrity: ^1.1.0
   pointer_interceptor: ^0.10.1+2
   volume_controller: ^3.4.4
+  meta: ^1.18.0
 
 dependency_overrides:
   device_info_plus: ^10.1.2
@@ -343,9 +340,7 @@ dev_dependencies:
   bloc_test: ^10.0.0
 
   # Code generation
-  # TODO(#3142): Unpin after build_runner >2.11.0 fixes InvalidTypeException
-  # with riverpod_generator. See https://github.com/dart-lang/build/issues
-  build_runner: ">=2.7.1 <2.11.0"
+  build_runner: ^2.15.0
   hive_ce_generator: ^1.6.0
 
   # Integration test utilities
@@ -353,7 +348,7 @@ dev_dependencies:
 
   # CLI tools
   args: ^2.4.2
-  riverpod_generator: ^3.0.0
+  riverpod_generator: ^4.0.4
   # custom_lint: ^0.6.4  # Temporarily disabled due to rxdart version conflict
   # riverpod_lint: ^2.3.10  # Depends on custom_lint
   freezed: ^3.0.0
@@ -363,7 +358,7 @@ dev_dependencies:
   golden_toolkit: ^0.15.0
   alchemist: ^0.12.1
   async: ^2.13.0
-  drift_dev: ^2.29.0
+  drift_dev: ^2.34.0
   melos: ^7.3.0
 
 # For information on the generic Dart part of this file, see the
@@ -461,6 +456,11 @@ patrol:
     package_name: co.openvine.app
   ios:
     bundle_id: co.openvine.app
+
+hooks:
+  user_defines:
+    sqlite3:
+      source: sqlite3mc
 
 melos:
   useRootAsPackage: true

--- a/mobile/test/database/sqlite3mc_configuration_test.dart
+++ b/mobile/test/database/sqlite3mc_configuration_test.dart
@@ -1,0 +1,96 @@
+// ABOUTME: Guards native SQLite encryption dependency wiring.
+// ABOUTME: Ensures sqlite3mc hooks stay active and plain SQLite providers stay out.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group('SQLite3MultipleCiphers configuration', () {
+    test('root pubspec selects sqlite3mc through package:sqlite3 hooks', () {
+      final pubspec = _readYamlFile('pubspec.yaml');
+      final hooks = pubspec['hooks'] as YamlMap?;
+      final userDefines = hooks?['user_defines'] as YamlMap?;
+      final sqlite3 = userDefines?['sqlite3'] as YamlMap?;
+
+      expect(
+        sqlite3?['source'],
+        equals('sqlite3mc'),
+        reason:
+            'Native builds must use SQLite3MultipleCiphers, not plain SQLite.',
+      );
+    });
+
+    test('plain SQLite native providers are not dependencies', () {
+      for (final path in const [
+        'pubspec.yaml',
+        'packages/db_client/pubspec.yaml',
+        'packages/cache_sync/pubspec.yaml',
+      ]) {
+        final names = _dependencyNames(_readYamlFile(path));
+        expect(
+          names,
+          isNot(contains('sqlcipher_flutter_libs')),
+          reason: '$path must not use the retired sqlite3 2.x SQLCipher path.',
+        );
+        expect(
+          names,
+          isNot(contains('sqlite3_flutter_libs')),
+          reason: '$path must not link a competing plain SQLite provider.',
+        );
+        expect(
+          names,
+          isNot(contains('drift_flutter')),
+          reason:
+              '$path must not pull sqlite3_flutter_libs back in transitively.',
+        );
+      }
+    });
+
+    test('iOS SwiftPM lockfiles do not pin stale CSQLite', () {
+      final xcodeProjectLockfile = [
+        'ios/Runner.xcodeproj/project.xcworkspace/xcshareddata',
+        'swiftpm',
+        'Package.resolved',
+      ].join('/');
+
+      for (final path in [
+        'ios/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved',
+        xcodeProjectLockfile,
+      ]) {
+        final json =
+            jsonDecode(File(path).readAsStringSync()) as Map<String, Object?>;
+        final pins = json['pins'] as List<Object?>? ?? const [];
+        final identities = pins
+            .whereType<Map<String, Object?>>()
+            .map((pin) => pin['identity'])
+            .toSet();
+        expect(
+          identities,
+          isNot(contains('csqlite')),
+          reason: '$path must not retain the old simolus3/CSQLite SwiftPM pin.',
+        );
+      }
+    });
+  });
+}
+
+YamlMap _readYamlFile(String path) =>
+    loadYaml(File(path).readAsStringSync()) as YamlMap;
+
+Set<String> _dependencyNames(YamlMap pubspec) {
+  final names = <String>{};
+  for (final sectionName in const [
+    'dependencies',
+    'dev_dependencies',
+    'dependency_overrides',
+  ]) {
+    final section = pubspec[sectionName];
+    if (section is YamlMap) {
+      names.addAll(section.keys.whereType<String>());
+    }
+  }
+  return names;
+}

--- a/mobile/test/services/database_encryption_bootstrap_test.dart
+++ b/mobile/test/services/database_encryption_bootstrap_test.dart
@@ -64,7 +64,7 @@ void main() {
       );
     }
 
-    test('throws StateError when SQLCipher is not linked', () {
+    test('throws StateError when SQLite3MultipleCiphers is not active', () {
       final bootstrap = buildBootstrap(
         cipherAvailable: false,
         outcome: CipherMigrationOutcome.noDatabase,
@@ -73,7 +73,7 @@ void main() {
 
       expect(
         bootstrap.resolveCipherKey(),
-        throwsA(isA<SqlCipherUnavailableError>()),
+        throwsA(isA<DatabaseCipherUnavailableError>()),
       );
     });
 

--- a/mobile/test/startup/database_bootstrap_failure_app_test.dart
+++ b/mobile/test/startup/database_bootstrap_failure_app_test.dart
@@ -142,7 +142,10 @@ void main() {
         Widget? renderedApp;
         var attempts = 0;
         var repaired = false;
-        final error = SqliteException(26, 'file is not a database');
+        final error = SqliteException(
+          extendedResultCode: 26,
+          message: 'file is not a database',
+        );
 
         final result = await resolveDatabaseBootstrapForAppStart(
           resolveCipherKey: () async {
@@ -207,7 +210,10 @@ void main() {
           resolveCipherKey: () async {
             attempts += 1;
             if (attempts == 1) {
-              throw SqliteException(26, 'file is not a database');
+              throw SqliteException(
+                extendedResultCode: 26,
+                message: 'file is not a database',
+              );
             }
             return 'c' * 64;
           },
@@ -255,12 +261,12 @@ void main() {
       expect(closed, isTrue);
     });
 
-    test('classifies SQLCipher link failures for release diagnostics', () {
+    test('classifies cipher availability failures for release diagnostics', () {
       expect(
         databaseBootstrapDiagnosticCode(
-          SqlCipherUnavailableError(),
+          DatabaseCipherUnavailableError(),
         ),
-        equals('db-sqlcipher-unavailable'),
+        equals('db-cipher-unavailable'),
       );
     });
   });
@@ -269,22 +275,28 @@ void main() {
     test('allowlists sqlite not-a-database and corruption errors', () {
       expect(
         shouldRepairLocalDatabaseCacheAfterBootstrapError(
-          SqliteException(26, 'file is not a database'),
+          SqliteException(
+            extendedResultCode: 26,
+            message: 'file is not a database',
+          ),
         ),
         isTrue,
       );
       expect(
         shouldRepairLocalDatabaseCacheAfterBootstrapError(
-          SqliteException(11, 'database disk image is malformed'),
+          SqliteException(
+            extendedResultCode: 11,
+            message: 'database disk image is malformed',
+          ),
         ),
         isTrue,
       );
     });
 
-    test('excludes SQLCipher linkage and secure-storage failures', () {
+    test('excludes cipher linkage and secure-storage failures', () {
       expect(
         shouldRepairLocalDatabaseCacheAfterBootstrapError(
-          SqlCipherUnavailableError(),
+          DatabaseCipherUnavailableError(),
         ),
         isFalse,
       );


### PR DESCRIPTION
Refs #570

Closes #5332

## Summary
- Migrates native at-rest `divine_db.db` encryption from the legacy `sqlcipher_flutter_libs` path to `package:sqlite3` 3.x SQLite3MultipleCiphers build hooks.
- Preserves the existing fail-closed raw-key design, existing SQLCipher DB compatibility (`cipher='sqlcipher'` + `legacy=4`), key-loss backup/recreate flow, and unkeyed `cache_sync.db` behavior.
- Replaces the old `sqlcipher_export` plaintext migration with a SQLite3MC-compatible `VACUUM INTO` + side-file `PRAGMA rekey` + verify-before-swap flow.

## Notes for reviewers
- This bumps `drift` / `sqlite3` / codegen tooling and refreshes Riverpod generated files to match the analyzer/generator stack required by `drift_dev` 2.34.
- `flutter_secure_storage` v9 -> v10/DataStore and explicit iOS keychain accessibility remain intentionally out of scope.
- Real-device QA was completed by Rabble before marking ready for review.

## Verification
- [x] `dart run build_runner clean && dart run build_runner build --force-jit`
- [x] `flutter analyze lib test integration_test`
- [x] `flutter test packages/db_client/test/src/database/connection/connection_native_test.dart test/database/sqlite3mc_configuration_test.dart test/providers/database_provider_test.dart test/services/database_encryption_bootstrap_test.dart`
- [x] `flutter test test/widgets/watermark_download_progress_sheet_test.dart test/widgets/save_original_progress_sheet_test.dart test/widgets/video_feed_item/actions/more_action_button_test.dart test/screens/feed/pooled_video_feed_item_repo_swap_test.dart`
- [x] `(cd packages/db_client && flutter test)`
- [x] `(cd packages/cache_sync && flutter test)`
- [x] `flutter build ios --debug --no-codesign`
- [x] `flutter build apk --debug`
- [x] pre-push hook: merge-conflict check, analyzer, generated files, changed-file tests

## Device QA
Completed by Rabble on 2026-06-19.

- [x] Real iOS device: existing SQLCipher-encrypted `divine_db.db` opens through the MC compatibility path with no data loss.
- [x] Real Android device: existing SQLCipher-encrypted `divine_db.db` opens through the MC compatibility path with no data loss.
- [x] Fresh iOS install creates an encrypted DB and plain `sqlite3` cannot read the file.
- [x] Fresh Android install creates an encrypted DB and plain `sqlite3` cannot read the file.
- [x] Legacy populated plaintext DB migrates once, preserves row counts and `user_version`, then removes pre-cipher plaintext backups after a keyed open.
- [x] Force-kill during migration resumes without data loss.
- [x] Clear secure storage / simulate key loss: app backs up the unreadable DB, creates a new encrypted DB, and does not brick.
- [x] Key material is absent from logs, Crashlytics, analytics, and thrown error strings.
