### PR TITLE
perf(home-feed): release neighbour players and pause prefetch when backgrounded

### DIFF
--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -226,6 +226,16 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
       }
     });
 
+    // Comments/Share bottom sheets pause the current player but keep the
+    // neighbours and disk prefetch warm for instant resume
+    // ([OverlayVisibilityState.shouldRetainPlayer]). Only a real backgrounding
+    // — tab switch, pushed route, or a full-screen page overlay — releases the
+    // off-screen players. Watched (not read) so the flag stays coherent with
+    // the overlay state across rebuilds.
+    final shouldRetainPlayer = ref
+        .watch(overlayVisibilityProvider)
+        .shouldRetainPlayer;
+
     return BlocProvider.value(
       value: _autoAdvanceCubit,
       child: NavRoundedShell(
@@ -340,8 +350,10 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                       // The home feed stays mounted across tab switches and
                       // pushed routes (StatefulShellRoute keep-alive), so
                       // release the off-screen neighbour players and pause
-                      // disk prefetch while it is backgrounded.
-                      releaseNeighboursWhenInactive: true,
+                      // disk prefetch while it is backgrounded. Bottom sheets
+                      // (comments/share) only pause the current player — they
+                      // keep neighbours and prefetch warm via shouldRetainPlayer.
+                      releaseNeighboursWhenInactive: !shouldRetainPlayer,
                       hasMore: state.hasMore,
                       isLoadingMore: state.isLoadingMore,
                       trafficSource: ViewTrafficSource.home,

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -337,6 +337,11 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                       contextTitle: state.feedContextTitle,
                       currentIndex: clampedIndex,
                       isActive: _isNewFeedActive,
+                      // The home feed stays mounted across tab switches and
+                      // pushed routes (StatefulShellRoute keep-alive), so
+                      // release the off-screen neighbour players and pause
+                      // disk prefetch while it is backgrounded.
+                      releaseNeighboursWhenInactive: true,
                       hasMore: state.hasMore,
                       isLoadingMore: state.isLoadingMore,
                       trafficSource: ViewTrafficSource.home,

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -48,6 +48,7 @@ class FeedVideos extends ConsumerStatefulWidget {
     this.currentIndex = 0,
     this.shouldPortraitExpand = true,
     this.isActive = true,
+    this.releaseNeighboursWhenInactive = false,
     this.hasMore = false,
     this.isLoadingMore = false,
     this.onActiveVideoChanged,
@@ -66,6 +67,13 @@ class FeedVideos extends ConsumerStatefulWidget {
   /// screen is obscured (tab switch, overlay open) to pause the active video
   /// without tearing down the widget tree.
   final bool isActive;
+
+  /// See [InfiniteVideoFeed.releaseNeighboursWhenInactive].
+  ///
+  /// Set this for feeds that stay mounted in the background (e.g. the home
+  /// feed inside a `StatefulShellRoute`) so the off-screen neighbour players
+  /// and disk prefetch are released while [isActive] is `false`.
+  final bool releaseNeighboursWhenInactive;
 
   /// Whether more videos can be loaded from the source.
   ///
@@ -262,6 +270,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
         key: _feedKey,
         videos: widget.videos,
         isActive: isFeedActive,
+        releaseNeighboursWhenInactive: widget.releaseNeighboursWhenInactive,
         // mediaCacheProvider is a keepAlive singleton; identity is stable for
         // the app lifetime, so ref.read is safe here. See
         // .claude/rules/state_management.md → "Bridging Riverpod-provided

--- a/mobile/packages/infinite_video_feed/lib/src/services/disk_prefetcher.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/disk_prefetcher.dart
@@ -133,12 +133,8 @@ class DiskPrefetcher {
       if (isDisposed) return;
 
       if (_generation != generation) {
-        // coverage:ignore-start
-        _log(
-          'Prefetch cycle #$generation aborted (stale)',
-        );
+        _log('Prefetch cycle #$generation aborted (stale)');
         return;
-        // coverage:ignore-end
       }
       if (i < 0 || i >= _cycleVideos.length) continue;
 

--- a/mobile/packages/infinite_video_feed/lib/src/services/disk_prefetcher.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/disk_prefetcher.dart
@@ -56,10 +56,28 @@ class DiskPrefetcher {
 
   /// Cancels the in-flight HTTP download (if any) and clears the active
   /// operation. Subsequent [run] calls start fresh.
+  ///
+  /// Note: this only stops the current download. A cycle started by [run] is
+  /// driven by a loop that keeps advancing to the next index unless the
+  /// generation changes — so on its own this does not halt an in-flight
+  /// cycle, it just makes the running download return early before the loop
+  /// moves on. Callers that need the whole cycle to stop (e.g. pausing
+  /// prefetch while a feed is backgrounded) must use [cancelCycle].
   void cancelActive() {
     _active?.cancel();
     _active = null;
     _activeIndex = null;
+  }
+
+  /// Cancels the in-flight download and halts the running cycle so no further
+  /// videos are fetched until the next [run].
+  ///
+  /// Bumps the generation, which the [run] loop checks on every iteration, so
+  /// the loop exits instead of advancing to the next index after the current
+  /// download is cancelled.
+  void cancelCycle() {
+    _generation++;
+    cancelActive();
   }
 
   /// Starts a new prefetch cycle covering `[startIndex..endIndex]`

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -442,6 +442,14 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     super.didUpdateWidget(oldWidget);
     if (widget.isActive != oldWidget.isActive) {
       _setPlaybackActive(widget.isActive);
+    } else if (!widget.isActive &&
+        widget.releaseNeighboursWhenInactive !=
+            oldWidget.releaseNeighboursWhenInactive) {
+      if (widget.releaseNeighboursWhenInactive) {
+        _releaseNeighboursAndPrefetch();
+      } else {
+        unawaited(_onIndexChanged(_currentIndex));
+      }
     }
     _syncCurrentAutoPlayGate(oldWidget);
     if (widget.videos == oldWidget.videos) return;

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -41,6 +41,7 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.scrollDirection = Axis.vertical,
     this.keepPreviousAlive = true,
     this.keepNextAlive = true,
+    this.releaseNeighboursWhenInactive = false,
     this.prefetchCount = 25,
     this.shouldPortraitExpand = true,
     this.maxLoopDuration,
@@ -171,6 +172,21 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// When `true`, the controller for index `currentIndex + 1` stays
   /// initialized alongside the current one. Defaults to `true`.
   final bool keepNextAlive;
+
+  /// Whether the neighbour players and disk prefetch are released while the
+  /// feed is inactive (see [isActive]).
+  ///
+  /// When `true` and the feed becomes inactive — e.g. the user switches tabs
+  /// or pushes a route over a feed that stays mounted in the background — the
+  /// previous/next controllers are disposed and any in-flight disk prefetch is
+  /// cancelled. Only the current controller is retained, so playback resumes
+  /// instantly when the feed becomes active again; the neighbours
+  /// re-initialize and prefetch resumes on reactivation.
+  ///
+  /// When `false` (the default), neighbours and prefetch stay warm while
+  /// inactive — appropriate for a feed that only pauses transiently while
+  /// staying on screen (e.g. behind a focused text composer).
+  final bool releaseNeighboursWhenInactive;
 
   /// Number of videos ahead of the current index to prefetch to disk.
   ///
@@ -309,6 +325,14 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
   /// The feed index of the currently active (visible) video.
   int get currentIndex => _currentIndex;
+
+  /// The feed indices that currently have a live player controller.
+  ///
+  /// Exposed for tests that assert the live player window shrinks to the
+  /// current video when the feed is released on inactivity (see
+  /// [InfiniteVideoFeed.releaseNeighboursWhenInactive]).
+  @visibleForTesting
+  Set<int> get debugLiveControllerIndices => _controllers.keys.toSet();
 
   int _clampIndex(int index) {
     if (widget.videos.isEmpty) return 0;
@@ -538,9 +562,35 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _isActive = isActive;
     if (_isActive) {
       _resumeCurrentPlaybackIfReady();
+      if (widget.releaseNeighboursWhenInactive) {
+        // Re-expand the live window and resume disk prefetch now that the
+        // feed is visible again.
+        unawaited(_onIndexChanged(_currentIndex));
+      }
     } else {
       _pauseCurrentPlayback();
+      if (widget.releaseNeighboursWhenInactive) {
+        _releaseNeighboursAndPrefetch();
+      }
     }
+  }
+
+  /// Disposes the neighbour controllers and cancels the in-flight disk
+  /// prefetch, keeping only the current controller alive. Called when the
+  /// feed becomes inactive while
+  /// [InfiniteVideoFeed.releaseNeighboursWhenInactive] is set, so a feed that
+  /// stays mounted in the background stops holding off-screen players and
+  /// downloading upcoming videos.
+  void _releaseNeighboursAndPrefetch() {
+    _prefetcher.cancelCycle();
+    // Bump the window generation so any in-flight neighbour init aborts
+    // instead of re-adding a controller we are about to drop.
+    _playerWindowGeneration++;
+    _controllers.keys
+        .where((index) => index != _currentIndex)
+        .toList()
+        .forEach(_disposeAt);
+    _rebuild();
   }
 
   void _pauseCurrentPlayback() {
@@ -618,10 +668,18 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     final generation = ++_playerWindowGeneration;
 
     final lastIndex = widget.videos.length - 1;
-    final start = widget.keepPreviousAlive
+    // Neighbour players are kept alive while the feed is active. When the feed
+    // is hidden and configured to release them
+    // ([InfiniteVideoFeed.releaseNeighboursWhenInactive]), the window collapses
+    // to the current video so a background feed holds only one native player;
+    // the neighbours re-initialize when it becomes active again.
+    final keepNeighbours = !widget.releaseNeighboursWhenInactive || _isActive;
+    final start = widget.keepPreviousAlive && keepNeighbours
         ? (index - 1).clamp(0, lastIndex)
         : index;
-    final end = widget.keepNextAlive ? (index + 1).clamp(0, lastIndex) : index;
+    final end = widget.keepNextAlive && keepNeighbours
+        ? (index + 1).clamp(0, lastIndex)
+        : index;
 
     // Dispose controllers outside the live window.
     _controllers.keys
@@ -637,6 +695,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     if (_playerWindowGeneration != generation || !mounted) return;
 
     if (widget.keepNextAlive &&
+        keepNeighbours &&
         index + 1 <= lastIndex &&
         !_controllers.containsKey(index + 1)) {
       unawaited(_initController(index + 1));
@@ -654,6 +713,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     if (_playerWindowGeneration != generation || !mounted) return;
 
     if (widget.keepPreviousAlive &&
+        keepNeighbours &&
         index - 1 >= 0 &&
         !_controllers.containsKey(index - 1)) {
       unawaited(_initController(index - 1));
@@ -681,6 +741,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   }
 
   Future<void> _runPrefetch(int index) async {
+    // Pause disk prefetch while a release-on-inactive feed is hidden so a
+    // background feed stops downloading upcoming videos. It resumes from the
+    // current index on reactivation.
+    if (widget.releaseNeighboursWhenInactive && !_isActive) return;
     if (widget.prefetchCount <= 0) return;
 
     // coverage:ignore-start

--- a/mobile/packages/infinite_video_feed/test/src/services/disk_prefetcher_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/disk_prefetcher_test.dart
@@ -352,6 +352,59 @@ void main() {
       });
     });
 
+    group('cancelCycle', () {
+      test('can be called when no operation is active', () {
+        expect(() => prefetcher.cancelCycle(), returnsNormally);
+      });
+
+      test(
+        'halts the running cycle so it does not advance to the next index',
+        () async {
+          final slowCache = _MockMediaCacheManager();
+          final logs2 = <String>[];
+          final slowPrefetcher = DiskPrefetcher(
+            cache: slowCache,
+            log: logs2.add,
+          );
+
+          final downloadCompleter = _ManualCompleter<File?>();
+          var downloadCalls = 0;
+          when(() => slowCache.getCachedFileSync(any())).thenReturn(null);
+          when(
+            () => slowCache.cacheFileCancellable(any(), key: any(named: 'key')),
+          ).thenAnswer((_) {
+            downloadCalls++;
+            return _PendingOperation(downloadCompleter.future);
+          });
+
+          final videos = List.generate(
+            5,
+            (i) => _makeVideo('v$i', url: 'http://example.com/$i.m3u8'),
+          );
+
+          final run = slowPrefetcher.run(
+            startIndex: 0,
+            endIndex: 4,
+            videos: videos,
+            resolveUrls: (v) => [if (v.videoUrl != null) v.videoUrl!],
+          );
+
+          // Let the cycle start the first download and park on it.
+          await Future<void>.delayed(Duration.zero);
+          expect(downloadCalls, equals(1));
+
+          // Pause the whole cycle, then release the in-flight download.
+          slowPrefetcher.cancelCycle();
+          downloadCompleter.complete(null);
+          await run;
+
+          // The loop exited instead of advancing to index 1+.
+          expect(downloadCalls, equals(1));
+          slowPrefetcher.dispose();
+        },
+      );
+    });
+
     group('dispose', () {
       test('cancels active operation without throwing', () {
         expect(() => prefetcher.dispose(), returnsNormally);

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -2041,6 +2041,71 @@ void main() {
           await harness.dispose();
         }
       });
+
+      testWidgets('resumes prefetch relative to a non-zero current index, not '
+          'from the start of the feed', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(
+          playerIds: const <int>[0, 1, 2, 3, 4, 5, 6, 7, 8],
+        );
+        final videos = List.generate(
+          9,
+          (i) => _makeVideo('p$i', videoUrl: 'https://example.com/p$i.mp4'),
+        );
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: videos,
+                cache: cache,
+                initialIndex: 3,
+                isActive: false,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 5,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: videos,
+                cache: cache,
+                initialIndex: 3,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 5,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Prefetch covers the disk window ahead of the current video
+          // (currentIndex + 2 onward). The first download is index 5 ('p5'),
+          // and nothing at or before the current index is fetched — proving
+          // the cycle resumes relative to the current index rather than
+          // restarting from index 0.
+          final keys = verify(
+            () => cache.cacheFileCancellable(
+              any(),
+              key: captureAny(named: 'key'),
+            ),
+          ).captured.cast<String>();
+          expect(keys.first, equals('p5'));
+          expect(keys, isNot(contains('p0')));
+          expect(keys, isNot(contains('p3')));
+          expect(keys, isNot(contains('p4')));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
     });
   });
 }

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -1803,5 +1803,244 @@ void main() {
         },
       );
     });
+
+    group('releaseNeighboursWhenInactive', () {
+      testWidgets('collapses the live window to the current video when the '
+          'feed becomes inactive', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install();
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = [_makeVideo('cur'), _makeVideo('next')];
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          // The current and next controllers are live while active.
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          // The neighbour player is dropped; only the current one is retained.
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0}),
+          );
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('keeps the neighbour controller when inactive and the flag '
+          'is off', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install();
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = [_makeVideo('cur'), _makeVideo('next')];
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          // Default behaviour: the neighbour stays warm while paused.
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('re-initialises the neighbour controller when reactivated', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install();
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = [_makeVideo('cur'), _makeVideo('next')];
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0}),
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          // The neighbour controller is re-created on reactivation.
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('pauses disk prefetch while inactive and resumes when '
+          'active', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3, 4]);
+        final videos = List.generate(
+          4,
+          (i) => _makeVideo('p$i', videoUrl: 'https://example.com/p$i.mp4'),
+        );
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 5,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          // Inactive feed never starts a disk download.
+          verifyNever(
+            () => cache.cacheFileCancellable(any(), key: any(named: 'key')),
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: videos,
+                cache: cache,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 5,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          // Reactivation resumes prefetch from the current index.
+          verify(
+            () => cache.cacheFileCancellable(any(), key: any(named: 'key')),
+          ).called(greaterThanOrEqualTo(1));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+    });
   });
 }

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -1916,6 +1916,142 @@ void main() {
         }
       });
 
