### PR TITLE
feat(subtitles): creator subtitle editing + republish to Blossom & 39307

### DIFF
--- a/docs/superpowers/plans/2026-06-20-subtitle-editing.md
+++ b/docs/superpowers/plans/2026-06-20-subtitle-editing.md
@@ -1,0 +1,2124 @@
+# Creator Subtitle Editing & Republish-to-Blossom — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a creator fix the (often-wrong) auto-generated subtitles on
+their own video, text-only, and republish the corrected captions to both
+Blossom (durable content-addressed blob) and a Kind 39307 Nostr event,
+with the video event referencing both for read-time redundancy.
+
+**Architecture:** UI (`SubtitleEditorScreen`, Page/View) → Cubit
+(`SubtitleEditorCubit`) → Repository (`SubtitleRepository`, owns
+generate→upload→publish→republish orchestration) → Clients
+(`BlossomUploadService.uploadSubtitleVtt`, `VideoEventPublisher`,
+`NostrClient`). A shared `fetchSubtitleCues` function is extracted so the
+display provider and the editor's load path share one fallback chain.
+
+**Tech Stack:** Flutter, flutter_bloc (Cubit), Riverpod (DI bridge),
+go_router, dio, nostr_sdk, Blossom BUD-01, WebVTT.
+
+Spec: `docs/superpowers/specs/2026-06-20-subtitle-editing-design.md`.
+
+---
+
+## Pre-flight
+
+- [ ] **Step 0: Create the worktree from `origin/main`** (run from repo root)
+
+```bash
+git fetch origin
+git worktree add .worktrees/subtitle-editing -b feat/subtitle-editing origin/main
+cd .worktrees/subtitle-editing/mobile
+mise trust && mise exec -- flutter pub get
+```
+
+All `flutter`/`dart` commands below run from `mobile/` in this worktree,
+prefixed with `mise exec --` per repo convention.
+
+---
+
+## File Structure
+
+**Create:**
+- `mobile/lib/services/subtitle_fetcher.dart` — shared `fetchSubtitleCues` + helpers (moved out of the provider).
+- `mobile/lib/repositories/subtitle_repository.dart` — orchestration + `SubtitleEditException`.
+- `mobile/lib/providers/subtitle_repository_provider.dart` — `subtitleRepositoryProvider`.
+- `mobile/lib/blocs/subtitle_editor/subtitle_editor_cubit.dart`
+- `mobile/lib/blocs/subtitle_editor/subtitle_editor_state.dart`
+- `mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart` — Page + View + private widgets.
+- Tests mirroring each of the above.
+
+**Modify:**
+- `mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart` — add `uploadSubtitleVtt`.
+- `mobile/packages/models/lib/src/video_event.dart` — add `textTrackRefs`, accumulate all `text-track` tags.
+- `mobile/lib/providers/subtitle_providers.dart` — delegate to `fetchSubtitleCues`, accept `textTrackRefs`.
+- `mobile/lib/widgets/video_feed_item/subtitle_overlay.dart` — pass `textTrackRefs`.
+- `mobile/lib/services/video_event_publisher.dart` — add `publishSubtitleEvent`, extend `republishWithSubtitles`.
+- `mobile/packages/models/lib/src/nip71_video_kinds.dart` — add subtitle kind constant.
+- `mobile/lib/router/app_router.dart` — add `/subtitle-edit/:videoId` route.
+- `mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart` — add "Edit subtitles" action.
+- `mobile/lib/l10n/app_en.arb` + `test/l10n/arb_consistency_test.dart` allowlist.
+
+---
+
+## Task 1: Blossom — `uploadSubtitleVtt`
+
+**Files:**
+- Modify: `mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart`
+- Test: `mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the existing `group('BlossomUploadService', ...)` in the test
+file. Mirrors the existing mock setup (`_MockAuthProvider`, `_MockDio`,
+`_MockResponse`, `_signedEvent`). It asserts the VTT bytes are PUT with
+`Content-Type: text/vtt` and that the sha256 is returned.
+
+```dart
+group('uploadSubtitleVtt', () {
+  test('PUTs VTT bytes with text/vtt content type and returns sha256',
+      () async {
+    final mockDio = _MockDio();
+    final mockResponse = _MockResponse();
+    when(() => mockResponse.statusCode).thenReturn(200);
+    when(() => mockResponse.data).thenReturn(<String, dynamic>{});
+    when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+    when(
+      () => mockAuthProvider.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer(
+      (_) async => _signedEvent(_testPublicKey, 24242, const [], ''),
+    );
+    when(
+      () => mockDio.put<dynamic>(
+        any(),
+        data: any(named: 'data'),
+        options: any(named: 'options'),
+        onSendProgress: any(named: 'onSendProgress'),
+      ),
+    ).thenAnswer((_) async => mockResponse);
+
+    final service = BlossomUploadService(
+      authProvider: mockAuthProvider,
+      dio: mockDio,
+    );
+
+    final vtt = utf8.encode('WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhi\n');
+    final result = await service.uploadSubtitleVtt(
+      bytes: Uint8List.fromList(vtt),
+    );
+
+    expect(result.success, isTrue);
+    expect(result.videoId, isNotNull);
+    expect(result.url, contains(result.videoId!));
+
+    final captured = verify(
+      () => mockDio.put<dynamic>(
+        any(),
+        data: any(named: 'data'),
+        options: captureAny(named: 'options'),
+        onSendProgress: any(named: 'onSendProgress'),
+      ),
+    ).captured.single as Options;
+    expect(captured.headers!['Content-Type'], 'text/vtt');
+  });
+
+  test('returns auth failure when not authenticated', () async {
+    when(() => mockAuthProvider.isAuthenticated).thenReturn(false);
+    final service = BlossomUploadService(authProvider: mockAuthProvider);
+    final result = await service.uploadSubtitleVtt(
+      bytes: Uint8List.fromList(utf8.encode('WEBVTT\n')),
+    );
+    expect(result.success, isFalse);
+    expect(result.failureReason, BlossomUploadFailureReason.auth);
+  });
+});
+```
+
+Add `import 'dart:convert';` to the test file if not already present
+(`dart:typed_data` is already imported).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `mise exec -- flutter test test/src/blossom_upload_service_test.dart --plain-name uploadSubtitleVtt` (from `mobile/packages/blossom_upload_service`)
+Expected: FAIL — `uploadSubtitleVtt` not defined.
+
+- [ ] **Step 3: Implement `uploadSubtitleVtt`**
+
+Add this method to `class BlossomUploadService`, directly after the
+existing `uploadAudio` method. It reuses `_BytesUploadSource`,
+`HashUtil.sha256Hash`, `_getServerUrlsForUpload`, `_uploadToServer`,
+`_classifyUploadException`, and `_defaultServerUrl` — all already in the
+file.
+
+```dart
+/// Uploads a subtitle VTT blob (BUD-01) and returns its sha256 + canonical
+/// URL. MIME defaults to `text/vtt`; Blossom is content-addressed so the
+/// stored Content-Type does not affect the address.
+Future<BlossomUploadResult> uploadSubtitleVtt({
+  required Uint8List bytes,
+  String mimeType = 'text/vtt',
+  void Function(double)? onProgress,
+}) async {
+  if (!authProvider.isAuthenticated) {
+    return const BlossomUploadResult(
+      success: false,
+      errorMessage: 'Not authenticated',
+      failureReason: BlossomUploadFailureReason.auth,
+    );
+  }
+
+  onProgress?.call(0.1);
+
+  final fileHash = HashUtil.sha256Hash(bytes);
+  final fileSize = bytes.length;
+
+  final serverUrls = await _getServerUrlsForUpload();
+  BlossomUploadResult? lastError;
+
+  for (final serverUrl in serverUrls) {
+    try {
+      final result = await _uploadToServer(
+        serverUrl: serverUrl,
+        source: _BytesUploadSource(bytes: bytes, filename: 'subtitles.vtt'),
+        fileHash: fileHash,
+        fileSize: fileSize,
+        contentType: mimeType,
+        onProgress: onProgress,
+      );
+
+      if (result.success) {
+        final canonicalUrl = '$_defaultServerUrl/$fileHash';
+        return BlossomUploadResult(
+          success: true,
+          url: canonicalUrl,
+          fallbackUrl: canonicalUrl,
+          videoId: fileHash,
+        );
+      }
+      lastError = result;
+    } on Object catch (e) {
+      final statusCode = e is DioException ? e.response?.statusCode : null;
+      lastError = BlossomUploadResult(
+        success: false,
+        statusCode: statusCode,
+        errorMessage: 'Upload to $serverUrl failed: $e',
+        failureReason: _classifyUploadException(e),
+      );
+    }
+  }
+
+  return lastError ??
+      const BlossomUploadResult(
+        success: false,
+        errorMessage: 'All servers failed',
+        failureReason: BlossomUploadFailureReason.unknown,
+      );
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass + analyze**
+
+Run: `mise exec -- flutter test test/src/blossom_upload_service_test.dart --plain-name uploadSubtitleVtt`
+Expected: PASS.
+Run: `mise exec -- flutter analyze lib test`
+Expected: No issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/blossom_upload_service
+git commit -m "feat(blossom): add uploadSubtitleVtt for text/vtt blobs"
+```
+
+---
+
+## Task 2: Subtitle kind constant
+
+**Files:**
+- Modify: `mobile/packages/models/lib/src/nip71_video_kinds.dart`
+- Test: `mobile/packages/models/test/src/nip71_video_kinds_test.dart` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(NIP71VideoKinds, () {
+    test('subtitleEventKind is 39307', () {
+      expect(NIP71VideoKinds.subtitleEventKind, 39307);
+    });
+  });
+}
+```
+
+(If the package uses `flutter_test` instead of `test`, match the
+neighbouring test files' import. Check an existing test in
+`mobile/packages/models/test/`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- flutter test test/src/nip71_video_kinds_test.dart` (from `mobile/packages/models`)
+Expected: FAIL — `subtitleEventKind` not defined.
+
+- [ ] **Step 3: Add the constant**
+
+In `class NIP71VideoKinds`, add:
+
+```dart
+/// Addressable subtitle/caption event kind referenced by a video's
+/// `text-track` tag as `39307:<pubkey>:subtitles:<video-d-tag>`.
+static const int subtitleEventKind = 39307;
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `mise exec -- flutter test test/src/nip71_video_kinds_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/models/lib/src/nip71_video_kinds.dart packages/models/test
+git commit -m "feat(models): add NIP71VideoKinds.subtitleEventKind constant"
+```
+
+---
+
+## Task 3: `VideoEvent.textTrackRefs` — capture all text-track tags
+
+**Files:**
+- Modify: `mobile/packages/models/lib/src/video_event.dart`
+- Test: `mobile/packages/models/test/src/video_event_text_track_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing text-track test file:
+
+```dart
+test('captures multiple text-track tags into textTrackRefs in order', () {
+  final event = Event(
+    testPubkey,
+    34236,
+    [
+      ['d', 'my-vine-id'],
+      [
+        'text-track',
+        'https://media.divine.video/abc123',
+        'wss://relay.divine.video',
+        'captions',
+        'en',
+      ],
+      [
+        'text-track',
+        '39307:$testPubkey:subtitles:my-vine-id',
+        'wss://relay.divine.video',
+        'captions',
+        'en',
+      ],
+    ],
+    'content',
+  );
+
+  final video = VideoEvent.fromNostrEvent(event);
+
+  expect(video.textTrackRefs, [
+    'https://media.divine.video/abc123',
+    '39307:$testPubkey:subtitles:my-vine-id',
+  ]);
+  // Back-compat: single-value getter still returns the first.
+  expect(video.textTrackRef, 'https://media.divine.video/abc123');
+});
+```
+
+(Match how the existing tests in this file construct `Event` /
+`testPubkey`; reuse the file's existing helpers.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- flutter test test/src/video_event_text_track_test.dart --plain-name "captures multiple"` (from `mobile/packages/models`)
+Expected: FAIL — `textTrackRefs` not defined (and only first tag captured).
+
+- [ ] **Step 3: Implement the field + accumulation**
+
+3a. Add the constructor parameter (in the `const VideoEvent({...})` list,
+next to `this.textTrackRef`):
+
+```dart
+    this.textTrackRefs = const [],
+```
+
+3b. Add the field declaration (next to `final String? textTrackRef;`):
+
+```dart
+  /// All `text-track` references in tag order, for read-time fallback.
+  /// `textTrackRef` mirrors the first entry for back-compat.
+  final List<String> textTrackRefs;
+```
+
+3c. Replace the `case 'text-track':` parse handler. It currently does:
+
+```dart
+        case 'text-track':
+          // Subtitle/caption track reference
+          // Format: ['text-track', '<coords-or-url>', '<relay>', 'captions',
+          //          '<lang>']
+          if (tagValue.isNotEmpty) {
+            textTrackRef ??= tagValue;
+          }
+```
+
+Replace with (accumulate into a list local, mirroring the `hashtags`
+pattern). First declare a local near the other tag-accumulator locals at
+the top of the parse loop (where `hashtags`, `collaboratorPubkeys` are
+declared):
+
+```dart
+    final textTrackRefs = <String>[];
+```
+
+Then the case body:
+
+```dart
+        case 'text-track':
+          // Subtitle/caption track reference(s). Format:
+          // ['text-track', '<coords-or-url>', '<relay>', 'captions', '<lang>']
+          if (tagValue.isNotEmpty) {
+            textTrackRefs.add(tagValue);
+          }
+```
+
+3d. Where `VideoEvent.fromNostrEvent` constructs the `VideoEvent(...)`,
+pass both the list and the first-element back-compat value. Find the
+existing `textTrackRef: textTrackRef,` argument and replace it with:
+
+```dart
+      textTrackRef: textTrackRefs.isNotEmpty ? textTrackRefs.first : null,
+      textTrackRefs: textTrackRefs,
+```
+
+Remove the now-unused `String? textTrackRef;` local that the old code
+declared for the `??=` accumulation (if present).
+
+3e. Add `textTrackRefs` to `copyWith` (find the `copyWith` method, add a
+`List<String>? textTrackRefs` param and
+`textTrackRefs: textTrackRefs ?? this.textTrackRefs,`).
+
+- [ ] **Step 4: Run to verify pass + full models suite**
+
+Run: `mise exec -- flutter test test/src/video_event_text_track_test.dart`
+Expected: PASS.
+Run: `mise exec -- flutter test` (from `mobile/packages/models`)
+Expected: PASS (no regression in VideoEvent parsing/copyWith tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/models
+git commit -m "feat(models): capture all text-track refs into VideoEvent.textTrackRefs"
+```
+
+---
+
+## Task 4: Extract `fetchSubtitleCues` shared fallback chain
+
+**Files:**
+- Create: `mobile/lib/services/subtitle_fetcher.dart`
+- Modify: `mobile/lib/providers/subtitle_providers.dart`
+- Modify: `mobile/lib/widgets/video_feed_item/subtitle_overlay.dart`
+- Test: `mobile/test/services/subtitle_fetcher_test.dart`
+
+This moves the triple-fetch logic into a plain function reusable by both
+the provider and the repository, and makes it iterate over an ordered
+ref list (Blossom URL → 39307 coords) before the auto-generated
+`{sha256}/vtt` path.
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:openvine/services/subtitle_fetcher.dart';
+import 'package:openvine/services/subtitle_service.dart';
+
+class _FakeClient extends http.BaseClient {
+  _FakeClient(this.handler);
+  final Future<http.Response> Function(http.Request) handler;
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final res = await handler(request as http.Request);
+    return http.StreamedResponse(
+      Stream.value(res.bodyBytes),
+      res.statusCode,
+      headers: res.headers,
+    );
+  }
+}
+
+const _vtt = 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n';
+
+void main() {
+  group('fetchSubtitleCues', () {
+    test('parses embedded textTrackContent first (no network)', () async {
+      final cues = await fetchSubtitleCues(
+        httpClient: _FakeClient((_) async => throw StateError('no network')),
+        nostrClient: null,
+        delay: (_) async {},
+        textTrackContent: _vtt,
+      );
+      expect(cues, hasLength(1));
+      expect(cues.first.text, 'hello');
+    });
+
+    test('falls back to second ref when first http ref is unavailable',
+        () async {
+      final cues = await fetchSubtitleCues(
+        httpClient: _FakeClient((req) async {
+          if (req.url.toString() == 'https://media.divine.video/dead') {
+            return http.Response('', 404);
+          }
+          if (req.url.toString() == 'https://media.divine.video/live') {
+            return http.Response(_vtt, 200);
+          }
+          return http.Response('', 500);
+        }),
+        nostrClient: null,
+        delay: (_) async {},
+        textTrackRefs: const [
+          'https://media.divine.video/dead',
+          'https://media.divine.video/live',
+        ],
+      );
+      expect(cues, hasLength(1));
+      expect(cues.first.text, 'hello');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- flutter test test/services/subtitle_fetcher_test.dart` (from `mobile/`)
+Expected: FAIL — `subtitle_fetcher.dart` does not exist.
+
+- [ ] **Step 3: Create `subtitle_fetcher.dart`**
+
+Move the helper functions out of `subtitle_providers.dart` and add the
+ref-iteration. `NostrClient` is nullable so the repository/tests can pass
+`null` when no relay is needed.
+
+```dart
+// ABOUTME: Shared subtitle fetch chain used by the display provider and the
+// ABOUTME: editor's load path. Ordered fallback: embedded content → each
+// ABOUTME: text-track ref (http or 39307 relay) → Blossom {sha256}/vtt.
+
+import 'package:http/http.dart' as http;
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/subtitle_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+typedef SubtitlePollDelay = Future<void> Function(Duration duration);
+
+const _maxBlossomPollAttempts = 4;
+const _maxBlossomPollWait = Duration(seconds: 15);
+const _defaultBlossomRetryAfter = Duration(seconds: 3);
+
+Duration _parseRetryAfter(Map<String, String> headers) {
+  final rawValue = headers['retry-after'];
+  if (rawValue == null) return _defaultBlossomRetryAfter;
+  final seconds = int.tryParse(rawValue.trim());
+  if (seconds == null || seconds <= 0) return _defaultBlossomRetryAfter;
+  return Duration(seconds: seconds);
+}
+
+Uri? _parseHttpSubtitleUrl(String ref) {
+  if (ref.isEmpty) return null;
+  final uri = Uri.tryParse(ref);
+  if (uri == null) return null;
+  if (uri.scheme != 'http' && uri.scheme != 'https') return null;
+  return uri;
+}
+
+Future<List<SubtitleCue>?> _fetchHttp(http.Client client, Uri url) async {
+  try {
+    final response = await client.get(url);
+    if (response.statusCode == 200 && response.body.trim().isNotEmpty) {
+      return SubtitleService.parseVtt(response.body);
+    }
+  } catch (e) {
+    Log.warning(
+      'Direct VTT fetch failed for $url: $e',
+      name: 'fetchSubtitleCues',
+      category: LogCategory.video,
+    );
+  }
+  return null;
+}
+
+Future<List<SubtitleCue>?> _fetchRelay(
+  NostrClient nostrClient,
+  String ref,
+) async {
+  final parts = ref.split(':');
+  if (parts.length < 3) return null;
+  final kind = int.tryParse(parts[0]);
+  if (kind == null) return null;
+  final pubkey = parts[1];
+  final dTag = parts.sublist(2).join(':');
+  final events = await nostrClient.queryEvents(
+    [
+      Filter(kinds: [kind], authors: [pubkey], d: [dTag], limit: 1),
+    ],
+    tempRelays: ['wss://relay.divine.video'],
+  );
+  if (events.isEmpty) return null;
+  return SubtitleService.parseVtt(events.first.content);
+}
+
+Future<List<SubtitleCue>?> _fetchBlossom({
+  required http.Client client,
+  required SubtitlePollDelay delay,
+  required Uri vttUrl,
+}) async {
+  var waited = Duration.zero;
+  for (var attempt = 0; attempt < _maxBlossomPollAttempts; attempt++) {
+    final response = await client.get(vttUrl);
+    if (response.statusCode == 200 && response.body.trim().isNotEmpty) {
+      return SubtitleService.parseVtt(response.body);
+    }
+    if (response.statusCode == 202) {
+      if (attempt == _maxBlossomPollAttempts - 1) return null;
+      final retryAfter = _parseRetryAfter(response.headers);
+      if (waited + retryAfter > _maxBlossomPollWait) return null;
+      waited += retryAfter;
+      await delay(retryAfter);
+      continue;
+    }
+    return null;
+  }
+  return null;
+}
+
+/// Resolves subtitle cues with ordered fallback. Returns `[]` when no
+/// source yields cues (e.g. auto-transcription not ready yet).
+Future<List<SubtitleCue>> fetchSubtitleCues({
+  required http.Client httpClient,
+  required NostrClient? nostrClient,
+  required SubtitlePollDelay delay,
+  String? textTrackContent,
+  List<String> textTrackRefs = const [],
+  String? sha256,
+}) async {
+  if (textTrackContent != null && textTrackContent.isNotEmpty) {
+    return SubtitleService.parseVtt(textTrackContent);
+  }
+
+  for (final ref in textTrackRefs) {
+    final httpUrl = _parseHttpSubtitleUrl(ref);
+    if (httpUrl != null) {
+      final cues = await _fetchHttp(httpClient, httpUrl);
+      if (cues != null) return cues;
+      continue;
+    }
+    if (nostrClient != null) {
+      try {
+        final cues = await _fetchRelay(nostrClient, ref);
+        if (cues != null) return cues;
+      } catch (e) {
+        Log.warning(
+          'Relay VTT fetch failed for $ref: $e',
+          name: 'fetchSubtitleCues',
+          category: LogCategory.video,
+        );
+      }
+    }
+  }
+
+  if (sha256 != null && sha256.isNotEmpty) {
+    final vttUrl = Uri.parse('https://media.divine.video/$sha256/vtt');
+    try {
+      final cues = await _fetchBlossom(
+        client: httpClient,
+        delay: delay,
+        vttUrl: vttUrl,
+      );
+      if (cues != null) return cues;
+    } catch (e) {
+      Log.warning(
+        'Blossom VTT fetch failed for $sha256: $e',
+        name: 'fetchSubtitleCues',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  return [];
+}
+```
+
+(Confirm the `nostr_client` import path matches the one used elsewhere in
+`lib/` — see `subtitle_providers.dart`'s existing imports. If `NostrClient`
+is surfaced via a different package name, use that.)
+
+- [ ] **Step 4: Run the new test to verify pass**
+
+Run: `mise exec -- flutter test test/services/subtitle_fetcher_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Rewire the provider to delegate**
+
+In `mobile/lib/providers/subtitle_providers.dart`:
+
+5a. Keep `subtitleHttpClientProvider`, `subtitlePollDelayProvider`, and
+`SubtitleVisibility`. Remove the now-moved helpers (`_parseRetryAfter`,
+`_parseHttpSubtitleUrl`, `_fetchBlossomSubtitles`) and the
+`SubtitlePollDelay` typedef — import them from the fetcher instead. Add:
+
+```dart
+import 'package:openvine/services/subtitle_fetcher.dart';
+```
+
+(Keep `subtitlePollDelayProvider` using the imported `SubtitlePollDelay`.)
+
+5b. Replace the `subtitleCues` provider body, adding an optional
+`textTrackRefs` param (existing `textTrackRef` retained for back-compat):
+
+```dart
+@riverpod
+Future<List<SubtitleCue>> subtitleCues(
+  Ref ref, {
+  required String videoId,
+  String? textTrackRef,
+  List<String> textTrackRefs = const [],
+  String? textTrackContent,
+  String? sha256,
+}) async {
+  final refs = textTrackRefs.isNotEmpty
+      ? textTrackRefs
+      : [
+          if (textTrackRef != null && textTrackRef.isNotEmpty) textTrackRef,
+        ];
+  return fetchSubtitleCues(
+    httpClient: ref.read(subtitleHttpClientProvider),
+    nostrClient: ref.read(nostrServiceProvider),
+    delay: ref.read(subtitlePollDelayProvider),
+    textTrackContent: textTrackContent,
+    textTrackRefs: refs,
+    sha256: sha256,
+  );
+}
+```
+
+5c. Regenerate Riverpod:
+
+Run: `mise exec -- dart run build_runner build --delete-conflicting-outputs`
+
+- [ ] **Step 6: Update the overlay caller**
+
+In `mobile/lib/widgets/video_feed_item/subtitle_overlay.dart` (~line 75),
+change:
+
+```dart
+    final cuesAsync = ref.watch(
+      subtitleCuesProvider(
+        videoId: widget.video.id,
+        textTrackRef: widget.video.textTrackRef,
+        textTrackContent: widget.video.textTrackContent,
+        sha256: widget.video.sha256,
+      ),
+    );
+```
+
+to:
+
+```dart
+    final cuesAsync = ref.watch(
+      subtitleCuesProvider(
+        videoId: widget.video.id,
+        textTrackRefs: widget.video.textTrackRefs,
+        textTrackContent: widget.video.textTrackContent,
+        sha256: widget.video.sha256,
+      ),
+    );
+```
+
+- [ ] **Step 7: Run the existing provider suite + analyze**
+
+Run: `mise exec -- flutter test test/providers/subtitle_providers_test.dart`
+Expected: PASS (the existing single-`textTrackRef` and `sha256` tests still
+hold; behavior preserved, with relay refs now tried before the auto-gen
+`sha256` path).
+Run: `mise exec -- flutter analyze lib test`
+Expected: No issues.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/services/subtitle_fetcher.dart \
+        lib/providers/subtitle_providers.dart \
+        lib/providers/subtitle_providers.g.dart \
+        lib/widgets/video_feed_item/subtitle_overlay.dart \
+        test/services/subtitle_fetcher_test.dart
+git commit -m "refactor(subtitles): extract shared fetchSubtitleCues with ordered ref fallback"
+```
+
+---
+
+## Task 5: `VideoEventPublisher` — publish 39307 + dual text-track refs
+
+**Files:**
+- Modify: `mobile/lib/services/video_event_publisher.dart`
+- Test: `mobile/test/services/video_event_publisher_subtitle_test.dart`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the existing subtitle publisher test file (reuse its mocks for
+`AuthService`, `NostrClient`, etc.; mirror how `republishWithSubtitles`
+is already tested there).
+
+```dart
+test('publishSubtitleEvent signs a 39307 with d=subtitles:<vineId>',
+    () async {
+  // Arrange: video with vineId, authed pubkey, signer returns an Event,
+  // publish succeeds. (Match the file's existing arrange helpers.)
+  final ref = await publisher.publishSubtitleEvent(
+    video: existingEvent, // has vineId 'my-vine-id'
+    vttContent: 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhi\n',
+    blossomUrl: 'https://media.divine.video/abc123',
+  );
+
+  expect(ref, '39307:$testPubkey:subtitles:my-vine-id');
+
+  final captured = verify(
+    () => mockAuthService.createAndSignEvent(
+      kind: captureAny(named: 'kind'),
+      content: captureAny(named: 'content'),
+      tags: captureAny(named: 'tags'),
+    ),
+  ).captured;
+  expect(captured[0], 39307);
+  final tags = (captured[2] as List).cast<List<String>>();
+  expect(tags, contains(['d', 'subtitles:my-vine-id']));
+  expect(tags, contains(['url', 'https://media.divine.video/abc123']));
+  expect(tags, contains(['m', 'text/vtt']));
+});
+
+test('republishWithSubtitles emits one text-track tag per ref', () async {
+  await publisher.republishWithSubtitles(
+    existingEvent: existingEvent,
+    textTrackRef: 'https://media.divine.video/abc123',
+    extraTextTrackRefs: const ['39307:$testPubkey:subtitles:my-vine-id'],
+  );
+
+  final captured = verify(
+    () => mockAuthService.createAndSignEvent(
+      kind: any(named: 'kind'),
+      content: any(named: 'content'),
+      tags: captureAny(named: 'tags'),
+    ),
+  ).captured.single as List;
+  final tags = captured.cast<List<String>>();
+  final trackTags = tags.where((t) => t.first == 'text-track').toList();
+  expect(trackTags, hasLength(2));
+  expect(trackTags[0][1], 'https://media.divine.video/abc123');
+  expect(trackTags[1][1], '39307:$testPubkey:subtitles:my-vine-id');
+});
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `mise exec -- flutter test test/services/video_event_publisher_subtitle_test.dart` (from `mobile/`)
+Expected: FAIL — `publishSubtitleEvent` undefined, `extraTextTrackRefs` undefined.
+
+- [ ] **Step 3: Implement**
+
+3a. Add `import 'package:models/models.dart';` if `NIP71VideoKinds`
+isn't already imported (it is used elsewhere in this file via
+`NIP71VideoKinds.getPreferredAddressableKind()`, so it is).
+
+3b. Extend `republishWithSubtitles`. Change its signature to add
+`extraTextTrackRefs` and emit one tag per ref. Replace the single
+`tags.add([...])` block:
+
+```dart
+  Future<bool> republishWithSubtitles({
+    required VideoEvent existingEvent,
+    required String textTrackRef,
+    List<String> extraTextTrackRefs = const [],
+    String textTrackLang = 'en',
+  }) async {
+    final tags = existingEvent.nostrEventTags
+        .where((t) => t.isNotEmpty && t.first != 'text-track')
+        .map(List<String>.from)
+        .toList();
+
+    for (final ref in [textTrackRef, ...extraTextTrackRefs]) {
+      tags.add([
+        'text-track',
+        ref,
+        'wss://relay.divine.video',
+        'captions',
+        textTrackLang,
+      ]);
+    }
+
+    final event = await _authService?.createAndSignEvent(
+      kind: NIP71VideoKinds.getPreferredAddressableKind(),
+      content: existingEvent.content,
+      tags: tags,
+    );
+    // ... rest of the method (null check, optimistic cache, publish)
+    // stays exactly as-is ...
+```
+
+3c. Add `publishSubtitleEvent` directly after `republishWithSubtitles`:
+
+```dart
+  /// Publishes a Kind 39307 subtitle event for [video] and returns its
+  /// addressable ref `39307:<pubkey>:subtitles:<vineId>`, or `null` on
+  /// failure (not authenticated, no addressable id, sign/publish failed).
+  Future<String?> publishSubtitleEvent({
+    required VideoEvent video,
+    required String vttContent,
+    required String blossomUrl,
+    String lang = 'en',
+  }) async {
+    final pubkey = _authService?.currentPublicKeyHex;
+    final vineId = video.vineId;
+    if (pubkey == null || vineId == null || vineId.isEmpty) return null;
+
+    final dTag = 'subtitles:$vineId';
+    final videoKind = NIP71VideoKinds.getPreferredAddressableKind();
+
+    final event = await _authService?.createAndSignEvent(
+      kind: NIP71VideoKinds.subtitleEventKind,
+      content: vttContent,
+      tags: [
+        ['d', dTag],
+        ['a', '$videoKind:$pubkey:$vineId'],
+        ['url', blossomUrl],
+        ['m', 'text/vtt'],
+        ['l', lang],
+      ],
+    );
+    if (event == null) {
+      Log.error(
+        'Failed to sign subtitle event',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+
+    final ok = await _publishEventToNostr(event);
+    if (!ok) return null;
+    return '${NIP71VideoKinds.subtitleEventKind}:$pubkey:$dTag';
+  }
+```
+
+- [ ] **Step 4: Run to verify pass + existing republish tests**
+
+Run: `mise exec -- flutter test test/services/video_event_publisher_subtitle_test.dart`
+Expected: PASS (existing `republishWithSubtitles` tests still green —
+`extraTextTrackRefs` defaults to empty → one tag).
+Run: `mise exec -- flutter analyze lib test`
+Expected: No issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/services/video_event_publisher.dart test/services/video_event_publisher_subtitle_test.dart
+git commit -m "feat(publisher): publish 39307 subtitle events + dual text-track refs"
+```
+
+---
+
+## Task 6: `SubtitleRepository` — orchestration
+
+**Files:**
+- Create: `mobile/lib/repositories/subtitle_repository.dart`
+- Create: `mobile/lib/providers/subtitle_repository_provider.dart`
+- Test: `mobile/test/repositories/subtitle_repository_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
+import 'package:openvine/services/subtitle_service.dart';
+
+class _MockBlossom extends Mock implements BlossomUploadService {}
+class _MockPublisher extends Mock implements _PublisherLike {}
+
+// If VideoEventPublisher is hard to mock directly, mock it as its concrete
+// type instead (import the real class). Keep a thin abstraction only if the
+// real type is final/sealed — otherwise mock VideoEventPublisher directly.
+
+abstract class _PublisherLike {} // placeholder; see note in Step 3
+
+void main() {
+  group(SubtitleRepository, () {
+    test('publishEditedSubtitles uploads VTT, publishes 39307, republishes',
+        () async {
+      // Arrange mocks per Step 3's final constructor shape, then:
+      // - blossom.uploadSubtitleVtt returns success url .../hash
+      // - publisher.publishSubtitleEvent returns coords ref
+      // - publisher.republishWithSubtitles returns true
+      // Act + assert order of calls and that republish receives both refs.
+    });
+
+    test('throws SubtitleEditException when vineId is null', () async {
+      // video with vineId == null → expect throwsA(isA<SubtitleEditException>())
+    });
+  });
+}
+```
+
+> Note: this test is fully fleshed out in Step 3 once the constructor
+> shape is fixed (mock `VideoEventPublisher` and `BlossomUploadService`
+> directly with mocktail — both are plain classes). Replace the
+> `_PublisherLike` placeholder with `_MockPublisher extends Mock
+> implements VideoEventPublisher`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- flutter test test/repositories/subtitle_repository_test.dart` (from `mobile/`)
+Expected: FAIL — `subtitle_repository.dart` does not exist.
+
+- [ ] **Step 3: Implement the repository + finalize the test**
+
+Create `mobile/lib/repositories/subtitle_repository.dart`:
+
+```dart
+// ABOUTME: Owns the edit-subtitles orchestration: load current cues, then
+// ABOUTME: generate VTT → upload to Blossom → publish 39307 → republish the
+// ABOUTME: video with both refs.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:http/http.dart' as http;
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/subtitle_fetcher.dart';
+import 'package:openvine/services/subtitle_service.dart';
+import 'package:openvine/services/video_event_publisher.dart';
+
+/// Thrown when an edited-subtitle publish cannot complete. Carries no PII.
+class SubtitleEditException implements Exception {
+  SubtitleEditException(this.message);
+  final String message;
+  @override
+  String toString() => 'SubtitleEditException: $message';
+}
+
+class SubtitleRepository {
+  SubtitleRepository({
+    required BlossomUploadService blossomUploadService,
+    required VideoEventPublisher videoEventPublisher,
+    required AuthService authService,
+    required NostrClient nostrClient,
+    required http.Client httpClient,
+    required SubtitlePollDelay pollDelay,
+  })  : _blossom = blossomUploadService,
+        _publisher = videoEventPublisher,
+        _authService = authService,
+        _nostrClient = nostrClient,
+        _httpClient = httpClient,
+        _pollDelay = pollDelay;
+
+  final BlossomUploadService _blossom;
+  final VideoEventPublisher _publisher;
+  final AuthService _authService;
+  final NostrClient _nostrClient;
+  final http.Client _httpClient;
+  final SubtitlePollDelay _pollDelay;
+
+  /// Loads the current cues for [video] using the shared fallback chain.
+  /// Returns `[]` when auto-transcription is not yet available.
+  Future<List<SubtitleCue>> loadCues(VideoEvent video) {
+    return fetchSubtitleCues(
+      httpClient: _httpClient,
+      nostrClient: _nostrClient,
+      delay: _pollDelay,
+      textTrackContent: video.textTrackContent,
+      textTrackRefs: video.textTrackRefs,
+      sha256: video.sha256,
+    );
+  }
+
+  /// Generates VTT from [cues], uploads it to Blossom, publishes a 39307
+  /// subtitle event, then republishes the video referencing both.
+  ///
+  /// Throws [SubtitleEditException] on any failed step.
+  Future<void> publishEditedSubtitles({
+    required VideoEvent video,
+    required List<SubtitleCue> cues,
+    String lang = 'en',
+  }) async {
+    if (_authService.currentPublicKeyHex == null) {
+      throw SubtitleEditException('Not authenticated');
+    }
+    final vineId = video.vineId;
+    if (vineId == null || vineId.isEmpty) {
+      throw SubtitleEditException('Video has no addressable identifier');
+    }
+
+    final vtt = SubtitleService.generateVtt(cues);
+    final bytes = Uint8List.fromList(utf8.encode(vtt));
+
+    final upload = await _blossom.uploadSubtitleVtt(bytes: bytes);
+    final blossomUrl = upload.url;
+    if (!upload.success || blossomUrl == null) {
+      throw SubtitleEditException('Subtitle upload to Blossom failed');
+    }
+
+    final coordsRef = await _publisher.publishSubtitleEvent(
+      video: video,
+      vttContent: vtt,
+      blossomUrl: blossomUrl,
+      lang: lang,
+    );
+    if (coordsRef == null) {
+      throw SubtitleEditException('Subtitle event publish failed');
+    }
+
+    final ok = await _publisher.republishWithSubtitles(
+      existingEvent: video,
+      textTrackRef: blossomUrl,
+      extraTextTrackRefs: [coordsRef],
+      textTrackLang: lang,
+    );
+    if (!ok) {
+      throw SubtitleEditException('Video republish failed');
+    }
+  }
+}
+```
+
+Now finalize the test (replace the Step-1 skeleton body):
+
+```dart
+class _MockBlossom extends Mock implements BlossomUploadService {}
+class _MockPublisher extends Mock implements VideoEventPublisher {}
+class _MockAuth extends Mock implements AuthService {}
+class _MockNostr extends Mock implements NostrClient {}
+class _MockHttp extends Mock implements http.Client {}
+
+final _video = VideoEvent(
+  id: 'vid1',
+  pubkey: 'pk1',
+  createdAt: 1,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+  vineId: 'my-vine-id',
+);
+
+final _cues = const [SubtitleCue(start: 0, end: 1000, text: 'hi')];
+
+void main() {
+  group(SubtitleRepository, () {
+    late _MockBlossom blossom;
+    late _MockPublisher publisher;
+    late _MockAuth auth;
+    late SubtitleRepository repo;
+
+    setUp(() {
+      blossom = _MockBlossom();
+      publisher = _MockPublisher();
+      auth = _MockAuth();
+      repo = SubtitleRepository(
+        blossomUploadService: blossom,
+        videoEventPublisher: publisher,
+        authService: auth,
+        nostrClient: _MockNostr(),
+        httpClient: _MockHttp(),
+        pollDelay: (_) async {},
+      );
+      when(() => auth.currentPublicKeyHex).thenReturn('pk1');
+    });
+
+    test('uploads VTT, publishes 39307, republishes with both refs',
+        () async {
+      when(() => blossom.uploadSubtitleVtt(bytes: any(named: 'bytes')))
+          .thenAnswer((_) async => const BlossomUploadResult(
+                success: true,
+                url: 'https://media.divine.video/hash',
+                videoId: 'hash',
+              ));
+      when(() => publisher.publishSubtitleEvent(
+            video: any(named: 'video'),
+            vttContent: any(named: 'vttContent'),
+            blossomUrl: any(named: 'blossomUrl'),
+            lang: any(named: 'lang'),
+          )).thenAnswer((_) async => '39307:pk1:subtitles:my-vine-id');
+      when(() => publisher.republishWithSubtitles(
+            existingEvent: any(named: 'existingEvent'),
+            textTrackRef: any(named: 'textTrackRef'),
+            extraTextTrackRefs: any(named: 'extraTextTrackRefs'),
+            textTrackLang: any(named: 'textTrackLang'),
+          )).thenAnswer((_) async => true);
+
+      await repo.publishEditedSubtitles(video: _video, cues: _cues);
+
+      verify(() => publisher.republishWithSubtitles(
+            existingEvent: _video,
+            textTrackRef: 'https://media.divine.video/hash',
+            extraTextTrackRefs: const ['39307:pk1:subtitles:my-vine-id'],
+            textTrackLang: 'en',
+          )).called(1);
+    });
+
+    test('throws when vineId is null', () async {
+      final noId = VideoEvent(
+        id: 'v',
+        pubkey: 'pk1',
+        createdAt: 1,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+      );
+      expect(
+        () => repo.publishEditedSubtitles(video: noId, cues: _cues),
+        throwsA(isA<SubtitleEditException>()),
+      );
+    });
+  });
+}
+```
+
+Add `registerFallbackValue(_video);` in a `setUpAll` if mocktail requires
+it for the `existingEvent`/`video` matchers.
+
+- [ ] **Step 4: Create the provider**
+
+`mobile/lib/providers/subtitle_repository_provider.dart`:
+
+```dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
+
+final subtitleRepositoryProvider = Provider<SubtitleRepository>((ref) {
+  return SubtitleRepository(
+    blossomUploadService: ref.watch(blossomUploadServiceProvider),
+    videoEventPublisher: ref.watch(videoEventPublisherProvider),
+    authService: ref.watch(authServiceProvider),
+    nostrClient: ref.watch(nostrServiceProvider),
+    httpClient: ref.watch(subtitleHttpClientProvider),
+    pollDelay: ref.watch(subtitlePollDelayProvider),
+  );
+});
+```
+
+(Confirm import paths: `authServiceProvider`, `blossomUploadServiceProvider`,
+`videoEventPublisherProvider`, `nostrServiceProvider` — grep for each to
+confirm its defining file, e.g. `rg "blossomUploadServiceProvider ="
+lib/providers`.)
+
+- [ ] **Step 5: Run tests + analyze**
+
+Run: `mise exec -- flutter test test/repositories/subtitle_repository_test.dart`
+Expected: PASS.
+Run: `mise exec -- flutter analyze lib test`
+Expected: No issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/repositories/subtitle_repository.dart \
+        lib/providers/subtitle_repository_provider.dart \
+        test/repositories/subtitle_repository_test.dart
+git commit -m "feat(subtitles): add SubtitleRepository orchestration"
+```
+
+---
+
+## Task 7: `SubtitleEditorCubit` + state
+
+**Files:**
+- Create: `mobile/lib/blocs/subtitle_editor/subtitle_editor_state.dart`
+- Create: `mobile/lib/blocs/subtitle_editor/subtitle_editor_cubit.dart`
+- Test: `mobile/test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
+import 'package:openvine/services/subtitle_service.dart';
+
+class _MockRepo extends Mock implements SubtitleRepository {}
+
+final _video = VideoEvent(
+  id: 'v',
+  pubkey: 'pk',
+  createdAt: 1,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+  vineId: 'd1',
+);
+
+void main() {
+  setUpAll(() => registerFallbackValue(_video));
+
+  group(SubtitleEditorCubit, () {
+    late _MockRepo repo;
+    setUp(() => repo = _MockRepo());
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'load → ready with cues',
+      setUp: () => when(() => repo.loadCues(any())).thenAnswer(
+        (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'a')],
+      ),
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) => c.load(),
+      expect: () => [
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.loading),
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.ready)
+            .having((s) => s.cues.length, 'cues', 1),
+      ],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'load with no cues → processing',
+      setUp: () =>
+          when(() => repo.loadCues(any())).thenAnswer((_) async => const []),
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) => c.load(),
+      expect: () => [
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.loading),
+        isA<SubtitleEditorState>().having(
+            (s) => s.status, 'status', SubtitleEditorStatus.processing),
+      ],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'updateCueText marks dirty',
+      setUp: () => when(() => repo.loadCues(any())).thenAnswer(
+        (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'a')],
+      ),
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) async {
+        await c.load();
+        c.updateCueText(0, 'fixed');
+      },
+      verify: (c) {
+        expect(c.state.isDirty, isTrue);
+        expect(c.state.cues.first.text, 'fixed');
+      },
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'save success emits saving then success',
+      setUp: () {
+        when(() => repo.loadCues(any())).thenAnswer(
+          (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'a')],
+        );
+        when(() => repo.publishEditedSubtitles(
+              video: any(named: 'video'),
+              cues: any(named: 'cues'),
+            )).thenAnswer((_) async {});
+      },
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) async {
+        await c.load();
+        await c.save();
+      },
+      skip: 2,
+      expect: () => [
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.saving),
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.success),
+      ],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'save failure emits failure and reports error',
+      setUp: () {
+        when(() => repo.loadCues(any())).thenAnswer(
+          (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'a')],
+        );
+        when(() => repo.publishEditedSubtitles(
+              video: any(named: 'video'),
+              cues: any(named: 'cues'),
+            )).thenThrow(SubtitleEditException('boom'));
+      },
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) async {
+        await c.load();
+        await c.save();
+      },
+      skip: 2,
+      expect: () => [
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.saving),
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.failure),
+      ],
+      errors: () => [isA<SubtitleEditException>()],
+    );
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- flutter test test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart`
+Expected: FAIL — cubit/state not defined.
+
+- [ ] **Step 3: Implement state**
+
+`subtitle_editor_state.dart`:
+
+```dart
+part of 'subtitle_editor_cubit.dart';
+
+enum SubtitleEditorStatus { loading, processing, ready, saving, success, failure }
+
+/// One editable subtitle cue. Timing is fixed (text-only editing).
+class EditableCue extends Equatable {
+  const EditableCue({
+    required this.start,
+    required this.end,
+    required this.text,
+  });
+
+  factory EditableCue.fromCue(SubtitleCue cue) =>
+      EditableCue(start: cue.start, end: cue.end, text: cue.text);
+
+  final int start;
+  final int end;
+  final String text;
+
+  SubtitleCue toCue() => SubtitleCue(start: start, end: end, text: text);
+
+  EditableCue copyWith({String? text}) =>
+      EditableCue(start: start, end: end, text: text ?? this.text);
+
+  /// `M:SS` label for display (timing is read-only).
+  String get timestampLabel {
+    final totalSeconds = start ~/ 1000;
+    final minutes = totalSeconds ~/ 60;
+    final seconds = totalSeconds % 60;
+    return '$minutes:${seconds.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  List<Object?> get props => [start, end, text];
+}
+
+class SubtitleEditorState extends Equatable {
+  const SubtitleEditorState({
+    this.status = SubtitleEditorStatus.loading,
+    this.cues = const [],
+    this.isDirty = false,
+  });
+
+  final SubtitleEditorStatus status;
+  final List<EditableCue> cues;
+  final bool isDirty;
+
+  SubtitleEditorState copyWith({
+    SubtitleEditorStatus? status,
+    List<EditableCue>? cues,
+    bool? isDirty,
+  }) {
+    return SubtitleEditorState(
+      status: status ?? this.status,
+      cues: cues ?? this.cues,
+      isDirty: isDirty ?? this.isDirty,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, cues, isDirty];
+}
+```
+
+- [ ] **Step 4: Implement cubit**
+
+`subtitle_editor_cubit.dart`:
+
+```dart
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
+import 'package:openvine/services/subtitle_service.dart';
+
+part 'subtitle_editor_state.dart';
+
+class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
+  SubtitleEditorCubit({
+    required SubtitleRepository repository,
+    required VideoEvent video,
+  })  : _repository = repository,
+        _video = video,
+        super(const SubtitleEditorState());
+
+  final SubtitleRepository _repository;
+  final VideoEvent _video;
+
+  Future<void> load() async {
+    emit(state.copyWith(status: SubtitleEditorStatus.loading));
+    try {
+      final cues = await _repository.loadCues(_video);
+      if (cues.isEmpty) {
+        emit(state.copyWith(status: SubtitleEditorStatus.processing));
+        return;
+      }
+      emit(state.copyWith(
+        status: SubtitleEditorStatus.ready,
+        cues: cues.map(EditableCue.fromCue).toList(),
+        isDirty: false,
+      ));
+    } catch (e, st) {
+      addError(e, st);
+      emit(state.copyWith(status: SubtitleEditorStatus.failure));
+    }
+  }
+
+  void updateCueText(int index, String text) {
+    if (index < 0 || index >= state.cues.length) return;
+    final updated = List<EditableCue>.from(state.cues);
+    updated[index] = updated[index].copyWith(text: text);
+    emit(state.copyWith(cues: updated, isDirty: true));
+  }
+
+  Future<void> save() async {
+    emit(state.copyWith(status: SubtitleEditorStatus.saving));
+    try {
+      await _repository.publishEditedSubtitles(
+        video: _video,
+        cues: state.cues.map((c) => c.toCue()).toList(),
+      );
+      emit(state.copyWith(status: SubtitleEditorStatus.success, isDirty: false));
+    } catch (e, st) {
+      addError(e, st);
+      emit(state.copyWith(status: SubtitleEditorStatus.failure));
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run to verify pass + analyze**
+
+Run: `mise exec -- flutter test test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart`
+Expected: PASS.
+Run: `mise exec -- flutter analyze lib test`
+Expected: No issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/blocs/subtitle_editor test/blocs/subtitle_editor
+git commit -m "feat(subtitles): add SubtitleEditorCubit and state"
+```
+
+---
+
+## Task 8: l10n keys
+
+**Files:**
+- Modify: `mobile/lib/l10n/app_en.arb`
+- Modify: `mobile/test/l10n/arb_consistency_test.dart` (allowlist) — see memory note `project_arb_consistency_test`.
+
+- [ ] **Step 1: Add keys to `app_en.arb`**
+
+Insert these keys (alphabetical placement not required, but keep valid
+JSON — comma discipline):
+
+```json
+  "subtitleEditorTitle": "Edit subtitles",
+  "subtitleEditorSave": "Save",
+  "subtitleEditorProcessing": "Subtitles are still being generated. Check back in a moment.",
+  "subtitleEditorLoadError": "Couldn't load subtitles. Try again.",
+  "subtitleEditorSaveSuccess": "Subtitles updated",
+  "subtitleEditorSaveError": "Couldn't save subtitles. Try again.",
+  "subtitleEditorRetry": "Retry",
+  "subtitleEditorCueHint": "Caption text",
+  "videoEditEditSubtitles": "Edit subtitles",
+```
+
+- [ ] **Step 2: Allowlist or translate (ARB consistency gate)**
+
+Add the nine keys above to the allowlist set in
+`mobile/test/l10n/arb_consistency_test.dart` (find the existing allowlist
+collection and append the keys), per the repo's ARB-consistency gate.
+
+- [ ] **Step 3: Regenerate l10n**
+
+Run: `mise exec -- flutter gen-l10n`
+Expected: regenerated files under `lib/l10n/generated/`.
+
+- [ ] **Step 4: Verify the ARB consistency test passes**
+
+Run: `mise exec -- flutter test test/l10n/arb_consistency_test.dart`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/l10n/app_en.arb lib/l10n/generated test/l10n/arb_consistency_test.dart
+git commit -m "feat(l10n): add subtitle editor strings"
+```
+
+---
+
+## Task 9: `SubtitleEditorScreen` (Page/View)
+
+**Files:**
+- Create: `mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart`
+- Test: `mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart`
+
+- [ ] **Step 1: Write the failing widget test**
+
+```dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
+
+class _MockCubit extends MockCubit<SubtitleEditorState>
+    implements SubtitleEditorCubit {}
+
+void main() {
+  late _MockCubit cubit;
+  setUp(() => cubit = _MockCubit());
+
+  Widget pump() => MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BlocProvider<SubtitleEditorCubit>.value(
+          value: cubit,
+          child: const SubtitleEditorView(),
+        ),
+      );
+
+  testWidgets('renders a text field per cue when ready', (tester) async {
+    when(() => cubit.state).thenReturn(const SubtitleEditorState(
+      status: SubtitleEditorStatus.ready,
+      cues: [
+        EditableCue(start: 0, end: 1000, text: 'one'),
+        EditableCue(start: 1000, end: 2000, text: 'two'),
+      ],
+    ));
+    await tester.pumpWidget(pump());
+    expect(find.byType(TextField), findsNWidgets(2));
+    expect(find.text('one'), findsOneWidget);
+  });
+
+  testWidgets('shows processing message when status is processing',
+      (tester) async {
+    when(() => cubit.state).thenReturn(
+      const SubtitleEditorState(status: SubtitleEditorStatus.processing),
+    );
+    await tester.pumpWidget(pump());
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.subtitleEditorProcessing), findsOneWidget);
+  });
+
+  testWidgets('editing a field dispatches updateCueText', (tester) async {
+    when(() => cubit.state).thenReturn(const SubtitleEditorState(
+      status: SubtitleEditorStatus.ready,
+      cues: [EditableCue(start: 0, end: 1000, text: 'one')],
+    ));
+    await tester.pumpWidget(pump());
+    await tester.enterText(find.byType(TextField).first, 'edited');
+    verify(() => cubit.updateCueText(0, 'edited')).called(1);
+  });
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `mise exec -- flutter test test/screens/subtitle_editor/subtitle_editor_screen_test.dart`
+Expected: FAIL — screen not defined.
+
+- [ ] **Step 3: Implement the screen**
+
+```dart
+// ABOUTME: Full-screen editor for correcting a video's subtitle text.
+// ABOUTME: Page builds the cubit from Riverpod; View renders cue text fields.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/subtitle_repository_provider.dart';
+
+class SubtitleEditorScreen extends ConsumerWidget {
+  const SubtitleEditorScreen({required this.video, super.key});
+
+  static const path = '/subtitle-edit';
+  static const routeName = 'subtitle-edit';
+
+  static String pathFor(String videoId) =>
+      '$path/${Uri.encodeComponent(videoId)}';
+
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repository = ref.watch(subtitleRepositoryProvider);
+    return BlocProvider<SubtitleEditorCubit>(
+      key: ObjectKey(repository),
+      create: (_) =>
+          SubtitleEditorCubit(repository: repository, video: video)..load(),
+      child: const SubtitleEditorView(),
+    );
+  }
+}
+
+@visibleForTesting
+class SubtitleEditorView extends StatelessWidget {
+  const SubtitleEditorView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Scaffold(
+      backgroundColor: VineTheme.surfaceBackground,
+      appBar: DiVineAppBar(
+        title: l10n.subtitleEditorTitle,
+        backgroundColor: VineTheme.surfaceBackground,
+        showBackButton: true,
+        onBackPressed: context.pop,
+      ),
+      body: BlocConsumer<SubtitleEditorCubit, SubtitleEditorState>(
+        listenWhen: (p, c) => p.status != c.status,
+        listener: (context, state) {
+          if (state.status == SubtitleEditorStatus.success) {
+            SemanticsService.sendAnnouncement(
+              View.of(context),
+              l10n.subtitleEditorSaveSuccess,
+              Directionality.of(context),
+            );
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(l10n.subtitleEditorSaveSuccess)),
+            );
+            context.pop();
+          } else if (state.status == SubtitleEditorStatus.failure) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(l10n.subtitleEditorSaveError)),
+            );
+          }
+        },
+        builder: (context, state) {
+          return switch (state.status) {
+            SubtitleEditorStatus.loading => const _Loading(),
+            SubtitleEditorStatus.processing => const _Processing(),
+            _ => _CueList(state: state),
+          };
+        },
+      ),
+    );
+  }
+}
+
+class _Loading extends StatelessWidget {
+  const _Loading();
+  @override
+  Widget build(BuildContext context) =>
+      const Center(child: CircularProgressIndicator());
+}
+
+class _Processing extends StatelessWidget {
+  const _Processing();
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        spacing: 16,
+        children: [
+          Text(
+            l10n.subtitleEditorProcessing,
+            textAlign: TextAlign.center,
+            style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+          ),
+          TextButton(
+            onPressed: () => context.read<SubtitleEditorCubit>().load(),
+            child: Text(l10n.subtitleEditorRetry),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CueList extends StatelessWidget {
+  const _CueList({required this.state});
+  final SubtitleEditorState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: state.cues.length,
+            itemBuilder: (context, index) =>
+                _CueRow(index: index, cue: state.cues[index]),
+          ),
+        ),
+        SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: _SaveButton(
+              enabled: state.isDirty &&
+                  state.status != SubtitleEditorStatus.saving,
+              busy: state.status == SubtitleEditorStatus.saving,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CueRow extends StatelessWidget {
+  const _CueRow({required this.index, required this.cue});
+  final int index;
+  final EditableCue cue;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 12,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 14),
+            child: Text(
+              cue.timestampLabel,
+              style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+            ),
+          ),
+          Expanded(
+            child: TextFormField(
+              initialValue: cue.text,
+              minLines: 1,
+              maxLines: null,
+              style: VineTheme.bodyMediumFont(),
+              decoration: InputDecoration(
+                hintText: context.l10n.subtitleEditorCueHint,
+              ),
+              onChanged: (value) =>
+                  context.read<SubtitleEditorCubit>().updateCueText(index, value),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SaveButton extends StatelessWidget {
+  const _SaveButton({required this.enabled, required this.busy});
+  final bool enabled;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: FilledButton(
+        onPressed: enabled
+            ? () => context.read<SubtitleEditorCubit>().save()
+            : null,
+        child: busy
+            ? const SizedBox(
+                height: 18,
+                width: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : Text(context.l10n.subtitleEditorSave),
+      ),
+    );
+  }
+}
+```
+
+> The widget test uses a `TextField` finder; `TextFormField` builds a
+> `TextField` internally so `find.byType(TextField)` matches. If the test's
+> `enterText` does not trigger `onChanged` for `TextFormField` in your
+> Flutter version, switch `_CueRow` to a `TextField` with a controller —
+> but prefer `TextFormField`'s `initialValue` to avoid controller lifecycle
+> management. Re-run the test to confirm.
+
+- [ ] **Step 4: Run to verify pass + analyze**
+
+Run: `mise exec -- flutter test test/screens/subtitle_editor/subtitle_editor_screen_test.dart`
+Expected: PASS.
+Run: `mise exec -- flutter analyze lib test`
+Expected: No issues.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/screens/subtitle_editor test/screens/subtitle_editor
+git commit -m "feat(subtitles): add SubtitleEditorScreen (Page/View)"
+```
+
+---
+
+## Task 10: Route + entry-point wiring
+
+**Files:**
+- Modify: `mobile/lib/router/app_router.dart`
+- Modify: `mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart`
+- Test: `mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart` (extend if present; else create a focused test)
+
+- [ ] **Step 1: Add the route**
+
+In `app_router.dart`, near the existing `VideoMetadataEditScreen` route,
+add (mirror that route's structure):
+
+```dart
+GoRoute(
+  path: '${SubtitleEditorScreen.path}/:videoId',
+  name: SubtitleEditorScreen.routeName,
+  builder: (ctx, st) {
+    final videoId = st.pathParameters['videoId'];
+    if (videoId == null || videoId.isEmpty) {
+      return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
+    }
+    final prefetched = st.extra as VideoEvent?;
+    if (prefetched == null) {
+      return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
+    }
+    return SubtitleEditorScreen(video: prefetched);
+  },
+),
+```
+
+Add the import for `SubtitleEditorScreen` at the top of `app_router.dart`.
+
+> The editor requires a `VideoEvent` (it edits an already-resolved own
+> video). The entry point always passes `extra: video`, so a missing
+> `extra` is a programming error → show the existing error screen. (A
+> future deep-link entry could resolve by id; out of scope for v1.)
+
+- [ ] **Step 2: Write the failing entry-point test**
+
+Add a test asserting the bottom bar shows an "Edit subtitles" control and
+navigates. Use the existing test's `MockGoRouter` pattern (see
+`badges_screen_test.dart`'s `MockGoRouterProvider`). Assert that tapping
+the control calls `push` with `SubtitleEditorScreen.pathFor(video.id)`.
+
+```dart
+testWidgets('tapping Edit subtitles pushes the subtitle editor route',
+    (tester) async {
+  final goRouter = MockGoRouter();
+  // pump the bottom bar (or the edit stack) wrapped in
+  // MockGoRouterProvider with localization delegates, with a test video.
+  await tester.tap(find.text(
+    lookupAppLocalizations(const Locale('en')).videoEditEditSubtitles,
+  ));
+  await tester.pump();
+  verify(() => goRouter.push(
+        SubtitleEditorScreen.pathFor(testVideo.id),
+        extra: testVideo,
+      )).called(1);
+});
+```
+
+(Match the bottom bar's existing test harness for how the video is
+injected. If the bottom bar doesn't currently receive the `VideoEvent`,
+thread it through from its parent — the edit stack already has the
+resolved video.)
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `mise exec -- flutter test test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart`
+Expected: FAIL — no "Edit subtitles" control.
+
+- [ ] **Step 4: Add the action to the bottom bar**
+
+Restructure the bottom bar's `build` `Row` into a `Column` so the new
+full-width action sits above the existing Delete/Update row. Replace the
+`child: Row(...)` (the Delete/Update row) with:
+
+```dart
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 10,
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: _isBusy ? null : _editSubtitles,
+                icon: const DivineIcon(icon: .closedCaption),
+                label: Text(context.l10n.videoEditEditSubtitles),
+              ),
+            ),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              spacing: 10,
+              children: [
+                Expanded(
+                  child: _DeleteButton(
+                    onTap: _confirmDelete,
+                    isBusy: _isBusy,
+                    isDeleting: _isDeleting,
+                  ),
+                ),
+                Expanded(
+                  child: _UpdateButton(
+                    onTap: _updateVideo,
+                    isBusy: _isBusy,
+                    isUpdating: _isUpdating,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+```
+
+Add the handler method (the bottom bar already has access to the video it
+edits — use that field; confirm its name, e.g. `widget.video`):
+
+```dart
+  void _editSubtitles() {
+    context.push(
+      SubtitleEditorScreen.pathFor(widget.video.id),
+      extra: widget.video,
+    );
+  }
+```
+
+Add imports for `SubtitleEditorScreen`, `context.l10n`, and `DivineIcon`
+if not present. Confirm the `closedCaption` icon exists in
+`DivineIconName`; if not, use the closest existing caption/subtitle icon
+or a generic edit icon — grep `rg "enum DivineIconName" -A60` in
+`divine_ui`.
+
+> Ownership: `VideoMetadataEditScreen` already resolves the video with
+> `allowOwnContentBypass: true`, so the edit surface (and therefore this
+> button) is only reachable for the creator's own video. No additional
+> pubkey gate is needed here.
+
+- [ ] **Step 5: Run to verify pass + analyze**
+
+Run: `mise exec -- flutter test test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart`
+Expected: PASS.
+Run: `mise exec -- flutter analyze lib test`
+Expected: No issues.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/router/app_router.dart \
+        lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart \
+        test/widgets/video_metadata/modes/edit
+git commit -m "feat(subtitles): wire Edit subtitles entry point and route"
+```
+
+---
+
+## Task 11: Full verification
+
+- [ ] **Step 1: Analyze the whole touched surface**
+
+Run: `mise exec -- flutter analyze lib test integration_test`
+Expected: No issues.
+
+- [ ] **Step 2: Format**
+
+Run: `mise exec -- dart format lib test`
+Expected: formats only changed files; commit if anything changed.
+
+- [ ] **Step 3: Run all affected suites**
+
+Run (from `mobile/`):
+```bash
+mise exec -- flutter test \
+  test/services/subtitle_fetcher_test.dart \
+  test/providers/subtitle_providers_test.dart \
+  test/repositories/subtitle_repository_test.dart \
+  test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart \
+  test/screens/subtitle_editor/subtitle_editor_screen_test.dart \
+  test/services/video_event_publisher_subtitle_test.dart \
+  test/l10n/arb_consistency_test.dart \
+  test/widgets/video_metadata/modes/edit
+```
+Run (from `mobile/packages/models`): `mise exec -- flutter test`
+Run (from `mobile/packages/blossom_upload_service`): `mise exec -- flutter test`
+Expected: all PASS.
+
+- [ ] **Step 4: Rebase + push**
+
+```bash
+git fetch origin
+git rebase origin/main
+# re-run analyze + affected tests if the rebase pulled changes
+git push --force-with-lease -u origin feat/subtitle-editing
+```
+
+- [ ] **Step 5: Open the PR** (targets `main`)
+
+Use `/pr-summary` to generate the body. Attach a screen recording of the
+edit→save→updated-captions flow. Manual test plan: own freshly-uploaded
+video (processing state), own video with ready auto-subs (edit a wrong
+word → save → confirm corrected caption appears), and a non-owner cannot
+reach the editor.
+
+---
+
+## Self-Review (completed during authoring)
+
+- **Spec coverage:** Blossom upload (T1), 39307 publish (T5), dual-ref
+  redundancy + reader fallback (T3/T4/T5), repository orchestration (T6),
+  Cubit with status enum + addError (T7), full-screen Page/View editor +
+  l10n + a11y announcement (T8/T9), both entry points via one screen — the
+  post-publish "Edit subtitles" action (T10), and the "publish now, edit
+  when ready" processing state (T7/T9). Author-only via existing
+  `allowOwnContentBypass` resolver (T10). Single language `en` throughout.
+- **Risk #1 resolved:** the HTTP text-track branch already exists; T3+T4
+  make the reader actually iterate refs so the Blossom fallback is real.
+- **Type consistency:** `textTrackRefs` (List<String>), `EditableCue`
+  (start/end/text + `toCue`/`fromCue`), `SubtitleEditorStatus` enum,
+  `publishSubtitleEvent` returns `String?`, `republishWithSubtitles` gains
+  `extraTextTrackRefs` — names match across tasks.
+- **At-publish entry:** v1 ships the activatable own-video affordance; the
+  "subtitles ready" badge is the same action becoming usable once
+  `loadCues` returns non-empty. No separate editor — matches the spec.

--- a/docs/superpowers/specs/2026-06-20-subtitle-editing-design.md
+++ b/docs/superpowers/specs/2026-06-20-subtitle-editing-design.md
@@ -1,0 +1,199 @@
+# Creator Subtitle Editing & Republish-to-Blossom — Design
+
+**Date:** 2026-06-20
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+Subtitles on Divine videos are auto-generated server-side from the
+uploaded video. They are frequently wrong, and creators currently have
+no way to correct them. Creators need to edit the subtitle text and
+publish the corrected version so viewers see it — both around the time
+of publishing a new video and later on an already-published video.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|----------|--------|
+| Editing model | **Text only** — edit cue text, timing stays fixed. |
+| Storage target | **Both** — VTT blob in Blossom *and* a Kind 39307 Nostr subtitle event. |
+| Entry points | **Both** at-publish and post-publish (they converge on one editor). |
+| Languages | **Single (en)** for v1. |
+| At-publish behavior | **Publish now, edit when ready** — never block publish on transcription. |
+| Editing permission | **Author-only** in v1 (no collaborator editing). |
+| Orchestration owner | **New `SubtitleRepository`** (Approach A). |
+
+## What already exists (reused, not rebuilt)
+
+- **VTT parse/generate:** `SubtitleService.parseVtt` / `generateVtt`
+  (`mobile/lib/services/subtitle_service.dart`).
+- **Triple-fetch display path:** `subtitleCuesProvider`
+  (`mobile/lib/providers/subtitle_providers.dart`):
+  1. embedded `textTrackContent` → parse directly,
+  2. `sha256` → fetch Blossom `media.divine.video/{videoSha256}/vtt`
+     (polls `202 Processing` up to ~15s),
+  3. `textTrackRef` = `39307:<pubkey>:subtitles:<d-tag>` → relay query.
+- **Subtitle display widgets:** `SubtitleCuePositionPill` / `_CaptionPill`
+  (`mobile/lib/widgets/video_feed_item/subtitle_overlay.dart`), respecting
+  the global `SubtitleVisibility` toggle.
+- **Blossom generic upload:** `BlossomUploadService.uploadAudio` already
+  takes an arbitrary `mimeType`, computes sha256
+  (`HashUtil.sha256File`), PUTs to `{server}/upload`, returns
+  `{ videoId: sha256, url: {server}/{sha256} }`. NIP-98 upload auth
+  (kind 24242) is handled in `_uploadToServer`.
+- **Addressable republish:** `VideoEventPublisher.republishWithSubtitles`
+  (`mobile/lib/services/video_event_publisher.dart`) — strips old
+  `text-track` tags, adds a new one, re-signs the kind-34236 event,
+  optimistically updates local cache, publishes. **Currently has no
+  production caller.**
+- **Event signing/publishing:** `AuthService.createAndSignEvent({kind,
+  content, tags, createdAt})` + the Nostr publish path.
+- **Replacement pattern:** `VideoMetadataUpdateService` republishes
+  addressable videos with `createdAt + 1` so relays treat it as a
+  replacement while preserving chronological position.
+
+## Architecture (UI → Cubit → Repository → Client)
+
+### Client layer
+
+- **`BlossomUploadService` — add `uploadSubtitleVtt`** (mirrors
+  `uploadAudio`): accepts VTT bytes, `mimeType: 'text/vtt'`, returns the
+  `BlossomUploadResult` (sha256 + canonical `{server}/{sha256}` URL).
+  Blossom is content-addressed by sha256; MIME only sets the stored
+  `Content-Type`.
+- **`AuthService` / Nostr publish** — unchanged, used to sign & publish
+  the kind-39307 event.
+
+### Repository layer (new): `SubtitleRepository`
+
+Owns all source-selection and publish composition (per
+`architecture.md` — fallback/composition belongs here, never in the
+Cubit/UI).
+
+- `loadEditableCues(VideoEvent video)` → reuses the existing triple-fetch
+  to return the current cues, or a **processing** signal when the
+  auto-VTT isn't ready yet.
+- `publishEditedSubtitles({video, cues, lang})`:
+  1. `SubtitleService.generateVtt(cues)` → VTT string.
+  2. Upload VTT to Blossom → `vttSha256` + canonical URL (the durable
+     "to Blossom too" copy).
+  3. Publish **kind 39307** event:
+     - `content` = VTT text,
+     - `d` = `subtitles:<videoDtag>` (per-video, addressable,
+       replaceable on re-edit),
+     - tags: `a` = `34236:<pubkey>:<videoDtag>` (video reference),
+       Blossom URL, `m` = `text/vtt`, language.
+  4. Republish the kind-34236 video via `republishWithSubtitles` with
+     **two** `text-track` tags for real read-time redundancy:
+     - `39307:<pubkey>:subtitles:<videoDtag>` (relay-queryable,
+       replaceable — the consumer already resolves this), and
+     - the Blossom canonical VTT URL (durable, CDN-served).
+     The consumer tries them in order and falls back if one source is
+     unavailable.
+  5. Invalidate `subtitleCuesProvider` so the feed updates immediately.
+
+Typed exceptions on failure; no user-facing strings (per
+`error_handling.md` per-layer contract).
+
+### Cubit layer (new): `SubtitleEditorCubit`
+
+- **State:** status enum
+  `{ loading, processing, ready, saving, success, failure }`,
+  `List<EditableCue>` (fixed timestamp + editable text), `isDirty`.
+  No error strings / exception objects in state; `addError` on failure.
+- **Methods:** `load()`, `updateCueText(index, text)`, `save()`.
+- All mutable data lives in state (no private mutable fields on the
+  Cubit).
+
+### UI layer (new): `SubtitleEditorScreen`
+
+- Page/View split; **full-screen** (no new bottom sheet), dark-mode
+  `VineTheme`.
+- `ListView.builder` of cue rows: read-only timestamp label +
+  editable text field (text-only; timing fixed).
+- Live preview reusing `_CaptionPill` styling; honors the global
+  subtitle toggle.
+- Save enabled only when `isDirty`; `BlocListener` drives
+  success/failure snackbars and a `SemanticsService.sendAnnouncement`
+  on completion.
+- All copy via `context.l10n`; new ARB keys added to `app_en.arb`.
+
+### Entry points (both route into the one screen)
+
+1. **Post-publish:** "Edit subtitles" action on the creator's **own**
+   video, surfaced in the existing `video_metadata_edit_screen` /
+   overflow, gated on `video.pubkey == myPubkey`.
+2. **At-publish ("publish now, edit when ready"):** publishing is never
+   blocked on transcription. After upload, once the auto-VTT is ready,
+   the same own-video affordance activates (a "subtitles ready — review"
+   badge/banner). No separate editor.
+
+## Data flow (save)
+
+```
+SubtitleEditorScreen.save()
+  → SubtitleEditorCubit.save()  (status: saving)
+    → SubtitleRepository.publishEditedSubtitles(video, cues, lang)
+        1. generateVtt(cues)
+        2. Blossom.uploadSubtitleVtt(bytes, text/vtt) → vttSha256, url
+        3. publish kind 39307 (d = subtitles:<videoDtag>, a, url, m, lang)
+        4. republishWithSubtitles(video, ref=39307:pubkey:subtitles:<dtag>)
+        5. invalidate subtitleCuesProvider
+    → status: success | failure (addError)
+  → BlocListener: snackbar + announcement; pop on success
+```
+
+## Re-edit semantics
+
+Re-editing publishes a new kind-39307 with the **same** `d` tag and a
+new kind-34236 video event (`createdAt + 1`); both replace by their
+addressable key, so relays keep the latest. Viewers' `subtitleCuesProvider`
+re-resolves to the newest 39307 content.
+
+## Testing
+
+- **`SubtitleRepository`:** VTT generated from edited cues; Blossom
+  called with `text/vtt`; 39307 event has correct `d` =
+  `subtitles:<videoDtag>` and `a`/url/`m`/lang tags; video republished
+  with **both** text-track refs (39307 coords + Blossom URL); error
+  paths translate to typed exceptions.
+- **Consumer fallback:** `subtitleCuesProvider` resolves cues from the
+  Blossom VTT URL when the 39307 relay query yields nothing (the
+  redundancy guarantee).
+- **`SubtitleEditorCubit`:** `blocTest` status transitions
+  (load → processing/ready, save → saving → success/failure);
+  `updateCueText` sets `isDirty`; `addError` on failure (no error
+  strings in state).
+- **`SubtitleEditorScreen`:** renders cues; editing a field updates
+  state; save gated on `isDirty`; l10n delegates wired; assertions
+  resolve strings from `AppLocalizations`.
+- **`BlossomUploadService`:** new VTT path sets `Content-Type: text/vtt`
+  and returns the sha256.
+- **Ownership:** edit affordance shows only when `video.pubkey ==
+  myPubkey`.
+
+## Risks / open items for the plan
+
+1. **HTTP text-track URL consumer support (now in scope).** Redundancy
+   requires the consumer to fall back to the Blossom VTT URL when the
+   39307 relay query fails. The 39307-coords path is confirmed in
+   `subtitleCuesProvider`; a *plain HTTP* text-track URL path is **not**
+   confirmed. The plan must verify it and, if missing, **add** an
+   HTTP-URL branch to the triple-fetch so the second `text-track` tag is
+   actually usable. This is required work for the chosen both-storage
+   redundancy, not an optional extra.
+2. **Processing state.** When the auto-VTT isn't ready at edit time, the
+   editor shows a "transcription still processing" state with retry.
+3. **Cache invalidation.** Ensure `subtitleCuesProvider` (and any
+   feed-item cached `VideoEvent`) refreshes after republish so the new
+   subtitles show without an app restart.
+4. **d-tag derivation.** Confirm the canonical source of `<videoDtag>`
+   on `VideoEvent` so the 39307 `d` and the `a`/`text-track` refs are
+   consistent with what the consumer parses.
+
+## Out of scope (v1)
+
+- Editing cue **timing** (split/merge/add/delete cues, nudging times).
+- **Multi-language** track management.
+- **Collaborator** editing (author-only).
+- Importing an external `.vtt`/`.srt` file.

--- a/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
@@ -91,6 +91,9 @@ VideoEvent _mergeEnrichmentIntoCurrent(
         : enriched.collaboratorPubkeys,
     inspiredByVideo: current.inspiredByVideo ?? enriched.inspiredByVideo,
     textTrackRef: current.textTrackRef ?? enriched.textTrackRef,
+    textTrackRefs: current.textTrackRefs.isNotEmpty
+        ? current.textTrackRefs
+        : enriched.textTrackRefs,
     textTrackContent: current.textTrackContent ?? enriched.textTrackContent,
     nostrEventTags: current.nostrEventTags.isNotEmpty
         ? current.nostrEventTags

--- a/mobile/lib/blocs/subtitle_editor/subtitle_editor_cubit.dart
+++ b/mobile/lib/blocs/subtitle_editor/subtitle_editor_cubit.dart
@@ -1,0 +1,86 @@
+// ABOUTME: Cubit that orchestrates the subtitle-editor flow: load cues,
+// ABOUTME: allow text edits, and publish the updated subtitle track.
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
+import 'package:openvine/services/subtitle_service.dart';
+
+part 'subtitle_editor_state.dart';
+
+/// Manages the subtitle-editing lifecycle for a single video.
+class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
+  /// Creates the cubit with the [repository] and the [video] being edited.
+  SubtitleEditorCubit({
+    required SubtitleRepository repository,
+    required VideoEvent video,
+  }) : _repository = repository,
+       _video = video,
+       super(const SubtitleEditorState());
+
+  final SubtitleRepository _repository;
+  final VideoEvent _video;
+
+  /// Loads existing subtitle cues for the video.
+  ///
+  /// Emits [SubtitleEditorStatus.loading] then either:
+  /// - [SubtitleEditorStatus.ready] with cues when they are available.
+  /// - [SubtitleEditorStatus.processing] when no cues are available yet.
+  /// - [SubtitleEditorStatus.failure] and calls [addError] on any exception.
+  Future<void> load() async {
+    emit(state.copyWith(status: SubtitleEditorStatus.loading));
+    try {
+      final cues = await _repository.loadCues(_video);
+      if (cues.isEmpty) {
+        emit(state.copyWith(status: SubtitleEditorStatus.processing));
+        return;
+      }
+      emit(
+        state.copyWith(
+          status: SubtitleEditorStatus.ready,
+          cues: cues.map(EditableCue.fromCue).toList(),
+          isDirty: false,
+        ),
+      );
+    } catch (e, st) {
+      addError(e, st);
+      emit(state.copyWith(status: SubtitleEditorStatus.failure));
+    }
+  }
+
+  /// Replaces the text of the cue at [index] with [text] and marks the
+  /// state as dirty.
+  ///
+  /// Out-of-range indices are silently ignored.
+  void updateCueText(int index, String text) {
+    if (index < 0 || index >= state.cues.length) return;
+    final updated = List<EditableCue>.from(state.cues);
+    updated[index] = updated[index].copyWith(text: text);
+    emit(state.copyWith(cues: updated, isDirty: true));
+  }
+
+  /// Publishes the current cues via the repository.
+  ///
+  /// Emits [SubtitleEditorStatus.saving] then either:
+  /// - [SubtitleEditorStatus.success] with `isDirty` reset to `false`.
+  /// - [SubtitleEditorStatus.failure] and calls [addError] on any exception.
+  Future<void> save() async {
+    emit(state.copyWith(status: SubtitleEditorStatus.saving));
+    try {
+      await _repository.publishEditedSubtitles(
+        video: _video,
+        cues: state.cues.map((c) => c.toCue()).toList(),
+      );
+      emit(
+        state.copyWith(
+          status: SubtitleEditorStatus.success,
+          isDirty: false,
+        ),
+      );
+    } catch (e, st) {
+      addError(e, st);
+      emit(state.copyWith(status: SubtitleEditorStatus.failure));
+    }
+  }
+}

--- a/mobile/lib/blocs/subtitle_editor/subtitle_editor_state.dart
+++ b/mobile/lib/blocs/subtitle_editor/subtitle_editor_state.dart
@@ -1,0 +1,100 @@
+part of 'subtitle_editor_cubit.dart';
+
+/// Loading and editing status for the subtitle editor.
+enum SubtitleEditorStatus {
+  /// Initial cue-load is in progress.
+  loading,
+
+  /// Auto-transcription is not yet available; polling is expected.
+  processing,
+
+  /// Cues are loaded and ready to edit.
+  ready,
+
+  /// Edited cues are being published.
+  saving,
+
+  /// Publish completed successfully.
+  success,
+
+  /// An operation failed; check [addError] for details.
+  failure,
+}
+
+/// A single subtitle cue whose text may be edited.
+///
+/// Timing is read-only; only [text] can be changed by the editor.
+class EditableCue extends Equatable {
+  /// Creates an editable cue.
+  const EditableCue({
+    required this.start,
+    required this.end,
+    required this.text,
+  });
+
+  /// Converts a [SubtitleCue] to an [EditableCue].
+  factory EditableCue.fromCue(SubtitleCue cue) =>
+      EditableCue(start: cue.start, end: cue.end, text: cue.text);
+
+  /// Start time in milliseconds (read-only).
+  final int start;
+
+  /// End time in milliseconds (read-only).
+  final int end;
+
+  /// The subtitle text content.
+  final String text;
+
+  /// Converts back to a [SubtitleCue] for publishing.
+  SubtitleCue toCue() => SubtitleCue(start: start, end: end, text: text);
+
+  /// Returns a copy with [text] replaced.
+  EditableCue copyWith({String? text}) =>
+      EditableCue(start: start, end: end, text: text ?? this.text);
+
+  /// `M:SS` label derived from [start] for display purposes.
+  String get timestampLabel {
+    final totalSeconds = start ~/ 1000;
+    final minutes = totalSeconds ~/ 60;
+    final seconds = totalSeconds % 60;
+    return '$minutes:${seconds.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  List<Object?> get props => [start, end, text];
+}
+
+/// State for [SubtitleEditorCubit].
+class SubtitleEditorState extends Equatable {
+  /// Creates the initial state.
+  const SubtitleEditorState({
+    this.status = SubtitleEditorStatus.loading,
+    this.cues = const [],
+    this.isDirty = false,
+  });
+
+  /// Current editor status.
+  final SubtitleEditorStatus status;
+
+  /// The editable cues loaded from the subtitle track.
+  final List<EditableCue> cues;
+
+  /// Whether [cues] have been modified since the last save or load.
+  final bool isDirty;
+
+  /// Returns a copy with selected fields replaced.
+  SubtitleEditorState copyWith({
+    SubtitleEditorStatus? status,
+    List<EditableCue>? cues,
+    bool? isDirty,
+  }) {
+    return SubtitleEditorState(
+      status: status ?? this.status,
+      cues: cues ?? this.cues,
+      isDirty: isDirty ?? this.isDirty,
+    );
+  }
+
+  @override
+  List<Object?> get props => [status, cues, isDirty];
+}

--- a/mobile/lib/constants/nip71_migration.dart
+++ b/mobile/lib/constants/nip71_migration.dart
@@ -10,6 +10,11 @@ class NIP71VideoKinds {
   static const int addressableNormalVideo = 34235; // Addressable normal videos
   static const int liveVideo = 34237; // Live video streams
 
+  /// Kind 39307 addressable subtitle event. Published separately from the
+  /// video event and referenced via a `text-track` tag as
+  /// `39307:<pubkey>:subtitles:<video-d-tag>`.
+  static const int subtitleEventKind = 39307;
+
   // Repost kinds
   static const int repost = 16; // NIP-18 generic reposts
 

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5182,5 +5182,14 @@
     "@videoEditorVolumeLongPressHint": {
         "description": "Semantic long-press hint for a volume arc control. Screen readers announce this as the long-press affordance, which mutes or unmutes all timeline tracks at once."
     },
-    "videoEditorSplitFailed": "Split failed. Please try again."
+    "videoEditorSplitFailed": "Split failed. Please try again.",
+    "videoEditEditSubtitles": "Edit subtitles",
+    "subtitleEditorTitle": "Edit subtitles",
+    "subtitleEditorSave": "Save",
+    "subtitleEditorProcessing": "Subtitles are still being generated. Check back in a moment.",
+    "subtitleEditorLoadError": "Couldn't load subtitles. Try again.",
+    "subtitleEditorSaveSuccess": "Subtitles updated",
+    "subtitleEditorSaveError": "Couldn't save subtitles. Try again.",
+    "subtitleEditorRetry": "Retry",
+    "subtitleEditorCueHint": "Caption text"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -15713,6 +15713,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Split failed. Please try again.'**
   String get videoEditorSplitFailed;
+
+  /// No description provided for @videoEditEditSubtitles.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit subtitles'**
+  String get videoEditEditSubtitles;
+
+  /// No description provided for @subtitleEditorTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit subtitles'**
+  String get subtitleEditorTitle;
+
+  /// No description provided for @subtitleEditorSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get subtitleEditorSave;
+
+  /// No description provided for @subtitleEditorProcessing.
+  ///
+  /// In en, this message translates to:
+  /// **'Subtitles are still being generated. Check back in a moment.'**
+  String get subtitleEditorProcessing;
+
+  /// No description provided for @subtitleEditorLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load subtitles. Try again.'**
+  String get subtitleEditorLoadError;
+
+  /// No description provided for @subtitleEditorSaveSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Subtitles updated'**
+  String get subtitleEditorSaveSuccess;
+
+  /// No description provided for @subtitleEditorSaveError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t save subtitles. Try again.'**
+  String get subtitleEditorSaveError;
+
+  /// No description provided for @subtitleEditorRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Retry'**
+  String get subtitleEditorRetry;
+
+  /// No description provided for @subtitleEditorCueHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Caption text'**
+  String get subtitleEditorCueHint;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -8889,4 +8889,32 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'መከፋፈሉ አልተሳካም። እባክዎ እንደገና ይሞክሩ።';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -8977,4 +8977,32 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'فشل التقسيم. يرجى المحاولة مرة أخرى.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9145,4 +9145,32 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get videoEditorSplitFailed =>
       'Разделянето не бе успешно. Моля, опитайте отново.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9155,4 +9155,32 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get videoEditorSplitFailed =>
       'Teilen fehlgeschlagen. Bitte erneut versuchen.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9043,4 +9043,32 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'Split failed. Please try again.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9140,4 +9140,32 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get videoEditorSplitFailed =>
       'Error al dividir. Por favor, inténtalo de nuevo.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9151,4 +9151,32 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'Nabigo ang paghati. Pakisubukan muli.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9177,4 +9177,32 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get videoEditorSplitFailed =>
       'Échec de la division. Veuillez réessayer.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9033,4 +9033,32 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'Pembagian gagal. Silakan coba lagi.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9136,4 +9136,32 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'Divisione non riuscita. Riprovare.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -8742,4 +8742,32 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => '分割に失敗しました。もう一度お試しください。';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -8766,4 +8766,32 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => '분할에 실패했습니다. 다시 시도해 주세요.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9099,4 +9099,32 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'Splitsen mislukt. Probeer het opnieuw.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9216,4 +9216,32 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'Podział nieudany. Spróbuj ponownie.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9110,4 +9110,32 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'Falha na divisão. Tente novamente.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9241,4 +9241,32 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get videoEditorSplitFailed =>
       'Împărțire eșuată. Vă rugăm să încercați din nou.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9064,4 +9064,32 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get videoEditorSplitFailed => 'Delning misslyckades. Försök igen.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9030,4 +9030,32 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get videoEditorSplitFailed =>
       'Bölme başarısız oldu. Lütfen tekrar deneyin.';
+
+  @override
+  String get videoEditEditSubtitles => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorTitle => 'Edit subtitles';
+
+  @override
+  String get subtitleEditorSave => 'Save';
+
+  @override
+  String get subtitleEditorProcessing =>
+      'Subtitles are still being generated. Check back in a moment.';
+
+  @override
+  String get subtitleEditorLoadError => 'Couldn\'t load subtitles. Try again.';
+
+  @override
+  String get subtitleEditorSaveSuccess => 'Subtitles updated';
+
+  @override
+  String get subtitleEditorSaveError => 'Couldn\'t save subtitles. Try again.';
+
+  @override
+  String get subtitleEditorRetry => 'Retry';
+
+  @override
+  String get subtitleEditorCueHint => 'Caption text';
 }

--- a/mobile/lib/providers/subtitle_providers.dart
+++ b/mobile/lib/providers/subtitle_providers.dart
@@ -41,6 +41,10 @@ Future<List<SubtitleCue>> subtitleCues(
   String? textTrackContent,
   String? sha256,
 }) async {
+  if (textTrackContent != null && textTrackContent.isNotEmpty) {
+    return SubtitleService.parseVtt(textTrackContent);
+  }
+
   final refs = textTrackRefs.isNotEmpty
       ? textTrackRefs
       : [

--- a/mobile/lib/providers/subtitle_providers.dart
+++ b/mobile/lib/providers/subtitle_providers.dart
@@ -1,24 +1,16 @@
-// ABOUTME: Providers for subtitle fetching with triple strategy.
-// ABOUTME: Fast path: parse embedded VTT from REST API. Blossom path: fetch VTT
-// ABOUTME: from media.divine.video/{sha256}/vtt. Slow path: query relay for
-// ABOUTME: Kind 39307 subtitle events.
+// ABOUTME: Providers for subtitle fetching with ordered fallback chain.
+// ABOUTME: Delegates fetch logic to fetchSubtitleCues in subtitle_fetcher.dart.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:http/http.dart' as http;
-import 'package:nostr_sdk/filter.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/subtitle_fetcher.dart';
 import 'package:openvine/services/subtitle_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:unified_logger/unified_logger.dart';
 
 part 'subtitle_providers.g.dart';
 
-typedef SubtitlePollDelay = Future<void> Function(Duration duration);
-
-const _maxBlossomPollAttempts = 4;
-const _maxBlossomPollWait = Duration(seconds: 15);
-const _defaultBlossomRetryAfter = Duration(seconds: 3);
 const _subtitleVisibilityPreferenceKey = 'subtitle_visibility_enabled';
 
 final subtitleHttpClientProvider = Provider<http.Client>((ref) {
@@ -31,153 +23,37 @@ final subtitlePollDelayProvider = Provider<SubtitlePollDelay>(
   (_) => Future<void>.delayed,
 );
 
-Duration _parseRetryAfter(Map<String, String> headers) {
-  final rawValue = headers['retry-after'];
-  if (rawValue == null) return _defaultBlossomRetryAfter;
-
-  final seconds = int.tryParse(rawValue.trim());
-  if (seconds == null || seconds <= 0) return _defaultBlossomRetryAfter;
-
-  return Duration(seconds: seconds);
-}
-
-Uri? _parseHttpSubtitleUrl(String? textTrackRef) {
-  if (textTrackRef == null || textTrackRef.isEmpty) return null;
-
-  final uri = Uri.tryParse(textTrackRef);
-  if (uri == null) return null;
-  if (uri.scheme != 'http' && uri.scheme != 'https') return null;
-  return uri;
-}
-
-Future<List<SubtitleCue>?> _fetchBlossomSubtitles({
-  required http.Client client,
-  required SubtitlePollDelay delay,
-  required Uri vttUrl,
-}) async {
-  var waited = Duration.zero;
-
-  for (var attempt = 0; attempt < _maxBlossomPollAttempts; attempt++) {
-    final response = await client.get(vttUrl);
-
-    if (response.statusCode == 200 && response.body.trim().isNotEmpty) {
-      return SubtitleService.parseVtt(response.body);
-    }
-
-    if (response.statusCode == 202) {
-      if (attempt == _maxBlossomPollAttempts - 1) return null;
-
-      final retryAfter = _parseRetryAfter(response.headers);
-      if (waited + retryAfter > _maxBlossomPollWait) {
-        return null;
-      }
-
-      waited += retryAfter;
-      await delay(retryAfter);
-      continue;
-    }
-
-    if (response.statusCode == 404) {
-      return null;
-    }
-
-    return null;
-  }
-
-  return null;
-}
-
-/// Fetches subtitle cues for a video, using the fastest available path.
+/// Fetches subtitle cues for a video, using ordered fallback.
 ///
 /// 1. If [textTrackContent] is present (REST API embedded the VTT), parse it
 ///    directly — zero network cost.
-/// 2. If [sha256] is present, fetch VTT from the Blossom server at
-///    `https://media.divine.video/{sha256}/vtt`. Returns empty list on 404
-///    (VTT not yet generated). Non-blocking.
-/// 3. If [textTrackRef] is present (addressable coordinates like
-///    `39307:<pubkey>:subtitles:<d-tag>`), query the relay for the subtitle
-///    event and parse its content.
+/// 2. For each ref in [textTrackRefs] (or [textTrackRef] for back-compat),
+///    try HTTP fetch or relay query in order.
+/// 3. If [sha256] is present, fetch from Blossom at
+///    `https://media.divine.video/{sha256}/vtt`.
 /// 4. Otherwise returns an empty list (no subtitles available).
 @riverpod
 Future<List<SubtitleCue>> subtitleCues(
   Ref ref, {
   required String videoId,
   String? textTrackRef,
+  List<String> textTrackRefs = const [],
   String? textTrackContent,
   String? sha256,
 }) async {
-  // Fast path: REST API already embedded the VTT content
-  if (textTrackContent != null && textTrackContent.isNotEmpty) {
-    return SubtitleService.parseVtt(textTrackContent);
-  }
-
-  final directSubtitleUrl = _parseHttpSubtitleUrl(textTrackRef);
-  if (directSubtitleUrl != null) {
-    final client = ref.read(subtitleHttpClientProvider);
-    try {
-      final response = await client.get(directSubtitleUrl);
-      if (response.statusCode == 200 && response.body.trim().isNotEmpty) {
-        return SubtitleService.parseVtt(response.body);
-      }
-    } catch (e) {
-      Log.warning(
-        'Direct VTT fetch failed for $directSubtitleUrl: $e',
-        name: 'subtitleCues',
-        category: LogCategory.video,
-      );
-    }
-  }
-
-  // Blossom path: fetch VTT from media server by sha256
-  if (sha256 != null && sha256.isNotEmpty) {
-    final vttUrl = Uri.parse('https://media.divine.video/$sha256/vtt');
-    final client = ref.read(subtitleHttpClientProvider);
-    final delay = ref.read(subtitlePollDelayProvider);
-    try {
-      final blossomCues = await _fetchBlossomSubtitles(
-        client: client,
-        delay: delay,
-        vttUrl: vttUrl,
-      );
-      if (blossomCues != null) {
-        return blossomCues;
-      }
-    } catch (e) {
-      Log.warning(
-        'Blossom VTT fetch failed for $sha256: $e',
-        name: 'subtitleCues',
-        category: LogCategory.video,
-      );
-      // Network error — fall through to relay path
-    }
-  }
-
-  // No ref at all → no subtitles
-  if (textTrackRef == null || textTrackRef.isEmpty) return [];
-
-  // Parse addressable coordinates: "39307:<pubkey>:<d-tag>"
-  final parts = textTrackRef.split(':');
-  // Need at least kind:pubkey:d-tag (3 parts minimum)
-  if (parts.length < 3) return [];
-
-  final kind = int.tryParse(parts[0]);
-  if (kind == null) return [];
-
-  final pubkey = parts[1];
-  // d-tag may contain colons (e.g. "subtitles:my-vine-id")
-  final dTag = parts.sublist(2).join(':');
-
-  // Slow path: query relay for the subtitle event
-  final nostrClient = ref.read(nostrServiceProvider);
-  final events = await nostrClient.queryEvents(
-    [
-      Filter(kinds: [kind], authors: [pubkey], d: [dTag], limit: 1),
-    ],
-    tempRelays: ['wss://relay.divine.video'],
+  final refs = textTrackRefs.isNotEmpty
+      ? textTrackRefs
+      : [
+          if (textTrackRef != null && textTrackRef.isNotEmpty) textTrackRef,
+        ];
+  return fetchSubtitleCues(
+    httpClient: ref.read(subtitleHttpClientProvider),
+    nostrClient: ref.read(nostrServiceProvider),
+    delay: ref.read(subtitlePollDelayProvider),
+    textTrackContent: textTrackContent,
+    textTrackRefs: refs,
+    sha256: sha256,
   );
-
-  if (events.isEmpty) return [];
-  return SubtitleService.parseVtt(events.first.content);
 }
 
 /// Tracks global subtitle visibility (CC on/off).

--- a/mobile/lib/providers/subtitle_providers.g.dart
+++ b/mobile/lib/providers/subtitle_providers.g.dart
@@ -116,7 +116,7 @@ final class SubtitleCuesProvider
   }
 }
 
-String _$subtitleCuesHash() => r'1715789c0a7b8c19b8261c94c38c649f3c57bc90';
+String _$subtitleCuesHash() => r'fea7fc72b8636d1d5701ab6a03a3ad7c937c2796';
 
 /// Fetches subtitle cues for a video, using ordered fallback.
 ///

--- a/mobile/lib/providers/subtitle_providers.g.dart
+++ b/mobile/lib/providers/subtitle_providers.g.dart
@@ -8,31 +8,27 @@ part of 'subtitle_providers.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// Fetches subtitle cues for a video, using the fastest available path.
+/// Fetches subtitle cues for a video, using ordered fallback.
 ///
 /// 1. If [textTrackContent] is present (REST API embedded the VTT), parse it
 ///    directly — zero network cost.
-/// 2. If [sha256] is present, fetch VTT from the Blossom server at
-///    `https://media.divine.video/{sha256}/vtt`. Returns empty list on 404
-///    (VTT not yet generated). Non-blocking.
-/// 3. If [textTrackRef] is present (addressable coordinates like
-///    `39307:<pubkey>:subtitles:<d-tag>`), query the relay for the subtitle
-///    event and parse its content.
+/// 2. For each ref in [textTrackRefs] (or [textTrackRef] for back-compat),
+///    try HTTP fetch or relay query in order.
+/// 3. If [sha256] is present, fetch from Blossom at
+///    `https://media.divine.video/{sha256}/vtt`.
 /// 4. Otherwise returns an empty list (no subtitles available).
 
 @ProviderFor(subtitleCues)
 final subtitleCuesProvider = SubtitleCuesFamily._();
 
-/// Fetches subtitle cues for a video, using the fastest available path.
+/// Fetches subtitle cues for a video, using ordered fallback.
 ///
 /// 1. If [textTrackContent] is present (REST API embedded the VTT), parse it
 ///    directly — zero network cost.
-/// 2. If [sha256] is present, fetch VTT from the Blossom server at
-///    `https://media.divine.video/{sha256}/vtt`. Returns empty list on 404
-///    (VTT not yet generated). Non-blocking.
-/// 3. If [textTrackRef] is present (addressable coordinates like
-///    `39307:<pubkey>:subtitles:<d-tag>`), query the relay for the subtitle
-///    event and parse its content.
+/// 2. For each ref in [textTrackRefs] (or [textTrackRef] for back-compat),
+///    try HTTP fetch or relay query in order.
+/// 3. If [sha256] is present, fetch from Blossom at
+///    `https://media.divine.video/{sha256}/vtt`.
 /// 4. Otherwise returns an empty list (no subtitles available).
 
 final class SubtitleCuesProvider
@@ -45,22 +41,21 @@ final class SubtitleCuesProvider
     with
         $FutureModifier<List<SubtitleCue>>,
         $FutureProvider<List<SubtitleCue>> {
-  /// Fetches subtitle cues for a video, using the fastest available path.
+  /// Fetches subtitle cues for a video, using ordered fallback.
   ///
   /// 1. If [textTrackContent] is present (REST API embedded the VTT), parse it
   ///    directly — zero network cost.
-  /// 2. If [sha256] is present, fetch VTT from the Blossom server at
-  ///    `https://media.divine.video/{sha256}/vtt`. Returns empty list on 404
-  ///    (VTT not yet generated). Non-blocking.
-  /// 3. If [textTrackRef] is present (addressable coordinates like
-  ///    `39307:<pubkey>:subtitles:<d-tag>`), query the relay for the subtitle
-  ///    event and parse its content.
+  /// 2. For each ref in [textTrackRefs] (or [textTrackRef] for back-compat),
+  ///    try HTTP fetch or relay query in order.
+  /// 3. If [sha256] is present, fetch from Blossom at
+  ///    `https://media.divine.video/{sha256}/vtt`.
   /// 4. Otherwise returns an empty list (no subtitles available).
   SubtitleCuesProvider._({
     required SubtitleCuesFamily super.from,
     required ({
       String videoId,
       String? textTrackRef,
+      List<String> textTrackRefs,
       String? textTrackContent,
       String? sha256,
     })
@@ -96,6 +91,7 @@ final class SubtitleCuesProvider
             as ({
               String videoId,
               String? textTrackRef,
+              List<String> textTrackRefs,
               String? textTrackContent,
               String? sha256,
             });
@@ -103,6 +99,7 @@ final class SubtitleCuesProvider
       ref,
       videoId: argument.videoId,
       textTrackRef: argument.textTrackRef,
+      textTrackRefs: argument.textTrackRefs,
       textTrackContent: argument.textTrackContent,
       sha256: argument.sha256,
     );
@@ -119,18 +116,16 @@ final class SubtitleCuesProvider
   }
 }
 
-String _$subtitleCuesHash() => r'f2f1b2025cc1aed796903a9d96fd5c64b5393263';
+String _$subtitleCuesHash() => r'1715789c0a7b8c19b8261c94c38c649f3c57bc90';
 
-/// Fetches subtitle cues for a video, using the fastest available path.
+/// Fetches subtitle cues for a video, using ordered fallback.
 ///
 /// 1. If [textTrackContent] is present (REST API embedded the VTT), parse it
 ///    directly — zero network cost.
-/// 2. If [sha256] is present, fetch VTT from the Blossom server at
-///    `https://media.divine.video/{sha256}/vtt`. Returns empty list on 404
-///    (VTT not yet generated). Non-blocking.
-/// 3. If [textTrackRef] is present (addressable coordinates like
-///    `39307:<pubkey>:subtitles:<d-tag>`), query the relay for the subtitle
-///    event and parse its content.
+/// 2. For each ref in [textTrackRefs] (or [textTrackRef] for back-compat),
+///    try HTTP fetch or relay query in order.
+/// 3. If [sha256] is present, fetch from Blossom at
+///    `https://media.divine.video/{sha256}/vtt`.
 /// 4. Otherwise returns an empty list (no subtitles available).
 
 final class SubtitleCuesFamily extends $Family
@@ -140,6 +135,7 @@ final class SubtitleCuesFamily extends $Family
           ({
             String videoId,
             String? textTrackRef,
+            List<String> textTrackRefs,
             String? textTrackContent,
             String? sha256,
           })
@@ -153,27 +149,27 @@ final class SubtitleCuesFamily extends $Family
         isAutoDispose: true,
       );
 
-  /// Fetches subtitle cues for a video, using the fastest available path.
+  /// Fetches subtitle cues for a video, using ordered fallback.
   ///
   /// 1. If [textTrackContent] is present (REST API embedded the VTT), parse it
   ///    directly — zero network cost.
-  /// 2. If [sha256] is present, fetch VTT from the Blossom server at
-  ///    `https://media.divine.video/{sha256}/vtt`. Returns empty list on 404
-  ///    (VTT not yet generated). Non-blocking.
-  /// 3. If [textTrackRef] is present (addressable coordinates like
-  ///    `39307:<pubkey>:subtitles:<d-tag>`), query the relay for the subtitle
-  ///    event and parse its content.
+  /// 2. For each ref in [textTrackRefs] (or [textTrackRef] for back-compat),
+  ///    try HTTP fetch or relay query in order.
+  /// 3. If [sha256] is present, fetch from Blossom at
+  ///    `https://media.divine.video/{sha256}/vtt`.
   /// 4. Otherwise returns an empty list (no subtitles available).
 
   SubtitleCuesProvider call({
     required String videoId,
     String? textTrackRef,
+    List<String> textTrackRefs = const [],
     String? textTrackContent,
     String? sha256,
   }) => SubtitleCuesProvider._(
     argument: (
       videoId: videoId,
       textTrackRef: textTrackRef,
+      textTrackRefs: textTrackRefs,
       textTrackContent: textTrackContent,
       sha256: sha256,
     ),

--- a/mobile/lib/providers/subtitle_repository_provider.dart
+++ b/mobile/lib/providers/subtitle_repository_provider.dart
@@ -1,0 +1,23 @@
+// ABOUTME: Riverpod provider that wires SubtitleRepository with its
+// ABOUTME: infrastructure dependencies (Blossom, VideoEventPublisher, auth,
+// ABOUTME: Nostr, HTTP client, and poll-delay function).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/subtitle_providers.dart';
+import 'package:openvine/providers/upload_media_providers.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
+
+/// Provides a fully-wired [SubtitleRepository] for the subtitle-edit pipeline.
+final subtitleRepositoryProvider = Provider<SubtitleRepository>((ref) {
+  return SubtitleRepository(
+    blossomUploadService: ref.watch(blossomUploadServiceProvider),
+    videoEventPublisher: ref.watch(videoEventPublisherProvider),
+    authService: ref.watch(authServiceProvider),
+    nostrClient: ref.watch(nostrServiceProvider),
+    httpClient: ref.watch(subtitleHttpClientProvider),
+    pollDelay: ref.watch(subtitlePollDelayProvider),
+  );
+});

--- a/mobile/lib/repositories/subtitle_repository.dart
+++ b/mobile/lib/repositories/subtitle_repository.dart
@@ -63,7 +63,12 @@ class SubtitleRepository {
       nostrClient: _nostrClient,
       delay: _pollDelay,
       textTrackContent: video.textTrackContent,
-      textTrackRefs: video.textTrackRefs,
+      textTrackRefs: video.textTrackRefs.isNotEmpty
+          ? video.textTrackRefs
+          : [
+              if (video.textTrackRef != null && video.textTrackRef!.isNotEmpty)
+                video.textTrackRef!,
+            ],
       sha256: video.sha256,
     );
   }

--- a/mobile/lib/repositories/subtitle_repository.dart
+++ b/mobile/lib/repositories/subtitle_repository.dart
@@ -1,0 +1,123 @@
+// ABOUTME: Owns the edit-subtitles orchestration: generate VTT → upload to
+// ABOUTME: Blossom → publish 39307 subtitle event → republish the video with
+// ABOUTME: both the Blossom URL and the addressable event reference.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:http/http.dart' as http;
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/subtitle_fetcher.dart';
+import 'package:openvine/services/subtitle_service.dart';
+import 'package:openvine/services/video_event_publisher.dart';
+
+/// Thrown when an edited-subtitle publish cannot complete. Carries no PII.
+class SubtitleEditException implements Exception {
+  SubtitleEditException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'SubtitleEditException: $message';
+}
+
+/// Orchestrates the full subtitle-edit publish pipeline.
+///
+/// Responsibilities:
+/// - Loading existing cues from the shared fallback chain.
+/// - Generating VTT, uploading it to Blossom, publishing a 39307 subtitle
+///   event, and republishing the video event with both refs attached.
+///
+/// Throws [SubtitleEditException] when any step fails.
+class SubtitleRepository {
+  SubtitleRepository({
+    required BlossomUploadService blossomUploadService,
+    required VideoEventPublisher videoEventPublisher,
+    required AuthService authService,
+    required NostrClient nostrClient,
+    required http.Client httpClient,
+    required SubtitlePollDelay pollDelay,
+  }) : _blossom = blossomUploadService,
+       _publisher = videoEventPublisher,
+       _authService = authService,
+       _nostrClient = nostrClient,
+       _httpClient = httpClient,
+       _pollDelay = pollDelay;
+
+  final BlossomUploadService _blossom;
+  final VideoEventPublisher _publisher;
+  final AuthService _authService;
+  final NostrClient _nostrClient;
+  final http.Client _httpClient;
+  final SubtitlePollDelay _pollDelay;
+
+  /// Loads the current cues for [video] using the shared fallback chain.
+  ///
+  /// Returns `[]` when no subtitle data is available yet.
+  Future<List<SubtitleCue>> loadCues(VideoEvent video) {
+    return fetchSubtitleCues(
+      httpClient: _httpClient,
+      nostrClient: _nostrClient,
+      delay: _pollDelay,
+      textTrackContent: video.textTrackContent,
+      textTrackRefs: video.textTrackRefs,
+      sha256: video.sha256,
+    );
+  }
+
+  /// Generates VTT from [cues], uploads it to Blossom, publishes a 39307
+  /// subtitle event, then republishes the video referencing both.
+  ///
+  /// Throws:
+  ///
+  /// * [SubtitleEditException] when the user is not authenticated.
+  /// * [SubtitleEditException] when [video] has no addressable identifier.
+  /// * [SubtitleEditException] when the Blossom upload fails.
+  /// * [SubtitleEditException] when the subtitle event publish fails.
+  /// * [SubtitleEditException] when the video republish fails.
+  Future<void> publishEditedSubtitles({
+    required VideoEvent video,
+    required List<SubtitleCue> cues,
+    String lang = 'en',
+  }) async {
+    if (_authService.currentPublicKeyHex == null) {
+      throw SubtitleEditException('Not authenticated');
+    }
+    final vineId = video.vineId;
+    if (vineId == null || vineId.isEmpty) {
+      throw SubtitleEditException('Video has no addressable identifier');
+    }
+
+    final vtt = SubtitleService.generateVtt(cues);
+    final bytes = Uint8List.fromList(utf8.encode(vtt));
+
+    final upload = await _blossom.uploadSubtitleVtt(bytes: bytes);
+    final blossomUrl = upload.url;
+    if (!upload.success || blossomUrl == null) {
+      throw SubtitleEditException('Subtitle upload to Blossom failed');
+    }
+
+    final coordsRef = await _publisher.publishSubtitleEvent(
+      video: video,
+      vttContent: vtt,
+      blossomUrl: blossomUrl,
+      lang: lang,
+    );
+    if (coordsRef == null) {
+      throw SubtitleEditException('Subtitle event publish failed');
+    }
+
+    final ok = await _publisher.republishWithSubtitles(
+      existingEvent: video,
+      textTrackRef: blossomUrl,
+      extraTextTrackRefs: [coordsRef],
+      textTrackLang: lang,
+    );
+    if (!ok) {
+      throw SubtitleEditException('Video republish failed');
+    }
+  }
+}

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -81,6 +81,7 @@ import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
+import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
 import 'package:openvine/screens/user_list_people_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
@@ -1324,6 +1325,21 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             videoId: videoId,
             prefetched: prefetched,
           );
+        },
+      ),
+      GoRoute(
+        path: '${SubtitleEditorScreen.path}/:videoId',
+        name: SubtitleEditorScreen.routeName,
+        builder: (ctx, st) {
+          final videoId = st.pathParameters['videoId'];
+          if (videoId == null || videoId.isEmpty) {
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
+          }
+          final prefetched = st.extra as VideoEvent?;
+          if (prefetched == null) {
+            return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
+          }
+          return SubtitleEditorScreen(video: prefetched);
         },
       ),
       GoRoute(

--- a/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
+++ b/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
@@ -79,7 +79,13 @@ class SubtitleEditorView extends StatelessWidget {
             context.pop();
           } else if (state.status == SubtitleEditorStatus.failure) {
             ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text(l10n.subtitleEditorSaveError)),
+              SnackBar(
+                content: Text(
+                  state.cues.isEmpty
+                      ? l10n.subtitleEditorLoadError
+                      : l10n.subtitleEditorSaveError,
+                ),
+              ),
             );
           }
         },

--- a/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
+++ b/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
@@ -1,0 +1,231 @@
+// ABOUTME: Full-screen editor for correcting a video's subtitle text.
+// ABOUTME: Page builds the cubit from Riverpod; View renders cue text fields.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/subtitle_repository_provider.dart';
+
+/// Full-screen subtitle editor page.
+///
+/// Wires [SubtitleEditorCubit] via Riverpod DI and delegates rendering to
+/// [SubtitleEditorView].
+class SubtitleEditorScreen extends ConsumerWidget {
+  /// Creates the subtitle editor page for [video].
+  const SubtitleEditorScreen({required this.video, super.key});
+
+  /// Base route path.
+  static const path = '/subtitle-edit';
+
+  /// GoRouter route name.
+  static const routeName = 'subtitle-edit';
+
+  /// Returns the full path for a given video id.
+  static String pathFor(String videoId) =>
+      '$path/${Uri.encodeComponent(videoId)}';
+
+  /// The video whose subtitles are being edited.
+  final VideoEvent video;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final repository = ref.watch(subtitleRepositoryProvider);
+    return BlocProvider<SubtitleEditorCubit>(
+      key: ObjectKey(repository),
+      create: (_) =>
+          SubtitleEditorCubit(repository: repository, video: video)..load(),
+      child: const SubtitleEditorView(),
+    );
+  }
+}
+
+/// Renders the subtitle editor UI.
+///
+/// Expects a [SubtitleEditorCubit] ancestor provided by [SubtitleEditorScreen].
+@visibleForTesting
+class SubtitleEditorView extends StatelessWidget {
+  /// Creates the subtitle editor view.
+  const SubtitleEditorView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Scaffold(
+      backgroundColor: VineTheme.surfaceBackground,
+      appBar: DiVineAppBar(
+        title: l10n.subtitleEditorTitle,
+        backgroundColor: VineTheme.surfaceBackground,
+        showBackButton: true,
+        onBackPressed: context.pop,
+      ),
+      body: BlocConsumer<SubtitleEditorCubit, SubtitleEditorState>(
+        listenWhen: (previous, current) => previous.status != current.status,
+        listener: (context, state) {
+          if (state.status == SubtitleEditorStatus.success) {
+            SemanticsService.sendAnnouncement(
+              View.of(context),
+              l10n.subtitleEditorSaveSuccess,
+              Directionality.of(context),
+            );
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(l10n.subtitleEditorSaveSuccess)),
+            );
+            context.pop();
+          } else if (state.status == SubtitleEditorStatus.failure) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(l10n.subtitleEditorSaveError)),
+            );
+          }
+        },
+        builder: (context, state) => switch (state.status) {
+          SubtitleEditorStatus.loading => const _Loading(),
+          SubtitleEditorStatus.processing => const _Processing(),
+          _ => _CueList(state: state),
+        },
+      ),
+    );
+  }
+}
+
+class _Loading extends StatelessWidget {
+  const _Loading();
+
+  @override
+  Widget build(BuildContext context) =>
+      const Center(child: CircularProgressIndicator());
+}
+
+class _Processing extends StatelessWidget {
+  const _Processing();
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        spacing: 16,
+        children: [
+          Text(
+            l10n.subtitleEditorProcessing,
+            textAlign: TextAlign.center,
+            style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+          ),
+          TextButton(
+            onPressed: () => context.read<SubtitleEditorCubit>().load(),
+            child: Text(l10n.subtitleEditorRetry),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CueList extends StatelessWidget {
+  const _CueList({required this.state});
+
+  final SubtitleEditorState state;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: state.cues.length,
+            itemBuilder: (context, index) =>
+                _CueRow(index: index, cue: state.cues[index]),
+          ),
+        ),
+        SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: _SaveButton(
+              enabled:
+                  state.isDirty && state.status != SubtitleEditorStatus.saving,
+              busy: state.status == SubtitleEditorStatus.saving,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CueRow extends StatelessWidget {
+  const _CueRow({required this.index, required this.cue});
+
+  final int index;
+  final EditableCue cue;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: 12,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 14),
+            child: Text(
+              cue.timestampLabel,
+              style: VineTheme.bodySmallFont(color: VineTheme.secondaryText),
+            ),
+          ),
+          Expanded(
+            child: TextFormField(
+              initialValue: cue.text,
+              minLines: 1,
+              maxLines: null,
+              style: VineTheme.bodyMediumFont(),
+              decoration: InputDecoration(
+                hintText: context.l10n.subtitleEditorCueHint,
+              ),
+              onChanged: (value) =>
+                  context.read<SubtitleEditorCubit>().updateCueText(
+                    index,
+                    value,
+                  ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SaveButton extends StatelessWidget {
+  const _SaveButton({required this.enabled, required this.busy});
+
+  final bool enabled;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      child: FilledButton(
+        onPressed: enabled
+            ? () => context.read<SubtitleEditorCubit>().save()
+            : null,
+        child: busy
+            ? const SizedBox(
+                height: 18,
+                width: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : Text(context.l10n.subtitleEditorSave),
+      ),
+    );
+  }
+}

--- a/mobile/lib/services/subtitle_fetcher.dart
+++ b/mobile/lib/services/subtitle_fetcher.dart
@@ -1,0 +1,173 @@
+// ABOUTME: Shared subtitle fetch chain used by the display provider and the
+// ABOUTME: editor's load path. Ordered fallback: embedded content → each
+// ABOUTME: text-track ref (http or 39307 relay) → Blossom {sha256}/vtt.
+
+import 'package:http/http.dart' as http;
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/subtitle_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Callback type for delaying between Blossom poll attempts.
+typedef SubtitlePollDelay = Future<void> Function(Duration duration);
+
+const _maxBlossomPollAttempts = 4;
+const _maxBlossomPollWait = Duration(seconds: 15);
+const _defaultBlossomRetryAfter = Duration(seconds: 3);
+
+Duration _parseRetryAfter(Map<String, String> headers) {
+  final rawValue = headers['retry-after'];
+  if (rawValue == null) return _defaultBlossomRetryAfter;
+
+  final seconds = int.tryParse(rawValue.trim());
+  if (seconds == null || seconds <= 0) return _defaultBlossomRetryAfter;
+
+  return Duration(seconds: seconds);
+}
+
+Uri? _parseHttpSubtitleUrl(String ref) {
+  if (ref.isEmpty) return null;
+
+  final uri = Uri.tryParse(ref);
+  if (uri == null) return null;
+  if (uri.scheme != 'http' && uri.scheme != 'https') return null;
+  return uri;
+}
+
+Future<List<SubtitleCue>?> _fetchHttp(http.Client client, Uri url) async {
+  try {
+    final response = await client.get(url);
+    if (response.statusCode == 200 && response.body.trim().isNotEmpty) {
+      return SubtitleService.parseVtt(response.body);
+    }
+  } catch (e) {
+    Log.warning(
+      'Direct VTT fetch failed for $url: $e',
+      name: 'fetchSubtitleCues',
+      category: LogCategory.video,
+    );
+  }
+  return null;
+}
+
+Future<List<SubtitleCue>?> _fetchRelay(
+  NostrClient nostrClient,
+  String ref,
+) async {
+  final parts = ref.split(':');
+  if (parts.length < 3) return null;
+
+  final kind = int.tryParse(parts[0]);
+  if (kind == null) return null;
+
+  final pubkey = parts[1];
+  // d-tag may contain colons (e.g. "subtitles:my-vine-id")
+  final dTag = parts.sublist(2).join(':');
+
+  final events = await nostrClient.queryEvents(
+    [
+      Filter(kinds: [kind], authors: [pubkey], d: [dTag], limit: 1),
+    ],
+    tempRelays: ['wss://relay.divine.video'],
+  );
+
+  if (events.isEmpty) return null;
+  return SubtitleService.parseVtt(events.first.content);
+}
+
+Future<List<SubtitleCue>?> _fetchBlossom({
+  required http.Client client,
+  required SubtitlePollDelay delay,
+  required Uri vttUrl,
+}) async {
+  var waited = Duration.zero;
+
+  for (var attempt = 0; attempt < _maxBlossomPollAttempts; attempt++) {
+    final response = await client.get(vttUrl);
+
+    if (response.statusCode == 200 && response.body.trim().isNotEmpty) {
+      return SubtitleService.parseVtt(response.body);
+    }
+
+    if (response.statusCode == 202) {
+      if (attempt == _maxBlossomPollAttempts - 1) return null;
+
+      final retryAfter = _parseRetryAfter(response.headers);
+      if (waited + retryAfter > _maxBlossomPollWait) return null;
+
+      waited += retryAfter;
+      await delay(retryAfter);
+      continue;
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+/// Resolves subtitle cues with ordered fallback.
+///
+/// Strategy (first success wins):
+/// 1. If [textTrackContent] is non-empty, parse it directly (zero network).
+/// 2. For each ref in [textTrackRefs], try HTTP fetch (http/https) or relay
+///    query (Nostr NIP coords). [nostrClient] may be null; relay refs are
+///    skipped when it is.
+/// 3. If [sha256] is present, fetch from Blossom at
+///    `https://media.divine.video/{sha256}/vtt`, polling on 202.
+///
+/// Returns `[]` when no source yields cues.
+Future<List<SubtitleCue>> fetchSubtitleCues({
+  required http.Client httpClient,
+  required NostrClient? nostrClient,
+  required SubtitlePollDelay delay,
+  String? textTrackContent,
+  List<String> textTrackRefs = const [],
+  String? sha256,
+}) async {
+  if (textTrackContent != null && textTrackContent.isNotEmpty) {
+    return SubtitleService.parseVtt(textTrackContent);
+  }
+
+  for (final ref in textTrackRefs) {
+    final httpUrl = _parseHttpSubtitleUrl(ref);
+    if (httpUrl != null) {
+      final cues = await _fetchHttp(httpClient, httpUrl);
+      if (cues != null) return cues;
+      continue;
+    }
+
+    if (nostrClient != null) {
+      try {
+        final cues = await _fetchRelay(nostrClient, ref);
+        if (cues != null) return cues;
+      } catch (e) {
+        Log.warning(
+          'Relay VTT fetch failed for $ref: $e',
+          name: 'fetchSubtitleCues',
+          category: LogCategory.video,
+        );
+      }
+    }
+  }
+
+  if (sha256 != null && sha256.isNotEmpty) {
+    final vttUrl = Uri.parse('https://media.divine.video/$sha256/vtt');
+    try {
+      final cues = await _fetchBlossom(
+        client: httpClient,
+        delay: delay,
+        vttUrl: vttUrl,
+      );
+      if (cues != null) return cues;
+    } catch (e) {
+      Log.warning(
+        'Blossom VTT fetch failed for $sha256: $e',
+        name: 'fetchSubtitleCues',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  return [];
+}

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -1582,30 +1582,33 @@ class VideoEventPublisher {
     }
   }
 
-  /// Republish a video event with an added text-track tag for subtitles.
+  /// Republish a video event with added text-track tags for subtitles.
   ///
-  /// Takes the existing video event's original tags, adds a text-track tag
-  /// referencing the subtitle event, and publishes the updated event.
-  /// Returns true if publishing succeeded.
+  /// Strips any existing text-track tags from the original event, then emits
+  /// one tag per ref ([textTrackRef] followed by each entry in
+  /// [extraTextTrackRefs]) for read-time redundancy. Returns true if
+  /// publishing succeeded.
   Future<bool> republishWithSubtitles({
     required VideoEvent existingEvent,
     required String textTrackRef,
+    List<String> extraTextTrackRefs = const [],
     String textTrackLang = 'en',
   }) async {
-    // Start from the original Nostr event tags
+    // Start from the original Nostr event tags, stripping old text-track tags.
     final tags = existingEvent.nostrEventTags
         .where((t) => t.isNotEmpty && t.first != 'text-track')
         .map(List<String>.from)
         .toList();
 
-    // Add the new text-track tag
-    tags.add([
-      'text-track',
-      textTrackRef,
-      'wss://relay.divine.video',
-      'captions',
-      textTrackLang,
-    ]);
+    for (final ref in [textTrackRef, ...extraTextTrackRefs]) {
+      tags.add([
+        'text-track',
+        ref,
+        'wss://relay.divine.video',
+        'captions',
+        textTrackLang,
+      ]);
+    }
 
     // Sign the updated event
     final event = await _authService?.createAndSignEvent(
@@ -1639,6 +1642,54 @@ class VideoEventPublisher {
     }
 
     return true;
+  }
+
+  /// Publishes a Kind 39307 subtitle event for [video] and returns its
+  /// addressable ref `39307:<pubkey>:subtitles:<vineId>`, or `null` on
+  /// failure (not authenticated, no addressable id, sign/publish failed).
+  Future<String?> publishSubtitleEvent({
+    required VideoEvent video,
+    required String vttContent,
+    required String blossomUrl,
+    String lang = 'en',
+  }) async {
+    final pubkey = _authService?.currentPublicKeyHex;
+    final vineId = video.vineId;
+    if (pubkey == null || vineId == null || vineId.isEmpty) return null;
+
+    final dTag = 'subtitles:$vineId';
+    final videoKind = NIP71VideoKinds.getPreferredAddressableKind();
+
+    final event = await _authService?.createAndSignEvent(
+      kind: NIP71VideoKinds.subtitleEventKind,
+      content: vttContent,
+      tags: [
+        ['d', dTag],
+        ['a', '$videoKind:$pubkey:$vineId'],
+        ['url', blossomUrl],
+        ['m', 'text/vtt'],
+        ['l', lang],
+      ],
+    );
+    if (event == null) {
+      Log.error(
+        'Failed to sign subtitle event',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+
+    final ok = await _publishEventToNostr(event);
+    if (!ok) {
+      Log.warning(
+        'Failed to publish subtitle event',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return null;
+    }
+    return '${NIP71VideoKinds.subtitleEventKind}:$pubkey:$dTag';
   }
 
   /// Check if a URL is a valid HTTP/HTTPS URL (not a local file path)

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -124,6 +124,9 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
               : video.collaboratorPubkeys,
           inspiredByVideo: video.inspiredByVideo ?? parsed.inspiredByVideo,
           textTrackRef: video.textTrackRef ?? parsed.textTrackRef,
+          textTrackRefs: video.textTrackRefs.isNotEmpty
+              ? video.textTrackRefs
+              : parsed.textTrackRefs,
           textTrackContent: video.textTrackContent ?? parsed.textTrackContent,
           nostrEventTags: video.nostrEventTags.isEmpty
               ? parsed.nostrEventTags

--- a/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
@@ -75,7 +75,7 @@ class _SubtitleCuePositionPillState
     final cuesAsync = ref.watch(
       subtitleCuesProvider(
         videoId: widget.video.id,
-        textTrackRef: widget.video.textTrackRef,
+        textTrackRefs: widget.video.textTrackRefs,
         textTrackContent: widget.video.textTrackContent,
         sha256: widget.video.sha256,
       ),

--- a/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
@@ -75,6 +75,7 @@ class _SubtitleCuePositionPillState
     final cuesAsync = ref.watch(
       subtitleCuesProvider(
         videoId: widget.video.id,
+        textTrackRef: widget.video.textTrackRef,
         textTrackRefs: widget.video.textTrackRefs,
         textTrackContent: widget.video.textTrackContent,
         sha256: widget.video.sha256,

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
@@ -11,6 +11,7 @@ import 'package:models/models.dart' show VideoEvent;
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
 import 'package:openvine/services/content_deletion_service.dart';
 import 'package:openvine/services/video_metadata_update_service.dart';
 import 'package:openvine/utils/delete_failure_localization.dart';
@@ -43,6 +44,13 @@ class _VideoMetadataEditBottomBarState
   bool _isDeleting = false;
 
   bool get _isBusy => _isUpdating || _isDeleting;
+
+  void _editSubtitles() {
+    context.push(
+      SubtitleEditorScreen.pathFor(widget.video.id),
+      extra: widget.video,
+    );
+  }
 
   Future<void> _updateVideo() async {
     if (_isBusy) return;
@@ -189,25 +197,61 @@ class _VideoMetadataEditBottomBarState
       data: MediaQuery.of(context).copyWith(textScaler: textScaler),
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.end,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           spacing: 10,
           children: [
-            Expanded(
-              child: _DeleteButton(
-                onTap: _confirmDelete,
-                isBusy: _isBusy,
-                isDeleting: _isDeleting,
-              ),
+            _EditSubtitlesButton(
+              onTap: _editSubtitles,
+              isBusy: _isBusy,
             ),
-            Expanded(
-              child: _UpdateButton(
-                onTap: _updateVideo,
-                isBusy: _isBusy,
-                isUpdating: _isUpdating,
-              ),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              spacing: 10,
+              children: [
+                Expanded(
+                  child: _DeleteButton(
+                    onTap: _confirmDelete,
+                    isBusy: _isBusy,
+                    isDeleting: _isDeleting,
+                  ),
+                ),
+                Expanded(
+                  child: _UpdateButton(
+                    onTap: _updateVideo,
+                    isBusy: _isBusy,
+                    isUpdating: _isUpdating,
+                  ),
+                ),
+              ],
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Full-width outlined button to open the subtitle editor.
+class _EditSubtitlesButton extends StatelessWidget {
+  const _EditSubtitlesButton({
+    required this.onTap,
+    required this.isBusy,
+  });
+
+  final VoidCallback onTap;
+  final bool isBusy;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      identifier: 'edit_subtitles_button',
+      child: SizedBox(
+        width: double.infinity,
+        child: OutlinedButton.icon(
+          onPressed: isBusy ? null : onTap,
+          icon: const DivineIcon(icon: DivineIconName.closedCaptioning),
+          label: Text(context.l10n.videoEditEditSubtitles),
         ),
       ),
     );

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2479,6 +2479,136 @@ class BlossomUploadService {
     }
   }
 
+  /// Uploads a subtitle VTT blob (BUD-01) and returns its sha256 and
+  /// canonical URL. MIME defaults to `text/vtt`; Blossom is
+  /// content-addressed so the stored Content-Type does not affect the
+  /// address.
+  Future<BlossomUploadResult> uploadSubtitleVtt({
+    required Uint8List bytes,
+    String mimeType = 'text/vtt',
+    void Function(double)? onProgress,
+  }) async {
+    try {
+      if (!authProvider.isAuthenticated) {
+        return const BlossomUploadResult(
+          success: false,
+          errorMessage: 'Not authenticated',
+          failureReason: BlossomUploadFailureReason.auth,
+        );
+      }
+
+      onProgress?.call(0.1);
+
+      final fileHash = HashUtil.sha256Hash(bytes);
+      final fileSize = bytes.length;
+
+      Log.info(
+        'Subtitle VTT hash: $fileHash, size: $fileSize bytes',
+        name: 'BlossomUploadService',
+        category: LogCategory.video,
+      );
+
+      final serverUrls = await _getServerUrlsForUpload();
+
+      Log.info(
+        'Trying ${serverUrls.length} Blossom servers for subtitle upload',
+        name: 'BlossomUploadService',
+        category: LogCategory.video,
+      );
+
+      BlossomUploadResult? lastError;
+
+      for (final serverUrl in serverUrls) {
+        try {
+          Log.info(
+            'Attempting subtitle upload to: $serverUrl',
+            name: 'BlossomUploadService',
+            category: LogCategory.video,
+          );
+
+          final result = await _uploadToServer(
+            serverUrl: serverUrl,
+            source: _BytesUploadSource(
+              bytes: bytes,
+              filename: 'subtitles.vtt',
+            ),
+            fileHash: fileHash,
+            fileSize: fileSize,
+            contentType: mimeType,
+            onProgress: onProgress,
+          );
+
+          if (result.success) {
+            final canonicalUrl = '$_defaultServerUrl/$fileHash';
+
+            Log.info(
+              'Subtitle uploaded to: $serverUrl, '
+              'canonical URL: $canonicalUrl',
+              name: 'BlossomUploadService',
+              category: LogCategory.video,
+            );
+
+            return BlossomUploadResult(
+              success: true,
+              url: canonicalUrl,
+              fallbackUrl: canonicalUrl,
+              videoId: fileHash,
+            );
+          }
+
+          lastError = result;
+          Log.warning(
+            'Subtitle upload to $serverUrl failed: '
+            '${result.errorMessage}, trying next server...',
+            name: 'BlossomUploadService',
+            category: LogCategory.video,
+          );
+          // coverage:ignore-start
+        } on Object catch (e) {
+          final statusCode = e is DioException ? e.response?.statusCode : null;
+          lastError = BlossomUploadResult(
+            success: false,
+            statusCode: statusCode,
+            errorMessage: 'Upload to $serverUrl failed: $e',
+            failureReason: _classifyUploadException(e),
+          );
+          Log.warning(
+            'Subtitle upload to $serverUrl failed: $e, '
+            'trying next server...',
+            name: 'BlossomUploadService',
+            category: LogCategory.video,
+          );
+          continue;
+          // coverage:ignore-end
+        }
+      }
+
+      Log.error(
+        'All ${serverUrls.length} servers failed for subtitle upload',
+        name: 'BlossomUploadService',
+        category: LogCategory.video,
+      );
+
+      return lastError ??
+          const BlossomUploadResult(
+            success: false,
+            errorMessage: 'All servers failed',
+            failureReason: BlossomUploadFailureReason.unknown,
+          );
+    } on Object catch (e) {
+      Log.error(
+        'Subtitle VTT upload error: $e',
+        name: 'BlossomUploadService',
+        category: LogCategory.video,
+      );
+      return BlossomUploadResult(
+        success: false,
+        errorMessage: 'Subtitle VTT upload failed: $e',
+        failureReason: _classifyUploadException(e),
+      );
+    }
+  }
+
   /// Test connection to a Blossom server
   ///
   /// Returns a [BlossomHealthCheckResult] with status, latency, and any errors.

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -2131,6 +2131,71 @@ void main() {
         expect(result.success, isFalse);
         expect(result.failureReason, equals(BlossomUploadFailureReason.auth));
       });
+
+      test('returns upload failure when subtitle PUT is rejected', () async {
+        final mockDio = _MockDio();
+        final mockResponse = _MockResponse();
+        when(() => mockResponse.statusCode).thenReturn(400);
+        when(() => mockResponse.headers).thenReturn(Headers());
+        when(() => mockResponse.data).thenReturn(<String, dynamic>{
+          'message': 'bad VTT',
+        });
+        when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+        when(
+          () => mockAuthProvider.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => _signedEvent(_testPublicKey, 24242, const [], ''),
+        );
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async => mockResponse);
+
+        final service = BlossomUploadService(
+          authProvider: mockAuthProvider,
+          dio: mockDio,
+        );
+        final progress = <double>[];
+
+        final result = await service.uploadSubtitleVtt(
+          bytes: Uint8List.fromList(utf8.encode('WEBVTT\n')),
+          onProgress: progress.add,
+        );
+
+        expect(progress.first, equals(0.1));
+        expect(result.success, isFalse);
+        expect(result.statusCode, equals(400));
+        expect(result.errorMessage, isNotNull);
+      });
+
+      test('returns failure when subtitle upload setup throws', () async {
+        when(() => mockAuthProvider.isAuthenticated).thenThrow(
+          StateError('auth state unavailable'),
+        );
+        final service = BlossomUploadService(authProvider: mockAuthProvider);
+
+        final result = await service.uploadSubtitleVtt(
+          bytes: Uint8List.fromList(utf8.encode('WEBVTT\n')),
+        );
+
+        expect(result.success, isFalse);
+        expect(
+          result.errorMessage,
+          contains('Subtitle VTT upload failed'),
+        );
+        expect(
+          result.failureReason,
+          equals(BlossomUploadFailureReason.unknown),
+        );
+      });
     });
 
     group('Model classes', () {

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -2,6 +2,7 @@
 // multi-server support
 // ABOUTME: Tests configuration persistence, server selection, and upload flow
 
+import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -2058,6 +2059,77 @@ void main() {
         ).called(1);
 
         await tempDir.delete(recursive: true);
+      });
+    });
+
+    group('uploadSubtitleVtt', () {
+      test(
+        'PUTs VTT bytes with text/vtt content type and returns sha256',
+        () async {
+          final mockDio = _MockDio();
+          final mockResponse = _MockResponse();
+          when(() => mockResponse.statusCode).thenReturn(200);
+          when(() => mockResponse.data).thenReturn(<String, dynamic>{
+            'url': 'https://media.divine.video/abc123',
+          });
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async => _signedEvent(_testPublicKey, 24242, const [], ''),
+          );
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((_) async => mockResponse);
+
+          final service = BlossomUploadService(
+            authProvider: mockAuthProvider,
+            dio: mockDio,
+          );
+
+          final vtt = utf8.encode(
+            'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhi\n',
+          );
+          final result = await service.uploadSubtitleVtt(
+            bytes: Uint8List.fromList(vtt),
+          );
+
+          expect(result.success, isTrue);
+          final videoId = result.videoId;
+          expect(videoId, isNotNull);
+          expect(result.url, contains(videoId));
+
+          final captured =
+              verify(
+                    () => mockDio.put<dynamic>(
+                      any(),
+                      data: any(named: 'data'),
+                      options: captureAny(named: 'options'),
+                      onSendProgress: any(named: 'onSendProgress'),
+                    ),
+                  ).captured.single
+                  as Options;
+          expect(captured.headers!['Content-Type'], equals('text/vtt'));
+        },
+      );
+
+      test('returns auth failure when not authenticated', () async {
+        when(() => mockAuthProvider.isAuthenticated).thenReturn(false);
+        final service = BlossomUploadService(authProvider: mockAuthProvider);
+        final result = await service.uploadSubtitleVtt(
+          bytes: Uint8List.fromList(utf8.encode('WEBVTT\n')),
+        );
+        expect(result.success, isFalse);
+        expect(result.failureReason, equals(BlossomUploadFailureReason.auth));
       });
     });
 

--- a/mobile/packages/models/lib/src/nip71_video_kinds.dart
+++ b/mobile/packages/models/lib/src/nip71_video_kinds.dart
@@ -10,6 +10,10 @@ class NIP71VideoKinds {
   static const int addressableShortVideo = 34236; // Addressable short videos
   static const int addressableNormalVideo = 34235; // Addressable normal videos
 
+  /// Addressable subtitle/caption event kind referenced by a video's
+  /// `text-track` tag as `39307:<pubkey>:subtitles:<video-d-tag>`.
+  static const int subtitleEventKind = 39307;
+
   // Repost kinds
   static const int repost = 16; // NIP-18 generic reposts
 

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -194,6 +194,7 @@ class VideoEvent {
     this.inspiredByNpub,
     this.nostrEventTags = const [],
     this.textTrackRef,
+    this.textTrackRefs = const [],
     this.textTrackContent,
     this.contentWarningLabels = const [],
     this.moderationLabels = const [],
@@ -334,7 +335,7 @@ class VideoEvent {
     String? audioEventRelay;
     final collaboratorPubkeys = <String>[];
     InspiredByInfo? inspiredByVideo;
-    String? textTrackRef;
+    final textTrackRefsLocal = <String>[];
     final contentWarningLabels = <String>[];
 
     // Parse event tags according to NIP-71
@@ -593,7 +594,7 @@ class VideoEvent {
           // Format: ['text-track', '<coords-or-url>', '<relay>', 'captions',
           //          '<lang>']
           if (tagValue.isNotEmpty) {
-            textTrackRef ??= tagValue;
+            textTrackRefsLocal.add(tagValue);
           }
         default:
           // POSTEL'S LAW: Check if any unknown tag contains a valid video URL
@@ -688,7 +689,10 @@ class VideoEvent {
       nostrEventTags: event.tags
           .map((t) => (t as List).map((e) => e.toString()).toList())
           .toList(),
-      textTrackRef: textTrackRef,
+      textTrackRef: textTrackRefsLocal.isNotEmpty
+          ? textTrackRefsLocal.first
+          : null,
+      textTrackRefs: textTrackRefsLocal,
       contentWarningLabels: contentWarningLabels,
     );
   }
@@ -784,6 +788,10 @@ class VideoEvent {
   /// Addressable coordinates or URL for text-track subtitle reference.
   /// Format: `39307:<pubkey>:subtitles:<video-d-tag>` or HTTP URL.
   final String? textTrackRef;
+
+  /// All `text-track` references in tag order, for read-time fallback.
+  /// `textTrackRef` mirrors the first entry for back-compat.
+  final List<String> textTrackRefs;
 
   /// Embedded VTT content from funnelcake REST API (skips relay fetch).
   final String? textTrackContent;
@@ -1407,6 +1415,7 @@ class VideoEvent {
     String? inspiredByNpub,
     List<List<String>>? nostrEventTags,
     String? textTrackRef,
+    List<String>? textTrackRefs,
     String? textTrackContent,
     List<String>? contentWarningLabels,
     List<String>? moderationLabels,
@@ -1466,6 +1475,7 @@ class VideoEvent {
     inspiredByNpub: inspiredByNpub ?? this.inspiredByNpub,
     nostrEventTags: nostrEventTags ?? this.nostrEventTags,
     textTrackRef: textTrackRef ?? this.textTrackRef,
+    textTrackRefs: textTrackRefs ?? this.textTrackRefs,
     textTrackContent: textTrackContent ?? this.textTrackContent,
     contentWarningLabels: contentWarningLabels ?? this.contentWarningLabels,
     moderationLabels: moderationLabels ?? this.moderationLabels,

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -223,6 +223,8 @@ class VideoEvent {
 
     final createdAt = optInt(json['createdAt']) ?? 0;
     final timestamp = json['timestamp'];
+    final textTrackRef = json['textTrackRef'] as String?;
+    final textTrackRefs = stringList(json['textTrackRefs']);
     return VideoEvent(
       id: json['id'] as String? ?? '',
       pubkey: json['pubkey'] as String? ?? '',
@@ -279,7 +281,12 @@ class VideoEvent {
               json['inspiredByVideo'] as Map<String, dynamic>,
             ),
       inspiredByNpub: json['inspiredByNpub'] as String?,
-      textTrackRef: json['textTrackRef'] as String?,
+      textTrackRef: textTrackRef,
+      textTrackRefs: textTrackRefs.isNotEmpty
+          ? textTrackRefs
+          : [
+              if (textTrackRef != null && textTrackRef.isNotEmpty) textTrackRef,
+            ],
       textTrackContent: json['textTrackContent'] as String?,
       contentWarningLabels: stringList(json['contentWarningLabels']),
       moderationLabels: stringList(json['moderationLabels']),
@@ -1554,6 +1561,7 @@ class VideoEvent {
     'inspiredByVideo': inspiredByVideo?.toJson(),
     'inspiredByNpub': inspiredByNpub,
     'textTrackRef': textTrackRef,
+    'textTrackRefs': textTrackRefs,
     'textTrackContent': textTrackContent,
     'contentWarningLabels': contentWarningLabels,
     'moderationLabels': moderationLabels,

--- a/mobile/packages/models/test/src/nip71_video_kinds_test.dart
+++ b/mobile/packages/models/test/src/nip71_video_kinds_test.dart
@@ -1,0 +1,10 @@
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(NIP71VideoKinds, () {
+    test('subtitleEventKind is 39307', () {
+      expect(NIP71VideoKinds.subtitleEventKind, equals(39307));
+    });
+  });
+}

--- a/mobile/packages/models/test/src/video_event_from_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_from_json_test.dart
@@ -14,6 +14,9 @@ final String _reposterPubkey = 'c' * 64;
 final String _otherCollab = 'd' * 64;
 final String _audioEventId = 'e' * 64;
 final String _sha256 = 'f' * 64;
+const String _subtitleEventRef =
+    '39307:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:subtitles:abc123def';
 
 VideoEvent _fullVideo() => VideoEvent(
   id: _id,
@@ -71,7 +74,7 @@ VideoEvent _fullVideo() => VideoEvent(
   textTrackRef: 'https://cdn.divine.video/captions.vtt',
   textTrackRefs: const [
     'https://cdn.divine.video/captions.vtt',
-    '39307:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:subtitles:abc123def',
+    _subtitleEventRef,
   ],
   textTrackContent: 'WEBVTT\n\n00:00.000 --> 00:06.000\nHello',
   contentWarningLabels: const ['nudity'],

--- a/mobile/packages/models/test/src/video_event_from_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_from_json_test.dart
@@ -69,6 +69,10 @@ VideoEvent _fullVideo() => VideoEvent(
   ),
   inspiredByNpub: 'npub1examplenpubvalue',
   textTrackRef: 'https://cdn.divine.video/captions.vtt',
+  textTrackRefs: const [
+    'https://cdn.divine.video/captions.vtt',
+    '39307:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:subtitles:abc123def',
+  ],
   textTrackContent: 'WEBVTT\n\n00:00.000 --> 00:06.000\nHello',
   contentWarningLabels: const ['nudity'],
   moderationLabels: const ['violence'],
@@ -131,6 +135,7 @@ void main() {
       expect(restored.authorAvatar, equals(original.authorAvatar));
       expect(restored.inspiredByNpub, equals(original.inspiredByNpub));
       expect(restored.textTrackRef, equals(original.textTrackRef));
+      expect(restored.textTrackRefs, equals(original.textTrackRefs));
       expect(restored.textTrackContent, equals(original.textTrackContent));
     });
 
@@ -177,6 +182,19 @@ void main() {
       expect(restored.videoUrl, equals(original.videoUrl));
       expect(restored.timestamp, equals(original.timestamp));
       expect(restored.originalLoops, equals(original.originalLoops));
+    });
+
+    test('backfills textTrackRefs from legacy singular textTrackRef', () {
+      final json = _fullVideo().toJson()
+        ..remove('textTrackRefs')
+        ..['textTrackRef'] = 'https://cdn.divine.video/legacy-captions.vtt';
+
+      final restored = VideoEvent.fromJson(json);
+
+      expect(
+        restored.textTrackRefs,
+        equals(['https://cdn.divine.video/legacy-captions.vtt']),
+      );
     });
 
     test('restores a minimal video with null optionals', () {

--- a/mobile/packages/models/test/src/video_event_text_track_test.dart
+++ b/mobile/packages/models/test/src/video_event_text_track_test.dart
@@ -1,0 +1,148 @@
+// ABOUTME: Tests for VideoEvent text-track tag parsing.
+// ABOUTME: Verifies all text-track references are captured in order into
+// ABOUTME: textTrackRefs, with textTrackRef as back-compat first entry.
+
+import 'package:models/models.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:test/test.dart';
+
+// Valid 64-character hex pubkey for testing
+const testPubkey =
+    'abc123def456789012345678901234'
+    '567890123456789012345678901234abcd';
+
+void main() {
+  group('VideoEvent text-track parsing', () {
+    test(
+      'captures single text-track tag into textTrackRefs and textTrackRef',
+      () {
+        final event = Event(
+          testPubkey,
+          34236,
+          [
+            ['d', 'my-vine-id'],
+            [
+              'text-track',
+              'https://media.divine.video/abc123',
+              'wss://relay.divine.video',
+              'captions',
+              'en',
+            ],
+          ],
+          'content',
+        );
+
+        final video = VideoEvent.fromNostrEvent(event);
+
+        expect(
+          video.textTrackRefs,
+          equals(['https://media.divine.video/abc123']),
+        );
+        expect(video.textTrackRef, equals('https://media.divine.video/abc123'));
+      },
+    );
+
+    test('captures multiple text-track tags into textTrackRefs in order', () {
+      final event = Event(
+        testPubkey,
+        34236,
+        [
+          ['d', 'my-vine-id'],
+          [
+            'text-track',
+            'https://media.divine.video/abc123',
+            'wss://relay.divine.video',
+            'captions',
+            'en',
+          ],
+          [
+            'text-track',
+            '39307:$testPubkey:subtitles:my-vine-id',
+            'wss://relay.divine.video',
+            'captions',
+            'en',
+          ],
+        ],
+        'content',
+      );
+
+      final video = VideoEvent.fromNostrEvent(event);
+
+      expect(video.textTrackRefs, [
+        'https://media.divine.video/abc123',
+        '39307:$testPubkey:subtitles:my-vine-id',
+      ]);
+      expect(video.textTrackRef, equals('https://media.divine.video/abc123'));
+    });
+
+    test('textTrackRefs is empty when no text-track tags present', () {
+      final event = Event(
+        testPubkey,
+        34236,
+        [
+          ['d', 'my-vine-id'],
+        ],
+        'content',
+      );
+
+      final video = VideoEvent.fromNostrEvent(event);
+
+      expect(video.textTrackRefs, isEmpty);
+      expect(video.textTrackRef, isNull);
+    });
+
+    test('copyWith preserves textTrackRefs when not overridden', () {
+      final event = Event(
+        testPubkey,
+        34236,
+        [
+          ['d', 'my-vine-id'],
+          [
+            'text-track',
+            'https://media.divine.video/abc123',
+            'wss://relay.divine.video',
+            'captions',
+            'en',
+          ],
+          [
+            'text-track',
+            '39307:$testPubkey:subtitles:my-vine-id',
+            'wss://relay.divine.video',
+            'captions',
+            'en',
+          ],
+        ],
+        'content',
+      );
+
+      final video = VideoEvent.fromNostrEvent(event);
+      final copy = video.copyWith(title: 'Updated title');
+
+      expect(copy.textTrackRefs, equals(video.textTrackRefs));
+    });
+
+    test('copyWith can override textTrackRefs', () {
+      final event = Event(
+        testPubkey,
+        34236,
+        [
+          ['d', 'my-vine-id'],
+          [
+            'text-track',
+            'https://media.divine.video/abc123',
+            'wss://relay.divine.video',
+            'captions',
+            'en',
+          ],
+        ],
+        'content',
+      );
+
+      final video = VideoEvent.fromNostrEvent(event);
+      final newRefs = ['https://other.example.com/captions.vtt'];
+      final copy = video.copyWith(textTrackRefs: newRefs);
+
+      expect(copy.textTrackRefs, equals(newRefs));
+    });
+  });
+}

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -75,6 +75,10 @@ VideoEvent _fullVideo() => VideoEvent(
     ['title', 'A short loop'],
   ],
   textTrackRef: 'https://cdn.divine.video/captions.vtt',
+  textTrackRefs: const [
+    'https://cdn.divine.video/captions.vtt',
+    '39307:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:subtitles:abc123def',
+  ],
   textTrackContent: 'WEBVTT\n\n00:00.000 --> 00:06.000\nHello',
   contentWarningLabels: const ['nudity'],
   moderationLabels: const ['ml-noisy-label'],
@@ -136,6 +140,7 @@ const _expectedKeys = <String>{
   'inspiredByVideo',
   'inspiredByNpub',
   'textTrackRef',
+  'textTrackRefs',
   'textTrackContent',
   'contentWarningLabels',
   'moderationLabels',

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -16,6 +16,9 @@ final String _reposterPubkey = 'c' * 64;
 final String _otherCollab = 'd' * 64;
 final String _audioEventId = 'e' * 64;
 final String _sha256 = 'f' * 64;
+const String _subtitleEventRef =
+    '39307:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:subtitles:abc123def';
 
 VideoEvent _fullVideo() => VideoEvent(
   id: _id,
@@ -77,7 +80,7 @@ VideoEvent _fullVideo() => VideoEvent(
   textTrackRef: 'https://cdn.divine.video/captions.vtt',
   textTrackRefs: const [
     'https://cdn.divine.video/captions.vtt',
-    '39307:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:subtitles:abc123def',
+    _subtitleEventRef,
   ],
   textTrackContent: 'WEBVTT\n\n00:00.000 --> 00:06.000\nHello',
   contentWarningLabels: const ['nudity'],

--- a/mobile/packages/videos_repository/lib/src/profile_video_merge.dart
+++ b/mobile/packages/videos_repository/lib/src/profile_video_merge.dart
@@ -95,6 +95,9 @@ VideoEvent mergeProfileFeedVideos(VideoEvent existing, VideoEvent incoming) {
         : secondary.collaboratorPubkeys,
     inspiredByVideo: primary.inspiredByVideo ?? secondary.inspiredByVideo,
     textTrackRef: primary.textTrackRef ?? secondary.textTrackRef,
+    textTrackRefs: primary.textTrackRefs.isNotEmpty
+        ? primary.textTrackRefs
+        : secondary.textTrackRefs,
     textTrackContent: primary.textTrackContent ?? secondary.textTrackContent,
     nostrEventTags: primary.nostrEventTags.isNotEmpty
         ? primary.nostrEventTags

--- a/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
+++ b/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
@@ -17,6 +17,8 @@ VideoEvent _video({
   List<String> hashtags = const [],
   List<String> collaboratorPubkeys = const [],
   List<List<String>> nostrEventTags = const [],
+  String? textTrackRef,
+  List<String> textTrackRefs = const [],
   List<String> contentWarningLabels = const [],
   int? originalLikes,
   int? originalComments,
@@ -41,6 +43,8 @@ VideoEvent _video({
     hashtags: hashtags,
     collaboratorPubkeys: collaboratorPubkeys,
     nostrEventTags: nostrEventTags,
+    textTrackRef: textTrackRef,
+    textTrackRefs: textTrackRefs,
     contentWarningLabels: contentWarningLabels,
     originalLikes: originalLikes,
     originalComments: originalComments,
@@ -134,6 +138,37 @@ void main() {
       );
 
       expect(merged.title, equals('new'));
+    });
+
+    test('fills plural text-track refs from the secondary copy', () {
+      final merged = mergeProfileFeedVideos(
+        _video(
+          id: 'rest',
+          pubkey: 'pubkey',
+          createdAt: 2000,
+          vineId: 'video-subtitles',
+        ),
+        _video(
+          id: 'nostr',
+          pubkey: 'pubkey',
+          createdAt: 1000,
+          vineId: 'video-subtitles',
+          textTrackRef: 'https://media.divine.video/subtitle-vtt',
+          textTrackRefs: const [
+            'https://media.divine.video/subtitle-vtt',
+            '39307:pubkey:subtitles:video-subtitles',
+          ],
+        ),
+      );
+
+      expect(
+        merged.textTrackRef,
+        equals('https://media.divine.video/subtitle-vtt'),
+      );
+      expect(merged.textTrackRefs, [
+        'https://media.divine.video/subtitle-vtt',
+        '39307:pubkey:subtitles:video-subtitles',
+      ]);
     });
 
     test('primary fields fall back to secondary when null', () {

--- a/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
+++ b/mobile/packages/videos_repository/test/src/profile_video_merge_test.dart
@@ -171,6 +171,39 @@ void main() {
       ]);
     });
 
+    test('keeps plural text-track refs from the primary copy', () {
+      final merged = mergeProfileFeedVideos(
+        _video(
+          id: 'primary',
+          pubkey: 'pubkey',
+          createdAt: 2000,
+          vineId: 'video-subtitles',
+          textTrackRef: 'https://media.divine.video/current-vtt',
+          textTrackRefs: const [
+            'https://media.divine.video/current-vtt',
+            '39307:pubkey:subtitles:current-video-subtitles',
+          ],
+        ),
+        _video(
+          id: 'secondary',
+          pubkey: 'pubkey',
+          createdAt: 1000,
+          vineId: 'video-subtitles',
+          textTrackRef: 'https://media.divine.video/old-vtt',
+          textTrackRefs: const ['https://media.divine.video/old-vtt'],
+        ),
+      );
+
+      expect(
+        merged.textTrackRef,
+        equals('https://media.divine.video/current-vtt'),
+      );
+      expect(merged.textTrackRefs, [
+        'https://media.divine.video/current-vtt',
+        '39307:pubkey:subtitles:current-video-subtitles',
+      ]);
+    });
+
     test('primary fields fall back to secondary when null', () {
       final merged = mergeProfileFeedVideos(
         _video(id: 'v', createdAt: 1000, videoUrl: 'http://old/v.mp4'),

--- a/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
@@ -1,0 +1,60 @@
+// ABOUTME: Regression tests for app-layer profile feed enrichment merge.
+// ABOUTME: Ensures Nostr-only metadata is not dropped when REST copies win.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/profile_feed/profile_feed_enrichment_merge.dart';
+import 'package:videos_repository/videos_repository.dart';
+
+VideoEvent _video({
+  required String id,
+  String pubkey = 'pubkey',
+  String? vineId,
+  String? textTrackRef,
+  List<String> textTrackRefs = const [],
+}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: 1704067200,
+    content: '',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
+    vineId: vineId,
+    textTrackRef: textTrackRef,
+    textTrackRefs: textTrackRefs,
+  );
+}
+
+void main() {
+  group('mergeProfileFeedEnrichment', () {
+    test('fills plural text-track refs from enriched Nostr copy', () {
+      final current = _video(id: 'rest', vineId: 'video-subtitles');
+      final enriched = _video(
+        id: 'nostr',
+        vineId: 'video-subtitles',
+        textTrackRef: 'https://media.divine.video/subtitle-vtt',
+        textTrackRefs: const [
+          'https://media.divine.video/subtitle-vtt',
+          '39307:pubkey:subtitles:video-subtitles',
+        ],
+      );
+
+      final merged = mergeProfileFeedEnrichment(
+        current: [current],
+        sourceKeys: {canonicalProfileFeedVideoKey(current)},
+        incoming: [enriched],
+        removeTombstones: (videos) => videos,
+      );
+
+      expect(merged, hasLength(1));
+      expect(
+        merged.single.textTrackRef,
+        equals('https://media.divine.video/subtitle-vtt'),
+      );
+      expect(merged.single.textTrackRefs, [
+        'https://media.divine.video/subtitle-vtt',
+        '39307:pubkey:subtitles:video-subtitles',
+      ]);
+    });
+  });
+}

--- a/mobile/test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart
+++ b/mobile/test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart
@@ -1,0 +1,170 @@
+// ABOUTME: Tests for SubtitleEditorCubit covering load, edit, and save flows.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
+import 'package:openvine/services/subtitle_service.dart';
+
+class _MockRepo extends Mock implements SubtitleRepository {}
+
+final _video = VideoEvent(
+  id: 'v',
+  pubkey: 'pk',
+  createdAt: 1,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+  vineId: 'd1',
+);
+
+void main() {
+  setUpAll(() => registerFallbackValue(_video));
+
+  group(SubtitleEditorCubit, () {
+    late _MockRepo repo;
+    setUp(() => repo = _MockRepo());
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'load -> ready with cues',
+      setUp: () => when(() => repo.loadCues(any())).thenAnswer(
+        (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'a')],
+      ),
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) => c.load(),
+      expect: () => [
+        isA<SubtitleEditorState>().having(
+          (s) => s.status,
+          'status',
+          SubtitleEditorStatus.loading,
+        ),
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.ready)
+            .having((s) => s.cues.length, 'cues', 1),
+      ],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'load with no cues -> processing',
+      setUp: () =>
+          when(() => repo.loadCues(any())).thenAnswer((_) async => const []),
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) => c.load(),
+      expect: () => [
+        isA<SubtitleEditorState>().having(
+          (s) => s.status,
+          'status',
+          SubtitleEditorStatus.loading,
+        ),
+        isA<SubtitleEditorState>().having(
+          (s) => s.status,
+          'status',
+          SubtitleEditorStatus.processing,
+        ),
+      ],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'load failure -> failure + reports error',
+      setUp: () =>
+          when(() => repo.loadCues(any())).thenThrow(Exception('boom')),
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) => c.load(),
+      expect: () => [
+        isA<SubtitleEditorState>().having(
+          (s) => s.status,
+          'status',
+          SubtitleEditorStatus.loading,
+        ),
+        isA<SubtitleEditorState>().having(
+          (s) => s.status,
+          'status',
+          SubtitleEditorStatus.failure,
+        ),
+      ],
+      errors: () => [isA<Exception>()],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'updateCueText marks dirty',
+      setUp: () => when(() => repo.loadCues(any())).thenAnswer(
+        (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'a')],
+      ),
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) async {
+        await c.load();
+        c.updateCueText(0, 'fixed');
+      },
+      verify: (c) {
+        expect(c.state.isDirty, isTrue);
+        expect(c.state.cues.first.text, 'fixed');
+      },
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'save success -> saving then success',
+      setUp: () {
+        when(() => repo.loadCues(any())).thenAnswer(
+          (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'a')],
+        );
+        when(
+          () => repo.publishEditedSubtitles(
+            video: any(named: 'video'),
+            cues: any(named: 'cues'),
+          ),
+        ).thenAnswer((_) async {});
+      },
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) async {
+        await c.load();
+        await c.save();
+      },
+      skip: 2,
+      expect: () => [
+        isA<SubtitleEditorState>().having(
+          (s) => s.status,
+          'status',
+          SubtitleEditorStatus.saving,
+        ),
+        isA<SubtitleEditorState>()
+            .having((s) => s.status, 'status', SubtitleEditorStatus.success)
+            .having((s) => s.isDirty, 'isDirty', false),
+      ],
+    );
+
+    blocTest<SubtitleEditorCubit, SubtitleEditorState>(
+      'save failure -> failure + reports error',
+      setUp: () {
+        when(() => repo.loadCues(any())).thenAnswer(
+          (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'a')],
+        );
+        when(
+          () => repo.publishEditedSubtitles(
+            video: any(named: 'video'),
+            cues: any(named: 'cues'),
+          ),
+        ).thenThrow(SubtitleEditException('boom'));
+      },
+      build: () => SubtitleEditorCubit(repository: repo, video: _video),
+      act: (c) async {
+        await c.load();
+        await c.save();
+      },
+      skip: 2,
+      expect: () => [
+        isA<SubtitleEditorState>().having(
+          (s) => s.status,
+          'status',
+          SubtitleEditorStatus.saving,
+        ),
+        isA<SubtitleEditorState>().having(
+          (s) => s.status,
+          'status',
+          SubtitleEditorStatus.failure,
+        ),
+      ],
+      errors: () => [isA<SubtitleEditException>()],
+    );
+  });
+}

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -803,6 +803,17 @@ const _knownUntranslatedDebt = {
   'shareSheetSaveClip',
   'shareSheetSavedClipToClips',
   'shareSheetUntitledClip',
+  // Added by the subtitle editor feature. Existing locales fall back to
+  // English until the next translation pass.
+  'videoEditEditSubtitles',
+  'subtitleEditorTitle',
+  'subtitleEditorSave',
+  'subtitleEditorProcessing',
+  'subtitleEditorLoadError',
+  'subtitleEditorSaveSuccess',
+  'subtitleEditorSaveError',
+  'subtitleEditorRetry',
+  'subtitleEditorCueHint',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/providers/subtitle_providers_test.dart
+++ b/mobile/test/providers/subtitle_providers_test.dart
@@ -339,7 +339,7 @@ void main() {
       expect(requestedDelays, equals([const Duration(seconds: 5)]));
     });
 
-    test('falls through to relay path on Blossom 404', () async {
+    test('prefers relay textTrackRef over auto-gen sha256 Blossom', () async {
       final container = createContainer();
       addTearDown(container.dispose);
 
@@ -359,7 +359,7 @@ void main() {
             [
               ['d', 'subtitles:test-vine-id'],
             ],
-            'WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nFrom relay fallback\n',
+            'WEBVTT\n\n1\n00:00:01.000 --> 00:00:02.000\nFrom relay ref\n',
             createdAt: 1757385263,
           ),
         ],
@@ -374,8 +374,36 @@ void main() {
       );
 
       expect(cues, hasLength(1));
-      expect(cues.first.text, equals('From relay fallback'));
+      expect(cues.first.text, equals('From relay ref'));
     });
+
+    test(
+      'returns empty when relay ref misses and Blossom sha256 404s',
+      () async {
+        final container = createContainer();
+        addTearDown(container.dispose);
+
+        when(
+          () => mockHttpClient.get(any()),
+        ).thenAnswer((_) async => http.Response('missing', 404));
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+          ),
+        ).thenAnswer((_) async => []);
+
+        final cues = await container.read(
+          subtitleCuesProvider(
+            videoId: 'test-id',
+            sha256: 'abc123',
+            textTrackRef: '39307:$testPubkey:subtitles:test-vine-id',
+          ).future,
+        );
+
+        expect(cues, isEmpty);
+      },
+    );
 
     test('parses Blossom VTT immediately on 200', () async {
       final container = createContainer();

--- a/mobile/test/repositories/subtitle_repository_test.dart
+++ b/mobile/test/repositories/subtitle_repository_test.dart
@@ -1,0 +1,170 @@
+// ABOUTME: Tests for SubtitleRepository: the orchestration layer that
+// ABOUTME: uploads VTT to Blossom, publishes a 39307, and republishes the
+// ABOUTME: video with both refs.
+
+import 'dart:typed_data';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/subtitle_service.dart';
+import 'package:openvine/services/video_event_publisher.dart';
+
+class _MockBlossom extends Mock implements BlossomUploadService {}
+
+class _MockPublisher extends Mock implements VideoEventPublisher {}
+
+class _MockAuth extends Mock implements AuthService {}
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+final _video = VideoEvent(
+  id: 'vid1',
+  pubkey: 'pk1',
+  createdAt: 1,
+  content: '',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+  vineId: 'my-vine-id',
+);
+
+const _cues = [SubtitleCue(start: 0, end: 1000, text: 'hi')];
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_video);
+    registerFallbackValue(Uint8List(0));
+    registerFallbackValue(<String>[]);
+  });
+
+  group(SubtitleRepository, () {
+    late _MockBlossom blossom;
+    late _MockPublisher publisher;
+    late _MockAuth auth;
+    late SubtitleRepository repo;
+
+    setUp(() {
+      blossom = _MockBlossom();
+      publisher = _MockPublisher();
+      auth = _MockAuth();
+      repo = SubtitleRepository(
+        blossomUploadService: blossom,
+        videoEventPublisher: publisher,
+        authService: auth,
+        nostrClient: _MockNostrClient(),
+        httpClient: _MockHttpClient(),
+        pollDelay: (_) async {},
+      );
+      when(() => auth.currentPublicKeyHex).thenReturn('pk1');
+    });
+
+    test('uploads VTT, publishes 39307, republishes with both refs', () async {
+      when(
+        () => blossom.uploadSubtitleVtt(bytes: any(named: 'bytes')),
+      ).thenAnswer(
+        (_) async => const BlossomUploadResult(
+          success: true,
+          url: 'https://media.divine.video/hash',
+          videoId: 'hash',
+        ),
+      );
+      when(
+        () => publisher.publishSubtitleEvent(
+          video: any(named: 'video'),
+          vttContent: any(named: 'vttContent'),
+          blossomUrl: any(named: 'blossomUrl'),
+          lang: any(named: 'lang'),
+        ),
+      ).thenAnswer((_) async => '39307:pk1:subtitles:my-vine-id');
+      when(
+        () => publisher.republishWithSubtitles(
+          existingEvent: any(named: 'existingEvent'),
+          textTrackRef: any(named: 'textTrackRef'),
+          extraTextTrackRefs: any(named: 'extraTextTrackRefs'),
+          textTrackLang: any(named: 'textTrackLang'),
+        ),
+      ).thenAnswer((_) async => true);
+
+      await repo.publishEditedSubtitles(video: _video, cues: _cues);
+
+      verify(
+        () => publisher.republishWithSubtitles(
+          existingEvent: _video,
+          textTrackRef: 'https://media.divine.video/hash',
+          extraTextTrackRefs: const ['39307:pk1:subtitles:my-vine-id'],
+        ),
+      ).called(1);
+    });
+
+    test('throws SubtitleEditException when vineId is null', () async {
+      final noId = VideoEvent(
+        id: 'v',
+        pubkey: 'pk1',
+        createdAt: 1,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+      );
+      expect(
+        () => repo.publishEditedSubtitles(video: noId, cues: _cues),
+        throwsA(isA<SubtitleEditException>()),
+      );
+    });
+
+    test('throws SubtitleEditException when Blossom upload fails', () async {
+      when(
+        () => blossom.uploadSubtitleVtt(bytes: any(named: 'bytes')),
+      ).thenAnswer(
+        (_) async => const BlossomUploadResult(
+          success: false,
+          errorMessage: 'network error',
+        ),
+      );
+      expect(
+        () => repo.publishEditedSubtitles(video: _video, cues: _cues),
+        throwsA(isA<SubtitleEditException>()),
+      );
+    });
+
+    test('throws SubtitleEditException when not authenticated', () async {
+      when(() => auth.currentPublicKeyHex).thenReturn(null);
+      expect(
+        () => repo.publishEditedSubtitles(video: _video, cues: _cues),
+        throwsA(isA<SubtitleEditException>()),
+      );
+    });
+
+    test(
+      'throws SubtitleEditException when subtitle event publish fails',
+      () async {
+        when(
+          () => blossom.uploadSubtitleVtt(bytes: any(named: 'bytes')),
+        ).thenAnswer(
+          (_) async => const BlossomUploadResult(
+            success: true,
+            url: 'https://media.divine.video/hash',
+            videoId: 'hash',
+          ),
+        );
+        when(
+          () => publisher.publishSubtitleEvent(
+            video: any(named: 'video'),
+            vttContent: any(named: 'vttContent'),
+            blossomUrl: any(named: 'blossomUrl'),
+            lang: any(named: 'lang'),
+          ),
+        ).thenAnswer((_) async => null);
+
+        expect(
+          () => repo.publishEditedSubtitles(video: _video, cues: _cues),
+          throwsA(isA<SubtitleEditException>()),
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/repositories/subtitle_repository_test.dart
+++ b/mobile/test/repositories/subtitle_repository_test.dart
@@ -40,6 +40,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(_video);
     registerFallbackValue(Uint8List(0));
+    registerFallbackValue(Uri.parse('https://media.divine.video/fallback.vtt'));
     registerFallbackValue(<String>[]);
   });
 
@@ -47,21 +48,46 @@ void main() {
     late _MockBlossom blossom;
     late _MockPublisher publisher;
     late _MockAuth auth;
+    late _MockHttpClient httpClient;
     late SubtitleRepository repo;
 
     setUp(() {
       blossom = _MockBlossom();
       publisher = _MockPublisher();
       auth = _MockAuth();
+      httpClient = _MockHttpClient();
       repo = SubtitleRepository(
         blossomUploadService: blossom,
         videoEventPublisher: publisher,
         authService: auth,
         nostrClient: _MockNostrClient(),
-        httpClient: _MockHttpClient(),
+        httpClient: httpClient,
         pollDelay: (_) async {},
       );
       when(() => auth.currentPublicKeyHex).thenReturn('pk1');
+    });
+
+    test('loadCues falls back to legacy singular textTrackRef', () async {
+      when(() => httpClient.get(any())).thenAnswer(
+        (_) async => http.Response(
+          'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\ncorrected\n',
+          200,
+        ),
+      );
+
+      final cues = await repo.loadCues(
+        VideoEvent(
+          id: 'vid1',
+          pubkey: 'pk1',
+          createdAt: 1,
+          content: '',
+          timestamp: DateTime.fromMillisecondsSinceEpoch(0),
+          textTrackRef: 'https://media.divine.video/fallback.vtt',
+        ),
+      );
+
+      expect(cues, hasLength(1));
+      expect(cues.single.text, equals('corrected'));
     });
 
     test('uploads VTT, publishes 39307, republishes with both refs', () async {

--- a/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
+++ b/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
@@ -63,4 +63,21 @@ void main() {
     await tester.enterText(find.byType(TextField).first, 'edited');
     verify(() => cubit.updateCueText(0, 'edited')).called(1);
   });
+
+  testWidgets('load failure shows the load error copy', (tester) async {
+    whenListen(
+      cubit,
+      Stream<SubtitleEditorState>.fromIterable(
+        const [SubtitleEditorState(status: SubtitleEditorStatus.failure)],
+      ),
+      initialState: const SubtitleEditorState(),
+    );
+
+    await tester.pumpWidget(pump());
+    await tester.pump();
+
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.subtitleEditorLoadError), findsOneWidget);
+    expect(find.text(l10n.subtitleEditorSaveError), findsNothing);
+  });
 }

--- a/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
+++ b/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
@@ -1,0 +1,66 @@
+// ABOUTME: Widget tests for SubtitleEditorView — rendering cues, status
+// ABOUTME: states, and editing interactions using a mocked cubit.
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
+
+class _MockCubit extends MockCubit<SubtitleEditorState>
+    implements SubtitleEditorCubit {}
+
+void main() {
+  late _MockCubit cubit;
+  setUp(() => cubit = _MockCubit());
+
+  Widget pump() => MaterialApp(
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: BlocProvider<SubtitleEditorCubit>.value(
+      value: cubit,
+      child: const SubtitleEditorView(),
+    ),
+  );
+
+  testWidgets('renders a text field per cue when ready', (tester) async {
+    when(() => cubit.state).thenReturn(
+      const SubtitleEditorState(
+        status: SubtitleEditorStatus.ready,
+        cues: [
+          EditableCue(start: 0, end: 1000, text: 'one'),
+          EditableCue(start: 1000, end: 2000, text: 'two'),
+        ],
+      ),
+    );
+    await tester.pumpWidget(pump());
+    expect(find.byType(TextField), findsNWidgets(2));
+    expect(find.text('one'), findsOneWidget);
+  });
+
+  testWidgets('shows processing message when status is processing', (
+    tester,
+  ) async {
+    when(() => cubit.state).thenReturn(
+      const SubtitleEditorState(status: SubtitleEditorStatus.processing),
+    );
+    await tester.pumpWidget(pump());
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    expect(find.text(l10n.subtitleEditorProcessing), findsOneWidget);
+  });
+
+  testWidgets('editing a field dispatches updateCueText', (tester) async {
+    when(() => cubit.state).thenReturn(
+      const SubtitleEditorState(
+        status: SubtitleEditorStatus.ready,
+        cues: [EditableCue(start: 0, end: 1000, text: 'one')],
+      ),
+    );
+    await tester.pumpWidget(pump());
+    await tester.enterText(find.byType(TextField).first, 'edited');
+    verify(() => cubit.updateCueText(0, 'edited')).called(1);
+  });
+}

--- a/mobile/test/services/subtitle_fetcher_test.dart
+++ b/mobile/test/services/subtitle_fetcher_test.dart
@@ -1,0 +1,103 @@
+// ABOUTME: Tests for the shared fetchSubtitleCues fallback chain.
+// ABOUTME: Verifies embedded content, ordered HTTP refs, and relay ref fallback.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:openvine/services/subtitle_fetcher.dart';
+
+class _FakeClient extends http.BaseClient {
+  _FakeClient(this.handler);
+  final Future<http.Response> Function(http.Request) handler;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final res = await handler(request as http.Request);
+    return http.StreamedResponse(
+      Stream.value(res.bodyBytes),
+      res.statusCode,
+      headers: res.headers,
+    );
+  }
+}
+
+const _vtt = 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhello\n';
+
+void main() {
+  group('fetchSubtitleCues', () {
+    test('parses embedded textTrackContent first (no network)', () async {
+      final cues = await fetchSubtitleCues(
+        httpClient: _FakeClient((_) async => throw StateError('no network')),
+        nostrClient: null,
+        delay: (_) async {},
+        textTrackContent: _vtt,
+      );
+      expect(cues, hasLength(1));
+      expect(cues.first.text, equals('hello'));
+    });
+
+    test(
+      'falls back to second ref when first http ref is unavailable',
+      () async {
+        final cues = await fetchSubtitleCues(
+          httpClient: _FakeClient((req) async {
+            if (req.url.toString() == 'https://media.divine.video/dead') {
+              return http.Response('', 404);
+            }
+            if (req.url.toString() == 'https://media.divine.video/live') {
+              return http.Response(_vtt, 200);
+            }
+            return http.Response('', 500);
+          }),
+          nostrClient: null,
+          delay: (_) async {},
+          textTrackRefs: const [
+            'https://media.divine.video/dead',
+            'https://media.divine.video/live',
+          ],
+        );
+        expect(cues, hasLength(1));
+        expect(cues.first.text, equals('hello'));
+      },
+    );
+
+    test('returns empty list when all sources fail', () async {
+      final cues = await fetchSubtitleCues(
+        httpClient: _FakeClient((_) async => http.Response('', 404)),
+        nostrClient: null,
+        delay: (_) async {},
+        textTrackRefs: const ['https://media.divine.video/missing'],
+      );
+      expect(cues, isEmpty);
+    });
+
+    test('returns empty list when no sources provided', () async {
+      final cues = await fetchSubtitleCues(
+        httpClient: _FakeClient(
+          (_) async => throw StateError('should not be called'),
+        ),
+        nostrClient: null,
+        delay: (_) async {},
+      );
+      expect(cues, isEmpty);
+    });
+
+    test(
+      'fetches from sha256 Blossom path when no refs and sha256 provided',
+      () async {
+        final cues = await fetchSubtitleCues(
+          httpClient: _FakeClient((req) async {
+            if (req.url.toString() == 'https://media.divine.video/abc123/vtt') {
+              return http.Response(_vtt, 200);
+            }
+            return http.Response('', 404);
+          }),
+          nostrClient: null,
+          delay: (_) async {},
+          sha256: 'abc123',
+        );
+        expect(cues, hasLength(1));
+        expect(cues.first.text, equals('hello'));
+      },
+    );
+  });
+}

--- a/mobile/test/services/video_event_publisher_subtitle_test.dart
+++ b/mobile/test/services/video_event_publisher_subtitle_test.dart
@@ -512,5 +512,199 @@ void main() {
       expect(result, isFalse);
       verifyNever(() => mockVideoEventService.addVideoEvent(any()));
     });
+
+    test(
+      'publishSubtitleEvent signs a 39307 with d=subtitles:<vineId>',
+      () async {
+        when(
+          () => mockAuthService.currentPublicKeyHex,
+        ).thenReturn(testPubkey);
+
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final tags = invocation.namedArguments[#tags] as List<List<String>>;
+          return createSignedEvent(tags);
+        });
+
+        when(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer(
+          (invocation) async => PublishOutcome(
+            eventId: (invocation.positionalArguments.first as Event).id,
+            acceptedBy: const ['wss://relay.divine.video'],
+            rejectedBy: const {},
+            noResponseFrom: const [],
+          ),
+        );
+
+        final ref = await publisher.publishSubtitleEvent(
+          video: existingEvent,
+          vttContent: 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhi\n',
+          blossomUrl: 'https://media.divine.video/abc123',
+        );
+
+        expect(ref, '39307:$testPubkey:subtitles:test-vine-id');
+
+        final captured = verify(
+          () => mockAuthService.createAndSignEvent(
+            kind: captureAny(named: 'kind'),
+            content: captureAny(named: 'content'),
+            tags: captureAny(named: 'tags'),
+          ),
+        ).captured;
+        expect(captured[0], equals(39307));
+        final tags = (captured[2] as List).cast<List<String>>();
+        expect(
+          _containsTag(tags, ['d', 'subtitles:test-vine-id']),
+          isTrue,
+          reason: 'Missing d=subtitles:test-vine-id tag',
+        );
+        expect(
+          _containsTag(tags, ['url', 'https://media.divine.video/abc123']),
+          isTrue,
+          reason: 'Missing url tag',
+        );
+        expect(
+          _containsTag(tags, ['m', 'text/vtt']),
+          isTrue,
+          reason: 'Missing m=text/vtt tag',
+        );
+        expect(
+          _containsTag(tags, ['l', 'en']),
+          isTrue,
+          reason: 'Missing default l=en language tag',
+        );
+      },
+    );
+
+    test('republishWithSubtitles emits one text-track tag per ref', () async {
+      late List<List<String>> capturedTags;
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((invocation) async {
+        capturedTags = invocation.namedArguments[#tags] as List<List<String>>;
+        return createSignedEvent(capturedTags);
+      });
+
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const ['wss://relay.divine.video'],
+          rejectedBy: const {},
+          noResponseFrom: const [],
+        ),
+      );
+
+      when(() => mockVideoEventService.addVideoEvent(any())).thenReturn(null);
+
+      await publisher.republishWithSubtitles(
+        existingEvent: existingEvent,
+        textTrackRef: 'https://media.divine.video/abc123',
+        extraTextTrackRefs: ['39307:$testPubkey:subtitles:test-vine-id'],
+      );
+
+      final captured =
+          verify(
+                () => mockAuthService.createAndSignEvent(
+                  kind: any(named: 'kind'),
+                  content: any(named: 'content'),
+                  tags: captureAny(named: 'tags'),
+                ),
+              ).captured.single
+              as List;
+      final tags = captured.cast<List<String>>();
+      final trackTags = tags.where((t) => t.first == 'text-track').toList();
+      expect(trackTags, hasLength(2));
+      expect(trackTags[0][1], equals('https://media.divine.video/abc123'));
+      expect(
+        trackTags[1][1],
+        equals('39307:$testPubkey:subtitles:test-vine-id'),
+      );
+    });
+
+    test('publishSubtitleEvent returns null when vineId is empty', () async {
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
+
+      final videoWithoutVineId = VideoEvent(
+        id: 'd' * 64,
+        pubkey: testPubkey,
+        createdAt: 1700000000,
+        content: 'Test video description',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+        title: 'Test Video',
+      );
+
+      final ref = await publisher.publishSubtitleEvent(
+        video: videoWithoutVineId,
+        vttContent: 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhi\n',
+        blossomUrl: 'https://media.divine.video/abc123',
+      );
+
+      expect(ref, isNull);
+      verifyNever(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      );
+    });
+
+    test('publishSubtitleEvent returns null when publish fails', () async {
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((invocation) async {
+        final tags = invocation.namedArguments[#tags] as List<List<String>>;
+        return createSignedEvent(tags);
+      });
+
+      when(
+        () => mockNostrClient.publishEventAwaitOk(
+          any(),
+          timeout: any(named: 'timeout'),
+        ),
+      ).thenAnswer(
+        (invocation) async => PublishOutcome(
+          eventId: (invocation.positionalArguments.first as Event).id,
+          acceptedBy: const [],
+          rejectedBy: const {
+            'wss://relay.divine.video': 'blocked: event rejected by policy',
+          },
+          noResponseFrom: const [],
+        ),
+      );
+
+      final ref = await publisher.publishSubtitleEvent(
+        video: existingEvent,
+        vttContent: 'WEBVTT\n\n00:00:00.000 --> 00:00:01.000\nhi\n',
+        blossomUrl: 'https://media.divine.video/abc123',
+      );
+
+      expect(ref, isNull);
+    });
   });
 }

--- a/mobile/test/utils/video_nostr_enrichment_views_test.dart
+++ b/mobile/test/utils/video_nostr_enrichment_views_test.dart
@@ -189,5 +189,57 @@ void main() {
       expect(enriched.single.rawTags['title'], equals('Nostr Title Wins'));
       expect(enriched.single.rawTags['views'], equals('7'));
     });
+
+    test(
+      'propagates all Nostr text-track refs into enriched REST videos',
+      () async {
+        const pubkey =
+            'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+        final nostrEvent = Event(
+          pubkey,
+          34236,
+          [
+            ['d', 'video-subtitles'],
+            ['url', 'https://example.com/video-subtitles.mp4'],
+            ['title', 'Captioned'],
+            ['m', 'video/mp4'],
+            [
+              'text-track',
+              'https://media.divine.video/subtitle-vtt',
+              'wss://relay.divine.video',
+              'captions',
+              'en',
+            ],
+            [
+              'text-track',
+              '39307:$pubkey:subtitles:video-subtitles',
+              'wss://relay.divine.video',
+              'captions',
+              'en',
+            ],
+          ],
+          'Nostr content',
+          createdAt: 1704067200,
+        );
+        final restVideo = _restVideo(id: nostrEvent.id);
+
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [nostrEvent]);
+
+        final enriched = await enrichVideosWithNostrTags([
+          restVideo,
+        ], nostrService: mockNostrClient);
+
+        expect(
+          enriched.single.textTrackRef,
+          equals('https://media.divine.video/subtitle-vtt'),
+        );
+        expect(enriched.single.textTrackRefs, [
+          'https://media.divine.video/subtitle-vtt',
+          '39307:$pubkey:subtitles:video-subtitles',
+        ]);
+      },
+    );
   });
 }

--- a/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart' show VideoEvent;
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
+import 'package:openvine/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart';
+
+import '../../../../helpers/go_router.dart';
+import '../../../../helpers/test_helpers.dart';
+
+void main() {
+  group(VideoMetadataEditBottomBar, () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+    late VideoEvent testVideo;
+
+    setUpAll(() {
+      registerFallbackValue(TestHelpers.createVideoEvent(id: 'fallback'));
+    });
+
+    setUp(() {
+      testVideo = TestHelpers.createVideoEvent(
+        id: '0000000000000000000000000000000000000000000000000000000000000000',
+      );
+    });
+
+    Widget buildSubject(MockGoRouter goRouter) {
+      return ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: MockGoRouterProvider(
+              goRouter: goRouter,
+              child: VideoMetadataEditBottomBar(
+                video: testVideo,
+                initialCollaboratorPubkeys: const {},
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('navigates to subtitle editor when tapped', (tester) async {
+      final mockGoRouter = MockGoRouter();
+      when(
+        () => mockGoRouter.push<Object?>(any(), extra: any(named: 'extra')),
+      ).thenAnswer((_) async => null);
+
+      await tester.pumpWidget(buildSubject(mockGoRouter));
+
+      await tester.tap(find.text(l10n.videoEditEditSubtitles));
+      await tester.pump();
+
+      verify(
+        () => mockGoRouter.push<Object?>(
+          SubtitleEditorScreen.pathFor(testVideo.id),
+          extra: testVideo,
+        ),
+      ).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Closes #5366

## What & why

Creators' auto-generated subtitles are frequently wrong and there was no way to fix them. This adds a **text-only subtitle editor** for a creator's own video, and republishes the corrected captions with **read-time redundancy** — the VTT lives both as a content-addressed **Blossom blob** and as a **Kind 39307** Nostr event, and the video event references both so display can fall back between them.

Design + plan: `docs/superpowers/specs/2026-06-20-subtitle-editing-design.md`, `docs/superpowers/plans/2026-06-20-subtitle-editing.md`.

## How it works

`UI → Cubit → Repository → Clients`, reusing existing infra (VTT parse/generate, the triple-fetch display path, the addressable republish).

- **Edit** (text only; timing fixed) on the creator's own video via an **Edit subtitles** action in the metadata edit screen → full-screen `SubtitleEditorScreen`.
- **Save** orchestration (`SubtitleRepository`): generate VTT → upload to Blossom (`text/vtt`) → publish Kind 39307 (`d = subtitles:<vineId>`) → republish the video (kind 34236) carrying **two** `text-track` refs (Blossom URL + `39307:…` coords).
- **Read** (`fetchSubtitleCues`, shared by the display provider and the editor): embedded content → each `text-track` ref in order (HTTP or relay) → auto-generated `{sha256}/vtt`. Edited refs now take precedence over the auto-generated track, and the two refs give genuine fallback.
- **At-publish** ("publish now, edit when ready"): publishing is never blocked on transcription; the same own-video action becomes useful once the auto-VTT is ready, and the editor shows a *processing* state until then.

## Commits

| Layer | Change |
|---|---|
| Client | `BlossomUploadService.uploadSubtitleVtt` (text/vtt blob upload) |
| Models | `NIP71VideoKinds.subtitleEventKind` (39307); `VideoEvent.textTrackRefs` (capture all `text-track` tags) |
| Service | Extract shared `fetchSubtitleCues` with ordered ref fallback |
| Publisher | `publishSubtitleEvent` (39307) + dual `text-track` refs on republish |
| Repository | `SubtitleRepository` orchestration (`loadCues` / `publishEditedSubtitles`) |
| BLoC | `SubtitleEditorCubit` + state (status enum, `addError`) |
| l10n | Subtitle editor strings |
| UI | `SubtitleEditorScreen` (Page/View) |
| Wiring | `/subtitle-edit/:videoId` route + Edit-subtitles entry point |

## Scope (v1)

In: text-only editing, both Blossom + 39307 storage with read fallback, author-only, single language (`en`), both at-publish and post-publish entry (one screen).
Out: editing cue timing, multi-language tracks, collaborator editing, external file import.

## Testing

`flutter analyze lib test` clean; affected app suites + `models` (687) and `blossom_upload_service` (182) packages green; `dart format` clean.

Manual test plan:
- Own video with ready auto-subs → edit a wrong word → Save → corrected caption shows in feed.
- Own freshly-uploaded video (transcription not ready) → editor shows the *processing* state with retry.
- A non-owner cannot reach the editor (gated by the edit screen's own-content resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
