### PR TITLE
fix(video-editor): cancel native editor tasks on teardown

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -981,6 +981,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     state = state.copyWith(isProcessing: false);
   }
 
+  /// Cancel all known native video editor render work.
+  ///
+  /// Used during app/editor teardown so the widget layer does not need to
+  /// import render services directly.
+  Future<void> cancelActiveNativeRenderTasks() {
+    return VideoEditorRenderService.cancelActiveNativeTasks();
+  }
+
   /// Publish the video to the Nostr network.
   ///
   /// Requires [finalRenderedClip] to be available. Throws [StateError] if

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -200,6 +200,9 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
     _stickerBloc.close();
     _clipEditorBloc.close();
     _timelineOverlayBloc.close();
+    unawaited(
+      ref.read(videoEditorProvider.notifier).cancelActiveNativeRenderTasks(),
+    );
     _isLoadingDraft.dispose();
     _bodySizeNotifier.dispose();
     _zoomMatrixNotifier.dispose();

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -239,6 +239,7 @@ class VideoEditorRenderService {
   static const _logName = 'VideoEditorRenderService';
   static final _compositeProgressController =
       StreamController<ProgressModel>.broadcast();
+  static final Set<String> _activeNativeTaskIds = <String>{};
 
   @visibleForTesting
   static double proofModeProgressBudgetForClipCount(int clipCount) {
@@ -259,6 +260,15 @@ class VideoEditorRenderService {
     _compositeProgressController.add(
       ProgressModel(id: taskId, progress: progress.clamp(0.0, 1.0)),
     );
+  }
+
+  @visibleForTesting
+  static Set<String> get activeNativeTaskIdsForTesting =>
+      Set.unmodifiable(_activeNativeTaskIds);
+
+  @visibleForTesting
+  static void resetActiveNativeTaskIdsForTesting() {
+    _activeNativeTaskIds.clear();
   }
 
   @visibleForTesting
@@ -670,6 +680,7 @@ class VideoEditorRenderService {
     );
 
     final task = VideoRenderData(
+      id: 'crop_${DateTime.now().microsecondsSinceEpoch}',
       videoSegments: [VideoSegment(video: video)],
       enableAudio: enableAudio,
       shouldOptimizeForNetworkUse: true,
@@ -1018,15 +1029,20 @@ class VideoEditorRenderService {
     VideoRenderData task,
   ) async {
     await cancelTask(task.id);
+    _activeNativeTaskIds.add(task.id);
     // Surface native renderer diagnostics (encoder fallbacks, bitrate clamps,
     // OOM guards, render errors) into the unified log via
     // ProVideoEditorLogForwarder — the signal set behind #4801. A clean render
     // stays quiet at this level, so it does not flood the capture buffer.
-    await ProVideoEditor.instance.renderVideoToFile(
-      outputPath,
-      task,
-      nativeLogLevel: NativeLogLevel.warning,
-    );
+    try {
+      await ProVideoEditor.instance.renderVideoToFile(
+        outputPath,
+        task,
+        nativeLogLevel: NativeLogLevel.warning,
+      );
+    } finally {
+      _activeNativeTaskIds.remove(task.id);
+    }
   }
 
   static Future<void> cancelTask(String id) async {
@@ -1049,6 +1065,27 @@ class VideoEditorRenderService {
         name: 'VideoEditorNotifier',
         category: .video,
       );
+    } finally {
+      _activeNativeTaskIds.remove(id);
     }
+  }
+
+  /// Cancels native pro_video_editor render tasks started by this service.
+  ///
+  /// This is intentionally best-effort: native tasks may have already completed
+  /// or been cancelled, and the plugin reports that as an error. The important
+  /// lifecycle behavior is that no known task is left running after app/editor
+  /// teardown requests cancellation.
+  static Future<void> cancelActiveNativeTasks() async {
+    final taskIds = List<String>.of(_activeNativeTaskIds);
+    if (taskIds.isEmpty) return;
+
+    Log.info(
+      '⏹️ Cancelling ${taskIds.length} active video editor task(s)',
+      name: _logName,
+      category: .video,
+    );
+
+    await Future.wait<void>(taskIds.map(cancelTask));
   }
 }

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -12,6 +12,7 @@ import 'package:openvine/notifications/services/notification_refresh_coordinator
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/background_activity_manager.dart';
@@ -168,10 +169,19 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         // Pause all videos and clear visibility state
         // Execute async to prevent blocking scene update
         Future.microtask(visibilityManager.pauseAllVideos);
+        unawaited(
+          ref
+              .read(videoEditorProvider.notifier)
+              .cancelActiveNativeRenderTasks(),
+        );
 
       case AppLifecycleState.detached:
         // App is being terminated
-        break;
+        unawaited(
+          ref
+              .read(videoEditorProvider.notifier)
+              .cancelActiveNativeRenderTasks(),
+        );
     }
   }
 

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -10,10 +10,16 @@ import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
+
+import '../mocks/mock_path_provider_platform.dart';
 
 class _ProgressProVideoEditor extends ProVideoEditor {
   final _progressController = StreamController<ProgressModel>.broadcast();
+  final renderStarted = Completer<VideoRenderData>();
+  final renderCompleter = Completer<void>();
+  final cancelCalls = <String>[];
 
   @override
   void initializeStream() {}
@@ -27,6 +33,22 @@ class _ProgressProVideoEditor extends ProVideoEditor {
     return _progressController.stream.where(
       (progress) => progress.id == taskId,
     );
+  }
+
+  @override
+  Future<String> renderVideoToFile(
+    String filePath,
+    VideoRenderData value, {
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    if (!renderStarted.isCompleted) renderStarted.complete(value);
+    await renderCompleter.future;
+    return filePath;
+  }
+
+  @override
+  Future<void> cancel(String taskId) async {
+    cancelCalls.add(taskId);
   }
 
   @override
@@ -62,6 +84,8 @@ DivineVideoClip _createClip(int index) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('VideoEditorRenderService proof progress allocation', () {
     test('reserves a minimum of 5 percent for proof finalization', () {
       expect(
@@ -102,11 +126,13 @@ void main() {
       originalProVideoEditor = ProVideoEditor.instance;
       proVideoEditor = _ProgressProVideoEditor();
       ProVideoEditor.instance = proVideoEditor;
+      VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
     });
 
     tearDown(() async {
       VideoEditorRenderService.renderVideoOverride = null;
       NativeProofModeService.proofFileOverride = null;
+      VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
       await proVideoEditor.dispose();
       ProVideoEditor.instance = originalProVideoEditor;
     });
@@ -122,9 +148,9 @@ void main() {
         };
 
         final progressSubscription =
-            VideoEditorRenderService.compositeProgressStreamById(taskId).listen(
-              (progress) => progressValues.add(progress.progress),
-            );
+            VideoEditorRenderService.compositeProgressStreamById(
+              taskId,
+            ).listen((progress) => progressValues.add(progress.progress));
         addTearDown(progressSubscription.cancel);
 
         VideoEditorRenderService.renderVideoOverride =
@@ -210,6 +236,51 @@ void main() {
           );
         }
         expect(progressValues.last, equals(1.0));
+      },
+    );
+
+    test(
+      'tracks in-flight native render tasks and bulk-cancels them on lifecycle teardown',
+      () async {
+        final originalPathProvider = PathProviderPlatform.instance;
+        final tempDir = Directory.systemTemp.createTempSync(
+          'video-render-lifecycle-test-',
+        );
+        final mockPathProvider = MockPathProviderPlatform()
+          ..setTemporaryPath(tempDir.path)
+          ..setApplicationDocumentsPath(tempDir.path);
+        PathProviderPlatform.instance = mockPathProvider;
+        addTearDown(() {
+          PathProviderPlatform.instance = originalPathProvider;
+          tempDir.deleteSync(recursive: true);
+        });
+
+        final renderFuture = VideoEditorRenderService.cropToAspectRatio(
+          video: EditorVideo.file('${tempDir.path}/source.mp4'),
+          aspectRatio: model.AspectRatio.square,
+        );
+
+        final task = await proVideoEditor.renderStarted.future;
+        expect(task.id, startsWith('crop_'));
+        expect(
+          VideoEditorRenderService.activeNativeTaskIdsForTesting,
+          contains(task.id),
+        );
+        expect(
+          proVideoEditor.cancelCalls,
+          equals([task.id]),
+          reason:
+              'the service cancels a stale task with the same id before render',
+        );
+
+        await VideoEditorRenderService.cancelActiveNativeTasks();
+
+        expect(proVideoEditor.cancelCalls, equals([task.id, task.id]));
+        expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
+
+        proVideoEditor.renderCompleter.complete();
+        await renderFuture;
+        expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
       },
     );
   });


### PR DESCRIPTION
## Summary
- Track native `pro_video_editor` render task IDs started through `VideoEditorRenderService`.
- Cancel active native editor render tasks when the video editor disposes and when the app moves to paused, hidden, or detached lifecycle states.
- Give crop renders explicit task IDs and add regression coverage for lifecycle bulk cancellation.

## Root Cause
Crashlytics issue #4400 narrowed to native editor progress callbacks surviving editor/app teardown. The app could start native render work and later stop only the Dart-side flow, leaving the native task free to keep posting progress while the Flutter engine was going away.

## Fix Notes
This keeps the fix in app-owned code instead of forking or vendoring `pro_video_editor`. The service now maintains an owned registry of in-flight native render tasks, removes IDs on normal completion or cancellation, and exposes a single teardown cancellation path for lifecycle callers.

## Verification
- `flutter analyze`
- `flutter test test/services/video_editor_render_service_test.dart`
- `flutter test test/providers/video_editor_provider_test.dart`
- `flutter test`
- Pre-push analyzer and changed-file test hook

Closes #4400
