### PR TITLE
fix(collabs): harden collaboration lifecycle edges

### DIFF
--- a/mobile/lib/blocs/dm/conversation/collaborator_invite_actions_cubit.dart
+++ b/mobile/lib/blocs/dm/conversation/collaborator_invite_actions_cubit.dart
@@ -73,12 +73,12 @@ class CollaboratorInviteActionsCubit
 
   Future<void> acceptInvite(CollaboratorInvite invite) async {
     assert(
-      _currentUserPubkey != invite.creatorPubkey,
+      !_isCurrentUserInviteCreator(invite),
       'CollaboratorInviteCard should not surface accept for sender-side '
       'invites (#3559)',
     );
     if (_currentUserPubkey.isEmpty) return;
-    if (_currentUserPubkey == invite.creatorPubkey) return;
+    if (_isCurrentUserInviteCreator(invite)) return;
 
     await _setInviteState(invite, CollaboratorInviteState.accepting);
 
@@ -100,12 +100,12 @@ class CollaboratorInviteActionsCubit
 
   Future<void> ignoreInvite(CollaboratorInvite invite) async {
     assert(
-      _currentUserPubkey != invite.creatorPubkey,
+      !_isCurrentUserInviteCreator(invite),
       'CollaboratorInviteCard should not surface ignore for sender-side '
       'invites (#3559)',
     );
     if (_currentUserPubkey.isEmpty) return;
-    if (_currentUserPubkey == invite.creatorPubkey) return;
+    if (_isCurrentUserInviteCreator(invite)) return;
     await _setInviteState(invite, CollaboratorInviteState.ignored);
     _confirmationRepository?.markLocal(
       videoAddress: invite.videoAddress,
@@ -134,4 +134,7 @@ class CollaboratorInviteActionsCubit
       ),
     );
   }
+
+  bool _isCurrentUserInviteCreator(CollaboratorInvite invite) =>
+      _currentUserPubkey.toLowerCase() == invite.creatorPubkey.toLowerCase();
 }

--- a/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
+++ b/mobile/lib/screens/inbox/message_requests/request_preview_view.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/dm/message_requests/message_request_actions_cubit
 import 'package:openvine/blocs/dm/message_requests/request_preview_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/collaborator_invite.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/conversation/widgets/widgets.dart';
@@ -43,6 +44,8 @@ class RequestPreviewView extends ConsumerWidget {
     final otherPubkey = participantPubkeys.isNotEmpty
         ? participantPubkeys.first
         : '';
+    final currentPubkey =
+        ref.watch(authServiceProvider).currentPublicKeyHex ?? '';
 
     final profileAsync = ref.watch(userProfileReactiveProvider(otherPubkey));
 
@@ -72,6 +75,7 @@ class RequestPreviewView extends ConsumerWidget {
                   displayName: displayName,
                   profile: profile,
                   otherPubkey: otherPubkey,
+                  currentPubkey: currentPubkey,
                   messageCount: messageCount,
                   messages: messages,
                 ),
@@ -90,6 +94,7 @@ class _ProfileContent extends StatelessWidget {
     required this.displayName,
     required this.profile,
     required this.otherPubkey,
+    required this.currentPubkey,
     required this.messageCount,
     required this.messages,
   });
@@ -97,6 +102,7 @@ class _ProfileContent extends StatelessWidget {
   final String displayName;
   final UserProfile? profile;
   final String otherPubkey;
+  final String currentPubkey;
   final int messageCount;
   final List<DmMessage> messages;
 
@@ -164,6 +170,7 @@ class _ProfileContent extends StatelessWidget {
               _InvitePreview(
                 messages: messages,
                 senderDisplayName: displayName,
+                currentPubkey: currentPubkey,
               ),
             ],
           ),