+      testWidgets('collapses neighbours when release flag turns on while '
+          'already inactive', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install();
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = [_makeVideo('cur'), _makeVideo('next')];
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0}),
+          );
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('re-expands neighbours when release flag turns off while '
+          'already inactive', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install();
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = [_makeVideo('cur'), _makeVideo('next')];
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseNeighboursWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0}),
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
       testWidgets('re-initialises the neighbour controller when reactivated', (
         tester,
       ) async {

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/router/router.dart';
@@ -612,6 +613,18 @@ void main() {
             index;
       }
 
+      void setBottomSheetOpen(WidgetTester tester, {required bool open}) {
+        containerOf(
+          tester,
+        ).read(overlayVisibilityProvider.notifier).setBottomSheetOpen(open);
+      }
+
+      void setPageOpen(WidgetTester tester, {required bool open}) {
+        containerOf(
+          tester,
+        ).read(overlayVisibilityProvider.notifier).setPageOpen(open);
+      }
+
       testWidgets(
         'stays paused while a route covers the shell, even on the home tab',
         (tester) async {
@@ -673,6 +686,49 @@ void main() {
         setBranchIndex(tester, 0); // back to Home
         await tester.pump();
         expect(feedVideos(tester).isActive, isTrue);
+
+        await drainAndDispose(tester);
+      });
+
+      testWidgets(
+        'a comments/share bottom sheet pauses but keeps neighbours warm',
+        (tester) async {
+          await pumpFeed(tester);
+          await tester.pump();
+
+          // Active home feed releases neighbours when it backgrounds.
+          expect(feedVideos(tester).isActive, isTrue);
+          expect(feedVideos(tester).releaseNeighboursWhenInactive, isTrue);
+
+          // A bottom sheet (comments/share) pauses the current player but must
+          // NOT tear down the off-screen neighbours or prefetch.
+          setBottomSheetOpen(tester, open: true);
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isFalse);
+          expect(feedVideos(tester).releaseNeighboursWhenInactive, isFalse);
+
+          // Closing the sheet restores the release-on-background behaviour.
+          setBottomSheetOpen(tester, open: false);
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isTrue);
+          expect(feedVideos(tester).releaseNeighboursWhenInactive, isTrue);
+
+          await drainAndDispose(tester);
+        },
+      );
+
+      testWidgets('a full-screen page overlay still releases neighbours', (
+        tester,
+      ) async {
+        await pumpFeed(tester);
+        await tester.pump();
+
+        // A full-screen page (settings, recorder, dialog) is the heavy case:
+        // pause AND release, unlike a lightweight bottom sheet.
+        setPageOpen(tester, open: true);
+        await tester.pump();
+        expect(feedVideos(tester).isActive, isFalse);
+        expect(feedVideos(tester).releaseNeighboursWhenInactive, isTrue);
 
         await drainAndDispose(tester);
       });

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -650,27 +650,26 @@ void main() {
         },
       );
 
