### PR TITLE
fix(notifications): bound inbox load + isolate revalidation bar repaint

### DIFF
--- a/mobile/lib/notifications/view/notifications_view.dart
+++ b/mobile/lib/notifications/view/notifications_view.dart
@@ -396,24 +396,31 @@ class _RevalidationBar extends StatelessWidget {
         ? Duration.zero
         : _transitionDuration;
 
-    return ExcludeSemantics(
-      child: AnimatedSwitcher(
-        duration: duration,
-        transitionBuilder: (child, animation) => SizeTransition(
-          sizeFactor: animation,
-          child: FadeTransition(opacity: animation, child: child),
+    // RepaintBoundary isolates the indeterminate progress animation's
+    // per-frame repaint from the cached list it overlays. Without it the
+    // bar's continuous `markNeedsPaint` propagates up to the enclosing
+    // Stack and re-runs the list pane's paint every frame for the entire
+    // refresh — the open-jank reported after stale-while-revalidate landed.
+    return RepaintBoundary(
+      child: ExcludeSemantics(
+        child: AnimatedSwitcher(
+          duration: duration,
+          transitionBuilder: (child, animation) => SizeTransition(
+            sizeFactor: animation,
+            child: FadeTransition(opacity: animation, child: child),
+          ),
+          child: visible
+              ? const SizedBox(
+                  key: ValueKey('revalidation-bar'),
+                  height: _height,
+                  child: LinearProgressIndicator(
+                    minHeight: _height,
+                    color: VineTheme.vineGreen,
+                    backgroundColor: VineTheme.transparent,
+                  ),
+                )
+              : const SizedBox(key: ValueKey('revalidation-bar-hidden')),
         ),
-        child: visible
-            ? const SizedBox(
-                key: ValueKey('revalidation-bar'),
-                height: _height,
-                child: LinearProgressIndicator(
-                  minHeight: _height,
-                  color: VineTheme.vineGreen,
-                  backgroundColor: VineTheme.transparent,
-                ),
-              )
-            : const SizedBox(key: ValueKey('revalidation-bar-hidden')),
       ),
     );
   }

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -318,6 +318,7 @@ class NotificationRepository {
         : <String, String>{};
     return _funnelcakeApiClient.getNotifications(
       pubkey: _userPubkey,
+      limit: _pageSize,
       cursor: cursor,
       cursorId: cursorId,
       requestUri: Uri.parse(requestUrl),

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -195,8 +195,11 @@ class NotificationRepository {
   /// render would then paint and project that entire accumulation before the
   /// first-page refresh trims it — janking the open in proportion to how far
   /// the previous session scrolled. Trimming to [_pageSize] here keeps the
-  /// newest page (so the derived unread badge is unaffected) and lets
-  /// [refresh] replace it with authoritative first-page data on reopen.
+  /// newest page and lets [refresh] replace it with authoritative first-page
+  /// data on reopen. The unread badge, derived from the snapshot, then
+  /// reflects only the newest page's unread rows — the same bound the next
+  /// `refresh()` would impose anyway, so this only brings that bound forward
+  /// to feed-close instead of next-open.
   void resetPaginationDepth() {
     final current = _snapshot.value;
     if (current.items.length > _pageSize) {

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -63,8 +63,16 @@ abstract class _NotificationRetryConfig {
   static const maxBackoff = Duration(milliseconds: 1500);
 }
 
-/// Number of cached rows hydrated from the DAO on cold start.
-const _hydrationLimit = 50;
+/// Number of notifications loaded per page.
+///
+/// Bounds both the cold-start cache hydration and the first-page REST
+/// fetch. Kept deliberately small: each first-page notification can fan
+/// out to a `getVideoStats` lookup (see `_fetchVideoMetadata`), so a large
+/// page turns every inbox open into a burst of parallel requests that
+/// keeps the stale-while-revalidate progress bar up — and the list
+/// janking — for seconds. Older notifications load on demand via
+/// `loadNextPage` as the user scrolls.
+const _pageSize = 20;
 
 /// Repository for fetching, enriching, grouping, and managing
 /// notifications.
@@ -173,13 +181,29 @@ class NotificationRepository {
   /// this to `false`.
   bool get hasPaginatedBeyondFirstPage => _pagesLoaded > 1;
 
-  /// Releases the current page-depth guard after the feed UI is gone.
+  /// Releases the current page-depth guard after the feed UI is gone, and
+  /// collapses any deep-scrolled accumulation back to the first page.
   ///
   /// While the notifications screen is visible, app-resume refreshes skip
   /// over a paginated snapshot so they do not collapse the list under the
   /// user. Once the feed BLoC closes, no visible list can collapse; resetting
   /// the depth lets out-of-screen liveness refresh the badge again.
+  ///
+  /// The snapshot is long-lived (the repository outlives the feed BLoC), so a
+  /// session that scrolled through several pages would otherwise leave every
+  /// loaded item in the snapshot. The next open's stale-while-revalidate
+  /// render would then paint and project that entire accumulation before the
+  /// first-page refresh trims it — janking the open in proportion to how far
+  /// the previous session scrolled. Trimming to [_pageSize] here keeps the
+  /// newest page (so the derived unread badge is unaffected) and lets
+  /// [refresh] replace it with authoritative first-page data on reopen.
   void resetPaginationDepth() {
+    final current = _snapshot.value;
+    if (current.items.length > _pageSize) {
+      _snapshot.add(
+        current.copyWith(items: current.items.take(_pageSize).toList()),
+      );
+    }
     _pagesLoaded = _snapshot.value.items.isEmpty ? 0 : 1;
   }
 
@@ -281,6 +305,7 @@ class NotificationRepository {
     final requestUrl = _funnelcakeApiClient
         .notificationsUri(
           pubkey: _userPubkey,
+          limit: _pageSize,
           cursor: cursor,
           cursorId: cursorId,
         )
@@ -385,7 +410,7 @@ class NotificationRepository {
     try {
       if (_snapshot.value.items.isNotEmpty) return;
       final rows = await _notificationsDao.getAllNotifications(
-        limit: _hydrationLimit,
+        limit: _pageSize,
       );
       if (rows.isEmpty) return;
       if (_snapshot.value.items.isNotEmpty) return;

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -656,19 +656,20 @@ void main() {
 
           await repository.getNotifications();
 
-          requestedUri =
-              verify(
-                    () => funnelcakeApiClient.getNotifications(
-                      pubkey: userPubkey,
-                      cursor: any(named: 'cursor'),
-                      requestUri: captureAny(named: 'requestUri'),
-                      authHeaders: any(named: 'authHeaders'),
-                      limit: any(named: 'limit'),
-                    ),
-                  ).captured.single
-                  as Uri;
+          final captured = verify(
+            () => funnelcakeApiClient.getNotifications(
+              pubkey: userPubkey,
+              cursor: any(named: 'cursor'),
+              requestUri: captureAny(named: 'requestUri'),
+              authHeaders: any(named: 'authHeaders'),
+              limit: captureAny(named: 'limit'),
+            ),
+          ).captured;
+          requestedUri = captured.whereType<Uri>().single;
+          final requestedLimit = captured.whereType<int>().single;
 
           expect(requestedUri.toString(), equals(signedUrl));
+          expect(requestedLimit, equals(20));
         },
       );
 
@@ -695,19 +696,20 @@ void main() {
 
           await repository.getNotifications();
 
-          requestedUri =
-              verify(
-                    () => funnelcakeApiClient.getNotifications(
-                      pubkey: userPubkey,
-                      cursor: 'cursor_abc',
-                      requestUri: captureAny(named: 'requestUri'),
-                      authHeaders: any(named: 'authHeaders'),
-                      limit: any(named: 'limit'),
-                    ),
-                  ).captured.single
-                  as Uri;
+          final captured = verify(
+            () => funnelcakeApiClient.getNotifications(
+              pubkey: userPubkey,
+              cursor: 'cursor_abc',
+              requestUri: captureAny(named: 'requestUri'),
+              authHeaders: any(named: 'authHeaders'),
+              limit: captureAny(named: 'limit'),
+            ),
+          ).captured;
+          requestedUri = captured.whereType<Uri>().single;
+          final requestedLimit = captured.whereType<int>().single;
 
           expect(requestedUri.toString(), equals(signedUrl));
+          expect(requestedLimit, equals(20));
         },
       );
     });

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -2407,12 +2407,13 @@ void main() {
       });
 
       test(
-        'resetPaginationDepth collapses the snapshot to the first page',
+        'resetPaginationDepth collapses the snapshot to the newest page',
         () async {
           stubProfiles({});
           // A session that scrolled deep leaves more than a page of items in
-          // the long-lived snapshot. Build a 25-item first page so the trim
-          // back to the 20-item page size is observable.
+          // the long-lived snapshot. Build a 25-item first page with distinct,
+          // descending timestamps (n0 newest) so the newest-first order is
+          // deterministic and the trim back to the page size is observable.
           stubNotifications([
             for (var i = 0; i < 25; i++)
               makeNotification(
@@ -2420,20 +2421,20 @@ void main() {
                 sourcePubkey: 'pub_$i',
                 sourceEventId: 'evt$i',
                 referencedEventId: 'video_$i',
+                createdAt: DateTime(2025).subtract(Duration(minutes: i)),
               ),
           ], hasMore: true);
           await repository.getNotifications();
-          expect(
-            (await repository.watchSnapshot().first).items,
-            hasLength(25),
-          );
+          final before = (await repository.watchSnapshot().first).items;
+          expect(before, hasLength(25));
+          // Contract: trimming keeps the *newest* page — the first 20 rows of
+          // the newest-first snapshot, in order — not an arbitrary 20.
+          final expectedKeptIds = before.take(20).map((n) => n.id).toList();
 
           repository.resetPaginationDepth();
 
-          expect(
-            (await repository.watchSnapshot().first).items,
-            hasLength(20),
-          );
+          final after = (await repository.watchSnapshot().first).items;
+          expect(after.map((n) => n.id).toList(), equals(expectedKeptIds));
         },
       );
     });

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -241,7 +241,7 @@ void main() {
           '${signedUri.scheme}://${signedUri.host}${signedUri.path}',
           equals('https://api.example.com/api/users/$userPubkey/notifications'),
         );
-        expect(signedUri.queryParameters['limit'], equals('50'));
+        expect(signedUri.queryParameters['limit'], equals('20'));
         expect(signedUri.queryParameters['before'], isNotNull);
         expect(int.tryParse(signedUri.queryParameters['before']!), isNotNull);
         expect(signedMethod, equals('GET'));
@@ -271,7 +271,7 @@ void main() {
           signedUrl,
           equals(
             'https://api.example.com/api/users/$userPubkey/notifications'
-            '?limit=50&before=cursor_abc',
+            '?limit=20&before=cursor_abc',
           ),
         );
       });
@@ -307,7 +307,7 @@ void main() {
             signedUrl,
             equals(
               'https://api.example.com/api/users/$userPubkey/notifications'
-              '?limit=50&before=1700000000'
+              '?limit=20&before=1700000000'
               '&before_id=$stableCursorId',
             ),
           );
@@ -343,7 +343,7 @@ void main() {
           signedUrl,
           equals(
             'https://api.example.com/api/users/$userPubkey/notifications'
-            '?limit=50&before=manual_cursor',
+            '?limit=20&before=manual_cursor',
           ),
         );
       });
@@ -2405,6 +2405,37 @@ void main() {
 
         expect(repository.hasPaginatedBeyondFirstPage, isFalse);
       });
+
+      test(
+        'resetPaginationDepth collapses the snapshot to the first page',
+        () async {
+          stubProfiles({});
+          // A session that scrolled deep leaves more than a page of items in
+          // the long-lived snapshot. Build a 25-item first page so the trim
+          // back to the 20-item page size is observable.
+          stubNotifications([
+            for (var i = 0; i < 25; i++)
+              makeNotification(
+                id: 'n$i',
+                sourcePubkey: 'pub_$i',
+                sourceEventId: 'evt$i',
+                referencedEventId: 'video_$i',
+              ),
+          ], hasMore: true);
+          await repository.getNotifications();
+          expect(
+            (await repository.watchSnapshot().first).items,
+            hasLength(25),
+          );
+
+          repository.resetPaginationDepth();
+
+          expect(
+            (await repository.watchSnapshot().first).items,
+            hasLength(20),
+          );
+        },
+      );
     });
 
     group('markAsRead', () {


### PR DESCRIPTION
Closes #5381

## Description

Opening the notifications inbox felt **extremely laggy** for some users after the stale-while-revalidate change in #5307. Before #5307 the inbox showed a static spinner over a blank screen while loading; now it renders the cached list immediately and animates a continuous progress bar over it for the whole refresh. Three compounding costs surfaced, all bounded here.

### 1. First-page + cache hydration capped at 20 (was 50)

Each first-page notification can fan out to a `getVideoStats` lookup, so a 50-item page turned every open into up to ~50 parallel requests that keep the revalidation bar, and the list jank, up for seconds. Cut the shared page size (cold-start hydration + first REST page) to 20; older notifications load on demand via the existing scroll pagination.

The derived unread badge is still based on the bounded visible snapshot while funnelcake#234 is open. That means this PR intentionally lowers the cold-start/first-page badge ceiling from about 50 visible unread rows to about 20 until older rows are paginated in or the authoritative server count is restored.

### 2. Collapse the accumulated snapshot on feed close

The `NotificationRepository` snapshot is long-lived (the repo outlives the feed BLoC). Scrolling through several pages left every loaded item in the snapshot, so reopening after a deep scroll re-rendered and re-projected the **entire accumulation** before the first-page refresh trimmed it, janking the open in proportion to how far the previous session scrolled. `resetPaginationDepth` (called on feed close) now collapses the snapshot back to the first page. The newest page is kept, and the next `refresh()` replaces it with authoritative first-page data.

### 3. Isolate the revalidation bar's repaint

The indeterminate `LinearProgressIndicator` overlaying the cached list (a `Positioned` sibling in a `Stack`, unlike the profile pattern's header-layer bar) had its continuous per-frame `markNeedsPaint` propagate up and re-run the list pane's paint every frame for the whole refresh. Wrapped it in a `RepaintBoundary` (per `rules/performance.md`).

### 4. Keep request-limit plumbing explicit

The signed request URI already carries `limit=20` and is passed to `getNotifications` as `requestUri`. The takeover commit also passes `limit: _pageSize` through the typed argument and pins both the signed/requested URI and typed limit in tests, so future readers do not have to infer that `requestUri` controls the actual request.

> Note: the DB cache itself was already bounded: `replaceAll` replaces the whole table with the first page on every refresh, and there is no incremental writer. The unbounded growth was the in-memory snapshot, addressed by #2.

## Out of Scope

- On-device profiling to confirm which of the three factors dominates per affected user. All three attack the same root cause (too much loaded/rendered eagerly + a continuous animation over it) and are low-risk.
- Replacing the bounded visible-list badge approximation with the authoritative server unread count. That remains tracked by funnelcake#234.

## Verification

- `flutter analyze lib/notifications packages/notification_repository`: clean
- `flutter test test/src/notification_repository_test.dart` from `mobile/packages/notification_repository`: 110 passed
- `flutter test test/notifications` from `mobile`: 185 passed
- Pre-push hook on the final rebased branch:
  - merge-conflict check against `main`: clean
  - changed-file analyze: clean
  - changed-file tests: passed

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)