### PR TITLE
fix(proofmode): enrich home feed proof tags

### DIFF
--- a/mobile/docs/2026-03-06-martin-follow-up-investigation.md
+++ b/mobile/docs/2026-03-06-martin-follow-up-investigation.md
@@ -58,8 +58,8 @@ Relevant code paths:
 
 Current badge logic:
 
-- `proofModeVerificationLevel` reads `rawTags['verification']`.
-- `hasProofMode` is true only when proof-related tags exist on the `VideoEvent`.
+- `proofModeVerificationLevel` reads `rawTags['verification']`, falling back to the compact backend proof summary when present.
+- `hasProofMode` is true when proof-related raw tags or a usable compact proof summary exist on the `VideoEvent`.
 - `shouldShowNotDivineBadge` is true when the video is not hosted on a Divine domain, has no proof tags, and is not classified as an original vine.
 
 Why Charlie can fall through to `Not Divine`:
@@ -71,8 +71,8 @@ Why Charlie can fall through to `Not Divine`:
 Most likely failure mode:
 
 - The post is being rendered from a REST video object that was not fully enriched with its Nostr tags.
-- `lib/utils/video_nostr_enrichment.dart` only attempts enrichment for videos where `rawTags.length < 4`.
-- If Charlie's REST object has a small set of non-proof tags but still misses `verification`, `proofmode`, or original-vine metrics, the UI can still misclassify it.
+- `lib/utils/video_nostr_enrichment.dart` now attempts enrichment for sparse compact rows and semi-compact rows that have ordinary media tags but no proof-critical raw tags or compact proof summary.
+- If Funnelcake returns neither raw proof tags nor the compact proof summary and relay enrichment cannot fetch the full event, the UI can still misclassify it.
 - If the relay query times out or returns no event, the original sparse REST object is also left in place.
 
 Important scope note:
@@ -84,5 +84,5 @@ Recommended follow-up:
 
 1. Capture the affected Charlie video as both REST JSON and raw Nostr event JSON.
 2. Compare `rawTags`, `verification`, `proofmode`, and original-vine metrics before and after enrichment.
-3. Decide whether enrichment eligibility should be broader than `rawTags.length < 4`, or whether badge-critical tags need a stronger merge path.
-4. Add temporary badge logging for the affected event ID so the next bug report includes the exact classification inputs.
+3. Confirm Funnelcake returns a compact `proof` summary on all feed/list/search rows so mobile can render badges without relay fallback.
+4. Add temporary badge logging for the affected event ID only if another report lacks the exact classification inputs.

--- a/mobile/lib/blocs/profile_feed/profile_feed_scope.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_scope.dart
@@ -43,6 +43,7 @@ class ProfileFeedScope extends ConsumerWidget {
     final videosRepository = ref.watch(videosRepositoryProvider);
     final videoEventService = ref.watch(videoEventServiceProvider);
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+    final enrichmentAttemptTracker = NostrTagEnrichmentAttemptTracker();
 
     return BlocProvider<ProfileFeedCubit>(
       key: ValueKey((
@@ -62,6 +63,7 @@ class ProfileFeedScope extends ConsumerWidget {
           videos,
           nostrService: ref.read(nostrServiceProvider),
           callerName: 'ProfileFeedCubit',
+          attemptTracker: enrichmentAttemptTracker,
         ),
       ),
       child: BlocListener<ProfileFeedCubit, ProfileFeedState>(

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -14,6 +14,7 @@ import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
 import 'package:openvine/blocs/video_feed/home_feed_resume_manager.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -137,6 +138,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   ) => !emit.isDone && state.source == source;
 
   bool _shouldEnrichSource(VideoFeedSource source) =>
+      // Subscribed-list rows are loaded from locally held event IDs and are
+      // already resolved as full events rather than compact server feed rows.
       source.type != VideoFeedSourceType.subscribedList;
 
   /// Handle feed started event.
@@ -892,7 +895,12 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
             );
           })
           .catchError((Object error, StackTrace stackTrace) {
-            if (!isClosed) addError(error, stackTrace);
+            if (!isClosed) {
+              addError(
+                Reportable(error, context: '_scheduleNostrEnrichment'),
+                stackTrace,
+              );
+            }
           }),
     );
   }

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -26,6 +26,13 @@ part 'video_feed_state.dart';
 /// Default interval between auto-refreshes of the home feed.
 const _defaultAutoRefreshMinInterval = Duration(minutes: 10);
 
+/// Enriches REST-sourced videos with their full Nostr tag set.
+///
+/// Injected so [VideoFeedBloc] stays decoupled from relay clients while still
+/// letting home feeds repair compact REST rows that omit ProofMode/C2PA tags.
+typedef EnrichVideos =
+    Future<List<VideoEvent>> Function(List<VideoEvent> videos);
+
 /// BLoC for managing the unified video feed.
 ///
 /// Handles:
