### PR TITLE
fix(trust-safety): route content reports to source relay

### DIFF
--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -149,6 +149,7 @@ class ContentReportingService {
     required String authorPubkey,
     required ContentFilterReason reason,
     required String details,
+    String? sourceRelay,
     String? additionalContext,
     List<String> hashtags = const [],
     List<String>? nip56EventIds,
@@ -186,7 +187,7 @@ class ContentReportingService {
 
       final sentEvent = await _nostrService.publishEvent(
         reportEvent,
-        targetRelays: [_moderationRelayUrl],
+        targetRelays: _targetRelaysForReport(sourceRelay),
       );
       // Always continue to local save regardless of publish outcome.
       final failureReason = sentEvent.failureReason;
@@ -243,6 +244,21 @@ class ContentReportingService {
       );
       return ReportResult.failure('Failed to submit report: $e');
     }
+  }
+
+  List<String> _targetRelaysForReport(String? sourceRelay) {
+    final relay = _normalizeRelayUrl(sourceRelay);
+    return [relay ?? _moderationRelayUrl];
+  }
+
+  String? _normalizeRelayUrl(String? relayUrl) {
+    final trimmed = relayUrl?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null || uri.host.isEmpty) return null;
+    if (uri.scheme != 'wss' && uri.scheme != 'ws') return null;
+    return trimmed;
   }
 
   /// Report user for harassment or abuse

