### PR TITLE
fix(verifier): open native verification in system browser

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -92,7 +92,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     on<ProfileBannerColorSelected>(_onProfileBannerColorSelected);
     on<ProfileBannerCleared>(_onProfileBannerCleared);
     on<VerifierLaunchRequested>(_onVerifierLaunchRequested);
-    on<VerifierWebViewDismissed>(_onVerifierWebViewDismissed);
+    on<VerifierLaunchHandled>(_onVerifierLaunchHandled);
   }
 
   final ProfileRepository _profileRepository;
@@ -1139,10 +1139,10 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     emit(state.copyWith(verifierStatus: VerifierStatus.launchRequested));
   }
 
-  void _onVerifierWebViewDismissed(
-    VerifierWebViewDismissed event,
+  void _onVerifierLaunchHandled(
+    VerifierLaunchHandled event,
     Emitter<ProfileEditorState> emit,
   ) {
-    emit(state.copyWith(verifierStatus: VerifierStatus.dismissed));
+    emit(state.copyWith(verifierStatus: VerifierStatus.handled));
   }
 }

--- a/mobile/lib/blocs/profile_editor/profile_editor_event.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_event.dart
@@ -182,14 +182,14 @@ final class ProfilePictureUrlSet extends ProfileEditorEvent {
   final String url;
 }
 
-/// User tapped the "Get verified" CTA — UI listens for this and pushes the
-/// in-app verifier WebView. The bloc only flips a status; no navigation here.
+/// User tapped the "Get verified" CTA. The UI listens for this and opens the
+/// verifier. The bloc only flips a status; no navigation here.
 final class VerifierLaunchRequested extends ProfileEditorEvent {
   const VerifierLaunchRequested();
 }
 
-/// In-app verifier WebView was popped — UI dispatches this so downstream
-/// consumers (e.g. MyProfileBloc) can refresh kind 0 and pick up new claims.
+/// Verifier flow returned. UI dispatches this so downstream consumers
+/// (e.g. MyProfileBloc) can refresh kind 0 and pick up new claims.
 final class VerifierWebViewDismissed extends ProfileEditorEvent {
   const VerifierWebViewDismissed();
 }

--- a/mobile/lib/blocs/profile_editor/profile_editor_event.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_event.dart
@@ -188,10 +188,12 @@ final class VerifierLaunchRequested extends ProfileEditorEvent {
   const VerifierLaunchRequested();
 }
 
