### PR TITLE
feat(dm): quoted video preview on shared-reel replies (#5388)

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -231,5 +231,9 @@ DmMessage _outgoingToBubble(OutgoingDm row) {
     content: row.content,
     createdAt: row.createdAt,
     giftWrapId: row.id,
+    // Carry the reply linkage so an optimistic reply bubble can resolve its
+    // parent's shared video and render the quoted preview immediately, before
+    // the persisted `watchMessages` tick replaces this row.
+    replyToId: row.replyToId,
   );
 }

--- a/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
+++ b/mobile/lib/blocs/dm/inline_reel_reply/inline_reel_reply_cubit.dart
@@ -44,19 +44,45 @@ class InlineReelReplyCubit extends Cubit<InlineReelReplyState> {
 
     try {
       final bool ok;
+      // When the reel has a structured video ref, the reply self-carries the
+      // NIP-18 `q` citation so it stays linked to the video across devices and
+      // other Nostr clients; otherwise it threads as a plain reply.
+      final videoRef = _replyContext.sharedVideoRef;
       if (_replyContext.isGroup) {
-        final results = await _dmRepository.sendGroupMessage(
-          recipientPubkeys: _replyContext.participantPubkeys,
-          content: trimmed,
-          replyToId: _replyContext.sharedReelMessageId,
-        );
+        final results = videoRef != null
+            ? await _dmRepository.sendSharedVideoGroup(
+                recipientPubkeys: _replyContext.participantPubkeys,
+                baseContent: trimmed,
+                videoKind: videoRef.videoKind.kind,
+                videoAuthorPubkey: videoRef.authorPubkey ?? '',
+                videoDTag: videoRef.dTag,
+                videoEventId: videoRef.eventId,
+                relayHint: videoRef.relayHint,
+                replyToId: _replyContext.sharedReelMessageId,
+              )
+            : await _dmRepository.sendGroupMessage(
+                recipientPubkeys: _replyContext.participantPubkeys,
+                content: trimmed,
+                replyToId: _replyContext.sharedReelMessageId,
+              );
         ok = results.any((r) => r.success);
       } else {
-        final result = await _dmRepository.sendMessage(
-          recipientPubkey: _replyContext.participantPubkeys.single,
-          content: trimmed,
-          replyToId: _replyContext.sharedReelMessageId,
-        );
+        final result = videoRef != null
+            ? await _dmRepository.sendSharedVideo(
+                recipientPubkey: _replyContext.participantPubkeys.single,
+                baseContent: trimmed,
+                videoKind: videoRef.videoKind.kind,
+                videoAuthorPubkey: videoRef.authorPubkey ?? '',
+                videoDTag: videoRef.dTag,
+                videoEventId: videoRef.eventId,
+                relayHint: videoRef.relayHint,
+                replyToId: _replyContext.sharedReelMessageId,
+              )
+            : await _dmRepository.sendMessage(
+                recipientPubkey: _replyContext.participantPubkeys.single,
+                content: trimmed,
+                replyToId: _replyContext.sharedReelMessageId,
+              );
         ok = result.success;
       }
       emit(

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "am",
+    "dmMessageBubbleVideoReplyHint": "የተጠቀሰውን ቪዲዮ ክፈት",
     "commonSomethingWentWrong": "የሆነ ችግር ተፈጥሯል",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ar",
+    "dmMessageBubbleVideoReplyHint": "افتح الفيديو المُشار إليه",
     "commonSomethingWentWrong": "حدث خطأ ما",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "bg",
+    "dmMessageBubbleVideoReplyHint": "Отваряне на посочения видеоклип",
     "commonSomethingWentWrong": "Нещо се обърка",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "de",
+    "dmMessageBubbleVideoReplyHint": "Referenziertes Video öffnen",
     "commonSomethingWentWrong": "Etwas ist schiefgelaufen",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1,5 +1,9 @@
 {
   "@@locale": "en",
+  "dmMessageBubbleVideoReplyHint": "Open the referenced video",
+  "@dmMessageBubbleVideoReplyHint": {
+    "description": "Accessibility label for the compact quoted-video preview shown above a DM reply that references a shared video; activating it opens that video."
+  },
   "appTitle": "Divine",
   "@appTitle": {
     "description": "App title shown in task switcher"

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "es",
+    "dmMessageBubbleVideoReplyHint": "Abrir el vídeo referenciado",
     "commonSomethingWentWrong": "Algo salió mal",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fil",
+    "dmMessageBubbleVideoReplyHint": "Buksan ang tinukoy na video",
     "commonSomethingWentWrong": "May nangyaring problema",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fr",
+    "dmMessageBubbleVideoReplyHint": "Ouvrir la vidéo référencée",
     "commonSomethingWentWrong": "Un problème est survenu",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "id",
+    "dmMessageBubbleVideoReplyHint": "Buka video yang dirujuk",
     "commonSomethingWentWrong": "Terjadi kesalahan",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "it",
+    "dmMessageBubbleVideoReplyHint": "Apri il video di riferimento",
     "commonSomethingWentWrong": "Qualcosa è andato storto",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ja",
+    "dmMessageBubbleVideoReplyHint": "参照先の動画を開く",
     "commonSomethingWentWrong": "問題が発生しました",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ko",
+    "dmMessageBubbleVideoReplyHint": "참조된 동영상 열기",
     "commonSomethingWentWrong": "문제가 생겼어요",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "nl",
+    "dmMessageBubbleVideoReplyHint": "Verwezen video openen",
     "commonSomethingWentWrong": "Er ging iets mis",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "pl",
+    "dmMessageBubbleVideoReplyHint": "Otwórz przywołane wideo",
     "commonSomethingWentWrong": "Coś poszło nie tak",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "pt",
+    "dmMessageBubbleVideoReplyHint": "Abrir o vídeo referenciado",
     "commonSomethingWentWrong": "Algo deu errado",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ro",
+    "dmMessageBubbleVideoReplyHint": "Deschide videoclipul referențiat",
     "commonSomethingWentWrong": "Ceva nu a mers bine",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "sv",
+    "dmMessageBubbleVideoReplyHint": "Öppna den refererade videon",
     "commonSomethingWentWrong": "Något gick fel",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "tr",
+    "dmMessageBubbleVideoReplyHint": "Atıfta bulunulan videoyu aç",
     "commonSomethingWentWrong": "Bir hata oluştu",
     "profileFeedError": "Couldn't load videos.",
     "profileFeedLoadMoreError": "Couldn't load more videos. Pull to refresh.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -130,6 +130,12 @@ abstract class AppLocalizations {
     Locale('tr'),
   ];
 
+  /// Accessibility label for the compact quoted-video preview shown above a DM reply that references a shared video; activating it opens that video.
+  ///
+  /// In en, this message translates to:
+  /// **'Open the referenced video'**
+  String get dmMessageBubbleVideoReplyHint;
+
   /// App title shown in task switcher
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9,6 +9,9 @@ class AppLocalizationsAm extends AppLocalizations {
   AppLocalizationsAm([String locale = 'am']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'የተጠቀሰውን ቪዲዮ ክፈት';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9,6 +9,9 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'افتح الفيديو المُشار إليه';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9,6 +9,9 @@ class AppLocalizationsBg extends AppLocalizations {
   AppLocalizationsBg([String locale = 'bg']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Отваряне на посочения видеоклип';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9,6 +9,9 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Referenziertes Video öffnen';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Open the referenced video';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9,6 +9,9 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Abrir el vídeo referenciado';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9,6 +9,9 @@ class AppLocalizationsFil extends AppLocalizations {
   AppLocalizationsFil([String locale = 'fil']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Buksan ang tinukoy na video';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Ouvrir la vidéo référencée';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9,6 +9,9 @@ class AppLocalizationsId extends AppLocalizations {
   AppLocalizationsId([String locale = 'id']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Buka video yang dirujuk';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9,6 +9,9 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Apri il video di riferimento';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9,6 +9,9 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => '参照先の動画を開く';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9,6 +9,9 @@ class AppLocalizationsKo extends AppLocalizations {
   AppLocalizationsKo([String locale = 'ko']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => '참조된 동영상 열기';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9,6 +9,9 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Verwezen video openen';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9,6 +9,9 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Otwórz przywołane wideo';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9,6 +9,9 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Abrir o vídeo referenciado';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9,6 +9,10 @@ class AppLocalizationsRo extends AppLocalizations {
   AppLocalizationsRo([String locale = 'ro']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint =>
+      'Deschide videoclipul referențiat';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9,6 +9,9 @@ class AppLocalizationsSv extends AppLocalizations {
   AppLocalizationsSv([String locale = 'sv']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Öppna den refererade videon';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9,6 +9,9 @@ class AppLocalizationsTr extends AppLocalizations {
   AppLocalizationsTr([String locale = 'tr']) : super(locale);
 
   @override
+  String get dmMessageBubbleVideoReplyHint => 'Atıfta bulunulan videoyu aç';
+
+  @override
   String get appTitle => 'Divine';
 
   @override

--- a/mobile/lib/screens/feed/dm_reply_context.dart
+++ b/mobile/lib/screens/feed/dm_reply_context.dart
@@ -1,15 +1,17 @@
 // ABOUTME: Context that marks a full-screen reel as opened from a DM thread.
-// ABOUTME: Drives the in-player reply/reaction bar. Plain strings only.
+// ABOUTME: Drives the in-player reply/reaction bar.
 
 import 'package:equatable/equatable.dart';
+import 'package:models/models.dart';
 
 /// Identifies the DM conversation a full-screen reel was opened from, so the
 /// player can show a reply/reaction bar that threads back into that chat.
 ///
-/// All fields are plain strings / lists so the value survives travel through
-/// go_router `extra`. It is intentionally `null` for reels opened from the feed
-/// or profile (no bar) and lost on a web hard-reload (the player still works,
-/// just without the bar).
+/// Fields are plain strings / lists plus the immutable [sharedVideoRef] value
+/// object, so the context survives travel through go_router `extra` (an
+/// in-process object reference). It is intentionally `null` for reels opened
+/// from the feed or profile (no bar) and lost on a web hard-reload (the player
+/// still works, just without the bar).
 class DmReplyContext extends Equatable {
   const DmReplyContext({
     required this.conversationId,
@@ -19,6 +21,7 @@ class DmReplyContext extends Equatable {
     required this.messageAuthorPubkey,
     required this.hintName,
     required this.isOwnMessage,
+    this.sharedVideoRef,
   });
 
   /// Deterministic conversation id (matches `DmMessage.conversationId`).
@@ -44,6 +47,15 @@ class DmReplyContext extends Equatable {
   /// (drives the "Reply to yourself…" hint).
   final bool isOwnMessage;
 
+  /// Structured reference to the reel the reply is about, when the shared-reel
+  /// message carries one. Lets a reel reply self-carry the video's NIP-18 `q`
+  /// citation so the reply stays linked to the video across devices and other
+  /// Nostr clients. `null` for legacy URL-only shares the reply can't cite.
+  final DmSharedVideoRef? sharedVideoRef;
+
+  /// Whether a structured video reference is available to cite on a reply.
+  bool get hasSharedVideoRef => sharedVideoRef != null;
+
   @override
   List<Object?> get props => [
     conversationId,
@@ -53,5 +65,6 @@ class DmReplyContext extends Equatable {
     messageAuthorPubkey,
     hintName,
     isOwnMessage,
+    sharedVideoRef,
   ];
 }

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -352,6 +352,30 @@ class _ConversationContent extends StatelessWidget {
   }
 }
 
+/// The video reference to render as a compact quoted preview above a reply's
+/// text: the parent shared-reel's video (resolved via `replyToId` from
+/// [messagesById]), falling back to the reply's own self-carried citation when
+/// the parent isn't in the local store (cross-device / reinstall). Returns
+/// `null` when [message] is not a reply.
+@visibleForTesting
+DmSharedVideoRef? resolveQuotedVideoRef(
+  DmMessage message,
+  Map<String, DmMessage> messagesById,
+) {
+  final replyToId = message.replyToId;
+  if (replyToId == null) return null;
+  return messagesById[replyToId]?.sharedVideoRef ?? message.sharedVideoRef;
+}
+
+/// The video reference to render as [message]'s own full share card: its
+/// `sharedVideoRef` only when it is NOT a reply. A reply that self-carries a
+/// citation renders a compact quote (via [resolveQuotedVideoRef]) instead of
+/// the full card, so this returns `null` for replies to keep the two paths
+/// mutually exclusive.
+@visibleForTesting
+DmSharedVideoRef? resolveOwnShareVideoRef(DmMessage message) =>
+    message.replyToId == null ? message.sharedVideoRef : null;
+
 class _MessageList extends StatelessWidget {
   const _MessageList({
     required this.messages,
@@ -429,6 +453,9 @@ class _MessageList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Index built once per render pass so a reply bubble can resolve its
+    // parent shared-reel message (and thus the quoted video) in O(1).
+    final messagesById = {for (final m in messages) m.id: m};
     return ListView.builder(
       reverse: true,
       keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
@@ -476,7 +503,9 @@ class _MessageList extends StatelessWidget {
             tryExtractDivineVideoUrl(message.content) != null;
 
         // Context for the in-player reply/reaction bar when this bubble's
-        // shared reel is opened.
+        // shared reel is opened. Carries the reel's structured video ref so a
+        // text reply can self-carry the NIP-18 `q` citation (cross-device /
+        // other-client durability).
         final dmReplyContext = DmReplyContext(
           conversationId: message.conversationId,
           participantPubkeys: participantPubkeys,
@@ -485,7 +514,13 @@ class _MessageList extends StatelessWidget {
           messageAuthorPubkey: message.senderPubkey,
           hintName: senderDisplayName,
           isOwnMessage: isSent,
+          sharedVideoRef: message.sharedVideoRef,
         );
+
+        // A non-reply share renders the full card; a reply that references a
+        // video renders a compact quote above its text (mutually exclusive).
+        final ownShareVideoRef = resolveOwnShareVideoRef(message);
+        final quotedVideoRef = resolveQuotedVideoRef(message, messagesById);
 
         Widget buildBubbleWithReactions(DmDeliveryStatus status) {
           final bubble = MessageBubble(
@@ -503,7 +538,8 @@ class _MessageList extends StatelessWidget {
                 _onMessageLongPress(context, message, isSent, status),
             deliveryStatus: status,
             dmReplyContext: dmReplyContext,
-            sharedVideoRef: message.sharedVideoRef,
+            sharedVideoRef: ownShareVideoRef,
+            quotedVideoRef: quotedVideoRef,
           );
           return Column(
             crossAxisAlignment: isSent

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -89,6 +89,7 @@ class MessageBubble extends StatelessWidget {
     this.deliveryStatus = DmDeliveryStatus.delivered,
     this.dmReplyContext,
     this.sharedVideoRef,
+    this.quotedVideoRef,
     super.key,
   });
 
@@ -118,7 +119,15 @@ class MessageBubble extends StatelessWidget {
   final DmReplyContext? dmReplyContext;
 
   /// Structured q-tag video reference parsed from the DM rumor, when present.
+  /// Drives the message's OWN full share card. Mutually exclusive with
+  /// [quotedVideoRef] — the call site passes one or the other.
   final DmSharedVideoRef? sharedVideoRef;
+
+  /// Structured reference to the video this message *replies to*, when the
+  /// message is a reply to a shared-reel DM. Renders a compact WhatsApp-style
+  /// quoted preview above the reply text (distinct from the full [sharedVideoRef]
+  /// card). Null for non-reply messages.
+  final DmSharedVideoRef? quotedVideoRef;
 
   @override
   Widget build(BuildContext context) {
@@ -195,6 +204,19 @@ class MessageBubble extends StatelessWidget {
     final hasVideo = videoStableId != null;
     final effectiveIsFirstInGroup = hasVideo || isFirstInGroup;
     final effectiveIsLastInGroup = hasVideo || isLastInGroup;
+
+    // A reply that references a video (but doesn't itself render a full card)
+    // shows a compact quoted preview above its text. Strip the trailing
+    // machine-readable `nostr:` citation line the reply carries on the wire so
+    // only the user's comment renders below the quote.
+    final hasQuotedVideo = quotedVideoRef != null && !hasVideo;
+    final quotedReplyText = hasQuotedVideo
+        ? safeMessage
+              .split('\n')
+              .where((line) => !_nostrRefLineRegex.hasMatch(line.trim()))
+              .join('\n')
+              .trim()
+        : safeMessage;
 
     return Padding(
       padding: EdgeInsets.only(
@@ -291,12 +313,25 @@ class MessageBubble extends StatelessWidget {
                           dmReplyContext: dmReplyContext,
                         ),
                       ),
-                  ] else
-                    _MessageText(
-                      message: safeMessage,
-                      isSent: isSent,
-                      dmReplyContext: dmReplyContext,
-                    ),
+                  ] else ...[
+                    if (hasQuotedVideo)
+                      Padding(
+                        padding: EdgeInsets.only(
+                          bottom: quotedReplyText.isEmpty ? 0 : 6,
+                        ),
+                        child: _QuotedVideoPreview(
+                          quotedVideoRef: quotedVideoRef!,
+                          isSent: isSent,
+                          dmReplyContext: dmReplyContext,
+                        ),
+                      ),
+                    if (quotedReplyText.isNotEmpty)
+                      _MessageText(
+                        message: quotedReplyText,
+                        isSent: isSent,
+                        dmReplyContext: dmReplyContext,
+                      ),
+                  ],
                   if (isSent && deliveryStatus != DmDeliveryStatus.delivered)
                     Padding(
                       padding: const EdgeInsets.only(top: 4),
@@ -643,6 +678,232 @@ class _VideoLinkPreview extends ConsumerWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Thumbnail width of the compact quoted-reply preview.
+const double _quotedThumbWidth = 40;
+
+/// Thumbnail height of the compact quoted-reply preview.
+const double _quotedThumbHeight = 56;
+
+/// Corner radius of the compact quoted-reply thumbnail.
+const double _quotedThumbRadius = 6;
+
+/// Compact WhatsApp-style quoted preview of the video a reply references.
+///
+/// Reuses the [VideoLinkPreviewCubit] resolve harness (cache → relay fetch) so
+/// it can render even when the cited video was never seen locally, and swaps
+/// the full [_VideoCard] for a small thumbnail + label strip rendered above the
+/// reply text.
+class _QuotedVideoPreview extends ConsumerWidget {
+  const _QuotedVideoPreview({
+    required this.quotedVideoRef,
+    required this.isSent,
+    this.dmReplyContext,
+  });
+
+  final DmSharedVideoRef quotedVideoRef;
+  final bool isSent;
+  final DmReplyContext? dmReplyContext;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final target = _videoTargetFromRef(quotedVideoRef);
+    if (target == null) return const SizedBox.shrink();
+    return BlocProvider(
+      create: (_) => VideoLinkPreviewCubit(
+        videoStableId: target.stableId,
+        videoEventService: ref.read(videoEventServiceProvider),
+        nostrClient: ref.read(nostrServiceProvider),
+        authorPubkey: target.authorPubkey,
+        videoKind: target.videoKind,
+      ),
+      child: BlocBuilder<VideoLinkPreviewCubit, VideoLinkPreviewState>(
+        builder: (context, state) => switch (state) {
+          VideoLinkPreviewLoading() => _QuotedVideoFrame(
+            isSent: isSent,
+            child: const _QuotedThumbPlaceholder(),
+          ),
+          VideoLinkPreviewNotFound() => _QuotedVideoUnavailable(isSent: isSent),
+          VideoLinkPreviewResolved(:final video) => _QuotedVideoCard(
+            video: video,
+            isSent: isSent,
+            dmReplyContext: dmReplyContext,
+          ),
+        },
+      ),
+    );
+  }
+}
+
+/// Accent-bar framed container that gives the quoted preview its WhatsApp-style
+/// "reply" affordance, readable on both sent and received bubble colors.
+class _QuotedVideoFrame extends StatelessWidget {
+  const _QuotedVideoFrame({
+    required this.isSent,
+    required this.child,
+    this.onTap,
+  });
+
+  final bool isSent;
+  final Widget child;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = isSent ? VineTheme.whiteText : VineTheme.primary;
+    final frame = DecoratedBox(
+      decoration: BoxDecoration(
+        color: VineTheme.whiteText.withValues(alpha: isSent ? 0.14 : 0.07),
+        borderRadius: BorderRadius.circular(8),
+        border: Border(left: BorderSide(color: accent, width: 3)),
+      ),
+      child: Padding(padding: const EdgeInsets.all(6), child: child),
+    );
+    if (onTap == null) return frame;
+    return GestureDetector(onTap: onTap, child: frame);
+  }
+}
+
+/// Loading placeholder sized to the compact thumbnail.
+class _QuotedThumbPlaceholder extends StatelessWidget {
+  const _QuotedThumbPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: _quotedThumbWidth,
+      height: _quotedThumbHeight,
+      decoration: BoxDecoration(
+        color: VineTheme.cardBackground,
+        borderRadius: BorderRadius.circular(_quotedThumbRadius),
+      ),
+    );
+  }
+}
+
+/// Resolved compact quoted preview: thumbnail + title/author, tappable to open
+/// the referenced video.
+class _QuotedVideoCard extends ConsumerWidget {
+  const _QuotedVideoCard({
+    required this.video,
+    required this.isSent,
+    this.dmReplyContext,
+  });
+
+  final VideoEvent video;
+  final bool isSent;
+  final DmReplyContext? dmReplyContext;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final title = video.title;
+    final hasTitle = title != null && title.isNotEmpty;
+    final profileAsync = ref.watch(userProfileReactiveProvider(video.pubkey));
+    final authorName = switch (profileAsync) {
+      AsyncData(:final value) when value != null => value.bestDisplayName,
+      AsyncData() ||
+      AsyncError() => UserProfile.defaultDisplayNameFor(video.pubkey),
+      AsyncLoading() => null,
+    };
+    final primaryColor = isSent ? VineTheme.whiteText : VineTheme.onSurface;
+    final secondaryColor = isSent
+        ? VineTheme.whiteText.withValues(alpha: 0.7)
+        : VineTheme.onSurfaceMuted;
+    final primaryLabel = hasTitle ? title : (authorName ?? '');
+    final showSecondary =
+        hasTitle && authorName != null && authorName.isNotEmpty;
+
+    return Semantics(
+      button: true,
+      label: context.l10n.dmMessageBubbleVideoReplyHint,
+      child: _QuotedVideoFrame(
+        isSent: isSent,
+        onTap: () => context.push(
+          VideoDetailScreen.pathForId(video.id),
+          extra: VideoDetailRouteExtra(
+            initialVideo: video,
+            dmReplyContext: dmReplyContext,
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(_quotedThumbRadius),
+              // VideoThumbnailWidget renders an AspectRatio internally, so it
+              // must be externally bounded (like the full _VideoCard's SizedBox)
+              // — its own width/height params only size the inner image.
+              child: SizedBox(
+                width: _quotedThumbWidth,
+                height: _quotedThumbHeight,
+                child: VideoThumbnailWidget(
+                  video: video,
+                  showPlayIcon: true,
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Flexible(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    primaryLabel,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: VineTheme.labelSmallFont(color: primaryColor),
+                  ),
+                  if (showSecondary)
+                    Text(
+                      authorName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: VineTheme.bodySmallFont(color: secondaryColor),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Compact non-tappable chip shown when the referenced video can't be resolved.
+class _QuotedVideoUnavailable extends StatelessWidget {
+  const _QuotedVideoUnavailable({required this.isSent});
+
+  final bool isSent;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isSent ? VineTheme.whiteText : VineTheme.onSurfaceMuted;
+    return _QuotedVideoFrame(
+      isSent: isSent,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          DivineIcon(
+            icon: DivineIconName.warningCircle,
+            color: color,
+            size: 16,
+          ),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              context.l10n.notificationsVideoUnavailable,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: VineTheme.bodySmallFont(color: color),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -692,6 +692,17 @@ const double _quotedThumbHeight = 56;
 /// Corner radius of the compact quoted-reply thumbnail.
 const double _quotedThumbRadius = 6;
 
+/// Fixed overall width of the compact quoted-reply preview. Pinning it keeps
+/// the bubble from reflowing when the cited video resolves out of its loading
+/// skeleton — the loading, resolved, and unavailable states all render at this
+/// width, so there is no horizontal jump as the reel loads.
+const double _quotedPreviewWidth = 200;
+
+/// Play-badge diameter for the compact quoted thumbnail. The shared
+/// [VideoThumbnailWidget] default (48) overflows the 40-wide thumb, so the
+/// quoted preview uses a smaller badge with breathing room around it.
+const double _quotedPlayIconSize = 24;
+
 /// Compact WhatsApp-style quoted preview of the video a reply references.
 ///
 /// Reuses the [VideoLinkPreviewCubit] resolve harness (cache → relay fetch) so
@@ -723,10 +734,7 @@ class _QuotedVideoPreview extends ConsumerWidget {
       ),
       child: BlocBuilder<VideoLinkPreviewCubit, VideoLinkPreviewState>(
         builder: (context, state) => switch (state) {
-          VideoLinkPreviewLoading() => _QuotedVideoFrame(
-            isSent: isSent,
-            child: const _QuotedThumbPlaceholder(),
-          ),
+          VideoLinkPreviewLoading() => _QuotedVideoLoading(isSent: isSent),
           VideoLinkPreviewNotFound() => _QuotedVideoUnavailable(isSent: isSent),
           VideoLinkPreviewResolved(:final video) => _QuotedVideoCard(
             video: video,
@@ -746,25 +754,72 @@ class _QuotedVideoFrame extends StatelessWidget {
     required this.isSent,
     required this.child,
     this.onTap,
+    this.semanticLabel,
   });
 
   final bool isSent;
   final Widget child;
   final VoidCallback? onTap;
 
+  /// Screen-reader label for the tappable affordance. Only used when [onTap]
+  /// is non-null (the resolved, openable card).
+  final String? semanticLabel;
+
   @override
   Widget build(BuildContext context) {
     final accent = isSent ? VineTheme.whiteText : VineTheme.primary;
-    final frame = DecoratedBox(
-      decoration: BoxDecoration(
-        color: VineTheme.whiteText.withValues(alpha: isSent ? 0.14 : 0.07),
-        borderRadius: BorderRadius.circular(8),
-        border: Border(left: BorderSide(color: accent, width: 3)),
+    final frame = SizedBox(
+      width: _quotedPreviewWidth,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: VineTheme.whiteText.withValues(alpha: isSent ? 0.14 : 0.07),
+          borderRadius: BorderRadius.circular(8),
+          border: Border(left: BorderSide(color: accent, width: 3)),
+        ),
+        child: Padding(padding: const EdgeInsets.all(6), child: child),
       ),
-      child: Padding(padding: const EdgeInsets.all(6), child: child),
     );
     if (onTap == null) return frame;
-    return GestureDetector(onTap: onTap, child: frame);
+    // Co-locate the button semantics with the tap target so every tappable
+    // frame is announced as a button — callers can't forget to wrap it.
+    return Semantics(
+      button: true,
+      label: semanticLabel,
+      child: GestureDetector(onTap: onTap, child: frame),
+    );
+  }
+}
+
+/// Loading skeleton for the compact quoted preview. Mirrors the resolved
+/// card's thumbnail + two-line label layout so the fixed-width frame reads as
+/// content rather than an empty box while the cited reel resolves.
+class _QuotedVideoLoading extends StatelessWidget {
+  const _QuotedVideoLoading({required this.isSent});
+
+  final bool isSent;
+
+  @override
+  Widget build(BuildContext context) {
+    return _QuotedVideoFrame(
+      isSent: isSent,
+      child: const Row(
+        spacing: 8,
+        children: [
+          _QuotedThumbPlaceholder(),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _QuotedSkeletonBar(widthFactor: 0.85),
+                SizedBox(height: 6),
+                _QuotedSkeletonBar(widthFactor: 0.5),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }
 
@@ -780,6 +835,29 @@ class _QuotedThumbPlaceholder extends StatelessWidget {
       decoration: BoxDecoration(
         color: VineTheme.cardBackground,
         borderRadius: BorderRadius.circular(_quotedThumbRadius),
+      ),
+    );
+  }
+}
+
+/// A single rounded skeleton bar for the quoted-preview loading state. The
+/// translucent white fill reads on both the sent and received bubble colors.
+class _QuotedSkeletonBar extends StatelessWidget {
+  const _QuotedSkeletonBar({required this.widthFactor});
+
+  final double widthFactor;
+
+  @override
+  Widget build(BuildContext context) {
+    return FractionallySizedBox(
+      alignment: Alignment.centerLeft,
+      widthFactor: widthFactor,
+      child: Container(
+        height: 10,
+        decoration: BoxDecoration(
+          color: VineTheme.whiteText.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(4),
+        ),
       ),
     );
   }
@@ -817,59 +895,56 @@ class _QuotedVideoCard extends ConsumerWidget {
     final showSecondary =
         hasTitle && authorName != null && authorName.isNotEmpty;
 
-    return Semantics(
-      button: true,
-      label: context.l10n.dmMessageBubbleVideoReplyHint,
-      child: _QuotedVideoFrame(
-        isSent: isSent,
-        onTap: () => context.push(
-          VideoDetailScreen.pathForId(video.id),
-          extra: VideoDetailRouteExtra(
-            initialVideo: video,
-            dmReplyContext: dmReplyContext,
-          ),
+    return _QuotedVideoFrame(
+      isSent: isSent,
+      semanticLabel: context.l10n.dmMessageBubbleVideoReplyHint,
+      onTap: () => context.push(
+        VideoDetailScreen.pathForId(video.id),
+        extra: VideoDetailRouteExtra(
+          initialVideo: video,
+          dmReplyContext: dmReplyContext,
         ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ClipRRect(
-              borderRadius: BorderRadius.circular(_quotedThumbRadius),
-              // VideoThumbnailWidget renders an AspectRatio internally, so it
-              // must be externally bounded (like the full _VideoCard's SizedBox)
-              // — its own width/height params only size the inner image.
-              child: SizedBox(
-                width: _quotedThumbWidth,
-                height: _quotedThumbHeight,
-                child: VideoThumbnailWidget(
-                  video: video,
-                  showPlayIcon: true,
-                ),
+      ),
+      child: Row(
+        spacing: 8,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(_quotedThumbRadius),
+            // VideoThumbnailWidget renders an AspectRatio internally, so it
+            // must be externally bounded (like the full _VideoCard's SizedBox)
+            // — its own width/height params only size the inner image.
+            child: SizedBox(
+              width: _quotedThumbWidth,
+              height: _quotedThumbHeight,
+              child: VideoThumbnailWidget(
+                video: video,
+                showPlayIcon: true,
+                playIconSize: _quotedPlayIconSize,
               ),
             ),
-            const SizedBox(width: 8),
-            Flexible(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
+          ),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  primaryLabel,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: VineTheme.labelSmallFont(color: primaryColor),
+                ),
+                if (showSecondary)
                   Text(
-                    primaryLabel,
+                    authorName,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: VineTheme.labelSmallFont(color: primaryColor),
+                    style: VineTheme.bodySmallFont(color: secondaryColor),
                   ),
-                  if (showSecondary)
-                    Text(
-                      authorName,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: VineTheme.bodySmallFont(color: secondaryColor),
-                    ),
-                ],
-              ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
@@ -887,15 +962,14 @@ class _QuotedVideoUnavailable extends StatelessWidget {
     return _QuotedVideoFrame(
       isSent: isSent,
       child: Row(
-        mainAxisSize: MainAxisSize.min,
+        spacing: 8,
         children: [
           DivineIcon(
             icon: DivineIconName.warningCircle,
             color: color,
             size: 16,
           ),
-          const SizedBox(width: 8),
-          Flexible(
+          Expanded(
             child: Text(
               context.l10n.notificationsVideoUnavailable,
               maxLines: 1,

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -20,6 +20,7 @@ class VideoThumbnailWidget extends StatefulWidget {
     this.height,
     this.fit = BoxFit.cover,
     this.showPlayIcon = false,
+    this.playIconSize = 48,
     this.borderRadius,
   });
   final VideoEvent video;
@@ -27,6 +28,11 @@ class VideoThumbnailWidget extends StatefulWidget {
   final double? height;
   final BoxFit fit;
   final bool showPlayIcon;
+
+  /// Diameter of the circular play badge shown when [showPlayIcon] is true.
+  /// The play glyph scales proportionally (two-thirds of the badge). Defaults
+  /// to 48 to match full-size cards; compact thumbnails pass a smaller value.
+  final double playIconSize;
   final BorderRadius? borderRadius;
 
   @override
@@ -124,16 +130,16 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
         if (widget.showPlayIcon)
           Center(
             child: Container(
-              width: 48,
-              height: 48,
+              width: widget.playIconSize,
+              height: widget.playIconSize,
               decoration: BoxDecoration(
                 color: VineTheme.backgroundColor.withValues(alpha: 0.6),
                 shape: BoxShape.circle,
               ),
-              child: const DivineIcon(
+              child: DivineIcon(
                 icon: DivineIconName.play,
                 color: VineTheme.whiteText,
-                size: 32,
+                size: widget.playIconSize * 2 / 3,
               ),
             ),
           ),

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1609,6 +1609,18 @@ class DmRepository {
     );
 
     if (citation == null) {
+      // The structured reference couldn't be built (most commonly a regular
+      // kind-22 ref whose source `q` tag omitted the author). Degrading to a
+      // plain message is acceptable, but log it so the lost cross-device /
+      // other-client durability isn't silent.
+      Log.warning(
+        'Shared-video citation could not be built (kind=$videoKind, '
+        'hasAuthor=${videoAuthorPubkey.isNotEmpty}, '
+        'hasDTag=${videoDTag?.isNotEmpty ?? false}, '
+        'hasEventId=${videoEventId?.isNotEmpty ?? false}); sending plain '
+        'message without the durable video reference.',
+        category: LogCategory.system,
+      );
       return sendMessage(
         recipientPubkey: recipientPubkey,
         content: baseContent,
@@ -1653,6 +1665,16 @@ class DmRepository {
     );
 
     if (citation == null) {
+      // See [sendSharedVideo]: log the degradation so a reel reply silently
+      // losing its durable video reference is observable.
+      Log.warning(
+        'Shared-video group citation could not be built (kind=$videoKind, '
+        'hasAuthor=${videoAuthorPubkey.isNotEmpty}, '
+        'hasDTag=${videoDTag?.isNotEmpty ?? false}, '
+        'hasEventId=${videoEventId?.isNotEmpty ?? false}); sending plain '
+        'group message without the durable video reference.',
+        category: LogCategory.system,
+      );
       return sendGroupMessage(
         recipientPubkeys: recipientPubkeys,
         content: baseContent,
@@ -1970,8 +1992,10 @@ class DmRepository {
             // hydrates the same read-time-derived fields (e.g. sharedVideoRef
             // from a NIP-18 q tag) as the happy-path send. Without this the
             // queue-recovery row drops its tags and the sender loses the
-            // shared-video reference locally. Mirrors the receive path, which
-            // persists the full rumor tags.
+            // shared-video reference locally. This intentionally also persists
+            // the rumor's leading recipient `p` tag — matching the receive
+            // path (L1121), not the happy-path 1:1 send which stores only its
+            // own rumorTags; harmless since only the `q` tag is read back.
             tagsJson: rumor.tags.isEmpty ? null : jsonEncode(rumor.tags),
             ownerPubkey: _userPubkey,
           );

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1624,6 +1624,50 @@ class DmRepository {
     );
   }
 
+  /// Group counterpart of [sendSharedVideo]: cites a video with a NIP-18 `q`
+  /// tag + NIP-21 `nostr:` URI on a kind-14 rumor sent to every member of a
+  /// group conversation.
+  ///
+  /// Used for a reel reply in a group so the reply self-carries the video
+  /// reference end-to-end (cross-device + other Nostr clients can resolve it
+  /// without the parent message). When a valid citation can't be built, falls
+  /// back to a plain-text [sendGroupMessage].
+  ///
+  /// Throws the same errors as [sendGroupMessage].
+  Future<List<NIP17SendResult>> sendSharedVideoGroup({
+    required List<String> recipientPubkeys,
+    required String baseContent,
+    required int videoKind,
+    required String videoAuthorPubkey,
+    String? videoDTag,
+    String? videoEventId,
+    String? relayHint,
+    String? replyToId,
+  }) async {
+    final citation = DmSharedVideoCitation.build(
+      videoKind: videoKind,
+      authorPubkey: videoAuthorPubkey,
+      relayHint: relayHint ?? DmShareConstants.defaultRelayHint,
+      dTag: videoDTag,
+      eventId: videoEventId,
+    );
+
+    if (citation == null) {
+      return sendGroupMessage(
+        recipientPubkeys: recipientPubkeys,
+        content: baseContent,
+        replyToId: replyToId,
+      );
+    }
+
+    return sendGroupMessage(
+      recipientPubkeys: recipientPubkeys,
+      content: '$baseContent\n${citation.nostrUri}',
+      additionalTags: [citation.qTag],
+      replyToId: replyToId,
+    );
+  }
+
   /// Re-publish only the sender self-addressed gift wrap for an
   /// already-sent rumor whose recipient publish landed but whose
   /// self-wrap did not.
@@ -2230,6 +2274,7 @@ class DmRepository {
     required List<String> recipientPubkeys,
     required String content,
     String? replyToId,
+    List<List<String>> additionalTags = const [],
   }) async {
     _assertInitialized();
     if (recipientPubkeys.isEmpty) {
@@ -2252,7 +2297,8 @@ class DmRepository {
     final results = <NIP17SendResult>[];
 
     for (final pubkey in recipientPubkeys) {
-      final additionalTags = <List<String>>[
+      final rumorTags = <List<String>>[
+        ...additionalTags,
         // Include all recipients as p tags per NIP-17
         for (final pk in recipientPubkeys)
           if (pk != pubkey) ['p', pk],
@@ -2266,7 +2312,7 @@ class DmRepository {
       final rumor = _messageService!.buildRumor(
         recipientPubkey: pubkey,
         content: content,
-        additionalTags: additionalTags,
+        additionalTags: rumorTags,
       );
 
       // Enqueue before publish so an app crash mid-send leaves a
@@ -2309,6 +2355,7 @@ class DmRepository {
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
       final firstSuccess = results.firstWhere((r) => r.success);
       final localTags = <List<String>>[
+        ...additionalTags,
         for (final pk in recipientPubkeys) ['p', pk],
         if (replyToId != null) ['e', replyToId],
       ];

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1966,6 +1966,13 @@ class DmRepository {
             giftWrapId: result.messageEventId!,
             messageKind: row.messageKind,
             replyToId: row.replyToId,
+            // Reconstruct tagsJson from the rebuilt rumor so a recovered row
+            // hydrates the same read-time-derived fields (e.g. sharedVideoRef
+            // from a NIP-18 q tag) as the happy-path send. Without this the
+            // queue-recovery row drops its tags and the sender loses the
+            // shared-video reference locally. Mirrors the receive path, which
+            // persists the full rumor tags.
+            tagsJson: rumor.tags.isEmpty ? null : jsonEncode(rumor.tags),
             ownerPubkey: _userPubkey,
           );
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7905,6 +7905,299 @@ void main() {
           );
         },
       );
+
+      test(
+        'threads additionalTags q-tag onto each recipient rumor and the '
+        'persisted tagsJson',
+        () async {
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+          stubDaoInserts();
+
+          const qTag = [
+            'q',
+            '34236:$_validPubkeyD:my-d',
+            'wss://relay.example',
+          ];
+
+          final repo = createRepository();
+          await repo.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'Group share!',
+            additionalTags: const [qTag],
+          );
+
+          // Each recipient's built rumor carries the q-tag (alongside the
+          // other recipient's p-tag).
+          final sentRumors = verify(
+            () => mockMessageService.sendRumor(
+              rumorEvent: captureAny(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+            ),
+          ).captured.cast<Event>();
+          expect(sentRumors, hasLength(2));
+          for (final rumor in sentRumors) {
+            expect(rumor.tags, contains(equals(qTag)));
+            // Both other-recipient p-tags ride along per NIP-17.
+            expect(
+              rumor.tags.where((tag) => tag.length >= 2 && tag[0] == 'p'),
+              isNotEmpty,
+            );
+          }
+
+          // The locally-persisted tagsJson carries the q-tag alongside the
+          // per-recipient p-tags.
+          final tagsJson =
+              verify(
+                    () => mockDirectMessagesDao.insertMessage(
+                      id: any(named: 'id'),
+                      conversationId: any(named: 'conversationId'),
+                      senderPubkey: any(named: 'senderPubkey'),
+                      content: any(named: 'content'),
+                      createdAt: any(named: 'createdAt'),
+                      giftWrapId: any(named: 'giftWrapId'),
+                      replyToId: any(named: 'replyToId'),
+                      ownerPubkey: any(named: 'ownerPubkey'),
+                      tagsJson: captureAny(named: 'tagsJson'),
+                    ),
+                  ).captured.single
+                  as String;
+          final persistedTags = (jsonDecode(tagsJson) as List<dynamic>)
+              .map((tag) => (tag as List<dynamic>).cast<String>())
+              .toList();
+          expect(persistedTags, contains(equals(qTag)));
+          expect(persistedTags, contains(equals(['p', _validPubkeyB])));
+          expect(persistedTags, contains(equals(['p', _validPubkeyC])));
+        },
+      );
+
+      test(
+        'threads additionalTags q-tag and the e reply tag into the '
+        'persisted tagsJson',
+        () async {
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+          stubDaoInserts();
+
+          const qTag = [
+            'q',
+            '34236:$_validPubkeyD:my-d',
+            'wss://relay.example',
+          ];
+
+          final repo = createRepository();
+          await repo.sendGroupMessage(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            content: 'Group reply!',
+            additionalTags: const [qTag],
+            replyToId: _giftWrapEventId,
+          );
+
+          final tagsJson =
+              verify(
+                    () => mockDirectMessagesDao.insertMessage(
+                      id: any(named: 'id'),
+                      conversationId: any(named: 'conversationId'),
+                      senderPubkey: any(named: 'senderPubkey'),
+                      content: any(named: 'content'),
+                      createdAt: any(named: 'createdAt'),
+                      giftWrapId: any(named: 'giftWrapId'),
+                      replyToId: any(named: 'replyToId'),
+                      ownerPubkey: any(named: 'ownerPubkey'),
+                      tagsJson: captureAny(named: 'tagsJson'),
+                    ),
+                  ).captured.single
+                  as String;
+          final persistedTags = (jsonDecode(tagsJson) as List<dynamic>)
+              .map((tag) => (tag as List<dynamic>).cast<String>())
+              .toList();
+          expect(persistedTags, contains(equals(qTag)));
+          expect(persistedTags, contains(equals(['e', _giftWrapEventId])));
+        },
+      );
+    });
+
+    group('sendSharedVideoGroup', () {
+      void stubDaoInserts() {
+        when(
+          () => mockDirectMessagesDao.insertMessage(
+            id: any(named: 'id'),
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            giftWrapId: any(named: 'giftWrapId'),
+            messageKind: any(named: 'messageKind'),
+            replyToId: any(named: 'replyToId'),
+            subject: any(named: 'subject'),
+            fileType: any(named: 'fileType'),
+            encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+            decryptionKey: any(named: 'decryptionKey'),
+            decryptionNonce: any(named: 'decryptionNonce'),
+            fileHash: any(named: 'fileHash'),
+            originalFileHash: any(named: 'originalFileHash'),
+            fileSize: any(named: 'fileSize'),
+            dimensions: any(named: 'dimensions'),
+            blurhash: any(named: 'blurhash'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            tagsJson: any(named: 'tagsJson'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.upsertConversation(
+            id: any(named: 'id'),
+            participantPubkeys: any(named: 'participantPubkeys'),
+            isGroup: any(named: 'isGroup'),
+            createdAt: any(named: 'createdAt'),
+            lastMessageContent: any(named: 'lastMessageContent'),
+            lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+            lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+            subject: any(named: 'subject'),
+            isRead: any(named: 'isRead'),
+            currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            dmProtocol: any(named: 'dmProtocol'),
+          ),
+        ).thenAnswer((_) async {});
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+      }
+
+      test(
+        'cites an addressable (34236) video as a q-tag + nostr: URI and '
+        'carries the reply e-tag on every recipient rumor',
+        () async {
+          stubSendRumor(
+            (_, recipientPubkey) async =>
+                const NIP17SendResult.failure('relay unavailable'),
+          );
+
+          final repository = createRepository();
+          const author =
+              'cccccccccccccccccccccccccccccccc'
+              'cccccccccccccccccccccccccccccccc';
+
+          await repository.sendSharedVideoGroup(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            baseContent: 'watch this https://divine.video/video/abc',
+            videoKind: 34236,
+            videoAuthorPubkey: author,
+            videoDTag: 'abc',
+            relayHint: 'wss://relay.example',
+            replyToId: _giftWrapEventId,
+          );
+
+          final sentRumors = verify(
+            () => mockMessageService.sendRumor(
+              rumorEvent: captureAny(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+            ),
+          ).captured.cast<Event>();
+          expect(sentRumors, hasLength(2));
+          for (final rumor in sentRumors) {
+            // q tag cites the video by coordinate, no 4th element
+            // (addressable).
+            expect(
+              rumor.tags,
+              contains(
+                equals(['q', '34236:$author:abc', 'wss://relay.example']),
+              ),
+            );
+            // Reply e-tag points at the parent message.
+            expect(rumor.tags, contains(equals(['e', _giftWrapEventId])));
+            // Content keeps the divine.video URL AND adds the nostr: URI.
+            expect(rumor.content, contains('nostr:naddr1'));
+            expect(
+              rumor.content,
+              contains('https://divine.video/video/abc'),
+            );
+          }
+        },
+      );
+
+      test(
+        'falls back to a plain sendGroupMessage when the citation cannot '
+        'be built (invalid author)',
+        () async {
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+          stubDaoInserts();
+
+          final repository = createRepository();
+
+          await repository.sendSharedVideoGroup(
+            recipientPubkeys: [_validPubkeyB, _validPubkeyC],
+            baseContent: 'watch this',
+            videoKind: 34236,
+            // Not a 64-char hex pubkey, so DmSharedVideoCitation.build
+            // returns null and the group send degrades to plain text.
+            videoAuthorPubkey: 'not-a-valid-author',
+            videoDTag: 'abc',
+            relayHint: 'wss://relay.example',
+          );
+
+          final sentRumors = verify(
+            () => mockMessageService.sendRumor(
+              rumorEvent: captureAny(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+            ),
+          ).captured.cast<Event>();
+          expect(sentRumors, hasLength(2));
+          for (final rumor in sentRumors) {
+            // No q-tag and no appended nostr: URI on the plain fallback.
+            expect(
+              rumor.tags.any((tag) => tag.isNotEmpty && tag[0] == 'q'),
+              isFalse,
+            );
+            expect(rumor.content, equals('watch this'));
+            expect(rumor.content, isNot(contains('nostr:')));
+          }
+
+          // The persisted tagsJson is the plain p-tag set — no q-tag.
+          final tagsJson =
+              verify(
+                    () => mockDirectMessagesDao.insertMessage(
+                      id: any(named: 'id'),
+                      conversationId: any(named: 'conversationId'),
+                      senderPubkey: any(named: 'senderPubkey'),
+                      content: any(named: 'content'),
+                      createdAt: any(named: 'createdAt'),
+                      giftWrapId: any(named: 'giftWrapId'),
+                      replyToId: any(named: 'replyToId'),
+                      ownerPubkey: any(named: 'ownerPubkey'),
+                      tagsJson: captureAny(named: 'tagsJson'),
+                    ),
+                  ).captured.single
+                  as String;
+          final persistedTags = (jsonDecode(tagsJson) as List<dynamic>)
+              .map((tag) => (tag as List<dynamic>).cast<String>())
+              .toList();
+          expect(
+            persistedTags.any((tag) => tag.isNotEmpty && tag[0] == 'q'),
+            isFalse,
+          );
+        },
+      );
     });
 
     group('_mergeDuplicateConversations', () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -10577,6 +10577,85 @@ void main() {
       );
 
       test(
+        'reconstructs tagsJson from the rebuilt rumor so a recovered '
+        'shared-video reply keeps its q citation locally',
+        () async {
+          final videoTags = [
+            ['p', _validPubkeyB],
+            ['q', '34236:$_validPubkeyB:my-reel', 'wss://relay.divine.video'],
+          ];
+          final videoRumorJson = jsonEncode({
+            'id': _rumorEventId,
+            'pubkey': _validPubkeyA,
+            'created_at': 1700000000,
+            'kind': EventKind.privateDirectMessage,
+            'tags': videoTags,
+            'content': 'love this reel',
+            'sig': '',
+          });
+          when(() => mockOutgoingDmsDao.getById(_rumorEventId)).thenAnswer(
+            (_) async => OutgoingDm(
+              id: _rumorEventId,
+              conversationId: 'conv',
+              recipientPubkey: _validPubkeyB,
+              content: 'love this reel',
+              createdAt: 1700000000,
+              rumorEventJson: videoRumorJson,
+              recipientWrapStatus: OutgoingWrapStatus.failed,
+              selfWrapStatus: OutgoingWrapStatus.failed,
+              queuedAt: DateTime.fromMillisecondsSinceEpoch(0),
+              ownerPubkey: _validPubkeyA,
+            ),
+          );
+          stubSendRumor(
+            (_, recipientPubkey) async => NIP17SendResult.success(
+              rumorEventId: _rumorEventId,
+              messageEventId: _giftWrapEventId2,
+              recipientPubkey: recipientPubkey,
+            ),
+          );
+
+          final repository = createRepository(
+            outgoingDmsDao: mockOutgoingDmsDao,
+          );
+
+          final result = await repository.recoverFullSend(
+            rumorId: _rumorEventId,
+          );
+
+          expect(result.success, isTrue);
+          // The recovered row persists the full rumor tags (including the
+          // NIP-18 q citation) instead of dropping them, so the sender's local
+          // bubble re-derives its sharedVideoRef.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: _rumorEventId,
+              conversationId: 'conv',
+              senderPubkey: _validPubkeyA,
+              content: 'love this reel',
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: _giftWrapEventId2,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: _validPubkeyA,
+              tagsJson: jsonEncode(videoTags),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
         'on partial delivery: keeps the queue row, marks recipient '
         'sent and self failed, still inserts direct_messages',
         () async {

--- a/mobile/packages/models/lib/src/dm_shared_video_ref.dart
+++ b/mobile/packages/models/lib/src/dm_shared_video_ref.dart
@@ -65,6 +65,21 @@ class DmSharedVideoRef extends Equatable {
       videoKind == DmSharedVideoKind.addressableShortVideo ||
       videoKind == DmSharedVideoKind.addressableNormalVideo;
 
+  /// For an addressable ref, the `<d>` identifier extracted from the
+  /// `<kind>:<author>:<d>` coordinate; `null` for regular events or a
+  /// malformed coordinate.
+  String? get dTag {
+    if (!isAddressable) return null;
+    final parts = coordinateOrId.split(':');
+    if (parts.length < 3) return null;
+    final d = parts.sublist(2).join(':');
+    return d.isEmpty ? null : d;
+  }
+
+  /// For a regular ref, the 64-hex event id (the `coordinateOrId` itself);
+  /// `null` for addressable events.
+  String? get eventId => isAddressable ? null : coordinateOrId;
+
   /// JSON form for persistence in the `direct_messages.shared_video_ref_json`
   /// Drift column.
   Map<String, dynamic> toJson() => <String, dynamic>{

--- a/mobile/packages/models/test/src/dm_shared_video_ref_test.dart
+++ b/mobile/packages/models/test/src/dm_shared_video_ref_test.dart
@@ -88,5 +88,49 @@ void main() {
         isNull,
       );
     });
+
+    group('dTag', () {
+      test('extracts the <d> from an addressable coordinate', () {
+        expect(addressable.dTag, equals('my-reel'));
+      });
+
+      test('works for an addressable normal video (kind 34235)', () {
+        const ref = DmSharedVideoRef(
+          coordinateOrId: '34235:author:normal-reel',
+          videoKind: DmSharedVideoKind.addressableNormalVideo,
+        );
+        expect(ref.dTag, equals('normal-reel'));
+      });
+
+      test('is null for a regular ref', () {
+        expect(regular.dTag, isNull);
+      });
+
+      test('is null for a malformed addressable coordinate', () {
+        const ref = DmSharedVideoRef(
+          coordinateOrId: '34236:onlyauthor',
+          videoKind: DmSharedVideoKind.addressableShortVideo,
+        );
+        expect(ref.dTag, isNull);
+      });
+
+      test('rejoins a <d> identifier that contains a colon', () {
+        const ref = DmSharedVideoRef(
+          coordinateOrId: '34236:abc:my:reel',
+          videoKind: DmSharedVideoKind.addressableShortVideo,
+        );
+        expect(ref.dTag, equals('my:reel'));
+      });
+    });
+
+    group('eventId', () {
+      test('is the coordinateOrId for a regular ref', () {
+        expect(regular.eventId, equals('a' * 64));
+      });
+
+      test('is null for an addressable ref', () {
+        expect(addressable.eventId, isNull);
+      });
+    });
   });
 }

--- a/mobile/test/blocs/dm/conversation/conversation_state_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_state_test.dart
@@ -1,0 +1,80 @@
+// ABOUTME: Tests for ConversationState's pure projection getters —
+// ABOUTME: specifically that an optimistic outgoing row's reply linkage
+// ABOUTME: survives into the displayedMessages bubble.
+
+import 'package:db_client/db_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/dm/conversation/conversation_bloc.dart';
+
+/// Builds an [OutgoingDm] queue row for the [ConversationState] projection
+/// tests. Mirrors the sibling builder in `conversation_bloc_test.dart` but
+/// additionally exposes [replyToId], which the reply-linkage case needs.
+OutgoingDm _outgoingDm({
+  required String id,
+  String content = 'test',
+  int createdAtSec = 1700000000,
+  String? replyToId,
+  String ownerPubkey =
+      '1111111111111111111111111111111111111111111111111111111111111111',
+  String recipientPubkey =
+      '2222222222222222222222222222222222222222222222222222222222222222',
+  String conversationId =
+      'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+  OutgoingWrapStatus recipientWrap = OutgoingWrapStatus.pending,
+  OutgoingWrapStatus selfWrap = OutgoingWrapStatus.pending,
+}) {
+  return OutgoingDm(
+    id: id,
+    conversationId: conversationId,
+    recipientPubkey: recipientPubkey,
+    content: content,
+    createdAt: createdAtSec,
+    rumorEventJson: '{}',
+    replyToId: replyToId,
+    recipientWrapStatus: recipientWrap,
+    selfWrapStatus: selfWrap,
+    queuedAt: DateTime.fromMillisecondsSinceEpoch(createdAtSec * 1000),
+    ownerPubkey: ownerPubkey,
+  );
+}
+
+void main() {
+  group(ConversationState, () {
+    group('displayedMessages', () {
+      const parentId =
+          '7777777777777777777777777777777777777777777777777777777777777777';
+
+      test(
+        'optimistic outgoing bubble carries its replyToId so an in-flight '
+        'reply can resolve its parent',
+        () {
+          final replyRow = _outgoingDm(
+            id: 'rumor-reply',
+            content: 'replying in-flight',
+            replyToId: parentId,
+          );
+          final state = ConversationState(pendingOutgoing: [replyRow]);
+
+          final bubble = state.displayedMessages.firstWhere(
+            (m) => m.id == 'rumor-reply',
+          );
+          expect(bubble.replyToId, equals(parentId));
+        },
+      );
+
+      test(
+        'optimistic outgoing bubble has a null replyToId when the queued '
+        'row is not a reply',
+        () {
+          final plainRow = _outgoingDm(id: 'rumor-plain', content: 'hi');
+          final state = ConversationState(pendingOutgoing: [plainRow]);
+
+          final bubble = state.displayedMessages.firstWhere(
+            (m) => m.id == 'rumor-plain',
+          );
+          expect(bubble.replyToId, isNull);
+        },
+      );
+    });
+  });
+}

--- a/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
+++ b/mobile/test/blocs/dm/inline_reel_reply/inline_reel_reply_cubit_test.dart
@@ -18,6 +18,27 @@ const _peer2 =
 const _convo = 'convo-id';
 const _reelId =
     'rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr';
+const _videoAuthor =
+    '4444444444444444444444444444444444444444444444444444444444444444';
+const _regularEventId =
+    '5555555555555555555555555555555555555555555555555555555555555555';
+const _relayHint = 'wss://relay.example.com';
+
+/// Addressable (kind 34236) reel ref — coordinate `<kind>:<author>:<d>`.
+const _addressableVideoRef = DmSharedVideoRef(
+  coordinateOrId: '34236:$_videoAuthor:my-reel',
+  videoKind: DmSharedVideoKind.addressableShortVideo,
+  authorPubkey: _videoAuthor,
+  relayHint: _relayHint,
+);
+
+/// Regular (kind 22) reel ref — `coordinateOrId` is the 64-hex event id.
+const _regularVideoRef = DmSharedVideoRef(
+  coordinateOrId: _regularEventId,
+  videoKind: DmSharedVideoKind.shortVideo,
+  authorPubkey: _videoAuthor,
+  relayHint: _relayHint,
+);
 
 DmReplyContext oneToOne({bool isOwn = false}) => DmReplyContext(
   conversationId: _convo,
@@ -29,6 +50,17 @@ DmReplyContext oneToOne({bool isOwn = false}) => DmReplyContext(
   isOwnMessage: isOwn,
 );
 
+DmReplyContext oneToOneWithVideo({DmSharedVideoRef? ref}) => DmReplyContext(
+  conversationId: _convo,
+  participantPubkeys: const [_peer],
+  isGroup: false,
+  sharedReelMessageId: _reelId,
+  messageAuthorPubkey: _peer,
+  hintName: 'Alice',
+  isOwnMessage: false,
+  sharedVideoRef: ref ?? _addressableVideoRef,
+);
+
 DmReplyContext groupCtx() => const DmReplyContext(
   conversationId: _convo,
   participantPubkeys: [_peer, _peer2],
@@ -37,6 +69,17 @@ DmReplyContext groupCtx() => const DmReplyContext(
   messageAuthorPubkey: _peer,
   hintName: 'The Group',
   isOwnMessage: false,
+);
+
+DmReplyContext groupCtxWithVideo({DmSharedVideoRef? ref}) => DmReplyContext(
+  conversationId: _convo,
+  participantPubkeys: const [_peer, _peer2],
+  isGroup: true,
+  sharedReelMessageId: _reelId,
+  messageAuthorPubkey: _peer,
+  hintName: 'The Group',
+  isOwnMessage: false,
+  sharedVideoRef: ref ?? _addressableVideoRef,
 );
 
 void main() {
@@ -58,6 +101,50 @@ void main() {
           messageEventId: 'g',
           recipientPubkey: _peer,
         ),
+      );
+    }
+
+    void stubSendSharedVideoSuccess() {
+      when(
+        () => repo.sendSharedVideo(
+          recipientPubkey: any(named: 'recipientPubkey'),
+          baseContent: any(named: 'baseContent'),
+          videoKind: any(named: 'videoKind'),
+          videoAuthorPubkey: any(named: 'videoAuthorPubkey'),
+          videoDTag: any(named: 'videoDTag'),
+          videoEventId: any(named: 'videoEventId'),
+          relayHint: any(named: 'relayHint'),
+          replyToId: any(named: 'replyToId'),
+        ),
+      ).thenAnswer(
+        (_) async => NIP17SendResult.success(
+          rumorEventId: 'r',
+          messageEventId: 'g',
+          recipientPubkey: _peer,
+        ),
+      );
+    }
+
+    void stubSendSharedVideoGroupSuccess() {
+      when(
+        () => repo.sendSharedVideoGroup(
+          recipientPubkeys: any(named: 'recipientPubkeys'),
+          baseContent: any(named: 'baseContent'),
+          videoKind: any(named: 'videoKind'),
+          videoAuthorPubkey: any(named: 'videoAuthorPubkey'),
+          videoDTag: any(named: 'videoDTag'),
+          videoEventId: any(named: 'videoEventId'),
+          relayHint: any(named: 'relayHint'),
+          replyToId: any(named: 'replyToId'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          NIP17SendResult.success(
+            rumorEventId: 'r',
+            messageEventId: 'g',
+            recipientPubkey: _peer,
+          ),
+        ],
       );
     }
 
@@ -248,6 +335,190 @@ void main() {
       expect: () => const [
         InlineReelReplyState(),
       ],
+    );
+
+    blocTest<InlineReelReplyCubit, InlineReelReplyState>(
+      '1:1 with addressable video ref cites the video via sendSharedVideo',
+      build: () {
+        stubSendSharedVideoSuccess();
+        return InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: oneToOneWithVideo(),
+        );
+      },
+      act: (cubit) => cubit.submit('hi'),
+      expect: () => const [
+        InlineReelReplyState(status: InlineReelReplyStatus.sending),
+        InlineReelReplyState(status: InlineReelReplyStatus.success),
+      ],
+      verify: (_) {
+        verify(
+          () => repo.sendSharedVideo(
+            recipientPubkey: _peer,
+            baseContent: 'hi',
+            videoKind: 34236,
+            videoAuthorPubkey: _videoAuthor,
+            videoDTag: 'my-reel',
+            videoEventId: any(named: 'videoEventId', that: isNull),
+            relayHint: _relayHint,
+            replyToId: _reelId,
+          ),
+        ).called(1);
+        verifyNever(
+          () => repo.sendMessage(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        );
+      },
+    );
+
+    blocTest<InlineReelReplyCubit, InlineReelReplyState>(
+      'group with addressable video ref cites via sendSharedVideoGroup',
+      build: () {
+        stubSendSharedVideoGroupSuccess();
+        return InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: groupCtxWithVideo(),
+        );
+      },
+      act: (cubit) => cubit.submit('hi'),
+      expect: () => const [
+        InlineReelReplyState(status: InlineReelReplyStatus.sending),
+        InlineReelReplyState(status: InlineReelReplyStatus.success),
+      ],
+      verify: (_) {
+        verify(
+          () => repo.sendSharedVideoGroup(
+            recipientPubkeys: const [_peer, _peer2],
+            baseContent: 'hi',
+            videoKind: 34236,
+            videoAuthorPubkey: _videoAuthor,
+            videoDTag: 'my-reel',
+            videoEventId: any(named: 'videoEventId', that: isNull),
+            relayHint: _relayHint,
+            replyToId: _reelId,
+          ),
+        ).called(1);
+        verifyNever(
+          () => repo.sendGroupMessage(
+            recipientPubkeys: any(named: 'recipientPubkeys'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        );
+      },
+    );
+
+    blocTest<InlineReelReplyCubit, InlineReelReplyState>(
+      'regular-kind video ref passes videoEventId and null videoDTag',
+      build: () {
+        stubSendSharedVideoSuccess();
+        return InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: oneToOneWithVideo(ref: _regularVideoRef),
+        );
+      },
+      act: (cubit) => cubit.submit('hi'),
+      expect: () => const [
+        InlineReelReplyState(status: InlineReelReplyStatus.sending),
+        InlineReelReplyState(status: InlineReelReplyStatus.success),
+      ],
+      verify: (_) {
+        verify(
+          () => repo.sendSharedVideo(
+            recipientPubkey: _peer,
+            baseContent: 'hi',
+            videoKind: 22,
+            videoAuthorPubkey: _videoAuthor,
+            videoDTag: any(named: 'videoDTag', that: isNull),
+            videoEventId: _regularEventId,
+            relayHint: _relayHint,
+            replyToId: _reelId,
+          ),
+        ).called(1);
+      },
+    );
+
+    blocTest<InlineReelReplyCubit, InlineReelReplyState>(
+      '1:1 without a video ref still uses plain sendMessage',
+      build: () {
+        stubSendSuccess();
+        return InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: oneToOne(),
+        );
+      },
+      act: (cubit) => cubit.submit('hi'),
+      verify: (_) {
+        verify(
+          () => repo.sendMessage(
+            recipientPubkey: _peer,
+            content: 'hi',
+            replyToId: _reelId,
+          ),
+        ).called(1);
+        verifyNever(
+          () => repo.sendSharedVideo(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            baseContent: any(named: 'baseContent'),
+            videoKind: any(named: 'videoKind'),
+            videoAuthorPubkey: any(named: 'videoAuthorPubkey'),
+            videoDTag: any(named: 'videoDTag'),
+            videoEventId: any(named: 'videoEventId'),
+            relayHint: any(named: 'relayHint'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        );
+      },
+    );
+
+    blocTest<InlineReelReplyCubit, InlineReelReplyState>(
+      'group without a video ref still uses plain sendGroupMessage',
+      build: () {
+        when(
+          () => repo.sendGroupMessage(
+            recipientPubkeys: any(named: 'recipientPubkeys'),
+            content: any(named: 'content'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            NIP17SendResult.success(
+              rumorEventId: 'r',
+              messageEventId: 'g',
+              recipientPubkey: _peer,
+            ),
+          ],
+        );
+        return InlineReelReplyCubit(
+          dmRepository: repo,
+          replyContext: groupCtx(),
+        );
+      },
+      act: (cubit) => cubit.submit('hi'),
+      verify: (_) {
+        verify(
+          () => repo.sendGroupMessage(
+            recipientPubkeys: const [_peer, _peer2],
+            content: 'hi',
+            replyToId: _reelId,
+          ),
+        ).called(1);
+        verifyNever(
+          () => repo.sendSharedVideoGroup(
+            recipientPubkeys: any(named: 'recipientPubkeys'),
+            baseContent: any(named: 'baseContent'),
+            videoKind: any(named: 'videoKind'),
+            videoAuthorPubkey: any(named: 'videoAuthorPubkey'),
+            videoDTag: any(named: 'videoDTag'),
+            videoEventId: any(named: 'videoEventId'),
+            relayHint: any(named: 'relayHint'),
+            replyToId: any(named: 'replyToId'),
+          ),
+        );
+      },
     );
   });
 }

--- a/mobile/test/screens/inbox/conversation/conversation_view_resolvers_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_resolvers_test.dart
@@ -1,0 +1,140 @@
+// ABOUTME: Unit tests for the conversation_view quoted/own-share resolvers.
+// ABOUTME: Covers resolveOwnShareVideoRef and resolveQuotedVideoRef pure fns.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/screens/inbox/conversation/conversation_view.dart';
+
+void main() {
+  const conversationId =
+      'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+  const senderPubkey =
+      '1122334411223344112233441122334411223344112233441122334411223344';
+
+  const sharedVideoRef = DmSharedVideoRef(
+    coordinateOrId:
+        '34236:1122334411223344112233441122334411223344112233441122334411223344:skate-loop',
+    videoKind: DmSharedVideoKind.addressableShortVideo,
+  );
+
+  const otherVideoRef = DmSharedVideoRef(
+    coordinateOrId:
+        '5555555555555555555555555555555555555555555555555555555555555555',
+    videoKind: DmSharedVideoKind.shortVideo,
+  );
+
+  DmMessage buildMessage({
+    required String id,
+    String? replyToId,
+    DmSharedVideoRef? sharedVideoRef,
+  }) {
+    return DmMessage(
+      id: id,
+      conversationId: conversationId,
+      senderPubkey: senderPubkey,
+      content: 'hello',
+      createdAt: 1700000000,
+      giftWrapId: 'gw-$id',
+      replyToId: replyToId,
+      sharedVideoRef: sharedVideoRef,
+    );
+  }
+
+  group('resolveOwnShareVideoRef', () {
+    test('returns sharedVideoRef when message is not a reply', () {
+      final message = buildMessage(
+        id: 'msg-1',
+        sharedVideoRef: sharedVideoRef,
+      );
+
+      expect(resolveOwnShareVideoRef(message), equals(sharedVideoRef));
+    });
+
+    test('returns null when message is a reply even if it self-carries a '
+        'sharedVideoRef', () {
+      final message = buildMessage(
+        id: 'msg-2',
+        replyToId: 'parent-1',
+        sharedVideoRef: sharedVideoRef,
+      );
+
+      expect(resolveOwnShareVideoRef(message), isNull);
+    });
+
+    test('returns null when a non-reply message has no sharedVideoRef', () {
+      final message = buildMessage(id: 'msg-3');
+
+      expect(resolveOwnShareVideoRef(message), isNull);
+    });
+  });
+
+  group('resolveQuotedVideoRef', () {
+    test('returns null when message is not a reply', () {
+      final message = buildMessage(
+        id: 'msg-1',
+        sharedVideoRef: sharedVideoRef,
+      );
+      final index = <String, DmMessage>{message.id: message};
+
+      expect(resolveQuotedVideoRef(message, index), isNull);
+    });
+
+    test('returns the parent ref when the parent is in the index with a '
+        'non-null sharedVideoRef', () {
+      final parent = buildMessage(
+        id: 'parent-1',
+        sharedVideoRef: sharedVideoRef,
+      );
+      // The reply self-carries a DIFFERENT ref to prove the parent wins.
+      final reply = buildMessage(
+        id: 'reply-1',
+        replyToId: 'parent-1',
+        sharedVideoRef: otherVideoRef,
+      );
+      final index = <String, DmMessage>{
+        parent.id: parent,
+        reply.id: reply,
+      };
+
+      expect(resolveQuotedVideoRef(reply, index), equals(sharedVideoRef));
+    });
+
+    test('falls back to the reply own sharedVideoRef when the parent is '
+        'absent from the index', () {
+      final reply = buildMessage(
+        id: 'reply-1',
+        replyToId: 'parent-1',
+        sharedVideoRef: otherVideoRef,
+      );
+      final index = <String, DmMessage>{reply.id: reply};
+
+      expect(resolveQuotedVideoRef(reply, index), equals(otherVideoRef));
+    });
+
+    test(
+      'returns null when neither the parent nor the reply carries a ref',
+      () {
+        final parent = buildMessage(id: 'parent-1');
+        final reply = buildMessage(id: 'reply-1', replyToId: 'parent-1');
+        final index = <String, DmMessage>{
+          parent.id: parent,
+          reply.id: reply,
+        };
+
+        expect(resolveQuotedVideoRef(reply, index), isNull);
+      },
+    );
+
+    test('returns null when the parent is present but has no ref and the '
+        'reply has none either', () {
+      final parent = buildMessage(id: 'parent-1');
+      final reply = buildMessage(id: 'reply-1', replyToId: 'parent-1');
+      final index = <String, DmMessage>{
+        parent.id: parent,
+        reply.id: reply,
+      };
+
+      expect(resolveQuotedVideoRef(reply, index), isNull);
+    });
+  });
+}

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -1222,6 +1222,50 @@ void main() {
               .dy;
           final textCenter = tester.getCenter(find.text('love this one')).dy;
           expect(thumbCenter, lessThan(textCenter));
+
+          // The compact thumbnail uses the smaller play badge so it doesn't
+          // overflow the 40-wide thumb.
+          final thumbWidget = tester.widget<VideoThumbnailWidget>(
+            find.byType(VideoThumbnailWidget),
+          );
+          expect(thumbWidget.playIconSize, 24);
+
+          // The preview is pinned to a fixed width so the bubble doesn't
+          // reflow when the cited reel resolves out of its loading skeleton.
+          expect(
+            find.byWidgetPredicate((w) => w is SizedBox && w.width == 200),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'exposes the resolved quoted preview as a button with the reply hint',
+        (tester) async {
+          when(
+            () => mockVideoEventService.getVideoEventByVineId('abc123'),
+          ).thenReturn(testVideo);
+
+          await tester.pumpWidget(
+            buildWithQuotedReply(
+              message: 'love this one',
+              quotedVideoRef: quotedRef,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // The tappable preview carries button semantics + the reply hint,
+          // co-located on the frame so the tap target is always announced.
+          expect(
+            find.byWidgetPredicate(
+              (w) =>
+                  w is Semantics &&
+                  (w.properties.button ?? false) &&
+                  w.properties.label ==
+                      AppLocalizationsEn().dmMessageBubbleVideoReplyHint,
+            ),
+            findsOneWidget,
+          );
         },
       );
 
@@ -1287,6 +1331,13 @@ void main() {
           expect(find.byType(VideoThumbnailWidget), findsNothing);
           // The reply comment still renders alongside the unavailable chip.
           expect(find.text('still good though'), findsOneWidget);
+
+          // The unavailable chip is pinned to the same fixed width as the
+          // resolved card, so swapping states never reflows the bubble.
+          expect(
+            find.byWidgetPredicate((w) => w is SizedBox && w.width == 200),
+            findsOneWidget,
+          );
         },
       );
 

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -1128,6 +1128,194 @@ void main() {
       );
     });
 
+    group('quoted video reply preview', () {
+      late _MockVideoEventService mockVideoEventService;
+      late MockNostrClient mockNostrClient;
+
+      final testVideo = VideoEvent(
+        id:
+            '0123456789abcdef0123456789abcdef'
+            '0123456789abcdef0123456789abcdef',
+        pubkey:
+            'abcdef0123456789abcdef0123456789'
+            'abcdef0123456789abcdef0123456789',
+        createdAt: 1757385263,
+        content: 'Test',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1757385263 * 1000),
+        title: 'My Cool Video',
+      );
+
+      const quotedRef = DmSharedVideoRef(
+        coordinateOrId: '34236:$_testHexPubkey:abc123',
+        videoKind: DmSharedVideoKind.addressableShortVideo,
+        relayHint: 'wss://relay.example',
+        authorPubkey: _testHexPubkey,
+      );
+
+      setUp(() {
+        mockVideoEventService = _MockVideoEventService();
+        mockNostrClient = createMockNostrService();
+
+        when(() => mockVideoEventService.getVideoById(any())).thenReturn(null);
+        when(
+          () => mockVideoEventService.getVideoEventByVineId(any()),
+        ).thenReturn(null);
+        when(
+          () => mockNostrClient.fetchEventById(any()),
+        ).thenAnswer((_) async => null);
+      });
+
+      Widget buildWithQuotedReply({
+        required String message,
+        DmSharedVideoRef? quotedVideoRef,
+      }) => testMaterialApp(
+        home: Scaffold(
+          body: MessageBubble(
+            message: message,
+            timestamp: '2:30 PM',
+            isSent: true,
+            quotedVideoRef: quotedVideoRef,
+          ),
+        ),
+        mockNostrService: mockNostrClient,
+        additionalOverrides: [
+          videoEventServiceProvider.overrideWithValue(
+            mockVideoEventService,
+          ),
+        ],
+      );
+
+      testWidgets(
+        'renders compact quoted thumbnail above the reply text and not the '
+        'full share card',
+        (tester) async {
+          when(
+            () => mockVideoEventService.getVideoEventByVineId('abc123'),
+          ).thenReturn(testVideo);
+
+          await tester.pumpWidget(
+            buildWithQuotedReply(
+              message: 'love this one',
+              quotedVideoRef: quotedRef,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // The compact quoted preview renders the resolved video as a small
+          // thumbnail bounded to 40x56, not the full 248x350 share card.
+          expect(find.byType(VideoThumbnailWidget), findsOneWidget);
+          final compactThumb = find.byWidgetPredicate(
+            (w) => w is SizedBox && w.width == 40 && w.height == 56,
+          );
+          expect(compactThumb, findsOneWidget);
+
+          // No full 248x350 share-card SizedBox is present.
+          final fullCard = find.byWidgetPredicate(
+            (w) => w is SizedBox && w.width == 248 && w.height == 350,
+          );
+          expect(fullCard, findsNothing);
+
+          // The reply text renders below the quoted preview.
+          expect(find.text('love this one'), findsOneWidget);
+          final thumbCenter = tester
+              .getCenter(find.byType(VideoThumbnailWidget))
+              .dy;
+          final textCenter = tester.getCenter(find.text('love this one')).dy;
+          expect(thumbCenter, lessThan(textCenter));
+        },
+      );
+
+      testWidgets(
+        'renders the full share card for a non-reply share '
+        '(sharedVideoRef set, quotedVideoRef null)',
+        (tester) async {
+          when(
+            () => mockVideoEventService.getVideoEventByVineId('abc123'),
+          ).thenReturn(testVideo);
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              home: const Scaffold(
+                body: MessageBubble(
+                  message: 'watch this',
+                  timestamp: '2:30 PM',
+                  isSent: true,
+                  sharedVideoRef: quotedRef,
+                ),
+              ),
+              mockNostrService: mockNostrClient,
+              additionalOverrides: [
+                videoEventServiceProvider.overrideWithValue(
+                  mockVideoEventService,
+                ),
+              ],
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // The full share card renders a 248x350 thumbnail (default size),
+          // not the compact 40x56 quoted thumbnail.
+          final fullCard = find.byWidgetPredicate(
+            (w) => w is SizedBox && w.width == 248 && w.height == 350,
+          );
+          expect(fullCard, findsOneWidget);
+          final thumbnail = tester.widget<VideoThumbnailWidget>(
+            find.byType(VideoThumbnailWidget),
+          );
+          expect(thumbnail.width, isNull);
+          expect(thumbnail.height, isNull);
+        },
+      );
+
+      testWidgets(
+        'renders the compact unavailable chip when the quoted video is '
+        'not found',
+        (tester) async {
+          // No cache hit, no relay event → VideoLinkPreviewNotFound.
+          await tester.pumpWidget(
+            buildWithQuotedReply(
+              message: 'still good though',
+              quotedVideoRef: quotedRef,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text(AppLocalizationsEn().notificationsVideoUnavailable),
+            findsOneWidget,
+          );
+          expect(find.byType(VideoThumbnailWidget), findsNothing);
+          // The reply comment still renders alongside the unavailable chip.
+          expect(find.text('still good though'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'strips the trailing nostr: citation line from the displayed reply '
+        'text when quotedVideoRef is set',
+        (tester) async {
+          when(
+            () => mockVideoEventService.getVideoEventByVineId('abc123'),
+          ).thenReturn(testVideo);
+
+          await tester.pumpWidget(
+            buildWithQuotedReply(
+              // The reply self-carries a NIP-21 citation of the quoted video on
+              // the wire; it must not render in the bubble text.
+              message:
+                  'this is hilarious\n'
+                  'nostr:naddr1qqxnzd3cxqmrzv3exgmr2wfeqy',
+              quotedVideoRef: quotedRef,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          expect(find.text('this is hilarious'), findsOneWidget);
+          expect(find.textContaining('nostr:'), findsNothing);
+        },
+      );
+    });
+
     group('long-press', () {
       testWidgets('calls onLongPress callback', (tester) async {
         var longPressed = false;

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -429,6 +429,35 @@ void main() {
 
       // Should show play icon
       expect(_divineIcon(DivineIconName.play), findsOneWidget);
+
+      // Default badge keeps the full-size glyph (two-thirds of 48).
+      final icon = tester.widget<DivineIcon>(_divineIcon(DivineIconName.play));
+      expect(icon.size, 32);
+    });
+
+    testWidgets('scales the play badge with playIconSize', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoThumbnailWidget(
+              video: videoWithBlurhash,
+              width: 200,
+              height: 200,
+              showPlayIcon: true,
+              playIconSize: 24,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // The play glyph scales to two-thirds of the badge diameter so a
+      // compact thumbnail doesn't get a badge wider than the thumb.
+      final icon = tester.widget<DivineIcon>(_divineIcon(DivineIconName.play));
+      expect(icon.size, 24 * 2 / 3);
     });
 
     testWidgets('applies border radius when provided', (tester) async {


### PR DESCRIPTION
Closes #5388

## Description

When a user replies to a shared video in a DM, the reply is now visibly **linked to that
specific video**: the reply bubble shows a compact, WhatsApp-style quoted preview of the
video above the reply text. This makes a conversation easy to follow — the recipient can
see which reel a comment refers to, even when several videos have been shared in the chat.

This is the reply-side follow-up to #5358 (which built the share card + the in-player reply
bar). #5358 let you reply to a reel; this PR makes the reply itself carry and show the
reference.

## How it works

- **Render (resolve from the parent, instant):** a reply threads to its shared-reel message
  via its existing NIP-10 `e` tag (`replyToId`). The conversation resolves
  `reply.replyToId → parent.sharedVideoRef` in-memory and renders a small thumbnail + title
  / author strip above the reply text. Because the parent is already in the in-memory list,
  the preview appears the instant the reply is sent (optimistic), and it is unaffected by the
  outgoing-queue recovery path.
- **Durability across devices / other clients:** the reply also self-carries the video's
  NIP-18 `q` citation + NIP-21 `nostr:` URI on the wire (the same envelope the share path
  already uses), so a second device, a reinstall, or another Nostr client (e.g. divine-web)
  can resolve the reference even when the original shared-reel message hasn't synced there.
  When the parent isn't local, rendering falls back to the reply's own citation.
- **Full card vs compact quote** are mutually exclusive and disambiguated on `replyToId`: a
  non-reply share renders the full 248×350 card; a reply renders the compact quote.

## What changed

- `dm_repository`: `sendGroupMessage` gains `additionalTags` (threaded into the per-recipient
  rumor and the locally-persisted `tags_json`); new `sendSharedVideoGroup` mirrors
  `sendSharedVideo` for groups. 1:1 reuses the existing `sendSharedVideo`.
- `dm_repository`: `recoverFullSend` now reconstructs `tags_json` from the rebuilt rumor on
  its local re-insert, so a message recovered from the outgoing-DM queue keeps its
  read-time-derived fields (e.g. the shared-video reference) on the sender's device. This was
  a pre-existing gap that Approach C surfaced, fixed here so the durability story is complete.
- `models`: `DmSharedVideoRef` gains `dTag` / `eventId` getters.
- `DmReplyContext` carries the `DmSharedVideoRef`; `InlineReelReplyCubit` cites the video when
  one is present.
- `ConversationState._outgoingToBubble` carries `replyToId` so an optimistic reply resolves
  its parent immediately.
- `conversation_view` adds two pure resolvers; `message_bubble` adds a `quotedVideoRef` param
  and a compact `_QuotedVideoPreview` (reuses `VideoLinkPreviewCubit`; resolved → tappable
  thumbnail + label, loading → placeholder, not-found → "Video unavailable" chip) and strips
  the trailing `nostr:` line from the displayed text.
- New l10n key `dmMessageBubbleVideoReplyHint` translated across all locales.
- No backend / relay / signer change, no DB migration (the reference rides `tags_json`).

## How to test on a real device

Use two accounts — **A** and **B** — ideally on two physical devices (or one device + a
second account), in a conversation where both can DM each other.

1. **Share a reel.** From **A**, share a video into a DM with **B** (the existing share flow).
   Confirm **B** sees the full video share card in the thread.
2. **Reply from the player.** On **B**, tap the shared reel to open the full-screen player,
   type a comment in the bottom bar, and send.
3. **Verify the reply preview (B).** B's reply bubble shows a small thumbnail + title/author
   of the reel **above** the comment text, and the comment text itself is clean (no raw
   `nostr:` link). The preview appears immediately on send, not after a delay.
4. **Verify the reply preview (A).** On **A**, confirm the incoming reply shows the same
   quoted preview above the text.
5. **Tap the preview.** Tapping the quoted preview opens that video.
6. **Group.** Repeat steps 1–4 in a group conversation (3+ people): reply to a shared reel
   and confirm every member's copy of the reply shows the quoted preview.
7. **Cross-device / reinstall durability.** Sign in as **B** on a second device (or
   reinstall) where the original shared-reel message may not have synced yet, open the
   conversation, and confirm the reply still shows the video reference (resolved from the
   reply's own citation).
8. **Unavailable video.** Reply to a reel whose video is deleted/unreachable and confirm the
   compact **"Video unavailable"** chip renders (non-tappable) instead of a broken preview.
9. **Regression.** Confirm a normal shared-video message (not a reply) still renders the full
   248×350 card, and a plain text reply with no video shows no preview.
10. **Accessibility (optional).** With VoiceOver / TalkBack, the quoted preview is announced
    as a button and is tappable.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- Package suites: `models` and `dm_repository` pass (incl. new `additionalTags` /
  `sendSharedVideoGroup` / `dTag` / `eventId` / `recoverFullSend` tag-reconstruction tests).
- App suites: DM bloc + conversation-screen tests pass, including new coverage for the
  resolvers, the optimistic-reply `replyToId`, the cubit citation dispatch, and the
  message-bubble compact-quote / full-card / unavailable / nostr-strip cases.
- `dart format` clean.

## Type of change

- [x] New feature
- [x] Bug fix / hardening