@@ -177,24 +184,31 @@ class _InvitePreview extends StatelessWidget {
   const _InvitePreview({
     required this.messages,
     required this.senderDisplayName,
+    required this.currentPubkey,
   });
 
   final List<DmMessage> messages;
   final String senderDisplayName;
+  final String currentPubkey;
 
   @override
   Widget build(BuildContext context) {
-    final inviteMessages = messages
-        .map(CollaboratorInviteParser.parse)
-        .whereType<CollaboratorInvite>()
-        .toList();
-    if (inviteMessages.isEmpty) return const SizedBox.shrink();
+    ({DmMessage message, CollaboratorInvite invite})? inviteMessage;
+    for (final message in messages) {
+      final invite = CollaboratorInviteParser.parse(message);
+      if (invite == null) continue;
+      inviteMessage = (message: message, invite: invite);
+      break;
+    }
+    if (inviteMessage == null) return const SizedBox.shrink();
 
     return Padding(
       padding: const EdgeInsets.only(top: 24),
       child: CollaboratorInviteCard(
-        invite: inviteMessages.first,
-        isSent: false,
+        invite: inviteMessage.invite,
+        isSent:
+            currentPubkey.isNotEmpty &&
+            inviteMessage.message.senderPubkey == currentPubkey,
         senderDisplayName: senderDisplayName,
       ),
     );

--- a/mobile/lib/services/collaborator_response_service.dart
+++ b/mobile/lib/services/collaborator_response_service.dart
@@ -51,6 +51,11 @@ class CollaboratorResponseService {
           'Could not determine collaborator pubkey',
         );
       }
+      if (currentPubkey == invite.creatorPubkey) {
+        return const CollaboratorResponseResult.failure(
+          'Creators cannot accept their own collaborator invites',
+        );
+      }
 
       final event = await _authService.createAndSignEvent(
         kind: CollaborationEventKinds.collaboratorResponse,

--- a/mobile/lib/services/collaborator_response_service.dart
+++ b/mobile/lib/services/collaborator_response_service.dart
@@ -51,7 +51,7 @@ class CollaboratorResponseService {
           'Could not determine collaborator pubkey',
         );
       }
-      if (currentPubkey == invite.creatorPubkey) {
+      if (currentPubkey.toLowerCase() == invite.creatorPubkey.toLowerCase()) {
         return const CollaboratorResponseResult.failure(
           'Creators cannot accept their own collaborator invites',
         );

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -161,12 +161,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     }
   }
 
-  /// Loads profiles of followed users for local search.
-  ///
-  /// For [UserPickerFilterMode.mutualFollowsOnly], fetches the current user's
-  /// followers from the relay in parallel with profile loading, then filters
-  /// the list to actual mutual follows. This way the mutual-follow check
-  /// happens once when the sheet opens rather than per-profile after selection.
+  /// Loads followed profiles for local search.
   Future<void> _loadFollowProfiles() async {
     final followRepo = ref.read(followRepositoryProvider);
     final profileRepo = ref.read(profileRepositoryProvider);
@@ -176,9 +171,8 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     }
 
     final followingPubkeys = followRepo.followingPubkeys;
+    final blocklistRepository = ref.read(contentBlocklistRepositoryProvider);
 
-    // Start both fetches in parallel: profile cache (fast, SQLite) and
-    // my followers from relay (needed for mutual-follow filtering).
     final profilesFuture = Future.wait(
       followingPubkeys.map((pk) => profileRepo.getCachedProfile(pubkey: pk)),
     );
@@ -198,6 +192,12 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
       ).wait;
 
       var profiles = rawProfiles.whereType<UserProfile>().toList();
+      profiles = profiles
+          .where(
+            (profile) =>
+                !blocklistRepository.shouldFilterFromFeeds(profile.pubkey),
+          )
+          .toList();
 
       // When mutual-follow fetch fails, fall back to local follows so the
       // picker remains usable instead of hanging in loading.

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -162,6 +162,10 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
   }
 
   /// Loads followed profiles for local search.
+  ///
+  /// For [UserPickerFilterMode.mutualFollowsOnly], fetches the current user's
+  /// followers in parallel with cached profiles so mutual-follow filtering is
+  /// done once when the sheet opens.
   Future<void> _loadFollowProfiles() async {
     final followRepo = ref.read(followRepositoryProvider);
     final profileRepo = ref.read(profileRepositoryProvider);

--- a/mobile/lib/widgets/user_picker_sheet.dart
+++ b/mobile/lib/widgets/user_picker_sheet.dart
@@ -161,11 +161,7 @@ class _UserPickerSheetState extends ConsumerState<UserPickerSheet> {
     }
   }
 
