### PR TITLE
fix(dm): visible padded play chip on quoted reply preview

### DIFF
--- a/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/message_bubble.dart
@@ -698,10 +698,14 @@ const double _quotedThumbRadius = 6;
 /// width, so there is no horizontal jump as the reel loads.
 const double _quotedPreviewWidth = 200;
 
-/// Play-badge diameter for the compact quoted thumbnail. The shared
-/// [VideoThumbnailWidget] default (48) overflows the 40-wide thumb, so the
-/// quoted preview uses a smaller badge with breathing room around it.
-const double _quotedPlayIconSize = 24;
+/// Diameter of the compact quoted-thumbnail play badge. Smaller than the shared
+/// [VideoThumbnailWidget] default so it reads as a neat chip with margin on the
+/// 40-wide thumb.
+const double _quotedPlayBadgeSize = 22;
+
+/// Play-glyph diameter inside the badge, inset from the badge edge so the
+/// triangle keeps visible padding within the chip.
+const double _quotedPlayGlyphSize = 11;
 
 /// Compact WhatsApp-style quoted preview of the video a reply references.
 ///
@@ -912,14 +916,18 @@ class _QuotedVideoCard extends ConsumerWidget {
             borderRadius: BorderRadius.circular(_quotedThumbRadius),
             // VideoThumbnailWidget renders an AspectRatio internally, so it
             // must be externally bounded (like the full _VideoCard's SizedBox)
-            // — its own width/height params only size the inner image.
+            // — its own width/height params only size the inner image. The
+            // compact play badge is overlaid here (rather than via
+            // showPlayIcon) so it stays visible on dark thumbnails.
             child: SizedBox(
               width: _quotedThumbWidth,
               height: _quotedThumbHeight,
-              child: VideoThumbnailWidget(
-                video: video,
-                showPlayIcon: true,
-                playIconSize: _quotedPlayIconSize,
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  VideoThumbnailWidget(video: video),
+                  const Center(child: _QuotedPlayBadge()),
+                ],
               ),
             ),
           ),
@@ -945,6 +953,36 @@ class _QuotedVideoCard extends ConsumerWidget {
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Compact play badge centered on the quoted-reply thumbnail. The translucent
+/// dark disc reads on light thumbnails; the hairline light ring keeps the chip
+/// visible on dark thumbnails, where a translucent-black disc would otherwise
+/// vanish into the content.
+class _QuotedPlayBadge extends StatelessWidget {
+  const _QuotedPlayBadge();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: _quotedPlayBadgeSize,
+      height: _quotedPlayBadgeSize,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: VineTheme.backgroundColor.withValues(alpha: 0.6),
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: VineTheme.whiteText.withValues(alpha: 0.9),
+          width: 1.5,
+        ),
+      ),
+      child: const DivineIcon(
+        icon: DivineIconName.play,
+        color: VineTheme.whiteText,
+        size: _quotedPlayGlyphSize,
       ),
     );
   }

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -20,7 +20,6 @@ class VideoThumbnailWidget extends StatefulWidget {
     this.height,
     this.fit = BoxFit.cover,
     this.showPlayIcon = false,
-    this.playIconSize = 48,
     this.borderRadius,
   });
   final VideoEvent video;
