### PR TITLE
fix(video-player): dispose iOS players on FlutterEngine teardown (#5371)

### DIFF
--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
@@ -95,6 +95,25 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
         PlayerRegistry.shared.forAll { $0.onAppForegrounded() }
     }
 
+    /// Called when this plugin's `FlutterEngine` is torn down — including
+    /// the teardown paths the Dart `dispose`/`disposeAll` channel never
+    /// reaches (OOM reclaim of the `FlutterViewController`, `destroyContext`,
+    /// multi-engine teardown). Without this, a `VideoTextureOutput`'s
+    /// `CADisplayLink` (which strongly retains the output) keeps firing
+    /// `textureFrameAvailable` into the freed engine shell.
+    ///
+    /// Scoped to this engine's own players via `disposeOwned(by:)` so that
+    /// the FCM background isolate's engine detaching does not dispose the UI
+    /// engine's live players (`PlayerRegistry.shared` is process-wide).
+    public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        DivineVideoPlayerLog.shared.info(
+            "Engine detaching — disposing this engine's players",
+            name: "DivineVideoPlayer.Lifecycle"
+        )
+        PlayerRegistry.shared.disposeOwned(by: self)
+        NotificationCenter.default.removeObserver(self)
+    }
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         // Re-claim the shared sink in case another FlutterEngine overwrote it.
         installLogSink()
@@ -141,7 +160,10 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
                 messenger: messenger,
                 playerId: id
             )
