### PR TITLE
fix(video-editor): resolve subtitle editor route by video id

### DIFF
--- a/mobile/lib/blocs/subtitle_editor/subtitle_editor_cubit.dart
+++ b/mobile/lib/blocs/subtitle_editor/subtitle_editor_cubit.dart
@@ -29,9 +29,11 @@ class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
   /// - [SubtitleEditorStatus.processing] when no cues are available yet.
   /// - [SubtitleEditorStatus.failure] and calls [addError] on any exception.
   Future<void> load() async {
+    if (isClosed) return;
     emit(state.copyWith(status: SubtitleEditorStatus.loading));
     try {
       final cues = await _repository.loadCues(_video);
+      if (isClosed) return;
       if (cues.isEmpty) {
         emit(state.copyWith(status: SubtitleEditorStatus.processing));
         return;
@@ -44,6 +46,7 @@ class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
         ),
       );
     } catch (e, st) {
+      if (isClosed) return;
       addError(e, st);
       emit(state.copyWith(status: SubtitleEditorStatus.failure));
     }
@@ -54,6 +57,7 @@ class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
   ///
   /// Out-of-range indices are silently ignored.
   void updateCueText(int index, String text) {
+    if (isClosed) return;
     if (index < 0 || index >= state.cues.length) return;
     final updated = List<EditableCue>.from(state.cues);
     updated[index] = updated[index].copyWith(text: text);
@@ -66,12 +70,14 @@ class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
   /// - [SubtitleEditorStatus.success] with `isDirty` reset to `false`.
   /// - [SubtitleEditorStatus.failure] and calls [addError] on any exception.
   Future<void> save() async {
+    if (isClosed) return;
     emit(state.copyWith(status: SubtitleEditorStatus.saving));
     try {
       await _repository.publishEditedSubtitles(
         video: _video,
         cues: state.cues.map((c) => c.toCue()).toList(),
       );
+      if (isClosed) return;
       emit(
         state.copyWith(
           status: SubtitleEditorStatus.success,
@@ -79,6 +85,7 @@ class SubtitleEditorCubit extends Cubit<SubtitleEditorState> {
         ),
       );
     } catch (e, st) {
+      if (isClosed) return;
       addError(e, st);
       emit(state.copyWith(status: SubtitleEditorStatus.failure));
     }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2182,6 +2182,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
         case RouteType.videoEditor:
         case RouteType.videoMetadata:
         case RouteType.videoEdit:
+        case RouteType.subtitleEdit:
           // Pop the video editing flow screens
           router.pop();
           return true; // Handled

--- a/mobile/lib/providers/active_video_provider.dart
+++ b/mobile/lib/providers/active_video_provider.dart
@@ -102,6 +102,7 @@ final activeVideoIdProvider = Provider<String?>((ref) {
     case RouteType.videoEditor:
     case RouteType.videoMetadata:
     case RouteType.videoEdit:
+    case RouteType.subtitleEdit:
     case RouteType.settings:
     case RouteType.badges:
     case RouteType.relaySettings:

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -1337,10 +1337,7 @@ final goRouterProvider = Provider<GoRouter>((ref) {
             return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
           }
           final prefetched = st.extra as VideoEvent?;
-          if (prefetched == null) {
-            return RouteErrorScreen(message: ctx.l10n.routeInvalidVideoId);
-          }
-          return SubtitleEditorScreen(video: prefetched);
+          return SubtitleEditorScreen(videoId: videoId, prefetched: prefetched);
         },
       ),
       GoRoute(

--- a/mobile/lib/router/providers/last_tab_position_provider.dart
+++ b/mobile/lib/router/providers/last_tab_position_provider.dart
@@ -19,6 +19,7 @@ class LastTabPosition extends Notifier<Map<RouteType, int>> {
       // Only track video-based routes
       if (ctx.type == RouteType.videoRecorder ||
           ctx.type == RouteType.videoEditor ||
+          ctx.type == RouteType.subtitleEdit ||
           ctx.type == RouteType.settings ||
           ctx.type == RouteType.badges ||
           ctx.type == RouteType.categoryGallery) {

--- a/mobile/lib/router/providers/page_context_provider.dart
+++ b/mobile/lib/router/providers/page_context_provider.dart
@@ -46,6 +46,7 @@ import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
 import 'package:openvine/screens/settings/support_center_screen.dart';
 import 'package:openvine/screens/sound_detail_screen.dart';
+import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
@@ -68,6 +69,7 @@ enum RouteType {
   videoEditor, // Video editor screen
   videoMetadata, // Video editor meta screen
   videoEdit, // Full-screen edit flow for published videos
+  subtitleEdit, // Full-screen subtitle edit flow for published videos
   importKey,
   invites, // Invite codes share/list screen
   badges, // Badge awards dashboard
@@ -283,6 +285,13 @@ RouteContext parseRoute(String path) {
         return RouteContext(type: RouteType.videoEdit, videoId: videoId);
       }
       return const RouteContext(type: RouteType.videoEdit);
+
+    case 'subtitle-edit':
+      if (segments.length > 1) {
+        final videoId = _safeDecode(segments[1]);
+        return RouteContext(type: RouteType.subtitleEdit, videoId: videoId);
+      }
+      return const RouteContext(type: RouteType.subtitleEdit);
 
     case 'settings':
       return const RouteContext(type: RouteType.settings);
@@ -544,6 +553,12 @@ String buildRoute(RouteContext context) {
         return VideoMetadataEditScreen.pathFor(context.videoId!);
       }
       return VideoMetadataEditScreen.path;
+
+    case RouteType.subtitleEdit:
+      if (context.videoId != null) {
+        return SubtitleEditorScreen.pathFor(context.videoId!);
+      }
+      return SubtitleEditorScreen.path;
 
     case RouteType.settings:
       if (context.appSlug != null) {

--- a/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
+++ b/mobile/lib/screens/subtitle_editor/subtitle_editor_screen.dart
@@ -11,14 +11,21 @@ import 'package:models/models.dart';
 import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/subtitle_repository_provider.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/router/route_error_screen.dart';
 
 /// Full-screen subtitle editor page.
 ///
-/// Wires [SubtitleEditorCubit] via Riverpod DI and delegates rendering to
-/// [SubtitleEditorView].
-class SubtitleEditorScreen extends ConsumerWidget {
-  /// Creates the subtitle editor page for [video].
-  const SubtitleEditorScreen({required this.video, super.key});
+/// The screen is keyed on [videoId] so it can be rebuilt from the route alone.
+/// A [prefetched] video may be passed as a fast path when navigating from a
+/// feed or metadata screen, but route state is not required for correctness.
+class SubtitleEditorScreen extends ConsumerStatefulWidget {
+  /// Creates the subtitle editor page for [videoId].
+  const SubtitleEditorScreen({
+    required this.videoId,
+    this.prefetched,
+    super.key,
+  });
 
   /// Base route path.
   static const path = '/subtitle-edit';
@@ -30,11 +37,59 @@ class SubtitleEditorScreen extends ConsumerWidget {
   static String pathFor(String videoId) =>
       '$path/${Uri.encodeComponent(videoId)}';
 
-  /// The video whose subtitles are being edited.
-  final VideoEvent video;
+  /// The event id of the video whose subtitles are being edited.
+  final String videoId;
+
+  /// Optional prefetched video used to avoid an async resolve on push.
+  final VideoEvent? prefetched;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<SubtitleEditorScreen> createState() =>
+      _SubtitleEditorScreenState();
+}
+
+class _SubtitleEditorScreenState extends ConsumerState<SubtitleEditorScreen> {
+  VideoEvent? _resolved;
+  bool _resolveFailed = false;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.prefetched != null && widget.prefetched!.id == widget.videoId) {
+      _resolved = widget.prefetched;
+    } else {
+      _resolve();
+    }
+  }
+
+  Future<void> _resolve() async {
+    final resolver = ref.read(videoEventResolverProvider);
+    final video = await resolver.resolveById(
+      widget.videoId,
+      allowOwnContentBypass: true,
+    );
+    if (!mounted) return;
+    setState(() {
+      _resolved = video;
+      _resolveFailed = video == null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final video = _resolved;
+    if (video == null) {
+      if (_resolveFailed) {
+        return RouteErrorScreen(message: context.l10n.routeInvalidVideoId);
+      }
+      return const Scaffold(
+        backgroundColor: VineTheme.backgroundColor,
+        body: Center(
+          child: CircularProgressIndicator(color: VineTheme.vineGreen),
+        ),
+      );
+    }
+
     final repository = ref.watch(subtitleRepositoryProvider);
     return BlocProvider<SubtitleEditorCubit>(
       key: ObjectKey(repository),
@@ -197,11 +252,9 @@ class _CueRow extends StatelessWidget {
               decoration: InputDecoration(
                 hintText: context.l10n.subtitleEditorCueHint,
               ),
-              onChanged: (value) =>
-                  context.read<SubtitleEditorCubit>().updateCueText(
-                    index,
-                    value,
-                  ),
+              onChanged: (value) => context
+                  .read<SubtitleEditorCubit>()
+                  .updateCueText(index, value),
             ),
           ),
         ],

--- a/mobile/lib/services/back_button_handler.dart
+++ b/mobile/lib/services/back_button_handler.dart
@@ -64,6 +64,7 @@ class BackButtonHandler {
       case RouteType.videoEditor:
       case RouteType.videoMetadata:
       case RouteType.videoEdit:
+      case RouteType.subtitleEdit:
         // Pop the video editing flow screens
         _router!.pop();
         return true; // Handled

--- a/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar.dart
@@ -201,10 +201,7 @@ class _VideoMetadataEditBottomBarState
           mainAxisSize: MainAxisSize.min,
           spacing: 10,
           children: [
-            _EditSubtitlesButton(
-              onTap: _editSubtitles,
-              isBusy: _isBusy,
-            ),
+            _EditSubtitlesButton(onTap: _editSubtitles, isBusy: _isBusy),
             Row(
               crossAxisAlignment: CrossAxisAlignment.end,
               spacing: 10,
@@ -232,12 +229,9 @@ class _VideoMetadataEditBottomBarState
   }
 }
 
-/// Full-width outlined button to open the subtitle editor.
+/// Full-width secondary button to open the subtitle editor.
 class _EditSubtitlesButton extends StatelessWidget {
-  const _EditSubtitlesButton({
-    required this.onTap,
-    required this.isBusy,
-  });
+  const _EditSubtitlesButton({required this.onTap, required this.isBusy});
 
   final VoidCallback onTap;
   final bool isBusy;
@@ -246,13 +240,12 @@ class _EditSubtitlesButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Semantics(
       identifier: 'edit_subtitles_button',
-      child: SizedBox(
-        width: double.infinity,
-        child: OutlinedButton.icon(
-          onPressed: isBusy ? null : onTap,
-          icon: const DivineIcon(icon: DivineIconName.closedCaptioning),
-          label: Text(context.l10n.videoEditEditSubtitles),
-        ),
+      child: DivineButton(
+        onPressed: isBusy ? null : onTap,
+        type: DivineButtonType.secondary,
+        expanded: true,
+        leadingIcon: DivineIconName.closedCaptioning,
+        label: context.l10n.videoEditEditSubtitles,
       ),
     );
   }

--- a/mobile/test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart
+++ b/mobile/test/blocs/subtitle_editor/subtitle_editor_cubit_test.dart
@@ -1,5 +1,7 @@
 // ABOUTME: Tests for SubtitleEditorCubit covering load, edit, and save flows.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -166,5 +168,40 @@ void main() {
       ],
       errors: () => [isA<SubtitleEditException>()],
     );
+
+    test('load completes without emitting after close', () async {
+      final completer = Completer<List<SubtitleCue>>();
+      when(() => repo.loadCues(any())).thenAnswer((_) => completer.future);
+      final cubit = SubtitleEditorCubit(repository: repo, video: _video);
+
+      final loadFuture = cubit.load();
+      expect(cubit.state.status, SubtitleEditorStatus.loading);
+
+      await cubit.close();
+      completer.complete(
+        const [SubtitleCue(start: 0, end: 1000, text: 'late')],
+      );
+
+      await expectLater(loadFuture, completes);
+    });
+
+    test('save completes without emitting after close', () async {
+      final completer = Completer<void>();
+      when(
+        () => repo.publishEditedSubtitles(
+          video: any(named: 'video'),
+          cues: any(named: 'cues'),
+        ),
+      ).thenAnswer((_) => completer.future);
+      final cubit = SubtitleEditorCubit(repository: repo, video: _video);
+
+      final saveFuture = cubit.save();
+      expect(cubit.state.status, SubtitleEditorStatus.saving);
+
+      await cubit.close();
+      completer.complete();
+
+      await expectLater(saveFuture, completes);
+    });
   });
 }

--- a/mobile/test/router/route_coverage_test.dart
+++ b/mobile/test/router/route_coverage_test.dart
@@ -27,6 +27,7 @@ import 'package:openvine/screens/settings/invites_screen.dart';
 import 'package:openvine/screens/settings/nip05_settings_screen.dart';
 import 'package:openvine/screens/settings/nostr_settings_screen.dart';
 import 'package:openvine/screens/settings/settings_screen.dart';
+import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart';
@@ -367,6 +368,17 @@ void main() {
         expect(context.type, RouteType.videoEdit);
         expect(context.videoId, 'test-id-abc');
       });
+      test('/subtitle-edit parses to RouteType.subtitleEdit', () {
+        final context = parseRoute('/subtitle-edit');
+        expect(context.type, RouteType.subtitleEdit);
+      });
+      test('/subtitle-edit/:videoId parses videoId', () {
+        final context = parseRoute(
+          SubtitleEditorScreen.pathFor('test-id-abc'),
+        );
+        expect(context.type, RouteType.subtitleEdit);
+        expect(context.videoId, 'test-id-abc');
+      });
     });
 
     group('Edge cases', () {
@@ -429,6 +441,7 @@ void main() {
       'badges': BadgesScreen.path,
       'relay settings': RelaySettingsScreen.path,
       'video edit': VideoMetadataEditScreen.pathFor('test-id-abc'),
+      'subtitle edit': SubtitleEditorScreen.pathFor('test-id-abc'),
       'invites': InvitesScreen.path,
       'people list create': CreatePeopleListPage.path,
       'people list members': '/people-lists/list%3A123',
@@ -465,6 +478,7 @@ void main() {
         RouteType.videoEditor: VideoEditorScreen.path,
         RouteType.videoMetadata: VideoMetadataScreen.path,
         RouteType.videoEdit: VideoMetadataEditScreen.pathFor('test-id-abc'),
+        RouteType.subtitleEdit: SubtitleEditorScreen.pathFor('test-id-abc'),
         RouteType.importKey: KeyImportScreen.path,
         RouteType.invites: InvitesScreen.path,
         RouteType.badges: BadgesScreen.path,

--- a/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
+++ b/mobile/test/screens/subtitle_editor/subtitle_editor_screen_test.dart
@@ -4,17 +4,52 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/subtitle_editor/subtitle_editor_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/subtitle_repository_provider.dart';
+import 'package:openvine/providers/video_providers.dart';
+import 'package:openvine/repositories/subtitle_repository.dart';
 import 'package:openvine/screens/subtitle_editor/subtitle_editor_screen.dart';
+import 'package:openvine/services/subtitle_service.dart';
+import 'package:openvine/services/video_event_resolver.dart';
+
+import '../../helpers/test_helpers.dart';
 
 class _MockCubit extends MockCubit<SubtitleEditorState>
     implements SubtitleEditorCubit {}
 
+class _MockSubtitleRepository extends Mock implements SubtitleRepository {}
+
+class _FakeVideoEventResolver implements VideoEventResolver {
+  _FakeVideoEventResolver(this.video);
+
+  final VideoEvent? video;
+  final resolvedIds = <String>[];
+  final allowOwnContentBypassValues = <bool>[];
+
+  @override
+  Future<VideoEvent?> resolveById(
+    String eventId, {
+    bool allowOwnContentBypass = false,
+    Duration timeout = const Duration(seconds: 10),
+  }) async {
+    resolvedIds.add(eventId);
+    allowOwnContentBypassValues.add(allowOwnContentBypass);
+    return video;
+  }
+}
+
 void main() {
   late _MockCubit cubit;
+
+  setUpAll(() {
+    registerFallbackValue(TestHelpers.createVideoEvent(id: 'fallback'));
+  });
+
   setUp(() => cubit = _MockCubit());
 
   Widget pump() => MaterialApp(
@@ -67,9 +102,9 @@ void main() {
   testWidgets('load failure shows the load error copy', (tester) async {
     whenListen(
       cubit,
-      Stream<SubtitleEditorState>.fromIterable(
-        const [SubtitleEditorState(status: SubtitleEditorStatus.failure)],
-      ),
+      Stream<SubtitleEditorState>.fromIterable(const [
+        SubtitleEditorState(status: SubtitleEditorStatus.failure),
+      ]),
       initialState: const SubtitleEditorState(),
     );
 
@@ -79,5 +114,66 @@ void main() {
     final l10n = lookupAppLocalizations(const Locale('en'));
     expect(find.text(l10n.subtitleEditorLoadError), findsOneWidget);
     expect(find.text(l10n.subtitleEditorSaveError), findsNothing);
+  });
+
+  group(SubtitleEditorScreen, () {
+    testWidgets('resolves video by id when no prefetched route extra exists', (
+      tester,
+    ) async {
+      final video = TestHelpers.createVideoEvent(
+        id: '0000000000000000000000000000000000000000000000000000000000000000',
+      );
+      final resolver = _FakeVideoEventResolver(video);
+      final repository = _MockSubtitleRepository();
+      when(() => repository.loadCues(any())).thenAnswer(
+        (_) async => const [SubtitleCue(start: 0, end: 1000, text: 'hello')],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            videoEventResolverProvider.overrideWithValue(resolver),
+            subtitleRepositoryProvider.overrideWithValue(repository),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: SubtitleEditorScreen(videoId: video.id),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      expect(resolver.resolvedIds, [video.id]);
+      expect(resolver.allowOwnContentBypassValues, [isTrue]);
+      expect(find.text('hello'), findsOneWidget);
+      verify(() => repository.loadCues(video)).called(1);
+    });
+
+    testWidgets('shows route error when the video id cannot be resolved', (
+      tester,
+    ) async {
+      const videoId =
+          'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+      final resolver = _FakeVideoEventResolver(null);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [videoEventResolverProvider.overrideWithValue(resolver)],
+          child: const MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: SubtitleEditorScreen(videoId: videoId),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      final l10n = lookupAppLocalizations(const Locale('en'));
+      expect(resolver.resolvedIds, [videoId]);
+      expect(find.text(l10n.routeInvalidVideoId), findsOneWidget);
+    });
   });
 }

--- a/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
@@ -1,3 +1,4 @@
+import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -60,6 +61,27 @@ void main() {
           extra: testVideo,
         ),
       ).called(1);
+    });
+
+    testWidgets('uses DivineButton styling for subtitle editing', (
+      tester,
+    ) async {
+      final mockGoRouter = MockGoRouter();
+
+      await tester.pumpWidget(buildSubject(mockGoRouter));
+
+      expect(find.byType(OutlinedButton), findsNothing);
+      expect(find.byType(DivineButton), findsNWidgets(3));
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is DivineButton &&
+              widget.leadingIcon == DivineIconName.closedCaptioning &&
+              widget.type == DivineButtonType.secondary &&
+              widget.expanded,
+        ),
+        findsOneWidget,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #5377.

This fixes the Android/main regression where tapping Edit subtitles from the video metadata editor could return the user to the home feed instead of opening the subtitle editor.

## Root Cause

The subtitle editor route was shaped as /subtitle-edit/:videoId, but the router still required a VideoEvent in GoRouter state.extra. Route extra is not durable route state, so rebuilding or entering the route from its URL could not reconstruct the screen.

## Changes

- Make SubtitleEditorScreen resolve the VideoEvent from videoId with videoEventResolverProvider, matching the existing /video-edit/:videoId pattern.
- Keep prefetched VideoEvent extra as an optional fast path for normal in-app navigation.
- Show the existing route invalid-video error when the id cannot resolve.
- Replace the raw Material OutlinedButton subtitle action with a DivineButton secondary action using the closed-captioning icon.
- Add regression coverage for resolving the subtitle editor without prefetched route extra and for the design-system button.

## Validation

- flutter test test/screens/subtitle_editor/subtitle_editor_screen_test.dart
- flutter test test/widgets/video_metadata/modes/edit/video_metadata_edit_bottom_bar_test.dart
- flutter test test/router/app_router_test.dart
- flutter analyze
- pre-push hook analyzer and changed-file tests passed