### PR TITLE
fix(camera): restore iOS flash mode build

### DIFF
--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -2142,7 +2142,7 @@ class CameraController: NSObject {
     private func photoFlashMode(for output: AVCapturePhotoOutput) -> AVCaptureDevice.FlashMode {
         let requestedMode = currentFlashMode
         let supportedModes = output.supportedFlashModes
-        if supportedModes.contains(NSNumber(value: requestedMode.rawValue)) {
+        if supportedModes.contains(requestedMode) {
             return requestedMode
         }
         return .off


### PR DESCRIPTION
Closes #5368

## Description

Fixes the iOS release/archive build failure from build ID `6a3617a5e52e212d23c2b977`.

Xcode now types `AVCapturePhotoOutput.supportedFlashModes` as `[AVCaptureDevice.FlashMode]`, so checking support with an `NSNumber` raw-value wrapper no longer compiles. This compares the requested `AVCaptureDevice.FlashMode` directly against the supported modes.

## Verification

- Reproduced the compiler error with an iPhoneOS Swift typecheck using the old `NSNumber(value: requestedMode.rawValue)` expression.
- Verified the corrected `supportedModes.contains(requestedMode)` expression with the same Swift typecheck.
- `flutter build ios --no-codesign`
- `git diff --check`

## Type of Change

- [x] Bug fix
