### PR TITLE
fix(profile): invalidate stats after video delete

### DIFF
--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -475,10 +475,12 @@ Future<ContentDeletionService> contentDeletionService(Ref ref) async {
   final nostrService = ref.watch(nostrServiceProvider);
   final authService = ref.watch(authServiceProvider);
   final prefs = ref.watch(sharedPreferencesProvider);
+  final profileStatsDao = ref.watch(databaseProvider).profileStatsDao;
   final service = ContentDeletionService(
     nostrService: nostrService,
     authService: authService,
     prefs: prefs,
+    profileStatsDao: profileStatsDao,
   );
 
   // Initialize the service to enable content deletion

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -674,7 +674,7 @@ final class ContentDeletionServiceProvider
 }
 
 String _$contentDeletionServiceHash() =>
-    r'595760368d4f392891586c43959ceba01e02bcd5';
+    r'de8df8e0106036b306b61ef2970e6b43ce1be68f';
 
 /// Bug report service for collecting diagnostics and sending encrypted reports
 

--- a/mobile/lib/services/content_deletion_service.dart
+++ b/mobile/lib/services/content_deletion_service.dart
@@ -3,6 +3,7 @@
 
 import 'dart:convert';
 
+import 'package:db_client/db_client.dart';
 import 'package:models/models.dart' hide LogCategory, NIP71VideoKinds;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
@@ -114,14 +115,17 @@ class ContentDeletionService {
     required NostrClient nostrService,
     required AuthService authService,
     required SharedPreferences prefs,
+    ProfileStatsDao? profileStatsDao,
   }) : _nostrService = nostrService,
        _authService = authService,
-       _prefs = prefs {
+       _prefs = prefs,
+       _profileStatsDao = profileStatsDao {
     _loadDeletionHistory();
   }
   final NostrClient _nostrService;
   final AuthService _authService;
   final SharedPreferences _prefs;
+  final ProfileStatsDao? _profileStatsDao;
 
   static const String deletionsStorageKey = 'content_deletions_history';
 
@@ -252,6 +256,7 @@ class ContentDeletionService {
 
       _deletionHistory.add(deletion);
       await _saveDeletionHistory();
+      await _invalidateProfileStatsAfterConfirmedDelete();
 
       Log.debug(
         '📱️ Content deletion confirmed: ${deleteEvent.id}',
@@ -268,6 +273,29 @@ class ContentDeletionService {
       return DeleteResult.failure(
         'Failed to delete content: $e',
         DeleteFailureKind.unknown,
+      );
+    }
+  }
+
+  Future<void> _invalidateProfileStatsAfterConfirmedDelete() async {
+    final dao = _profileStatsDao;
+    if (dao == null) return;
+
+    final currentPubkey = _authService.currentPublicKeyHex;
+    if (currentPubkey == null || currentPubkey.isEmpty) return;
+
+    try {
+      await dao.deleteStats(currentPubkey);
+      Log.debug(
+        'Invalidated profile stats cache after content deletion',
+        name: 'ContentDeletionService',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      Log.warning(
+        'Failed to invalidate profile stats after content deletion: $e',
+        name: 'ContentDeletionService',
+        category: LogCategory.system,
       );
     }
   }

--- a/mobile/test/services/content_deletion_service_test.dart
+++ b/mobile/test/services/content_deletion_service_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:db_client/db_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -19,6 +20,8 @@ class _MockNostrClient extends Mock implements NostrClient {}
 
 class _MockAuthService extends Mock implements AuthService {}
 
+class _MockProfileStatsDao extends Mock implements ProfileStatsDao {}
+
 class _FakeEvent extends Fake implements Event {}
 
 void main() {
@@ -30,6 +33,7 @@ void main() {
   group(ContentDeletionService, () {
     late _MockNostrClient mockNostrService;
     late _MockAuthService mockAuthService;
+    late _MockProfileStatsDao mockProfileStatsDao;
     late ContentDeletionService service;
     late SharedPreferences prefs;
     late String testPublicKey;
@@ -115,15 +119,20 @@ void main() {
 
       mockNostrService = _MockNostrClient();
       mockAuthService = _MockAuthService();
+      mockProfileStatsDao = _MockProfileStatsDao();
 
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPublicKey);
       when(() => mockNostrService.isInitialized).thenReturn(true);
+      when(
+        () => mockProfileStatsDao.deleteStats(any()),
+      ).thenAnswer((_) async => 1);
 
       service = ContentDeletionService(
         nostrService: mockNostrService,
         authService: mockAuthService,
         prefs: prefs,
+        profileStatsDao: mockProfileStatsDao,
       );
 
       await service.initialize();
@@ -231,6 +240,55 @@ void main() {
               tags: any(named: 'tags'),
             ),
           ).called(1);
+          verify(
+            () => mockProfileStatsDao.deleteStats(testPublicKey),
+          ).called(1);
+        },
+      );
+
+      test(
+        'does not fail a confirmed delete when profile stats invalidation fails',
+        () async {
+          final video = createTestVideoEvent(testPublicKey);
+          final deleteEvent = createTestEvent(
+            pubkey: testPublicKey,
+            kind: 5,
+            tags: [
+              ['e', video.id],
+              ['a', video.addressableId!],
+              ['k', '34236'],
+            ],
+            content: 'CONTENT DELETION',
+          );
+
+          when(
+            () => mockProfileStatsDao.deleteStats(testPublicKey),
+          ).thenThrow(Exception('database unavailable'));
+          when(
+            () => mockAuthService.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => deleteEvent);
+
+          when(
+            () => mockNostrService.publishEventAwaitOk(
+              any(),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => accepted(deleteEvent.id));
+
+          final result = await service.deleteContent(
+            video: video,
+            reason: 'Personal choice',
+          );
+
+          expect(result.success, isTrue);
+          expect(service.hasBeenDeleted(video.id), isTrue);
+          verify(
+            () => mockProfileStatsDao.deleteStats(testPublicKey),
+          ).called(1);
         },
       );
 
@@ -275,6 +333,7 @@ void main() {
           expect(result.error, contains('blocked: policy'));
           expect(service.hasBeenDeleted(video.id), isFalse);
           expect(service.deletionHistory, isEmpty);
+          verifyNever(() => mockProfileStatsDao.deleteStats(any()));
         },
       );
 


### PR DESCRIPTION
## Summary

Closes #2984.

This fixes the stale profile stats cache after a user deletes one of their own videos. The delete path already waits for a relay-confirmed NIP-09 delete before recording local deletion history, but it did not invalidate the cached profile stats row. Publish already invalidates this cache after a confirmed publish, so delete and publish were asymmetric.

## Changes

- Inject `ProfileStatsDao` into `ContentDeletionService` from `contentDeletionServiceProvider`.
- Invalidate the current user's cached profile stats only after a relay-confirmed delete.
- Keep cache invalidation non-fatal so a local cache failure cannot turn a confirmed delete into a failed user action.
- Add regression coverage for confirmed delete, cache invalidation failure, and relay rejection.
- Regenerate the Riverpod provider hash for the provider body change.

## Validation

- `mise exec -- flutter test test/services/content_deletion_service_test.dart test/blocs/owner_video_actions/owner_video_actions_cubit_test.dart`
- `mise exec -- flutter analyze`
- pre-push hook: merge-conflict check, analyzer, generated-file verification, changed-file tests