### PR TITLE
feat(camera): add single-photo capture for stop-motion

### DIFF
--- a/mobile/integration_test/video_recorder/camera_photo_capture_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_photo_capture_integration_test.dart
@@ -50,7 +50,6 @@ void main() {
         onUpdateState: ({forceCameraRebuild}) {},
         onAutoStopped: (_) {},
       );
-      await cameraService.initialize();
     });
 
     tearDown(() async {
@@ -59,6 +58,7 @@ void main() {
 
     patrolTest('captures a single photo and writes a JPEG to disk', ($) async {
       await _grantPermissions($);
+      await cameraService.initialize();
 
       final result = await cameraService.capturePhoto();
 
@@ -72,6 +72,7 @@ void main() {
 
     patrolTest('captures multiple frames in sequence (stop-motion)', ($) async {
       await _grantPermissions($);
+      await cameraService.initialize();
       final tester = $.tester;
 
       final results = <PhotoCaptureResult>[];
@@ -96,6 +97,7 @@ void main() {
       $,
     ) async {
       await _grantPermissions($);
+      await cameraService.initialize();
 
       final dir = await Directory.systemTemp.createTemp('stop_motion_frames');
       try {

--- a/mobile/integration_test/video_recorder/camera_photo_capture_integration_test.dart
+++ b/mobile/integration_test/video_recorder/camera_photo_capture_integration_test.dart
@@ -1,0 +1,116 @@
+// ABOUTME: Integration tests for single-photo (stop-motion) capture
+// ABOUTME: Tests that capturePhoto writes real JPEG frames to disk on device
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:divine_camera/divine_camera.dart' show PhotoCaptureResult;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
+import 'package:patrol/patrol.dart';
+import 'package:permissions_service/permissions_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Grant camera and microphone permissions via Patrol native automation.
+Future<void> _grantPermissions(PatrolIntegrationTester $) async {
+  const service = PermissionHandlerPermissionsService();
+  unawaited(service.requestCameraPermission());
+  if (await $.platformAutomator.mobile.isPermissionDialogVisible(
+    timeout: const Duration(seconds: 5),
+  )) {
+    await $.platformAutomator.mobile.grantPermissionWhenInUse();
+  }
+  unawaited(service.requestMicrophonePermission());
+  if (await $.platformAutomator.mobile.isPermissionDialogVisible(
+    timeout: const Duration(seconds: 5),
+  )) {
+    await $.platformAutomator.mobile.grantPermissionWhenInUse();
+  }
+}
+
+void main() {
+  group('Camera Photo Capture Integration Tests', () {
+    late CameraService cameraService;
+
+    setUpAll(() async {
+      Log.info(
+        'Running Camera Photo Capture Integration Tests',
+        name: 'CameraPhotoCaptureIntegrationTest',
+        category: LogCategory.system,
+      );
+      Log.info(
+        'Platform: ${Platform.operatingSystem}',
+        name: 'CameraPhotoCaptureIntegrationTest',
+        category: LogCategory.system,
+      );
+    });
+
+    setUp(() async {
+      cameraService = CameraService.create(
+        onUpdateState: ({forceCameraRebuild}) {},
+        onAutoStopped: (_) {},
+      );
+      await cameraService.initialize();
+    });
+
+    tearDown(() async {
+      await cameraService.dispose();
+    });
+
+    patrolTest('captures a single photo and writes a JPEG to disk', ($) async {
+      await _grantPermissions($);
+
+      final result = await cameraService.capturePhoto();
+
+      expect(result, isNotNull);
+      expect(result!.filePath, endsWith('.jpg'));
+
+      final file = File(result.filePath);
+      expect(file.existsSync(), isTrue);
+      expect(file.lengthSync(), greaterThan(0));
+    });
+
+    patrolTest('captures multiple frames in sequence (stop-motion)', ($) async {
+      await _grantPermissions($);
+      final tester = $.tester;
+
+      final results = <PhotoCaptureResult>[];
+      for (var i = 0; i < 3; i++) {
+        final result = await cameraService.capturePhoto();
+        expect(result, isNotNull);
+        results.add(result!);
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      // Every frame produced a distinct, non-empty file on disk.
+      final paths = results.map((r) => r.filePath).toSet();
+      expect(paths, hasLength(3));
+      for (final result in results) {
+        final file = File(result.filePath);
+        expect(file.existsSync(), isTrue);
+        expect(file.lengthSync(), greaterThan(0));
+      }
+    });
+
+    patrolTest('writes the photo into the provided output directory', (
+      $,
+    ) async {
+      await _grantPermissions($);
+
+      final dir = await Directory.systemTemp.createTemp('stop_motion_frames');
+      try {
+        final result = await cameraService.capturePhoto(
+          outputDirectory: dir.path,
+        );
+
+        expect(result, isNotNull);
+        expect(result!.filePath, startsWith(dir.path));
+        expect(File(result.filePath).existsSync(), isTrue);
+      } finally {
+        if (dir.existsSync()) {
+          await dir.delete(recursive: true);
+        }
+      }
+    });
+  });
+}

--- a/mobile/lib/services/video_recorder/camera/camera_base_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_base_service.dart
@@ -6,7 +6,8 @@ import 'package:divine_camera/divine_camera.dart'
         CameraLensMetadata,
         DivineCameraLens,
         DivineVideoQuality,
-        DivineVideoStabilizationMode;
+        DivineVideoStabilizationMode,
+        PhotoCaptureResult;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
@@ -86,6 +87,12 @@ abstract class CameraService {
 
   /// Stops video recording.
   Future<EditorVideo?> stopRecording();
+
+  /// Captures a single still photo (e.g. for stop-motion).
+  ///
+  /// [outputDirectory] specifies where to save the photo. Returns the
+  /// captured photo, or null if the camera is not ready or capture failed.
+  Future<PhotoCaptureResult?> capturePhoto({String? outputDirectory});
 
   /// Handles app lifecycle changes (pause, resume, etc.).
   Future<void> handleAppLifecycleState(AppLifecycleState state);

--- a/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_linux_service.dart
@@ -6,7 +6,8 @@ import 'package:divine_camera/divine_camera.dart'
         CameraLensMetadata,
         DivineCameraLens,
         DivineVideoQuality,
-        DivineVideoStabilizationMode;
+        DivineVideoStabilizationMode,
+        PhotoCaptureResult;
 import 'package:flutter/widgets.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
@@ -128,6 +129,10 @@ class CameraLinuxService extends CameraService {
 
   @override
   Future<EditorVideo?> stopRecording() async => null;
+
+  @override
+  Future<PhotoCaptureResult?> capturePhoto({String? outputDirectory}) async =>
+      null;
 
   @override
   Future<void> handleAppLifecycleState(AppLifecycleState state) async {

--- a/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
+++ b/mobile/lib/services/video_recorder/camera/camera_mobile_service.dart
@@ -341,6 +341,42 @@ class CameraMobileService extends CameraService {
   }
 
   @override
+  Future<PhotoCaptureResult?> capturePhoto({String? outputDirectory}) async {
+    if (!_isInitialized) return null;
+    try {
+      final docsDir = await getDocumentsPath();
+      final outputPath = outputDirectory ?? docsDir;
+
+      Log.info(
+        '📷 Capturing photo to: $outputPath',
+        name: 'CameraMobileService',
+        category: .video,
+      );
+
+      final result = await _camera.capturePhoto(
+        outputDirectory: outputPath,
+        useCache: false,
+      );
+
+      if (result == null) {
+        Log.warning(
+          '📷 Photo capture returned no result',
+          name: 'CameraMobileService',
+          category: .video,
+        );
+      }
+      return result;
+    } catch (e) {
+      Log.error(
+        '📷 Failed to capture photo (unexpected error): $e',
+        name: 'CameraMobileService',
+        category: .video,
+      );
+      return null;
+    }
+  }
+
+  @override
   Future<void> handleAppLifecycleState(AppLifecycleState state) async {
     return _camera.handleAppLifecycleState(state);
   }

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -8,6 +8,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.BitmapFactory
 import android.graphics.SurfaceTexture
 import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraCharacteristics
@@ -52,6 +53,11 @@ class CameraController(
     private var preview: Preview? = null
     private var videoCapture: VideoCapture<Recorder>? = null
     private var recording: Recording? = null
+
+    // Still-photo use case for single-frame (stop-motion) capture. Null when the
+    // device cannot bind it concurrently with Preview + VideoCapture, in which
+    // case photo capture is unavailable but video keeps working.
+    private var imageCapture: ImageCapture? = null
 
     private var textureEntry: TextureRegistry.SurfaceTextureEntry? = null
     private var flutterSurfaceTexture: SurfaceTexture? = null
@@ -893,12 +899,7 @@ class CameraController(
             DivineCameraLog.d(TAG, "Binding use cases to lifecycle...")
 
             // Bind use cases to camera
-            camera = provider.bindToLifecycle(
-                activity as LifecycleOwner,
-                cameraSelector,
-                preview,
-                videoCapture
-            )
+            camera = bindUseCasesWithPhoto(provider, cameraSelector)
 
             DivineCameraLog.d(TAG, "Camera bound successfully")
 
@@ -1045,12 +1046,7 @@ class CameraController(
                 .build()
 
             // Bind use cases to the new camera
-            camera = provider.bindToLifecycle(
-                activity as LifecycleOwner,
-                cameraSelector,
-                preview,
-                videoCapture
-            )
+            camera = bindUseCasesWithPhoto(provider, cameraSelector)
 
             // Get camera info from new camera
             camera?.let { cam ->
@@ -1623,12 +1619,7 @@ class CameraController(
                 )
                 .build()
 
-            camera = provider.bindToLifecycle(
-                activity as LifecycleOwner,
-                cameraSelector,
-                preview,
-                videoCapture
-            )
+            camera = bindUseCasesWithPhoto(provider, cameraSelector)
 
             camera?.let { cam ->
                 val zoomState =
@@ -1801,6 +1792,98 @@ class CameraController(
         AudioStats.AUDIO_STATE_ENCODER_ERROR -> "ENCODER_ERROR"
         AudioStats.AUDIO_STATE_SOURCE_ERROR -> "SOURCE_ERROR"
         else -> "UNKNOWN($state)"
+    }
+
+    /**
+     * Binds Preview + VideoCapture + ImageCapture, falling back to
+     * Preview + VideoCapture when the device cannot support all three
+     * concurrently. When the photo use case is dropped, [imageCapture] is left
+     * null (photo capture unavailable) and video recording keeps working.
+     */
+    private fun bindUseCasesWithPhoto(
+        provider: ProcessCameraProvider,
+        cameraSelector: CameraSelector
+    ): Camera? {
+        val owner = activity as LifecycleOwner
+        val photo = ImageCapture.Builder()
+            .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
+            .setFlashMode(currentFlashMode)
+            .build()
+        return try {
+            val bound = provider.bindToLifecycle(
+                owner, cameraSelector, preview, videoCapture, photo
+            )
+            imageCapture = photo
+            bound
+        } catch (e: Exception) {
+            DivineCameraLog.e(
+                TAG,
+                "Cannot bind ImageCapture with Preview+VideoCapture; photo " +
+                    "capture disabled on this device: ${e.message}"
+            )
+            imageCapture = null
+            provider.unbindAll()
+            provider.bindToLifecycle(owner, cameraSelector, preview, videoCapture)
+        }
+    }
+
+    /**
+     * Captures a single still photo and writes it to disk as JPEG.
+     * @param outputDirectory If provided, saves the photo there; otherwise uses
+     *   the cache or files directory per [useCache].
+     * @param useCache If true, saves to the cache directory (temporary),
+     *   otherwise the files directory (permanent).
+     * @param callback Result map (`filePath`, `width`, `height`) on success, or
+     *   null plus an error message on failure. Invoked on the main thread.
+     */
+    fun capturePhoto(
+        outputDirectory: String?,
+        useCache: Boolean,
+        callback: (Map<String, Any?>?, String?) -> Unit
+    ) {
+        val capture = imageCapture
+        if (capture == null) {
+            callback(null, "Photo capture not available")
+            return
+        }
+        if (isRecording) {
+            callback(null, "Cannot capture photo while recording")
+            return
+        }
+
+        val outputDir = when {
+            outputDirectory != null -> File(outputDirectory)
+            useCache -> context.cacheDir
+            else -> context.filesDir
+        }
+        if (!outputDir.exists()) outputDir.mkdirs()
+        val photoFile = File(outputDir, "IMG_${System.currentTimeMillis()}.jpg")
+        val options = ImageCapture.OutputFileOptions.Builder(photoFile).build()
+
+        capture.takePicture(
+            options,
+            cameraExecutor,
+            object : ImageCapture.OnImageSavedCallback {
+                override fun onImageSaved(output: ImageCapture.OutputFileResults) {
+                    val bounds = BitmapFactory.Options().apply {
+                        inJustDecodeBounds = true
+                    }
+                    BitmapFactory.decodeFile(photoFile.absolutePath, bounds)
+                    val map = mapOf(
+                        "filePath" to photoFile.absolutePath,
+                        "width" to bounds.outWidth.takeIf { it > 0 },
+                        "height" to bounds.outHeight.takeIf { it > 0 }
+                    )
+                    mainHandler.post { callback(map, null) }
+                }
+
+                override fun onError(exception: ImageCaptureException) {
+                    mainHandler.post {
+                        callback(null, exception.message ?: "Photo capture failed")
+                    }
+                }
+            }
+        )
     }
 
     /**

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -17,6 +17,7 @@ import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
 import android.hardware.camera2.CaptureResult
 import android.hardware.camera2.TotalCaptureResult
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.Surface
@@ -1896,8 +1897,14 @@ class CameraController(
         )
     }
 
-    private fun currentTargetRotation(): Int =
-        activity.windowManager.defaultDisplay.rotation
+    @Suppress("DEPRECATION")
+    private fun currentTargetRotation(): Int {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.display?.rotation ?: Surface.ROTATION_0
+        } else {
+            activity.windowManager.defaultDisplay.rotation
+        }
+    }
 
     private fun applyPhotoFlashMode() {
         imageCapture?.flashMode = currentFlashMode

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -1096,6 +1096,8 @@ class CameraController(
                     enableScreenFlash()
                     isTorchEnabled = true
                     isAutoFlashMode = false
+                    currentFlashMode = ImageCapture.FLASH_MODE_OFF
+                    applyPhotoFlashMode()
                     return true
                 } else if (mode == "auto") {
                     // Auto mode for front camera - will check brightness when recording starts
@@ -1103,6 +1105,7 @@ class CameraController(
                     isTorchEnabled = false
                     isAutoFlashMode = true
                     currentFlashMode = ImageCapture.FLASH_MODE_AUTO
+                    applyPhotoFlashMode()
                     DivineCameraLog.d(TAG, "Auto flash mode enabled for front camera")
                     return true
                 } else {
@@ -1141,8 +1144,10 @@ class CameraController(
                     cam.cameraControl.enableTorch(true)
                     isTorchEnabled = true
                     isAutoFlashMode = false
+                    currentFlashMode = ImageCapture.FLASH_MODE_OFF
                 }
             }
+            applyPhotoFlashMode()
             true
         } catch (e: Exception) {
             DivineCameraLog.e(TAG, "Failed to set flash mode", e)
@@ -1807,6 +1812,8 @@ class CameraController(
         val owner = activity as LifecycleOwner
         val photo = ImageCapture.Builder()
             .setCaptureMode(ImageCapture.CAPTURE_MODE_MINIMIZE_LATENCY)
+            .setTargetAspectRatio(AspectRatio.RATIO_16_9)
+            .setTargetRotation(currentTargetRotation())
             .setFlashMode(currentFlashMode)
             .build()
         return try {
@@ -1851,6 +1858,9 @@ class CameraController(
             return
         }
 
+        capture.targetRotation = currentTargetRotation()
+        capture.flashMode = currentFlashMode
+
         val outputDir = when {
             outputDirectory != null -> File(outputDirectory)
             useCache -> context.cacheDir
@@ -1884,6 +1894,13 @@ class CameraController(
                 }
             }
         )
+    }
+
+    private fun currentTargetRotation(): Int =
+        activity.windowManager.defaultDisplay.rotation
+
+    private fun applyPhotoFlashMode() {
+        imageCapture?.flashMode = currentFlashMode
     }
 
     /**

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
@@ -144,6 +144,12 @@ class DivineCameraPlugin :
                 stopRecording(oneShotResult)
             }
 
+            "capturePhoto" -> {
+                val useCache = call.argument<Boolean>("useCache") ?: true
+                val outputDirectory = call.argument<String>("outputDirectory")
+                capturePhoto(useCache, outputDirectory, oneShotResult)
+            }
+
             "pausePreview" -> {
                 pausePreview(oneShotResult)
             }
@@ -376,6 +382,25 @@ class DivineCameraPlugin :
             }
         } catch (e: Exception) {
             result.error("RECORD_STOP_EXCEPTION", e.message, null)
+        }
+    }
+
+    private fun capturePhoto(useCache: Boolean, outputDirectory: String?, result: Result) {
+        val controller = cameraController
+        if (controller == null) {
+            result.error("NOT_INITIALIZED", "Camera not initialized", null)
+            return
+        }
+        try {
+            controller.capturePhoto(outputDirectory, useCache) { photoResult, error ->
+                if (error != null) {
+                    result.error("PHOTO_CAPTURE_ERROR", error, null)
+                } else {
+                    result.success(photoResult)
+                }
+            }
+        } catch (e: Exception) {
+            result.error("PHOTO_CAPTURE_EXCEPTION", e.message, null)
         }
     }
 

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -21,7 +21,15 @@ class CameraController: NSObject {
     private var audioInput: AVCaptureDeviceInput?
     private var videoOutput: AVCaptureVideoDataOutput?
     private var audioOutput: AVCaptureAudioDataOutput?
-    
+
+    /// Still-photo output for single-frame capture (stop-motion). Added at
+    /// session setup alongside the video data output; AVCapturePhotoOutput
+    /// coexists with AVCaptureVideoDataOutput (unlike AVCaptureMovieFileOutput).
+    private var photoOutput: AVCapturePhotoOutput?
+    /// Retains in-flight photo capture delegates until their completion fires —
+    /// AVCapturePhotoOutput does not retain its delegate.
+    private var activePhotoDelegates: [PhotoCaptureDelegate] = []
+
     // AVAssetWriter for video recording (replaces AVCaptureMovieFileOutput)
     private var assetWriter: AVAssetWriter?
     private var videoWriterInput: AVAssetWriterInput?
@@ -718,7 +726,22 @@ class CameraController: NSObject {
         } else {
             DivineCameraLog.shared.error("DivineCamera: Cannot add video output to session", name: "DivineCamera.Setup")
         }
-        
+
+        // Still-photo output for single-frame (stop-motion) capture. Safe to add
+        // here: AVCapturePhotoOutput does not conflict with the video data output.
+        let photoOutput = AVCapturePhotoOutput()
+        if session.canAddOutput(photoOutput) {
+            session.addOutput(photoOutput)
+            self.photoOutput = photoOutput
+            if let connection = photoOutput.connection(with: .video),
+               connection.isVideoOrientationSupported {
+                connection.videoOrientation = .portrait
+            }
+            DivineCameraLog.shared.debug("DivineCamera: Photo output added successfully")
+        } else {
+            DivineCameraLog.shared.error("DivineCamera: Cannot add photo output to session", name: "DivineCamera.Setup")
+        }
+
         // NOTE: AVCaptureAudioDataOutput is also added lazily in startRecording().
         
         // NOTE: MovieOutput is intentionally NOT added here during initialization.
@@ -2153,6 +2176,48 @@ class CameraController: NSObject {
 // MARK: - FlutterTexture
 
 extension CameraController: FlutterTexture {
+    /// Captures a single still photo and writes it to disk as JPEG.
+    ///
+    /// Completion is invoked with a result map (`filePath`, `width`, `height`)
+    /// on success, or nil plus an error message on failure. Rejected while a
+    /// video recording is in progress.
+    func capturePhoto(
+        outputDirectory: String?,
+        useCache: Bool,
+        completion: @escaping ([String: Any]?, String?) -> Void
+    ) {
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard let photoOutput = self.photoOutput else {
+                completion(nil, "Photo output not available")
+                return
+            }
+            guard !self.isRecording else {
+                completion(nil, "Cannot capture photo while recording")
+                return
+            }
+
+            let settings = AVCapturePhotoSettings(
+                format: [AVVideoCodecKey: AVVideoCodecType.jpeg]
+            )
+            settings.flashMode = .off
+
+            let delegate = PhotoCaptureDelegate(
+                outputDirectory: outputDirectory,
+                useCache: useCache
+            )
+            delegate.onFinished = { [weak self, weak delegate] map, error in
+                completion(map, error)
+                guard let self = self, let delegate = delegate else { return }
+                self.sessionQueue.async {
+                    self.activePhotoDelegates.removeAll { $0 === delegate }
+                }
+            }
+            self.activePhotoDelegates.append(delegate)
+            photoOutput.capturePhoto(with: settings, delegate: delegate)
+        }
+    }
+
     func copyPixelBuffer() -> Unmanaged<CVPixelBuffer>? {
         pixelBufferLock.lock()
         defer { pixelBufferLock.unlock() }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -733,9 +733,14 @@ class CameraController: NSObject {
         if session.canAddOutput(photoOutput) {
             session.addOutput(photoOutput)
             self.photoOutput = photoOutput
-            if let connection = photoOutput.connection(with: .video),
-               connection.isVideoOrientationSupported {
-                connection.videoOrientation = .portrait
+            if let connection = photoOutput.connection(with: .video) {
+                if connection.isVideoOrientationSupported {
+                    connection.videoOrientation = .portrait
+                }
+                if connection.isVideoMirroringSupported {
+                    let isFront = currentLens == .front
+                    connection.isVideoMirrored = isFront && mirrorFrontCameraOutput
+                }
             }
             DivineCameraLog.shared.debug("DivineCamera: Photo output added successfully")
         } else {
@@ -1191,6 +1196,15 @@ class CameraController: NSObject {
                         videoConnection.isVideoMirrored = isFront && self.mirrorFrontCameraOutput
                     }
                 }
+                if let photoConnection = self.photoOutput?.connection(with: .video) {
+                    if photoConnection.isVideoOrientationSupported {
+                        photoConnection.videoOrientation = .portrait
+                    }
+                    let isFront = newDevice.position == .front
+                    if photoConnection.isVideoMirroringSupported {
+                        photoConnection.isVideoMirrored = isFront && self.mirrorFrontCameraOutput
+                    }
+                }
             } catch {
                 // Re-add old input if failed
                 if let oldInput = self.videoInput {
@@ -1247,6 +1261,7 @@ class CameraController: NSObject {
                 enableScreenFlash()
                 currentTorchMode = .on
                 isAutoFlashMode = false
+                currentFlashMode = .off
                 return true
             } else if mode == "auto" {
                 // Auto mode for front camera - will check brightness when recording starts
@@ -1287,7 +1302,11 @@ class CameraController: NSObject {
                 DivineCameraLog.shared.debug("DivineCamera: Auto flash mode enabled - will check brightness when recording starts")
                 
             case "on":
+                if device.isTorchModeSupported(.off) {
+                    device.torchMode = .off
+                }
                 currentFlashMode = .on
+                currentTorchMode = .off
                 isAutoFlashMode = false
                 
             case "torch":
@@ -1295,6 +1314,7 @@ class CameraController: NSObject {
                     device.torchMode = .on
                 }
                 currentTorchMode = .on
+                currentFlashMode = .off
                 isAutoFlashMode = false
                 
             default:
@@ -2118,7 +2138,16 @@ class CameraController: NSObject {
             return "off"
         }
     }
-    
+
+    private func photoFlashMode(for output: AVCapturePhotoOutput) -> AVCaptureDevice.FlashMode {
+        let requestedMode = currentFlashMode
+        let supportedModes = output.supportedFlashModes
+        if supportedModes.contains(NSNumber(value: requestedMode.rawValue)) {
+            return requestedMode
+        }
+        return .off
+    }
+
     /// Releases all camera resources.
     func release() {
         // Restore screen brightness if screen flash was enabled
@@ -2200,7 +2229,7 @@ extension CameraController: FlutterTexture {
             let settings = AVCapturePhotoSettings(
                 format: [AVVideoCodecKey: AVVideoCodecType.jpeg]
             )
-            settings.flashMode = .off
+            settings.flashMode = self.photoFlashMode(for: photoOutput)
 
             let delegate = PhotoCaptureDelegate(
                 outputDirectory: outputDirectory,

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -215,7 +215,13 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             
         case "stopRecording":
             stopRecording(result: result)
-            
+
+        case "capturePhoto":
+            let args = call.arguments as? [String: Any] ?? [:]
+            let useCache = args["useCache"] as? Bool ?? true
+            let outputDirectory = args["outputDirectory"] as? String
+            capturePhoto(useCache: useCache, outputDirectory: outputDirectory, result: result)
+
         case "pausePreview":
             pausePreview(result: result)
             
@@ -420,13 +426,30 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
             result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
             return
         }
-        
+
         controller.stopRecording { recordingResult, error in
             DispatchQueue.main.async {
                 if let error = error {
                     result(Self.cameraError("RECORD_STOP_ERROR", error))
                 } else {
                     result(recordingResult)
+                }
+            }
+        }
+    }
+
+    private func capturePhoto(useCache: Bool, outputDirectory: String?, result: @escaping FlutterResult) {
+        guard let controller = cameraController else {
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
+            return
+        }
+
+        controller.capturePhoto(outputDirectory: outputDirectory, useCache: useCache) { photoResult, error in
+            DispatchQueue.main.async {
+                if let error = error {
+                    result(Self.cameraError("PHOTO_CAPTURE_ERROR", error))
+                } else {
+                    result(photoResult)
                 }
             }
         }

--- a/mobile/packages/divine_camera/ios/Classes/PhotoCaptureDelegate.swift
+++ b/mobile/packages/divine_camera/ios/Classes/PhotoCaptureDelegate.swift
@@ -49,6 +49,10 @@ final class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
         let outputURL = outputDir.appendingPathComponent("IMG_\(timestamp).jpg")
 
         do {
+            try FileManager.default.createDirectory(
+                at: outputDir,
+                withIntermediateDirectories: true
+            )
             try data.write(to: outputURL)
             let dimensions = photo.resolvedSettings.photoDimensions
             onFinished?(

--- a/mobile/packages/divine_camera/ios/Classes/PhotoCaptureDelegate.swift
+++ b/mobile/packages/divine_camera/ios/Classes/PhotoCaptureDelegate.swift
@@ -1,0 +1,66 @@
+// ABOUTME: AVCapturePhotoCaptureDelegate that writes a captured still to JPEG
+// ABOUTME: Used by CameraController for single-frame (stop-motion) capture
+
+import AVFoundation
+
+/// Receives a single captured photo, writes it to disk as JPEG, and reports
+/// the resulting file path and pixel dimensions via [onFinished].
+final class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
+    init(outputDirectory: String?, useCache: Bool) {
+        self.outputDirectory = outputDirectory
+        self.useCache = useCache
+        super.init()
+    }
+
+    private let outputDirectory: String?
+    private let useCache: Bool
+
+    /// Invoked once when processing finishes. First argument is the result map
+    /// (`filePath`, `width`, `height`) on success, or nil on failure with a
+    /// message in the second argument.
+    var onFinished: (([String: Any]?, String?) -> Void)?
+
+    func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        didFinishProcessingPhoto photo: AVCapturePhoto,
+        error: Error?
+    ) {
+        if let error = error {
+            onFinished?(nil, error.localizedDescription)
+            return
+        }
+        guard let data = photo.fileDataRepresentation() else {
+            onFinished?(nil, "Photo data unavailable")
+            return
+        }
+
+        // Mirror startRecording's path resolution: explicit dir, cache, or docs.
+        let outputDir: URL
+        if let customDir = outputDirectory {
+            outputDir = URL(fileURLWithPath: customDir)
+        } else if useCache {
+            outputDir = FileManager.default.temporaryDirectory
+        } else {
+            let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
+            outputDir = paths[0]
+        }
+
+        let timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+        let outputURL = outputDir.appendingPathComponent("IMG_\(timestamp).jpg")
+
+        do {
+            try data.write(to: outputURL)
+            let dimensions = photo.resolvedSettings.photoDimensions
+            onFinished?(
+                [
+                    "filePath": outputURL.path,
+                    "width": Int(dimensions.width),
+                    "height": Int(dimensions.height),
+                ],
+                nil
+            )
+        } catch {
+            onFinished?(nil, error.localizedDescription)
+        }
+    }
+}

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -6,6 +6,7 @@ import 'package:divine_camera/src/models/audio_device.dart';
 import 'package:divine_camera/src/models/camera_lens.dart';
 import 'package:divine_camera/src/models/camera_state.dart';
 import 'package:divine_camera/src/models/flash_mode.dart';
+import 'package:divine_camera/src/models/photo_capture_result.dart';
 import 'package:divine_camera/src/models/remote_record_trigger.dart';
 import 'package:divine_camera/src/models/video_quality.dart';
 import 'package:divine_camera/src/models/video_recording_result.dart';
@@ -18,6 +19,7 @@ export 'src/models/camera_lens.dart';
 export 'src/models/camera_lens_metadata.dart';
 export 'src/models/camera_state.dart';
 export 'src/models/flash_mode.dart';
+export 'src/models/photo_capture_result.dart';
 export 'src/models/remote_record_trigger.dart';
 export 'src/models/video_quality.dart';
 export 'src/models/video_recording_result.dart';
@@ -296,6 +298,29 @@ class DivineCamera {
       _state = _state.copyWith(isRecording: false);
       _notifyStateChanged();
     }
+  }
+
+  /// Captures a single still photo from the live camera feed.
+  ///
+  /// Intended for stop-motion capture: each call writes one JPEG frame to
+  /// disk and returns its location. Audio is never involved.
+  ///
+  /// [useCache] if true, saves the photo to the cache directory (temporary),
+  /// otherwise to the documents directory (permanent). Defaults to true.
+  /// [outputDirectory] specifies where to save the photo.
+  ///
+  /// Returns the captured photo result, or null if the camera is not ready
+  /// or capture failed. Capture is rejected while a video recording is in
+  /// progress.
+  Future<PhotoCaptureResult?> capturePhoto({
+    String? outputDirectory,
+    bool useCache = true,
+  }) async {
+    if (!_state.isInitialized || _state.isRecording) return null;
+    return _platform.capturePhoto(
+      outputDirectory: outputDirectory,
+      useCache: useCache,
+    );
   }
 
   /// Handles app lifecycle changes (pause, resume, etc.).

--- a/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_method_channel.dart
@@ -6,6 +6,7 @@ import 'package:divine_camera/src/models/audio_device.dart';
 import 'package:divine_camera/src/models/camera_lens.dart';
 import 'package:divine_camera/src/models/camera_state.dart';
 import 'package:divine_camera/src/models/flash_mode.dart';
+import 'package:divine_camera/src/models/photo_capture_result.dart';
 import 'package:divine_camera/src/models/remote_record_trigger.dart';
 import 'package:divine_camera/src/models/video_quality.dart';
 import 'package:divine_camera/src/models/video_recording_result.dart';
@@ -265,6 +266,30 @@ class MethodChannelDivineCamera extends DivineCameraPlatform {
     );
     if (result == null) return null;
     return VideoRecordingResult.fromMap(result);
+  }
+
+  @override
+  Future<PhotoCaptureResult?> capturePhoto({
+    String? outputDirectory,
+    bool useCache = true,
+  }) async {
+    try {
+      final result = await methodChannel.invokeMapMethod<dynamic, dynamic>(
+        'capturePhoto',
+        {'outputDirectory': ?outputDirectory, 'useCache': useCache},
+      );
+      if (result == null) return null;
+      return PhotoCaptureResult.fromMap(result);
+    } on PlatformException catch (e, stackTrace) {
+      Log.error(
+        'capturePhoto failed: ${e.code} ${e.message ?? ''}',
+        name: 'DivineCameraMethodChannel',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
   }
 
   @override

--- a/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera_platform_interface.dart
@@ -6,6 +6,7 @@ import 'package:divine_camera/src/models/audio_device.dart';
 import 'package:divine_camera/src/models/camera_lens.dart';
 import 'package:divine_camera/src/models/camera_state.dart';
 import 'package:divine_camera/src/models/flash_mode.dart';
+import 'package:divine_camera/src/models/photo_capture_result.dart';
 import 'package:divine_camera/src/models/remote_record_trigger.dart';
 import 'package:divine_camera/src/models/video_quality.dart';
 import 'package:divine_camera/src/models/video_recording_result.dart';
@@ -120,6 +121,20 @@ abstract class DivineCameraPlatform extends PlatformInterface {
     throw UnimplementedError('stopRecording() has not been implemented.');
   }
 
+  /// Captures a single still photo from the live camera feed.
+  ///
+  /// [useCache] if true, saves the photo to the cache directory (temporary),
+  /// otherwise to the documents directory (permanent). Defaults to true.
+  /// [outputDirectory] specifies where to save the photo.
+  ///
+  /// Returns the captured photo result, or null if capture failed.
+  Future<PhotoCaptureResult?> capturePhoto({
+    String? outputDirectory,
+    bool useCache = true,
+  }) {
+    throw UnimplementedError('capturePhoto() has not been implemented.');
+  }
+
   /// Pauses the camera preview.
   Future<void> pausePreview() {
     throw UnimplementedError('pausePreview() has not been implemented.');
@@ -159,18 +174,14 @@ abstract class DivineCameraPlatform extends PlatformInterface {
   /// Callback for when a remote record trigger is detected (volume button
   /// or Bluetooth remote).
   void Function(RemoteRecordTrigger trigger)? get onRemoteRecordTrigger {
-    throw UnimplementedError(
-      'onRemoteRecordTrigger has not been implemented.',
-    );
+    throw UnimplementedError('onRemoteRecordTrigger has not been implemented.');
   }
 
   /// Sets the callback for when a remote record trigger is detected.
   set onRemoteRecordTrigger(
     void Function(RemoteRecordTrigger trigger)? callback,
   ) {
-    throw UnimplementedError(
-      'onRemoteRecordTrigger has not been implemented.',
-    );
+    throw UnimplementedError('onRemoteRecordTrigger has not been implemented.');
   }
 
   /// Enables or disables remote record control via volume buttons.
@@ -199,8 +210,6 @@ abstract class DivineCameraPlatform extends PlatformInterface {
   /// Returns an empty list on platforms that do not support device
   /// enumeration.
   Future<List<AudioDevice>> listAudioDevices() {
-    throw UnimplementedError(
-      'listAudioDevices() has not been implemented.',
-    );
+    throw UnimplementedError('listAudioDevices() has not been implemented.');
   }
 }

--- a/mobile/packages/divine_camera/lib/src/models/photo_capture_result.dart
+++ b/mobile/packages/divine_camera/lib/src/models/photo_capture_result.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Result class for single-photo capture operations
+// ABOUTME: Contains the file path and pixel dimensions of the captured photo
+
+import 'dart:io';
+
+import 'package:equatable/equatable.dart';
+
+/// Result of a single-photo capture operation.
+class PhotoCaptureResult extends Equatable {
+  /// Creates a new photo capture result.
+  const PhotoCaptureResult({required this.filePath, this.width, this.height});
+
+  /// Creates a [PhotoCaptureResult] from a map.
+  factory PhotoCaptureResult.fromMap(Map<dynamic, dynamic> map) {
+    return PhotoCaptureResult(
+      filePath: map['filePath'] as String,
+      width: map['width'] as int?,
+      height: map['height'] as int?,
+    );
+  }
+
+  /// The path to the captured photo file (JPEG).
+  final String filePath;
+
+  /// The width of the captured photo in pixels.
+  final int? width;
+
+  /// The height of the captured photo in pixels.
+  final int? height;
+
+  /// Returns the captured photo file.
+  File get file => File(filePath);
+
+  /// Converts this result to a map.
+  Map<String, dynamic> toMap() {
+    return {'filePath': filePath, 'width': width, 'height': height};
+  }
+
+  @override
+  String toString() {
+    return 'PhotoCaptureResult(filePath: $filePath, width: $width, '
+        'height: $height)';
+  }
+
+  @override
+  List<Object?> get props => [filePath, width, height];
+}

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Photo.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Photo.swift
@@ -1,0 +1,88 @@
+// ABOUTME: Single-photo (stop-motion) capture extension for macOS CameraController
+// ABOUTME: Grabs the latest preview pixel buffer and writes it to disk as JPEG
+
+import AppKit
+import AVFoundation
+import CoreImage
+
+extension CameraController {
+    /// Captures a single still photo and writes it to disk as JPEG.
+    ///
+    /// macOS deploys to 10.14 where `AVCapturePhotoOutput.fileDataRepresentation`
+    /// is unavailable, so this grabs the most recent preview frame (the same
+    /// buffer that drives the texture) and encodes it. Completion receives a
+    /// result map (`filePath`, `width`, `height`) on success, or nil plus an
+    /// error message on failure. Rejected while a video recording is in progress.
+    func capturePhoto(
+        outputDirectory: String?,
+        useCache: Bool,
+        completion: @escaping ([String: Any]?, String?) -> Void
+    ) {
+        videoOutputQueue.async { [weak self] in
+            guard let self = self else { return }
+            guard !self.isRecording else {
+                completion(nil, "Cannot capture photo while recording")
+                return
+            }
+
+            self.pixelBufferLock.lock()
+            let buffer = self.pixelBufferRef
+            self.pixelBufferLock.unlock()
+
+            guard let pixelBuffer = buffer else {
+                completion(nil, "No frame available")
+                return
+            }
+
+            let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+            let ciContext = CIContext()
+            guard
+                let cgImage = ciContext.createCGImage(ciImage, from: ciImage.extent)
+            else {
+                completion(nil, "Failed to render frame")
+                return
+            }
+
+            let bitmap = NSBitmapImageRep(cgImage: cgImage)
+            guard
+                let data = bitmap.representation(
+                    using: .jpeg,
+                    properties: [.compressionFactor: 0.9]
+                )
+            else {
+                completion(nil, "Failed to encode JPEG")
+                return
+            }
+
+            let outputDir: URL
+            if let customDir = outputDirectory {
+                outputDir = URL(fileURLWithPath: customDir)
+            } else if useCache {
+                outputDir = FileManager.default.temporaryDirectory
+            } else {
+                let paths = FileManager.default.urls(
+                    for: .documentDirectory,
+                    in: .userDomainMask
+                )
+                outputDir = paths[0]
+            }
+
+            let timestamp = Int64(Date().timeIntervalSince1970 * 1000)
+            let outputURL = outputDir.appendingPathComponent("IMG_\(timestamp).jpg")
+
+            do {
+                try data.write(to: outputURL)
+                completion(
+                    [
+                        "filePath": outputURL.path,
+                        "width": CVPixelBufferGetWidth(pixelBuffer),
+                        "height": CVPixelBufferGetHeight(pixelBuffer),
+                    ],
+                    nil
+                )
+            } catch {
+                completion(nil, error.localizedDescription)
+            }
+        }
+    }
+}

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Photo.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Photo.swift
@@ -71,6 +71,10 @@ extension CameraController {
             let outputURL = outputDir.appendingPathComponent("IMG_\(timestamp).jpg")
 
             do {
+                try FileManager.default.createDirectory(
+                    at: outputDir,
+                    withIntermediateDirectories: true
+                )
                 try data.write(to: outputURL)
                 completion(
                     [

--- a/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
@@ -163,6 +163,16 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         case "stopRecording":
             stopRecording(result: result)
 
+        case "capturePhoto":
+            let args = call.arguments as? [String: Any] ?? [:]
+            let useCache = args["useCache"] as? Bool ?? true
+            let outputDirectory = args["outputDirectory"] as? String
+            capturePhoto(
+                useCache: useCache,
+                outputDirectory: outputDirectory,
+                result: result
+            )
+
         case "pausePreview":
             pausePreview(result: result)
 
@@ -369,6 +379,30 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
                     result(Self.cameraError("RECORD_STOP_ERROR", error))
                 } else {
                     result(recordingResult)
+                }
+            }
+        }
+    }
+
+    private func capturePhoto(
+        useCache: Bool,
+        outputDirectory: String?,
+        result: @escaping FlutterResult
+    ) {
+        guard let controller = cameraController else {
+            result(Self.cameraError("NOT_INITIALIZED", "Camera not initialized"))
+            return
+        }
+
+        controller.capturePhoto(
+            outputDirectory: outputDirectory,
+            useCache: useCache
+        ) { photoResult, error in
+            DispatchQueue.main.async {
+                if let error = error {
+                    result(Self.cameraError("PHOTO_CAPTURE_ERROR", error))
+                } else {
+                    result(photoResult)
                 }
             }
         }

--- a/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_method_channel_test.dart
@@ -14,114 +14,102 @@ void main() {
   setUp(() {
     platform = MethodChannelDivineCamera();
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(
-          channel,
-          (methodCall) async {
-            final args = methodCall.arguments as Map<dynamic, dynamic>?;
-            switch (methodCall.method) {
-              case 'getPlatformVersion':
-                return 'Android 14';
-              case 'initializeCamera':
-                return {
-                  'isInitialized': true,
-                  'isRecording': false,
-                  'flashMode': 'off',
-                  'lens': args?['lens'] ?? 'back',
-                  'zoomLevel': 1.0,
-                  'minZoomLevel': 1.0,
-                  'maxZoomLevel': 8.0,
-                  'aspectRatio': 1.777,
-                  'hasFlash': true,
-                  'hasFrontCamera': true,
-                  'hasBackCamera': true,
-                  'isFocusPointSupported': true,
-                  'isExposurePointSupported': true,
-                  'textureId': 1,
-                  'availableLenses': [
-                    'front',
-                    'back',
-                    'ultraWide',
-                    'telephoto',
-                  ],
-                };
-              case 'disposeCamera':
-                return null;
-              case 'setFlashMode':
-                return true;
-              case 'setFocusPoint':
-                return true;
-              case 'setExposurePoint':
-                return true;
-              case 'cancelFocusAndMetering':
-                return true;
-              case 'setZoomLevel':
-                return true;
-              case 'setVideoStabilizationMode':
-                return true;
-              case 'switchCamera':
-                return {
-                  'isInitialized': true,
-                  'isRecording': false,
-                  'flashMode': 'off',
-                  'lens': args?['lens'] ?? 'front',
-                  'zoomLevel': 1.0,
-                  'minZoomLevel': 1.0,
-                  'maxZoomLevel': 8.0,
-                  'aspectRatio': 1.777,
-                  'hasFlash': true,
-                  'hasFrontCamera': true,
-                  'hasBackCamera': true,
-                  'isFocusPointSupported': true,
-                  'isExposurePointSupported': true,
-                  'textureId': 1,
-                  'availableLenses': [
-                    'front',
-                    'back',
-                    'ultraWide',
-                    'telephoto',
-                  ],
-                };
-              case 'startRecording':
-                return null;
-              case 'stopRecording':
-                return {
-                  'filePath': '/path/to/video.mp4',
-                  'durationMs': 5000,
-                  'width': 1920,
-                  'height': 1080,
-                };
-              case 'pausePreview':
-                return null;
-              case 'resumePreview':
-                return null;
-              case 'getCameraState':
-                return {
-                  'isInitialized': true,
-                  'isRecording': false,
-                  'flashMode': 'off',
-                  'lens': 'back',
-                  'zoomLevel': 1.0,
-                  'minZoomLevel': 1.0,
-                  'maxZoomLevel': 8.0,
-                  'aspectRatio': 1.777,
-                  'hasFlash': true,
-                  'hasFrontCamera': true,
-                  'hasBackCamera': true,
-                  'isFocusPointSupported': true,
-                  'isExposurePointSupported': true,
-                  'textureId': 1,
-                  'availableLenses': [
-                    'front',
-                    'back',
-                    'ultraWide',
-                    'telephoto',
-                  ],
-                };
-              default:
-                return null;
-            }
-          },
-        );
+        .setMockMethodCallHandler(channel, (methodCall) async {
+          final args = methodCall.arguments as Map<dynamic, dynamic>?;
+          switch (methodCall.method) {
+            case 'getPlatformVersion':
+              return 'Android 14';
+            case 'initializeCamera':
+              return {
+                'isInitialized': true,
+                'isRecording': false,
+                'flashMode': 'off',
+                'lens': args?['lens'] ?? 'back',
+                'zoomLevel': 1.0,
+                'minZoomLevel': 1.0,
+                'maxZoomLevel': 8.0,
+                'aspectRatio': 1.777,
+                'hasFlash': true,
+                'hasFrontCamera': true,
+                'hasBackCamera': true,
+                'isFocusPointSupported': true,
+                'isExposurePointSupported': true,
+                'textureId': 1,
+                'availableLenses': ['front', 'back', 'ultraWide', 'telephoto'],
+              };
+            case 'disposeCamera':
+              return null;
+            case 'setFlashMode':
+              return true;
+            case 'setFocusPoint':
+              return true;
+            case 'setExposurePoint':
+              return true;
+            case 'cancelFocusAndMetering':
+              return true;
+            case 'setZoomLevel':
+              return true;
+            case 'setVideoStabilizationMode':
+              return true;
+            case 'switchCamera':
+              return {
+                'isInitialized': true,
+                'isRecording': false,
+                'flashMode': 'off',
+                'lens': args?['lens'] ?? 'front',
+                'zoomLevel': 1.0,
+                'minZoomLevel': 1.0,
+                'maxZoomLevel': 8.0,
+                'aspectRatio': 1.777,
+                'hasFlash': true,
+                'hasFrontCamera': true,
+                'hasBackCamera': true,
+                'isFocusPointSupported': true,
+                'isExposurePointSupported': true,
+                'textureId': 1,
+                'availableLenses': ['front', 'back', 'ultraWide', 'telephoto'],
+              };
+            case 'startRecording':
+              return null;
+            case 'stopRecording':
+              return {
+                'filePath': '/path/to/video.mp4',
+                'durationMs': 5000,
+                'width': 1920,
+                'height': 1080,
+              };
+            case 'capturePhoto':
+              return {
+                'filePath': '/path/to/photo.jpg',
+                'width': 1080,
+                'height': 1920,
+              };
+            case 'pausePreview':
+              return null;
+            case 'resumePreview':
+              return null;
+            case 'getCameraState':
+              return {
+                'isInitialized': true,
+                'isRecording': false,
+                'flashMode': 'off',
+                'lens': 'back',
+                'zoomLevel': 1.0,
+                'minZoomLevel': 1.0,
+                'maxZoomLevel': 8.0,
+                'aspectRatio': 1.777,
+                'hasFlash': true,
+                'hasFrontCamera': true,
+                'hasBackCamera': true,
+                'isFocusPointSupported': true,
+                'isExposurePointSupported': true,
+                'textureId': 1,
+                'availableLenses': ['front', 'back', 'ultraWide', 'telephoto'],
+              };
+            default:
+              return null;
+          }
+        });
   });
 
   tearDown(() {
@@ -161,9 +149,7 @@ void main() {
     });
 
     test('initializeCamera with enableScreenFlash false', () async {
-      final state = await platform.initializeCamera(
-        enableScreenFlash: false,
-      );
+      final state = await platform.initializeCamera(enableScreenFlash: false);
 
       expect(state.isInitialized, isTrue);
     });
@@ -305,10 +291,7 @@ void main() {
     });
 
     test('startRecording with useCache false', () async {
-      await expectLater(
-        platform.startRecording(useCache: false),
-        completes,
-      );
+      await expectLater(platform.startRecording(useCache: false), completes);
     });
 
     test('startRecording with outputDirectory', () async {
@@ -320,18 +303,15 @@ void main() {
 
     test('startRecording returns false on PlatformException', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            channel,
-            (methodCall) async {
-              if (methodCall.method == 'startRecording') {
-                throw PlatformException(
-                  code: 'RECORD_START_ERROR',
-                  message: 'Recording failed to start',
-                );
-              }
-              return null;
-            },
-          );
+          .setMockMethodCallHandler(channel, (methodCall) async {
+            if (methodCall.method == 'startRecording') {
+              throw PlatformException(
+                code: 'RECORD_START_ERROR',
+                message: 'Recording failed to start',
+              );
+            }
+            return null;
+          });
 
       final result = await platform.startRecording();
       expect(result, isFalse);
@@ -352,6 +332,68 @@ void main() {
       expect(result.durationMs, 5000);
       expect(result.width, 1920);
       expect(result.height, 1080);
+    });
+
+    test('capturePhoto returns PhotoCaptureResult', () async {
+      final result = await platform.capturePhoto();
+
+      expect(result, isNotNull);
+      expect(result!.filePath, '/path/to/photo.jpg');
+      expect(result.width, 1080);
+      expect(result.height, 1920);
+    });
+
+    test('capturePhoto forwards outputDirectory and useCache', () async {
+      Map<dynamic, dynamic>? sentArgs;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+            if (methodCall.method == 'capturePhoto') {
+              sentArgs = methodCall.arguments as Map<dynamic, dynamic>?;
+              return {'filePath': '/custom/photo.jpg'};
+            }
+            return null;
+          });
+
+      await platform.capturePhoto(outputDirectory: '/custom', useCache: false);
+
+      expect(sentArgs?['outputDirectory'], '/custom');
+      expect(sentArgs?['useCache'], isFalse);
+    });
+
+    test('capturePhoto returns null when result is null', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+            if (methodCall.method == 'capturePhoto') {
+              return null;
+            }
+            return null;
+          });
+
+      final result = await platform.capturePhoto();
+      expect(result, isNull);
+    });
+
+    test('capturePhoto returns null and logs on PlatformException', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (methodCall) async {
+            if (methodCall.method == 'capturePhoto') {
+              throw PlatformException(
+                code: 'PHOTO_CAPTURE_ERROR',
+                message: 'Capture failed',
+              );
+            }
+            return null;
+          });
+
+      final result = await platform.capturePhoto();
+      expect(result, isNull);
+
+      final logged = LogCaptureService().getRecentLogs().any(
+        (entry) =>
+            entry.level == LogLevel.error &&
+            entry.message.contains('PHOTO_CAPTURE_ERROR'),
+      );
+      expect(logged, isTrue);
     });
 
     test('pausePreview completes without error', () async {
@@ -520,11 +562,7 @@ void main() {
 
       await expectLater(
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .handlePlatformMessage(
-              'divine_camera',
-              envelope,
-              (data) {},
-            ),
+            .handlePlatformMessage('divine_camera', envelope, (data) {}),
         completes,
       );
 
@@ -544,11 +582,7 @@ void main() {
       // Should not throw
       await expectLater(
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .handlePlatformMessage(
-              'divine_camera',
-              envelope,
-              (data) {},
-            ),
+            .handlePlatformMessage('divine_camera', envelope, (data) {}),
         completes,
       );
     });
@@ -558,19 +592,13 @@ void main() {
 
       const codec = StandardMethodCodec();
       final envelope = codec.encodeMethodCall(
-        const MethodCall('onRecordingAutoStopped', {
-          'filePath': '/test.mp4',
-        }),
+        const MethodCall('onRecordingAutoStopped', {'filePath': '/test.mp4'}),
       );
 
       // Should not throw
       await expectLater(
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .handlePlatformMessage(
-              'divine_camera',
-              envelope,
-              (data) {},
-            ),
+            .handlePlatformMessage('divine_camera', envelope, (data) {}),
         completes,
       );
     });
@@ -584,11 +612,7 @@ void main() {
       // Should not throw, just return null
       await expectLater(
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .handlePlatformMessage(
-              'divine_camera',
-              envelope,
-              (data) {},
-            ),
+            .handlePlatformMessage('divine_camera', envelope, (data) {}),
         completes,
       );
     });
@@ -683,10 +707,7 @@ void main() {
 
     test('falls back to the native name when none is provided', () async {
       const message = 'onNativeLog-test-default-name-unique';
-      await dispatchNativeLog({
-        'level': 'info',
-        'message': message,
-      });
+      await dispatchNativeLog({'level': 'info', 'message': message});
 
       final entry = latestEntryWithMessage(message);
       expect(entry, isNotNull);

--- a/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_platform_interface_test.dart
@@ -187,6 +187,13 @@ void main() {
         );
       });
 
+      test('capturePhoto throws', () {
+        expect(
+          () => basePlatform.capturePhoto(),
+          throwsA(isA<UnimplementedError>()),
+        );
+      });
+
       test('pausePreview throws', () {
         expect(
           () => basePlatform.pausePreview(),

--- a/mobile/packages/divine_camera/test/divine_camera_test.dart
+++ b/mobile/packages/divine_camera/test/divine_camera_test.dart
@@ -155,6 +155,18 @@ class MockDivineCameraPlatform
   }
 
   @override
+  Future<PhotoCaptureResult?> capturePhoto({
+    String? outputDirectory,
+    bool useCache = true,
+  }) async {
+    return const PhotoCaptureResult(
+      filePath: '/test/photo.jpg',
+      width: 1080,
+      height: 1920,
+    );
+  }
+
+  @override
   Future<void> pausePreview() async {}
 
   @override
@@ -217,10 +229,7 @@ void main() {
       });
 
       test('listAudioDevices throws', () {
-        expect(
-          () => basePlatform.listAudioDevices(),
-          throwsUnimplementedError,
-        );
+        expect(() => basePlatform.listAudioDevices(), throwsUnimplementedError);
       });
     });
   });
@@ -289,9 +298,7 @@ void main() {
       });
 
       test('mirrorFrontCameraOutput reflects initialization value', () async {
-        await DivineCamera.instance.initialize(
-          mirrorFrontCameraOutput: true,
-        );
+        await DivineCamera.instance.initialize(mirrorFrontCameraOutput: true);
 
         expect(DivineCamera.instance.mirrorFrontCameraOutput, isTrue);
       });
@@ -580,6 +587,36 @@ void main() {
       });
     });
 
+    group('photo capture', () {
+      test('captures a photo when initialized', () async {
+        await DivineCamera.instance.initialize();
+
+        final result = await DivineCamera.instance.capturePhoto();
+
+        expect(result, isNotNull);
+        expect(result!.filePath, '/test/photo.jpg');
+        expect(result.width, 1080);
+        expect(result.height, 1920);
+      });
+
+      test('returns null when not initialized', () async {
+        await DivineCamera.instance.dispose();
+
+        final result = await DivineCamera.instance.capturePhoto();
+
+        expect(result, isNull);
+      });
+
+      test('returns null while recording', () async {
+        await DivineCamera.instance.initialize();
+        await DivineCamera.instance.startRecording();
+
+        final result = await DivineCamera.instance.capturePhoto();
+
+        expect(result, isNull);
+      });
+    });
+
     group('listAudioDevices', () {
       test('returns list of audio devices', () async {
         final devices = await DivineCamera.instance.listAudioDevices();
@@ -738,9 +775,7 @@ void main() {
     });
 
     test('copyWith creates new state with updated values', () {
-      const original = CameraState(
-        isInitialized: true,
-      );
+      const original = CameraState(isInitialized: true);
 
       final copied = original.copyWith(
         flashMode: DivineCameraFlashMode.on,
@@ -798,9 +833,7 @@ void main() {
     });
 
     test('duration getter returns null when durationMs is null', () {
-      const result = VideoRecordingResult(
-        filePath: '/path/to/video.mp4',
-      );
+      const result = VideoRecordingResult(filePath: '/path/to/video.mp4');
 
       expect(result.duration, isNull);
     });
@@ -935,10 +968,7 @@ void main() {
     });
 
     test('toNativeString returns correct string for volumeUp', () {
-      expect(
-        RemoteRecordTrigger.volumeUp.toNativeString(),
-        equals('volumeUp'),
-      );
+      expect(RemoteRecordTrigger.volumeUp.toNativeString(), equals('volumeUp'));
     });
 
     test('toNativeString returns correct string for volumeDown', () {
@@ -994,10 +1024,7 @@ void main() {
     });
 
     test('toString returns formatted string', () {
-      const state = CameraState(
-        isInitialized: true,
-        textureId: 1,
-      );
+      const state = CameraState(isInitialized: true, textureId: 1);
 
       final str = state.toString();
 
@@ -1152,9 +1179,7 @@ void main() {
     });
 
     test('file getter returns File object', () {
-      const result = VideoRecordingResult(
-        filePath: '/path/to/video.mp4',
-      );
+      const result = VideoRecordingResult(filePath: '/path/to/video.mp4');
 
       expect(result.file.path, '/path/to/video.mp4');
     });
@@ -1608,9 +1633,7 @@ void main() {
     });
 
     test('props returns correct list', () {
-      const metadata = CameraLensMetadata(
-        lensType: 'back',
-      );
+      const metadata = CameraLensMetadata(lensType: 'back');
 
       final props = metadata.props;
 
@@ -1648,10 +1671,7 @@ void main() {
     });
 
     test('fromMap handles null currentLensMetadata', () {
-      final map = {
-        'isInitialized': true,
-        'currentLensMetadata': null,
-      };
+      final map = {'isInitialized': true, 'currentLensMetadata': null};
 
       final state = CameraState.fromMap(map);
 
@@ -1659,9 +1679,7 @@ void main() {
     });
 
     test('fromMap handles missing currentLensMetadata', () {
-      final map = {
-        'isInitialized': true,
-      };
+      final map = {'isInitialized': true};
 
       final state = CameraState.fromMap(map);
 
@@ -1743,10 +1761,7 @@ class _NoExposureSupportMock extends MockDivineCameraPlatform {
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
   }) async {
-    return const CameraState(
-      isInitialized: true,
-      isFocusPointSupported: true,
-    );
+    return const CameraState(isInitialized: true, isFocusPointSupported: true);
   }
 }
 
@@ -1760,10 +1775,7 @@ class _SingleCameraMock extends MockDivineCameraPlatform {
     bool mirrorFrontCameraOutput = false,
     bool enableAutoLensSwitch = false,
   }) async {
-    return const CameraState(
-      isInitialized: true,
-      hasBackCamera: true,
-    );
+    return const CameraState(isInitialized: true, hasBackCamera: true);
   }
 }
 
@@ -1781,28 +1793,24 @@ void _runMethodChannelTests() {
       capturedCalls = <MethodCall>[];
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            methodChannelImpl.methodChannel,
-            (methodCall) async {
-              capturedCalls.add(methodCall);
-              switch (methodCall.method) {
-                case 'setRemoteRecordControlEnabled':
-                  return true;
-                case 'setVolumeKeysEnabled':
-                  return true;
-                default:
-                  return null;
-              }
-            },
-          );
+          .setMockMethodCallHandler(methodChannelImpl.methodChannel, (
+            methodCall,
+          ) async {
+            capturedCalls.add(methodCall);
+            switch (methodCall.method) {
+              case 'setRemoteRecordControlEnabled':
+                return true;
+              case 'setVolumeKeysEnabled':
+                return true;
+              default:
+                return null;
+            }
+          });
     });
 
     tearDown(() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-            methodChannelImpl.methodChannel,
-            null,
-          );
+          .setMockMethodCallHandler(methodChannelImpl.methodChannel, null);
     });
 
     test('onRemoteRecordTrigger getter returns null initially', () {
@@ -1866,19 +1874,18 @@ void _runMethodChannelTests() {
     group('listAudioDevices', () {
       test('returns parsed devices from method channel', () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              methodChannelImpl.methodChannel,
-              (methodCall) async {
-                capturedCalls.add(methodCall);
-                if (methodCall.method == 'listAudioDevices') {
-                  return <Map<dynamic, dynamic>>[
-                    {'id': 'mic-1', 'name': 'Built-in Microphone'},
-                    {'id': 'mic-2', 'name': 'External Mic'},
-                  ];
-                }
-                return null;
-              },
-            );
+            .setMockMethodCallHandler(methodChannelImpl.methodChannel, (
+              methodCall,
+            ) async {
+              capturedCalls.add(methodCall);
+              if (methodCall.method == 'listAudioDevices') {
+                return <Map<dynamic, dynamic>>[
+                  {'id': 'mic-1', 'name': 'Built-in Microphone'},
+                  {'id': 'mic-2', 'name': 'External Mic'},
+                ];
+              }
+              return null;
+            });
 
         final devices = await methodChannelImpl.listAudioDevices();
 
@@ -1891,13 +1898,12 @@ void _runMethodChannelTests() {
 
       test('returns empty list when platform returns null', () async {
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(
-              methodChannelImpl.methodChannel,
-              (methodCall) async {
-                capturedCalls.add(methodCall);
-                return null;
-              },
-            );
+            .setMockMethodCallHandler(methodChannelImpl.methodChannel, (
+              methodCall,
+            ) async {
+              capturedCalls.add(methodCall);
+              return null;
+            });
 
         final devices = await methodChannelImpl.listAudioDevices();
 

--- a/mobile/packages/divine_camera/test/models/photo_capture_result_test.dart
+++ b/mobile/packages/divine_camera/test/models/photo_capture_result_test.dart
@@ -1,0 +1,101 @@
+import 'package:divine_camera/divine_camera.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(PhotoCaptureResult, () {
+    test('creates result with all fields', () {
+      const result = PhotoCaptureResult(
+        filePath: '/path/to/photo.jpg',
+        width: 1080,
+        height: 1920,
+      );
+
+      expect(result.filePath, '/path/to/photo.jpg');
+      expect(result.width, 1080);
+      expect(result.height, 1920);
+    });
+
+    test('creates result from map', () {
+      final map = {
+        'filePath': '/path/to/photo.jpg',
+        'width': 720,
+        'height': 1280,
+      };
+
+      final result = PhotoCaptureResult.fromMap(map);
+
+      expect(result.filePath, '/path/to/photo.jpg');
+      expect(result.width, 720);
+      expect(result.height, 1280);
+    });
+
+    test('fromMap tolerates missing dimensions', () {
+      final result = PhotoCaptureResult.fromMap(const {
+        'filePath': '/path/to/photo.jpg',
+      });
+
+      expect(result.filePath, '/path/to/photo.jpg');
+      expect(result.width, isNull);
+      expect(result.height, isNull);
+    });
+
+    test('toMap converts result to map', () {
+      const result = PhotoCaptureResult(
+        filePath: '/path/to/photo.jpg',
+        width: 1080,
+        height: 1920,
+      );
+
+      final map = result.toMap();
+
+      expect(map['filePath'], '/path/to/photo.jpg');
+      expect(map['width'], 1080);
+      expect(map['height'], 1920);
+    });
+
+    test('file getter returns File object', () {
+      const result = PhotoCaptureResult(filePath: '/path/to/photo.jpg');
+
+      expect(result.file.path, '/path/to/photo.jpg');
+    });
+
+    test('toString returns formatted string', () {
+      const result = PhotoCaptureResult(
+        filePath: '/path/to/photo.jpg',
+        width: 1080,
+        height: 1920,
+      );
+
+      final str = result.toString();
+
+      expect(str, contains('PhotoCaptureResult'));
+      expect(str, contains('filePath: /path/to/photo.jpg'));
+      expect(str, contains('width: 1080'));
+      expect(str, contains('height: 1920'));
+    });
+
+    test('props returns correct list of properties', () {
+      const result = PhotoCaptureResult(
+        filePath: '/test.jpg',
+        width: 720,
+        height: 1280,
+      );
+
+      final props = result.props;
+
+      expect(props.length, 3);
+      expect(props[0], '/test.jpg');
+      expect(props[1], 720);
+      expect(props[2], 1280);
+    });
+
+    test('equality works correctly', () {
+      const result1 = PhotoCaptureResult(filePath: '/test.jpg', width: 720);
+      const result2 = PhotoCaptureResult(filePath: '/test.jpg', width: 720);
+      const result3 = PhotoCaptureResult(filePath: '/other.jpg', width: 720);
+
+      expect(result1, equals(result2));
+      expect(result1, isNot(equals(result3)));
+    });
+  });
+}

--- a/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
+++ b/mobile/packages/divine_camera/test/widgets/camera_preview_widget_test.dart
@@ -110,6 +110,12 @@ class MockDivineCameraPlatform
   Future<VideoRecordingResult?> stopRecording() async => null;
 
   @override
+  Future<PhotoCaptureResult?> capturePhoto({
+    String? outputDirectory,
+    bool useCache = true,
+  }) async => null;
+
+  @override
   Future<void> pausePreview() async {}
 
   @override

--- a/mobile/test/mocks/mock_camera_service.dart
+++ b/mobile/test/mocks/mock_camera_service.dart
@@ -6,7 +6,8 @@ import 'package:divine_camera/divine_camera.dart'
         CameraLensMetadata,
         DivineCameraLens,
         DivineVideoQuality,
-        DivineVideoStabilizationMode;
+        DivineVideoStabilizationMode,
+        PhotoCaptureResult;
 import 'package:flutter/material.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
@@ -99,6 +100,16 @@ class MockCameraService extends CameraService {
   Future<EditorVideo?> stopRecording() async {
     _isRecording = false;
     return null; // Return null in mock
+  }
+
+  @override
+  Future<PhotoCaptureResult?> capturePhoto({String? outputDirectory}) async {
+    if (!_isInitialized) return null;
+    return const PhotoCaptureResult(
+      filePath: '/mock/photo.jpg',
+      width: 1080,
+      height: 1920,
+    );
   }
 
   @override

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -60,9 +60,10 @@ void main() {
       mockService = _MockCuratedListService();
 
       // Create enough lists so auto-pagination doesn't kick in
-      // (_minListsBeforeAutoPaginate = 10)
+      // (_minListsBeforeAutoPaginate = 10), and so the list is scrollable
+      // across widget-test viewport differences.
       preloadedLists = List.generate(
-        15,
+        50,
         (i) => _makeList(
           'list_$i',
           createdAt: DateTime(2025).subtract(Duration(hours: i)),
@@ -79,7 +80,10 @@ void main() {
     }) {
       final lists = initialLists ?? preloadedLists;
       final oldest =
-          oldestTimestamp ?? DateTime(2025).subtract(const Duration(hours: 14));
+          oldestTimestamp ??
+          lists
+              .map((list) => list.createdAt)
+              .reduce((a, b) => a.isBefore(b) ? a : b);
 
       return ProviderScope(
         overrides: [
@@ -110,6 +114,11 @@ void main() {
         // timeout timer to complete. The timeout fires within FakeAsync,
         // resolving the Completer and running the finally block.
         final controllers = <StreamController<List<CuratedList>>>[];
+        addTearDown(() async {
+          for (final controller in controllers) {
+            await controller.close();
+          }
+        });
 
         when(
           () => mockService.streamPublicListsFromRelays(
@@ -131,7 +140,11 @@ void main() {
         expect(find.byType(CircularProgressIndicator), findsNothing);
 
         // --- First scroll: triggers pagination ---
-        await tester.drag(find.byType(ListView), const Offset(0, -5000));
+        await tester.scrollUntilVisible(
+          find.text('List list_49'),
+          500,
+          scrollable: find.byType(Scrollable),
+        );
 
         // pump() processes microtasks: _loadMoreLists starts, calls mock,
         // listens to stream, awaits completer. Stream stays open.
@@ -156,9 +169,13 @@ void main() {
         // --- Second scroll: should NOT trigger pagination again ---
         // Scroll UP first so the subsequent scroll DOWN actually changes
         // the position and fires the _onScroll listener at the bottom.
-        await tester.drag(find.byType(ListView), const Offset(0, 500));
+        await tester.drag(find.byType(ListView), const Offset(0, 1000));
         await tester.pump();
-        await tester.drag(find.byType(ListView), const Offset(0, -5000));
+        await tester.scrollUntilVisible(
+          find.text('List list_49'),
+          500,
+          scrollable: find.byType(Scrollable),
+        );
         await tester.pump();
         await tester.pump(const Duration(seconds: 4));
         await tester.pump();

--- a/mobile/test/services/video_recorder/camera/camera_linux_service_test.dart
+++ b/mobile/test/services/video_recorder/camera/camera_linux_service_test.dart
@@ -89,6 +89,12 @@ void main() {
 
         expect(result, isNull);
       });
+
+      test('capturePhoto returns null', () async {
+        final result = await service.capturePhoto();
+
+        expect(result, isNull);
+      });
     });
 
     group('camera control methods', () {


### PR DESCRIPTION
Closes #5353

## Summary

Adds single-photo capture support to the Divine camera stack for future stop-motion recording.

- Extends the Dart camera API and platform interface with capturePhoto support and a structured PhotoCaptureResult model.
- Implements native photo capture on Android, iOS, and macOS, with Linux returning the existing unsupported-camera behavior.
- Wires the mobile video recorder camera service to capture still photos and adds coverage for the new model, method channel, platform interface, and service behavior.
- Hardens review findings by creating Darwin output directories before writing photos, granting Patrol permissions before initialization, and avoiding an unsuppressed deprecated Android rotation API.

## Impact

Stop-motion flows can capture individual frames through the shared camera abstraction instead of relying on video-recording-only behavior. Existing video recording paths should continue using the same camera lifecycle and recording APIs.

## Validation

- git rebase origin/main
- mise exec -- flutter test from mobile/packages/divine_camera
- mise exec -- flutter test test/services/video_recorder/camera/camera_linux_service_test.dart from mobile
- mise exec -- flutter analyze from mobile
- CI checks on PR #5352