### PR TITLE
perf(db): run SQLite on a background isolate + batch EventRouter writes

### DIFF
--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -7,6 +7,8 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_sdk/event.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+const eventRouterBatchFlushThreshold = 50;
+
 /// Routes incoming Nostr events to appropriate database tables
 ///
 /// All events go to NostrEvents table (single source of truth)
@@ -34,7 +36,8 @@ class EventRouter {
     _batchTimer ??= Timer(const Duration(milliseconds: 50), _processBatch);
 
     // If queue is large, process immediately
-    if (_eventQueue.length >= 50 && !_isProcessingBatch) {
+    if (_eventQueue.length >= eventRouterBatchFlushThreshold &&
+        !_isProcessingBatch) {
       _batchTimer?.cancel();
       _batchTimer = null;
       await _processBatch();
@@ -61,10 +64,15 @@ class EventRouter {
       // Batch insert to nostr_events table
       await _db.nostrEventsDao.upsertEventsBatch(batch);
 
-      // Process kind-specific routing for each event
-      for (final event in batch) {
-        await _routeEvent(event);
-      }
+      // Run kind-specific routing inside a single transaction so the per-event
+      // writes (e.g. profile upserts) commit once instead of once per event.
+      // Each commit is an fsync + journal write — now also encrypted under
+      // SQLCipher — so collapsing N commits into one is the dominant saving.
+      await _db.transaction(() async {
+        for (final event in batch) {
+          await _routeEvent(event);
+        }
+      });
 
       Log.verbose(
         'Completed batch of ${batch.length} events',

--- a/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
+++ b/mobile/packages/db_client/lib/src/database/connection/connection_native.dart
@@ -22,7 +22,9 @@ QueryExecutor openConnection() {
   return LazyDatabase(() async {
     final dbPath = await getSharedDatabasePath();
     final dbFile = prepareDatabaseFile(dbPath);
-    return NativeDatabase(dbFile);
+    // Background isolate keeps all SQLite work off the UI isolate; see the
+    // encrypted variant below for the perf rationale.
+    return NativeDatabase.createInBackground(dbFile);
   });
 }
 
@@ -56,7 +58,12 @@ QueryExecutor openEncryptedConnection({required String rawKeyHex}) {
   return LazyDatabase(() async {
     final dbPath = await getSharedDatabasePath();
     final dbFile = prepareDatabaseFile(dbPath);
-    return NativeDatabase(
+    // Open on a background isolate so the SQLite3MultipleCiphers per-page
+    // AES-256-CBC + HMAC-SHA512 work (every read and write) never runs on the
+    // UI isolate. The [setup] closure — including the raw key string and the
+    // top-level helpers — is sendable, so it runs on the spawned isolate and
+    // still fails closed if sqlite3mc is not the active build.
+    return NativeDatabase.createInBackground(
       dbFile,
       setup: (rawDb) {
         applyCipherKey(rawDb, rawKeyHex);

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -1,338 +1,103 @@
-// ABOUTME: TDD tests for EventRouter verifying centralized event caching to database
-// ABOUTME: Tests routing logic, kind-specific processing, and error handling
+// ABOUTME: Tests EventRouter batch caching + transaction-wrapped kind routing
+// ABOUTME: Verifies events are stored and kind 0 profiles extracted in one batch
 
-// TODO(any): Fix and re-enable this test
-void main() {}
+import 'dart:async';
+import 'dart:convert';
 
-//import 'dart:convert';
-//import 'dart:io';
-//import 'package:db_client/db_client.dart';
-//import 'package:drift/native.dart';
-//import 'package:flutter_test/flutter_test.dart';
-//import 'package:nostr_sdk/event.dart';
-//import 'package:openvine/services/event_router.dart';
-//import 'package:path/path.dart' as p;
-//
-//void main() {
-//  group('EventRouter', () {
-//    late AppDatabase db;
-//    late EventRouter eventRouter;
-//    late String testDbPath;
-//
-//    setUp(() async {
-//      // Create temporary database for testing
-//      final tempDir = Directory.systemTemp.createTempSync('openvine_test_');
-//      testDbPath = p.join(tempDir.path, 'test.db');
-//      db = AppDatabase.test(NativeDatabase(File(testDbPath)));
-//      eventRouter = EventRouter(db);
-//    });
-//
-//    tearDown(() async {
-//      await db.close();
-//      // Clean up test database
-//      final file = File(testDbPath);
-//      if (await file.exists()) {
-//        await file.delete();
-//      }
-//    });
-//
-//    test(
-//      'handleEvent inserts kind 34236 (video) event to NostrEvents table',
-//      () async {
-//        final videoEvent = Event(
-//          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-//          34236,
-//          [
-//            ['url', 'https://example.com/video.mp4'],
-//          ],
-//          'Test video content',
-//          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//        );
-//        // Set id and sig manually since they're calculated fields
-//        videoEvent.id =
-//            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
-//        videoEvent.sig =
-//            'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
-//
-//        await eventRouter.handleEvent(videoEvent);
-//
-//        // Verify event was inserted to NostrEvents table
-//        final storedEvent = await db.nostrEventsDao.getEventById(
-//          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-//        );
-//        expect(storedEvent, isNotNull);
-//        expect(
-//          storedEvent!.id,
-//          equals(
-//            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-//          ),
-//        );
-//        expect(storedEvent.kind, equals(34236));
-//        expect(
-//          storedEvent.pubkey,
-//          equals(
-//            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-//          ),
-//        );
-//        expect(storedEvent.content, equals('Test video content'));
-//      },
-//    );
-//
-//    test('handleEvent inserts kind 0 (profile) event to both tables', () async {
-//      final profileContent = jsonEncode({
-//        'name': 'testuser',
-//        'display_name': 'Test User',
-//        'about': 'Test bio',
-//        'picture': 'https://example.com/avatar.jpg',
-//      });
-//
-//      final profileEvent = Event(
-//        'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
-//        0,
-//        [],
-//        profileContent,
-//        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//      );
-//      profileEvent.id =
-//          'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
-//      profileEvent.sig =
-//          'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
-//
-//      await eventRouter.handleEvent(profileEvent);
-//
-//      // Verify event was inserted to NostrEvents table
-//      final storedEvent = await db.nostrEventsDao.getEventById(
-//        'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-//      );
-//      expect(storedEvent, isNotNull);
-//      expect(storedEvent!.kind, equals(0));
-//
-//      // Verify profile was extracted to UserProfiles table
-//      final profile = await db.userProfilesDao.getProfile(
-//        'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
-//      );
-//      expect(profile, isNotNull);
-//      expect(profile!.name, equals('testuser'));
-//      expect(profile.displayName, equals('Test User'));
-//      expect(profile.about, equals('Test bio'));
-//      expect(profile.picture, equals('https://example.com/avatar.jpg'));
-//    });
-//
-//    test(
-//      'handleEvent inserts kind 3 (contacts) event to NostrEvents table',
-//      () async {
-//        final contactsEvent = Event(
-//          '1111111111111111111111111111111111111111111111111111111111111111',
-//          3,
-//          [
-//            [
-//              'p',
-//              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-//            ],
-//            [
-//              'p',
-//              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-//            ],
-//          ],
-//          '',
-//          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//        );
-//        contactsEvent.id =
-//            '2222222222222222222222222222222222222222222222222222222222222222';
-//        contactsEvent.sig =
-//            '3333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333';
-//
-//        await eventRouter.handleEvent(contactsEvent);
-//
-//        // Verify event was inserted to NostrEvents table
-//        final storedEvent = await db.nostrEventsDao.getEventById(
-//          '2222222222222222222222222222222222222222222222222222222222222222',
-//        );
-//        expect(storedEvent, isNotNull);
-//        expect(storedEvent!.kind, equals(3));
-//        expect(storedEvent.tags.length, equals(2));
-//      },
-//    );
-//
-//    test(
-//      'handleEvent inserts kind 7 (reaction) event to NostrEvents table',
-//      () async {
-//        final reactionEvent = Event(
-//          '4444444444444444444444444444444444444444444444444444444444444444',
-//          7,
-//          [
-//            [
-//              'e',
-//              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-//            ], // Event being reacted to
-//          ],
-//          '+',
-//          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//        );
-//        reactionEvent.id =
-//            '5555555555555555555555555555555555555555555555555555555555555555';
-//        reactionEvent.sig =
-//            '6666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666666';
-//
-//        await eventRouter.handleEvent(reactionEvent);
-//
-//        // Verify event was inserted to NostrEvents table
-//        final storedEvent = await db.nostrEventsDao.getEventById(
-//          '5555555555555555555555555555555555555555555555555555555555555555',
-//        );
-//        expect(storedEvent, isNotNull);
-//        expect(storedEvent!.kind, equals(7));
-//        expect(storedEvent.content, equals('+'));
-//      },
-//    );
-//
-//    test(
-//      'handleEvent inserts kind 6 (repost) event to NostrEvents table',
-//      () async {
-//        final repostEvent = Event(
-//          '7777777777777777777777777777777777777777777777777777777777777777',
-//          6,
-//          [
-//            [
-//              'e',
-//              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-//            ],
-//            [
-//              'p',
-//              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-//            ],
-//          ],
-//          '',
-//          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//        );
-//        repostEvent.id =
-//            '8888888888888888888888888888888888888888888888888888888888888888';
-//        repostEvent.sig =
-//            '9999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999';
-//
-//        await eventRouter.handleEvent(repostEvent);
-//
-//        // Verify event was inserted to NostrEvents table
-//        final storedEvent = await db.nostrEventsDao.getEventById(
-//          '8888888888888888888888888888888888888888888888888888888888888888',
-//        );
-//        expect(storedEvent, isNotNull);
-//        expect(storedEvent!.kind, equals(6));
-//      },
-//    );
-//
-//    test('handleEvent handles duplicate events (upsert behavior)', () async {
-//      final event1 = Event(
-//        'abababababababababababababababababababababababababababababababab',
-//        34236,
-//        [],
-//        'Original content',
-//        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//      );
-//      event1.id =
-//          'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd';
-//      event1.sig =
-//          'efefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefefef';
-//
-//      // Insert first time
-//      await eventRouter.handleEvent(event1);
-//
-//      final storedEvent1 = await db.nostrEventsDao.getEventById(
-//        'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd',
-//      );
-//      expect(storedEvent1, isNotNull);
-//      expect(storedEvent1!.content, equals('Original content'));
-//
-//      // Insert same ID with different content (should replace)
-//      final event2 = Event(
-//        'abababababababababababababababababababababababababababababababab',
-//        34236,
-//        [],
-//        'Updated content',
-//        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//      );
-//      event2.id =
-//          'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd';
-//      event2.sig =
-//          '0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a';
-//
-//      await eventRouter.handleEvent(event2);
-//
-//      final storedEvent2 = await db.nostrEventsDao.getEventById(
-//        'cdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd',
-//      );
-//      expect(storedEvent2, isNotNull);
-//      expect(storedEvent2!.content, equals('Updated content'));
-//      expect(
-//        storedEvent2.sig,
-//        equals(
-//          '0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a',
-//        ),
-//      );
-//    });
-//
-//    test('handleEvent handles malformed profile event gracefully', () async {
-//      final malformedProfileEvent = Event(
-//        'f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
-//        0,
-//        [],
-//        'This is not valid JSON', // Invalid JSON
-//        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//      );
-//      malformedProfileEvent.id =
-//          'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1';
-//      malformedProfileEvent.sig =
-//          'b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2';
-//
-//      // Should not throw - gracefully handle malformed profile
-//      await expectLater(
-//        eventRouter.handleEvent(malformedProfileEvent),
-//        completes,
-//      );
-//
-//      // Event should still be in NostrEvents table
-//      final storedEvent = await db.nostrEventsDao.getEventById(
-//        'a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1',
-//      );
-//      expect(storedEvent, isNotNull);
-//      expect(storedEvent!.kind, equals(0));
-//
-//      // Profile should exist with minimal data (from fallback in UserProfile.fromNostrEvent)
-//      final profile = await db.userProfilesDao.getProfile(
-//        'f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
-//      );
-//      expect(profile, isNotNull);
-//      expect(
-//        profile!.pubkey,
-//        equals(
-//          'f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0',
-//        ),
-//      );
-//    });
-//
-//    test('handleEvent inserts unknown kind to NostrEvents table', () async {
-//      final unknownKindEvent = Event(
-//        'c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3',
-//        12345, // Unknown kind
-//        [],
-//        'Unknown kind content',
-//        createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
-//      );
-//      unknownKindEvent.id =
-//          'd4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4';
-//      unknownKindEvent.sig =
-//          'e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5';
-//
-//      await eventRouter.handleEvent(unknownKindEvent);
-//
-//      // Verify event was inserted to NostrEvents table
-//      final storedEvent = await db.nostrEventsDao.getEventById(
-//        'd4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4',
-//      );
-//      expect(storedEvent, isNotNull);
-//      expect(storedEvent!.kind, equals(12345));
-//      expect(storedEvent.content, equals('Unknown kind content'));
-//    });
-//  });
-//}
-//
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/services/event_router.dart';
+
+void main() {
+  group(EventRouter, () {
+    late AppDatabase db;
+    late EventRouter router;
+
+    setUp(() {
+      db = AppDatabase.test(NativeDatabase.memory());
+      router = EventRouter(db);
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    /// Returns a 64-hex pubkey derived from [seed] (valid per `keyIsValid`).
+    String pubkeyFor(int seed) => seed.toRadixString(16).padLeft(64, '0');
+
+    Event videoEvent(int seed) =>
+        Event(pubkeyFor(seed), NIP71VideoKinds.addressableShortVideo, const [
+          ['url', 'https://example.com/video.mp4'],
+        ], 'video $seed');
+
+    Event profileEvent(int seed, {required String content}) =>
+        Event(pubkeyFor(seed), 0, const [], content);
+
+    /// Drives [events] through [handleEvent] so the whole list is flushed in a
+    /// single batch. The queue processes immediately once it reaches 50, so the
+    /// list is padded with filler video events and the final `handleEvent` is
+    /// awaited — no reliance on the 50ms batch timer.
+    Future<void> flush(List<Event> events) async {
+      // Only the final handleEvent is awaited, and it's the one that trips the
+      // immediate flush. That holds only because the input is padded up to the
+      // production threshold; with that many or more input events, the trip
+      // would fire inside an unawaited call and the batch would not be awaited.
+      assert(
+        events.length < eventRouterBatchFlushThreshold,
+        'flush() awaits only the padded final event; pass fewer than '
+        '$eventRouterBatchFlushThreshold events.',
+      );
+      final padded = [...events];
+      var filler = 1 << 20;
+      while (padded.length < eventRouterBatchFlushThreshold) {
+        padded.add(videoEvent(filler++));
+      }
+      for (var i = 0; i < padded.length - 1; i++) {
+        unawaited(router.handleEvent(padded[i]));
+      }
+      await router.handleEvent(padded.last);
+    }
+
+    test('stores every event in the batch in the nostr_events table', () async {
+      final video = videoEvent(1);
+      final profile = profileEvent(2, content: jsonEncode({'name': 'alice'}));
+
+      await flush([video, profile]);
+
+      expect(await db.nostrEventsDao.getEventById(video.id), isNotNull);
+      expect(await db.nostrEventsDao.getEventById(profile.id), isNotNull);
+    });
+
+    test('extracts multiple kind 0 profiles from a single batch', () async {
+      final alice = profileEvent(2, content: jsonEncode({'name': 'alice'}));
+      final bob = profileEvent(3, content: jsonEncode({'name': 'bob'}));
+
+      await flush([alice, bob]);
+
+      final aliceProfile = await db.userProfilesDao.getProfile(alice.pubkey);
+      final bobProfile = await db.userProfilesDao.getProfile(bob.pubkey);
+      expect(aliceProfile?.name, equals('alice'));
+      expect(bobProfile?.name, equals('bob'));
+    });
+
+    test('a malformed profile does not abort routing for the rest of the '
+        'batch', () async {
+      final broken = profileEvent(2, content: 'not-json-{');
+      final valid = profileEvent(3, content: jsonEncode({'name': 'carol'}));
+      final video = videoEvent(4);
+
+      await flush([broken, valid, video]);
+
+      // The valid profile and the raw events are still persisted.
+      expect(
+        (await db.userProfilesDao.getProfile(valid.pubkey))?.name,
+        equals('carol'),
+      );
+      expect(await db.nostrEventsDao.getEventById(video.id), isNotNull);
+      expect(await db.nostrEventsDao.getEventById(broken.id), isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #5396

## Description

The local Drift database opened its SQLite connection synchronously on the UI isolate. With SQLite3MultipleCiphers enabled for at-rest encryption, steady-state page reads/writes also perform AES-256-CBC + HMAC-SHA512 work, which can contribute to home-feed jank while the feed cache is active.

This PR moves that work off the UI isolate and reduces write commits:

- **Background isolate** - `openConnection()` and `openEncryptedConnection()` now use `NativeDatabase.createInBackground(...)`, so native SQLite work runs on Drift's long-lived worker isolate. The encrypted path still applies the raw-key cipher setup and fail-closed guard when the worker opens the connection.
- **Batched writes** - `EventRouter` routes per-event kind-specific writes inside a single `transaction(...)`, so profile extraction and future kind-specific writes commit once per batch instead of once per event.
- **Tests / cleanup** - replaced the disabled `event_router_test.dart` stub with deterministic coverage for raw event storage, multi-profile extraction, and malformed-profile resilience. The EventRouter batch flush threshold is now a shared constant so tests cannot silently drift from production behavior.

## Related Issue

Closes #5396

## Out of Scope

- The one-time plaintext-to-encrypted migration path (`migratePlaintextToEncrypted`) stays on the main isolate. It runs at startup/migration time, not in steady-state feed scrolling.
- The `ForegroundIdleWarmupCoordinator` ordering is a separate first-load-latency item and is not addressed here.

## Verification

Local verification after rebuilding the PR branch on current `origin/main`:

- `flutter pub get` from `mobile/`
- `mise exec -- dart format lib test integration_test` from `mobile/` - 0 files changed
- `flutter analyze lib/services/event_router.dart test/services/event_router_test.dart packages/db_client/lib/src/database/connection/connection_native.dart` from `mobile/` - no issues
- `flutter test test/services/event_router_test.dart` from `mobile/` - 3/3 pass
- `flutter test test/src/database/connection/connection_native_test.dart` from `mobile/packages/db_client/` - 42/42 pass
- `flutter test` from `mobile/packages/db_client/` - 667/667 pass
- Pre-push hook on the force-with-lease push reran merge-conflict check, targeted analyze, and `test/services/event_router_test.dart` - all passed

Manual gate before merge:

- Please verify on a real Android device or emulator with an existing encrypted local database that the app opens the DB and can perform a read/write through the background isolate.

## Type of Change

- [x] Code refactor
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore
