### PR TITLE
feat(video-recorder): add lip-sync camera mode

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3332,6 +3332,7 @@
     "videoRecorderContinueToEditorLabel": "ወደ ቪዲዮ አርታዒ ይቀጥሉ",
     "videoRecorderCaptureCloseLabel": "ገጠመ",
     "videoRecorderCaptureNextLabel": "ቀጥሎ",
+    "videoRecorderLipSyncAddAudioFirst": "ከመቅረጽ በፊት ኦዲዮ ያክሉ",
     "videoRecorderToggleFlashLabel": "ብልጭታ ቀያይር",
     "videoRecorderCycleTimerLabel": "የዑደት ሰዓት ቆጣሪ",
     "videoRecorderToggleAspectRatioLabel": "ምጥጥን ቀያይር",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2999,6 +2999,7 @@
     "videoRecorderAutosaveRestoreFailure": "تعذر استعادة مسودتك",
     "videoRecorderCaptureCloseLabel": "إغلاق",
     "videoRecorderCaptureNextLabel": "التالي",
+    "videoRecorderLipSyncAddAudioFirst": "أضف صوتًا قبل التسجيل",
     "videoRecorderClipDeletedMessage": "تم نقل المقطع إلى المهملات",
     "videoRecorderClipUndoLabel": "تراجع",
     "libraryTrashTitle": "المحذوفة مؤخرًا",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3022,6 +3022,7 @@
     "videoRecorderContinueToEditorLabel": "Продължете към видеоредактора",
     "videoRecorderCaptureCloseLabel": "Затвори",
     "videoRecorderCaptureNextLabel": "Следваща",
+    "videoRecorderLipSyncAddAudioFirst": "Добавете аудио преди запис",
     "videoRecorderToggleFlashLabel": "Превключване на светкавицата",
     "videoRecorderCycleTimerLabel": "Цикъл таймер",
     "videoRecorderToggleAspectRatioLabel": "Превключване на пропорциите",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2772,6 +2772,7 @@
     "videoRecorderContinueToEditorLabel": "Zum Videoeditor weiter",
     "videoRecorderCaptureCloseLabel": "Schließen",
     "videoRecorderCaptureNextLabel": "Weiter",
+    "videoRecorderLipSyncAddAudioFirst": "Audio vor der Aufnahme hinzufügen",
     "videoRecorderToggleFlashLabel": "Blitz ein-/ausschalten",
     "videoRecorderCycleTimerLabel": "Timer wechseln",
     "videoRecorderToggleAspectRatioLabel": "Seitenverhältnis wechseln",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4396,6 +4396,10 @@
   "videoRecorderContinueToEditorLabel": "Continue to video editor",
   "videoRecorderCaptureCloseLabel": "Close",
   "videoRecorderCaptureNextLabel": "Next",
+  "videoRecorderLipSyncAddAudioFirst": "Add audio before recording",
+  "@videoRecorderLipSyncAddAudioFirst": {
+    "description": "Snackbar shown when the user taps the record button in lip-sync mode without first selecting a sound."
+  },
   "videoRecorderToggleFlashLabel": "Toggle flash",
   "videoRecorderCycleTimerLabel": "Cycle timer",
   "videoRecorderToggleAspectRatioLabel": "Toggle aspect ratio",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2780,6 +2780,7 @@
     "videoRecorderContinueToEditorLabel": "Continuar al editor de video",
     "videoRecorderCaptureCloseLabel": "Cerrar",
     "videoRecorderCaptureNextLabel": "Siguiente",
+    "videoRecorderLipSyncAddAudioFirst": "Agrega audio antes de grabar",
     "videoRecorderToggleFlashLabel": "Activar o desactivar flash",
     "videoRecorderCycleTimerLabel": "Cambiar temporizador",
     "videoRecorderToggleAspectRatioLabel": "Cambiar relación de aspecto",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1689,6 +1689,7 @@
     "videoRecorderContinueToEditorLabel": "Magpatuloy sa video editor",
     "videoRecorderCaptureCloseLabel": "Isara",
     "videoRecorderCaptureNextLabel": "Susunod",
+    "videoRecorderLipSyncAddAudioFirst": "Magdagdag ng audio bago mag-record",
     "videoRecorderToggleFlashLabel": "I-toggle ang flash",
     "videoRecorderCycleTimerLabel": "I-cycle ang timer",
     "videoRecorderToggleAspectRatioLabel": "I-toggle ang aspect ratio",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2772,6 +2772,7 @@
     "videoRecorderContinueToEditorLabel": "Continuer vers l'éditeur vidéo",
     "videoRecorderCaptureCloseLabel": "Fermer",
     "videoRecorderCaptureNextLabel": "Suivant",
+    "videoRecorderLipSyncAddAudioFirst": "Ajoutez de l'audio avant d'enregistrer",
     "videoRecorderToggleFlashLabel": "Activer/désactiver le flash",
     "videoRecorderCycleTimerLabel": "Changer le minuteur",
     "videoRecorderToggleAspectRatioLabel": "Changer le format d'image",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3006,6 +3006,7 @@
     "videoRecorderAutosaveRestoreFailure": "Tidak dapat memulihkan draf kamu",
     "videoRecorderCaptureCloseLabel": "Tutup",
     "videoRecorderCaptureNextLabel": "Berikutnya",
+    "videoRecorderLipSyncAddAudioFirst": "Tambahkan audio sebelum merekam",
     "videoRecorderClipDeletedMessage": "Klip dipindahkan ke sampah",
     "videoRecorderClipUndoLabel": "Urungkan",
     "libraryTrashTitle": "Baru-baru ini dihapus",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2772,6 +2772,7 @@
     "videoRecorderContinueToEditorLabel": "Continua all'editor video",
     "videoRecorderCaptureCloseLabel": "Chiudi",
     "videoRecorderCaptureNextLabel": "Avanti",
+    "videoRecorderLipSyncAddAudioFirst": "Aggiungi audio prima di registrare",
     "videoRecorderToggleFlashLabel": "Attiva/disattiva flash",
     "videoRecorderCycleTimerLabel": "Cambia timer",
     "videoRecorderToggleAspectRatioLabel": "Cambia rapporto d'aspetto",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2999,6 +2999,7 @@
     "videoRecorderAutosaveRestoreFailure": "下書きを復元できませんでした",
     "videoRecorderCaptureCloseLabel": "閉じる",
     "videoRecorderCaptureNextLabel": "次へ",
+    "videoRecorderLipSyncAddAudioFirst": "録画する前にオーディオを追加してください",
     "videoRecorderClipDeletedMessage": "クリップをゴミ箱に移動しました",
     "videoRecorderClipUndoLabel": "元に戻す",
     "libraryTrashTitle": "最近削除した項目",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2295,6 +2295,7 @@
     "videoRecorderAutosaveRestoreFailure": "임시저장을 복원할 수 없습니다",
     "videoRecorderCaptureCloseLabel": "닫기",
     "videoRecorderCaptureNextLabel": "다음",
+    "videoRecorderLipSyncAddAudioFirst": "녹화하기 전에 오디오를 추가하세요",
     "videoRecorderClipDeletedMessage": "클립이 휴지통으로 이동되었습니다",
     "videoRecorderClipUndoLabel": "실행 취소",
     "libraryTrashTitle": "최근 삭제된 항목",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2772,6 +2772,7 @@
     "videoRecorderContinueToEditorLabel": "Doorgaan naar video-editor",
     "videoRecorderCaptureCloseLabel": "Sluiten",
     "videoRecorderCaptureNextLabel": "Volgende",
+    "videoRecorderLipSyncAddAudioFirst": "Voeg audio toe vóór de opname",
     "videoRecorderToggleFlashLabel": "Flitser in-/uitschakelen",
     "videoRecorderCycleTimerLabel": "Timer wisselen",
     "videoRecorderToggleAspectRatioLabel": "Beeldverhouding wisselen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2772,6 +2772,7 @@
     "videoRecorderContinueToEditorLabel": "Przejdź do edytora wideo",
     "videoRecorderCaptureCloseLabel": "Zamknij",
     "videoRecorderCaptureNextLabel": "Dalej",
+    "videoRecorderLipSyncAddAudioFirst": "Dodaj audio przed nagraniem",
     "videoRecorderToggleFlashLabel": "Przełącz lampę błyskową",
     "videoRecorderCycleTimerLabel": "Zmień timer",
     "videoRecorderToggleAspectRatioLabel": "Przełącz proporcje",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2772,6 +2772,7 @@
     "videoRecorderContinueToEditorLabel": "Continuar para o editor de vídeo",
     "videoRecorderCaptureCloseLabel": "Fechar",
     "videoRecorderCaptureNextLabel": "Próximo",
+    "videoRecorderLipSyncAddAudioFirst": "Adicione áudio antes de gravar",
     "videoRecorderToggleFlashLabel": "Alternar flash",
     "videoRecorderCycleTimerLabel": "Alternar temporizador",
     "videoRecorderToggleAspectRatioLabel": "Alternar proporção",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2772,6 +2772,7 @@
     "videoRecorderContinueToEditorLabel": "Continuă către editorul video",
     "videoRecorderCaptureCloseLabel": "Închide",
     "videoRecorderCaptureNextLabel": "Următorul",