--- a/mobile/lib/services/content_reporting_service.dart
+++ b/mobile/lib/services/content_reporting_service.dart
@@ -248,7 +248,7 @@ class ContentReportingService {
 
   List<String> _targetRelaysForReport(String? sourceRelay) {
     final relay = _normalizeRelayUrl(sourceRelay);
-    return [relay ?? _moderationRelayUrl];
+    return {_moderationRelayUrl, ?relay}.toList();
   }
 
   String? _normalizeRelayUrl(String? relayUrl) {
@@ -257,7 +257,7 @@ class ContentReportingService {
 
     final uri = Uri.tryParse(trimmed);
     if (uri == null || uri.host.isEmpty) return null;
-    if (uri.scheme != 'wss' && uri.scheme != 'ws') return null;
+    if (uri.scheme != 'wss') return null;
     return trimmed;
   }
 

--- a/mobile/lib/widgets/report_content_dialog.dart
+++ b/mobile/lib/widgets/report_content_dialog.dart
@@ -430,6 +430,7 @@ class _ReportContentDialogState extends ConsumerState<ReportContentDialog> {
               authorPubkey: _authorPubkey,
               reason: _selectedReason!,
               details: details,
+              sourceRelay: widget.video?.sourceRelay,
             );
 
       if (mounted) {

--- a/mobile/lib/widgets/share_video_menu.dart
+++ b/mobile/lib/widgets/share_video_menu.dart
@@ -245,6 +245,7 @@ class _ShareVideoMenuState extends ConsumerState<ShareVideoMenu> {
         authorPubkey: widget.video.pubkey,
         reason: ContentFilterReason.other,
         details: 'Suspected AI-generated content',
+        sourceRelay: widget.video.sourceRelay,
       );
 
       if (mounted) {

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -667,6 +667,16 @@ class VideoEvent {
       vineId = event.id; // Use event ID as unique identifier
     }
 
+    if (sourceRelay == null) {
+      for (final source in event.sources) {
+        final trimmed = source.trim();
+        if (trimmed.isNotEmpty) {
+          sourceRelay = trimmed;
+          break;
+        }
+      }
+    }
+
     return VideoEvent(
       id: event.id,
       pubkey: event.pubkey,
@@ -751,8 +761,9 @@ class VideoEvent {
   /// [shareKind] for a safe value.
   final int? eventKind;
 
-  /// A relay hint (`wss://`/`ws://`) where this event was advertised, captured
-  /// from an `r` tag if present. Used as a relay hint when citing the video.
+  /// A relay hint (`wss://`/`ws://`) where this event was advertised or
+  /// received. Prefers an `r` tag when present, then falls back to SDK
+  /// receive-source metadata. Used as a relay hint when citing the video.
   final String? sourceRelay;
 
   // Repost metadata fields

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -115,6 +115,44 @@ void main() {
       }
     });
 
+    test('uses received relay source when no relay hint tag exists', () {
+      final nostrEvent =
+          Event(
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+              34236,
+              [
+                ['url', 'https://example.com/source-relay.mp4'],
+              ],
+              'Test video',
+              createdAt: 1757385263,
+            )
+            ..sources.addAll([
+              'wss://relay.staging.dvines.org',
+              'wss://relay.divine.video',
+            ]);
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.sourceRelay, 'wss://relay.staging.dvines.org');
+    });
+
+    test('keeps explicit relay hint over received relay source', () {
+      final nostrEvent = Event(
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        34236,
+        [
+          ['r', 'wss://relay.hint.example'],
+          ['url', 'https://example.com/source-relay.mp4'],
+        ],
+        'Test video',
+        createdAt: 1757385263,
+      )..sources.add('wss://relay.staging.dvines.org');
+
+      final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+      expect(videoEvent.sourceRelay, 'wss://relay.hint.example');
+    });
+
     test('should handle both d tag and vine_id tag for Vine ID', () {
       // Test with 'd' tag
       final eventWithDTag = Event(

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -747,6 +747,88 @@ void main() {
       ).called(1);
     });
 
+    test('publishes report to the source relay when provided', () async {
+      const sourceRelay = 'wss://relay.staging.dvines.org';
+      final reportEvent = Event(
+        testPublicKey,
+        EventKind.report,
+        [],
+        'test',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+      reportEvent.id = 'test_id';
+      reportEvent.sig = 'test_sig';
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => reportEvent);
+
+      when(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
+
+      await service.reportContent(
+        eventId: _validEventId('5'),
+        authorPubkey: 'author_source_relay',
+        reason: ContentFilterReason.other,
+        details: 'source relay routing test',
+        sourceRelay: '  $sourceRelay  ',
+      );
+
+      verify(
+        () => mockNostrService.publishEvent(any(), targetRelays: [sourceRelay]),
+      ).called(1);
+    });
+
+    test('falls back to configured relay for invalid source relay', () async {
+      final reportEvent = Event(
+        testPublicKey,
+        EventKind.report,
+        [],
+        'test',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+      reportEvent.id = 'test_id';
+      reportEvent.sig = 'test_sig';
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => reportEvent);
+
+      when(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
+
+      await service.reportContent(
+        eventId: _validEventId('6'),
+        authorPubkey: 'author_invalid_relay',
+        reason: ContentFilterReason.other,
+        details: 'invalid relay routing test',
+        sourceRelay: 'https://relay.staging.dvines.org',
+      );
+
+      verify(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: ['wss://relay.divine.video'],
+        ),
+      ).called(1);
+    });
+
     test('places NIP-56 report type as 3rd element of e and p tags', () async {
       List<List<String>>? capturedTags;
 

--- a/mobile/test/services/content_reporting_service_test.dart
+++ b/mobile/test/services/content_reporting_service_test.dart
@@ -747,8 +747,54 @@ void main() {
       ).called(1);
     });
 
-    test('publishes report to the source relay when provided', () async {
-      const sourceRelay = 'wss://relay.staging.dvines.org';
+    test(
+      'publishes report to moderation and source relays when provided',
+      () async {
+        const sourceRelay = 'wss://relay.staging.dvines.org';
+        final reportEvent = Event(
+          testPublicKey,
+          EventKind.report,
+          [],
+          'test',
+          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+        );
+        reportEvent.id = 'test_id';
+        reportEvent.sig = 'test_sig';
+
+        when(
+          () => mockAuthService.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((_) async => reportEvent);
+
+        when(
+          () => mockNostrService.publishEvent(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
+
+        await service.reportContent(
+          eventId: _validEventId('5'),
+          authorPubkey: 'author_source_relay',
+          reason: ContentFilterReason.other,
+          details: 'source relay routing test',
+          sourceRelay: '  $sourceRelay  ',
+        );
+
+        verify(
+          () => mockNostrService.publishEvent(
+            any(),
+            targetRelays: ['wss://relay.divine.video', sourceRelay],
+          ),
+        ).called(1);
+      },
+    );
+
+    test('dedupes source relay when it matches configured relay', () async {
+      const sourceRelay = 'wss://relay.divine.video';
       final reportEvent = Event(
         testPublicKey,
         EventKind.report,
@@ -775,15 +821,61 @@ void main() {
       ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
 
       await service.reportContent(
-        eventId: _validEventId('5'),
+        eventId: _validEventId('6'),
         authorPubkey: 'author_source_relay',
         reason: ContentFilterReason.other,
-        details: 'source relay routing test',
-        sourceRelay: '  $sourceRelay  ',
+        details: 'source relay dedupe test',
+        sourceRelay: sourceRelay,
       );
 
       verify(
-        () => mockNostrService.publishEvent(any(), targetRelays: [sourceRelay]),
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: ['wss://relay.divine.video'],
+        ),
+      ).called(1);
+    });
+
+    test('author supplied relay cannot remove moderation relay', () async {
+      const unmonitoredRelay = 'wss://unmonitored.relay.example';
+      final reportEvent = Event(
+        testPublicKey,
+        EventKind.report,
+        [],
+        'test',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+      reportEvent.id = 'test_id';
+      reportEvent.sig = 'test_sig';
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => reportEvent);
+
+      when(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
+
+      await service.reportContent(
+        eventId: _validEventId('7'),
+        authorPubkey: 'author_relay_hint',
+        reason: ContentFilterReason.other,
+        details: 'author relay hint routing test',
+        sourceRelay: unmonitoredRelay,
+      );
+
+      verify(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: ['wss://relay.divine.video', unmonitoredRelay],
+        ),
       ).called(1);
     });
 
@@ -819,6 +911,48 @@ void main() {
         reason: ContentFilterReason.other,
         details: 'invalid relay routing test',
         sourceRelay: 'https://relay.staging.dvines.org',
+      );
+
+      verify(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: ['wss://relay.divine.video'],
+        ),
+      ).called(1);
+    });
+
+    test('falls back to configured relay for plaintext source relay', () async {
+      final reportEvent = Event(
+        testPublicKey,
+        EventKind.report,
+        [],
+        'test',
+        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      );
+      reportEvent.id = 'test_id';
+      reportEvent.sig = 'test_sig';
+
+      when(
+        () => mockAuthService.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => reportEvent);
+
+      when(
+        () => mockNostrService.publishEvent(
+          any(),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => PublishSuccess(event: reportEvent));
+
+      await service.reportContent(
+        eventId: _validEventId('8'),
+        authorPubkey: 'author_plaintext_relay',
+        reason: ContentFilterReason.other,
+        details: 'plaintext relay routing test',
+        sourceRelay: 'ws://relay.staging.dvines.org',
       );
 
       verify(

--- a/mobile/test/unit/services/video_event_service_force_refresh_test.dart
+++ b/mobile/test/unit/services/video_event_service_force_refresh_test.dart
@@ -14,8 +14,6 @@ import 'package:openvine/services/video_event_service.dart';
 // Mock classes
 class MockNostrService extends Mock implements NostrClient {}
 
-class MockEvent extends Mock implements Event {}
-
 class TestSubscriptionManager extends Mock implements SubscriptionManager {
   TestSubscriptionManager(this.eventStreamController);
   final StreamController<Event> eventStreamController;
@@ -43,6 +41,29 @@ class TestSubscriptionManager extends Mock implements SubscriptionManager {
 
 // Fake classes for setUpAll
 class FakeFilter extends Fake implements Filter {}
+
+Event createVideoEvent({
+  required String id,
+  required String pubkey,
+  required String content,
+  required String videoUrl,
+}) {
+  final event = Event(
+    pubkey,
+    34236,
+    [
+      ['url', videoUrl],
+      ['m', 'video/mp4'],
+    ],
+    content,
+    createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+  );
+  event.id = id;
+  event.sig =
+      'sig_aaaabbbbccccddddeeeeffff1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff11112222333344445555666677778888';
+  event.sources.add('wss://relay.divine.video');
+  return event;
+}
 
 void main() {
   setUpAll(() {
@@ -90,44 +111,20 @@ void main() {
 
     test('force refresh should preserve existing videos, not clear them', () async {
       // Create mock video events with unique IDs
-      final event1 = MockEvent();
-      when(() => event1.id).thenReturn(
-        'video1_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
-      );
-      when(() => event1.kind).thenReturn(34236);
-      when(() => event1.pubkey).thenReturn(
-        'author1_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
-      );
-      when(() => event1.content).thenReturn('First video');
-      when(
-        () => event1.createdAt,
-      ).thenReturn(DateTime.now().millisecondsSinceEpoch ~/ 1000);
-      when(() => event1.tags).thenReturn([
-        ['url', 'https://example.com/video1.mp4'],
-        ['m', 'video/mp4'],
-      ]);
-      when(() => event1.sig).thenReturn(
-        'sig1_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnooooppppqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzz00001111222233334444',
+      final event1 = createVideoEvent(
+        id: 'video1_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
+        pubkey:
+            '1111111111111111111111111111111111111111111111111111111111111111',
+        content: 'First video',
+        videoUrl: 'https://example.com/video1.mp4',
       );
 
-      final event2 = MockEvent();
-      when(() => event2.id).thenReturn(
-        'video2_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
-      );
-      when(() => event2.kind).thenReturn(34236);
-      when(() => event2.pubkey).thenReturn(
-        'author2_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
-      );
-      when(() => event2.content).thenReturn('Second video');
-      when(
-        () => event2.createdAt,
-      ).thenReturn(DateTime.now().millisecondsSinceEpoch ~/ 1000);
-      when(() => event2.tags).thenReturn([
-        ['url', 'https://example.com/video2.mp4'],
-        ['m', 'video/mp4'],
-      ]);
-      when(() => event2.sig).thenReturn(
-        'sig2_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnooooppppqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzz00001111222233334444',
+      final event2 = createVideoEvent(
+        id: 'video2_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
+        pubkey:
+            '2222222222222222222222222222222222222222222222222222222222222222',
+        content: 'Second video',
+        videoUrl: 'https://example.com/video2.mp4',
       );
 
       // Step 1: Initial subscription
@@ -196,24 +193,12 @@ void main() {
 
     test('force refresh should not duplicate existing videos', () async {
       // Create mock video event
-      final event1 = MockEvent();
-      when(() => event1.id).thenReturn(
-        'video1_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
-      );
-      when(() => event1.kind).thenReturn(34236);
-      when(() => event1.pubkey).thenReturn(
-        'author1_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
-      );
-      when(() => event1.content).thenReturn('Video content');
-      when(
-        () => event1.createdAt,
-      ).thenReturn(DateTime.now().millisecondsSinceEpoch ~/ 1000);
-      when(() => event1.tags).thenReturn([
-        ['url', 'https://example.com/video1.mp4'],
-        ['m', 'video/mp4'],
-      ]);
-      when(() => event1.sig).thenReturn(
-        'sig1_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnooooppppqqqqrrrrssssttttuuuuvvvvwwwwxxxxyyyyzzzz00001111222233334444',
+      final event1 = createVideoEvent(
+        id: 'video1_aaaabbbbccccddddeeeeffffgggghhhhiiiijjjjkkkkllllmmmmnnnnoooopppp',
+        pubkey:
+            '1111111111111111111111111111111111111111111111111111111111111111',
+        content: 'Video content',
+        videoUrl: 'https://example.com/video1.mp4',
       );
 
       // Step 1: Initial subscription

--- a/mobile/test/unit/services/video_event_service_reset_resubscribe_test.dart
+++ b/mobile/test/unit/services/video_event_service_reset_resubscribe_test.dart
@@ -16,8 +16,6 @@ import 'package:openvine/services/video_filter_builder.dart';
 // Mock classes
 class MockNostrService extends Mock implements NostrClient {}
 
-class MockEvent extends Mock implements Event {}
-
 class TestSubscriptionManager extends Mock implements SubscriptionManager {
   TestSubscriptionManager(this.eventStreamController);
   final StreamController<Event> eventStreamController;
@@ -44,6 +42,29 @@ class TestSubscriptionManager extends Mock implements SubscriptionManager {
 
 // Fake classes for setUpAll
 class FakeFilter extends Fake implements Filter {}
+
+Event createVideoEvent({
+  required String id,
+  required String pubkey,
+  required String content,
+  required String videoUrl,
+}) {
+  final event = Event(
+    pubkey,
+    34236,
+    [
+      ['url', videoUrl],
+      ['m', 'video/mp4'],
+    ],
+    content,
+    createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+  );
+  event.id = id;
+  event.sig =
+      'sig_1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff1111222233334444555566667777888899990000aaaabbbbcccc';
+  event.sources.add('wss://relay.divine.video');
+  return event;
+}
 
 void main() {
   setUpAll(() {
@@ -101,24 +122,12 @@ void main() {
       await Future<void>.delayed(const Duration(milliseconds: 50));
 
       // Add a mock video event to the stream
-      final event = MockEvent();
-      when(() => event.id).thenReturn(
-        'aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666777788889999aaaa',
-      );
-      when(() => event.kind).thenReturn(34236);
-      when(() => event.pubkey).thenReturn(
-        'pub11111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff',
-      );
-      when(() => event.content).thenReturn('Test video');
-      when(
-        () => event.createdAt,
-      ).thenReturn(DateTime.now().millisecondsSinceEpoch ~/ 1000);
-      when(() => event.tags).thenReturn([
-        ['url', 'https://example.com/video.mp4'],
-        ['m', 'video/mp4'],
-      ]);
-      when(() => event.sig).thenReturn(
-        'sig11111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff',
+      final event = createVideoEvent(
+        id: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666777788889999aaaa',
+        pubkey:
+            '3333333333333333333333333333333333333333333333333333333333333333',
+        content: 'Test video',
+        videoUrl: 'https://example.com/video.mp4',
       );
 
       eventStreamController.add(event);

--- a/mobile/test/widgets/report_content_dialog_test.dart
+++ b/mobile/test/widgets/report_content_dialog_test.dart
@@ -71,6 +71,7 @@ void main() {
         authorPubkey: any(named: 'authorPubkey'),
         reason: any(named: 'reason'),
         details: any(named: 'details'),
+        sourceRelay: any(named: 'sourceRelay'),
         additionalContext: any(named: 'additionalContext'),
         hashtags: any(named: 'hashtags'),
       ),
@@ -380,6 +381,35 @@ void main() {
           authorPubkey: any(named: 'authorPubkey'),
           reason: any(named: 'reason'),
           details: any(named: 'details'),
+          sourceRelay: any(named: 'sourceRelay'),
+          additionalContext: any(named: 'additionalContext'),
+          hashtags: any(named: 'hashtags'),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('video report forwards the source relay to reportContent', (
+      tester,
+    ) async {
+      const sourceRelay = 'wss://relay.staging.dvines.org';
+      testVideo = testVideo.copyWith(sourceRelay: sourceRelay);
+
+      await setLargeSurface(tester);
+      await openReportDialog(tester);
+
+      await tester.tap(find.text(l10n.reportReasonSpam));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(DivineButton, l10n.reportSubmit));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockReportingService.reportContent(
+          eventId: any(named: 'eventId'),
+          authorPubkey: any(named: 'authorPubkey'),
+          reason: any(named: 'reason'),
+          details: any(named: 'details'),
+          sourceRelay: sourceRelay,
           additionalContext: any(named: 'additionalContext'),
           hashtags: any(named: 'hashtags'),
         ),
@@ -413,6 +443,7 @@ void main() {
             authorPubkey: any(named: 'authorPubkey'),
             reason: any(named: 'reason'),
             details: any(named: 'details'),
+            sourceRelay: any(named: 'sourceRelay'),
             additionalContext: any(named: 'additionalContext'),
             hashtags: any(named: 'hashtags'),
           ),
@@ -448,6 +479,7 @@ void main() {
           authorPubkey: any(named: 'authorPubkey'),
           reason: any(named: 'reason'),
           details: any(named: 'details'),
+          sourceRelay: any(named: 'sourceRelay'),
           additionalContext: any(named: 'additionalContext'),
           hashtags: any(named: 'hashtags'),
         ),
@@ -473,6 +505,7 @@ void main() {
           authorPubkey: any(named: 'authorPubkey'),
           reason: any(named: 'reason'),
           details: any(named: 'details'),
+          sourceRelay: any(named: 'sourceRelay'),
           additionalContext: any(named: 'additionalContext'),
           hashtags: any(named: 'hashtags'),
         ),
@@ -500,6 +533,7 @@ void main() {
             authorPubkey: any(named: 'authorPubkey'),
             reason: any(named: 'reason'),
             details: any(named: 'details'),
+            sourceRelay: any(named: 'sourceRelay'),
             additionalContext: any(named: 'additionalContext'),
             hashtags: any(named: 'hashtags'),
           ),
@@ -560,6 +594,7 @@ void main() {
           authorPubkey: any(named: 'authorPubkey'),
           reason: ContentFilterReason.other,
           details: 'Custom report details',
+          sourceRelay: any(named: 'sourceRelay'),
           additionalContext: any(named: 'additionalContext'),
           hashtags: any(named: 'hashtags'),
         ),
@@ -1213,6 +1248,7 @@ void main() {
             authorPubkey: any(named: 'authorPubkey'),
             reason: any(named: 'reason'),
             details: any(named: 'details'),
+            sourceRelay: any(named: 'sourceRelay'),
             additionalContext: any(named: 'additionalContext'),
             hashtags: any(named: 'hashtags'),
           ),


### PR DESCRIPTION
## Summary

Closes #4019.

Routes video content reports to the relay where the reported video was received, instead of always sending the Kind 1984 report to the environment default relay.

## Root cause

The Nostr SDK records receive-source relay URLs on Event.sources, but VideoEvent.fromNostrEvent only populated sourceRelay from explicit r-tag relay hints. ReportContentDialog and the share-menu AI report path also dropped VideoEvent.sourceRelay before calling ContentReportingService.reportContent, so reports for content from a non-default relay could land somewhere the content does not exist.

## Changes

- Preserve SDK Event.sources on VideoEvent.sourceRelay when no explicit r-tag relay hint is present.
- Thread video.sourceRelay through the report dialog and share-menu AI report flow.
- Let ContentReportingService.reportContent target a valid source relay when supplied, with a safe fallback to the configured environment relay.
- Add regression tests for model relay-source parsing, source-relay publish routing, invalid-relay fallback, and dialog relay forwarding.

## Validation

- mise exec -- flutter analyze
- mise exec -- flutter test packages/models/test/src/video_event_parsing_test.dart test/services/content_reporting_service_test.dart test/widgets/report_content_dialog_test.dart
- git push pre-push hook: analyzer and changed-file tests passed