-/// Verifier flow returned. UI dispatches this so downstream consumers
-/// (e.g. MyProfileBloc) can refresh kind 0 and pick up new claims.
-final class VerifierWebViewDismissed extends ProfileEditorEvent {
-  const VerifierWebViewDismissed();
+/// UI handled the one-shot verifier launch request.
+///
+/// The UI owns navigation/browser launch and any follow-up profile refresh.
+/// The bloc only resets the launch signal so future taps can emit again.
+final class VerifierLaunchHandled extends ProfileEditorEvent {
+  const VerifierLaunchHandled();
 }
 
 /// Sets the user's existing persisted banner value after profile load.

--- a/mobile/lib/blocs/profile_editor/profile_editor_state.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_state.dart
@@ -191,8 +191,8 @@ enum UsernameValidationError {
 /// Status of the verifier launch flow.
 ///
 /// Used as a one-shot signal: the UI listens for [launchRequested], opens the
-/// verifier, and dispatches [VerifierWebViewDismissed] on return so the status
-/// flips to [dismissed]. The bloc never navigates itself.
+/// verifier, and dispatches [VerifierLaunchHandled] after handling the request
+/// so future taps can emit another launch signal. The bloc never navigates.
 enum VerifierStatus {
   /// No launch pending.
   idle,
@@ -200,8 +200,8 @@ enum VerifierStatus {
   /// User tapped "Get verified" and the UI should open the verifier.
   launchRequested,
 
-  /// Verifier flow returned and UI should refresh kind 0 for new claims.
-  dismissed,
+  /// UI has handled the verifier launch request.
+  handled,
 }
 
 /// Whether the profile editor is in divine.video username or external NIP-05
@@ -356,7 +356,7 @@ final class ProfileEditorState extends Equatable {
     return persistedBanner;
   }
 
-  /// One-shot signal driving the in-app verifier WebView launch + dismiss.
+  /// One-shot signal driving verifier launch handling in the UI.
   final VerifierStatus verifierStatus;
 
   /// Whether the username state allows saving the profile (divine.video mode).

--- a/mobile/lib/blocs/profile_editor/profile_editor_state.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_state.dart
@@ -188,19 +188,19 @@ enum UsernameValidationError {
   networkError,
 }
 
-/// Status of the in-app verifier WebView launch flow.
+/// Status of the verifier launch flow.
 ///
-/// Used as a one-shot signal — the UI listens for [launchRequested], pushes
-/// the WebView, and dispatches [VerifierWebViewDismissed] on return so the
-/// status flips to [dismissed]. The bloc never navigates itself.
+/// Used as a one-shot signal: the UI listens for [launchRequested], opens the
+/// verifier, and dispatches [VerifierWebViewDismissed] on return so the status
+/// flips to [dismissed]. The bloc never navigates itself.
 enum VerifierStatus {
   /// No launch pending.
   idle,
 
-  /// User tapped "Get verified" — UI should push the WebView.
+  /// User tapped "Get verified" and the UI should open the verifier.
   launchRequested,
 
-  /// WebView was popped — UI should refresh kind 0 to pick up new claims.
+  /// Verifier flow returned and UI should refresh kind 0 for new claims.
   dismissed,
 }
 

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -21,10 +21,8 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
-import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
 import 'package:openvine/screens/apps/web_iframe_sandbox_screen.dart';
 import 'package:openvine/screens/key_management_screen.dart';
-import 'package:openvine/utils/nostr_apps_platform_support.dart';
 import 'package:openvine/widgets/branded_loading_scaffold.dart';
 import 'package:openvine/widgets/profile/nostr_info_sheet_content.dart';
 import 'package:openvine/widgets/profile/verified_accounts_row.dart';
@@ -477,36 +475,13 @@ class _ProfileSetupScreenViewState
               prev.verifierStatus != curr.verifierStatus &&
               curr.verifierStatus == VerifierStatus.launchRequested,
           listener: (context, state) async {
-            final editorBloc = context.read<ProfileEditorBloc>();
-            final myProfileBloc = context.read<MyProfileBloc>();
-            final verifyer = preloadedNostrApps.firstWhere(
-              (app) => app.slug == 'verifyer',
+            await launchVerifierFlow(
+              editorBloc: context.read<ProfileEditorBloc>(),
+              myProfileBloc: context.read<MyProfileBloc>(),
+              pushVerifierRoute: (location, {extra}) async {
+                await context.push(location, extra: extra);
+              },
             );
-            if (nostrAppsSandboxSupported) {
-              // Native (iOS / Android / macOS): full webview_flutter
-              // sandbox with NIP-07 bridge injection.
-              await context.push(
-                NostrAppSandboxScreen.pathForAppId(verifyer.id),
-                extra: verifyer,
-              );
-            } else if (kIsWeb) {
-              // Flutter web: webview_flutter is unavailable, but we can
-              // host the verifyer in an <iframe> with a postMessage
-              // NIP-07 bridge to Divine's web signer.
-              await context.push(
-                WebIframeSandboxScreen.pathForAppId(verifyer.id),
-                extra: verifyer,
-              );
-            } else {
-              // Last-resort fallback for any future platform without
-              // either capability — open in the system browser.
-              await launchUrl(
-                Uri.parse(verifyer.launchUrl),
-                mode: LaunchMode.externalApplication,
-              );
-            }
-            editorBloc.add(const VerifierWebViewDismissed());
-            myProfileBloc.add(const MyProfileFetchRequested());
           },
         ),
       ],
@@ -1868,6 +1843,44 @@ class _VerifiedAccountsSection extends StatelessWidget {
       ),
     );
   }
