### PR TITLE
fix(apps): harden Nostr bridge edge cases

### DIFF
--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -517,10 +517,21 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
         id: responseId,
         result: BridgeResult.error(
           'invalid_request',
-          errorMessage: error.toString(),
+          errorMessage: _safeBridgeErrorMessage(error),
         ),
       );
     }
+  }
+
+  String? _safeBridgeErrorMessage(Object error) {
+    const safeFormatMessages = {
+      'Bridge payload must be a JSON object',
+      'Bridge method is required',
+      'Bridge args must be an object',
+    };
+
+    final message = error is FormatException ? error.message : null;
+    return safeFormatMessages.contains(message) ? message : null;
   }
 
   Future<bool> _showPermissionPrompt(BridgePermissionRequest request) async {

--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -26,6 +26,15 @@ typedef SandboxViewBuilder =
     Widget Function(void Function(Uri uri) onNavigationAttempt);
 typedef SandboxJavaScriptRunner = Future<void> Function(String script);
 
+const _bridgePayloadObjectMessage = 'Bridge payload must be a JSON object';
+const _bridgeMethodRequiredMessage = 'Bridge method is required';
+const _bridgeArgsObjectMessage = 'Bridge args must be an object';
+const Set<String> _safeBridgeFormatMessages = {
+  _bridgePayloadObjectMessage,
+  _bridgeMethodRequiredMessage,
+  _bridgeArgsObjectMessage,
+};
+
 class NostrAppSandboxScreen extends ConsumerStatefulWidget {
   static const routeName = 'nostr-app-sandbox';
   static const path = '/apps/:appId/sandbox';
@@ -474,7 +483,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
     try {
       final payload = jsonDecode(message);
       if (payload is! Map) {
-        throw const FormatException('Bridge payload must be a JSON object');
+        throw const FormatException(_bridgePayloadObjectMessage);
       }
 
       final request = payload.map(
@@ -496,10 +505,10 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
       final args = request['args'];
 
       if (method == null || method.isEmpty) {
-        throw const FormatException('Bridge method is required');
+        throw const FormatException(_bridgeMethodRequiredMessage);
       }
       if (args is! Map) {
-        throw const FormatException('Bridge args must be an object');
+        throw const FormatException(_bridgeArgsObjectMessage);
       }
 
       final origin = _currentPageUri ?? Uri.parse(widget.app.launchUrl);
@@ -524,14 +533,8 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
   }
 
   String? _safeBridgeErrorMessage(Object error) {
-    const safeFormatMessages = {
-      'Bridge payload must be a JSON object',
-      'Bridge method is required',
-      'Bridge args must be an object',
-    };
-
     final message = error is FormatException ? error.message : null;
-    return safeFormatMessages.contains(message) ? message : null;
+    return _safeBridgeFormatMessages.contains(message) ? message : null;
   }
 
   Future<bool> _showPermissionPrompt(BridgePermissionRequest request) async {

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/nostr_app_bridge_service.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/nostr_app_bridge_service.dart
@@ -269,6 +269,7 @@ class NostrAppBridgeService {
           result = await _handleNip44Decrypt(args);
       }
     } on _BridgeInvalidRequestException catch (error) {
+      auditDecision = NostrAppAuditDecision.blocked;
       result = BridgeResult.error(
         'invalid_request',
         errorMessage: error.message,
@@ -305,7 +306,12 @@ class NostrAppBridgeService {
     }
 
     if (relayMap.isEmpty) {
-      final signerRelays = await _signerFactory().getRelays();
+      Map<dynamic, dynamic>? signerRelays;
+      try {
+        signerRelays = await _signerFactory().getRelays();
+      } on Object catch (_) {
+        signerRelays = null;
+      }
       if (signerRelays case final Map<dynamic, dynamic> relays) {
         for (final entry in relays.entries) {
           final key = entry.key;
@@ -379,7 +385,12 @@ class NostrAppBridgeService {
       args['plaintext'],
       fieldName: 'plaintext',
     );
-    final ciphertext = await signer.nip44Encrypt(pubkey, plaintext);
+    final String? ciphertext;
+    try {
+      ciphertext = await signer.nip44Encrypt(pubkey, plaintext);
+    } on Object catch (_) {
+      return const BridgeResult.error('encrypt_failed');
+    }
     if (ciphertext == null || ciphertext.isEmpty) {
       return const BridgeResult.error('encrypt_failed');
     }
@@ -401,7 +412,7 @@ class NostrAppBridgeService {
     final String? plaintext;
     try {
       plaintext = await signer.nip44Decrypt(pubkey, ciphertext);
-    } on Exception {
+    } on Object catch (_) {
       // Signer implementations do not expose structured NIP-44 failure
       // details consistently, so keep decrypt errors stable and non-leaky.
       return const BridgeResult.error('decrypt_failed');
@@ -490,7 +501,11 @@ class NostrAppBridgeService {
                     'event.tags must not contain null elements',
                   );
                 }
-                return item.toString();
+                if (item is String) return item;
+                if (item is num || item is bool) return item.toString();
+                throw const _BridgeInvalidRequestException(
+                  'event.tags must only contain strings, numbers, or booleans',
+                );
               })
               .toList(growable: false);
         })

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/nostr_app_bridge_service.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/nostr_app_bridge_service.dart
@@ -130,6 +130,15 @@ class BridgeSignedEvent {
   final Map<String, dynamic> json;
 }
 
+class _BridgeInvalidRequestException implements Exception {
+  const _BridgeInvalidRequestException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
 /// Handles NIP-07 bridge requests from third-party Nostr web
 /// apps running inside the host application.
 class NostrAppBridgeService {
@@ -246,17 +255,24 @@ class NostrAppBridgeService {
     }
 
     late final BridgeResult result;
-    switch (method) {
-      case 'getPublicKey':
-        result = _handleGetPublicKey();
-      case 'getRelays':
-        result = await _handleGetRelays();
-      case 'signEvent':
-        result = await _handleSignEvent(args);
-      case 'nip44.encrypt':
-        result = await _handleNip44Encrypt(args);
-      case 'nip44.decrypt':
-        result = await _handleNip44Decrypt(args);
+    try {
+      switch (method) {
+        case 'getPublicKey':
+          result = _handleGetPublicKey();
+        case 'getRelays':
+          result = await _handleGetRelays();
+        case 'signEvent':
+          result = await _handleSignEvent(args);
+        case 'nip44.encrypt':
+          result = await _handleNip44Encrypt(args);
+        case 'nip44.decrypt':
+          result = await _handleNip44Decrypt(args);
+      }
+    } on _BridgeInvalidRequestException catch (error) {
+      result = BridgeResult.error(
+        'invalid_request',
+        errorMessage: error.message,
+      );
     }
 
     _recordAudit(
@@ -382,7 +398,14 @@ class NostrAppBridgeService {
       args['ciphertext'],
       fieldName: 'ciphertext',
     );
-    final plaintext = await signer.nip44Decrypt(pubkey, ciphertext);
+    final String? plaintext;
+    try {
+      plaintext = await signer.nip44Decrypt(pubkey, ciphertext);
+    } on Exception {
+      // Signer implementations do not expose structured NIP-44 failure
+      // details consistently, so keep decrypt errors stable and non-leaky.
+      return const BridgeResult.error('decrypt_failed');
+    }
     if (plaintext == null || plaintext.isEmpty) {
       return const BridgeResult.error('decrypt_failed');
     }
@@ -403,7 +426,9 @@ class NostrAppBridgeService {
     required String fieldName,
   }) {
     if (value is! Map) {
-      throw ArgumentError('$fieldName must be an object');
+      throw _BridgeInvalidRequestException(
+        '$fieldName must be an object',
+      );
     }
 
     return value.map(
@@ -417,7 +442,7 @@ class NostrAppBridgeService {
     bool allowEmpty = false,
   }) {
     if (value is! String || (!allowEmpty && value.isEmpty)) {
-      throw ArgumentError(
+      throw _BridgeInvalidRequestException(
         allowEmpty
             ? '$fieldName must be a string'
             : '$fieldName must be a non-empty string',
@@ -432,7 +457,9 @@ class NostrAppBridgeService {
   }) {
     if (value is int) return value;
     if (value is num) return value.toInt();
-    throw ArgumentError('$fieldName must be an integer');
+    throw _BridgeInvalidRequestException(
+      '$fieldName must be an integer',
+    );
   }
 
   static int? _readOptionalInt(dynamic value) {
@@ -444,17 +471,28 @@ class NostrAppBridgeService {
   static List<List<String>> _readTags(dynamic value) {
     if (value == null) return const [];
     if (value is! List) {
-      throw ArgumentError('event.tags must be an array');
+      throw const _BridgeInvalidRequestException(
+        'event.tags must be an array',
+      );
     }
 
     return value
         .map<List<String>>((dynamic tag) {
           if (tag is! List) {
-            throw ArgumentError(
+            throw const _BridgeInvalidRequestException(
               'event.tags must only contain arrays',
             );
           }
-          return tag.map((item) => item.toString()).toList(growable: false);
+          return tag
+              .map((item) {
+                if (item == null) {
+                  throw const _BridgeInvalidRequestException(
+                    'event.tags must not contain null elements',
+                  );
+                }
+                return item.toString();
+              })
+              .toList(growable: false);
         })
         .toList(growable: false);
   }

--- a/mobile/packages/nostr_app_bridge_repository/test/nostr_app_bridge_service_test.dart
+++ b/mobile/packages/nostr_app_bridge_repository/test/nostr_app_bridge_service_test.dart
@@ -169,6 +169,94 @@ void main() {
     );
 
     test(
+      'signs control character content with JSON-compatible event id',
+      () async {
+        const tagPubkey =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+        final result = await service.handleRequest(
+          app: _app(promptRequiredFor: const ['signEvent']),
+          origin: Uri.parse('https://primal.net'),
+          method: 'signEvent',
+          args: {
+            'event': {
+              'kind': 1,
+              'created_at': 1234567890,
+              'content': 'line\nbell\u0007nul\u0000unit\u001f',
+              'tags': [
+                ['p', tagPubkey],
+                ['mixed', '42', 'true'],
+              ],
+            },
+          },
+          promptForPermission: (_) async => true,
+        );
+
+        expect(result.success, isTrue);
+        expect(
+          (result.data! as Map)['id'],
+          'bf207992e6131b67730e9d8eb00bcbc1dbb98c25d3ac9974da4d'
+          '6fda5c3c4ef4',
+        );
+      },
+    );
+
+    test(
+      'rejects null tag elements with a stable invalid request error',
+      () async {
+        final result = await service.handleRequest(
+          app: _app(promptRequiredFor: const ['signEvent']),
+          origin: Uri.parse('https://primal.net'),
+          method: 'signEvent',
+          args: {
+            'event': {
+              'kind': 1,
+              'content': 'hello',
+              'tags': const [
+                ['p', null],
+              ],
+            },
+          },
+          promptForPermission: (_) async => true,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, 'invalid_request');
+        expect(
+          result.errorMessage,
+          'event.tags must not contain null elements',
+        );
+      },
+    );
+
+    test(
+      'keeps primitive tag coercion for compatibility',
+      () async {
+        final result = await service.handleRequest(
+          app: _app(promptRequiredFor: const ['signEvent']),
+          origin: Uri.parse('https://primal.net'),
+          method: 'signEvent',
+          args: {
+            'event': {
+              'kind': 1,
+              'content': 'hello',
+              'tags': const [
+                ['amount', 42, true],
+              ],
+            },
+          },
+          promptForPermission: (_) async => true,
+        );
+
+        expect(result.success, isTrue);
+        expect(authProvider.lastTags, [
+          ['amount', '42', 'true'],
+        ]);
+      },
+    );
+
+    test(
       'routes nip44.encrypt through the signer',
       () async {
         final result = await service.handleRequest(
@@ -191,6 +279,37 @@ void main() {
 
         expect(result.success, isTrue);
         expect(result.data, 'ciphertext-for-top secret');
+      },
+    );
+
+    test(
+      'returns decrypt failed when nip44.decrypt signer throws',
+      () async {
+        signer.nip44DecryptException = Exception(
+          'Unknown encryption version 3',
+        );
+
+        final result = await service.handleRequest(
+          app: _app(
+            allowedMethods: const [
+              'getPublicKey',
+              'signEvent',
+              'nip44.decrypt',
+            ],
+          ),
+          origin: Uri.parse('https://primal.net'),
+          method: 'nip44.decrypt',
+          args: const {
+            'pubkey':
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'ciphertext': 'bad-version-ciphertext',
+          },
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, 'decrypt_failed');
+        expect(result.errorMessage, isNull);
       },
     );
 
@@ -263,6 +382,8 @@ NostrAppDirectoryEntry _app({
 }
 
 class _FakeAuthProvider implements BridgeAuthProvider {
+  List<List<String>>? lastTags;
+
   @override
   String? get currentPublicKeyHex => 'f' * 64;
 
@@ -282,6 +403,7 @@ class _FakeAuthProvider implements BridgeAuthProvider {
     required List<List<String>> tags,
     int? createdAt,
   }) async {
+    lastTags = tags;
     final event = Event(
       'f' * 64,
       kind,
@@ -294,6 +416,8 @@ class _FakeAuthProvider implements BridgeAuthProvider {
 }
 
 class _FakeSigner implements NostrSigner {
+  Exception? nip44DecryptException;
+
   @override
   void close() {}
 
@@ -328,6 +452,10 @@ class _FakeSigner implements NostrSigner {
     String pubkey,
     String ciphertext,
   ) async {
+    final exception = nip44DecryptException;
+    if (exception != null) {
+      throw exception;
+    }
     return 'plaintext-for-$ciphertext';
   }
 

--- a/mobile/packages/nostr_app_bridge_repository/test/nostr_app_bridge_service_test.dart
+++ b/mobile/packages/nostr_app_bridge_repository/test/nostr_app_bridge_service_test.dart
@@ -232,6 +232,39 @@ void main() {
     );
 
     test(
+      'rejects nested tag elements instead of stringifying Dart collections',
+      () async {
+        final result = await service.handleRequest(
+          app: _app(promptRequiredFor: const ['signEvent']),
+          origin: Uri.parse('https://primal.net'),
+          method: 'signEvent',
+          args: {
+            'event': {
+              'kind': 1,
+              'content': 'hello',
+              'tags': const [
+                [
+                  'nested',
+                  ['x'],
+                  {'a': 1},
+                ],
+              ],
+            },
+          },
+          promptForPermission: (_) async => true,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, 'invalid_request');
+        expect(
+          result.errorMessage,
+          'event.tags must only contain strings, numbers, or booleans',
+        );
+        expect(authProvider.lastTags, isNull);
+      },
+    );
+
+    test(
       'keeps primitive tag coercion for compatibility',
       () async {
         final result = await service.handleRequest(
@@ -258,6 +291,58 @@ void main() {
     );
 
     test(
+      'records malformed requests as blocked audit events',
+      () async {
+        final auditService = NostrAppAuditService(
+          workerBaseUri: Uri.parse('https://apps.divine.video'),
+          authTokenProvider:
+              ({
+                required url,
+                required method,
+                required payload,
+              }) async => null,
+          httpClient: MockClient(
+            (_) async => throw UnimplementedError(),
+          ),
+        );
+        service = NostrAppBridgeService(
+          authProvider: authProvider,
+          policy: policy,
+          signerFactory: () => signer,
+          auditService: auditService,
+        );
+
+        final result = await service.handleRequest(
+          app: _app(id: '17'),
+          origin: Uri.parse('https://primal.net'),
+          method: 'signEvent',
+          args: const {
+            'event': {
+              'kind': 1,
+              'content': 'hello',
+              'tags': [
+                [
+                  'nested',
+                  <String>['x'],
+                ],
+              ],
+            },
+          },
+          promptForPermission: (_) async => true,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, 'invalid_request');
+        expect(auditService.queuedEvents, hasLength(1));
+        expect(
+          auditService.queuedEvents.single.decision,
+          NostrAppAuditDecision.blocked,
+        );
+        expect(auditService.queuedEvents.single.errorCode, 'invalid_request');
+      },
+    );
+
+    test(
       'routes nip44.encrypt through the signer',
       () async {
         final result = await service.handleRequest(
@@ -280,6 +365,37 @@ void main() {
 
         expect(result.success, isTrue);
         expect(result.data, 'ciphertext-for-top secret');
+      },
+    );
+
+    test(
+      'returns encrypt failed when nip44.encrypt signer throws',
+      () async {
+        signer.nip44EncryptError = ArgumentError(
+          'Invalid point compression',
+        );
+
+        final result = await service.handleRequest(
+          app: _app(
+            allowedMethods: const [
+              'getPublicKey',
+              'signEvent',
+              'nip44.encrypt',
+            ],
+          ),
+          origin: Uri.parse('https://primal.net'),
+          method: 'nip44.encrypt',
+          args: const {
+            'pubkey':
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'plaintext': 'top secret',
+          },
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, 'encrypt_failed');
+        expect(result.errorMessage, isNull);
       },
     );
 
@@ -311,6 +427,69 @@ void main() {
         expect(result.success, isFalse);
         expect(result.errorCode, 'decrypt_failed');
         expect(result.errorMessage, isNull);
+      },
+    );
+
+    test(
+      'returns decrypt failed when nip44.decrypt signer throws an error',
+      () async {
+        signer.nip44DecryptError = RangeError.range(
+          63,
+          0,
+          15,
+          'end',
+        );
+
+        final result = await service.handleRequest(
+          app: _app(
+            allowedMethods: const [
+              'getPublicKey',
+              'signEvent',
+              'nip44.decrypt',
+            ],
+          ),
+          origin: Uri.parse('https://primal.net'),
+          method: 'nip44.decrypt',
+          args: const {
+            'pubkey':
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'ciphertext': 'bad-version-ciphertext',
+          },
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, 'decrypt_failed');
+        expect(result.errorMessage, isNull);
+      },
+    );
+
+    test(
+      'falls back to the default relay when signer relay lookup throws',
+      () async {
+        authProvider.relays = const [];
+        signer.getRelaysError = StateError('relay lookup failed');
+
+        final result = await service.handleRequest(
+          app: _app(
+            allowedMethods: const [
+              'getPublicKey',
+              'signEvent',
+              'getRelays',
+            ],
+          ),
+          origin: Uri.parse('https://primal.net'),
+          method: 'getRelays',
+          args: const {},
+        );
+
+        expect(result.success, isTrue);
+        expect(result.data, {
+          'wss://relay.divine.video': {
+            'read': true,
+            'write': true,
+          },
+        });
       },
     );
 
@@ -384,18 +563,19 @@ NostrAppDirectoryEntry _app({
 
 class _FakeAuthProvider implements BridgeAuthProvider {
   List<List<String>>? lastTags;
-
-  @override
-  String? get currentPublicKeyHex => 'f' * 64;
-
-  @override
-  List<BridgeRelay> get userRelays => const [
+  List<BridgeRelay> relays = const [
     BridgeRelay(url: 'wss://relay.divine.video'),
     BridgeRelay(
       url: 'wss://relay.primal.net',
       write: false,
     ),
   ];
+
+  @override
+  String? get currentPublicKeyHex => 'f' * 64;
+
+  @override
+  List<BridgeRelay> get userRelays => relays;
 
   @override
   Future<BridgeSignedEvent?> createAndSignEvent({
@@ -418,6 +598,9 @@ class _FakeAuthProvider implements BridgeAuthProvider {
 
 class _FakeSigner implements NostrSigner {
   Exception? nip44DecryptException;
+  Error? getRelaysError;
+  Error? nip44DecryptError;
+  Error? nip44EncryptError;
 
   @override
   void close() {}
@@ -445,6 +628,10 @@ class _FakeSigner implements NostrSigner {
 
   @override
   Future<Map<dynamic, dynamic>?> getRelays() async {
+    final error = getRelaysError;
+    if (error != null) {
+      throw error;
+    }
     return null;
   }
 
@@ -453,6 +640,10 @@ class _FakeSigner implements NostrSigner {
     String pubkey,
     String ciphertext,
   ) async {
+    final error = nip44DecryptError;
+    if (error != null) {
+      throw error;
+    }
     final exception = nip44DecryptException;
     if (exception != null) {
       throw exception;
@@ -465,6 +656,10 @@ class _FakeSigner implements NostrSigner {
     String pubkey,
     String plaintext,
   ) async {
+    final error = nip44EncryptError;
+    if (error != null) {
+      throw error;
+    }
     return 'ciphertext-for-$plaintext';
   }
 

--- a/mobile/packages/nostr_app_bridge_repository/test/nostr_app_bridge_service_test.dart
+++ b/mobile/packages/nostr_app_bridge_repository/test/nostr_app_bridge_service_test.dart
@@ -194,6 +194,7 @@ void main() {
         );
 
         expect(result.success, isTrue);
+        // Pins JSON-compatible event serialization for control characters.
         expect(
           (result.data! as Map)['id'],
           'bf207992e6131b67730e9d8eb00bcbc1dbb98c25d3ac9974da4d'

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -335,6 +335,65 @@ void main() {
       );
     });
 
+    testWidgets('keeps static bridge request errors but hides exception text', (
+      tester,
+    ) async {
+      SharedPreferences.setMockInitialValues({});
+      final sharedPreferences = await SharedPreferences.getInstance();
+      Future<void> Function(String message)? bridgeHandler;
+      final executedScripts = <String>[];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: NostrAppSandboxScreen(
+            app: _fixtureApp(),
+            sandboxBuilder: (_) => const SizedBox.shrink(),
+            bridgeServiceOverride: _ThrowingBridgeService(sharedPreferences),
+            javaScriptRunnerOverride: (script) async {
+              executedScripts.add(script);
+            },
+            onBridgeMessageHandlerReady: (handler) => bridgeHandler = handler,
+            bridgeNonceOverride: 'test-nonce',
+            currentUserPubkeyOverride: 'f' * 64,
+          ),
+        ),
+      );
+
+      await bridgeHandler!(
+        jsonEncode({
+          'id': 'missing-method',
+          'args': <String, dynamic>{},
+          'nonce': 'test-nonce',
+        }),
+      );
+      await bridgeHandler!(
+        jsonEncode({
+          'id': 'service-error',
+          'method': 'getPublicKey',
+          'args': <String, dynamic>{},
+          'nonce': 'test-nonce',
+        }),
+      );
+      await bridgeHandler!('{bad json');
+      await tester.pump();
+
+      expect(executedScripts, hasLength(3));
+      expect(executedScripts[0], contains('missing-method'));
+      expect(executedScripts[0], contains('Bridge method is required'));
+
+      expect(executedScripts[1], contains('service-error'));
+      expect(executedScripts[1], contains('invalid_request'));
+      expect(executedScripts[1], isNot(contains('secret internal failure')));
+      expect(executedScripts[1], isNot(contains('"message"')));
+
+      expect(executedScripts[2], contains('unknown'));
+      expect(executedScripts[2], contains('invalid_request'));
+      expect(executedScripts[2], isNot(contains('FormatException')));
+      expect(executedScripts[2], isNot(contains('"message"')));
+    });
+
     testWidgets(
       'rejects bridge messages with a mismatched nonce as unauthorized',
       (tester) async {
@@ -1089,6 +1148,31 @@ class _FakeAuthProvider implements BridgeAuthProvider {
   }) async {
     final event = Event('f' * 64, kind, tags, content, createdAt: createdAt);
     return BridgeSignedEvent(json: event.toJson());
+  }
+}
+
+class _ThrowingBridgeService extends NostrAppBridgeService {
+  _ThrowingBridgeService(SharedPreferences sharedPreferences)
+    : super(
+        authProvider: _FakeAuthProvider(),
+        policy: NostrAppBridgePolicy(
+          grantStore: NostrAppGrantStore(
+            sharedPreferences: sharedPreferences,
+          ),
+          currentUserPubkey: 'f' * 64,
+        ),
+        signerFactory: _FakeNostrSigner.new,
+      );
+
+  @override
+  Future<BridgeResult> handleRequest({
+    required NostrAppDirectoryEntry app,
+    required Uri origin,
+    required String method,
+    required Map<String, dynamic> args,
+    BridgePermissionPrompter? promptForPermission,
+  }) async {
+    throw StateError('secret internal failure');
   }
 }
 


### PR DESCRIPTION
## Summary

- normalize malformed bridge request payloads into stable invalid_request results at the bridge service boundary
- keep NIP-44 decrypt signer failures generic and non-leaky as decrypt_failed
- reject null event tag elements while preserving existing primitive tag coercion for compatibility
- pin a control-character event-id vector so current JSON-compatible serialization remains explicit

## Root cause

Issue #5334 tracked residual NIP edge cases left after #5318: implicit event serialization behavior, unsupported NIP-44 decrypt version error shape, and JSON null tag coercion. The bridge previously relied on caller-level exception handling for malformed request payloads and could leak signer exception text through the sandbox invalid_request path.

## Validation

- mise exec flutter@3.44.0 -- flutter analyze
- mise exec flutter@3.44.0 -- flutter test packages/nostr_app_bridge_repository/test/nostr_app_bridge_service_test.dart
- mise exec flutter@3.44.0 -- flutter test test/screens/apps/nostr_app_sandbox_screen_test.dart
- git push pre-push checks: merge conflict check, changed-file analyzer, changed bridge test

Closes #5334