-  /// Loads followed profiles for local search.
-  ///
-  /// For [UserPickerFilterMode.mutualFollowsOnly], fetches the current user's
-  /// followers in parallel with cached profiles so mutual-follow filtering is
-  /// done once when the sheet opens.
+  /// Loads followed profiles and fetches followers in parallel for mutual mode.
   Future<void> _loadFollowProfiles() async {
     final followRepo = ref.read(followRepositoryProvider);
     final profileRepo = ref.read(profileRepositoryProvider);

--- a/mobile/packages/collaborator_repository/lib/src/collaborator_visibility.dart
+++ b/mobile/packages/collaborator_repository/lib/src/collaborator_visibility.dart
@@ -49,12 +49,20 @@ class CollaboratorVisibility extends Equatable {
   /// True when the current user authored the video. Always false in
   /// fallback mode.
   bool get isInviterView =>
-      _hasStatusPipeline && currentUserPubkey == creatorPubkey;
+      _hasStatusPipeline && _samePubkey(currentUserPubkey, creatorPubkey);
 
   /// Status for [pubkey]. Returns [CollaboratorStatus.pending] when the
   /// status pipeline is unavailable or no entry exists.
-  CollaboratorStatus statusFor(String pubkey) =>
-      statusByPubkey[pubkey] ?? CollaboratorStatus.pending;
+  CollaboratorStatus statusFor(String pubkey) {
+    final directStatus = statusByPubkey[pubkey];
+    if (directStatus != null) return directStatus;
+
+    final normalizedPubkey = pubkey.toLowerCase();
+    for (final entry in statusByPubkey.entries) {
+      if (entry.key.toLowerCase() == normalizedPubkey) return entry.value;
+    }
+    return CollaboratorStatus.pending;
+  }
 
   /// Pubkeys to render. The current user's pubkey is filtered out when
   /// they have locally ignored the invite. In fallback mode this is the
@@ -82,8 +90,11 @@ class CollaboratorVisibility extends Equatable {
   }
 
   bool _isHiddenByCurrentUserIgnore(String pubkey) =>
-      pubkey == currentUserPubkey &&
+      _samePubkey(pubkey, currentUserPubkey) &&
       statusFor(pubkey) == CollaboratorStatus.ignored;
+
+  static bool _samePubkey(String a, String b) =>
+      a.toLowerCase() == b.toLowerCase();
 
   @override
   List<Object?> get props => [

--- a/mobile/packages/collaborator_repository/test/src/collaborator_visibility_test.dart
+++ b/mobile/packages/collaborator_repository/test/src/collaborator_visibility_test.dart
@@ -6,8 +6,12 @@ import 'package:test/test.dart';
 
 const _creator =
     'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _creatorUpper =
+    'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const _collab1 =
     'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _collab1Upper =
+    'BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
 const _collab2 =
     'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
 const _viewer =
@@ -76,6 +80,18 @@ void main() {
         );
         expect(vis.isPendingForInviter(_collab1), isTrue);
         expect(vis.isPendingForInviter(_collab2), isFalse);
+      });
+
+      test('creator and status comparisons are case-insensitive', () {
+        const vis = CollaboratorVisibility(
+          taggedPubkeys: [_collab1],
+          statusByPubkey: {_collab1Upper: CollaboratorStatus.pending},
+          currentUserPubkey: _creatorUpper,
+          creatorPubkey: _creator,
+        );
+        expect(vis.isInviterView, isTrue);
+        expect(vis.isPendingForInviter(_collab1), isTrue);
+        expect(vis.pendingCount, equals(1));
       });
 
       test('missing entries default to pending', () {
@@ -149,6 +165,19 @@ void main() {
         );
         expect(vis.visiblePubkeys, equals([_collab2]));
       });
+
+      test(
+        'current user ignore is hidden when visibility receives normalized tag',
+        () {
+          const vis = CollaboratorVisibility(
+            taggedPubkeys: [_collab1],
+            statusByPubkey: {_collab1Upper: CollaboratorStatus.ignored},
+            currentUserPubkey: _collab1Upper,
+            creatorPubkey: _creator,
+          );
+          expect(vis.visiblePubkeys, isEmpty);
+        },
+      );
 
       test('current user not filtered out when their status is confirmed', () {
         const vis = CollaboratorVisibility(

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -551,11 +551,14 @@ class VideoEvent {
         case 'p':
           // Divine collaborator p-tag convention on NIP-71 video events:
           // ["p", "<pubkey>", "<relay>", "collaborator"]
-          if (tagValue.isNotEmpty && tagValue != event.pubkey) {
+          final normalizedPubkey = tagValue.toLowerCase();
+          final normalizedAuthorPubkey = event.pubkey.toLowerCase();
+          if (normalizedPubkey.isNotEmpty &&
+              normalizedPubkey != normalizedAuthorPubkey) {
             final role = tag.length >= 4 ? tag[3].toLowerCase() : null;
             if (role == 'collaborator' &&
-                !collaboratorPubkeys.contains(tagValue)) {
-              collaboratorPubkeys.add(tagValue);
+                !collaboratorPubkeys.contains(normalizedPubkey)) {
+              collaboratorPubkeys.add(normalizedPubkey);
             }
           }
         case 'a':

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -334,14 +334,8 @@ void main() {
 
     test('should ignore invalid thumbnail URLs from imeta tags', () {
       final invalidImetaTags = [
-        [
-          'imeta',
-          'thumb https:///missing-host.jpg',
-        ],
-        [
-          'imeta',
-          'image https:///missing-host.jpg',
-        ],
+        ['imeta', 'thumb https:///missing-host.jpg'],
+        ['imeta', 'image https:///missing-host.jpg'],
       ];
 
       for (final imetaTag in invalidImetaTags) {
@@ -431,10 +425,7 @@ void main() {
 
       expect(videoEvent.collaboratorPubkeys, hasLength(1));
       expect(videoEvent.collaboratorPubkeys, contains(collabPubkey1));
-      expect(
-        videoEvent.collaboratorPubkeys,
-        isNot(contains(authorPubkey)),
-      );
+      expect(videoEvent.collaboratorPubkeys, isNot(contains(authorPubkey)));
     });
 
     test('should deduplicate collaborator pubkeys', () {
@@ -468,12 +459,7 @@ void main() {
         34236,
         [
           ['url', 'https://example.com/video.mp4'],
-          [
-            'p',
-            collabPubkey1,
-            'wss://relay.divine.video',
-            'collaborator',
-          ],
+          ['p', collabPubkey1, 'wss://relay.divine.video', 'collaborator'],
           ['p', strayMentionPubkey, 'wss://relay.divine.video', 'mention'],
           ['p', collabPubkey2, 'wss://relay.divine.video'],
         ],
@@ -503,11 +489,36 @@ void main() {
 
       expect(
         videoEvent.collaboratorPubkeys,
-        equals([
-          collabPubkey1,
-          collabPubkey2,
-        ]),
+        equals([collabPubkey1, collabPubkey2]),
       );
+    });
+
+    test('should normalize uppercase collaborator pubkeys', () {
+      final nostrEvent = Event(
+        authorPubkey,
+        34236,
+        [
+          ['url', 'https://example.com/video.mp4'],
+          [
+            'p',
+            collabPubkey1.toUpperCase(),
+            'wss://relay.divine.video',
+            'collaborator',
+          ],
+          [
+            'p',
+            authorPubkey.toUpperCase(),
+            'wss://relay.divine.video',
+            'collaborator',
+          ],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      );
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.collaboratorPubkeys, equals([collabPubkey1]));
     });
 
     test('should return empty collaborators when no p-tags', () {
@@ -579,10 +590,7 @@ void main() {
         videoEvent.inspiredByVideo!.relayUrl,
         equals('wss://relay.divine.video'),
       );
-      expect(
-        videoEvent.inspiredByVideo!.creatorPubkey,
-        equals(creatorPubkey),
-      );
+      expect(videoEvent.inspiredByVideo!.creatorPubkey, equals(creatorPubkey));
       expect(videoEvent.inspiredByVideo!.dTag, equals('test-d-tag'));
       expect(videoEvent.hasInspiredBy, isTrue);
     });
@@ -617,10 +625,7 @@ void main() {
 
       final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
 
-      expect(
-        videoEvent.inspiredByNpub,
-        equals('npub1abc123def456ghi789'),
-      );
+      expect(videoEvent.inspiredByNpub, equals('npub1abc123def456ghi789'));
       expect(videoEvent.hasInspiredBy, isTrue);
     });
 
@@ -646,11 +651,7 @@ void main() {
         34236,
         [
           ['url', 'https://example.com/video.mp4'],
-          [
-            'a',
-            '34236:$creatorPubkey:test-d-tag',
-            'wss://relay.divine.video',
-          ],
+          ['a', '34236:$creatorPubkey:test-d-tag', 'wss://relay.divine.video'],
         ],
         'Inspired by nostr:npub1xyz789abc',
         createdAt: 1757385263,
@@ -684,17 +685,13 @@ void main() {
 
   group(InspiredByInfo, () {
     test('should parse creatorPubkey from addressableId', () {
-      const info = InspiredByInfo(
-        addressableId: '34236:abc123:my-video',
-      );
+      const info = InspiredByInfo(addressableId: '34236:abc123:my-video');
 
       expect(info.creatorPubkey, equals('abc123'));
     });
 
     test('should parse dTag from addressableId', () {
-      const info = InspiredByInfo(
-        addressableId: '34236:abc123:my-video',
-      );
+      const info = InspiredByInfo(addressableId: '34236:abc123:my-video');
 
       expect(info.dTag, equals('my-video'));
     });
@@ -738,9 +735,7 @@ void main() {
         addressableId: '34236:abc:vid',
         relayUrl: 'wss://relay2.com', // Different relay, same ID
       );
-      const info3 = InspiredByInfo(
-        addressableId: '34236:different:vid',
-      );
+      const info3 = InspiredByInfo(addressableId: '34236:different:vid');
 
       expect(info1, equals(info2));
       expect(info1, isNot(equals(info3)));

--- a/mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart
+++ b/mobile/test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart
@@ -274,5 +274,41 @@ void main() {
         );
       },
     );
+
+    test(
+      'acceptInvite no-ops when current user matches uppercase invite creator',
+      () async {
+        final uppercaseInvite = CollaboratorInvite(
+          messageId: invite.messageId,
+          videoAddress: '34236:${creatorPubkey.toUpperCase()}:skate-loop',
+          videoKind: invite.videoKind,
+          creatorPubkey: creatorPubkey.toUpperCase(),
+          videoDTag: invite.videoDTag,
+          role: invite.role,
+          title: invite.title,
+        );
+        final selfCreatorCubit = CollaboratorInviteActionsCubit(
+          stateStore: store,
+          responseService: responseService,
+          currentUserPubkey: creatorPubkey,
+        );
+        addTearDown(selfCreatorCubit.close);
+
+        await expectLater(
+          selfCreatorCubit.acceptInvite(uppercaseInvite),
+          throwsA(isA<AssertionError>()),
+        );
+
+        verifyNever(() => responseService.acceptInvite(any()));
+        verifyNever(
+          () => store.setState(
+            videoAddress: any(named: 'videoAddress'),
+            creatorPubkey: any(named: 'creatorPubkey'),
+            collaboratorPubkey: any(named: 'collaboratorPubkey'),
+            state: any(named: 'state'),
+          ),
+        );
+      },
+    );
   });
 }

--- a/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
+++ b/mobile/test/screens/inbox/message_requests/request_preview_view_test.dart
@@ -106,9 +106,9 @@ void main() {
       );
 
       when(() => mockPreviewCubit.conversationId).thenReturn(conversationId);
-      when(() => mockInviteActionsCubit.state).thenReturn(
-        const CollaboratorInviteActionsState(),
-      );
+      when(
+        () => mockInviteActionsCubit.state,
+      ).thenReturn(const CollaboratorInviteActionsState());
       when(
         () => mockInviteActionsCubit.acceptInvite(any()),
       ).thenAnswer((_) async {});
@@ -276,12 +276,50 @@ void main() {
         await tester.tap(find.text(l10n.inboxCollabInviteNotMineButton));
         await tester.pump();
 
-        verify(
-          () => mockInviteActionsCubit.ignoreInvite(any()),
-        ).called(1);
-        verifyNever(
-          () => mockActionsCubit.declineRequest(any()),
+        verify(() => mockInviteActionsCubit.ignoreInvite(any())).called(1);
+        verifyNever(() => mockActionsCubit.declineRequest(any()));
+      });
+
+      testWidgets('renders sent collaborator invite preview without actions', (
+        tester,
+      ) async {
+        const inviteMessage = DmMessage(
+          id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+          conversationId: conversationId,
+          senderPubkey: currentPubkey,
+          content: 'You were invited to collaborate.',
+          createdAt: 1700000000,
+          giftWrapId:
+              'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+          tags: [
+            ['divine', 'collab-invite'],
+            [
+              'a',
+              '34236:aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd:skate-loop',
+              'wss://relay.divine.video',
+            ],
+            ['p', currentPubkey],
+            ['role', 'Collaborator'],
+            ['title', 'Skate loop'],
+          ],
         );
+
+        await tester.pumpWidget(
+          buildSubject(
+            previewState: const RequestPreviewState(
+              status: RequestPreviewStatus.loaded,
+              messageCount: 1,
+              participantPubkeys: [otherPubkey],
+              messages: [inviteMessage],
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.inboxCollabInviteCardTitle), findsOneWidget);
+        expect(find.text(l10n.inboxCollabInviteSentStatus), findsOneWidget);
+        expect(find.text(l10n.inboxCollabInviteCoPostButton), findsNothing);
+        expect(find.text(l10n.inboxCollabInviteNotMineButton), findsNothing);
       });
     });
 

--- a/mobile/test/services/collaborator_response_service_test.dart
+++ b/mobile/test/services/collaborator_response_service_test.dart
@@ -69,9 +69,9 @@ void main() {
       );
       return signedEvent;
     });
-    when(() => nostrClient.publishEvent(any())).thenAnswer(
-      (_) async => PublishSuccess(event: signedEvent),
-    );
+    when(
+      () => nostrClient.publishEvent(any()),
+    ).thenAnswer((_) async => PublishSuccess(event: signedEvent));
 
     final result = await service.acceptInvite(invite);
 
@@ -160,6 +160,23 @@ void main() {
 
     expect(result.success, isFalse);
     expect(result.error, contains('sign'));
+    verifyNever(() => nostrClient.publishEvent(any()));
+  });
+
+  test('rejects self-acceptance before signing', () async {
+    when(() => authService.currentPublicKeyHex).thenReturn(creatorPubkey);
+
+    final result = await service.acceptInvite(invite);
+
+    expect(result.success, isFalse);
+    expect(result.error, contains('Creators cannot accept'));
+    verifyNever(
+      () => authService.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    );
     verifyNever(() => nostrClient.publishEvent(any()));
   });
 }

--- a/mobile/test/services/collaborator_response_service_test.dart
+++ b/mobile/test/services/collaborator_response_service_test.dart
@@ -179,4 +179,31 @@ void main() {
     );
     verifyNever(() => nostrClient.publishEvent(any()));
   });
+
+  test('rejects self-acceptance case-insensitively before signing', () async {
+    when(() => authService.currentPublicKeyHex).thenReturn(creatorPubkey);
+
+    final uppercaseInvite = CollaboratorInvite(
+      messageId: invite.messageId,
+      videoAddress: '34236:${creatorPubkey.toUpperCase()}:video-d-tag',
+      videoKind: invite.videoKind,
+      creatorPubkey: creatorPubkey.toUpperCase(),
+      videoDTag: invite.videoDTag,
+      role: invite.role,
+      relayHint: invite.relayHint,
+    );
+
+    final result = await service.acceptInvite(uppercaseInvite);
+
+    expect(result.success, isFalse);
+    expect(result.error, contains('Creators cannot accept'));
+    verifyNever(
+      () => authService.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    );
+    verifyNever(() => nostrClient.publishEvent(any()));
+  });
 }

