### PR TITLE
fix(dm): route followed 1:1 peers to inbox by participant count, not isGroup flag (#5374)

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -100,6 +100,12 @@ const _relayLoopbackHosts = <String>{
   '::1',
 };
 
+/// Compile-time gate for temporary per-conversation classification
+/// diagnostics. Off by default and tree-shaken from release builds; enable
+/// for a targeted repro with `--dart-define=DM_CLASSIFY_DIAGNOSTICS=true`.
+// TODO(realmeylisdev): remove DM classify diagnostics after #5374.
+const _classifyDiagnostics = bool.fromEnvironment('DM_CLASSIFY_DIAGNOSTICS');
+
 bool _isAllowedDmRelayUrl(String url) {
   final uri = Uri.tryParse(url.trim());
   if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return false;
@@ -2745,8 +2751,16 @@ class DmRepository {
   /// Classifies potential request conversations by follow state.
   ///
   /// Conversations where `currentUserHasSent == false` are "potential
-  /// requests". For 1:1 conversations from followed contacts, they go to
-  /// the followed list (Messages tab). Everything else is a true request.
+  /// requests". A 1:1 conversation from a followed contact goes to the
+  /// followed list (Messages tab); everything else is a true request.
+  ///
+  /// 1:1-ness is derived from the deduplicated non-self participant count,
+  /// NOT the denormalized `DmConversation.isGroup` flag. That column is
+  /// written from `participants.length > 2` and overwritten on every
+  /// upsert, so it can drift from a row's real participants — which was
+  /// stranding followed 1:1 peers under "Message requests" (#5374). Groups
+  /// (2+ non-self participants) are always requests here, independent of
+  /// follow state.
   static ({List<DmConversation> followed, List<DmConversation> requests})
   classifyPotentialRequests(
     List<DmConversation> potentialRequests, {
@@ -2757,19 +2771,34 @@ class DmRepository {
     final requests = <DmConversation>[];
 
     for (final conversation in potentialRequests) {
-      final otherPubkeys = conversation.participantPubkeys.where(
-        (pk) => pk != userPubkey,
-      );
+      final otherPubkeys = conversation.participantPubkeys
+          .where((pk) => pk != userPubkey)
+          .toSet();
 
-      // A 1:1 conversation from a followed contact is not a request
-      // even if the user hasn't replied yet. For groups, follow state
-      // is irrelevant per the spec.
-      final isFollowedContact =
-          !conversation.isGroup && otherPubkeys.any(isFollowing);
+      // A 1:1 conversation from a followed contact is not a request even
+      // if the user hasn't replied yet. Derive 1:1-ness from the actual
+      // (deduplicated) non-self participant count rather than the stored
+      // `isGroup` flag, which can drift from the row's real participants and
+      // mis-route followed 1:1 peers to requests (#5374).
+      final isOneToOne = otherPubkeys.length == 1;
+      final isFollowedContact = isOneToOne && otherPubkeys.any(isFollowing);
 
       if (otherPubkeys.isEmpty || isFollowedContact) {
         followed.add(conversation);
       } else {
+        if (_classifyDiagnostics) {
+          final follows = otherPubkeys
+              .map((pk) => '$pk:${isFollowing(pk)}')
+              .join(', ');
+          Log.debug(
+            'classifyPotentialRequests → request: '
+            'conversationId=${conversation.id} '
+            'isGroup=${conversation.isGroup} '
+            'participantCount=${conversation.participantPubkeys.length} '
+            'otherPubkeys=$otherPubkeys follows={$follows}',
+            category: LogCategory.system,
+          );
+        }
         requests.add(conversation);
       }
     }

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -101,10 +101,14 @@ const _relayLoopbackHosts = <String>{
 };
 
 /// Compile-time gate for temporary per-conversation classification
-/// diagnostics. Off by default and tree-shaken from release builds; enable
-/// for a targeted repro with `--dart-define=DM_CLASSIFY_DIAGNOSTICS=true`.
+/// diagnostics. Off by default and structurally disabled in release builds:
+/// the `!kReleaseMode` term folds the constant to `false` under AOT product
+/// mode, so `DM_CLASSIFY_DIAGNOSTICS` can never enable follow-graph logging
+/// in a distributed build. Enable for a targeted repro on a debug/profile
+/// build with `--dart-define=DM_CLASSIFY_DIAGNOSTICS=true`.
 // TODO(realmeylisdev): remove DM classify diagnostics after #5374.
-const _classifyDiagnostics = bool.fromEnvironment('DM_CLASSIFY_DIAGNOSTICS');
+const bool _classifyDiagnostics =
+    bool.fromEnvironment('DM_CLASSIFY_DIAGNOSTICS') && !kReleaseMode;
 
 bool _isAllowedDmRelayUrl(String url) {
   final uri = Uri.tryParse(url.trim());

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -6470,6 +6470,65 @@ void main() {
         expect(result.requests, hasLength(1));
       });
 
+      test(
+        '1:1 with a stale isGroup=true flag still routes a followed peer to '
+        'the followed list (#5374)',
+        () {
+          final conv = makeConversation(
+            id: 'conv1',
+            participantPubkeys: [_validPubkeyA, _validPubkeyB],
+            isGroup: true, // stale/inconsistent flag on a 1:1 row
+          );
+
+          final result = DmRepository.classifyPotentialRequests(
+            [conv],
+            userPubkey: _validPubkeyA,
+            isFollowing: (pk) => pk == _validPubkeyB,
+          );
+
+          expect(result.followed, hasLength(1));
+          expect(result.requests, isEmpty);
+        },
+      );
+
+      test(
+        'conversation with 2+ non-self participants is a request even when '
+        'isGroup is false and a member is followed',
+        () {
+          final conv = makeConversation(
+            id: 'conv1',
+            participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+            // isGroup defaults to false — classification must rely on the
+            // participant count, not the flag.
+          );
+
+          final result = DmRepository.classifyPotentialRequests(
+            [conv],
+            userPubkey: _validPubkeyA,
+            isFollowing: (_) => true,
+          );
+
+          expect(result.followed, isEmpty);
+          expect(result.requests, hasLength(1));
+        },
+      );
+
+      test('duplicate peer pubkeys are deduplicated to a 1:1', () {
+        final conv = makeConversation(
+          id: 'conv1',
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyB],
+        );
+
+        final result = DmRepository.classifyPotentialRequests(
+          [conv],
+          userPubkey: _validPubkeyA,
+          isFollowing: (pk) => pk == _validPubkeyB,
+        );
+
+        expect(result.followed, hasLength(1));
+        expect(result.requests, isEmpty);
+      });
+
       test('empty input returns both lists empty', () {
         final result = DmRepository.classifyPotentialRequests(
           [],


### PR DESCRIPTION
## Description

Direct messages from people the recipient **follows** (e.g. rabble, improvising) were landing in **Message Requests** instead of the main inbox.

**Root cause.** `DmRepository.classifyPotentialRequests` skipped the follow check whenever `conversation.isGroup == true`:

```dart
final isFollowedContact = !conversation.isGroup && otherPubkeys.any(isFollowing);
```

`isGroup` is a **denormalized column** — written from `participants.length > 2` and overwritten on every conversation upsert — so it can drift from a row's real participant list. A logically-1:1 row carrying a stale `isGroup == true` therefore bypassed the follow check and was routed to Requests, even for a followed peer. The mis-bucketing is longstanding (the split logic is byte-identical to #5311); it became visible once #5304's one-time recovery gate completed and stopped suppressing request-classified conversations.

**Fix.** Derive 1:1-ness from the **authoritative, deduplicated non-self participant count** rather than the drift-prone `isGroup` flag:

```dart
final otherPubkeys = conversation.participantPubkeys.where((pk) => pk != userPubkey).toSet();
final isOneToOne = otherPubkeys.length == 1;
final isFollowedContact = isOneToOne && otherPubkeys.any(isFollowing);
```

A followed 1:1 peer now reaches the inbox regardless of the stored flag. Genuine groups (2+ non-self participants) still route to Requests — consistent with the message-requests spec (`nip17-message-requests-spec.md`), which classifies the inbox/request split by `currentUserHasSent` with no follow-override for groups. (Canonical NIP-17 is silent on message requests — it is a client UX convention.)

Also adds **temporary, `--dart-define=DM_CLASSIFY_DIAGNOSTICS`-gated** per-conversation diagnostics (off by default, tree-shaken from release builds) that log the participant set, per-pubkey follow state, and stored `isGroup` for any conversation routed to Requests — to confirm the exact mis-bucketing variant on the reporter's device and verify the fix in production.

**Related Issue:** Relates to #5374

## Out of Scope

- **Self-wrap / `currentUserHasSent` recovery** (the spec's "Missing Self-Wrap" limitation): *unfollowed* conversations the user actually replied to can still appear as requests when the self-wrap record is missing. The follow-override only helps *followed* peers. Tracked as follow-up (the #5304/#5202 axis).
- **Spec-orthogonality redesign:** the base spec keeps "is-a-request" (`currentUserHasSent`) and "is-trusted" (follow graph) orthogonal; divine's 1:1 follow-override conflates them. A split-by-`currentUserHasSent`-only model plus a separate trusted-network filter is a larger, separate effort.
- Removal of the temporary diagnostics (to be removed once the variant is confirmed in prod).

## Verification

- `flutter test packages/dm_repository/test/src/dm_repository_test.dart` — 199 passed, including 3 new cases: stale-`isGroup` 1:1 repro (#5374), participant-count-over-flag consistency, and duplicate-peer dedup.
- `flutter test test/blocs/dm/conversation_list/` (the only consumer of `classifyPotentialRequests`) — 50 passed.
- `flutter analyze lib test` (dm_repository) — No issues found.
- Pre-commit + pre-push hooks (format + analyze + tests) — green.
- **On-device repro (pending, for the reporter):** run with `--dart-define=DM_CLASSIFY_DIAGNOSTICS=true`, open Inbox → Message Requests, and confirm the previously-misbucketed followed peers now appear in the inbox; the diagnostic line records the exact mechanism.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
