### PR TITLE
fix(video): restore owner edit delete actions

### DIFF
--- a/mobile/lib/blocs/owner_video_actions/owner_video_actions_cubit.dart
+++ b/mobile/lib/blocs/owner_video_actions/owner_video_actions_cubit.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Cubit for owner-only video actions such as deleting own videos.
 // ABOUTME: Keeps service-layer calls out of feed UI widgets.
 
+import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/services/content_deletion_service.dart';
@@ -9,32 +10,23 @@ import 'package:unified_logger/unified_logger.dart';
 
 enum OwnerVideoDeleteStatus { idle, deleting, success, failure }
 
-enum OwnerVideoDeleteFailureKind {
-  notInitialized,
-  notOwner,
-  notAuthenticated,
-  couldNotSign,
-  relayRejected,
-  relayNoResponse,
-  unknown,
-}
-
-class OwnerVideoActionsState {
+class OwnerVideoActionsState extends Equatable {
   const OwnerVideoActionsState({
     this.deleteStatus = OwnerVideoDeleteStatus.idle,
-    this.deleteFailureKind,
+    this.deleteResult,
   });
 
   final OwnerVideoDeleteStatus deleteStatus;
-  final OwnerVideoDeleteFailureKind? deleteFailureKind;
+  final DeleteResult? deleteResult;
 
-  OwnerVideoActionsState copyWith({
-    OwnerVideoDeleteStatus? deleteStatus,
-    OwnerVideoDeleteFailureKind? deleteFailureKind,
-  }) => OwnerVideoActionsState(
-    deleteStatus: deleteStatus ?? this.deleteStatus,
-    deleteFailureKind: deleteFailureKind,
-  );
+  @override
+  List<Object?> get props => [
+    deleteStatus,
+    deleteResult?.success,
+    deleteResult?.failureKind,
+    deleteResult?.deleteEventId,
+    deleteResult?.error,
+  ];
 }
 
 class OwnerVideoActionsCubit extends Cubit<OwnerVideoActionsState> {
@@ -67,15 +59,16 @@ class OwnerVideoActionsCubit extends Cubit<OwnerVideoActionsState> {
       if (result.success) {
         _videoEventService.removeVideoEventCompletely(video);
         emit(
-          const OwnerVideoActionsState(
+          OwnerVideoActionsState(
             deleteStatus: OwnerVideoDeleteStatus.success,
+            deleteResult: result,
           ),
         );
       } else {
         emit(
           OwnerVideoActionsState(
             deleteStatus: OwnerVideoDeleteStatus.failure,
-            deleteFailureKind: _mapFailureKind(result.failureKind),
+            deleteResult: result,
           ),
         );
       }
@@ -87,31 +80,14 @@ class OwnerVideoActionsCubit extends Cubit<OwnerVideoActionsState> {
       );
       if (isClosed) return;
       emit(
-        const OwnerVideoActionsState(
+        OwnerVideoActionsState(
           deleteStatus: OwnerVideoDeleteStatus.failure,
-          deleteFailureKind: OwnerVideoDeleteFailureKind.unknown,
+          deleteResult: DeleteResult.failure(
+            'Failed to delete video',
+            DeleteFailureKind.unknown,
+          ),
         ),
       );
-    }
-  }
-
-  OwnerVideoDeleteFailureKind _mapFailureKind(DeleteFailureKind? kind) {
-    switch (kind) {
-      case DeleteFailureKind.notInitialized:
-        return OwnerVideoDeleteFailureKind.notInitialized;
-      case DeleteFailureKind.notOwner:
-        return OwnerVideoDeleteFailureKind.notOwner;
-      case DeleteFailureKind.notAuthenticated:
-        return OwnerVideoDeleteFailureKind.notAuthenticated;
-      case DeleteFailureKind.couldNotSign:
-        return OwnerVideoDeleteFailureKind.couldNotSign;
-      case DeleteFailureKind.relayRejected:
-        return OwnerVideoDeleteFailureKind.relayRejected;
-      case DeleteFailureKind.relayNoResponse:
-        return OwnerVideoDeleteFailureKind.relayNoResponse;
-      case DeleteFailureKind.unknown:
-      case null:
-        return OwnerVideoDeleteFailureKind.unknown;
     }
   }
 }

--- a/mobile/lib/blocs/owner_video_actions/owner_video_actions_cubit.dart
+++ b/mobile/lib/blocs/owner_video_actions/owner_video_actions_cubit.dart
@@ -1,0 +1,117 @@
+// ABOUTME: Cubit for owner-only video actions such as deleting own videos.
+// ABOUTME: Keeps service-layer calls out of feed UI widgets.
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+enum OwnerVideoDeleteStatus { idle, deleting, success, failure }
+
+enum OwnerVideoDeleteFailureKind {
+  notInitialized,
+  notOwner,
+  notAuthenticated,
+  couldNotSign,
+  relayRejected,
+  relayNoResponse,
+  unknown,
+}
+
+class OwnerVideoActionsState {
+  const OwnerVideoActionsState({
+    this.deleteStatus = OwnerVideoDeleteStatus.idle,
+    this.deleteFailureKind,
+  });
+
+  final OwnerVideoDeleteStatus deleteStatus;
+  final OwnerVideoDeleteFailureKind? deleteFailureKind;
+
+  OwnerVideoActionsState copyWith({
+    OwnerVideoDeleteStatus? deleteStatus,
+    OwnerVideoDeleteFailureKind? deleteFailureKind,
+  }) => OwnerVideoActionsState(
+    deleteStatus: deleteStatus ?? this.deleteStatus,
+    deleteFailureKind: deleteFailureKind,
+  );
+}
+
+class OwnerVideoActionsCubit extends Cubit<OwnerVideoActionsState> {
+  OwnerVideoActionsCubit({
+    required Future<ContentDeletionService> contentDeletionServiceFuture,
+    required VideoEventService videoEventService,
+  }) : _contentDeletionServiceFuture = contentDeletionServiceFuture,
+       _videoEventService = videoEventService,
+       super(const OwnerVideoActionsState());
+
+  final Future<ContentDeletionService> _contentDeletionServiceFuture;
+  final VideoEventService _videoEventService;
+
+  Future<void> deleteVideo(VideoEvent video) async {
+    emit(
+      const OwnerVideoActionsState(
+        deleteStatus: OwnerVideoDeleteStatus.deleting,
+      ),
+    );
+
+    try {
+      final deletionService = await _contentDeletionServiceFuture;
+      final result = await deletionService.quickDelete(
+        video: video,
+        reason: DeleteReason.personalChoice,
+      );
+
+      if (isClosed) return;
+
+      if (result.success) {
+        _videoEventService.removeVideoEventCompletely(video);
+        emit(
+          const OwnerVideoActionsState(
+            deleteStatus: OwnerVideoDeleteStatus.success,
+          ),
+        );
+      } else {
+        emit(
+          OwnerVideoActionsState(
+            deleteStatus: OwnerVideoDeleteStatus.failure,
+            deleteFailureKind: _mapFailureKind(result.failureKind),
+          ),
+        );
+      }
+    } catch (e) {
+      Log.error(
+        'Failed to delete video: $e',
+        name: 'OwnerVideoActionsCubit',
+        category: LogCategory.ui,
+      );
+      if (isClosed) return;
+      emit(
+        const OwnerVideoActionsState(
+          deleteStatus: OwnerVideoDeleteStatus.failure,
+          deleteFailureKind: OwnerVideoDeleteFailureKind.unknown,
+        ),
+      );
+    }
+  }
+
+  OwnerVideoDeleteFailureKind _mapFailureKind(DeleteFailureKind? kind) {
+    switch (kind) {
+      case DeleteFailureKind.notInitialized:
+        return OwnerVideoDeleteFailureKind.notInitialized;
+      case DeleteFailureKind.notOwner:
+        return OwnerVideoDeleteFailureKind.notOwner;
+      case DeleteFailureKind.notAuthenticated:
+        return OwnerVideoDeleteFailureKind.notAuthenticated;
+      case DeleteFailureKind.couldNotSign:
+        return OwnerVideoDeleteFailureKind.couldNotSign;
+      case DeleteFailureKind.relayRejected:
+        return OwnerVideoDeleteFailureKind.relayRejected;
+      case DeleteFailureKind.relayNoResponse:
+        return OwnerVideoDeleteFailureKind.relayNoResponse;
+      case DeleteFailureKind.unknown:
+      case null:
+        return OwnerVideoDeleteFailureKind.unknown;
+    }
+  }
+}

--- a/mobile/lib/screens/feed/feed_settings_menu.dart
+++ b/mobile/lib/screens/feed/feed_settings_menu.dart
@@ -13,6 +13,8 @@ import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dar
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
+import 'package:openvine/utils/delete_failure_localization.dart';
+import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
 import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
 
 /// More icon button + playback-controls popover for feed surfaces.
@@ -95,33 +97,8 @@ class _FeedSettingsMenuState extends ConsumerState<FeedSettingsMenu> {
     final video = widget.video;
     if (video == null) return;
 
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: VineTheme.cardBackground,
-        title: Text(
-          dialogContext.l10n.shareMenuDeleteVideo,
-          style: const TextStyle(color: VineTheme.whiteText),
-        ),
-        content: Text(
-          dialogContext.l10n.shareMenuDeleteConfirmation,
-          style: const TextStyle(color: VineTheme.whiteText),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: Text(dialogContext.l10n.shareMenuCancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            style: TextButton.styleFrom(foregroundColor: VineTheme.error),
-            child: Text(dialogContext.l10n.shareMenuDelete),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed == true && mounted) {
+    final confirmed = await showOwnerVideoDeleteConfirmationDialog(context);
+    if (confirmed && mounted) {
       await _deleteVideo(video);
     }
   }
@@ -149,7 +126,9 @@ class _FeedSettingsMenuState extends ConsumerState<FeedSettingsMenu> {
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
         DivineSnackbarContainer.snackBar(
-          _localizedDeleteFailureMessage(context, state.deleteFailureKind),
+          state.deleteResult == null
+              ? context.l10n.shareMenuDeleteFailedGeneric
+              : localizedDeleteFailureMessage(context, state.deleteResult!),
           error: true,
         ),
       );
@@ -185,29 +164,6 @@ class _FeedSettingsMenuState extends ConsumerState<FeedSettingsMenu> {
         ),
       ),
     );
-  }
-}
-
-String _localizedDeleteFailureMessage(
-  BuildContext context,
-  OwnerVideoDeleteFailureKind? kind,
-) {
-  final l10n = context.l10n;
-  switch (kind ?? OwnerVideoDeleteFailureKind.unknown) {
-    case OwnerVideoDeleteFailureKind.notInitialized:
-      return l10n.shareMenuDeleteFailedNotInitialized;
-    case OwnerVideoDeleteFailureKind.notOwner:
-      return l10n.shareMenuDeleteFailedNotOwner;
-    case OwnerVideoDeleteFailureKind.notAuthenticated:
-      return l10n.shareMenuDeleteFailedNotAuthenticated;
-    case OwnerVideoDeleteFailureKind.couldNotSign:
-      return l10n.shareMenuDeleteFailedCouldNotSign;
-    case OwnerVideoDeleteFailureKind.relayRejected:
-      return l10n.shareMenuDeleteFailedRelayRejected;
-    case OwnerVideoDeleteFailureKind.relayNoResponse:
-      return l10n.shareMenuDeleteFailedRelayNoResponse;
-    case OwnerVideoDeleteFailureKind.unknown:
-      return l10n.shareMenuDeleteFailedGeneric;
   }
 }
 