+    "videoRecorderLipSyncAddAudioFirst": "Adaugă audio înainte de înregistrare",
     "videoRecorderToggleFlashLabel": "Activează/dezactivează blițul",
     "videoRecorderCycleTimerLabel": "Schimbă temporizatorul",
     "videoRecorderToggleAspectRatioLabel": "Schimbă raportul de aspect",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2772,6 +2772,7 @@
     "videoRecorderContinueToEditorLabel": "Fortsätt till videoredigeraren",
     "videoRecorderCaptureCloseLabel": "Stäng",
     "videoRecorderCaptureNextLabel": "Nästa",
+    "videoRecorderLipSyncAddAudioFirst": "Lägg till ljud innan inspelning",
     "videoRecorderToggleFlashLabel": "Växla blixt",
     "videoRecorderCycleTimerLabel": "Växla timer",
     "videoRecorderToggleAspectRatioLabel": "Växla bildförhållande",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3006,6 +3006,7 @@
     "videoRecorderAutosaveRestoreFailure": "Taslağınız geri yüklenemedi",
     "videoRecorderCaptureCloseLabel": "Kapat",
     "videoRecorderCaptureNextLabel": "İleri",
+    "videoRecorderLipSyncAddAudioFirst": "Kayıttan önce ses ekleyin",
     "videoRecorderClipDeletedMessage": "Klip çöp kutusuna taşındı",
     "videoRecorderClipUndoLabel": "Geri al",
     "libraryTrashTitle": "Son silinenler",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13436,6 +13436,12 @@ abstract class AppLocalizations {
   /// **'Next'**
   String get videoRecorderCaptureNextLabel;
 
+  /// Snackbar shown when the user taps the record button in lip-sync mode without first selecting a sound.
+  ///
+  /// In en, this message translates to:
+  /// **'Add audio before recording'**
+  String get videoRecorderLipSyncAddAudioFirst;
+
   /// No description provided for @videoRecorderToggleFlashLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7593,7 +7593,7 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'ቀጥሎ';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst => 'ከመቅረጽ በፊት ኦዲዮ ያክሉ';
 
   @override
   String get videoRecorderToggleFlashLabel => 'ብልጭታ ቀያይር';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7593,6 +7593,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'ቀጥሎ';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'ብልጭታ ቀያይር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7669,6 +7669,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'التالي';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'تبديل الفلاش';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7669,7 +7669,7 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'التالي';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst => 'أضف صوتًا قبل التسجيل';
 
   @override
   String get videoRecorderToggleFlashLabel => 'تبديل الفلاش';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7799,7 +7799,7 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Следваща';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst => 'Добавете аудио преди запис';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Превключване на светкавицата';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7799,6 +7799,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Следваща';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Превключване на светкавицата';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7813,7 +7813,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Weiter';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Audio vor der Aufnahme hinzufügen';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Blitz ein-/ausschalten';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7813,6 +7813,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Weiter';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Blitz ein-/ausschalten';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7727,6 +7727,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Next';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Toggle flash';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7798,7 +7798,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Siguiente';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Agrega audio antes de grabar';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Activar o desactivar flash';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7798,6 +7798,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Siguiente';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Activar o desactivar flash';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7815,7 +7815,8 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Susunod';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Magdagdag ng audio bago mag-record';
 
   @override
   String get videoRecorderToggleFlashLabel => 'I-toggle ang flash';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7815,6 +7815,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Susunod';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'I-toggle ang flash';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7824,6 +7824,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Suivant';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Activer/désactiver le flash';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7824,7 +7824,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Suivant';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Ajoutez de l\'audio avant d\'enregistrer';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Activer/désactiver le flash';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7705,7 +7705,8 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Berikutnya';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Tambahkan audio sebelum merekam';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Ganti flash';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7705,6 +7705,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Berikutnya';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Ganti flash';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7794,6 +7794,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Avanti';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Attiva/disattiva flash';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7794,7 +7794,8 @@ class AppLocalizationsIt extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Avanti';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Aggiungi audio prima di registrare';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Attiva/disattiva flash';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7457,7 +7457,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => '次へ';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst => '録画する前にオーディオを追加してください';
 
   @override
   String get videoRecorderToggleFlashLabel => 'フラッシュを切り替え';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7457,6 +7457,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => '次へ';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'フラッシュを切り替え';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7479,7 +7479,7 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => '다음';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst => '녹화하기 전에 오디오를 추가하세요';
 
   @override
   String get videoRecorderToggleFlashLabel => '플래시 전환';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7479,6 +7479,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => '다음';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => '플래시 전환';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7765,7 +7765,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Volgende';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Voeg audio toe vóór de opname';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Flitser in-/uitschakelen';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7765,6 +7765,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Volgende';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Flitser in-/uitschakelen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7882,7 +7882,7 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Dalej';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst => 'Dodaj audio przed nagraniem';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Przełącz lampę błyskową';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7882,6 +7882,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Dalej';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Przełącz lampę błyskową';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7775,7 +7775,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Próximo';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Adicione áudio antes de gravar';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Alternar flash';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7775,6 +7775,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Próximo';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Alternar flash';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7893,6 +7893,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Următorul';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Activează/dezactivează blițul';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7893,7 +7893,8 @@ class AppLocalizationsRo extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Următorul';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Adaugă audio înainte de înregistrare';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Activează/dezactivează blițul';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7736,7 +7736,8 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Nästa';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst =>
+      'Lägg till ljud innan inspelning';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Växla blixt';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7736,6 +7736,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'Nästa';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Växla blixt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7708,6 +7708,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'İleri';
 
   @override
+  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+
+  @override
   String get videoRecorderToggleFlashLabel => 'Flaşı değiştir';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7708,7 +7708,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get videoRecorderCaptureNextLabel => 'İleri';
 
   @override
-  String get videoRecorderLipSyncAddAudioFirst => 'Add audio before recording';
+  String get videoRecorderLipSyncAddAudioFirst => 'Kayıttan önce ses ekleyin';
 
   @override
   String get videoRecorderToggleFlashLabel => 'Flaşı değiştir';

--- a/mobile/lib/models/video_editor/video_editor_provider_state.dart
+++ b/mobile/lib/models/video_editor/video_editor_provider_state.dart
@@ -35,6 +35,7 @@ class VideoEditorProviderState {
     this.inspiredByVideo,
     this.inspiredByNpub,
     this.selectedSound,
+    this.seedSelectedSoundAsAudioTrack = false,
     this.contentWarnings = const {},
     this.proofManifestJson,
     this.thumbnailTimestamp,
@@ -104,6 +105,14 @@ class VideoEditorProviderState {
   /// This is persisted in drafts and used for audio playback during editing.
   final AudioEvent? selectedSound;
 
+  /// Whether [selectedSound] was recorded against in the recorder and should
+  /// be seeded into the editor timeline as a concrete audio track.
+  ///
+  /// Generic editor/draft sound state is not enough to infer this. Lip-sync
+  /// uses this handoff flag so restoring a draft or selecting audio elsewhere
+  /// cannot accidentally create a duplicate editor track.
+  final bool seedSelectedSoundAsAudioTrack;
+
   /// NIP-32 content warning labels for sensitive content self-labeling.
   final Set<ContentLabel> contentWarnings;
 
@@ -171,6 +180,7 @@ class VideoEditorProviderState {
     bool clearInspiredByNpub = false,
     AudioEvent? selectedSound,
     bool clearSelectedSound = false,
+    bool? seedSelectedSoundAsAudioTrack,
     Set<ContentLabel>? contentWarnings,
     Duration? thumbnailTimestamp,
     bool clearThumbnailTimestamp = false,
@@ -207,6 +217,9 @@ class VideoEditorProviderState {
       selectedSound: clearSelectedSound
           ? null
           : (selectedSound ?? this.selectedSound),
+      seedSelectedSoundAsAudioTrack:
+          !clearSelectedSound &&
+          (seedSelectedSoundAsAudioTrack ?? this.seedSelectedSoundAsAudioTrack),
       contentWarnings: contentWarnings ?? this.contentWarnings,
       proofManifestJson: clearProofManifestJson || clearFinalRenderedClip
           ? null

--- a/mobile/lib/models/video_recorder/video_recorder_mode.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_mode.dart
@@ -1,9 +1,10 @@
 import 'package:models/models.dart' as model show AspectRatio;
 
 enum VideoRecorderMode {
-  capture,
-  classic,
   upload,
+  capture,
+  lipSync,
+  classic,
   ;
 
   /// SharedPreferences key for the last-used recorder mode.
@@ -18,38 +19,44 @@ enum VideoRecorderMode {
       values.firstWhere((m) => m.name == name, orElse: () => capture);
 
   String get label => switch (this) {
-    .capture => 'Capture',
-    .classic => 'Classic',
     .upload => 'Upload',
+    .capture => 'Capture',
+    .lipSync => 'Lip Sync',
+    .classic => 'Classic',
   };
 
   bool get hasRecordingLimit => switch (this) {
-    .capture => false,
-    .classic => true,
     .upload => false,
+    .capture => false,
+    .lipSync => true,
+    .classic => true,
   };
 
   bool get hasVideoEditor => switch (this) {
-    .capture => true,
-    .classic => false,
     .upload => false,
+    .capture => true,
+    .lipSync => true,
+    .classic => false,
   };
 
   bool get supportGridLines => switch (this) {
-    .capture => false,
-    .classic => true,
     .upload => false,
+    .capture => false,
+    .lipSync => false,
+    .classic => true,
   };
 
   bool get supportsCountdownTimer => switch (this) {
-    .capture => true,
-    .classic => false,
     .upload => false,
+    .capture => true,
+    .lipSync => true,
+    .classic => false,
   };
 
   model.AspectRatio get defaultAspectRatio => switch (this) {
-    .capture => .vertical,
-    .classic => .square,
     .upload => .vertical,
+    .capture => .vertical,
+    .lipSync => .vertical,
+    .classic => .square,
   };
 }

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -523,6 +523,24 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
     _triggerAutosave();
   }
 
+  /// Mutes every clip by setting its volume to zero.
+  ///
+  /// Used by lip-sync mode before handing off to the editor so the recorded
+  /// clips are silent and only the selected sound is audible.
+  void muteAllClips() {
+    if (_clips.isEmpty || _clips.every((c) => c.volume == 0)) return;
+    for (var i = 0; i < _clips.length; i++) {
+      _clips[i] = _clips[i].copyWith(volume: 0);
+    }
+    state = state.copyWith(clips: List.unmodifiable(_clips));
+    Log.debug(
+      '🔇 Muted all clips for lip-sync',
+      name: 'ClipManagerNotifier',
+      category: .video,
+    );
+    _triggerAutosave();
+  }
+
   /// Update ghost frame path for a clip.
   void updateGhostFrame({
     required String clipId,

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -410,6 +410,27 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     state = state.copyWith(
       selectedSound: sound,
       clearSelectedSound: sound == null,
+      seedSelectedSoundAsAudioTrack: false,
+    );
+    invalidateFinalRenderedClip();
+    triggerAutosave();
+  }
+
+  /// Select a recorder-backed sound that should become an editor audio track.
+  ///
+  /// Lip-sync records clips while playing this sound, then mutes those clips
+  /// before opening the editor. The selected sound must therefore be seeded
+  /// into the editor timeline exactly once on editor initialization.
+  void selectRecorderAudioTrack(AudioEvent? sound) {
+    if (sound == state.selectedSound &&
+        state.seedSelectedSoundAsAudioTrack == (sound != null)) {
+      return;
+    }
+
+    state = state.copyWith(
+      selectedSound: sound,
+      clearSelectedSound: sound == null,
+      seedSelectedSoundAsAudioTrack: sound != null,
     );
     invalidateFinalRenderedClip();
     triggerAutosave();
@@ -799,6 +820,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       inspiredByVideo: draft.inspiredByVideo,
       inspiredByNpub: draft.inspiredByNpub,
       selectedSound: draft.selectedSound,
+      seedSelectedSoundAsAudioTrack: false,
       contentWarnings: draft.contentWarnings,
       finalRenderedClip: validFinalRenderedClip,
       clearFinalRenderedClip: validFinalRenderedClip == null,

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -60,7 +60,8 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
       child: GestureDetector(
         onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
         child: switch (recorderMode) {
-          .capture => const VideoMetadataCaptureStack(),
+          // Lip-sync shares capture's editor + metadata flow.
+          .capture || .lipSync => const VideoMetadataCaptureStack(),
           .classic => const VideoMetadataClassicStack(),
           // Deliberately unreachable: upload mode has no record button, so no
           // clips can be created and the user cannot navigate to the metadata

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -25,6 +25,7 @@ import 'package:openvine/utils/video_controller_cleanup.dart';
 import 'package:openvine/widgets/camera_permission_gate.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/classic/video_recorder_classic_stack.dart';
+import 'package:openvine/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/upload/video_recorder_upload_stack.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_bottom_bar.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
@@ -405,6 +406,12 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
   @override
   Widget build(BuildContext context) {
     return BlocProvider<SoundWaveformBloc>(
+      // Eager: the create factory installs the selected-sound listener that
+      // drives waveform extraction. The only consumer (the lip-sync audio
+      // progress bar) mounts during recording, but extraction must already be
+      // running when the user picks a sound beforehand so the waveform is
+      // ready by the time recording starts.
+      lazy: false,
       create: (context) {
         final bloc = SoundWaveformBloc();
         _setupSoundWaveformListener(bloc);
@@ -451,11 +458,12 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
                       child: switch (context.select(
                         (VideoRecorderBloc b) => b.state.recorderMode,
                       )) {
+                        .upload => const VideoRecorderUploadStack(),
                         .capture => VideoRecorderCaptureStack(
                           fromEditor: widget.fromEditor,
                         ),
+                        .lipSync => const VideoRecorderLipSyncStack(),
                         .classic => const VideoRecorderClassicStack(),
-                        .upload => const VideoRecorderUploadStack(),
                       },
                     ),
                   ),

--- a/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
@@ -40,10 +40,10 @@ class VideoEditorAudioChip extends StatelessWidget {
     onSelectionStarted?.call();
 
     try {
-      AudioEvent? soundToEdit = previousSound;
-
-      // If no sound selected, show selection sheet first
-      if (soundToEdit == null) {
+      // No sound yet: the selection sheet already trims long sounds via the
+      // timing screen and returns the final, timed sound, so use its result
+      // directly. Re-opening the timing screen here would show it twice.
+      if (previousSound == null) {
         final result = await VineBottomSheet.show<AudioEvent>(
           context: context,
           maxChildSize: 1,
@@ -52,27 +52,21 @@ class VideoEditorAudioChip extends StatelessWidget {
           buildScrollBody: (scrollController) =>
               AudioSelectionBottomSheet(scrollController: scrollController),
         );
-        if (result == null) {
-          onSoundChanged(null);
-          return;
-        }
-        soundToEdit = result;
-        // Notify parent about initial selection
+        onSoundChanged(result);
+        return;
       }
 
-      if (!context.mounted) return;
-
-      // Open timing screen and wait for result
+      // Re-editing an already-selected sound: jump straight to the timing
+      // screen so the user can adjust the start offset or remove the sound.
       final timingResult = await Navigator.of(context).push<AudioTimingResult>(
         PageRouteBuilder(
           opaque: false,
           barrierColor: VineTheme.transparent,
           pageBuilder: (_, _, _) =>
-              VideoAudioEditorTimingScreen(sound: soundToEdit!),
+              VideoAudioEditorTimingScreen(sound: previousSound),
         ),
       );
 
-      // Handle timing screen result
       if (timingResult != null) {
         switch (timingResult) {
           case AudioTimingConfirmed(:final sound):

--- a/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/video_editor_audio_chip.dart
@@ -35,6 +35,10 @@ class VideoEditorAudioChip extends StatelessWidget {
   /// Called when audio selection ends (e.g. to resume playback).
   final VoidCallback? onSelectionEnded;
 
+  @visibleForTesting
+  static bool shouldOpenTimingScreen(AudioEvent? selectedSound) =>
+      selectedSound != null;
+
   Future<void> _selectAudio(BuildContext context) async {
     final previousSound = selectedSound;
     onSelectionStarted?.call();
@@ -43,7 +47,7 @@ class VideoEditorAudioChip extends StatelessWidget {
       // No sound yet: the selection sheet already trims long sounds via the
       // timing screen and returns the final, timed sound, so use its result
       // directly. Re-opening the timing screen here would show it twice.
-      if (previousSound == null) {
+      if (!shouldOpenTimingScreen(previousSound)) {
         final result = await VineBottomSheet.show<AudioEvent>(
           context: context,
           maxChildSize: 1,
@@ -63,7 +67,7 @@ class VideoEditorAudioChip extends StatelessWidget {
           opaque: false,
           barrierColor: VineTheme.transparent,
           pageBuilder: (_, _, _) =>
-              VideoAudioEditorTimingScreen(sound: previousSound),
+              VideoAudioEditorTimingScreen(sound: previousSound!),
         ),
       );
 

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -82,6 +82,12 @@ class VideoEditorCanvas extends StatelessWidget {
         previous.clips != current.clips;
   }
 
+  @visibleForTesting
+  static bool shouldSeedSelectedSoundAsAudioTrack({
+    required bool hasSelectedSound,
+    required bool seedSelectedSoundAsAudioTrack,
+  }) => hasSelectedSound && seedSelectedSoundAsAudioTrack;
+
   @override
   Widget build(BuildContext context) {
     final isSubEditorOpen = context.select(
@@ -1442,9 +1448,14 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
               if (editorStateHistory.isEmpty) {
                 final clips = ref.read(clipManagerProvider).clips;
-                final selectedSound = ref
-                    .read(videoEditorProvider)
-                    .selectedSound;
+                final editorState = ref.read(videoEditorProvider);
+                final selectedSound = editorState.selectedSound;
+                final shouldSeedSelectedSound =
+                    VideoEditorCanvas.shouldSeedSelectedSoundAsAudioTrack(
+                      hasSelectedSound: selectedSound != null,
+                      seedSelectedSoundAsAudioTrack:
+                          editorState.seedSelectedSoundAsAudioTrack,
+                    );
 
                 scope.requireEditor.stateManager.replaceHistory(
                   scope.requireEditor.stateHistory.first.copyWith(
@@ -1455,12 +1466,14 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
                           .toList(),
                       // Lip-sync: the recorder picked a sound the clips were
                       // recorded against (and muted on handoff). Seed it as the
-                      // timeline's audio track so it's visible and editable. The
-                      // editor re-clamps the window to the real video duration
-                      // on the next TimelineOverlayTotalDurationChanged.
-                      if (selectedSound != null)
+                      // timeline's audio track only when the recorder marked
+                      // this as a handoff, not for every selected editor/draft
+                      // sound. The editor re-clamps the window to the real
+                      // video duration on the next
+                      // TimelineOverlayTotalDurationChanged.
+                      if (shouldSeedSelectedSound)
                         VideoEditorConstants.audioStateHistoryKey: [
-                          selectedSound
+                          selectedSound!
                               .copyWith(
                                 id:
                                     '${selectedSound.id}-'

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -636,6 +636,23 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
   }
 
   /// Syncs the main-editor capabilities from the main editor to the bloc.
+  /// Timeline end position for a lip-sync sound seeded on editor init.
+  ///
+  /// Spans from zero up to the sound's own length, capped at the editor's hard
+  /// duration ceiling. The editor re-clamps it to the real video duration once
+  /// that is measured.
+  Duration _lipSyncAudioEndTime(double? durationSecs) {
+    final soundMs = durationSecs != null
+        ? (durationSecs * 1000).round()
+        : VideoEditorConstants.maxDuration.inMilliseconds;
+    return Duration(
+      milliseconds: min(
+        soundMs,
+        VideoEditorConstants.maxDuration.inMilliseconds,
+      ),
+    );
+  }
+
   void _syncMainCapabilities(VideoEditorScope scope, VideoEditorMainBloc bloc) {
     final editor = scope.editor;
     if (editor == null) return;
@@ -1425,6 +1442,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
 
               if (editorStateHistory.isEmpty) {
                 final clips = ref.read(clipManagerProvider).clips;
+                final selectedSound = ref
+                    .read(videoEditorProvider)
+                    .selectedSound;
 
                 scope.requireEditor.stateManager.replaceHistory(
                   scope.requireEditor.stateHistory.first.copyWith(
@@ -1433,6 +1453,25 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
                       VideoEditorConstants.clipsStateHistoryKey: clips
                           .map((e) => e.toJson())
                           .toList(),
+                      // Lip-sync: the recorder picked a sound the clips were
+                      // recorded against (and muted on handoff). Seed it as the
+                      // timeline's audio track so it's visible and editable. The
+                      // editor re-clamps the window to the real video duration
+                      // on the next TimelineOverlayTotalDurationChanged.
+                      if (selectedSound != null)
+                        VideoEditorConstants.audioStateHistoryKey: [
+                          selectedSound
+                              .copyWith(
+                                id:
+                                    '${selectedSound.id}-'
+                                    '${DateTime.now().millisecondsSinceEpoch}',
+                                startTime: Duration.zero,
+                                endTime: _lipSyncAudioEndTime(
+                                  selectedSound.duration,
+                                ),
+                              )
+                              .toJson(),
+                        ],
                     },
                   ),
                   index: 0,

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -21,10 +21,24 @@ const double _zoomIndicatorBottomInset = 24.0 + 96.0 + 12.0;
 
 /// Capture-mode stack with viewfinder, controls, and top bar.
 class VideoRecorderCaptureStack extends ConsumerWidget {
-  const VideoRecorderCaptureStack({required this.fromEditor, super.key});
+  const VideoRecorderCaptureStack({
+    required this.fromEditor,
+    this.topBarCenter,
+    this.audioProgressBar,
+    super.key,
+  });
 
   /// Whether the recorder was opened from the video editor.
   final bool fromEditor;
+
+  /// Optional widget rendered in the top bar between the close and next
+  /// buttons. Lip-sync mode uses this slot for the audio-select chip.
+  final Widget? topBarCenter;
+
+  /// Optional waveform progress bar overlaid during recording. Lip-sync mode
+  /// supplies [VideoRecorderAudioProgressBar]; when set, the top bar's generic
+  /// recording-progress bar is suppressed so the two don't overlap.
+  final Widget? audioProgressBar;
 
   void _deleteLastClip(BuildContext context, WidgetRef ref) {
     unawaited(ref.read(clipManagerProvider.notifier).scheduleDeleteLastClip());
@@ -106,10 +120,17 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
             ),
           ),
 
+          // Waveform progress bar overlaid during recording (lip-sync mode).
+          ?audioProgressBar,
+
           // Top bar with close-button and confirm-button
           Align(
             alignment: .topCenter,
-            child: VideoRecorderCaptureTopBar(fromEditor: fromEditor),
+            child: VideoRecorderCaptureTopBar(
+              fromEditor: fromEditor,
+              center: topBarCenter,
+              showRecordingProgress: audioProgressBar == null,
+            ),
           ),
 
           // Countdown overlay

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart
@@ -25,6 +25,7 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
     required this.fromEditor,
     this.topBarCenter,
     this.audioProgressBar,
+    this.recordButton = const RecordButton(),
     super.key,
   });
 
@@ -39,6 +40,10 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
   /// supplies [VideoRecorderAudioProgressBar]; when set, the top bar's generic
   /// recording-progress bar is suppressed so the two don't overlap.
   final Widget? audioProgressBar;
+
+  /// The record button rendered at the bottom center. Defaults to the standard
+  /// [RecordButton]; lip-sync mode supplies one gated on audio selection.
+  final Widget recordButton;
 
   void _deleteLastClip(BuildContext context, WidgetRef ref) {
     unawaited(ref.read(clipManagerProvider.notifier).scheduleDeleteLastClip());
@@ -101,7 +106,7 @@ class VideoRecorderCaptureStack extends ConsumerWidget {
                     ),
                   ),
 
-                  const RecordButton(),
+                  recordButton,
 
                   /// Dummy placeholder button
                   const Opacity(

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
@@ -12,12 +12,27 @@ import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
 
 /// Top bar for capture mode with close and confirm buttons.
 class VideoRecorderCaptureTopBar extends ConsumerWidget {
-  const VideoRecorderCaptureTopBar({required this.fromEditor, super.key});
+  const VideoRecorderCaptureTopBar({
+    required this.fromEditor,
+    this.center,
+    this.showRecordingProgress = true,
+    super.key,
+  });
 
   static const _animationDuration = Duration(milliseconds: 220);
 
   /// Whether the recorder was opened from the video editor.
   final bool fromEditor;
+
+  /// Optional widget rendered between the close and next buttons while not
+  /// recording. Lip-sync mode uses this slot for the audio-select chip.
+  final Widget? center;
+
+  /// Whether the thin recording-progress bar is shown while recording.
+  ///
+  /// Lip-sync mode sets this to `false` because its audio waveform already
+  /// conveys recording progress, and the two would overlap.
+  final bool showRecordingProgress;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -31,7 +46,9 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
       child: AnimatedSwitcher(
         duration: _animationDuration,
         child: isRecording
-            ? const _RecordingProgressBar()
+            ? (showRecordingProgress
+                  ? const _RecordingProgressBar()
+                  : const SizedBox.shrink())
             : Padding(
                 padding: const EdgeInsetsGeometry.fromLTRB(12, 12, 12, 0),
                 child: Row(
@@ -48,6 +65,7 @@ class VideoRecorderCaptureTopBar extends ConsumerWidget {
                           ? context.pop(false)
                           : closeVideoRecorder(context),
                     ),
+                    ?center,
                     AnimatedOpacity(
                       duration: _animationDuration,
                       opacity: hasClips ? 1 : 0,

--- a/mobile/lib/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
+import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_audio_progress_bar.dart';
+
+/// Lip-sync mode stack.
+///
+/// Identical to capture mode, with an audio-select chip added to the top bar
+/// so the user can pick a sound to lip-sync to, and the audio waveform
+/// progress bar overlaid while recording. Reuses the capture stack and only
+/// supplies the lip-sync-specific slots.
+class VideoRecorderLipSyncStack extends StatelessWidget {
+  const VideoRecorderLipSyncStack({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const VideoRecorderCaptureStack(
+      fromEditor: false,
+      topBarCenter: _LipSyncAudioButton(),
+      audioProgressBar: VideoRecorderAudioProgressBar(),
+    );
+  }
+}
+
+/// Audio-select chip wired to the recorder's selected sound.
+///
+/// Pauses remote-triggered recording while the selection sheet is open so a
+/// remote start can't fire behind the picker, mirroring the recorder's
+/// existing audio-chip behavior.
+class _LipSyncAudioButton extends ConsumerWidget {
+  const _LipSyncAudioButton();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedSound = ref.watch(
+      videoEditorProvider.select((s) => s.selectedSound),
+    );
+
+    return Flexible(
+      child: VideoEditorAudioChip(
+        selectedSound: selectedSound,
+        onSoundChanged: (sound) => _onSoundChanged(ref, sound),
+        onSelectionStarted: () => context.read<VideoRecorderBloc>().add(
+          const VideoRecorderRemoteRecordPaused(),
+        ),
+        onSelectionEnded: () => context.read<VideoRecorderBloc>().add(
+          const VideoRecorderRemoteRecordResumed(),
+        ),
+      ),
+    );
+  }
+
+  /// Adopts the newly selected [sound], discarding any recorded clips first.
+  ///
+  /// Recorded clips are synced to the previously selected sound, so changing
+  /// the selection invalidates them. Clips are cleared before the new sound is
+  /// stored because [ClipManagerNotifier.clearAll] resets the editor (which
+  /// would otherwise wipe the just-selected sound).
+  Future<void> _onSoundChanged(WidgetRef ref, AudioEvent? sound) async {
+    final previousSound = ref.read(videoEditorProvider).selectedSound;
+    if (sound != previousSound && ref.read(clipManagerProvider).hasClips) {
+      await ref.read(clipManagerProvider.notifier).clearAll();
+    }
+    ref.read(videoEditorProvider.notifier).selectSound(sound);
+  }
+}

--- a/mobile/lib/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart
@@ -102,6 +102,6 @@ class _LipSyncAudioButton extends ConsumerWidget {
     if (sound != previousSound && ref.read(clipManagerProvider).hasClips) {
       await ref.read(clipManagerProvider.notifier).clearAll();
     }
-    ref.read(videoEditorProvider.notifier).selectSound(sound);
+    ref.read(videoEditorProvider.notifier).selectRecorderAudioTrack(sound);
   }
 }

--- a/mobile/lib/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart
+++ b/mobile/lib/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart
@@ -1,13 +1,16 @@
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_audio_progress_bar.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_record_button.dart';
 
 /// Lip-sync mode stack.
 ///
@@ -24,7 +27,39 @@ class VideoRecorderLipSyncStack extends StatelessWidget {
       fromEditor: false,
       topBarCenter: _LipSyncAudioButton(),
       audioProgressBar: VideoRecorderAudioProgressBar(),
+      recordButton: _LipSyncRecordButton(),
     );
+  }
+}
+
+/// Record button gated on an audio selection.
+///
+/// Until a sound is picked it renders disabled (grayed) and a tap shows a
+/// snackbar telling the user to add audio first, rather than starting a
+/// recording that wouldn't be synced to anything.
+class _LipSyncRecordButton extends ConsumerWidget {
+  const _LipSyncRecordButton();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final hasSound = ref.watch(
+      videoEditorProvider.select((s) => s.selectedSound != null),
+    );
+
+    return RecordButton(
+      onBlockedTap: hasSound ? null : () => _showAddAudioSnackbar(context),
+    );
+  }
+
+  void _showAddAudioSnackbar(BuildContext context) {
+    ScaffoldMessenger.of(context)
+      ..removeCurrentSnackBar()
+      ..showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          context.l10n.videoRecorderLipSyncAddAudioFirst,
+          margin: const EdgeInsets.fromLTRB(16, 0, 16, 140),
+        ),
+      );
   }
 }
 

--- a/mobile/lib/widgets/video_recorder/video_recorder_audio_progress_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_audio_progress_bar.dart
@@ -35,10 +35,8 @@ class VideoRecorderAudioProgressBar extends ConsumerWidget {
       videoEditorProvider.select((s) => s.selectedSound),
     );
 
-    return Positioned(
-      top: 24,
-      left: 0,
-      right: 0,
+    return Align(
+      alignment: .topCenter,
       child: SafeArea(
         child: AnimatedSwitcher(
           duration: const Duration(milliseconds: 220),

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -11,7 +11,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/feed/video_feed_page.dart';
@@ -47,6 +49,13 @@ Future<void> openVideoEditorFromRecorder(
 
   final bloc = context.read<VideoRecorderBloc>();
   final recorderMode = bloc.state.recorderMode;
+
+  // Lip-sync records against a selected sound, so silence the clips before the
+  // editor: only the chosen audio should be heard, with the clips muted and
+  // the sound carried in as its own track (seeded on editor init).
+  if (recorderMode == VideoRecorderMode.lipSync) {
+    ref.read(clipManagerProvider.notifier).muteAllClips();
+  }
 
   if (!recorderMode.hasVideoEditor) {
     ref.read(videoEditorProvider.notifier).startRenderVideo();

--- a/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
@@ -10,10 +10,20 @@ import 'package:openvine/widgets/video_recorder/shutter_gesture_detector.dart';
 
 /// Circular record button for starting/stopping video recording.
 class RecordButton extends ConsumerWidget {
-  const RecordButton({super.key});
+  const RecordButton({this.onBlockedTap, super.key});
+
+  /// When non-null, the button is shown in a disabled (grayed) state and a tap
+  /// invokes this callback instead of starting recording. Lip-sync mode uses
+  /// this to require an audio selection before recording.
+  final VoidCallback? onBlockedTap;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final onBlockedTap = this.onBlockedTap;
+    if (onBlockedTap != null) {
+      return _BlockedRecordButton(onTap: onBlockedTap);
+    }
+
     final state = context.select(
       (VideoRecorderBloc b) => (
         isRecording: b.state.isRecording,
@@ -70,42 +80,84 @@ class RecordButton extends ConsumerWidget {
                 VideoRecorderZoomedByLongPress(details.localOffsetFromOrigin),
               )
             : null,
-        child: AnimatedOpacity(
-          duration: const Duration(milliseconds: 200),
-          opacity: isEnabled ? 1.0 : 0.5,
+        child: _RecordButtonVisual(
+          isEnabled: isEnabled,
+          isRecording: state.isRecording,
+        ),
+      ),
+    );
+  }
+}
+
+/// Record button shown disabled (grayed) with a tap that reports a reason
+/// instead of starting recording. Used by lip-sync mode to require an audio
+/// selection before recording.
+class _BlockedRecordButton extends StatelessWidget {
+  const _BlockedRecordButton({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      identifier: 'divine-camera-record-button',
+      button: true,
+      tooltip: context.l10n.videoRecorderStartRecordingTooltip,
+      onTap: onTap,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: const _RecordButtonVisual(isEnabled: false, isRecording: false),
+      ),
+    );
+  }
+}
+
+/// The visual chrome of the record button: a 96px ring with an inner shape
+/// that morphs between the idle dot and the recording square.
+class _RecordButtonVisual extends StatelessWidget {
+  const _RecordButtonVisual({
+    required this.isEnabled,
+    required this.isRecording,
+  });
+
+  final bool isEnabled;
+  final bool isRecording;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedOpacity(
+      duration: const Duration(milliseconds: 200),
+      opacity: isEnabled ? 1.0 : 0.5,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 100),
+        width: 96,
+        height: 96,
+        decoration: BoxDecoration(
+          border: .all(
+            color: isRecording ? VineTheme.error : VineTheme.whiteText,
+            width: 4,
+          ),
+          borderRadius: .circular(36),
+        ),
+        child: Center(
           child: AnimatedContainer(
-            duration: const Duration(milliseconds: 100),
-            width: 96,
-            height: 96,
-            decoration: BoxDecoration(
-              border: .all(
-                color: state.isRecording
-                    ? VineTheme.error
-                    : VineTheme.whiteText,
-                width: 4,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeOut,
+            width: isRecording ? 32 : 64,
+            height: isRecording ? 32 : 64,
+            decoration: ShapeDecoration(
+              color: VineTheme.error,
+              shape: RoundedRectangleBorder(
+                borderRadius: .circular(isRecording ? 6 : 20),
               ),
-              borderRadius: .circular(36),
-            ),
-            child: Center(
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 300),
-                curve: Curves.easeOut,
-                width: state.isRecording ? 32 : 64,
-                height: state.isRecording ? 32 : 64,
-                decoration: ShapeDecoration(
-                  color: VineTheme.error,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: .circular(state.isRecording ? 6 : 20),
-                  ),
-                  shadows: const [
-                    BoxShadow(
-                      color: VineTheme.innerShadow,
-                      blurRadius: 1,
-                      offset: Offset(1, 1),
-                    ),
-                  ],
+              shadows: const [
+                BoxShadow(
+                  color: VineTheme.innerShadow,
+                  blurRadius: 1,
+                  offset: Offset(1, 1),
                 ),
-              ),
+              ],
             ),
           ),
         ),

--- a/mobile/test/models/video_editor_state_test.dart
+++ b/mobile/test/models/video_editor_state_test.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show AudioEvent;
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_metadata/video_metadata_expiration.dart';
@@ -27,6 +28,7 @@ void main() {
       expect(state.inspiredByVideo, isNull);
       expect(state.inspiredByNpub, isNull);
       expect(state.selectedSound, isNull);
+      expect(state.seedSelectedSoundAsAudioTrack, isFalse);
       expect(state.contentWarnings, isEmpty);
       expect(state.proofManifestJson, isNull);
       expect(state.deleteButtonKey, isA<GlobalKey>());
@@ -108,11 +110,24 @@ void main() {
     });
 
     test('copyWith with clearSelectedSound sets sound to null', () {
-      final state = VideoEditorProviderState();
+      final state = VideoEditorProviderState(
+        selectedSound: _sound,
+        seedSelectedSoundAsAudioTrack: true,
+      );
 
       final cleared = state.copyWith(clearSelectedSound: true);
 
       expect(cleared.selectedSound, isNull);
+      expect(cleared.seedSelectedSoundAsAudioTrack, isFalse);
+    });
+
+    test('copyWith can mark selected sound as recorder audio handoff', () {
+      final state = VideoEditorProviderState(selectedSound: _sound);
+
+      final updated = state.copyWith(seedSelectedSoundAsAudioTrack: true);
+
+      expect(updated.selectedSound, _sound);
+      expect(updated.seedSelectedSoundAsAudioTrack, isTrue);
     });
 
     test('thumbnailTimestamp defaults to null', () {
@@ -190,3 +205,11 @@ void main() {
     });
   });
 }
+
+const _sound = AudioEvent(
+  id: 'sound-id',
+  pubkey: 'pubkey',
+  createdAt: 1704067200,
+  url: 'https://example.com/sound.mp3',
+  duration: 5,
+);

--- a/mobile/test/models/video_recorder/video_recorder_mode_test.dart
+++ b/mobile/test/models/video_recorder/video_recorder_mode_test.dart
@@ -9,6 +9,10 @@ void main() {
         expect(VideoRecorderMode.capture.label, equals('Capture'));
       });
 
+      test('lipSync has label "Lip Sync"', () {
+        expect(VideoRecorderMode.lipSync.label, equals('Lip Sync'));
+      });
+
       test('classic has label "Classic"', () {
         expect(VideoRecorderMode.classic.label, equals('Classic'));
       });
@@ -21,6 +25,10 @@ void main() {
     group('hasRecordingLimit', () {
       test('capture has no recording limit', () {
         expect(VideoRecorderMode.capture.hasRecordingLimit, isFalse);
+      });
+
+      test('lipSync has recording limit', () {
+        expect(VideoRecorderMode.lipSync.hasRecordingLimit, isTrue);
       });
 
       test('classic has recording limit', () {
@@ -37,6 +45,10 @@ void main() {
         expect(VideoRecorderMode.capture.hasVideoEditor, isTrue);
       });
 
+      test('lipSync has video editor', () {
+        expect(VideoRecorderMode.lipSync.hasVideoEditor, isTrue);
+      });
+
       test('classic has no video editor', () {
         expect(VideoRecorderMode.classic.hasVideoEditor, isFalse);
       });
@@ -49,6 +61,10 @@ void main() {
     group('supportGridLines', () {
       test('capture does not support grid lines', () {
         expect(VideoRecorderMode.capture.supportGridLines, isFalse);
+      });
+
+      test('lipSync does not support grid lines', () {
+        expect(VideoRecorderMode.lipSync.supportGridLines, isFalse);
       });
 
       test('classic supports grid lines', () {
@@ -64,6 +80,13 @@ void main() {
       test('capture defaults to vertical', () {
         expect(
           VideoRecorderMode.capture.defaultAspectRatio,
+          equals(model.AspectRatio.vertical),
+        );
+      });
+
+      test('lipSync defaults to vertical', () {
+        expect(
+          VideoRecorderMode.lipSync.defaultAspectRatio,
           equals(model.AspectRatio.vertical),
         );
       });

--- a/mobile/test/providers/clip_manager_provider_test.dart
+++ b/mobile/test/providers/clip_manager_provider_test.dart
@@ -80,6 +80,46 @@ void main() {
       expect(state.totalDuration, equals(const Duration(seconds: 2)));
     });
 
+    group('muteAllClips', () {
+      test('sets every clip volume to zero', () {
+        final notifier = container.read(clipManagerProvider.notifier);
+        notifier.addClip(
+          limitClipDuration: false,
+          video: EditorVideo.file('/path/to/video1.mp4'),
+          duration: const Duration(seconds: 2),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+        notifier.addClip(
+          limitClipDuration: false,
+          video: EditorVideo.file('/path/to/video2.mp4'),
+          duration: const Duration(seconds: 1),
+          targetAspectRatio: .vertical,
+          originalAspectRatio: 9 / 16,
+        );
+
+        expect(
+          container.read(clipManagerProvider).clips.every((c) => c.volume == 1),
+          isTrue,
+        );
+
+        notifier.muteAllClips();
+
+        expect(
+          container.read(clipManagerProvider).clips.every((c) => c.volume == 0),
+          isTrue,
+        );
+      });
+
+      test('does nothing when there are no clips', () {
+        final notifier = container.read(clipManagerProvider.notifier);
+
+        notifier.muteAllClips();
+
+        expect(container.read(clipManagerProvider).clips, isEmpty);
+      });
+    });
+
     test('deleteClip removes clip from state', () async {
       final notifier = container.read(clipManagerProvider.notifier);
 

--- a/mobile/test/widgets/video_editor/audio_editor/video_editor_audio_chip_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/video_editor_audio_chip_test.dart
@@ -171,6 +171,16 @@ void main() {
         // Callback is not invoked just by rendering
         expect(receivedSound, isNull);
       });
+
+      test('opens selection first when no sound is selected', () {
+        expect(VideoEditorAudioChip.shouldOpenTimingScreen(null), isFalse);
+      });
+
+      test('opens timing directly when a sound is selected', () {
+        final sound = _createTestAudioEvent(title: 'Test Sound');
+
+        expect(VideoEditorAudioChip.shouldOpenTimingScreen(sound), isTrue);
+      });
     });
   });
 }

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -121,6 +121,32 @@ void main() {
     );
   });
 
+  group('VideoEditorCanvas.shouldSeedSelectedSoundAsAudioTrack', () {
+    test('requires both a selected sound and recorder handoff flag', () {
+      expect(
+        VideoEditorCanvas.shouldSeedSelectedSoundAsAudioTrack(
+          hasSelectedSound: true,
+          seedSelectedSoundAsAudioTrack: true,
+        ),
+        isTrue,
+      );
+      expect(
+        VideoEditorCanvas.shouldSeedSelectedSoundAsAudioTrack(
+          hasSelectedSound: true,
+          seedSelectedSoundAsAudioTrack: false,
+        ),
+        isFalse,
+      );
+      expect(
+        VideoEditorCanvas.shouldSeedSelectedSoundAsAudioTrack(
+          hasSelectedSound: false,
+          seedSelectedSoundAsAudioTrack: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('VideoEditorCanvas.shouldSyncPlayerForClipStateChange', () {
     test('skips split render intermediate clip updates', () {
       final source = _createClip(id: 'source');

--- a/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar_test.dart
@@ -33,6 +33,7 @@ void main() {
       VideoRecorderState recordingState = VideoRecorderState.idle,
       List<DivineVideoClip>? clips,
       Duration activeRecordingDuration = Duration.zero,
+      bool showRecordingProgress = true,
     }) {
       when(() => recorderBloc.state).thenReturn(
         VideoRecorderBlocState(
@@ -53,10 +54,15 @@ void main() {
         ],
         child: BlocProvider<VideoRecorderBloc>.value(
           value: recorderBloc,
-          child: const MaterialApp(
+          child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: VideoRecorderCaptureTopBar(fromEditor: false)),
+            home: Scaffold(
+              body: VideoRecorderCaptureTopBar(
+                fromEditor: false,
+                showRecordingProgress: showRecordingProgress,
+              ),
+            ),
           ),
         ),
       );
@@ -182,6 +188,24 @@ void main() {
         // Should show combined duration 3s + 1s = "00:04"
         expect(find.textContaining('00:04'), findsOneWidget);
       });
+
+      testWidgets(
+        'hides the recording-progress bar when showRecordingProgress is false',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidget(
+              recordingState: VideoRecorderState.recording,
+              activeRecordingDuration: const Duration(seconds: 2),
+              showRecordingProgress: false,
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 300));
+
+          // The time display from the progress bar must not be rendered.
+          expect(find.textContaining('00:02'), findsNothing);
+        },
+      );
     });
   });
 }

--- a/mobile/test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart
@@ -241,7 +241,7 @@ void main() {
         await changeSound(tester, sound('b'));
 
         expect(clipNotifier.clearAllCallCount, 1);
-        expect(editorNotifier.selectSoundCalls, [sound('b')]);
+        expect(editorNotifier.selectRecorderAudioTrackCalls, [sound('b')]);
       });
 
       testWidgets('does not clear clips when the same sound is reselected', (
@@ -255,7 +255,7 @@ void main() {
         await changeSound(tester, sound('a'));
 
         expect(clipNotifier.clearAllCallCount, 0);
-        expect(editorNotifier.selectSoundCalls, [sound('a')]);
+        expect(editorNotifier.selectRecorderAudioTrackCalls, [sound('a')]);
       });
 
       testWidgets('does not clear when there are no recorded clips', (
@@ -267,7 +267,7 @@ void main() {
         await changeSound(tester, sound('b'));
 
         expect(clipNotifier.clearAllCallCount, 0);
-        expect(editorNotifier.selectSoundCalls, [sound('b')]);
+        expect(editorNotifier.selectRecorderAudioTrackCalls, [sound('b')]);
       });
     });
   });
@@ -296,7 +296,7 @@ class _TestVideoEditorNotifier extends VideoEditorNotifier {
   _TestVideoEditorNotifier({this.selectedSound});
 
   final AudioEvent? selectedSound;
-  final List<AudioEvent?> selectSoundCalls = [];
+  final List<AudioEvent?> selectRecorderAudioTrackCalls = [];
 
   @override
   VideoEditorProviderState build() {
@@ -304,8 +304,12 @@ class _TestVideoEditorNotifier extends VideoEditorNotifier {
   }
 
   @override
-  void selectSound(AudioEvent? sound) {
-    selectSoundCalls.add(sound);
-    state = state.copyWith(selectedSound: sound);
+  void selectRecorderAudioTrack(AudioEvent? sound) {
+    selectRecorderAudioTrackCalls.add(sound);
+    state = state.copyWith(
+      selectedSound: sound,
+      clearSelectedSound: sound == null,
+      seedSelectedSoundAsAudioTrack: sound != null,
+    );
   }
 }

--- a/mobile/test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart
@@ -18,6 +18,7 @@ import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_ch
 import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart';
 import 'package:openvine/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_audio_progress_bar.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_record_button.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -135,6 +136,58 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.textContaining('My Sound'), findsOneWidget);
+      });
+    });
+
+    group('record button gating', () {
+      AudioEvent sound(String id) => AudioEvent(
+        id: id,
+        pubkey: 'pubkey',
+        createdAt: 1704067200,
+        url: 'https://example.com/audio/$id.mp3',
+        title: id,
+        duration: 5,
+      );
+
+      testWidgets('blocks the record button when no sound is selected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        final recordButton = tester.widget<RecordButton>(
+          find.byType(RecordButton),
+        );
+        expect(recordButton.onBlockedTap, isNotNull);
+      });
+
+      testWidgets('shows a snackbar when tapping the blocked record button', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(RecordButton));
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text(l10n.videoRecorderLipSyncAddAudioFirst),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('does not block the record button when a sound is selected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(selectedSound: sound('a')));
+        await tester.pumpAndSettle();
+
+        final recordButton = tester.widget<RecordButton>(
+          find.byType(RecordButton),
+        );
+        expect(recordButton.onBlockedTap, isNull);
       });
     });
 

--- a/mobile/test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart
+++ b/mobile/test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart
@@ -1,0 +1,258 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/clip_manager_state.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/models/video_recorder/video_recorder_state.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
+import 'package:openvine/widgets/video_recorder/modes/capture/video_recorder_capture_stack.dart';
+import 'package:openvine/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack.dart';
+import 'package:openvine/widgets/video_recorder/video_recorder_audio_progress_bar.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockVideoRecorderBloc
+    extends MockBloc<VideoRecorderEvent, VideoRecorderBlocState>
+    implements VideoRecorderBloc {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(VideoRecorderLipSyncStack, () {
+    late _MockVideoRecorderBloc recorderBloc;
+    late SharedPreferences testPrefs;
+    late _TestClipManagerNotifier clipNotifier;
+    late _TestVideoEditorNotifier editorNotifier;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      testPrefs = await SharedPreferences.getInstance();
+      recorderBloc = _MockVideoRecorderBloc();
+    });
+
+    Widget buildWidget({
+      VideoRecorderState recordingState = VideoRecorderState.idle,
+      AudioEvent? selectedSound,
+      List<DivineVideoClip>? clips,
+    }) {
+      when(() => recorderBloc.state).thenReturn(
+        VideoRecorderBlocState(
+          recordingState: recordingState,
+          isCameraInitialized: true,
+          canRecord: true,
+        ),
+      );
+
+      clipNotifier = _TestClipManagerNotifier(clips: clips ?? []);
+      editorNotifier = _TestVideoEditorNotifier(selectedSound: selectedSound);
+
+      return ProviderScope(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(testPrefs),
+          clipManagerProvider.overrideWith(() => clipNotifier),
+          videoEditorProvider.overrideWith(() => editorNotifier),
+        ],
+        child: BlocProvider<VideoRecorderBloc>.value(
+          value: recorderBloc,
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Scaffold(body: VideoRecorderLipSyncStack()),
+          ),
+        ),
+      );
+    }
+
+    group('renders', () {
+      testWidgets('renders $VideoRecorderLipSyncStack', (tester) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoRecorderLipSyncStack), findsOneWidget);
+      });
+
+      testWidgets('reuses $VideoRecorderCaptureStack', (tester) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoRecorderCaptureStack), findsOneWidget);
+      });
+
+      testWidgets('renders the $VideoEditorAudioChip in the top bar', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoEditorAudioChip), findsOneWidget);
+      });
+
+      testWidgets('wires in the $VideoRecorderAudioProgressBar', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.byType(VideoRecorderAudioProgressBar), findsOneWidget);
+      });
+
+      testWidgets('shows the add-audio label when no sound selected', (
+        tester,
+      ) async {
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        expect(find.text(l10n.videoEditorAudioAddAudio), findsOneWidget);
+      });
+
+      testWidgets('shows the selected sound title when a sound is selected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            selectedSound: const AudioEvent(
+              id: 'sound-1',
+              pubkey: 'pubkey',
+              createdAt: 1704067200,
+              url: 'https://example.com/audio/sound-1.mp3',
+              title: 'My Sound',
+              duration: 5,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('My Sound'), findsOneWidget);
+      });
+    });
+
+    group('recording', () {
+      testWidgets('hides the audio chip while recording', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(recordingState: VideoRecorderState.recording),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(find.byType(VideoEditorAudioChip), findsNothing);
+      });
+    });
+
+    group('changing the sound selection', () {
+      AudioEvent sound(String id) => AudioEvent(
+        id: id,
+        pubkey: 'pubkey',
+        createdAt: 1704067200,
+        url: 'https://example.com/audio/$id.mp3',
+        title: id,
+        duration: 5,
+      );
+
+      DivineVideoClip clip() => DivineVideoClip(
+        id: 'clip1',
+        video: EditorVideo.file('/test/clip1.mp4'),
+        duration: const Duration(seconds: 2),
+        recordedAt: DateTime.now(),
+        targetAspectRatio: .vertical,
+        originalAspectRatio: 9 / 16,
+      );
+
+      Future<void> changeSound(WidgetTester tester, AudioEvent? next) async {
+        final chip = tester.widget<VideoEditorAudioChip>(
+          find.byType(VideoEditorAudioChip),
+        );
+        chip.onSoundChanged(next);
+        await tester.pumpAndSettle();
+      }
+
+      testWidgets('clears recorded clips when a different sound is selected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(selectedSound: sound('a'), clips: [clip()]),
+        );
+        await tester.pumpAndSettle();
+
+        await changeSound(tester, sound('b'));
+
+        expect(clipNotifier.clearAllCallCount, 1);
+        expect(editorNotifier.selectSoundCalls, [sound('b')]);
+      });
+
+      testWidgets('does not clear clips when the same sound is reselected', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(selectedSound: sound('a'), clips: [clip()]),
+        );
+        await tester.pumpAndSettle();
+
+        await changeSound(tester, sound('a'));
+
+        expect(clipNotifier.clearAllCallCount, 0);
+        expect(editorNotifier.selectSoundCalls, [sound('a')]);
+      });
+
+      testWidgets('does not clear when there are no recorded clips', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(selectedSound: sound('a')));
+        await tester.pumpAndSettle();
+
+        await changeSound(tester, sound('b'));
+
+        expect(clipNotifier.clearAllCallCount, 0);
+        expect(editorNotifier.selectSoundCalls, [sound('b')]);
+      });
+    });
+  });
+}
+
+class _TestClipManagerNotifier extends ClipManagerNotifier {
+  _TestClipManagerNotifier({required this.clips});
+
+  @override
+  final List<DivineVideoClip> clips;
+
+  int clearAllCallCount = 0;
+
+  @override
+  ClipManagerState build() {
+    return ClipManagerState(clips: clips);
+  }
+
+  @override
+  Future<void> clearAll({bool keepAutosavedDraft = false}) async {
+    clearAllCallCount++;
+  }
+}
+
+class _TestVideoEditorNotifier extends VideoEditorNotifier {
+  _TestVideoEditorNotifier({this.selectedSound});
+
+  final AudioEvent? selectedSound;
+  final List<AudioEvent?> selectSoundCalls = [];
+
+  @override
+  VideoEditorProviderState build() {
+    return VideoEditorProviderState(selectedSound: selectedSound);
+  }
+
+  @override
+  void selectSound(AudioEvent? sound) {
+    selectSoundCalls.add(sound);
+    state = state.copyWith(selectedSound: sound);
+  }
+}

--- a/mobile/test/widgets/video_recorder/video_recorder_audio_progress_bar_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_audio_progress_bar_test.dart
@@ -226,7 +226,7 @@ void main() {
         );
       });
 
-      testWidgets('renders within Positioned widget', (tester) async {
+      testWidgets('aligns its content to the top', (tester) async {
         await tester.pumpWidget(
           buildWidget(
             recordingState: VideoRecorderState.recording,
@@ -239,7 +239,15 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.byType(Positioned), findsWidgets);
+        final align = tester.widget<Align>(
+          find
+              .descendant(
+                of: find.byType(VideoRecorderAudioProgressBar),
+                matching: find.byType(Align),
+              )
+              .first,
+        );
+        expect(align.alignment, Alignment.topCenter);
       });
 
       testWidgets('uses SafeArea for status bar padding', (tester) async {

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -13,8 +13,11 @@ import 'package:go_router/go_router.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/clip_manager_state.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
+import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/library_screen.dart';
@@ -54,11 +57,13 @@ void main() {
   late _MockAuthService mockAuthService;
   late _MockVideoRecorderBloc recorderBloc;
   late _FakeVideoEditorNotifier fakeEditor;
+  late _FakeClipManagerNotifier fakeClipManager;
 
   setUp(() {
     mockAuthService = _MockAuthService();
     recorderBloc = _MockVideoRecorderBloc();
     fakeEditor = _FakeVideoEditorNotifier();
+    fakeClipManager = _FakeClipManagerNotifier();
 
     when(() => recorderBloc.state).thenReturn(const VideoRecorderBlocState());
     when(
@@ -97,6 +102,7 @@ void main() {
       overrides: [
         authServiceProvider.overrideWithValue(mockAuthService),
         videoEditorProvider.overrideWith(() => fakeEditor),
+        clipManagerProvider.overrideWith(() => fakeClipManager),
       ],
       child: MaterialApp.router(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -136,6 +142,35 @@ void main() {
 
         expect(find.text('library'), findsOneWidget);
         expect(fakeEditor.saveAsDraftCalled, isFalse);
+      });
+
+      testWidgets('openVideoEditorFromRecorder mutes clips in lip-sync mode', (
+        tester,
+      ) async {
+        when(() => recorderBloc.state).thenReturn(
+          const VideoRecorderBlocState(recorderMode: VideoRecorderMode.lipSync),
+        );
+
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('open-editor')));
+        await tester.pumpAndSettle();
+
+        expect(fakeClipManager.muteAllClipsCalled, isTrue);
+        expect(find.text('editor'), findsOneWidget);
+      });
+
+      testWidgets('openVideoEditorFromRecorder does not mute clips in '
+          'capture mode', (tester) async {
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('open-editor')));
+        await tester.pumpAndSettle();
+
+        expect(fakeClipManager.muteAllClipsCalled, isFalse);
+        expect(find.text('editor'), findsOneWidget);
       });
     });
 
@@ -188,6 +223,18 @@ void main() {
       });
     });
   });
+}
+
+class _FakeClipManagerNotifier extends ClipManagerNotifier {
+  bool muteAllClipsCalled = false;
+
+  @override
+  ClipManagerState build() => ClipManagerState();
+
+  @override
+  void muteAllClips() {
+    muteAllClipsCalled = true;
+  }
 }
 
 class _RecorderHarness extends ConsumerWidget {

--- a/mobile/test/widgets/video_recorder/video_recorder_record_button_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_record_button_test.dart
@@ -37,6 +37,7 @@ void main() {
       bool canRecord = true,
       bool isCameraInitialized = true,
       List<DivineVideoClip>? clips,
+      VoidCallback? onBlockedTap,
     }) {
       when(() => recorderBloc.state).thenReturn(
         VideoRecorderBlocState(
@@ -55,10 +56,12 @@ void main() {
         ],
         child: BlocProvider<VideoRecorderBloc>.value(
           value: recorderBloc,
-          child: const MaterialApp(
+          child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(body: Center(child: RecordButton())),
+            home: Scaffold(
+              body: Center(child: RecordButton(onBlockedTap: onBlockedTap)),
+            ),
           ),
         ),
       );
@@ -163,6 +166,39 @@ void main() {
           find.byType(AnimatedOpacity),
         );
         expect(opacity.opacity, equals(1.0));
+      });
+    });
+
+    group('blocked state', () {
+      testWidgets('renders grayed out when onBlockedTap is provided', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(onBlockedTap: () {}));
+        await tester.pumpAndSettle();
+
+        final opacity = tester.widget<AnimatedOpacity>(
+          find.byType(AnimatedOpacity),
+        );
+        expect(opacity.opacity, equals(0.5));
+      });
+
+      testWidgets('tap invokes onBlockedTap instead of starting recording', (
+        tester,
+      ) async {
+        var blockedTaps = 0;
+        await tester.pumpWidget(buildWidget(onBlockedTap: () => blockedTaps++));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byType(RecordButton));
+        await tester.pumpAndSettle();
+
+        expect(blockedTaps, equals(1));
+        verifyNever(
+          () => recorderBloc.add(const VideoRecorderRecordingToggleRequested()),
+        );
+        verifyNever(
+          () => recorderBloc.add(const VideoRecorderRecordingStartRequested()),
+        );
       });
     });
 