@@ -46,6 +53,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     Duration autoRefreshMinInterval = _defaultAutoRefreshMinInterval,
     FeedPerformanceTracker? feedTracker,
     HomeFeedCache? homeFeedCache,
+    EnrichVideos? enrichVideos,
   }) : _videosRepository = videosRepository,
        _followRepository = followRepository,
        _curatedListRepository = curatedListRepository,
@@ -56,6 +64,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
        _serveCachedHomeFeed = serveCachedHomeFeed,
        _autoRefreshMinInterval = autoRefreshMinInterval,
        _feedTracker = feedTracker,
+       _enrichVideos = enrichVideos,
        _resumeManager = HomeFeedResumeManager(
          cache: homeFeedCache ?? const HomeFeedCache(),
          videosRepository: videosRepository,
@@ -80,6 +89,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     on<VideoFeedCuratedListsChanged>(_onCuratedListsChanged);
     on<VideoFeedBlocklistChanged>(_onBlocklistChanged);
     on<VideoFeedActiveIndexChanged>(_onActiveIndexChanged);
+    on<VideoFeedEnrichmentReady>(_onEnrichmentReady);
   }
 
   final VideosRepository _videosRepository;
@@ -92,6 +102,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   final bool _serveCachedHomeFeed;
   final Duration _autoRefreshMinInterval;
   final FeedPerformanceTracker? _feedTracker;
+  final EnrichVideos? _enrichVideos;
 
   /// Owns the cross-restart cache serve / splice / resume-persist logic.
   final HomeFeedResumeManager _resumeManager;
@@ -124,6 +135,9 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     VideoFeedSource source,
     Emitter<VideoFeedBlocState> emit,
   ) => !emit.isDone && state.source == source;
+
+  bool _shouldEnrichSource(VideoFeedSource source) =>
+      source.type != VideoFeedSourceType.subscribedList;
 
   /// Handle feed started event.
   ///
@@ -396,6 +410,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           clearPaginationCursor: result.paginationCursor == null,
         ),
       );
+
+      _scheduleNostrEnrichment(source: source, videos: updatedVideos);
 
       // Batch-fetch profiles for new creators only.
       await _fetchCreatorProfiles(validNewVideos, source, emit);
@@ -670,6 +686,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         ),
       );
 
+      _scheduleNostrEnrichment(source: source, videos: displayedVideos);
+
       _feedTracker?.markFeedDisplayed(source.mode.name, displayedVideos.length);
 
       // Batch-fetch creator profiles to warm the Drift cache.
@@ -846,6 +864,79 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           .getNewVideos(until: until, skipCache: skipCache)
           .then((videos) => HomeFeedResult(videos: videos)),
   };
+
+  void _scheduleNostrEnrichment({
+    required VideoFeedSource source,
+    required List<VideoEvent> videos,
+  }) {
+    final enrichVideos = _enrichVideos;
+    if (enrichVideos == null ||
+        videos.isEmpty ||
+        !_shouldEnrichSource(source)) {
+      return;
+    }
+
+    final snapshot = List<VideoEvent>.unmodifiable(videos);
+    final sourceIds = {for (final video in snapshot) video.id.toLowerCase()};
+
+    unawaited(
+      enrichVideos(snapshot)
+          .then((enrichedVideos) {
+            if (isClosed || identical(enrichedVideos, snapshot)) return;
+            add(
+              VideoFeedEnrichmentReady(
+                source: source,
+                enrichedVideos: enrichedVideos,
+                sourceIds: sourceIds,
+              ),
+            );
+          })
+          .catchError((Object error, StackTrace stackTrace) {
+            if (!isClosed) addError(error, stackTrace);
+          }),
+    );
+  }
+
+  void _onEnrichmentReady(
+    VideoFeedEnrichmentReady event,
+    Emitter<VideoFeedBlocState> emit,
+  ) {
+    if (state.source != event.source || state.videos.isEmpty) return;
+
+    final enrichedById = {
+      for (final video in event.enrichedVideos) video.id.toLowerCase(): video,
+    };
+
+    var changed = false;
+    final mergedVideos = state.videos.map((video) {
+      final key = video.id.toLowerCase();
+      if (!event.sourceIds.contains(key)) return video;
+
+      final enriched = enrichedById[key];
+      if (enriched == null || identical(enriched, video)) return video;
+
+      changed = true;
+      return enriched;
+    }).toList();
+
+    if (!changed) return;
+
+    emit(
+      state.copyWith(
+        videos: mergedVideos,
+        enrichmentRevision: state.enrichmentRevision + 1,
+      ),
+    );
+
+    if (_usesHomeFeedCache(state.source)) {
+      _resumeManager.persistNow(
+        pubkey: _userPubkey,
+        mode: state.source.mode.name,
+        videos: mergedVideos,
+        activeIndex: state.currentIndex,
+      );
+    }
+  }
 
   /// Batch-fetch creator profiles for the given videos.
   ///

