### PR TITLE
fix(notifications): fall back to profile on any unresolved in-app tap

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -255,17 +255,18 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
         switch (target) {
           case OpenVideoTarget():
             // targetEventId is the event the resolver walks to find the root
-            // video. A mention with no resolvable video falls back to the
-            // actor's profile.
+            // video. Any comment/reply/likeComment/mention target whose root
+            // video cannot be resolved falls back to the actor's profile —
+            // mirroring the push tap path (`_resolveAndPushVideoLink`, the
+            // #5079 failure-UX contract) so every tap entry point shares one
+            // policy instead of silently dead-ending after marking the row read.
             final navigated = await _navigateToVideo(
               context,
               targetEventId!,
               videoAddressableId: videoAddressableId,
               notificationKind: type,
             );
-            if (!navigated &&
-                type == NotificationKind.mention &&
-                context.mounted) {
+            if (!navigated && context.mounted) {
               _navigateToProfile(context, actor.pubkey);
             }
           case OpenProfileTarget(:final actorPubkey):

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -603,6 +603,129 @@ void main() {
       });
 
       testWidgets(
+        'likeComment tap falls back to actor profile when resolver cannot '
+        'find the root video',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const commentEventId = 'unresolvable_liked_comment';
+          final likerPubkey = 'a' * 64;
+
+          // Cold-start cache miss + relay returns a comment with no resolvable
+          // root E/e tag, so the resolver cannot walk to a video and returns
+          // null. The tap must not silently dead-end.
+          when(
+            () => videoService.getVideoById(commentEventId),
+          ).thenReturn(null);
+          when(() => nostrClient.fetchEventById(commentEventId)).thenAnswer((
+            _,
+          ) async {
+            final event = Event(
+              'b' * 64,
+              1111,
+              const [],
+              'liked comment with no root reference',
+              createdAt: 1700000000,
+            );
+            event.id = commentEventId;
+            return event;
+          });
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'lc-fallback',
+                  type: NotificationKind.likeComment,
+                  actor: ActorInfo(pubkey: likerPubkey, displayName: 'Liz'),
+                  timestamp: DateTime(2026),
+                  targetEventId: commentEventId,
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          expect(result.videoDetailRoutes, isEmpty);
+          expect(result.videoArgs, isEmpty);
+          expect(result.profileNpubs, hasLength(1));
+          expect(result.profileNpubs.single, startsWith('npub'));
+        },
+      );
+
+      testWidgets(
+        'reply tap falls back to actor profile when resolver cannot find the '
+        'root video',
+        (tester) async {
+          final videoService = _MockVideoEventService();
+          final nostrClient = _MockNostrClient();
+          final videosRepository = _MockVideosRepository();
+          const parentCommentId = 'unresolvable_parent_comment';
+          final replierPubkey = 'c' * 64;
+
+          when(
+            () => videoService.getVideoById(parentCommentId),
+          ).thenReturn(null);
+          when(() => nostrClient.fetchEventById(parentCommentId)).thenAnswer((
+            _,
+          ) async {
+            final event = Event(
+              'd' * 64,
+              1111,
+              const [],
+              'parent comment with no root reference',
+              createdAt: 1700000000,
+            );
+            event.id = parentCommentId;
+            return event;
+          });
+
+          when(() => mockBloc.state).thenReturn(
+            NotificationFeedState(
+              status: NotificationFeedStatus.loaded,
+              notifications: [
+                ActorNotification(
+                  id: 'r-fallback',
+                  type: NotificationKind.reply,
+                  actor: ActorInfo(pubkey: replierPubkey, displayName: 'Bob'),
+                  timestamp: DateTime(2026),
+                  targetEventId: parentCommentId,
+                ),
+              ],
+            ),
+          );
+
+          final result = await _pumpRoutedViewFull(
+            tester,
+            mockBloc,
+            videoEventService: videoService,
+            nostrClient: nostrClient,
+            videosRepository: videosRepository,
+          );
+
+          await tester.tap(find.byType(NotificationListItem).first);
+          await tester.pumpAndSettle();
+
+          expect(result.videoDetailRoutes, isEmpty);
+          expect(result.videoArgs, isEmpty);
+          expect(result.profileNpubs, hasLength(1));
+          expect(result.profileNpubs.single, startsWith('npub'));
+        },
+      );
+
+      testWidgets(
         'reply tap waits for root video resolution before pushing video route',
         (tester) async {
           final videoService = _MockVideoEventService();


### PR DESCRIPTION
## Description

In-app `reply` / `likeComment` / `comment` notification taps silently dead-ended — the row was marked read, then **nothing happened** — when the `NotificationTargetResolver` E/e-walk could not reach the root video (cold-start cache miss + relay null, or a deleted/offline parent comment). The post-resolution profile fallback in `NotificationsView` (`notifications_view.dart`) was gated on `type == NotificationKind.mention` only, so every other comment-thread kind that resolved to `OpenVideoTarget` had no fallback.

The **push** tap path already implements the decided failure-UX contract (`_resolveAndPushVideoLink` in `main.dart`, **#5079** / PR #5114): when the event-id walk fails, route to the actor's profile (or inbox) instead of doing nothing. This drops the `mention`-only gate so the in-app executor shares that **one** policy across all `OpenVideoTarget` kinds — restoring conformance to the contract that the three tap entry points are meant to share via `resolveNotificationTapTarget`.

This is the one remaining in-app correctness gap (AC2) found while verifying epic #4200's acceptance criteria on `main`; the other four criteria are met.

**Related Issue:** Relates to #4200

## Out of Scope

- The valid-coordinate failure path (addressable / raw event id) is intentionally untouched — per the #5079 contract it trusts the coordinate and lands on `VideoDetailScreen`'s error state, and the in-app path already honors that half.
- Epic #4200 close-out coordination (housekeeping #5223, residual dispositions) is handled separately, not in this PR.

## Verification

- `dart format` — clean (pre-commit hook).
- `flutter analyze lib/notifications test/notifications` — No issues found.
- `flutter test test/notifications/view/notifications_view_test.dart` — 34/34 pass, including two new resolution-failure tests (reply + likeComment → actor profile). Both new tests **fail before this change** and pass after, pinning the regression.
- Pre-push hook (analyze + changed-file tests) green.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)