### PR TITLE
fix(content-warnings): allow clearing video labels

### DIFF
--- a/mobile/lib/widgets/video_metadata/video_metadata_content_warning_selector.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_content_warning_selector.dart
@@ -122,9 +122,7 @@ class _ContentWarningMultiSelectState
           trailingAction: DivineIconButton(
             icon: .check,
             size: .small,
-            onPressed: _selected.isNotEmpty
-                ? () => context.pop(_selected)
-                : null,
+            onPressed: () => context.pop(_selected),
           ),
         ),
         const Divider(
@@ -205,9 +203,7 @@ class _ContentLabelTile extends StatelessWidget {
                   style: VineTheme.titleMediumFont(color: VineTheme.onSurface),
                 ),
               ),
-              DivineSpriteCheckbox(
-                state: isChecked ? .selected : .unselected,
-              ),
+              DivineSpriteCheckbox(state: isChecked ? .selected : .unselected),
             ],
           ),
         ),

--- a/mobile/test/widgets/video_metadata/video_metadata_content_warning_selector_test.dart
+++ b/mobile/test/widgets/video_metadata/video_metadata_content_warning_selector_test.dart
@@ -55,10 +55,7 @@ void main() {
     testWidgets('renders $VideoMetadataContentWarningSelector', (tester) async {
       await tester.pumpWidget(buildWidget());
 
-      expect(
-        find.byType(VideoMetadataContentWarningSelector),
-        findsOneWidget,
-      );
+      expect(find.byType(VideoMetadataContentWarningSelector), findsOneWidget);
     });
 
     testWidgets('renders $VideoMetadataSelectionTile', (tester) async {
@@ -140,9 +137,7 @@ void main() {
       expect(find.text(l10n.videoMetadataContentWarnings), findsOneWidget);
     });
 
-    testWidgets('bottom sheet shows all ContentLabel options', (
-      tester,
-    ) async {
+    testWidgets('bottom sheet shows all ContentLabel options', (tester) async {
       addTearDown(() => tester.view.resetPhysicalSize());
       tester.view.physicalSize = const Size(1080, 2400);
       tester.view.devicePixelRatio = 1;
@@ -179,7 +174,12 @@ void main() {
       await tester.pumpAndSettle();
 
       // Tap "Nudity" in the list.
-      await tester.tap(find.text('Nudity'));
+      await tester.tap(
+        find.descendant(
+          of: find.byType(BottomSheet),
+          matching: find.text('Nudity'),
+        ),
+      );
       await tester.pumpAndSettle();
 
       // Tap the check (confirm) icon button.
@@ -194,14 +194,55 @@ void main() {
       await tester.pumpAndSettle();
 
       // The bottom sheet pops via go_router with the selected labels.
+      verify(() => mockGoRouter.pop<Set<ContentLabel>>(any())).called(1);
+    });
+
+    testWidgets('can clear all selected content warnings', (tester) async {
+      addTearDown(() => tester.view.resetPhysicalSize());
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 1;
+
+      final state = VideoEditorProviderState(
+        contentWarnings: {ContentLabel.nudity},
+      );
+      await tester.pumpWidget(buildWidget(state: state));
+
+      await tester.tap(
+        find.bySemanticsLabel(
+          l10n.videoMetadataSelectContentWarningsSemanticLabel,
+        ),
+        warnIfMissed: false,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(
+        find.descendant(
+          of: find.byType(BottomSheet),
+          matching: find.text('Nudity'),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final confirmButton = find.descendant(
+        of: find.byType(BottomSheet),
+        matching: find.byWidgetPredicate(
+          (w) => w is DivineIconButton && w.icon == DivineIconName.check,
+        ),
+      );
+      expect(
+        tester.widget<DivineIconButton>(confirmButton).onPressed,
+        isNotNull,
+      );
+
+      await tester.tap(confirmButton);
+      await tester.pumpAndSettle();
+
       verify(
-        () => mockGoRouter.pop<Set<ContentLabel>>(any()),
+        () => mockGoRouter.pop<Set<ContentLabel>>(<ContentLabel>{}),
       ).called(1);
     });
 
-    testWidgets('tapping an option toggles its checkbox state', (
-      tester,
-    ) async {
+    testWidgets('tapping an option toggles its checkbox state', (tester) async {
       addTearDown(() => tester.view.resetPhysicalSize());
       tester.view.physicalSize = const Size(1080, 2400);
       tester.view.devicePixelRatio = 1;


### PR DESCRIPTION
## Summary
- allow the video content-warning selector to confirm an empty label set
- add a regression widget test for deselecting the last selected warning and submitting the empty set

## Root Cause
The bottom-sheet confirm action was disabled whenever the local selection became empty. Lower layers already support empty content warnings and omit warning tags when the set is empty, so the validation belonged nowhere in the UI.

## Issue
Refs #5062.

This fixes the confirmed clear-all failure from #5062. I am intentionally not using an auto-close keyword for #5062 because the issue also reports warned videos disappearing from feeds/profile/search, and that half still requires the authenticated moderation-state check requested in the issue before a safe filtering change can be made.

## Verification
- flutter test test/widgets/video_metadata/video_metadata_content_warning_selector_test.dart
- flutter analyze
- pre-push hook: changed-file analyzer and widget test