--- a/mobile/test/widgets/user_picker_sheet_test.dart
+++ b/mobile/test/widgets/user_picker_sheet_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -21,6 +22,22 @@ class _MockProfileRepository extends Mock implements ProfileRepository {}
 
 /// Mock for FollowRepository
 class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+_MockContentBlocklistRepository _createMockContentBlocklistRepository({
+  Set<String> blockedPubkeys = const {},
+}) {
+  final mock = _MockContentBlocklistRepository();
+  when(
+    () => mock.shouldFilterFromFeeds(any()),
+  ).thenReturn(false);
+  for (final pubkey in blockedPubkeys) {
+    when(() => mock.shouldFilterFromFeeds(pubkey)).thenReturn(true);
+  }
+  return mock;
+}
 
 /// Create a mock ProfileRepository
 _MockProfileRepository _createMockProfileRepository({
@@ -216,6 +233,9 @@ void main() {
             overrides: [
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
             ],
             child: const MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -246,6 +266,9 @@ void main() {
                 _createMockProfileRepository(),
               ),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
             ],
             child: const MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -278,6 +301,9 @@ void main() {
                 _createMockProfileRepository(),
               ),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
             ],
             child: const MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -297,55 +323,57 @@ void main() {
         expect(find.text('Go back'), findsOneWidget);
       });
 