@@ -28,11 +27,6 @@ class VideoThumbnailWidget extends StatefulWidget {
   final double? height;
   final BoxFit fit;
   final bool showPlayIcon;
-
-  /// Diameter of the circular play badge shown when [showPlayIcon] is true.
-  /// The play glyph scales proportionally (two-thirds of the badge). Defaults
-  /// to 48 to match full-size cards; compact thumbnails pass a smaller value.
-  final double playIconSize;
   final BorderRadius? borderRadius;
 
   @override
@@ -130,16 +124,16 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
         if (widget.showPlayIcon)
           Center(
             child: Container(
-              width: widget.playIconSize,
-              height: widget.playIconSize,
+              width: 48,
+              height: 48,
               decoration: BoxDecoration(
                 color: VineTheme.backgroundColor.withValues(alpha: 0.6),
                 shape: BoxShape.circle,
               ),
-              child: DivineIcon(
+              child: const DivineIcon(
                 icon: DivineIconName.play,
                 color: VineTheme.whiteText,
-                size: widget.playIconSize * 2 / 3,
+                size: 32,
               ),
             ),
           ),

--- a/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/message_bubble_test.dart
@@ -1223,12 +1223,15 @@ void main() {
           final textCenter = tester.getCenter(find.text('love this one')).dy;
           expect(thumbCenter, lessThan(textCenter));
 
-          // The compact thumbnail uses the smaller play badge so it doesn't
-          // overflow the 40-wide thumb.
-          final thumbWidget = tester.widget<VideoThumbnailWidget>(
-            find.byType(VideoThumbnailWidget),
+          // The compact thumbnail carries its own small play badge (an 11px
+          // glyph) overlaid on the thumbnail, not the full-size 32px badge —
+          // so it reads as a neat chip with margin on the 40-wide thumb.
+          final playIcon = tester.widget<DivineIcon>(
+            find.byWidgetPredicate(
+              (w) => w is DivineIcon && w.icon == DivineIconName.play,
+            ),
           );
-          expect(thumbWidget.playIconSize, 24);
+          expect(playIcon.size, 11);
 
           // The preview is pinned to a fixed width so the bubble doesn't
           // reflow when the cited reel resolves out of its loading skeleton.

--- a/mobile/test/widgets/video_thumbnail_widget_test.dart
+++ b/mobile/test/widgets/video_thumbnail_widget_test.dart
@@ -435,31 +435,6 @@ void main() {
       expect(icon.size, 32);
     });
 
-    testWidgets('scales the play badge with playIconSize', (tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: Scaffold(
-            body: VideoThumbnailWidget(
-              video: videoWithBlurhash,
-              width: 200,
-              height: 200,
-              showPlayIcon: true,
-              playIconSize: 24,
-            ),
-          ),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-
-      // The play glyph scales to two-thirds of the badge diameter so a
-      // compact thumbnail doesn't get a badge wider than the thumb.
-      final icon = tester.widget<DivineIcon>(_divineIcon(DivineIconName.play));
-      expect(icon.size, 24 * 2 / 3);
-    });
-
     testWidgets('applies border radius when provided', (tester) async {
       await tester.pumpWidget(
         MaterialApp(


### PR DESCRIPTION
## Description

Follow-up to #5392 (already merged) addressing @hm21's review comment that
the play-icon on the compact quoted-reply thumbnail had no padding/margin.

The merged badge was the shared `VideoThumbnailWidget` overlay: a pure-black
disc (`backgroundColor` @ 0.6 alpha) with a centered play glyph. On a dark
thumbnail (hair, jacket, etc.) that disc is effectively invisible — and a
pure-black chip can't be made visible by raising opacity alone — so the white
play triangle read as a bare outline floating on the image.

This reworks it into a purpose-built compact chip scoped to the quoted preview:

- A smaller **22px disc** centered on the 40×56 thumb (clear margin on all sides).
- A **hairline light ring** (white @ 0.9, 1.5px) so the chip stays visible on
  *dark* thumbnails, where the translucent-black disc disappears.
- An **11px play glyph** inset inside the disc for visible padding.
- Overlaid via a `Stack` with `showPlayIcon: false`, which made the
  `playIconSize` param previously added to `VideoThumbnailWidget` unused — so it
  is reverted. The shared widget is byte-identical to its pre-#5392 state again.

**Related Issue:** Relates to #5392 (merged) — addresses hm21's review comment
that landed ~35 min before the squash-merge, so it wasn't included in that PR.

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `message_bubble_test.dart` + `video_thumbnail_widget_test.dart` — 70 pass
  (updated the compact-badge assertion to the new 11px glyph; removed the now
  obsolete `playIconSize` scaling test; kept the default-48/32 badge assertion).
- `dart format` — clean.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)