+}
+
+typedef VerifierRoutePusher =
+    Future<void> Function(String location, {Object? extra});
+
+/// Opens the Divine verifyer and refreshes the profile when the user returns.
+///
+/// Native in-app WebViews cannot complete the verifyer's login flow because it
+/// leaves `verifyer.divine.video` for `login.divine.video` and OAuth providers.
+/// Those hand-offs need real browser tabs, cookies, and redirects, so native
+/// platforms launch the system browser. Flutter web keeps the existing iframe
+/// signer bridge because it runs in the browser and does not use
+/// `webview_flutter`.
+@visibleForTesting
+Future<void> launchVerifierFlow({
+  required ProfileEditorBloc editorBloc,
+  required MyProfileBloc myProfileBloc,
+  VerifierRoutePusher? pushVerifierRoute,
+  bool isWeb = kIsWeb,
+}) async {
+  final verifyer = preloadedNostrApps.firstWhere(
+    (app) => app.slug == 'verifyer',
+  );
+
+  if (isWeb && pushVerifierRoute != null) {
+    await pushVerifierRoute(
+      WebIframeSandboxScreen.pathForAppId(verifyer.id),
+      extra: verifyer,
+    );
+  } else {
+    await launchUrl(
+      Uri.parse(verifyer.launchUrl),
+      mode: LaunchMode.externalApplication,
+    );
+  }
+
+  editorBloc.add(const VerifierWebViewDismissed());
+  myProfileBloc.add(const MyProfileFetchRequested());
 }
 
 class _GetVerifiedTile extends StatelessWidget {

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -143,19 +143,32 @@ class ProfileSetupScreenView extends ConsumerStatefulWidget {
       _ProfileSetupScreenViewState();
 }
 
-class _ProfileSetupScreenViewState
-    extends ConsumerState<ProfileSetupScreenView> {
+class _ProfileSetupScreenViewState extends ConsumerState<ProfileSetupScreenView>
+    with WidgetsBindingObserver {
   final _nameController = TextEditingController();
   final _bioController = TextEditingController();
   final _websiteController = TextEditingController();
   final _pictureController = TextEditingController();
   final _nip05Controller = TextEditingController();
   final ImagePicker _picker = ImagePicker();
+  bool _refreshProfileOnResume = false;
 
   static const _kInputBorder = UnderlineInputBorder(
     borderRadius: BorderRadius.zero,
     borderSide: BorderSide(color: VineTheme.neutral10),
   );
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+    if (state != AppLifecycleState.resumed || !_refreshProfileOnResume) {
+      return;
+    }
+
+    _refreshProfileOnResume = false;
+    context.read<MyProfileBloc>().add(const MyProfileFetchRequested());
+  }
+
   static const _kHintStyle = TextStyle(color: VineTheme.lightText);
 
   // Focus nodes for tracking field focus state
@@ -179,6 +192,7 @@ class _ProfileSetupScreenViewState
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     // Rebuild when display name changes so save button updates.
     _nameController.addListener(_onFocusChange);
     _websiteFocusNode.addListener(_onFocusChange);
@@ -194,6 +208,7 @@ class _ProfileSetupScreenViewState
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _nameController.removeListener(_onFocusChange);
     _nameController.dispose();
     _bioController.dispose();
@@ -482,6 +497,9 @@ class _ProfileSetupScreenViewState
                 await context.push(location, extra: extra);
               },
             );