-      testWidgets(
-        'falls back to local follows when getMyFollowers fails',
-        (tester) async {
-          final profile = UserProfile(
-            pubkey: 'pubkey1',
-            name: 'User One',
-            rawData: const {'name': 'User One'},
-            createdAt: DateTime.now(),
-            eventId: 'event1',
-          );
+      testWidgets('falls back to local follows when getMyFollowers fails', (
+        tester,
+      ) async {
+        final profile = UserProfile(
+          pubkey: 'pubkey1',
+          name: 'User One',
+          rawData: const {'name': 'User One'},
+          createdAt: DateTime.now(),
+          eventId: 'event1',
+        );
 
-          final mockFollowRepo = _createMockFollowRepository(
-            followingPubkeys: ['pubkey1'],
-          );
-          when(
-            mockFollowRepo.getMyFollowers,
-          ).thenAnswer((_) async => throw Exception('relay down'));
+        final mockFollowRepo = _createMockFollowRepository(
+          followingPubkeys: ['pubkey1'],
+        );
+        when(
+          mockFollowRepo.getMyFollowers,
+        ).thenAnswer((_) async => throw Exception('relay down'));
 
-          final mockProfileRepo = _createMockProfileRepository();
-          when(
-            () => mockProfileRepo.getCachedProfile(pubkey: 'pubkey1'),
-          ).thenAnswer((_) async => profile);
+        final mockProfileRepo = _createMockProfileRepository();
+        when(
+          () => mockProfileRepo.getCachedProfile(pubkey: 'pubkey1'),
+        ).thenAnswer((_) async => profile);
 
-          await tester.pumpWidget(
-            ProviderScope(
-              overrides: [
-                profileRepositoryProvider.overrideWithValue(mockProfileRepo),
-                followRepositoryProvider.overrideWithValue(mockFollowRepo),
-              ],
-              child: const MaterialApp(
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                home: Scaffold(
-                  body: UserPickerSheet(
-                    title: 'Title',
-                    filterMode: UserPickerFilterMode.mutualFollowsOnly,
-                  ),
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
                 ),
               ),
             ),
-          );
+          ),
+        );
 
-          await tester.pumpAndSettle();
+        await tester.pumpAndSettle();
 
-          expect(find.byType(CircularProgressIndicator), findsNothing);
-          expect(find.text('User One'), findsOneWidget);
-          expect(tester.takeException(), isNull);
-        },
-      );
+        expect(find.byType(CircularProgressIndicator), findsNothing);
+        expect(find.text('User One'), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
 
       testWidgets('displays follow list after loading', (tester) async {
         final followPubkeys = ['pubkey1', 'pubkey2'];
@@ -386,6 +414,9 @@ void main() {
             overrides: [
               profileRepositoryProvider.overrideWithValue(mockProfileRepo),
               followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
+              ),
             ],
             child: const MaterialApp(
               localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -404,6 +435,70 @@ void main() {
 
         // Should not show empty state
         expect(find.text('Your crew is out there'), findsNothing);
+      });
+
+      testWidgets('filters blocked users from the follow list', (tester) async {
+        final allowedProfile = UserProfile(
+          pubkey: 'pubkey1',
+          name: 'Allowed User',
+          rawData: const {'name': 'Allowed User'},
+          createdAt: DateTime.now(),
+          eventId: 'event1',
+        );
+        final blockedProfile = UserProfile(
+          pubkey: 'pubkey2',
+          name: 'Blocked User',
+          rawData: const {'name': 'Blocked User'},
+          createdAt: DateTime.now(),
+          eventId: 'event2',
+        );
+
+        final mockFollowRepo = _createMockFollowRepository(
+          followingPubkeys: [allowedProfile.pubkey, blockedProfile.pubkey],
+        );
+        final mockProfileRepo = _createMockProfileRepository(
+          cachedProfiles: [allowedProfile, blockedProfile],
+        );
+        when(
+          () => mockProfileRepo.getCachedProfile(
+            pubkey: allowedProfile.pubkey,
+          ),
+        ).thenAnswer((_) async => allowedProfile);
+        when(
+          () => mockProfileRepo.getCachedProfile(
+            pubkey: blockedProfile.pubkey,
+          ),
+        ).thenAnswer((_) async => blockedProfile);
+        final mockBlocklistRepo = _createMockContentBlocklistRepository(
+          blockedPubkeys: {blockedProfile.pubkey},
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              profileRepositoryProvider.overrideWithValue(mockProfileRepo),
+              followRepositoryProvider.overrideWithValue(mockFollowRepo),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                mockBlocklistRepo,
+              ),
+            ],
+            child: const MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: UserPickerSheet(
+                  title: 'Title',
+                  filterMode: UserPickerFilterMode.mutualFollowsOnly,
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('Allowed User'), findsOneWidget);
+        expect(find.text('Blocked User'), findsNothing);
       });
 
       testWidgets(
@@ -434,6 +529,9 @@ void main() {
               overrides: [
                 profileRepositoryProvider.overrideWithValue(mockProfileRepo),
                 followRepositoryProvider.overrideWithValue(mockFollowRepo),
+                contentBlocklistRepositoryProvider.overrideWithValue(
+                  _createMockContentBlocklistRepository(),
+                ),
               ],
               child: const MaterialApp(
                 localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -938,6 +1036,9 @@ void main() {
               profileRepositoryProvider.overrideWithValue(null),
               followRepositoryProvider.overrideWithValue(
                 _createMockFollowRepository(),
+              ),
+              contentBlocklistRepositoryProvider.overrideWithValue(
+                _createMockContentBlocklistRepository(),
               ),
             ],
             child: const MaterialApp(

--- a/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
+++ b/mobile/test/widgets/video_feed_item/collaborator_avatar_row_test.dart
@@ -56,15 +56,12 @@ AppLocalizations get _l10n => lookupAppLocalizations(const Locale('en'));
 
 void main() {
   group(CollaboratorAvatarRow, () {
-    testWidgets(
-      'renders SizedBox.shrink when video has no collaborators',
-      (tester) async {
-        await tester.pumpWidget(
-          _wrap(CollaboratorAvatarRow(video: _video())),
-        );
-        expect(find.byIcon(Icons.people), findsNothing);
-      },
-    );
+    testWidgets('renders SizedBox.shrink when video has no collaborators', (
+      tester,
+    ) async {
+      await tester.pumpWidget(_wrap(CollaboratorAvatarRow(video: _video())));
+      expect(find.byIcon(Icons.people), findsNothing);
+    });
   });
 
   group(CollaboratorAvatarRowBody, () {
@@ -106,9 +103,7 @@ void main() {
         );
 
         // Exactly one avatar is wrapped in Opacity (the pending one).
-        final opacityWidgets = tester.widgetList<Opacity>(
-          find.byType(Opacity),
-        );
+        final opacityWidgets = tester.widgetList<Opacity>(find.byType(Opacity));
         expect(opacityWidgets, hasLength(1));
         expect(opacityWidgets.first.opacity, closeTo(0.55, 0.001));
 
@@ -126,103 +121,91 @@ void main() {
       },
     );
 
-    testWidgets(
-      'inviter view: pending count appears in label suffix',
-      (tester) async {
-        await tester.pumpWidget(
-          _wrap(
-            const CollaboratorAvatarRowBody(
-              visibility: CollaboratorVisibility(
-                taggedPubkeys: [_collab1, _collab2],
-                statusByPubkey: {
-                  _collab1: CollaboratorStatus.pending,
-                  _collab2: CollaboratorStatus.pending,
-                },
-                currentUserPubkey: _creatorPubkey,
-                creatorPubkey: _creatorPubkey,
-              ),
-            ),
-            overrides: [
-              fetchUserProfileProvider(
-                _collab1,
-              ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
-              fetchUserProfileProvider(
-                _collab2,
-              ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
-            ],
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        final base = _l10n.videoCollaboratorWithMore('Alice', 1);
-        final expectedLabel = _l10n.videoCollaboratorWithPendingSuffix(
-          base,
-          2,
-        );
-        expect(find.text(expectedLabel), findsOneWidget);
-      },
-    );
-
-    testWidgets(
-      'recipient view (ignored): own avatar filtered out',
-      (tester) async {
-        await tester.pumpWidget(
-          _wrap(
-            const CollaboratorAvatarRowBody(
-              visibility: CollaboratorVisibility(
-                taggedPubkeys: [_collab1, _collab2],
-                statusByPubkey: {_collab1: CollaboratorStatus.ignored},
-                currentUserPubkey: _collab1,
-                creatorPubkey: _creatorPubkey,
-              ),
-            ),
-            overrides: [
-              fetchUserProfileProvider(
-                _collab1,
-              ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
-              fetchUserProfileProvider(
-                _collab2,
-              ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
-            ],
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        // Row still renders for _collab2.
-        expect(find.byIcon(Icons.people), findsOneWidget);
-        // Label is the single-collaborator variant naming Bob — not Alice.
-        expect(
-          find.text(_l10n.videoCollaboratorWithOne('Bob')),
-          findsOneWidget,
-        );
-        expect(
-          find.text(_l10n.videoCollaboratorWithOne('Alice')),
-          findsNothing,
-        );
-        // No pending decoration on recipient view.
-        expect(find.byType(Opacity), findsNothing);
-      },
-    );
-
-    testWidgets(
-      'recipient view (ignored, sole collaborator): row shrinks',
-      (tester) async {
-        await tester.pumpWidget(
-          _wrap(
-            const CollaboratorAvatarRowBody(
-              visibility: CollaboratorVisibility(
-                taggedPubkeys: [_collab1],
-                statusByPubkey: {_collab1: CollaboratorStatus.ignored},
-                currentUserPubkey: _collab1,
-                creatorPubkey: _creatorPubkey,
-              ),
+    testWidgets('inviter view: pending count appears in label suffix', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const CollaboratorAvatarRowBody(
+            visibility: CollaboratorVisibility(
+              taggedPubkeys: [_collab1, _collab2],
+              statusByPubkey: {
+                _collab1: CollaboratorStatus.pending,
+                _collab2: CollaboratorStatus.pending,
+              },
+              currentUserPubkey: _creatorPubkey,
+              creatorPubkey: _creatorPubkey,
             ),
           ),
-        );
+          overrides: [
+            fetchUserProfileProvider(
+              _collab1,
+            ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
+            fetchUserProfileProvider(
+              _collab2,
+            ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
 
-        expect(find.byIcon(Icons.people), findsNothing);
-      },
-    );
+      final base = _l10n.videoCollaboratorWithMore('Alice', 1);
+      final expectedLabel = _l10n.videoCollaboratorWithPendingSuffix(base, 2);
+      expect(find.text(expectedLabel), findsOneWidget);
+    });
+
+    testWidgets('recipient view (ignored): own avatar filtered out', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const CollaboratorAvatarRowBody(
+            visibility: CollaboratorVisibility(
+              taggedPubkeys: [_collab1, _collab2],
+              statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+              currentUserPubkey: _collab1,
+              creatorPubkey: _creatorPubkey,
+            ),
+          ),
+          overrides: [
+            fetchUserProfileProvider(
+              _collab1,
+            ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
+            fetchUserProfileProvider(
+              _collab2,
+            ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Row still renders for _collab2.
+      expect(find.byIcon(Icons.people), findsOneWidget);
+      // Label is the single-collaborator variant naming Bob — not Alice.
+      expect(find.text(_l10n.videoCollaboratorWithOne('Bob')), findsOneWidget);
+      expect(find.text(_l10n.videoCollaboratorWithOne('Alice')), findsNothing);
+      // No pending decoration on recipient view.
+      expect(find.byType(Opacity), findsNothing);
+    });
+
+    testWidgets('recipient view (ignored, sole collaborator): row shrinks', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const CollaboratorAvatarRowBody(
+            visibility: CollaboratorVisibility(
+              taggedPubkeys: [_collab1],
+              statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+              currentUserPubkey: _collab1,
+              creatorPubkey: _creatorPubkey,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.people), findsNothing);
+    });
 
     testWidgets(
       'recipient view (confirmed): own avatar visible without decoration',
@@ -334,13 +317,48 @@ void main() {
         findsNothing,
       );
 
-      await tester.tap(
-        find.text(_l10n.videoCollaboratorWithMore('Alice', 2)),
-      );
+      await tester.tap(find.text(_l10n.videoCollaboratorWithMore('Alice', 2)));
       await tester.pumpAndSettle();
 
       expect(find.text(_l10n.metadataCollaboratorsLabel), findsOneWidget);
       expect(find.text('Alice'), findsOneWidget);
+      expect(find.text('Bob'), findsOneWidget);
+      expect(find.text('Casey'), findsOneWidget);
+    });
+
+    testWidgets('expanded picker omits collaborator ignored by current user', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        _wrap(
+          const CollaboratorAvatarRowBody(
+            visibility: CollaboratorVisibility(
+              taggedPubkeys: [_collab1, _collab2, _collab3],
+              statusByPubkey: {_collab1: CollaboratorStatus.ignored},
+              currentUserPubkey: _collab1,
+              creatorPubkey: _creatorPubkey,
+            ),
+          ),
+          overrides: [
+            fetchUserProfileProvider(
+              _collab1,
+            ).overrideWith((ref) async => _makeProfile(_collab1, 'Alice')),
+            fetchUserProfileProvider(
+              _collab2,
+            ).overrideWith((ref) async => _makeProfile(_collab2, 'Bob')),
+            fetchUserProfileProvider(
+              _collab3,
+            ).overrideWith((ref) async => _makeProfile(_collab3, 'Casey')),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(_l10n.videoCollaboratorWithMore('Bob', 1)));
+      await tester.pumpAndSettle();
+
+      expect(find.text(_l10n.metadataCollaboratorsLabel), findsOneWidget);
+      expect(find.text('Alice'), findsNothing);
       expect(find.text('Bob'), findsOneWidget);
       expect(find.text('Casey'), findsOneWidget);
     });


### PR DESCRIPTION
## Summary

Closes #5337
Closes #5164
Refs #4201
Refs #3664

This PR hardens the remaining mobile collaboration lifecycle edge cases found during the audit:

- blocks creator self-acceptance in `CollaboratorResponseService`, so the invariant is enforced below the UI/cubit layer
- filters `UserPickerSheet` mutual-follow results through the content blocklist so blocked-but-followed accounts cannot be selected for collaboration
- renders collaborator invite previews in message requests with the correct sent/received state, preventing sent previews from showing accept/ignore actions
- normalizes collaborator p-tag pubkeys in `VideoEvent.fromNostrEvent`, matching stats parsing behavior and excluding self-tags case-insensitively
- adds expanded collaborator picker coverage so ignored current-user collaborators remain hidden outside the compact row too

## Root Cause

The mobile collaboration rollout had the right high-level protections, but a few lower-level and secondary display paths did not share the same invariants:

- self-acceptance was guarded in `CollaboratorInviteActionsCubit` but not in the signing service itself
- the mutual-follow picker loaded cached followed profiles without applying the shared blocklist filter used by feeds
- request-preview invite rendering discarded the source `DmMessage`, so it could not determine whether the invite was sent by the current user
- model parsing preserved collaborator p-tag casing even though Nostr hex pubkeys should be compared and stored case-insensitively in this path

## Verification

- `mise exec flutter@3.44.0 -- flutter analyze`
- `mise exec flutter@3.44.0 -- flutter test test/services/collaborator_response_service_test.dart test/blocs/dm/conversation/collaborator_invite_actions_cubit_test.dart test/widgets/video_feed_item/collaborator_avatar_row_test.dart test/widgets/user_picker_sheet_test.dart test/screens/inbox/message_requests/request_preview_view_test.dart test/blocs/profile_collab_videos/profile_collab_videos_bloc_test.dart packages/collaborator_repository/test/src/collaborator_confirmation_repository_test.dart packages/collaborator_repository/test/src/collaborator_visibility_test.dart packages/dm_repository/test/src/collaborator_invite_recovery_test.dart packages/models/test/src/video_event_parsing_test.dart`
- pre-push hook: analyzer and changed-file tests passed

## Notes

#3664 remains the backend ingestion audit. This PR prevents the mobile app from creating self-acceptance events through the service path but does not close the backend audit.