--- a/mobile/lib/blocs/video_feed/video_feed_event.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_event.dart
@@ -136,6 +136,27 @@ final class VideoFeedActiveIndexChanged extends VideoFeedEvent {
   List<Object?> get props => [index];
 }
 
+/// Full Nostr tags arrived for REST-sourced feed videos.
+final class VideoFeedEnrichmentReady extends VideoFeedEvent {
+  const VideoFeedEnrichmentReady({
+    required this.source,
+    required this.enrichedVideos,
+    required this.sourceIds,
+  });
+
+  /// Feed source that requested enrichment.
+  final VideoFeedSource source;
+
+  /// Enriched videos returned by the injected enrichment function.
+  final List<VideoEvent> enrichedVideos;
+
+  /// IDs present in the source snapshot that was enriched.
+  final Set<String> sourceIds;
+
+  @override
+  List<Object?> get props => [source, enrichedVideos, sourceIds];
+}
+
 /// A user was blocked or the blocklist changed.
 ///
 /// When [blockedPubkey] is provided, the handler removes that user's videos

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -145,6 +145,7 @@ final class VideoFeedBlocState extends Equatable {
     this.creatorProfiles = const {},
     this.paginationCursor,
     this.currentIndex = 0,
+    this.enrichmentRevision = 0,
   }) : source =
            source ??
            (mode == FeedMode.following
@@ -203,6 +204,13 @@ final class VideoFeedBlocState extends Equatable {
   /// profile lookups are instant hits.
   final Map<String, UserProfile> creatorProfiles;
 
+  /// Monotonic revision bumped when background Nostr enrichment replaces
+  /// videos with the same IDs but richer tag data.
+  ///
+  /// [VideoEvent] equality is ID-based, so without a separate revision the
+  /// BLoC can suppress an otherwise valid state emission.
+  final int enrichmentRevision;
+
   /// Whether data has been successfully loaded.
   bool get isLoaded => status == VideoFeedStatus.success;
 
@@ -239,6 +247,7 @@ final class VideoFeedBlocState extends Equatable {
     String? paginationCursor,
     bool clearPaginationCursor = false,
     int? currentIndex,
+    int? enrichmentRevision,
   }) {
     return VideoFeedBlocState(
       status: status ?? this.status,
@@ -257,6 +266,7 @@ final class VideoFeedBlocState extends Equatable {
           ? null
           : (paginationCursor ?? this.paginationCursor),
       currentIndex: currentIndex ?? this.currentIndex,
+      enrichmentRevision: enrichmentRevision ?? this.enrichmentRevision,
     );
   }
 
@@ -274,5 +284,6 @@ final class VideoFeedBlocState extends Equatable {
     creatorProfiles,
     paginationCursor,
     currentIndex,
+    enrichmentRevision,
   ];
 }

--- a/mobile/lib/providers/new_videos_feed_provider.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.dart
@@ -23,6 +23,7 @@ part 'new_videos_feed_provider.g.dart';
 @Riverpod(keepAlive: true)
 class NewVideosFeed extends _$NewVideosFeed {
   int? _nextCursor;
+  final _enrichmentAttemptTracker = NostrTagEnrichmentAttemptTracker();
 
   @override
   Future<VideoFeedState> build() async {
@@ -219,6 +220,7 @@ class NewVideosFeed extends _$NewVideosFeed {
       videos,
       nostrService: ref.read(nostrServiceProvider),
       callerName: 'NewVideosFeedProvider',
+      attemptTracker: _enrichmentAttemptTracker,
       onEnriched: (enrichedVideos) {
         if (!ref.mounted || !state.hasValue) return;
 

--- a/mobile/lib/providers/new_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/new_videos_feed_provider.g.dart
@@ -45,7 +45,7 @@ final class NewVideosFeedProvider
   NewVideosFeed create() => NewVideosFeed();
 }
 
-String _$newVideosFeedHash() => r'f8f6d8069e144d5f67e1d7cd8557c8b388389d16';
+String _$newVideosFeedHash() => r'faa810e056887ad2f420147a187bc4e82bbdf861';
 
 /// New Videos feed provider - shows newest videos first.
 ///

--- a/mobile/lib/providers/popular_now_feed_provider.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.dart
@@ -33,6 +33,7 @@ part 'popular_now_feed_provider.g.dart';
 @Riverpod(keepAlive: true) // Keep alive to prevent state loss on tab switches
 class PopularNowFeed extends _$PopularNowFeed {
   VideoFeedBuilder? _builder;
+  final _enrichmentAttemptTracker = NostrTagEnrichmentAttemptTracker();
 
   /// REST API pagination cursor (oldest video timestamp). Non-null implies
   /// REST is the active source; null means we are in Nostr-fallback mode.
@@ -532,6 +533,7 @@ class PopularNowFeed extends _$PopularNowFeed {
       videos,
       nostrService: ref.read(nostrServiceProvider),
       callerName: 'PopularNowFeedProvider',
+      attemptTracker: _enrichmentAttemptTracker,
       onEnriched: (enrichedVideos) {
         if (!ref.mounted || !state.hasValue) return;
         // Skip if we've left REST mode while enrichment was running.

--- a/mobile/lib/providers/popular_now_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_now_feed_provider.g.dart
@@ -63,7 +63,7 @@ final class PopularNowFeedProvider
   PopularNowFeed create() => PopularNowFeed();
 }
 
-String _$popularNowFeedHash() => r'b9f9fe96c39df3f3266034a298707412c7770741';
+String _$popularNowFeedHash() => r'97f9c9dd20e6f6dd3fd2741b6f496149fe77cb61';
 
 /// PopularNow feed provider - shows newest videos (sorted by creation time)
 ///

--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -38,6 +38,7 @@ final popularVideosVariantProvider = StateProvider<PopularVideosVariant>(
 @Riverpod(keepAlive: true)
 class PopularVideosFeed extends _$PopularVideosFeed {
   String? _nextCursor;
+  final _enrichmentAttemptTracker = NostrTagEnrichmentAttemptTracker();
 
   @override
   Future<VideoFeedState> build() async {
@@ -284,6 +285,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
       videos,
       nostrService: ref.read(nostrServiceProvider),
       callerName: 'PopularVideosFeedProvider',
+      attemptTracker: _enrichmentAttemptTracker,
       onEnriched: (enrichedVideos) {
         if (!ref.mounted || !state.hasValue) return;
 

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -60,7 +60,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'96b3d6aa20361070cfdea3395665d8d56a55e61a';
+String _$popularVideosFeedHash() => r'21c0da7f654380965c6ecfd0ed0ff378bc54ad84';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -10,6 +10,7 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -21,6 +22,7 @@ import 'package:openvine/screens/feed/feed_mode_switch.dart';
 import 'package:openvine/services/startup_performance_service.dart';
 import 'package:openvine/services/view_event_publisher.dart'
     show ViewTrafficSource;
+import 'package:openvine/utils/video_nostr_enrichment.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/nav_rounded_shell.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
@@ -83,6 +85,11 @@ class VideoFeedPage extends ConsumerWidget {
             // on read and the splice-on-refresh keeps the post-active tail
             // fresh, so the cached serve is never stale to the viewer.
             feedTracker: FeedPerformanceTracker(),
+            enrichVideos: (videos) => enrichVideosWithNostrTags(
+              videos,
+              nostrService: ref.read(nostrServiceProvider),
+              callerName: 'VideoFeedBloc',
+            ),
           )..add(VideoFeedStarted(mode: initialMode)),
         ),
         BlocProvider(create: (_) => VideoPlaybackStatusCubit()),

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -67,6 +67,7 @@ class VideoFeedPage extends ConsumerWidget {
         .showDivineHostedOnly;
 
     final blocklistRepository = ref.watch(contentBlocklistRepositoryProvider);
+    final enrichmentAttemptTracker = NostrTagEnrichmentAttemptTracker();
 
     return MultiBlocProvider(
       key: ValueKey('video-feed-$showDivineHostedOnly-$contentFilterVersion'),
@@ -89,6 +90,7 @@ class VideoFeedPage extends ConsumerWidget {
               videos,
               nostrService: ref.read(nostrServiceProvider),
               callerName: 'VideoFeedBloc',
+              attemptTracker: enrichmentAttemptTracker,
             ),
           )..add(VideoFeedStarted(mode: initialMode)),
         ),

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -6,6 +6,43 @@ import 'package:nostr_sdk/nostr_sdk.dart' show Filter;
 import 'package:unified_logger/unified_logger.dart';
 import 'package:videos_repository/videos_repository.dart';
 
+const _proofCriticalRawTagKeys = <String>{
+  'verification',
+  'proofmode',
+  'device_attestation',
+  'c2pa_manifest_id',
+  'identity_binding',
+  'identity_verifier',
+  'identity_portable',
+};
+
+/// Returns whether a REST-sourced video should be fetched from Nostr for the
+/// full event tag set.
+///
+/// Funnelcake has returned both very compact rows with fewer than four tags
+/// and semi-compact rows with ordinary media tags (`d`, `url`, `title`,
+/// thumbnail) but no proof-critical tags. The old raw tag count check missed
+/// the latter, which can hide Human-Made / ProofMode badges until the backend
+/// includes compact proof summaries on all feed rows.
+bool needsNostrTagEnrichment(VideoEvent video) {
+  if (video.rawTags.length < 4) return true;
+  if (video.proofSummary != null) return false;
+  if (video.hasProofMode || video.hasBasicProof) return false;
+
+  final rawTagKeys = video.rawTags.keys.toSet();
+  if (rawTagKeys.intersection(_proofCriticalRawTagKeys).isNotEmpty) {
+    return false;
+  }
+
+  final hasCoreMediaTags =
+      rawTagKeys.contains('d') &&
+      rawTagKeys.contains('title') &&
+      (rawTagKeys.contains('url') ||
+          rawTagKeys.contains('thumb') ||
+          rawTagKeys.contains('thumbnail'));
+  return hasCoreMediaTags;
+}
+
 /// Enrich REST API videos with full Nostr event data.
 ///
 /// REST API responses may be missing fields that are present in the raw
@@ -25,12 +62,8 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
 }) async {
   if (videos.isEmpty) return videos;
 
-  // Collect IDs of videos that need enrichment.
-  // It's possible that stat's are already added like 'views', 'loops', 'id'
-  // which is the reason we check for < 4 tags to identify
-  // videos missing the full tag set.
   final idsToEnrich = videos
-      .where((v) => v.rawTags.length < 4)
+      .where(needsNostrTagEnrichment)
       .map((v) => v.id)
       .toList();
 

--- a/mobile/lib/utils/video_nostr_enrichment.dart
+++ b/mobile/lib/utils/video_nostr_enrichment.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show Filter;
@@ -15,6 +16,66 @@ const _proofCriticalRawTagKeys = <String>{
   'identity_verifier',
   'identity_portable',
 };
+
+/// Bounded, time-based throttle for REST rows that still need relay
+/// enrichment after a previous lookup missed.
+///
+/// Misses are retried after [retryDelay] rather than suppressed forever, so a
+/// transient relay miss/timeout can still recover on a later feed pass.
+class NostrTagEnrichmentAttemptTracker {
+  NostrTagEnrichmentAttemptTracker({
+    this.retryDelay = const Duration(minutes: 5),
+    this.maxEntries = 500,
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  final Duration retryDelay;
+  final int maxEntries;
+  final DateTime Function() _now;
+  final _nextAttemptAtById = <String, DateTime>{};
+
+  bool shouldAttempt(String id) {
+    final retryAt = _nextAttemptAtById[id.toLowerCase()];
+    return retryAt == null || !_now().isBefore(retryAt);
+  }
+
+  void recordAttemptResults({
+    required Iterable<String> attemptedIds,
+    required Iterable<String> enrichedIds,
+  }) {
+    final now = _now();
+    final enriched = {for (final id in enrichedIds) id.toLowerCase()};
+
+    for (final id in enriched) {
+      _nextAttemptAtById.remove(id);
+    }
+
+    for (final id in attemptedIds) {
+      final key = id.toLowerCase();
+      if (!enriched.contains(key)) {
+        _nextAttemptAtById[key] = now.add(retryDelay);
+      }
+    }
+
+    _prune(now);
+  }
+
+  @visibleForTesting
+  bool isThrottling(String id) =>
+      _nextAttemptAtById.containsKey(id.toLowerCase());
+
+  void _prune(DateTime now) {
+    _nextAttemptAtById.removeWhere((_, retryAt) => !now.isBefore(retryAt));
+    if (_nextAttemptAtById.length <= maxEntries) return;
+
+    final entries = _nextAttemptAtById.entries.toList()
+      ..sort((a, b) => a.value.compareTo(b.value));
+    final overflow = _nextAttemptAtById.length - maxEntries;
+    for (final entry in entries.take(overflow)) {
+      _nextAttemptAtById.remove(entry.key);
+    }
+  }
+}
 
 /// Returns whether a REST-sourced video should be fetched from Nostr for the
 /// full event tag set.
@@ -59,11 +120,13 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
   List<VideoEvent> videos, {
   required NostrClient nostrService,
   String callerName = 'VideoEnrichment',
+  NostrTagEnrichmentAttemptTracker? attemptTracker,
 }) async {
   if (videos.isEmpty) return videos;
 
   final idsToEnrich = videos
       .where(needsNostrTagEnrichment)
+      .where((v) => attemptTracker?.shouldAttempt(v.id) ?? true)
       .map((v) => v.id)
       .toList();
 
@@ -80,7 +143,13 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
         .queryEvents([filter])
         .timeout(const Duration(seconds: 5));
 
-    if (nostrEvents.isEmpty) return videos;
+    if (nostrEvents.isEmpty) {
+      attemptTracker?.recordAttemptResults(
+        attemptedIds: idsToEnrich,
+        enrichedIds: const [],
+      );
+      return videos;
+    }
 
     // Build a lookup map: event ID -> parsed VideoEvent for enrichment
     final nostrEventsMap = <String, VideoEvent>{};
@@ -101,7 +170,18 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
       }
     }
 
-    if (nostrEventsMap.isEmpty) return videos;
+    if (nostrEventsMap.isEmpty) {
+      attemptTracker?.recordAttemptResults(
+        attemptedIds: idsToEnrich,
+        enrichedIds: const [],
+      );
+      return videos;
+    }
+
+    attemptTracker?.recordAttemptResults(
+      attemptedIds: idsToEnrich,
+      enrichedIds: nostrEventsMap.keys,
+    );
 
     // Merge Nostr-parsed fields into REST API videos
     return videos.map((video) {
@@ -181,6 +261,10 @@ Future<List<VideoEvent>> enrichVideosWithNostrTags(
       return video;
     }).toList();
   } catch (e) {
+    attemptTracker?.recordAttemptResults(
+      attemptedIds: idsToEnrich,
+      enrichedIds: const [],
+    );
     // Non-fatal: return original videos if enrichment fails
     Log.warning(
       '$callerName: Failed to enrich with Nostr tags: $e',
@@ -205,12 +289,14 @@ List<VideoEvent> enrichVideosInBackground(
   required NostrClient nostrService,
   required void Function(List<VideoEvent> enrichedVideos) onEnriched,
   String callerName = 'VideoEnrichment',
+  NostrTagEnrichmentAttemptTracker? attemptTracker,
 }) {
   unawaited(
     enrichVideosWithNostrTags(
       videos,
       nostrService: nostrService,
       callerName: callerName,
+      attemptTracker: attemptTracker,
     ).then((enriched) {
       // Only call back if enrichment actually changed something
       if (enriched != videos) {

--- a/mobile/lib/widgets/video_metadata/video_metadata_user_chip.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_user_chip.dart
@@ -104,6 +104,7 @@ class VideoMetadataUserChip extends ConsumerWidget {
                   removeLabel ?? context.l10n.videoMetadataRemoveSemanticLabel,
               button: true,
               child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
                 onTap: onRemove,
                 child: SizedBox(
                   width: 16,

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -15,6 +15,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -335,6 +336,61 @@ void main() {
                 (s) => s.videos.single.rawTags['verification'],
                 'verification tag',
                 'verified_mobile',
+              ),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'reports unexpected background enrichment failures as Reportable',
+        setUp: () {
+          final authors = ['author1'];
+          final compactVideo = createTestVideo('video-1').copyWith(
+            rawTags: const {
+              'd': 'video-1',
+              'url': 'https://example.com/video-1.mp4',
+              'title': 'REST row',
+              'thumb': 'https://example.com/video-1.jpg',
+            },
+          );
+
+          when(() => mockFollowRepository.followingPubkeys).thenReturn(authors);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: authors,
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: [compactVideo]));
+        },
+        build: () => VideoFeedBloc(
+          videosRepository: mockVideosRepository,
+          followRepository: mockFollowRepository,
+          curatedListRepository: mockCuratedListRepository,
+          enrichVideos: (_) async => throw StateError('enrichment broke'),
+        ),
+        act: (bloc) =>
+            bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.videos.length, 'videos count', 1),
+        ],
+        errors: () => [
+          isA<Reportable<Object>>()
+              .having(
+                (error) => error.context,
+                'context',
+                '_scheduleNostrEnrichment',
+              )
+              .having(
+                (error) => error.unwrap(),
+                'inner error',
+                isA<StateError>(),
               ),
         ],
       );

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -274,6 +274,72 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'applies background Nostr enrichment to following feed videos',
+        setUp: () {
+          final authors = ['author1'];
+          final compactVideo = createTestVideo('video-1').copyWith(
+            rawTags: const {
+              'd': 'video-1',
+              'url': 'https://example.com/video-1.mp4',
+              'title': 'REST row',
+              'thumb': 'https://example.com/video-1.jpg',
+            },
+          );
+
+          when(() => mockFollowRepository.followingPubkeys).thenReturn(authors);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: authors,
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: [compactVideo]));
+        },
+        build: () => VideoFeedBloc(
+          videosRepository: mockVideosRepository,
+          followRepository: mockFollowRepository,
+          curatedListRepository: mockCuratedListRepository,
+          enrichVideos: (videos) async => [
+            videos.single.copyWith(
+              rawTags: {
+                ...videos.single.rawTags,
+                'verification': 'verified_mobile',
+                'proofmode': '{}',
+              },
+            ),
+          ],
+        ),
+        act: (bloc) =>
+            bloc.add(const VideoFeedStarted(mode: FeedMode.following)),
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          const VideoFeedBlocState(mode: FeedMode.following),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having(
+                (s) => s.videos.single.hasProofMode,
+                'proof before',
+                isFalse,
+              ),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having(
+                (s) => s.videos.single.hasProofMode,
+                'proof after',
+                isTrue,
+              )
+              .having(
+                (s) => s.videos.single.rawTags['verification'],
+                'verification tag',
+                'verified_mobile',
+              ),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'maps legacy latest start mode to New Videos',
         setUp: () {
           final videos = createTestVideos(5);
@@ -1077,9 +1143,9 @@ void main() {
           final followingResult = Completer<HomeFeedResult>();
           final newVideosResult = Completer<List<VideoEvent>>();
 
-          when(() => mockFollowRepository.followingPubkeys).thenReturn([
-            'pubkey',
-          ]);
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn(['pubkey']);
           when(
             () => mockVideosRepository.getHomeFeedVideos(
               authors: any(named: 'authors'),
@@ -1285,14 +1351,10 @@ void main() {
           final bloc = createBloc();
           addTearDown(bloc.close);
 
-          bloc.add(
-            const VideoFeedSourceChanged(VideoFeedSource.following()),
-          );
+          bloc.add(const VideoFeedSourceChanged(VideoFeedSource.following()));
           await pumpEventQueue();
 
-          bloc.add(
-            const VideoFeedSourceChanged(VideoFeedSource.newVideos()),
-          );
+          bloc.add(const VideoFeedSourceChanged(VideoFeedSource.newVideos()));
           await pumpEventQueue();
 
           newVideosResult.complete(newVideos);

--- a/mobile/test/utils/video_nostr_enrichment_streaming_test.dart
+++ b/mobile/test/utils/video_nostr_enrichment_streaming_test.dart
@@ -33,6 +33,68 @@ void main() {
     registerFallbackValue(<Filter>[]);
   });
 
+  group('needsNostrTagEnrichment', () {
+    test('selects compact REST rows with sparse raw tags', () {
+      final video = _createTestVideo(
+        id: 'v1',
+        rawTags: {'views': '10', 'loops': '5'},
+      );
+
+      expect(needsNostrTagEnrichment(video), isTrue);
+    });
+
+    test('selects semi-compact REST rows missing proof-critical tags', () {
+      final video = _createTestVideo(
+        id: 'v1',
+        rawTags: {
+          'd': 'v1',
+          'url': 'https://example.com/v1.mp4',
+          'title': 'Semi compact',
+          'thumb': 'https://example.com/v1.jpg',
+        },
+      );
+
+      expect(needsNostrTagEnrichment(video), isTrue);
+    });
+
+    test('skips rows that already have compact proof summary', () {
+      final video =
+          _createTestVideo(
+            id: 'v1',
+            rawTags: {
+              'd': 'v1',
+              'url': 'https://example.com/v1.mp4',
+              'title': 'Already summarized',
+              'thumb': 'https://example.com/v1.jpg',
+            },
+          ).copyWith(
+            proofSummary: const ProofVerificationSummary(
+              status: 'present',
+              level: 'basic_proof',
+              version: 1,
+              checks: {'proofmode_present': true},
+            ),
+          );
+
+      expect(needsNostrTagEnrichment(video), isFalse);
+    });
+
+    test('skips rows that already have proof-critical raw tags', () {
+      final video = _createTestVideo(
+        id: 'v1',
+        rawTags: {
+          'd': 'v1',
+          'url': 'https://example.com/v1.mp4',
+          'title': 'Already proof tagged',
+          'thumb': 'https://example.com/v1.jpg',
+          'proofmode': '{}',
+        },
+      );
+
+      expect(needsNostrTagEnrichment(video), isFalse);
+    });
+  });
+
   group('enrichVideosInBackground', () {
     late _MockNostrClient mockNostrService;
 
@@ -156,34 +218,37 @@ void main() {
       expect(onEnrichedCalled, isFalse);
     });
 
-    test('does not call onEnriched when no enrichment needed', () async {
-      final videos = [
-        _createTestVideo(
-          id: 'v1',
-          rawTags: {
-            'url': 'https://example.com/v1.mp4',
-            'title': 'Already enriched',
-            'd': 'v1',
-            'proof': 'c2pa-hash',
+    test(
+      'does not call onEnriched when proof tags are already present',
+      () async {
+        final videos = [
+          _createTestVideo(
+            id: 'v1',
+            rawTags: {
+              'url': 'https://example.com/v1.mp4',
+              'title': 'Already enriched',
+              'd': 'v1',
+              'c2pa_manifest_id': 'c2pa-hash',
+            },
+          ),
+        ];
+
+        // queryEvents should not be called since badge-critical tags are present.
+        final result = enrichVideosInBackground(
+          videos,
+          nostrService: mockNostrService,
+          onEnriched: (_) {
+            fail('onEnriched should not be called');
           },
-        ),
-      ];
+        );
 
-      // queryEvents should not be called since rawTags.length >= 4
-      final result = enrichVideosInBackground(
-        videos,
-        nostrService: mockNostrService,
-        onEnriched: (_) {
-          fail('onEnriched should not be called');
-        },
-      );
+        expect(result, same(videos));
 
-      expect(result, same(videos));
+        // Wait to ensure no callback
+        await Future<void>.delayed(const Duration(milliseconds: 100));
 
-      // Wait to ensure no callback
-      await Future<void>.delayed(const Duration(milliseconds: 100));
-
-      verifyNever(() => mockNostrService.queryEvents(any()));
-    });
+        verifyNever(() => mockNostrService.queryEvents(any()));
+      },
+    );
   });
 }

--- a/mobile/test/utils/video_nostr_enrichment_streaming_test.dart
+++ b/mobile/test/utils/video_nostr_enrichment_streaming_test.dart
@@ -193,6 +193,46 @@ void main() {
       expect(enriched.first.contentWarningLabels, equals(['nudity']));
     });
 
+    test('throttles unresolved rows until the retry delay expires', () async {
+      var now = DateTime(2026);
+      final tracker = NostrTagEnrichmentAttemptTracker(
+        now: () => now,
+      );
+      final videos = [_createTestVideo(id: 'v1')];
+
+      when(
+        () => mockNostrService.queryEvents(any()),
+      ).thenAnswer((_) async => []);
+
+      await enrichVideosWithNostrTags(
+        videos,
+        nostrService: mockNostrService,
+        attemptTracker: tracker,
+      );
+
+      verify(() => mockNostrService.queryEvents(any())).called(1);
+      expect(tracker.isThrottling('v1'), isTrue);
+      clearInteractions(mockNostrService);
+
+      await enrichVideosWithNostrTags(
+        videos,
+        nostrService: mockNostrService,
+        attemptTracker: tracker,
+      );
+
+      verifyNever(() => mockNostrService.queryEvents(any()));
+
+      now = now.add(const Duration(minutes: 5));
+
+      await enrichVideosWithNostrTags(
+        videos,
+        nostrService: mockNostrService,
+        attemptTracker: tracker,
+      );
+
+      verify(() => mockNostrService.queryEvents(any())).called(1);
+    });
+
     test('enrichment failure does not affect initial return', () async {
       final videos = [_createTestVideo(id: 'v1')];
 


### PR DESCRIPTION
## Summary

- broaden REST/Nostr enrichment eligibility from the old raw-tag-count heuristic to an explicit proof-aware predicate
- wire home feed BLoC enrichment through an injected function so `VideoFeedBloc` stays decoupled from `NostrClient`
- apply enriched same-ID videos reliably by tracking an enrichment revision in feed state
- throttle unresolved relay-enrichment misses with a shared bounded retry tracker so sparse rows are not re-queried on every feed/page pass
- update the stale March investigation note to point at the backend proof-summary contract

## Root Cause

REST feed rows can arrive without raw ProofMode/C2PA tags and without the compact `proof` summary that mobile already parses. Existing non-home feeds had background Nostr enrichment, but the home feed BLoC did not, and the shared enrichment helper skipped semi-compact rows that already had four ordinary tags.

## Blast Radius

The proof-aware predicate is shared by home, popular, new, popular-now, and profile feed enrichment. That intentionally broadens relay fallback eligibility for semi-compact REST rows across those feeds, not only home. The load remains bounded to the existing batched `queryEvents` flow per scheduled enrichment pass; this PR does not add per-row relay queries. Rows that remain unresolved after a relay lookup are now throttled for a bounded retry window instead of being re-queried on every subsequent load or pagination merge.

## Validation

- `flutter test test/utils/video_nostr_enrichment_streaming_test.dart test/blocs/video_feed/video_feed_bloc_test.dart test/screens/feed/video_feed_page_test.dart`
- `flutter test test/blocs/profile_feed/profile_feed_cubit_test.dart`
- `flutter analyze`
- pre-push hook: analyzer and changed-file tests, including `test/screens/feed/video_feed_page_test.dart`

## Related

Closes #3915
Depends on the backend contract tracked in divinevideo/divine-funnelcake#567 for complete feed-row coverage without relay fallback.
