### PR TITLE
fix(video-editor): track native renders for detached teardown

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -18,6 +18,7 @@ import 'package:openvine/services/circuit_breaker_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
 import 'package:openvine/services/upload_publishability.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/async_utils.dart';
 import 'package:path/path.dart' as path;
@@ -403,7 +404,7 @@ class UploadManager {
         name: 'UploadManager',
         category: .video,
       );
-      await ProVideoEditor.instance.renderVideoToFile(
+      await VideoEditorRenderService.renderNativeVideoToFile(
         mergedPath,
         VideoRenderData(
           videoSegments: draft.clips

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -167,14 +167,12 @@ class _CropParameters {
 }
 
 class _RenderProgressTracker {
-  _RenderProgressTracker({
-    required this.taskId,
-    required int clipCount,
-  }) : _proofBudget =
-           VideoEditorRenderService.proofModeProgressBudgetForClipCount(
-             clipCount,
-           ),
-       _proofSteps = clipCount + 1;
+  _RenderProgressTracker({required this.taskId, required int clipCount})
+    : _proofBudget =
+          VideoEditorRenderService.proofModeProgressBudgetForClipCount(
+            clipCount,
+          ),
+      _proofSteps = clipCount + 1;
 
   final String taskId;
   final double _proofBudget;
@@ -239,6 +237,8 @@ class VideoEditorRenderService {
   static const _logName = 'VideoEditorRenderService';
   static final _compositeProgressController =
       StreamController<ProgressModel>.broadcast();
+  static final Map<String, Object> _activeNativeRenderTokens =
+      <String, Object>{};
 
   @visibleForTesting
   static double proofModeProgressBudgetForClipCount(int clipCount) {
@@ -259,6 +259,15 @@ class VideoEditorRenderService {
     _compositeProgressController.add(
       ProgressModel(id: taskId, progress: progress.clamp(0.0, 1.0)),
     );
+  }
+
+  @visibleForTesting
+  static Set<String> get activeNativeTaskIdsForTesting =>
+      Set.unmodifiable(_activeNativeRenderTokens.keys);
+
+  @visibleForTesting
+  static void resetActiveNativeTaskIdsForTesting() {
+    _activeNativeRenderTokens.clear();
   }
 
   @visibleForTesting
@@ -1017,16 +1026,7 @@ class VideoEditorRenderService {
     String outputPath,
     VideoRenderData task,
   ) async {
-    await cancelTask(task.id);
-    // Surface native renderer diagnostics (encoder fallbacks, bitrate clamps,
-    // OOM guards, render errors) into the unified log via
-    // ProVideoEditorLogForwarder — the signal set behind #4801. A clean render
-    // stays quiet at this level, so it does not flood the capture buffer.
-    await ProVideoEditor.instance.renderVideoToFile(
-      outputPath,
-      task,
-      nativeLogLevel: NativeLogLevel.warning,
-    );
+    await renderNativeVideoToFile(outputPath, task);
   }
 
   static Future<void> cancelTask(String id) async {
@@ -1050,5 +1050,49 @@ class VideoEditorRenderService {
         category: .video,
       );
     }
+  }
+
+  /// Cancels any existing native render with [task.id], tracks this render
+  /// instance, then renders to [outputPath].
+  ///
+  /// All app-owned `pro_video_editor` render entry points should use this
+  /// helper so teardown cancellation has a complete view of native work.
+  static Future<String> renderNativeVideoToFile(
+    String outputPath,
+    VideoRenderData task, {
+    NativeLogLevel? nativeLogLevel = NativeLogLevel.warning,
+  }) async {
+    await cancelTask(task.id);
+    final token = Object();
+    _activeNativeRenderTokens[task.id] = token;
+    try {
+      return await ProVideoEditor.instance.renderVideoToFile(
+        outputPath,
+        task,
+        nativeLogLevel: nativeLogLevel,
+      );
+    } finally {
+      if (identical(_activeNativeRenderTokens[task.id], token)) {
+        _activeNativeRenderTokens.remove(task.id);
+      }
+    }
+  }
+
+  /// Cancels native `pro_video_editor` render tasks started by this app.
+  ///
+  /// Intended for genuine teardown such as `AppLifecycleState.detached`.
+  /// Transient background states must not call this: exports may legitimately
+  /// continue while the user briefly switches apps or locks the device.
+  static Future<void> cancelActiveNativeTasks() async {
+    final taskIds = List<String>.of(_activeNativeRenderTokens.keys);
+    if (taskIds.isEmpty) return;
+
+    Log.info(
+      '⏹️ Cancelling ${taskIds.length} active video editor task(s)',
+      name: _logName,
+      category: .video,
+    );
+
+    await Future.wait<void>(taskIds.map(cancelTask));
   }
 }

--- a/mobile/lib/services/video_editor/video_editor_reverse_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_reverse_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -18,10 +19,7 @@ class VideoEditorReverseService {
   }) async {
     final documentsPath = await getDocumentsPath();
     final inputPath = await sourceClip.video.safeFilePath();
-    final outputPath = p.join(
-      documentsPath,
-      '${sourceClip.id}_reversed.mp4',
-    );
+    final outputPath = p.join(documentsPath, '${sourceClip.id}_reversed.mp4');
 
     // Defensive: refuse to render when the input path collides with the
     // output path. We delete the output file before rendering, so a collision
@@ -41,16 +39,6 @@ class VideoEditorReverseService {
     );
 
     try {
-      try {
-        await ProVideoEditor.instance.cancel(renderId);
-      } catch (e) {
-        Log.debug(
-          '⏹️ Reverse cancel returned for $renderId: $e',
-          name: 'VideoEditorReverseService',
-          category: LogCategory.video,
-        );
-      }
-
       if (outputFile.existsSync()) {
         await outputFile.delete();
         Log.debug(
@@ -60,7 +48,7 @@ class VideoEditorReverseService {
         );
       }
 
-      await ProVideoEditor.instance.renderVideoToFile(
+      await VideoEditorRenderService.renderNativeVideoToFile(
         outputPath,
         VideoRenderData(
           id: renderId,

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:path/path.dart' as p;
@@ -215,7 +216,10 @@ class VideoEditorSplitService {
         category: .video,
       );
 
-      await ProVideoEditor.instance.renderVideoToFile(outputPath, renderData);
+      await VideoEditorRenderService.renderNativeVideoToFile(
+        outputPath,
+        renderData,
+      );
 
       Log.info(
         '✅ Render complete: ${clip.id}',

--- a/mobile/lib/services/video_editor/video_editor_transform_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_transform_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:path/path.dart' as p;
 import 'package:pro_video_editor/pro_video_editor.dart';
@@ -52,16 +53,6 @@ class VideoEditorTransformService {
     );
 
     try {
-      try {
-        await ProVideoEditor.instance.cancel(renderId);
-      } catch (e) {
-        Log.debug(
-          '⏹️ Transform cancel returned for $renderId: $e',
-          name: 'VideoEditorTransformService',
-          category: LogCategory.video,
-        );
-      }
-
       if (outputFile.existsSync()) {
         await outputFile.delete();
         Log.debug(
@@ -71,7 +62,7 @@ class VideoEditorTransformService {
         );
       }
 
-      await ProVideoEditor.instance.renderVideoToFile(
+      await VideoEditorRenderService.renderNativeVideoToFile(
         outputPath,
         VideoRenderData(
           id: renderId,

--- a/mobile/lib/services/watermark_download_service.dart
+++ b/mobile/lib/services/watermark_download_service.dart
@@ -8,6 +8,7 @@ import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/gallery_save_service.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/watermark_image_generator.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -392,7 +393,7 @@ class WatermarkDownloadService {
         ],
       );
 
-      await ProVideoEditor.instance.renderVideoToFile(outputPath, task);
+      await VideoEditorRenderService.renderNativeVideoToFile(outputPath, task);
 
       Log.debug(
         'Watermarked video rendered to: $outputPath',

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -15,6 +15,7 @@ import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/background_activity_manager.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/utils/log_message_batcher.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -171,7 +172,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
 
       case AppLifecycleState.detached:
         // App is being terminated
-        break;
+        unawaited(VideoEditorRenderService.cancelActiveNativeTasks());
     }
   }
 

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -14,6 +14,9 @@ import 'package:pro_video_editor/pro_video_editor.dart';
 
 class _ProgressProVideoEditor extends ProVideoEditor {
   final _progressController = StreamController<ProgressModel>.broadcast();
+  final renderStarts = StreamController<VideoRenderData>.broadcast();
+  final _pendingRenders = <_PendingRender>[];
+  final cancelCalls = <String>[];
 
   @override
   void initializeStream() {}
@@ -27,6 +30,32 @@ class _ProgressProVideoEditor extends ProVideoEditor {
     return _progressController.stream.where(
       (progress) => progress.id == taskId,
     );
+  }
+
+  @override
+  Future<String> renderVideoToFile(
+    String filePath,
+    VideoRenderData value, {
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    final pending = _PendingRender(filePath: filePath, task: value);
+    _pendingRenders.add(pending);
+    renderStarts.add(value);
+    await pending.completer.future;
+    return filePath;
+  }
+
+  @override
+  Future<void> cancel(String taskId) async {
+    cancelCalls.add(taskId);
+    final matchingRender = _pendingRenders.where(
+      (pending) => pending.task.id == taskId && !pending.completer.isCompleted,
+    );
+    if (matchingRender.isNotEmpty) {
+      matchingRender.first.completer.completeError(
+        const RenderCanceledException(),
+      );
+    }
   }
 
   @override
@@ -45,7 +74,18 @@ class _ProgressProVideoEditor extends ProVideoEditor {
     );
   }
 
-  Future<void> dispose() => _progressController.close();
+  Future<void> dispose() async {
+    await _progressController.close();
+    await renderStarts.close();
+  }
+}
+
+class _PendingRender {
+  _PendingRender({required this.filePath, required this.task});
+
+  final String filePath;
+  final VideoRenderData task;
+  final completer = Completer<void>();
 }
 
 Future<void> _flushStreamEvents() => Future<void>.delayed(Duration.zero);
@@ -102,11 +142,13 @@ void main() {
       originalProVideoEditor = ProVideoEditor.instance;
       proVideoEditor = _ProgressProVideoEditor();
       ProVideoEditor.instance = proVideoEditor;
+      VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
     });
 
     tearDown(() async {
       VideoEditorRenderService.renderVideoOverride = null;
       NativeProofModeService.proofFileOverride = null;
+      VideoEditorRenderService.resetActiveNativeTaskIdsForTesting();
       await proVideoEditor.dispose();
       ProVideoEditor.instance = originalProVideoEditor;
     });
@@ -122,9 +164,9 @@ void main() {
         };
 
         final progressSubscription =
-            VideoEditorRenderService.compositeProgressStreamById(taskId).listen(
-              (progress) => progressValues.add(progress.progress),
-            );
+            VideoEditorRenderService.compositeProgressStreamById(
+              taskId,
+            ).listen((progress) => progressValues.add(progress.progress));
         addTearDown(progressSubscription.cancel);
 
         VideoEditorRenderService.renderVideoOverride =
@@ -212,5 +254,98 @@ void main() {
         expect(progressValues.last, equals(1.0));
       },
     );
+
+    test(
+      'tracks native renders and clears them when teardown cancellation throws',
+      () async {
+        final renderStarted = proVideoEditor.renderStarts.stream.first;
+        final renderFuture = VideoEditorRenderService.renderNativeVideoToFile(
+          '${Directory.systemTemp.path}/render-cancelled.mp4',
+          VideoRenderData(
+            id: 'tracked-render',
+            videoSegments: [
+              VideoSegment(
+                video: EditorVideo.file('${Directory.systemTemp.path}/a.mp4'),
+              ),
+            ],
+          ),
+        );
+
+        await renderStarted;
+        expect(
+          proVideoEditor.cancelCalls,
+          equals(['tracked-render']),
+          reason: 'renders unconditionally pre-cancel the task id',
+        );
+        expect(
+          VideoEditorRenderService.activeNativeTaskIdsForTesting,
+          contains('tracked-render'),
+        );
+
+        final renderCancellation = expectLater(
+          renderFuture,
+          throwsA(isA<RenderCanceledException>()),
+        );
+        await VideoEditorRenderService.cancelActiveNativeTasks();
+
+        expect(
+          proVideoEditor.cancelCalls,
+          equals(['tracked-render', 'tracked-render']),
+        );
+        await renderCancellation;
+        expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
+      },
+    );
+
+    test('keeps a reused task id tracked for the latest render', () async {
+      final firstRenderStarted = proVideoEditor.renderStarts.stream.first;
+      final firstRender = VideoEditorRenderService.renderNativeVideoToFile(
+        '${Directory.systemTemp.path}/first.mp4',
+        VideoRenderData(
+          id: 'reused-render-id',
+          videoSegments: [
+            VideoSegment(
+              video: EditorVideo.file('${Directory.systemTemp.path}/first.mov'),
+            ),
+          ],
+        ),
+      );
+      await firstRenderStarted;
+
+      final firstCancellation = expectLater(
+        firstRender,
+        throwsA(isA<RenderCanceledException>()),
+      );
+      final secondRenderStarted = proVideoEditor.renderStarts.stream.first;
+      final secondRender = VideoEditorRenderService.renderNativeVideoToFile(
+        '${Directory.systemTemp.path}/second.mp4',
+        VideoRenderData(
+          id: 'reused-render-id',
+          videoSegments: [
+            VideoSegment(
+              video: EditorVideo.file(
+                '${Directory.systemTemp.path}/second.mov',
+              ),
+            ),
+          ],
+        ),
+      );
+      await secondRenderStarted;
+
+      await firstCancellation;
+      expect(
+        VideoEditorRenderService.activeNativeTaskIdsForTesting,
+        equals({'reused-render-id'}),
+      );
+
+      final secondCancellation = expectLater(
+        secondRender,
+        throwsA(isA<RenderCanceledException>()),
+      );
+      await VideoEditorRenderService.cancelActiveNativeTasks();
+
+      await secondCancellation;
+      expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Route all app-owned ProVideoEditor renderVideoToFile calls through VideoEditorRenderService.renderNativeVideoToFile.
- Track native render task IDs with per-render ownership tokens so reused IDs cannot untrack a newer render.
- Cancel tracked native render tasks only on AppLifecycleState.detached, avoiding paused/hidden export cancellation.
- Remove duplicated reverse/transform pre-cancel code now that the shared helper owns that behavior.
- Add regression coverage for teardown cancellation throwing RenderCanceledException and reused task IDs.

## Root Cause

The previous lifecycle approach in PR #5384 mixed genuine teardown with transient background states. iOS paused/hidden can happen for lock screen, app switching, calls, or notification shade, and cancelling native renders there can kill an active publish/export render the user is waiting on.

The proposed render registry also only covered one render path. Split, reverse, transform, watermark, and upload fallback renders called ProVideoEditor.instance.renderVideoToFile directly, so detached teardown still could leave native ProVideoEditor work outside the registry.

## Fix Notes

This keeps the safe ProVideoEditor subset narrow:

- The app lifecycle handler calls cancellation only for detached.
- The lifecycle handler calls the render service directly and does not materialize videoEditorProvider.
- All app-owned renderVideoToFile entry points now share one helper.
- The helper pre-cancels the task ID, tracks the specific render instance, preserves native warning log forwarding, and only removes the active ID if the completing render still owns it.

This PR does not close the broader #4400 native player lifecycle umbrella. FVP event bridge, frame updater, and texture-output lifecycle concerns remain separate from this ProVideoEditor render tracking change unless covered by other native player work.

Closes #5399

## Verification

- flutter analyze
- flutter test test/services/video_editor_render_service_test.dart
- flutter test test/services/video_editor/video_editor_split_service_test.dart test/services/video_editor/video_editor_reverse_service_test.dart test/services/video_editor/video_editor_transform_service_test.dart test/services/watermark_download_service_test.dart test/services/upload_manager_from_draft_test.dart
- flutter test
- pre-push analyzer and changed-file test hook