--- a/mobile/lib/screens/feed/feed_settings_menu.dart
+++ b/mobile/lib/screens/feed/feed_settings_menu.dart
@@ -2,9 +2,17 @@
 // ABOUTME: Renders the More icon button and the playback-controls popover
 // ABOUTME: that toggles auto-advance, audio mute, and closed captions.
 
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
 import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart';
 
 /// More icon button + playback-controls popover for feed surfaces.
@@ -21,16 +29,19 @@ import 'package:openvine/widgets/video_feed_item/feed_playback_toggles_pill.dart
 /// `VideoVolumeCubit`, and the Riverpod `subtitleVisibilityProvider`) so the
 /// popover does not need any props from the page — it works as a drop-in
 /// child of any feed surface that provides those scopes.
-class FeedSettingsMenu extends StatefulWidget {
-  const FeedSettingsMenu({super.key});
+class FeedSettingsMenu extends ConsumerStatefulWidget {
+  const FeedSettingsMenu({super.key, this.video});
+
+  final VideoEvent? video;
 
   @override
-  State<FeedSettingsMenu> createState() => _FeedSettingsMenuState();
+  ConsumerState<FeedSettingsMenu> createState() => _FeedSettingsMenuState();
 }
 
-class _FeedSettingsMenuState extends State<FeedSettingsMenu> {
+class _FeedSettingsMenuState extends ConsumerState<FeedSettingsMenu> {
   final OverlayPortalController _controller = OverlayPortalController();
   final LayerLink _link = LayerLink();
+  OwnerVideoActionsCubit? _ownerVideoActionsCubit;
 
   /// Mirrors [_controller.isShowing] so the trigger button can rebuild via a
   /// [ValueListenableBuilder] without setState on the whole subtree.
@@ -40,6 +51,10 @@ class _FeedSettingsMenuState extends State<FeedSettingsMenu> {
 
   @override
   void dispose() {
+    final ownerVideoActionsCubit = _ownerVideoActionsCubit;
+    if (ownerVideoActionsCubit != null) {
+      unawaited(ownerVideoActionsCubit.close());
+    }
     _isShowing.dispose();
     super.dispose();
   }
@@ -60,14 +75,102 @@ class _FeedSettingsMenuState extends State<FeedSettingsMenu> {
     _isShowing.value = false;
   }
 
+  bool get _isOwnVideo {
+    final video = widget.video;
+    if (video == null) return false;
+    final currentUserPubkey = ref
+        .watch(authServiceProvider)
+        .currentPublicKeyHex;
+    return currentUserPubkey != null && currentUserPubkey == video.pubkey;
+  }
+
+  void _editVideo() {
+    final video = widget.video;
+    if (video == null) return;
+    _close();
+    context.push(VideoMetadataEditScreen.pathFor(video.id), extra: video);
+  }
+
+  Future<void> _confirmDeleteVideo() async {
+    final video = widget.video;
+    if (video == null) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: VineTheme.cardBackground,
+        title: Text(
+          dialogContext.l10n.shareMenuDeleteVideo,
+          style: const TextStyle(color: VineTheme.whiteText),
+        ),
+        content: Text(
+          dialogContext.l10n.shareMenuDeleteConfirmation,
+          style: const TextStyle(color: VineTheme.whiteText),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(dialogContext.l10n.shareMenuCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            style: TextButton.styleFrom(foregroundColor: VineTheme.error),
+            child: Text(dialogContext.l10n.shareMenuDelete),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      await _deleteVideo(video);
+    }
+  }
+
+  Future<void> _deleteVideo(VideoEvent video) async {
+    final ownerVideoActionsCubit = _ownerVideoActionsCubit ??=
+        OwnerVideoActionsCubit(
+          contentDeletionServiceFuture: ref.read(
+            contentDeletionServiceProvider.future,
+          ),
+          videoEventService: ref.read(videoEventServiceProvider),
+        );
+    await ownerVideoActionsCubit.deleteVideo(video);
+
+    if (!mounted) return;
+
+    final state = ownerVideoActionsCubit.state;
+    if (state.deleteStatus == OwnerVideoDeleteStatus.success) {
+      final messenger = ScaffoldMessenger.of(context);
+      final snackBar = DivineSnackbarContainer.snackBar(
+        context.l10n.shareMenuVideoDeletionRequested,
+      );
+      _close();
+      messenger.showSnackBar(snackBar);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          _localizedDeleteFailureMessage(context, state.deleteFailureKind),
+          error: true,
+        ),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    final isOwnVideo = _isOwnVideo;
+
     return CompositedTransformTarget(
       link: _link,
       child: OverlayPortal(
         controller: _controller,
-        overlayChildBuilder: (_) =>
-            _FeedSettingsOverlay(link: _link, onClose: _close),
+        overlayChildBuilder: (_) => _FeedSettingsOverlay(
+          link: _link,
+          onClose: _close,
+          isOwnVideo: isOwnVideo,
+          onEditVideo: _editVideo,
+          onDeleteVideo: _confirmDeleteVideo,
+        ),
         child: ValueListenableBuilder<bool>(
           valueListenable: _isShowing,
           builder: (context, isShowing, _) => DivineIconButton(
@@ -85,14 +188,46 @@ class _FeedSettingsMenuState extends State<FeedSettingsMenu> {
   }
 }
 
+String _localizedDeleteFailureMessage(
+  BuildContext context,
+  OwnerVideoDeleteFailureKind? kind,
+) {
+  final l10n = context.l10n;
+  switch (kind ?? OwnerVideoDeleteFailureKind.unknown) {
+    case OwnerVideoDeleteFailureKind.notInitialized:
+      return l10n.shareMenuDeleteFailedNotInitialized;
+    case OwnerVideoDeleteFailureKind.notOwner:
+      return l10n.shareMenuDeleteFailedNotOwner;
+    case OwnerVideoDeleteFailureKind.notAuthenticated:
+      return l10n.shareMenuDeleteFailedNotAuthenticated;
+    case OwnerVideoDeleteFailureKind.couldNotSign:
+      return l10n.shareMenuDeleteFailedCouldNotSign;
+    case OwnerVideoDeleteFailureKind.relayRejected:
+      return l10n.shareMenuDeleteFailedRelayRejected;
+    case OwnerVideoDeleteFailureKind.relayNoResponse:
+      return l10n.shareMenuDeleteFailedRelayNoResponse;
+    case OwnerVideoDeleteFailureKind.unknown:
+      return l10n.shareMenuDeleteFailedGeneric;
+  }
+}
+
 /// Overlay rendered while the popover is open: a full-screen tap catcher
 /// that dismisses the popover, plus the popover itself anchored 16 px below
 /// the trigger button's bottom-right corner.
 class _FeedSettingsOverlay extends StatelessWidget {
-  const _FeedSettingsOverlay({required this.link, required this.onClose});
+  const _FeedSettingsOverlay({
+    required this.link,
+    required this.onClose,
+    required this.isOwnVideo,
+    required this.onEditVideo,
+    required this.onDeleteVideo,
+  });
 
   final LayerLink link;
   final VoidCallback onClose;
+  final bool isOwnVideo;
+  final VoidCallback onEditVideo;
+  final VoidCallback onDeleteVideo;
 
   @override
   Widget build(BuildContext context) {
@@ -120,12 +255,116 @@ class _FeedSettingsOverlay extends StatelessWidget {
             targetAnchor: Alignment.bottomRight,
             followerAnchor: Alignment.topRight,
             offset: const Offset(0, 16),
-            child: const Material(
+            child: Material(
               color: VineTheme.transparent,
-              child: FeedPlaybackTogglesPill(),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (isOwnVideo) ...[
+                    _OwnerVideoActionsPill(
+                      onEditVideo: onEditVideo,
+                      onDeleteVideo: onDeleteVideo,
+                    ),
+                    const SizedBox(height: 8),
+                  ],
+                  const FeedPlaybackTogglesPill(),
+                ],
+              ),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _OwnerVideoActionsPill extends StatelessWidget {
+  const _OwnerVideoActionsPill({
+    required this.onEditVideo,
+    required this.onDeleteVideo,
+  });
+
+  final VoidCallback onEditVideo;
+  final VoidCallback onDeleteVideo;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.scrim30,
+        borderRadius: BorderRadius.circular(24),
+        border: Border.all(color: VineTheme.scrim15),
+        boxShadow: const [
+          BoxShadow(color: VineTheme.shadow25, blurRadius: 4),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 8,
+          children: [
+            _OwnerVideoAction(
+              icon: DivineIconName.pencilSimpleLine,
+              label: context.l10n.shareMenuEditVideo,
+              onTap: onEditVideo,
+            ),
+            _OwnerVideoAction(
+              icon: DivineIconName.trash,
+              label: context.l10n.shareMenuDeleteVideo,
+              onTap: onDeleteVideo,
+              isDestructive: true,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _OwnerVideoAction extends StatelessWidget {
+  const _OwnerVideoAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.isDestructive = false,
+  });
+
+  final DivineIconName icon;
+  final String label;
+  final VoidCallback onTap;
+  final bool isDestructive;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isDestructive ? VineTheme.error : VineTheme.onSurface;
+    return Semantics(
+      button: true,
+      label: label,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: onTap,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: VineTheme.scrim15,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              spacing: 6,
+              children: [
+                DivineIcon(icon: icon, color: color, size: 18),
+                Text(
+                  label,
+                  style: VineTheme.labelSmallFont(color: color),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -545,7 +545,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                 // leading slot. The fullscreen feed sits over playing
                 // video so a small icon hit-target is easy to miss.
                 expandLeadingHitArea: true,
-                customActions: const [FeedSettingsMenu()],
+                customActions: [FeedSettingsMenu(video: state.currentVideo)],
                 style: DiVineAppBarStyle.transparentStyle.copyWith(
                   horizontalPadding: 12,
                   // With the default 48 px icon button and 12 px

--- a/mobile/lib/widgets/owner_video_delete_confirmation_dialog.dart
+++ b/mobile/lib/widgets/owner_video_delete_confirmation_dialog.dart
@@ -1,0 +1,38 @@
+// ABOUTME: Shared confirmation dialog for deleting the signed-in user's video.
+// ABOUTME: Keeps owner-delete confirmation copy and styling consistent.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+Future<bool> showOwnerVideoDeleteConfirmationDialog(
+  BuildContext context,
+) async {
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (dialogContext) => AlertDialog(
+      backgroundColor: VineTheme.cardBackground,
+      title: Text(
+        dialogContext.l10n.shareMenuDeleteVideo,
+        style: const TextStyle(color: VineTheme.whiteText),
+      ),
+      content: Text(
+        dialogContext.l10n.shareMenuDeleteConfirmation,
+        style: const TextStyle(color: VineTheme.whiteText),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(false),
+          child: Text(dialogContext.l10n.shareMenuCancel),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(dialogContext).pop(true),
+          style: TextButton.styleFrom(foregroundColor: VineTheme.error),
+          child: Text(dialogContext.l10n.shareMenuDelete),
+        ),
+      ],
+    ),
+  );
+
+  return confirmed ?? false;
+}

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -18,8 +18,11 @@ import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_clip_import_provider.dart';
+import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
+import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
+import 'package:openvine/utils/delete_failure_localization.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/watermark_text_resolver.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
@@ -184,6 +187,8 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
           isOwnContent: isOwnContent,
           onFindPeople: _handleFindPeople,
           onAddToList: _handleAddToList,
+          onEditVideo: isOwnContent ? _handleEditVideo : null,
+          onDeleteVideo: isOwnContent ? _handleDeleteVideo : null,
           onSaveOriginal: isOwnContent ? _handleSaveOriginal : null,
           onSaveWithWatermark: _handleSaveWithWatermark,
           onAddVideoToClips: canAddVideoToClips ? _handleAddVideoToClips : null,
@@ -321,6 +326,95 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
         builder: (context) => SelectListDialog(video: widget.video),
       );
     });
+  }
+
+  void _handleEditVideo() {
+    _presentAfterDismiss<void>((hostContext) async {
+      hostContext.push(
+        VideoMetadataEditScreen.pathFor(widget.video.id),
+        extra: widget.video,
+      );
+    });
+  }
+
+  Future<void> _handleDeleteVideo() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: VineTheme.cardBackground,
+        title: Text(
+          dialogContext.l10n.shareMenuDeleteVideo,
+          style: const TextStyle(color: VineTheme.whiteText),
+        ),
+        content: Text(
+          dialogContext.l10n.shareMenuDeleteConfirmation,
+          style: const TextStyle(color: VineTheme.whiteText),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(dialogContext.l10n.shareMenuCancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            style: TextButton.styleFrom(foregroundColor: VineTheme.error),
+            child: Text(dialogContext.l10n.shareMenuDelete),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && mounted) {
+      await _deleteVideo();
+    }
+  }
+
+  Future<void> _deleteVideo() async {
+    try {
+      final deletionService = await ref.read(
+        contentDeletionServiceProvider.future,
+      );
+      final result = await deletionService.quickDelete(
+        video: widget.video,
+        reason: DeleteReason.personalChoice,
+      );
+
+      if (!mounted) return;
+
+      if (result.success) {
+        ref
+            .read(videoEventServiceProvider)
+            .removeVideoEventCompletely(
+              widget.video,
+            );
+        final messenger = ScaffoldMessenger.of(context);
+        final snackBar = DivineSnackbarContainer.snackBar(
+          context.l10n.shareMenuVideoDeletionRequested,
+        );
+        _safePop(context);
+        messenger.showSnackBar(snackBar);
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          DivineSnackbarContainer.snackBar(
+            localizedDeleteFailureMessage(context, result),
+            error: true,
+          ),
+        );
+      }
+    } catch (e) {
+      Log.error(
+        'Failed to delete video: $e',
+        name: 'ShareActionButton',
+        category: LogCategory.ui,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        DivineSnackbarContainer.snackBar(
+          context.l10n.shareMenuDeleteFailedGeneric,
+          error: true,
+        ),
+      );
+    }
   }
 
   bool _isUserOwnContent() {
@@ -507,6 +601,8 @@ class _UnifiedShareSheetView extends StatelessWidget {
     required this.onAddToList,
     required this.onSaveWithWatermark,
     this.onAddVideoToClips,
+    this.onEditVideo,
+    this.onDeleteVideo,
     this.onSaveOriginal,
   });
 
@@ -515,6 +611,8 @@ class _UnifiedShareSheetView extends StatelessWidget {
   final bool isOwnContent;
   final VoidCallback onFindPeople;
   final VoidCallback onAddToList;
+  final VoidCallback? onEditVideo;
+  final Future<void> Function()? onDeleteVideo;
   final Future<void> Function()? onSaveOriginal;
   final Future<void> Function() onSaveWithWatermark;
   final VoidCallback? onAddVideoToClips;
@@ -571,6 +669,8 @@ class _UnifiedShareSheetView extends StatelessWidget {
                         onSaveOriginal: onSaveOriginal,
                         onSaveWithWatermark: onSaveWithWatermark,
                         onAddVideoToClips: onAddVideoToClips,
+                        onEditVideo: onEditVideo,
+                        onDeleteVideo: onDeleteVideo,
                         onAddToList: onAddToList,
                         onCopyLink: () =>
                             bloc.add(const ShareSheetCopyLinkRequested()),

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
 import 'package:openvine/blocs/share_sheet/share_sheet_bloc.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
@@ -19,7 +20,6 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_clip_import_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
-import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/video_clip_import_service.dart';
 import 'package:openvine/services/video_sharing_service.dart';
 import 'package:openvine/utils/delete_failure_localization.dart';
@@ -27,6 +27,7 @@ import 'package:openvine/utils/pause_aware_modals.dart';
 import 'package:openvine/utils/watermark_text_resolver.dart';
 import 'package:openvine/widgets/add_to_list_dialog.dart';
 import 'package:openvine/widgets/find_people_sheet.dart';
+import 'package:openvine/widgets/owner_video_delete_confirmation_dialog.dart';
 import 'package:openvine/widgets/profile/profile_saved_videos_sync_scope.dart';
 import 'package:openvine/widgets/save_original_progress_sheet.dart';
 import 'package:openvine/widgets/user_avatar.dart';
@@ -130,6 +131,7 @@ class _UnifiedShareSheet extends ConsumerStatefulWidget {
 class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
   final TextEditingController _messageController = TextEditingController();
   late final ShareSheetBloc _shareSheetBloc;
+  OwnerVideoActionsCubit? _ownerVideoActionsCubit;
 
   @override
   void initState() {
@@ -150,6 +152,7 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
 
   @override
   void dispose() {
+    _ownerVideoActionsCubit?.close();
     _shareSheetBloc.close();
     _messageController.dispose();
     super.dispose();
@@ -338,79 +341,38 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
   }
 
   Future<void> _handleDeleteVideo() async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) => AlertDialog(
-        backgroundColor: VineTheme.cardBackground,
-        title: Text(
-          dialogContext.l10n.shareMenuDeleteVideo,
-          style: const TextStyle(color: VineTheme.whiteText),
-        ),
-        content: Text(
-          dialogContext.l10n.shareMenuDeleteConfirmation,
-          style: const TextStyle(color: VineTheme.whiteText),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(false),
-            child: Text(dialogContext.l10n.shareMenuCancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(dialogContext).pop(true),
-            style: TextButton.styleFrom(foregroundColor: VineTheme.error),
-            child: Text(dialogContext.l10n.shareMenuDelete),
-          ),
-        ],
-      ),
-    );
-
-    if (confirmed == true && mounted) {
+    final confirmed = await showOwnerVideoDeleteConfirmationDialog(context);
+    if (confirmed && mounted) {
       await _deleteVideo();
     }
   }
 
   Future<void> _deleteVideo() async {
-    try {
-      final deletionService = await ref.read(
-        contentDeletionServiceProvider.future,
-      );
-      final result = await deletionService.quickDelete(
-        video: widget.video,
-        reason: DeleteReason.personalChoice,
-      );
-
-      if (!mounted) return;
-
-      if (result.success) {
-        ref
-            .read(videoEventServiceProvider)
-            .removeVideoEventCompletely(
-              widget.video,
-            );
-        final messenger = ScaffoldMessenger.of(context);
-        final snackBar = DivineSnackbarContainer.snackBar(
-          context.l10n.shareMenuVideoDeletionRequested,
-        );
-        _safePop(context);
-        messenger.showSnackBar(snackBar);
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            localizedDeleteFailureMessage(context, result),
-            error: true,
+    final ownerVideoActionsCubit = _ownerVideoActionsCubit ??=
+        OwnerVideoActionsCubit(
+          contentDeletionServiceFuture: ref.read(
+            contentDeletionServiceProvider.future,
           ),
+          videoEventService: ref.read(videoEventServiceProvider),
         );
-      }
-    } catch (e) {
-      Log.error(
-        'Failed to delete video: $e',
-        name: 'ShareActionButton',
-        category: LogCategory.ui,
+    await ownerVideoActionsCubit.deleteVideo(widget.video);
+
+    if (!mounted) return;
+
+    final state = ownerVideoActionsCubit.state;
+    if (state.deleteStatus == OwnerVideoDeleteStatus.success) {
+      final messenger = ScaffoldMessenger.of(context);
+      final snackBar = DivineSnackbarContainer.snackBar(
+        context.l10n.shareMenuVideoDeletionRequested,
       );
-      if (!mounted) return;
+      _safePop(context);
+      messenger.showSnackBar(snackBar);
+    } else {
       ScaffoldMessenger.of(context).showSnackBar(
         DivineSnackbarContainer.snackBar(
-          context.l10n.shareMenuDeleteFailedGeneric,
+          state.deleteResult == null
+              ? context.l10n.shareMenuDeleteFailedGeneric
+              : localizedDeleteFailureMessage(context, state.deleteResult!),
           error: true,
         ),
       );

--- a/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart
@@ -15,6 +15,8 @@ class _MoreActionsSection extends ConsumerWidget {
     required this.onShareVia,
     required this.onCopyEventJson,
     required this.onCopyEventId,
+    this.onEditVideo,
+    this.onDeleteVideo,
     this.onAddVideoToClips,
     this.onSaveOriginal,
   });
@@ -29,6 +31,8 @@ class _MoreActionsSection extends ConsumerWidget {
   final VoidCallback onShareVia;
   final VoidCallback onCopyEventJson;
   final VoidCallback onCopyEventId;
+  final VoidCallback? onEditVideo;
+  final Future<void> Function()? onDeleteVideo;
   final VoidCallback? onAddVideoToClips;
 
   @override
@@ -41,6 +45,18 @@ class _MoreActionsSection extends ConsumerWidget {
     );
 
     final actions = <_ActionData>[
+      if (onEditVideo != null)
+        _ActionData(
+          icon: DivineIconName.pencilSimpleLine,
+          label: context.l10n.shareMenuEditVideo,
+          onTap: onEditVideo!,
+        ),
+      if (onDeleteVideo != null)
+        _ActionData(
+          icon: DivineIconName.trash,
+          label: context.l10n.shareMenuDeleteVideo,
+          onTap: onDeleteVideo!,
+        ),
       _ActionData(
         icon: DivineIconName.bookmarkSimple,
         label: context.l10n.shareSheetSave,

--- a/mobile/test/blocs/owner_video_actions/owner_video_actions_cubit_test.dart
+++ b/mobile/test/blocs/owner_video_actions/owner_video_actions_cubit_test.dart
@@ -1,0 +1,165 @@
+// ABOUTME: Unit tests for owner-only video action business logic.
+// ABOUTME: Verifies delete success, typed failures, and exception handling.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/owner_video_actions/owner_video_actions_cubit.dart';
+import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+class _MockContentDeletionService extends Mock
+    implements ContentDeletionService {}
+
+class _MockVideoEventService extends Mock implements VideoEventService {}
+
+void main() {
+  group(OwnerVideoActionsCubit, () {
+    final video = VideoEvent(
+      id: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+      pubkey:
+          'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      createdAt: 1757385263,
+      content: 'Test video content',
+      timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+      videoUrl: 'https://example.com/video.mp4',
+    );
+
+    late _MockContentDeletionService deletionService;
+    late _MockVideoEventService videoEventService;
+
+    OwnerVideoActionsCubit buildCubit() => OwnerVideoActionsCubit(
+      contentDeletionServiceFuture: Future.value(deletionService),
+      videoEventService: videoEventService,
+    );
+
+    setUp(() {
+      deletionService = _MockContentDeletionService();
+      videoEventService = _MockVideoEventService();
+    });
+
+    blocTest<OwnerVideoActionsCubit, OwnerVideoActionsState>(
+      'removes the video locally after delete success',
+      build: buildCubit,
+      setUp: () {
+        when(
+          () => deletionService.quickDelete(
+            video: video,
+            reason: DeleteReason.personalChoice,
+          ),
+        ).thenAnswer(
+          (_) async => DeleteResult.createSuccess('delete-event-id'),
+        );
+      },
+      act: (cubit) => cubit.deleteVideo(video),
+      expect: () => [
+        const OwnerVideoActionsState(
+          deleteStatus: OwnerVideoDeleteStatus.deleting,
+        ),
+        isA<OwnerVideoActionsState>()
+            .having(
+              (state) => state.deleteStatus,
+              'deleteStatus',
+              OwnerVideoDeleteStatus.success,
+            )
+            .having(
+              (state) => state.deleteResult?.success,
+              'deleteResult.success',
+              isTrue,
+            )
+            .having(
+              (state) => state.deleteResult?.deleteEventId,
+              'deleteResult.deleteEventId',
+              'delete-event-id',
+            ),
+      ],
+      verify: (_) {
+        verify(
+          () => videoEventService.removeVideoEventCompletely(video),
+        ).called(1);
+      },
+    );
+
+    blocTest<OwnerVideoActionsCubit, OwnerVideoActionsState>(
+      'surfaces typed delete failures without removing the video locally',
+      build: buildCubit,
+      setUp: () {
+        when(
+          () => deletionService.quickDelete(
+            video: video,
+            reason: DeleteReason.personalChoice,
+          ),
+        ).thenAnswer(
+          (_) async => DeleteResult.failure(
+            'Relay rejected delete event',
+            DeleteFailureKind.relayRejected,
+          ),
+        );
+      },
+      act: (cubit) => cubit.deleteVideo(video),
+      expect: () => [
+        const OwnerVideoActionsState(
+          deleteStatus: OwnerVideoDeleteStatus.deleting,
+        ),
+        isA<OwnerVideoActionsState>()
+            .having(
+              (state) => state.deleteStatus,
+              'deleteStatus',
+              OwnerVideoDeleteStatus.failure,
+            )
+            .having(
+              (state) => state.deleteResult?.success,
+              'deleteResult.success',
+              isFalse,
+            )
+            .having(
+              (state) => state.deleteResult?.failureKind,
+              'deleteResult.failureKind',
+              DeleteFailureKind.relayRejected,
+            ),
+      ],
+      verify: (_) {
+        verifyNever(() => videoEventService.removeVideoEventCompletely(video));
+      },
+    );
+
+    blocTest<OwnerVideoActionsCubit, OwnerVideoActionsState>(
+      'reports unknown failure when delete throws',
+      build: buildCubit,
+      setUp: () {
+        when(
+          () => deletionService.quickDelete(
+            video: video,
+            reason: DeleteReason.personalChoice,
+          ),
+        ).thenThrow(Exception('network failed'));
+      },
+      act: (cubit) => cubit.deleteVideo(video),
+      expect: () => [
+        const OwnerVideoActionsState(
+          deleteStatus: OwnerVideoDeleteStatus.deleting,
+        ),
+        isA<OwnerVideoActionsState>()
+            .having(
+              (state) => state.deleteStatus,
+              'deleteStatus',
+              OwnerVideoDeleteStatus.failure,
+            )
+            .having(
+              (state) => state.deleteResult?.success,
+              'deleteResult.success',
+              isFalse,
+            )
+            .having(
+              (state) => state.deleteResult?.failureKind,
+              'deleteResult.failureKind',
+              DeleteFailureKind.unknown,
+            ),
+      ],
+      verify: (_) {
+        verifyNever(() => videoEventService.removeVideoEventCompletely(video));
+      },
+    );
+  });
+}

--- a/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
+++ b/mobile/test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart
@@ -141,6 +141,8 @@ const testVideoId3 =
     'c3d4e5f6789012345678901234567890abcdef123456789012345678901234a1b2';
 const testPubkey =
     'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3';
+const otherPubkey =
+    'e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3d4';
 
 class _PopCountingObserver extends NavigatorObserver {
   _PopCountingObserver({required this.onPop});
@@ -258,6 +260,7 @@ void main() {
     Widget buildSubject({
       FullscreenFeedState? state,
       List<dynamic>? additionalOverrides,
+      MockAuthService? mockAuthService,
       String? contextTitle,
       ViewTrafficSource trafficSource = ViewTrafficSource.unknown,
       String? sourceDetail,
@@ -267,6 +270,7 @@ void main() {
 
       return testMaterialApp(
         additionalOverrides: additionalOverrides,
+        mockAuthService: mockAuthService,
         mockProfileRepository: mockProfileRepository,
         mockNip05VerificationService: mockNip05VerificationService,
         home: buildContent(
@@ -1097,6 +1101,69 @@ void main() {
 
         expect(find.byType(FeedSettingsMenu), findsOneWidget);
       });
+
+      testWidgets('shows owner edit and delete actions in the more menu', (
+        tester,
+      ) async {
+        final videos = createTestVideos();
+        final mockAuth = createMockAuthService();
+        when(() => mockAuth.isAuthenticated).thenReturn(true);
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(testPubkey);
+
+        await tester.pumpWidget(
+          buildSubject(
+            state: FullscreenFeedState(
+              status: FullscreenFeedStatus.ready,
+              videos: videos,
+            ),
+            mockAuthService: mockAuth,
+          ),
+        );
+        await tester.pump();
+
+        await tester.tap(find.byType(FeedSettingsMenu));
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(find.text('Edit Video'), findsOneWidget);
+        expect(find.text('Delete Video'), findsOneWidget);
+
+        await tester.pumpWidget(const SizedBox.shrink());
+        await tester.pump();
+        await tester.pump(Duration.zero);
+      });
+
+      testWidgets(
+        'hides owner edit and delete actions for non-owned videos in the more menu',
+        (tester) async {
+          final videos = createTestVideos();
+          final mockAuth = createMockAuthService();
+          when(() => mockAuth.isAuthenticated).thenReturn(true);
+          when(() => mockAuth.currentPublicKeyHex).thenReturn(otherPubkey);
+
+          await tester.pumpWidget(
+            buildSubject(
+              state: FullscreenFeedState(
+                status: FullscreenFeedStatus.ready,
+                videos: videos,
+              ),
+              mockAuthService: mockAuth,
+            ),
+          );
+          await tester.pump();
+
+          await tester.tap(find.byType(FeedSettingsMenu));
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 100));
+
+          expect(find.text('Edit Video'), findsNothing);
+          expect(find.text('Delete Video'), findsNothing);
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await tester.pump(Duration.zero);
+        },
+      );
 
       testWidgets('requests pagination at the end when more content exists', (
         tester,

--- a/mobile/test/widgets/share_video_menu_comprehensive_test.dart
+++ b/mobile/test/widgets/share_video_menu_comprehensive_test.dart
@@ -290,6 +290,34 @@ void main() {
       },
     );
 
+    testWidgets('More actions row shows owner edit and delete actions', (
+      tester,
+    ) async {
+      final authService = createMockAuthService();
+      when(() => authService.isAuthenticated).thenReturn(true);
+      when(
+        () => authService.currentPublicKeyHex,
+      ).thenReturn(testVideo.pubkey);
+
+      await tester.pumpWidget(buildSubject(mockAuthService: authService));
+      await tester.tap(find.byType(ShareActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit Video'), findsOneWidget);
+      expect(find.text('Delete Video'), findsOneWidget);
+    });
+
+    testWidgets('More actions row hides owner actions for non-owned videos', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject());
+      await tester.tap(find.byType(ShareActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit Video'), findsNothing);
+      expect(find.text('Delete Video'), findsNothing);
+    });
+
     testWidgets('tapping Add to clips shows success snackbar with clip title', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

Restores owner-only Edit Video and Delete Video actions to both current video-management surfaces:

- unified share sheet More actions row
- fullscreen feed settings menu

Delete now flows through the shared `OwnerVideoActionsCubit` business-logic layer on both surfaces, uses the existing `DeleteResult` / `DeleteFailureKind` model, removes the video from local feeds only after successful deletion, and reuses the shared localized delete-failure messages.

Closes #5364

## Out of Scope

None.

## Verification

- `mise exec -- flutter analyze lib/blocs/owner_video_actions/owner_video_actions_cubit.dart lib/screens/feed/feed_settings_menu.dart lib/widgets/owner_video_delete_confirmation_dialog.dart lib/widgets/video_feed_item/actions/share_action_button.dart lib/widgets/video_feed_item/actions/share_sheet_more_actions.dart test/blocs/owner_video_actions/owner_video_actions_cubit_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart test/widgets/share_video_menu_comprehensive_test.dart`
- `mise exec -- flutter test test/blocs/owner_video_actions/owner_video_actions_cubit_test.dart test/widgets/share_video_menu_comprehensive_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
