### PR TITLE
test(explore): stabilize top hashtags asset loading

### DIFF
--- a/mobile/lib/services/top_hashtags_service.dart
+++ b/mobile/lib/services/top_hashtags_service.dart
@@ -6,6 +6,8 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+typedef _AssetStringLoader = Future<String> Function(String key);
+
 /// Minimal seam for loading hashtag suggestions.
 abstract interface class TopHashtagsLoader {
   /// Loads the top hashtag data used by explore surfaces.
@@ -36,7 +38,14 @@ class HashtagData {
 }
 
 class TopHashtagsService implements TopHashtagsLoader {
-  TopHashtagsService._();
+  TopHashtagsService._({_AssetStringLoader? loadAssetString})
+    : _loadAssetString = loadAssetString ?? rootBundle.loadString;
+
+  @visibleForTesting
+  TopHashtagsService.forTesting({
+    required Future<String> Function(String key) loadAssetString,
+  }) : this._(loadAssetString: loadAssetString);
+
   static final TopHashtagsService _instance = TopHashtagsService._();
   static TopHashtagsService get instance => _instance;
 
@@ -67,18 +76,13 @@ class TopHashtagsService implements TopHashtagsLoader {
 
   List<HashtagData>? _topHashtags;
   bool _isLoaded = false;
+  final _AssetStringLoader _loadAssetString;
 
   /// Get top hashtags (returns empty list if not loaded)
   List<HashtagData> get topHashtags => _topHashtags ?? [];
 
   /// Check if hashtags are loaded
   bool get isLoaded => _isLoaded;
-
-  @visibleForTesting
-  void resetForTesting() {
-    _topHashtags = null;
-    _isLoaded = false;
-  }
 
   /// Load top hashtags from JSON file
   @override
@@ -100,7 +104,7 @@ class TopHashtagsService implements TopHashtagsLoader {
       );
 
       // Load the JSON file from assets
-      final jsonString = await rootBundle.loadString(
+      final jsonString = await _loadAssetString(
         'assets/top_1000_hashtags.json',
       );
 

--- a/mobile/lib/services/top_hashtags_service.dart
+++ b/mobile/lib/services/top_hashtags_service.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Provides popular hashtag suggestions for discovery and exploration.
 
 import 'dart:convert';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -72,6 +73,12 @@ class TopHashtagsService implements TopHashtagsLoader {
 
   /// Check if hashtags are loaded
   bool get isLoaded => _isLoaded;
+
+  @visibleForTesting
+  void resetForTesting() {
+    _topHashtags = null;
+    _isLoaded = false;
+  }
 
   /// Load top hashtags from JSON file
   @override

--- a/mobile/test/screens/discover_lists_screen_test.dart
+++ b/mobile/test/screens/discover_lists_screen_test.dart
@@ -109,6 +109,11 @@ void main() {
       'scrolling to bottom again after finding no new lists should not '
       're-trigger pagination',
       (tester) async {
+        tester.view.physicalSize = const Size(390, 844);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
         // Each call gets a fresh StreamController. The stream stays open
         // (no data, no close) so _loadMoreLists relies on its 3-second
         // timeout timer to complete. The timeout fires within FakeAsync,

--- a/mobile/test/screens/explore_screen_hashtag_loading_test.dart
+++ b/mobile/test/screens/explore_screen_hashtag_loading_test.dart
@@ -1,11 +1,52 @@
 // ABOUTME: Tests for hashtag loading and display in ExploreScreen Trending tab
 // ABOUTME: Verifies hashtags load quickly from JSON and display immediately after loading
 
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/top_hashtags_service.dart';
 
+void _mockTopHashtagsAsset(String payload) {
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler('flutter/assets', (ByteData? message) async {
+        if (message == null) return null;
+
+        final assetName = utf8.decode(message.buffer.asUint8List());
+        if (assetName != 'assets/top_1000_hashtags.json') return null;
+
+        final bytes = Uint8List.fromList(utf8.encode(payload));
+        return ByteData.sublistView(bytes);
+      });
+}
+
+void _resetTopHashtagsAssetState() {
+  TopHashtagsService.instance.resetForTesting();
+  rootBundle.clear();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler('flutter/assets', null);
+}
+
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late String bundledTopHashtagsJson;
+
+  setUpAll(() {
+    bundledTopHashtagsJson = File(
+      'assets/top_1000_hashtags.json',
+    ).readAsStringSync();
+  });
+
   group('TopHashtagsService Performance Tests', () {
+    setUp(() {
+      _resetTopHashtagsAssetState();
+      _mockTopHashtagsAsset(bundledTopHashtagsJson);
+    });
+
+    tearDown(_resetTopHashtagsAssetState);
+
     test('Hashtags load quickly from JSON asset (< 200ms)', () async {
       // Start timing hashtag load
       final startTime = DateTime.now();

--- a/mobile/test/screens/explore_screen_hashtag_loading_test.dart
+++ b/mobile/test/screens/explore_screen_hashtag_loading_test.dart
@@ -1,37 +1,16 @@
 // ABOUTME: Tests for hashtag loading and display in ExploreScreen Trending tab
 // ABOUTME: Verifies hashtags load quickly from JSON and display immediately after loading
 
-import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/services/top_hashtags_service.dart';
-
-void _mockTopHashtagsAsset(String payload) {
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMessageHandler('flutter/assets', (ByteData? message) async {
-        if (message == null) return null;
-
-        final assetName = utf8.decode(message.buffer.asUint8List());
-        if (assetName != 'assets/top_1000_hashtags.json') return null;
-
-        final bytes = Uint8List.fromList(utf8.encode(payload));
-        return ByteData.sublistView(bytes);
-      });
-}
-
-void _resetTopHashtagsAssetState() {
-  TopHashtagsService.instance.resetForTesting();
-  rootBundle.clear();
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMessageHandler('flutter/assets', null);
-}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late String bundledTopHashtagsJson;
+  late TopHashtagsService service;
 
   setUpAll(() {
     bundledTopHashtagsJson = File(
@@ -41,18 +20,17 @@ void main() {
 
   group('TopHashtagsService Performance Tests', () {
     setUp(() {
-      _resetTopHashtagsAssetState();
-      _mockTopHashtagsAsset(bundledTopHashtagsJson);
+      service = TopHashtagsService.forTesting(
+        loadAssetString: (_) async => bundledTopHashtagsJson,
+      );
     });
-
-    tearDown(_resetTopHashtagsAssetState);
 
     test('Hashtags load quickly from JSON asset (< 200ms)', () async {
       // Start timing hashtag load
       final startTime = DateTime.now();
 
       // Load hashtags from JSON
-      await TopHashtagsService.instance.loadTopHashtags();
+      await service.loadTopHashtags();
 
       final loadDuration = DateTime.now().difference(startTime);
 
@@ -64,13 +42,11 @@ void main() {
       );
 
       // Verify hashtags are loaded in service
-      expect(TopHashtagsService.instance.isLoaded, isTrue);
-      expect(TopHashtagsService.instance.topHashtags.length, greaterThan(0));
+      expect(service.isLoaded, isTrue);
+      expect(service.topHashtags.length, greaterThan(0));
     });
 
     test('TopHashtagsService loads hashtags only once (idempotent)', () async {
-      final service = TopHashtagsService.instance;
-
       // First load
       await service.loadTopHashtags();
       final firstLoadCount = service.topHashtags.length;
@@ -86,7 +62,6 @@ void main() {
     });
 
     test('getTopHashtags returns requested number of hashtags', () async {
-      final service = TopHashtagsService.instance;
       await service.loadTopHashtags();
 
       // Test various limits
@@ -103,7 +78,6 @@ void main() {
     test(
       'bundled popular hashtags use current API-derived suggestions',
       () async {
-        final service = TopHashtagsService.instance;
         await service.loadTopHashtags();
 
         final topHashtags = service.getTopHashtags(limit: 5);
@@ -113,17 +87,13 @@ void main() {
       },
     );
 
-    test('getTopHashtags returns empty list before loading', () {
-      // Create fresh service instance would normally need a reset mechanism
-      // For now, test the guard condition
-      final hashtags = TopHashtagsService.instance.getTopHashtags(limit: 20);
+    test('getTopHashtags returns fallback defaults before loading', () {
+      final hashtags = service.getTopHashtags(limit: 20);
 
-      // Should either be loaded (from previous test) or empty
-      expect(hashtags, isA<List<String>>());
+      expect(hashtags, equals(TopHashtagsService.defaultHashtags));
     });
 
     test('searchHashtags finds exact matches', () async {
-      final service = TopHashtagsService.instance;
       await service.loadTopHashtags();
 
       // Search for common hashtag (from bundled popular hashtag list)
@@ -134,7 +104,6 @@ void main() {
     });
 
     test('searchHashtags finds prefix matches', () async {
-      final service = TopHashtagsService.instance;
       await service.loadTopHashtags();
 
       // Search with prefix (from bundled popular hashtag list)
@@ -148,7 +117,6 @@ void main() {
     });
 
     test('searchHashtags is case insensitive', () async {
-      final service = TopHashtagsService.instance;
       await service.loadTopHashtags();
 
       final lowercase = service.searchHashtags('funny', limit: 10);


### PR DESCRIPTION
Closes #5361
Closes #5363

## Description

The top hashtags loading tests were sharing process-global state through `TopHashtagsService.instance` and the default Flutter asset bundle. That made the tests depend on prior asset-loading state and on the singleton cache left by earlier tests.

This PR keeps runtime behavior unchanged and stabilizes the test path by:

- adding a `@visibleForTesting` constructor that accepts an asset-string loader
- using fresh `TopHashtagsService` instances in the affected test file
- loading the bundled JSON fixture through the test-owned loader instead of replacing Flutter's global `flutter/assets` channel

The first split attempt used a global asset-channel mock and CI exposed that it could pollute later widget tests. This revision removes that global mutation.

CI also exposed that `discover_lists_screen_test.dart` depended on inherited widget-test viewport state. This PR fixes that existing test isolation debt by setting and resetting the viewport in the pagination test that depends on scrollability.

## Verification

- `mise exec -- flutter test test/screens/explore_screen_hashtag_loading_test.dart`
- `mise exec -- flutter test test/screens/discover_lists_screen_test.dart`
- Pre-push analyzer and changed-file test run passed for the touched files.
- GitHub CI is expected to provide the full-suite validation with the repository toolchain.

## Type of Change

- [x] Test
