### PR TITLE
fix(video-player): stop iOS texture frame driver on app background (build 766 crash)

### DIFF
--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -1108,6 +1108,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     private var wasPlayingBeforePause = false
 
     func onAppBackgrounded() {
+        // Stop the texture frame driver first. A display-link or
+        // AVFoundation-notification frame delivered during the
+        // resign-active → suspend window dereferences a torn-down Flutter
+        // shell and crashes. Unconditional: the driver polls even while the
+        // player is paused, and a paused-player seek/forceRefresh can still
+        // push a frame.
+        textureOutput?.suspendFrameDelivery()
         wasPlayingBeforePause = player?.rate ?? 0 > 0
         if wasPlayingBeforePause {
             player?.pause()
@@ -1117,6 +1124,7 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
     }
 
     func onAppForegrounded() {
+        textureOutput?.resumeFrameDelivery()
         if wasPlayingBeforePause {
             player?.play()
             player?.rate = Float(speed)

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/VideoTextureOutput.swift
@@ -71,6 +71,16 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// thread via `copyPixelBuffer()`.
     private var pixelBufferLock = os_unfair_lock()
 
+    /// Gates every path that calls `registry.textureFrameAvailable`.
+    /// Flipped to `false` while the app is backgrounded (and on
+    /// `dispose`) so the display-link / AVFoundation-notification / preroll
+    /// paths stop pushing frames into the Flutter engine during the
+    /// resign-active → suspend window. Delivering a frame in that window
+    /// dereferences a torn-down `Shell` inside
+    /// `-[FlutterEngine textureFrameAvailable:]` and crashes with
+    /// EXC_BAD_ACCESS. Read/written on the main thread only.
+    private var isFrameDeliveryEnabled = true
+
     /// Fired when the force window expires without a frame; caller should
     /// retry the seek with tolerance. Suppressed for retry windows.
     var onSeekStuck: ((CMTime) -> Void)?
@@ -239,8 +249,35 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         deliverFrame(pixelBuffer)
     }
 
+    // MARK: - App lifecycle
+
+    /// Pauses frame delivery into the Flutter texture while the app is
+    /// backgrounded. The display link is paused so it stops polling, and
+    /// `isFrameDeliveryEnabled` gates the AVFoundation-notification and
+    /// preroll paths too — together they guarantee no `textureFrameAvailable`
+    /// call reaches the engine while it may be tearing down its shell during
+    /// suspension. Must be called on the main thread.
+    func suspendFrameDelivery() {
+        isFrameDeliveryEnabled = false
+        #if os(iOS)
+        displayLink?.isPaused = true
+        #endif
+    }
+
+    /// Re-enables frame delivery when the app returns to the foreground.
+    /// The retained `latestPixelBuffer` keeps the texture populated across
+    /// the background period, so resuming does not flash black. Must be
+    /// called on the main thread.
+    func resumeFrameDelivery() {
+        isFrameDeliveryEnabled = true
+        #if os(iOS)
+        displayLink?.isPaused = false
+        #endif
+    }
+
     /// Cleans up the frame driver and unregisters the texture.
     func dispose() {
+        isFrameDeliveryEnabled = false
         stopFrameDriver()
         itemStatusObservation?.invalidate()
         itemStatusObservation = nil
@@ -304,6 +341,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         os_unfair_lock_lock(&pixelBufferLock)
         latestPixelBuffer = pixelBuffer
         os_unfair_lock_unlock(&pixelBufferLock)
+        guard isFrameDeliveryEnabled else { return }
         registry.textureFrameAvailable(textureId)
         if !hasDeliveredFirstFrame {
             hasDeliveredFirstFrame = true
@@ -314,7 +352,8 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// Pulls the current frame and pushes it into the Flutter texture.
     /// Driven by `CADisplayLink` on iOS and a `Timer` on macOS.
     private func pullAndDeliverFrame() {
-        guard let output = videoOutput,
+        guard isFrameDeliveryEnabled,
+              let output = videoOutput,
               let player else { return }
 
         let itemTime = player.currentTime()


### PR DESCRIPTION
Closes #5370

## Description

Fixes a frequent crash in TestFlight build 766 (`EXC_BAD_ACCESS (SIGSEGV)`,
`KERN_INVALID_ADDRESS at 0x6c8`) on the texture video path.

`VideoTextureOutput` drives frame delivery from a `CADisplayLink` (iOS) /
`Timer` (macOS) whose tick calls `registry.textureFrameAvailable()` into the
Flutter engine. `onAppBackgrounded()` previously **only paused the `AVPlayer`** —
it never stopped the frame driver. So during the `resignActive → suspend`
window the display link kept delivering frames, and if the engine's `Shell`
was torn down in that window, `-[FlutterEngine textureFrameAvailable:]`
dereferenced a freed/null `Shell` (`Shell::GetPlatformView()`) → crash.

Crash stack (build 766, iPhone 13 Pro, iOS 26.5, backgrounded):

```
VideoTextureOutput.onDisplayLink()            ← CADisplayLink tick
 → pullAndDeliverFrame() → deliverFrame()
  → registry.textureFrameAvailable(textureId)
   → -[FlutterEngine textureFrameAvailable:]
    → flutter::Shell::GetPlatformView()        ← reads field of a null/freed Shell → fault
```

The texture path (`useTexture: true`) is used by the recently-shipped editor /
metadata / clip-preview screens — exactly where an interruption (incoming call,
app switch, audio route change) backgrounds the app mid-render.

### Fix

A main-thread `isFrameDeliveryEnabled` gate makes **every**
`textureFrameAvailable` path inert while backgrounded or disposed, plus the
`CADisplayLink` is paused:

- `VideoTextureOutput.swift`: new `suspendFrameDelivery()` / `resumeFrameDelivery()`;
  `guard isFrameDeliveryEnabled` in `deliverFrame` (the single choke point) and
  `pullAndDeliverFrame`; `dispose()` sets it false.
- `DivineVideoPlayerInstance.swift`: `onAppBackgrounded()` calls
  `suspendFrameDelivery()` **unconditionally** (the driver polls even while the
  player is paused) before pausing the player; `onAppForegrounded()` calls
  `resumeFrameDelivery()` unconditionally.

The gate flips at `willResignActive` (the start of the suspend window) and is
always re-enabled on `didBecomeActive`, so it can't get stuck. The retained
`latestPixelBuffer` keeps the texture populated across the background period,
so resume does not flash black.

**Related Issue:** Relates to the build-766 TestFlight crash report (no GitHub
issue filed yet).

## Out of Scope

Two orthogonal follow-ups, intentionally not bundled into this crash fix
(distinct failure signature; tracked separately):

1. **Zombie-driver teardown path.** `CADisplayLink(target: self)` retains the
   output; it is only invalidated by `dispose()`, reached solely via the Dart
   dispose channel. An engine/`FlutterViewController` teardown that bypasses
   Dart dispose (OOM reclaim, `destroyContext`) leaks the driver. The standard
   fix (`detachFromEngineForRegistrar` → dispose) needs per-engine ownership
   handling because `PlayerRegistry` is process-wide and the FCM background
   isolate also registers this plugin — a naive `disposeAll()` on detach could
   kill live UI playback. Needs its own PR. Tracked in #5371 (recommended to tackle after this PR merges).
2. **Resume-side liveness guard** — largely subsumed once (1) is done.

## Verification

- `flutter build ios --simulator --debug` → `✓ Built Runner.app` (Swift
  compiles + links; pod install + Xcode build green).
- Installed + launched on iOS 26.5 simulator; cycled background→foreground
  twice — app stayed alive, no crash reports. (Simulator can't drive the
  editor-only texture path; full crash repro needs the editor flow on device.)
- No Dart changed; no Swift test target exists in this package.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