+            if (launched && !kIsWeb && mounted) {
+              _refreshProfileOnResume = true;
+            }
             if (!launched && context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
@@ -1856,14 +1874,15 @@ class _VerifiedAccountsSection extends StatelessWidget {
 typedef VerifierRoutePusher =
     Future<void> Function(String location, {Object? extra});
 
-/// Opens the Divine verifyer and refreshes the profile after the flow opens.
+/// Opens the Divine verifyer.
 ///
 /// Native in-app WebViews cannot complete the verifyer's login flow because it
 /// leaves `verifyer.divine.video` for `login.divine.video` and OAuth providers.
 /// Those hand-offs need real browser tabs, cookies, and redirects, so native
 /// platforms launch the system browser. Flutter web keeps the existing iframe
 /// signer bridge because it runs in the browser and does not use
-/// `webview_flutter`.
+/// `webview_flutter`. Web refreshes after the iframe route returns; native
+/// refreshes from the screen's app-resume callback.
 @visibleForTesting
 Future<bool> launchVerifierFlow({
   required ProfileEditorBloc editorBloc,
@@ -1889,15 +1908,15 @@ Future<bool> launchVerifierFlow({
         mode: LaunchMode.externalApplication,
       );
     }
-  } catch (error, stackTrace) {
+  } catch (error) {
     UnifiedLogger.warning(
-      'Failed to open Divine verifyer: $error\n$stackTrace',
+      'Failed to open Divine verifyer: $error',
       name: 'ProfileSetupScreen',
     );
   }
 
-  editorBloc.add(const VerifierWebViewDismissed());
-  if (launched) {
+  editorBloc.add(const VerifierLaunchHandled());
+  if (launched && isWeb) {
     myProfileBloc.add(const MyProfileFetchRequested());
   }
   return launched;

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -475,13 +475,21 @@ class _ProfileSetupScreenViewState
               prev.verifierStatus != curr.verifierStatus &&
               curr.verifierStatus == VerifierStatus.launchRequested,
           listener: (context, state) async {
-            await launchVerifierFlow(
+            final launched = await launchVerifierFlow(
               editorBloc: context.read<ProfileEditorBloc>(),
               myProfileBloc: context.read<MyProfileBloc>(),
               pushVerifierRoute: (location, {extra}) async {
                 await context.push(location, extra: extra);
               },
             );
+            if (!launched && context.mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(context.l10n.relaySettingsCouldNotOpenBrowser),
+                  backgroundColor: VineTheme.error,
+                ),
+              );
+            }
           },
         ),
       ],
@@ -1848,7 +1856,7 @@ class _VerifiedAccountsSection extends StatelessWidget {
 typedef VerifierRoutePusher =
     Future<void> Function(String location, {Object? extra});
 
-/// Opens the Divine verifyer and refreshes the profile when the user returns.
+/// Opens the Divine verifyer and refreshes the profile after the flow opens.
 ///
 /// Native in-app WebViews cannot complete the verifyer's login flow because it
 /// leaves `verifyer.divine.video` for `login.divine.video` and OAuth providers.
@@ -1857,7 +1865,7 @@ typedef VerifierRoutePusher =
 /// signer bridge because it runs in the browser and does not use
 /// `webview_flutter`.
 @visibleForTesting
-Future<void> launchVerifierFlow({
+Future<bool> launchVerifierFlow({
   required ProfileEditorBloc editorBloc,
   required MyProfileBloc myProfileBloc,
   VerifierRoutePusher? pushVerifierRoute,
@@ -1867,20 +1875,32 @@ Future<void> launchVerifierFlow({
     (app) => app.slug == 'verifyer',
   );
 
-  if (isWeb && pushVerifierRoute != null) {
-    await pushVerifierRoute(
-      WebIframeSandboxScreen.pathForAppId(verifyer.id),
-      extra: verifyer,
-    );
-  } else {
-    await launchUrl(
-      Uri.parse(verifyer.launchUrl),
-      mode: LaunchMode.externalApplication,
+  var launched = false;
+  try {
+    if (isWeb && pushVerifierRoute != null) {
+      await pushVerifierRoute(
+        WebIframeSandboxScreen.pathForAppId(verifyer.id),
+        extra: verifyer,
+      );
+      launched = true;
+    } else {
+      launched = await launchUrl(
+        Uri.parse(verifyer.launchUrl),
+        mode: LaunchMode.externalApplication,
+      );
+    }
+  } catch (error, stackTrace) {
+    UnifiedLogger.warning(
+      'Failed to open Divine verifyer: $error\n$stackTrace',
+      name: 'ProfileSetupScreen',
     );
   }
 
   editorBloc.add(const VerifierWebViewDismissed());
-  myProfileBloc.add(const MyProfileFetchRequested());
+  if (launched) {
+    myProfileBloc.add(const MyProfileFetchRequested());
+  }
+  return launched;
 }
 
 class _GetVerifiedTile extends StatelessWidget {

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -3105,7 +3105,7 @@ void main() {
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
-        'flips verifierStatus to dismissed on VerifierWebViewDismissed',
+        'flips verifierStatus to handled on VerifierLaunchHandled',
         build: () => ProfileEditorBloc(
           profileRepository: mockProfileRepository,
           blossomUploadService: mockBlossomUploadService,
@@ -3115,12 +3115,12 @@ void main() {
         seed: () => const ProfileEditorState(
           verifierStatus: VerifierStatus.launchRequested,
         ),
-        act: (bloc) => bloc.add(const VerifierWebViewDismissed()),
+        act: (bloc) => bloc.add(const VerifierLaunchHandled()),
         expect: () => [
           isA<ProfileEditorState>().having(
             (s) => s.verifierStatus,
             'verifierStatus',
-            VerifierStatus.dismissed,
+            VerifierStatus.handled,
           ),
         ],
       );

--- a/mobile/test/helpers/url_launcher_test_double.dart
+++ b/mobile/test/helpers/url_launcher_test_double.dart
@@ -17,6 +17,14 @@ class LaunchedCall {
 /// ```
 /// then assert against [launched] after the action under test runs.
 class UrlLauncherTestDouble extends UrlLauncherPlatform {
+  UrlLauncherTestDouble({
+    this.launchResult = true,
+    this.launchError,
+  });
+
+  final bool launchResult;
+  final Object? launchError;
+
   /// Calls captured in order of arrival.
   final List<LaunchedCall> launched = [];
 
@@ -52,6 +60,10 @@ class UrlLauncherTestDouble extends UrlLauncherPlatform {
             options.mode == PreferredLaunchMode.externalApplication,
       ),
     );
-    return true;
+    final error = launchError;
+    if (error != null) {
+      throw error;
+    }
+    return launchResult;
   }
 }

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -885,12 +885,13 @@ void main() {
     test(
       'opens the verifyer in the external browser and refreshes profile',
       () async {
-        await launchVerifierFlow(
+        final launched = await launchVerifierFlow(
           editorBloc: editorBloc,
           myProfileBloc: myProfileBloc,
           isWeb: false,
         );
 
+        expect(launched, isTrue);
         expect(launcher.launched, hasLength(1));
         expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
         expect(launcher.launched.single.useExternalApplication, isTrue);
@@ -908,7 +909,7 @@ void main() {
       () async {
         final pushedRoutes = <({String location, Object? extra})>[];
 
-        await launchVerifierFlow(
+        final launched = await launchVerifierFlow(
           editorBloc: editorBloc,
           myProfileBloc: myProfileBloc,
           isWeb: true,
@@ -917,6 +918,7 @@ void main() {
           },
         );
 
+        expect(launched, isTrue);
         expect(launcher.launched, isEmpty);
         expect(pushedRoutes, hasLength(1));
         expect(
@@ -929,6 +931,56 @@ void main() {
         verify(
           () => myProfileBloc.add(const MyProfileFetchRequested()),
         ).called(1);
+      },
+    );
+
+    test(
+      'resets the launch signal and skips refresh when native launch fails',
+      () async {
+        launcher = UrlLauncherTestDouble(launchResult: false);
+        UrlLauncherPlatform.instance = launcher;
+
+        final launched = await launchVerifierFlow(
+          editorBloc: editorBloc,
+          myProfileBloc: myProfileBloc,
+          isWeb: false,
+        );
+
+        expect(launched, isFalse);
+        expect(launcher.launched, hasLength(1));
+        expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
+        verify(
+          () => editorBloc.add(const VerifierWebViewDismissed()),
+        ).called(1);
+        verifyNever(
+          () => myProfileBloc.add(const MyProfileFetchRequested()),
+        );
+      },
+    );
+
+    test(
+      'resets the launch signal and skips refresh when native launch throws',
+      () async {
+        launcher = UrlLauncherTestDouble(
+          launchError: PlatformException(code: 'launch_failed'),
+        );
+        UrlLauncherPlatform.instance = launcher;
+
+        final launched = await launchVerifierFlow(
+          editorBloc: editorBloc,
+          myProfileBloc: myProfileBloc,
+          isWeb: false,
+        );
+
+        expect(launched, isFalse);
+        expect(launcher.launched, hasLength(1));
+        expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
+        verify(
+          () => editorBloc.add(const VerifierWebViewDismissed()),
+        ).called(1);
+        verifyNever(
+          () => myProfileBloc.add(const MyProfileFetchRequested()),
+        );
       },
     );
   });

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -18,8 +18,10 @@ import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/key_management_screen.dart';
 import 'package:openvine/screens/profile_setup_screen.dart';
 import 'package:openvine/widgets/profile_editor/username_status_indicator.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import '../helpers/test_provider_overrides.dart';
+import '../helpers/url_launcher_test_double.dart';
 
 class _MockProfileEditorBloc
     extends MockBloc<ProfileEditorEvent, ProfileEditorState>
@@ -860,5 +862,74 @@ void main() {
         },
       );
     });
+  });
+
+  group('launchVerifierFlow', () {
+    late UrlLauncherPlatform originalPlatform;
+    late UrlLauncherTestDouble launcher;
+    late _MockProfileEditorBloc editorBloc;
+    late _MockMyProfileBloc myProfileBloc;
+
+    setUp(() {
+      originalPlatform = UrlLauncherPlatform.instance;
+      launcher = UrlLauncherTestDouble();
+      UrlLauncherPlatform.instance = launcher;
+      editorBloc = _MockProfileEditorBloc();
+      myProfileBloc = _MockMyProfileBloc();
+    });
+
+    tearDown(() {
+      UrlLauncherPlatform.instance = originalPlatform;
+    });
+
+    test(
+      'opens the verifyer in the external browser and refreshes profile',
+      () async {
+        await launchVerifierFlow(
+          editorBloc: editorBloc,
+          myProfileBloc: myProfileBloc,
+          isWeb: false,
+        );
+
+        expect(launcher.launched, hasLength(1));
+        expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
+        expect(launcher.launched.single.useExternalApplication, isTrue);
+        verify(
+          () => editorBloc.add(const VerifierWebViewDismissed()),
+        ).called(1);
+        verify(
+          () => myProfileBloc.add(const MyProfileFetchRequested()),
+        ).called(1);
+      },
+    );
+
+    test(
+      'keeps the existing web iframe route and refreshes profile',
+      () async {
+        final pushedRoutes = <({String location, Object? extra})>[];
+
+        await launchVerifierFlow(
+          editorBloc: editorBloc,
+          myProfileBloc: myProfileBloc,
+          isWeb: true,
+          pushVerifierRoute: (location, {extra}) async {
+            pushedRoutes.add((location: location, extra: extra));
+          },
+        );
+
+        expect(launcher.launched, isEmpty);
+        expect(pushedRoutes, hasLength(1));
+        expect(
+          pushedRoutes.single.location,
+          '/apps/bundled-verifyer/web-sandbox',
+        );
+        verify(
+          () => editorBloc.add(const VerifierWebViewDismissed()),
+        ).called(1);
+        verify(
+          () => myProfileBloc.add(const MyProfileFetchRequested()),
+        ).called(1);
+      },
+    );
   });
 }

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -691,6 +691,52 @@ void main() {
       );
     }
 
+    testWidgets(
+      'refreshes profile on resume after native verifier launch',
+      (tester) async {
+        final originalPlatform = UrlLauncherPlatform.instance;
+        final launcher = UrlLauncherTestDouble();
+        UrlLauncherPlatform.instance = launcher;
+        addTearDown(() {
+          UrlLauncherPlatform.instance = originalPlatform;
+        });
+
+        whenListen(
+          mockEditorBloc,
+          Stream<ProfileEditorState>.fromIterable([
+            const ProfileEditorState(
+              verifierStatus: VerifierStatus.launchRequested,
+            ),
+          ]),
+          initialState: const ProfileEditorState(),
+        );
+
+        await pumpScreen(tester);
+        await tester.pump();
+
+        expect(launcher.launched, hasLength(1));
+        verify(
+          () => mockEditorBloc.add(const VerifierLaunchHandled()),
+        ).called(1);
+        verifyNever(
+          () => mockMyProfileBloc.add(const MyProfileFetchRequested()),
+        );
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.inactive,
+        );
+        await tester.pump();
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+        await tester.pump();
+
+        verify(
+          () => mockMyProfileBloc.add(const MyProfileFetchRequested()),
+        ).called(1);
+      },
+    );
+
     group('banner block', () {
       testWidgets(
         'pre-filled hex banner shows color preview',
@@ -883,7 +929,7 @@ void main() {
     });
 
     test(
-      'opens the verifyer in the external browser and refreshes profile',
+      'opens the verifyer in the external browser without immediate refresh',
       () async {
         final launched = await launchVerifierFlow(
           editorBloc: editorBloc,
@@ -896,11 +942,11 @@ void main() {
         expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
         expect(launcher.launched.single.useExternalApplication, isTrue);
         verify(
-          () => editorBloc.add(const VerifierWebViewDismissed()),
+          () => editorBloc.add(const VerifierLaunchHandled()),
         ).called(1);
-        verify(
+        verifyNever(
           () => myProfileBloc.add(const MyProfileFetchRequested()),
-        ).called(1);
+        );
       },
     );
 
@@ -926,7 +972,7 @@ void main() {
           '/apps/bundled-verifyer/web-sandbox',
         );
         verify(
-          () => editorBloc.add(const VerifierWebViewDismissed()),
+          () => editorBloc.add(const VerifierLaunchHandled()),
         ).called(1);
         verify(
           () => myProfileBloc.add(const MyProfileFetchRequested()),
@@ -950,7 +996,7 @@ void main() {
         expect(launcher.launched, hasLength(1));
         expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
         verify(
-          () => editorBloc.add(const VerifierWebViewDismissed()),
+          () => editorBloc.add(const VerifierLaunchHandled()),
         ).called(1);
         verifyNever(
           () => myProfileBloc.add(const MyProfileFetchRequested()),
@@ -976,7 +1022,7 @@ void main() {
         expect(launcher.launched, hasLength(1));
         expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
         verify(
-          () => editorBloc.add(const VerifierWebViewDismissed()),
+          () => editorBloc.add(const VerifierLaunchHandled()),
         ).called(1);
         verifyNever(
           () => myProfileBloc.add(const MyProfileFetchRequested()),


### PR DESCRIPTION
## Summary

- Open the profile verification flow in the system browser on native/non-web platforms.
- Keep the existing Flutter web iframe signer bridge path intact.
- Extract the verifier launch/refresh contract into `launchVerifierFlow` and cover both native and web branches with regression tests.
- Clean up stale verifier-flow comments that described the launch as WebView-only.

## Root Cause

The profile editor's `Get verified` flow routed native users into `NostrAppSandboxScreen`. That WebView sandbox only permits the verifier's configured origins, but the verifier login flow leaves `verifyer.divine.video` for `login.divine.video` and OAuth providers. Those redirects/new-window/cookie handoffs are browser flows, so native users hit the blocked page instead of completing verification.

## Behavior

Native platforms now launch `https://verifyer.divine.video/` with `LaunchMode.externalApplication`, allowing the login and OAuth handoffs to run in the system browser. When the user returns, the existing `VerifierWebViewDismissed` and `MyProfileFetchRequested` refresh path still runs. Flutter web continues using `WebIframeSandboxScreen`, preserving the existing web signer bridge rather than widening the blast radius.

Closes #4861

## Verification

- `flutter test test/screens/profile_setup_screen_test.dart`
- `flutter analyze lib test integration_test`
- Pre-push hook: merge-conflict check, analyzer, changed-file tests (`test/blocs/profile_editor/profile_editor_state_test.dart`, `test/screens/profile_setup_screen_test.dart`)