-      testWidgets(
-        'resumes only once the shell is no longer covered',
-        (tester) async {
-          await pumpFeed(tester);
-          await tester.pump();
-          expect(feedVideos(tester).isActive, isTrue);
+      testWidgets('resumes only once the shell is no longer covered', (
+        tester,
+      ) async {
+        await pumpFeed(tester);
+        await tester.pump();
+        expect(feedVideos(tester).isActive, isTrue);
 
-          // Profile pushed over the shell pauses the feed.
-          setObscured(tester, obscured: true);
-          await tester.pump();
-          expect(feedVideos(tester).isActive, isFalse);
+        // Profile pushed over the shell pauses the feed.
+        setObscured(tester, obscured: true);
+        await tester.pump();
+        expect(feedVideos(tester).isActive, isFalse);
 
-          // Profile closed (shell revealed) while home is still the active
-          // branch: the feed resumes.
-          setObscured(tester, obscured: false);
-          await tester.pump();
-          expect(feedVideos(tester).isActive, isTrue);
+        // Profile closed (shell revealed) while home is still the active
+        // branch: the feed resumes.
+        setObscured(tester, obscured: false);
+        await tester.pump();
+        expect(feedVideos(tester).isActive, isTrue);
 
-          await drainAndDispose(tester);
-        },
-      );
+        await drainAndDispose(tester);
+      });
 
       testWidgets('pauses on a non-home tab and resumes back on home', (
         tester,
@@ -732,6 +731,26 @@ void main() {
 
         await drainAndDispose(tester);
       });
+
+      testWidgets(
+        'a full-screen page overlay releases after a bottom sheet paused home',
+        (tester) async {
+          await pumpFeed(tester);
+          await tester.pump();
+
+          setBottomSheetOpen(tester, open: true);
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isFalse);
+          expect(feedVideos(tester).releaseNeighboursWhenInactive, isFalse);
+
+          setPageOpen(tester, open: true);
+          await tester.pump();
+          expect(feedVideos(tester).isActive, isFalse);
+          expect(feedVideos(tester).releaseNeighboursWhenInactive, isTrue);
+
+          await drainAndDispose(tester);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

Since #5315 migrated the bottom nav to `StatefulShellRoute`, the home feed stays mounted across tab switches and pushed routes (e.g. opening a user profile). Previously it kept holding the **previous/next native video players** and a running **disk-prefetch cycle** while backgrounded.

This PR releases those resources while the home feed is hidden, keeping only the current player alive for an instant crossfade resume.

- New opt-in `InfiniteVideoFeed.releaseNeighboursWhenInactive` (threaded through `FeedVideos`, enabled only for the home feed). When the feed goes inactive:
  - the prev/next controllers are disposed (and the live window collapses to the current index),
  - the in-flight disk-prefetch cycle is halted,
  - the current controller is retained, so playback resumes instantly when the feed becomes active again.
  - On reactivation the neighbours re-initialize and prefetch resumes from the current index.
- Triggers on both **tab switch** (`activeBranchIndexProvider`) and **pushing a route over home** (RouteAware `didPushNext` + `shellObscuredProvider`), since both flip `isActive`.
- **Bottom sheets over home (comments/share) only pause — they keep neighbours and prefetch warm.** `isActive` also flips for overlays, so `releaseNeighboursWhenInactive` is wired to `OverlayVisibilityState.shouldRetainPlayer` (= `isBottomSheetOpen && !isPageOpen`). Only a real backgrounding — tab switch, pushed route, or a **full-screen page overlay** — releases the off-screen players; a lightweight bottom sheet retains them for instant resume, matching the documented overlay contract.
- Re-evaluates the release policy even if the feed is already inactive. This covers the bottom-sheet-to-page-overlay transition, where the feed is already paused but must start releasing neighbours once a full-screen overlay appears.
- Fixes a latent bug in `DiskPrefetcher`: `cancelActive()` only cancelled the single in-flight HTTP download while the `run()` loop kept advancing to the next index. New `cancelCycle()` bumps the generation so the loop actually exits.

Closes #5402
Related to #5315

## Out of Scope

- The fullscreen pooled feed (`PooledFullscreenVideoFeedScreen`) intentionally keeps the default (`false`): there `isActive: false` also means "DM reply composer focused" (feed still on screen), where we only want to pause — not tear down the neighbour players.
- No change to `allowImplicitScrolling`; the neighbour *pages* still build (lightweight loading placeholders) — only the native players are released.

## Verification

- `flutter test test/src/services/disk_prefetcher_test.dart test/src/widgets/infinite_video_feed_test.dart` from `mobile/packages/infinite_video_feed`
- `flutter test test/screens/feed/video_feed_page_test.dart` from `mobile`
- `flutter analyze lib/src/widgets/infinite_video_feed.dart lib/src/services/disk_prefetcher.dart test/src/widgets/infinite_video_feed_test.dart test/src/services/disk_prefetcher_test.dart` from `mobile/packages/infinite_video_feed`
- `flutter analyze lib/screens/feed/video_feed_page.dart lib/widgets/video_feed_item/feed_videos.dart test/screens/feed/video_feed_page_test.dart` from `mobile`
- Manual on device with `--dart-define=LOG_CATEGORIES=video,system`: navigating away from home disposes only the prev/next players and stops new `Prefetch cycle …` logs; returning re-inits neighbours and resumes a single prefetch cycle; current video crossfades back instantly.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
