### PR TITLE
fix(notifications): fall back to profile on any unresolvable in-app tap

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -255,17 +255,25 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
         switch (target) {
           case OpenVideoTarget():
             // targetEventId is the event the resolver walks to find the root
-            // video. A mention with no resolvable video falls back to the
-            // actor's profile.
+            // video. Any comment/reply/likeComment/mention whose root video
+            // can't be resolved falls back to the actor's profile, mirroring
+            // the push executor's #5079 fallback contract
+            // (main.dart:_resolveAndPushVideoLink) so the tap never silently
+            // dead-ends regardless of kind.
             final navigated = await _navigateToVideo(
               context,
               targetEventId!,
               videoAddressableId: videoAddressableId,
               notificationKind: type,
             );
-            if (!navigated &&
-                type == NotificationKind.mention &&
-                context.mounted) {
+            if (!navigated && context.mounted) {
+              Log.warning(
+                'Notification tap could not resolve a video '
+                '(kind=$type, targetEventId=$targetEventId) — '
+                'falling back to actor profile',
+                name: 'NotificationsView',
+                category: LogCategory.ui,
+              );
               _navigateToProfile(context, actor.pubkey);
             }
           case OpenProfileTarget(:final actorPubkey):

--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -288,7 +288,8 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
   ///
   /// Returns `true` if a navigation was pushed, `false` if resolution failed
   /// (resolver returned null) and no navigation occurred. The caller decides
-  /// what to do on `false` — e.g. the mention branch falls back to profile.
+  /// what to do on `false`, such as falling back to the actor profile for
+  /// unresolvable comment-opening notifications.
   ///
   /// This uses the durable `/video/<id>` route rather than the ephemeral
   /// fullscreen feed route, so web builds do not depend on in-memory
@@ -314,9 +315,9 @@ class _NotificationsViewState extends ConsumerState<NotificationsView> {
     // Resolve the navigation target.
     //
     // The stable-ID path (videoAddressableId set) and raw-event-id fallback
-    // are synchronous. Comment/reply/mention targets without an addressable
-    // coordinate may be Kind 1111 comments, so resolve them to the root video
-    // before pushing the durable video route.
+    // are synchronous. Comment/reply/likeComment/mention targets without an
+    // addressable coordinate may be Kind 1111 comments, so resolve them to the
+    // root video before pushing the durable video route.
     String? routeId;
     var fallbackVideoIds = const <String>[];
     if (videoAddressableId != null && videoAddressableId.isNotEmpty) {

--- a/mobile/test/notifications/view/notifications_view_test.dart
+++ b/mobile/test/notifications/view/notifications_view_test.dart
@@ -602,6 +602,121 @@ void main() {
         );
       });
 
+      testWidgets('likeComment tap falls back to actor profile when the root '
+          'video cannot be resolved', (tester) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        const commentEventId = 'unresolvable_comment_event';
+        final likerPubkey = 'a' * 64;
+
+        // Resolver returns null: the comment is not a video and carries no
+        // E/e tag pointing at a root video, so _navigateToVideo returns false.
+        when(() => videoService.getVideoById(commentEventId)).thenReturn(null);
+        when(() => nostrClient.fetchEventById(commentEventId)).thenAnswer((
+          _,
+        ) async {
+          final event = Event(
+            'd' * 64,
+            1111,
+            const [],
+            'orphan comment with no root reference',
+            createdAt: 1700000000,
+          );
+          event.id = commentEventId;
+          return event;
+        });
+
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              ActorNotification(
+                id: 'lc-fail',
+                type: NotificationKind.likeComment,
+                actor: ActorInfo(pubkey: likerPubkey, displayName: 'Liz'),
+                timestamp: DateTime(2026),
+                targetEventId: commentEventId,
+              ),
+            ],
+          ),
+        );
+
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
+
+        await tester.tap(find.byType(NotificationListItem).first);
+        await tester.pumpAndSettle();
+
+        // Pre-fix this dead-ended (row marked read, no navigation). The shared
+        // #5079 fallback now sends every unresolvable OpenVideoTarget kind to
+        // the actor profile, not just mention.
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, isEmpty);
+        expect(result.profileNpubs, hasLength(1));
+        expect(result.profileNpubs.single, startsWith('npub'));
+      });
+
+      testWidgets('reply tap falls back to actor profile when the root '
+          'video cannot be resolved', (tester) async {
+        final videoService = _MockVideoEventService();
+        final nostrClient = _MockNostrClient();
+        final videosRepository = _MockVideosRepository();
+        const parentCommentId = 'unresolvable_parent_comment';
+        final replierPubkey = 'b' * 64;
+
+        when(() => videoService.getVideoById(parentCommentId)).thenReturn(null);
+        when(() => nostrClient.fetchEventById(parentCommentId)).thenAnswer((
+          _,
+        ) async {
+          final event = Event(
+            'd' * 64,
+            1111,
+            const [],
+            'orphan reply with no root reference',
+            createdAt: 1700000000,
+          );
+          event.id = parentCommentId;
+          return event;
+        });
+
+        when(() => mockBloc.state).thenReturn(
+          NotificationFeedState(
+            status: NotificationFeedStatus.loaded,
+            notifications: [
+              ActorNotification(
+                id: 'r-fail',
+                type: NotificationKind.reply,
+                actor: ActorInfo(pubkey: replierPubkey, displayName: 'Bob'),
+                timestamp: DateTime(2026),
+                targetEventId: parentCommentId,
+              ),
+            ],
+          ),
+        );
+
+        final result = await _pumpRoutedViewFull(
+          tester,
+          mockBloc,
+          videoEventService: videoService,
+          nostrClient: nostrClient,
+          videosRepository: videosRepository,
+        );
+
+        await tester.tap(find.byType(NotificationListItem).first);
+        await tester.pumpAndSettle();
+
+        expect(result.videoArgs, isEmpty);
+        expect(result.videoDetailRoutes, isEmpty);
+        expect(result.profileNpubs, hasLength(1));
+        expect(result.profileNpubs.single, startsWith('npub'));
+      });
+
       testWidgets(
         'reply tap waits for root video resolution before pushing video route',
         (tester) async {


### PR DESCRIPTION
## What

In-app `reply`/`likeComment`/`comment` notification taps **silently dead-ended** when the root video couldn't be resolved — no navigation, no error state — while the row was still marked read. This makes the tap fall back to the actor's profile for every comment-class kind, mirroring the push path.

## Why

`notifications_view.dart`'s `ActorNotification → OpenVideoTarget` branch walks the comment `E`/`e` tags via `NotificationTargetResolver`; on a resolver miss `_navigateToVideo` returns `false`. The fallback to the actor profile was gated on `type == NotificationKind.mention` only, but `notificationKindOpensComments` also includes `comment`/`reply`/`likeComment`, so those kinds returned `false` and then did nothing.

The push executor already implements the correct behaviour: per the **#5079** contract (closed by PR #5114), `main.dart`'s `_resolveAndPushVideoLink` falls back to profile (or inbox) on a resolver miss **for all kinds** "instead of silently doing nothing." This restores conformance to that shared contract in the in-app path.

## Changes

- `notifications_view.dart`: drop the `mention`-only condition so every unresolvable `OpenVideoTarget` kind falls back to `_navigateToProfile(actor.pubkey)`; add a parity warning log; update the now-accurate doc comment.
- `notifications_view_test.dart`: add the missing failure-branch tests for `reply` and `likeComment` (the suite previously covered only their success path + mention failure). Verified both **fail without the fix** and pass with it.

## Scope / risk

- In-app inbox taps only; the push path is unchanged. Triggers only on a resolver miss (cold-start cache miss + relay null, deleted/offline parent comment). Pre-existing; not a recent regression.
- UI-only, one conditional removed. No data/repository/BLoC/router/l10n changes; no new user-facing strings (reuses the existing profile route).
- The valid-coordinate path (addressable/raw id) is untouched and still lands on `VideoDetailScreen`'s error state per the other half of the #5079 contract.

## Testing

```
flutter analyze lib/notifications test/notifications/view/notifications_view_test.dart   # No issues found
flutter test test/notifications/view/notifications_view_test.dart                        # 34/34 pass (2 new)
```

## Context

Part of epic #4200 (notifications stabilization). Fixes #5344. This is the one remaining AC2 (tap-target) gap found while verifying the epic's acceptance criteria; the other four ACs are met on main.