-            PlayerRegistry.shared.set(instance, for: id)
+            // Record `self` as the owner: the plugin instance whose global
+            // channel received this `create` is the engine the Dart side is
+            // talking to, so it is the engine whose detach should dispose it.
+            PlayerRegistry.shared.set(instance, for: id, owner: self)
 
             let useTexture = args["useTexture"] as? Bool ?? false
             DivineVideoPlayerLog.shared.info(
@@ -236,21 +258,53 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
 
 /// Global registry so that ``DivineVideoPlayerViewFactory`` can find
 /// instances created during the `create` method call.
+///
+/// `shared` is process-wide and outlives any single `FlutterEngine`. Each
+/// player records the plugin (engine) that created it so a teardown of one
+/// engine can dispose only its own players — see `disposeOwned(by:)`. A
+/// blanket `disposeAll()` on engine detach would otherwise free the UI
+/// engine's live players when the FCM background isolate's engine detaches.
+/// Main-thread only, like all plugin entry points.
 final class PlayerRegistry {
     static let shared = PlayerRegistry()
     private var players: [Int: DivineVideoPlayerInstance] = [:]
+    /// Owning plugin per player id. `ObjectIdentifier` is stable while the
+    /// owning plugin is alive, which it is throughout `detachFromEngine`.
+    private var owners: [Int: ObjectIdentifier] = [:]
     private init() {}
 
     func get(_ id: Int) -> DivineVideoPlayerInstance? { players[id] }
-    func set(_ instance: DivineVideoPlayerInstance, for id: Int) { players[id] = instance }
+    func set(
+        _ instance: DivineVideoPlayerInstance,
+        for id: Int,
+        owner: DivineVideoPlayerPlugin
+    ) {
+        players[id] = instance
+        owners[id] = ObjectIdentifier(owner)
+    }
     @discardableResult
     func remove(_ id: Int) -> DivineVideoPlayerInstance? {
+        owners[id] = nil
         let instance = players.removeValue(forKey: id)
         return instance
     }
     func disposeAll() {
         players.values.forEach { $0.dispose() }
         players.removeAll()
+        owners.removeAll()
+    }
+
+    /// Disposes only the players created by `owner` (one `FlutterEngine`),
+    /// leaving every other engine's players running. Called on engine detach
+    /// so a torn-down engine cannot leave a zombie `CADisplayLink` firing
+    /// `textureFrameAvailable` into its freed shell.
+    func disposeOwned(by owner: DivineVideoPlayerPlugin) {
+        let ownerId = ObjectIdentifier(owner)
+        let ownedIds = owners.compactMap { $0.value == ownerId ? $0.key : nil }
+        for id in ownedIds {
+            players.removeValue(forKey: id)?.dispose()
+            owners[id] = nil
+        }
     }
     func forAll(_ action: (DivineVideoPlayerInstance) -> Void) {
         players.values.forEach(action)

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/VideoTextureOutput.swift
@@ -81,6 +81,12 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// EXC_BAD_ACCESS. Read/written on the main thread only.
     private var isFrameDeliveryEnabled = true
 
+    /// Set once `dispose()` has run. Guards `resumeFrameDelivery()` so a
+    /// foreground notification that races a teardown-driven dispose can never
+    /// re-arm delivery on an output whose texture is already unregistered.
+    /// Read/written on the main thread only.
+    private var isDisposed = false
+
     /// Fired when the force window expires without a frame; caller should
     /// retry the seek with tolerance. Suppressed for retry windows.
     var onSeekStuck: ((CMTime) -> Void)?
@@ -269,6 +275,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// the background period, so resuming does not flash black. Must be
     /// called on the main thread.
     func resumeFrameDelivery() {
+        guard !isDisposed else { return }
         isFrameDeliveryEnabled = true
         #if os(iOS)
         displayLink?.isPaused = false
@@ -277,6 +284,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
 
     /// Cleans up the frame driver and unregisters the texture.
     func dispose() {
+        isDisposed = true
         isFrameDeliveryEnabled = false
         stopFrameDriver()
         itemStatusObservation?.invalidate()

--- a/mobile/packages/divine_video_player/test/src/apple_engine_teardown_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_engine_teardown_contract_test.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// These assertions guard the Apple-side fix for the "zombie CADisplayLink"
+/// crash (#5371): a `FlutterEngine` torn down without routing through the Dart
+/// `dispose`/`disposeAll` channel must still invalidate its own players'
+/// frame drivers, and must do so without tearing down another engine's
+/// players. The native player has no host-side Swift test harness (it links
+/// Flutter), so the contract is asserted against the source like the sibling
+/// threading contract test.
+void main() {
+  group('Apple native player engine-teardown contract', () {
+    test("disposes this engine's players on FlutterEngine detach", () {
+      final source = _pluginSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains(
+          'public func detachFromEngine(for registrar: FlutterPluginRegistrar)',
+        ),
+        reason:
+            'A FlutterEngine teardown that bypasses the Dart dispose channel '
+            '(OOM reclaim, destroyContext, multi-engine teardown) must reach '
+            'the plugin so the CADisplayLink can be invalidated.',
+      );
+      expect(
+        source,
+        contains('PlayerRegistry.shared.disposeOwned(by: self)'),
+        reason:
+            "Detach must dispose this engine's players so their display "
+            'links stop firing textureFrameAvailable into the freed shell.',
+      );
+      expect(
+        source,
+        contains('NotificationCenter.default.removeObserver(self)'),
+        reason:
+            "Detach must drop this engine's lifecycle observers so a stray "
+            'foreground notification cannot resume a torn-down engine.',
+      );
+    });
+
+    test('scopes teardown to the detaching engine', () {
+      final source = _pluginSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('func disposeOwned(by owner: DivineVideoPlayerPlugin)'),
+        reason:
+            'PlayerRegistry.shared is process-wide and shared with the FCM '
+            'background isolate; teardown must be scoped per owning engine, '
+            'never a blanket disposeAll on detach.',
+      );
+      expect(
+        source,
+        contains('owner: DivineVideoPlayerPlugin'),
+        reason: 'Each player must record the engine that created it.',
+      );
+      expect(
+        source,
+        contains('PlayerRegistry.shared.set(instance, for: id, owner: self)'),
+        reason:
+            'create must record the receiving plugin (engine) as the owner so '
+            "detach can identify this engine's players.",
+      );
+      expect(
+        source,
+        contains('ObjectIdentifier(owner)'),
+        reason: 'Ownership is matched by object identity of the owning plugin.',
+      );
+    });
+
+    test('guards resume against a disposed texture output', () {
+      final source = _textureOutputSourceFile().readAsStringSync();
+
+      expect(
+        source,
+        contains('guard !isDisposed else { return }'),
+        reason:
+            'resumeFrameDelivery must no-op once the output is disposed so a '
+            'foreground notification racing a teardown-driven dispose cannot '
+            're-arm delivery on an unregistered texture.',
+      );
+      expect(
+        source,
+        contains('isDisposed = true'),
+        reason: 'dispose() must mark the output disposed for the resume guard.',
+      );
+    });
+  });
+}
+
+/// The iOS and macOS players share a single Darwin source tree
+/// (`darwin/divine_video_player/Sources/`), so the contract is asserted once.
+File _pluginSourceFile() => _resolve('DivineVideoPlayerPlugin.swift');
+
+File _textureOutputSourceFile() => _resolve('VideoTextureOutput.swift');
+
+File _resolve(String fileName) {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/$fileName',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/$fileName',
+  );
+}


### PR DESCRIPTION
## Description

`VideoTextureOutput`'s `CADisplayLink` (`target: self`) strongly retains the output, and the only thing that invalidates it is `dispose()`, reachable **solely** through the Dart `dispose`/`disposeAll` method channel. A `FlutterEngine` torn down **without** routing through that channel — OOM reclaim of the `FlutterViewController`, `destroyContext`, multi-engine teardown — leaves a **zombie display link** that keeps calling `registry.textureFrameAvailable()` into a freed engine shell on the next foreground. That is the same dereference behind the build-766 crash that #5369 fixed for the background/suspend path; this PR closes the orthogonal teardown path #5369 deliberately did not cover.

**Changes**

- **`DivineVideoPlayerPlugin.swift`**
  - Implement `FlutterPlugin.detachFromEngine(for:)` to dispose this engine's players on teardown and drop its lifecycle observers.
  - `PlayerRegistry` now records the **owning plugin (engine)** per player id and exposes `disposeOwned(by:)`. Teardown is scoped per engine, so the process-wide `PlayerRegistry.shared` no longer risks tearing down the **UI engine's live players** when the FCM background isolate's engine detaches (the "needs care" caveat in the issue).
- **`VideoTextureOutput.swift`**
  - Add an `isDisposed` guard so `resumeFrameDelivery()` no-ops once the output is disposed — closes the resume-side reopening of the window (the optional secondary fix).
- **Test**: `apple_engine_teardown_contract_test.dart` asserts the native invariants by parsing the Swift source, mirroring the existing `apple_threading_contract_test` (the player links Flutter, so there is no host-side Swift test harness).

**Related Issue:** Closes #5371

## Out of Scope

- The pre-existing `register(with:) → disposeAll()` hot-restart cleanup is left blanket (process-wide). Orphaned players from a previous run of the same engine have no live owner to scope to, so a global cleanup is still correct there; changing it risks regressing hot-restart behavior.

## Verification

- `flutter analyze lib test` → No issues found.
- `flutter test` (package `divine_video_player`) → all 225 pass (3 new).
- iOS Swift compiles in CI; the `detachFromEngine(for:)` signature matches the proven cross-platform `firebase_database` Swift plugin. A local iOS build was not run — the package links the Flutter framework, which is unavailable for host `swift build`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)