### PR TITLE
fix(lists): initialize people-list storage before watchers

### DIFF
--- a/mobile/lib/features/app/startup/startup_coordinator.dart
+++ b/mobile/lib/features/app/startup/startup_coordinator.dart
@@ -42,6 +42,12 @@ class StartupCoordinator {
   /// Check if a phase is complete
   bool isPhaseComplete(StartupPhase phase) => _completedPhases[phase] ?? false;
 
+  /// Returns a registered service for startup-registration tests.
+  @visibleForTesting
+  ServiceRegistration? serviceRegistrationForTesting(String name) {
+    return _services[name];
+  }
+
   /// Register a service for initialization
   void registerService({
     required String name,

--- a/mobile/lib/features/app/startup/startup_coordinator.dart
+++ b/mobile/lib/features/app/startup/startup_coordinator.dart
@@ -206,8 +206,10 @@ class StartupCoordinator {
       for (final serviceName in remaining) {
         final service = _services[serviceName]!;
 
-        // Check if all dependencies are processed
-        if (service.dependencies.every(processed.contains)) {
+        // Dependencies may have completed in an earlier startup phase.
+        if (service.dependencies.every(
+          (dependency) => _isDependencySatisfied(dependency, processed),
+        )) {
           currentLevel.add(serviceName);
         }
       }
@@ -225,6 +227,14 @@ class StartupCoordinator {
     }
 
     return levels;
+  }
+
+  bool _isDependencySatisfied(
+    String dependency,
+    Set<String> processedInCurrentPhase,
+  ) {
+    return processedInCurrentPhase.contains(dependency) ||
+        (_completedServices[dependency] ?? false);
   }
 
   /// Mark a phase as complete

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -724,7 +724,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
 
   coordinator.registerService(
     name: 'HiveStorage',
-    phase: StartupPhase.standard,
+    phase: StartupPhase.critical,
     initialize: () async {
       await _runTimedStartupTask(
         phaseName: 'hive_storage',
@@ -733,7 +733,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
       );
     },
   );
-  // Critical: home feed reads this cache on first build (cold-start race).
+  // Critical: first-frame BLoCs can subscribe to disk-backed caches.
   coordinator.registerService(
     name: 'CacheSync',
     phase: StartupPhase.critical,
@@ -925,6 +925,13 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
   }
 
   return coordinator;
+}
+
+@visibleForTesting
+StartupCoordinator createStartupCoordinatorForTesting(
+  ProviderContainer container,
+) {
+  return _createStartupCoordinator(container);
 }
 
 Future<void> _startOpenVineApp() async {

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -733,7 +733,8 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
       );
     },
   );
-  // Critical: first-frame BLoCs can subscribe to disk-backed caches.
+  // Critical phase (best-effort): first-frame BLoCs can subscribe to
+  // disk-backed caches.
   coordinator.registerService(
     name: 'CacheSync',
     phase: StartupPhase.critical,

--- a/mobile/packages/people_lists_repository/lib/src/local_people_lists_cache.dart
+++ b/mobile/packages/people_lists_repository/lib/src/local_people_lists_cache.dart
@@ -33,15 +33,29 @@ const String _logName = 'people_lists_repository.local_cache';
 class LocalPeopleListsCache {
   /// Creates a cache that lazily opens the backing Hive box via [openBox].
   ///
-  /// The opener is invoked at most once per cache instance; subsequent calls
-  /// reuse the cached [Box].
+  /// The opener is invoked once successfully per cache instance; subsequent
+  /// calls reuse the cached [Box]. Failed opens are not cached so callers can
+  /// retry after storage becomes available.
   LocalPeopleListsCache({required Future<Box<dynamic>> Function() openBox})
     : _openBox = openBox;
 
   final Future<Box<dynamic>> Function() _openBox;
   Future<Box<dynamic>>? _boxFuture;
 
-  Future<Box<dynamic>> _box() => _boxFuture ??= _openBox();
+  Future<Box<dynamic>> _box() {
+    final cached = _boxFuture;
+    if (cached != null) return cached;
+
+    final opening = _openBox();
+    _boxFuture = opening;
+
+    return opening.onError<Object>((error, stackTrace) {
+      if (identical(_boxFuture, opening)) {
+        _boxFuture = null;
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    });
+  }
 
   /// Returns all non-tombstoned lists owned by [ownerPubkey], sorted by
   /// `updatedAt` descending.

--- a/mobile/packages/people_lists_repository/lib/src/local_people_lists_cache.dart
+++ b/mobile/packages/people_lists_repository/lib/src/local_people_lists_cache.dart
@@ -65,16 +65,23 @@ class LocalPeopleListsCache {
     StreamSubscription<BoxEvent>? subscription;
 
     Future<void> start() async {
-      final box = await _box();
-      if (controller.isClosed) return;
-      controller.add(_collectLists(box, ownerPubkey));
-      subscription = box.watch().listen((event) {
-        final key = event.key;
-        if (key is! String || !_keyBelongsToOwner(key, ownerPubkey)) {
-          return;
-        }
+      try {
+        final box = await _box();
+        if (controller.isClosed) return;
         controller.add(_collectLists(box, ownerPubkey));
-      });
+        subscription = box.watch().listen((event) {
+          final key = event.key;
+          if (key is! String || !_keyBelongsToOwner(key, ownerPubkey)) {
+            return;
+          }
+          controller.add(_collectLists(box, ownerPubkey));
+        });
+      } on Object catch (error, stackTrace) {
+        if (!controller.isClosed) {
+          controller.addError(error, stackTrace);
+          await controller.close();
+        }
+      }
     }
 
     controller = StreamController<List<UserList>>(

--- a/mobile/packages/people_lists_repository/test/local_people_lists_cache_test.dart
+++ b/mobile/packages/people_lists_repository/test/local_people_lists_cache_test.dart
@@ -266,6 +266,31 @@ void main() {
         );
       });
 
+      test('retries box opener after a failed open', () async {
+        final error = StateError('Hive storage is not initialized');
+        final boxName = 'people_lists_test_retry_${boxCounter++}';
+        var attempts = 0;
+        final cache = LocalPeopleListsCache(
+          openBox: () async {
+            attempts += 1;
+            if (attempts == 1) {
+              throw error;
+            }
+            return Hive.openBox<dynamic>(boxName, path: tempDir.path);
+          },
+        );
+
+        await expectLater(
+          cache.watchLists(ownerPubkey: _ownerA),
+          emitsInOrder([emitsError(same(error)), emitsDone]),
+        );
+
+        final lists = await cache.readLists(ownerPubkey: _ownerA);
+
+        expect(lists, isEmpty);
+        expect(attempts, 2);
+      });
+
       test('emits current lists immediately, then on updates', () async {
         final cache = LocalPeopleListsCache(openBox: makeOpener());
 

--- a/mobile/packages/people_lists_repository/test/local_people_lists_cache_test.dart
+++ b/mobile/packages/people_lists_repository/test/local_people_lists_cache_test.dart
@@ -256,6 +256,16 @@ void main() {
     });
 
     group('watchLists', () {
+      test('forwards box opener failures as stream errors', () async {
+        final error = StateError('Hive storage is not initialized');
+        final cache = LocalPeopleListsCache(openBox: () async => throw error);
+
+        await expectLater(
+          cache.watchLists(ownerPubkey: _ownerA),
+          emitsInOrder([emitsError(same(error)), emitsDone]),
+        );
+      });
+
       test('emits current lists immediately, then on updates', () async {
         final cache = LocalPeopleListsCache(openBox: makeOpener());
 

--- a/mobile/test/features/app/startup/startup_coordinator_test.dart
+++ b/mobile/test/features/app/startup/startup_coordinator_test.dart
@@ -222,6 +222,43 @@ void main() {
       },
     );
 
+    test('should resolve dependencies completed in earlier phases', () async {
+      coordinator.registerService(
+        name: 'HiveStorage',
+        phase: StartupPhase.critical,
+        initialize: createServiceInitializer('HiveStorage'),
+      );
+
+      coordinator.registerService(
+        name: 'UploadManager',
+        phase: StartupPhase.standard,
+        initialize: createServiceInitializer('UploadManager'),
+        dependencies: ['HiveStorage'],
+      );
+
+      final criticalFuture = coordinator.initializeThrough(
+        StartupPhase.critical,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(initializationLog, contains('HiveStorage:start'));
+      expect(initializationLog, isNot(contains('UploadManager:start')));
+
+      serviceCompleters['HiveStorage']!.complete();
+      await criticalFuture;
+
+      final remainingFuture = coordinator.initializeRemaining();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(initializationLog, contains('UploadManager:start'));
+
+      serviceCompleters['UploadManager']!.complete();
+      await remainingFuture;
+
+      expect(coordinator.isPhaseComplete(StartupPhase.critical), isTrue);
+      expect(coordinator.isPhaseComplete(StartupPhase.standard), isTrue);
+    });
+
     test(
       'should reject service registration after initialization starts',
       () async {

--- a/mobile/test/startup/main_startup_registration_test.dart
+++ b/mobile/test/startup/main_startup_registration_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/features/app/startup/startup_phase.dart';
+import 'package:openvine/main.dart' as app;
+
+void main() {
+  test('initializes disk-backed startup services before runApp', () {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    final coordinator = app.createStartupCoordinatorForTesting(container);
+
+    expect(
+      coordinator.serviceRegistrationForTesting('HiveStorage')?.phase,
+      StartupPhase.critical,
+    );
+    expect(
+      coordinator.serviceRegistrationForTesting('CacheSync')?.phase,
+      StartupPhase.critical,
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the startup race where the global people-lists watcher can reach the Hive-backed people-lists cache before Hive storage is initialized.

## Root cause

`HiveStorage` was registered in the `standard` startup phase, but `runApp` only waits for `critical` services. When `FeatureFlag.curatedLists` is enabled, the app shell can create `PeopleListsBloc` during first build, dispatch `PeopleListsStarted`, and subscribe to `PeopleListsRepository.watchLists`. That path lazily opens `people_lists_v1` before `Hive.initFlutter()` has necessarily completed.

`LocalPeopleListsCache.watchLists` also documented opener failures as stream errors, but its unawaited startup task did not catch `_box()` failures, allowing unhandled async errors.

## Changes

- Move `HiveStorage` to `StartupPhase.critical` so Hive initialization completes before first-frame BLoCs can subscribe to disk-backed caches.
- Keep `CacheSync` in the same critical pre-`runApp` bucket and update the startup comment to cover first-frame disk-backed cache subscribers.
- Harden `LocalPeopleListsCache.watchLists` so box opener failures are emitted as stream errors and the watcher closes cleanly.
- Add regression coverage for people-list watcher opener failures.
- Add startup-registration coverage proving `HiveStorage` and `CacheSync` are critical services.

## Validation

- `flutter test test/local_people_lists_cache_test.dart test/people_lists_repository_impl_test.dart` from `mobile/packages/people_lists_repository`
- `flutter test test/startup/main_startup_registration_test.dart test/features/people_lists/bloc/people_lists_bloc_test.dart` from `mobile`
- `flutter test test/blocs/my_following/my_following_bloc_test.dart test/startup/app_first_frame_startup_test.dart` from `mobile`
- `flutter test test/cache_sync_watch_one_test.dart` from `mobile/packages/cache_sync`
- `flutter analyze` from `mobile`
- Pre-push hook: analyzer plus changed-file tests passed

Closes #4394