### PR DESCRIPTION
Closes #5349

## Summary

Adds a new **Lip Sync** recorder mode. It mirrors capture mode with two
differences: an audio-select chip in the top bar so you pick a sound to
lip-sync to, and the audio waveform progress bar shown while recording. Like
classic mode, it enforces the 6.3s recording limit and auto-stops. On handoff
to the editor, the clips are muted and the chosen sound becomes the timeline's
own editable audio track.

<img width="322" alt="image" src="https://github.com/user-attachments/assets/010d807c-0d39-47fb-8ccb-d7e75a9c303b" />

## Changes

- **New `lipSync` mode** in `VideoRecorderMode` (vertical, has video editor,
  countdown timer, **recording limit on** -> stops at `maxDuration` = 6.3s).
  Wired into the recorder screen and metadata screen switches.
- **Reuses the capture stack** via optional slots: `topBarCenter` (the
  `VideoEditorAudioChip`), `audioProgressBar` (`VideoRecorderAudioProgressBar`),
  and `recordButton`. When the waveform is shown, the top bar's generic
  recording-progress line is suppressed so the two don't overlap. Capture mode
  is unchanged.
- **Record button gated on audio selection:** until a sound is picked the
  record button is grayed out, and tapping it shows a snackbar ("Add audio
  before recording") instead of starting a recording that wouldn't be synced.
- **Explicit editor handoff:** lip-sync now marks the selected sound as a
  recorder-backed audio handoff. The editor only seeds that sound into the
  timeline when this handoff flag is set, so generic editor/draft selected
  audio cannot accidentally create a duplicate timeline track.
- **Clip audio handling:** when leaving the lip-sync recorder, all clips are
  muted (`ClipManagerNotifier.muteAllClips`) and the selected sound is seeded
  as the editor timeline's own audio track on fresh entry, so only the chosen
  sound is heard and it stays visible/editable.
- **Eager `SoundWaveformBloc`** (`lazy: false`): waveform extraction now runs
  when a sound is picked, not only once recording starts. The provider
  previously had no consumer and never ran.
- **Top-aligns** the audio waveform progress bar so it sits below the status
  bar.
- **Fix:** `VideoEditorAudioChip` opened the audio timing screen twice for
  sounds longer than the max duration (the selection sheet already handles
  trimming). It now uses the sheet's result directly for new selections and
  only opens the timing screen when re-editing an existing sound.
- **Resets recorded clips** when the audio selection changes, since clips are
  synced to the previously selected sound.

## Test plan

- `mise exec -- flutter analyze lib test`
- `mise exec -- flutter test test/models/video_recorder/video_recorder_mode_test.dart test/models/video_editor_state_test.dart test/providers/clip_manager_provider_test.dart test/widgets/video_recorder/video_recorder_navigation_test.dart test/widgets/video_recorder/video_recorder_record_button_test.dart test/widgets/video_recorder/video_recorder_audio_progress_bar_test.dart test/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar_test.dart test/widgets/video_recorder/modes/lip_sync/video_recorder_lip_sync_stack_test.dart test/widgets/video_editor/audio_editor/video_editor_audio_chip_test.dart test/widgets/video_editor/main_editor/video_editor_canvas_test.dart`
- Pre-push hook also ran analyzer and changed-file tests successfully before
  pushing `2388947461`.

## Notes

- Waveform extraction covers bundled and Nostr sounds; purely local-imported
  audio (no URL) has no waveform — pre-existing `SoundWaveformBloc` limitation.
