### PR TITLE
perf(dm): batch/throttle DM ingestion + cache_sync on a background isolate (#5391)

### DIFF
--- a/mobile/packages/cache_sync/lib/src/connection/connection_native.dart
+++ b/mobile/packages/cache_sync/lib/src/connection/connection_native.dart
@@ -20,7 +20,9 @@ QueryExecutor openConnection() {
     final dir = await getApplicationSupportDirectory();
     final file = File(p.join(dir.path, 'openvine', 'cache', 'cache_sync.db'));
     await file.parent.create(recursive: true);
-    return NativeDatabase(file);
+    // Open on a background isolate so cache reads/writes stay off the UI
+    // thread (#5391). This DB is unencrypted, so there is no setup callback.
+    return NativeDatabase.createInBackground(file);
   });
 }
 

--- a/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
+++ b/mobile/packages/db_client/test/src/database/connection/connection_native_test.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
+import 'package:db_client/db_client.dart' show AppDatabase;
 import 'package:db_client/src/database/connection/connection_native.dart';
 import 'package:drift/drift.dart' show QueryExecutor;
+import 'package:drift/native.dart' show NativeDatabase;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as p;
@@ -567,6 +569,53 @@ void main() {
       expect(
         openEncryptedConnection(rawKeyHex: validKey),
         isA<QueryExecutor>(),
+      );
+    });
+  });
+
+  // The production opens use NativeDatabase.createInBackground (#5391), which
+  // runs the cipher `setup:` on a spawned background isolate. This proves
+  // sqlite3mc resolves there (else applyCipherKey fails closed) and the DB is
+  // genuinely encrypted, exercising the real background-isolate open path the
+  // unit tests above only construct lazily.
+  group('createInBackground encrypted open', () {
+    const validKey =
+        '2dd29ca851e7b56e4697b0e1f08507293d761a05ce4d1b628663f411a8086d99';
+
+    test('opens an encrypted DB with the cipher applied on the background '
+        'isolate and persists a keyed round-trip', () async {
+      final tempRoot = Directory.systemTemp.createTempSync(
+        'db_client_cib_cipher_test_',
+      );
+      addTearDown(() {
+        if (tempRoot.existsSync()) tempRoot.deleteSync(recursive: true);
+      });
+      final dbPath = p.join(tempRoot.path, 'encrypted.db');
+
+      final db = AppDatabase(
+        NativeDatabase.createInBackground(
+          File(dbPath),
+          setup: (rawDb) => applyCipherKey(rawDb, validKey),
+        ),
+      );
+
+      // Forces the background isolate to open, run `setup:` (applyCipherKey)
+      // there, and run drift's onCreate migration. If sqlite3mc did not
+      // resolve on the spawned isolate, applyCipherKey throws StateError and
+      // this fails.
+      final rows = await db
+          .customSelect('SELECT count(*) AS c FROM sqlite_master;')
+          .get();
+      expect(rows.single.read<int>('c'), greaterThanOrEqualTo(0));
+      await db.close();
+
+      // Prove the file is genuinely encrypted by the bg-isolate cipher: a
+      // plaintext open must fail to read its schema.
+      final plaintext = sqlite3.open(dbPath, mode: OpenMode.readOnly);
+      addTearDown(plaintext.close);
+      expect(
+        () => plaintext.select('SELECT count(*) FROM sqlite_master;'),
+        throwsA(isA<SqliteException>()),
       );
     });
   });

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -91,6 +91,17 @@ abstract class DmHistoryDrainConfig {
   /// recovers, while a permanently-undecryptable wrap cannot loop forever.
   /// See #5202.
   static const int maxDecryptRetries = 10;
+
+  /// Gift wraps decrypted per [compute] isolate hop on the history-drain
+  /// path: one hop covers this many wraps instead of one spawn per wrap.
+  /// Sub-chunks a [pageSize] page to bound peak isolate memory and the
+  /// off-lock decrypt duration. See #5391.
+  static const int decryptBatchSize = 20;
+
+  /// Events processed between cooperative event-loop yields in the serial
+  /// backfill loops, so a large drain cannot starve frame rendering. See
+  /// #5391.
+  static const int drainYieldInterval = 16;
 }
 
 const _relayLoopbackHosts = <String>{
@@ -485,9 +496,30 @@ class DmRepository {
     );
     if (_disposed || _userPubkey != pubkey) return null;
 
-    for (final event in events) {
+    // Pass 1 (off the _eventLock): batch-decrypt this page's gift wraps in one
+    // isolate hop per chunk for local-key signers, instead of one isolate
+    // spawn per wrap. Remote signers and undecryptable wraps stay out of the
+    // map and fall through to the per-event path in pass 2. See #5391.
+    final preDecrypted = await _batchDecryptGiftWraps(events);
+    // The batch decrypt above can span many events with no inner guard, so
+    // re-check before persisting that the user did not switch / tear down.
+    if (_disposed || _userPubkey != pubkey) return null;
+
+    // Pass 2 (original page order): persist. Pre-decrypted gift wraps skip the
+    // per-event decrypt; everything else (NIP-04, deletions, remote-signer or
+    // failed wraps) routes through the unchanged per-event handler.
+    for (var i = 0; i < events.length; i++) {
       if (_disposed || _userPubkey != pubkey) return null;
-      await _handleIncomingEvent(event);
+      final event = events[i];
+      final rumor = preDecrypted[event.id];
+      if (rumor != null) {
+        await _withEventLock(
+          () => _persistDecryptedGiftWrap(event, rumor),
+        );
+      } else {
+        await _handleIncomingEvent(event);
+      }
+      await _maybeYieldDuringDrain(i);
     }
     return events;
   }
@@ -537,9 +569,10 @@ class DmRepository {
           // user's outgoing NIP-04 (the #5202 failure mode, mirrored here).
           return _nostrClient.connectedRelayCount > 0;
         }
-        for (final event in events) {
+        for (var i = 0; i < events.length; i++) {
           if (_disposed || _userPubkey != pubkey) return false;
-          await _handleIncomingEvent(event);
+          await _handleIncomingEvent(events[i]);
+          await _maybeYieldDuringDrain(i);
         }
         // Step strictly below the oldest event seen so the loop terminates;
         // `until` is inclusive, so a re-requested boundary is absorbed by the
@@ -694,8 +727,9 @@ class DmRepository {
       // inbox open (empty queue) never flickers the progress indicator.
       _beginRecovery();
       began = true;
-      for (final row in pending) {
+      for (var i = 0; i < pending.length; i++) {
         if (_disposed || _userPubkey != pubkey) return;
+        final row = pending[i];
         // Already recovered by the live sub / drain — clear the stale row so
         // it does not linger and re-query on every inbox open.
         if (await _directMessagesDao.hasGiftWrap(row.giftWrapId)) {
@@ -727,6 +761,9 @@ class DmRepository {
         // successful decrypt deletes the pending row inside
         // _handleGiftWrapEvent; a failure increments its attempts.
         await _handleIncomingEvent(giftWrapEvent);
+        // WS3: yield periodically so a large retry queue cannot starve frame
+        // rendering. See #5391.
+        await _maybeYieldDuringDrain(i);
       }
     } on Object catch (e, stackTrace) {
       // Relay/DB/IO failures here are expected (e.g. a transient read-only
@@ -929,13 +966,7 @@ class DmRepository {
   /// Serialized via [_eventLock] so that subscription events never race
   /// into the dedup/insert path concurrently.
   Future<void> _handleIncomingEvent(Event event) async {
-    // Wait for any in-flight event processing to complete.
-    while (_eventLock != null) {
-      await _eventLock;
-    }
-    final completer = Completer<void>();
-    _eventLock = completer.future;
-    try {
+    await _withEventLock(() async {
       if (event.kind == EventKind.eventDeletion) {
         await _handleDeletionEvent(event);
       } else if (event.kind == EventKind.directMessage) {
@@ -943,6 +974,22 @@ class DmRepository {
       } else {
         await _handleGiftWrapEvent(event);
       }
+    });
+  }
+
+  /// Runs [body] under the [_eventLock] so dedup/insert work is serialized,
+  /// whether it comes from the live subscription ([_handleIncomingEvent]) or
+  /// the batched history-drain persist path ([_fetchHistoryPage]). The lock
+  /// guards only persistence; batched decryption runs off-lock. See #5391.
+  Future<void> _withEventLock(Future<void> Function() body) async {
+    // Wait for any in-flight event processing to complete.
+    while (_eventLock != null) {
+      await _eventLock;
+    }
+    final completer = Completer<void>();
+    _eventLock = completer.future;
+    try {
+      await body();
     } finally {
       _eventLock = null;
       completer.complete();
@@ -999,7 +1046,12 @@ class DmRepository {
     }
   }
 
+  /// Single-event gift-wrap entry (live subscription + retry replay): dedup,
+  /// decrypt, then persist. The persist body is shared with the batched
+  /// history-drain path via [_persistDecryptedGiftWrap]. Callers must already
+  /// hold the [_eventLock] (via [_handleIncomingEvent]).
   Future<void> _handleGiftWrapEvent(Event giftWrapEvent) async {
+    final Event? rumorEvent;
     try {
       // Dedup: skip if already processed
       if (await _directMessagesDao.hasGiftWrap(giftWrapEvent.id)) {
@@ -1012,7 +1064,30 @@ class DmRepository {
       final nostr = Nostr(signer, [], _dummyRelay);
       await nostr.refreshPublicKey();
 
-      final rumorEvent = await _decryptRumor(nostr, giftWrapEvent);
+      rumorEvent = await _decryptRumor(nostr, giftWrapEvent);
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to process gift wrap event: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return;
+    }
+
+    await _persistDecryptedGiftWrap(giftWrapEvent, rumorEvent);
+  }
+
+  /// Persists a single (already-decrypted) gift wrap. [rumorEvent] is the
+  /// decrypted inner rumor, or `null` when decryption failed (the wrap is
+  /// then queued for a later retry). Shared by the single-event path
+  /// ([_handleGiftWrapEvent]) and the batched history-drain path. Callers must
+  /// hold the [_eventLock]. See #5391.
+  Future<void> _persistDecryptedGiftWrap(
+    Event giftWrapEvent,
+    Event? rumorEvent,
+  ) async {
+    try {
       if (rumorEvent == null) {
         // Persist the still-encrypted wrap so a later retry can recover the
         // conversation instead of losing it — flaky remote-signer (Keycast
@@ -1037,37 +1112,41 @@ class DmRepository {
         ownerPubkey: _userPubkey,
       );
 
+      // Bind to a final local so the non-null type promotes inside the
+      // runInTransaction closure below (a nullable parameter would not).
+      final rumor = rumorEvent;
+
       // NIP-17 spec line 14 explicitly permits kind 7 reactions inside
       // the gift-wrap envelope. Reaction deletions are also wrapped by
       // this feature so the remove path preserves DM privacy. Route both
       // before the DM-only kinds gate below. #4633.
-      if (rumorEvent.kind == EventKind.reaction) {
+      if (rumor.kind == EventKind.reaction) {
         await _reactionsRepository?.persistIncoming(
-          rumorEvent: rumorEvent,
+          rumorEvent: rumor,
           giftWrapId: giftWrapEvent.id,
         );
         return;
       }
-      if (rumorEvent.kind == EventKind.eventDeletion) {
+      if (rumor.kind == EventKind.eventDeletion) {
         await _reactionsRepository?.handleIncomingDeletion(
-          rumorEvent: rumorEvent,
+          rumorEvent: rumor,
           giftWrapId: giftWrapEvent.id,
         );
         return;
       }
 
       // Accept kind 14 (text) and kind 15 (file)
-      if (!_supportedDmKinds.contains(rumorEvent.kind)) return;
+      if (!_supportedDmKinds.contains(rumor.kind)) return;
 
       // Extract conversation participants from pubkey + p tags, then
       // resolve against existing conversations to prevent duplicates
       // from non-compliant clients that add extra p-tags.
-      final rawParticipants = _extractParticipants(rumorEvent);
+      final rawParticipants = _extractParticipants(rumor);
       if (rawParticipants.length < 2) return;
 
       final participants = await _resolveConversationParticipants(
         rawParticipants,
-        rumorEvent.pubkey,
+        rumor.pubkey,
       );
 
       // Reject self-conversations (all participants are the same pubkey).
@@ -1080,7 +1159,7 @@ class DmRepository {
       // Extract common tags
       String? replyToId;
       String? subject;
-      for (final tag in rumorEvent.tags) {
+      for (final tag in rumor.tags) {
         if (tag.length >= 2) {
           if (tag[0] == 'e') replyToId = tag[1];
           if (tag[0] == 'subject') subject = tag[1];
@@ -1088,17 +1167,17 @@ class DmRepository {
       }
 
       // Extract file metadata for kind 15
-      final fileMetadata = rumorEvent.kind == EventKind.fileMessage
-          ? _extractFileMetadata(rumorEvent)
+      final fileMetadata = rumor.kind == EventKind.fileMessage
+          ? _extractFileMetadata(rumor)
           : null;
 
       // Cross-protocol dedup: if a NIP-04 copy of this message was
       // processed first (network reordering), skip the duplicate.
       final isDuplicate = await _directMessagesDao.hasMatchingMessage(
         conversationId: conversationId,
-        senderPubkey: rumorEvent.pubkey,
-        content: rumorEvent.content,
-        createdAt: rumorEvent.createdAt,
+        senderPubkey: rumor.pubkey,
+        content: rumor.content,
+        createdAt: rumor.createdAt,
         ownerPubkey: _userPubkey,
       );
       if (isDuplicate) {
@@ -1109,26 +1188,26 @@ class DmRepository {
       // The inner hasGiftWrap re-check guards against TOCTOU races where
       // a poll and subscription event both pass the outer fast-path check.
       final isGroup = participants.length > 2;
-      final isSentByMe = rumorEvent.pubkey == _userPubkey;
-      final previewContent = rumorEvent.kind == EventKind.fileMessage
+      final isSentByMe = rumor.pubkey == _userPubkey;
+      final previewContent = rumor.kind == EventKind.fileMessage
           ? _filePreviewText(fileMetadata?.fileType)
-          : rumorEvent.content;
+          : rumor.content;
 
       await _conversationsDao.runInTransaction(() async {
         // Re-check dedup inside transaction (TOCTOU protection).
         if (await _directMessagesDao.hasGiftWrap(giftWrapEvent.id)) return;
 
         await _directMessagesDao.insertMessage(
-          id: rumorEvent.id,
+          id: rumor.id,
           conversationId: conversationId,
-          senderPubkey: rumorEvent.pubkey,
-          content: rumorEvent.content,
-          createdAt: rumorEvent.createdAt,
+          senderPubkey: rumor.pubkey,
+          content: rumor.content,
+          createdAt: rumor.createdAt,
           giftWrapId: giftWrapEvent.id,
-          messageKind: rumorEvent.kind,
+          messageKind: rumor.kind,
           replyToId: replyToId,
           subject: subject,
-          tagsJson: jsonEncode(rumorEvent.tags),
+          tagsJson: jsonEncode(rumor.tags),
           fileType: fileMetadata?.fileType,
           encryptionAlgorithm: fileMetadata?.encryptionAlgorithm,
           decryptionKey: fileMetadata?.decryptionKey,
@@ -1151,10 +1230,10 @@ class DmRepository {
           id: conversationId,
           participantPubkeys: jsonEncode(participants),
           isGroup: isGroup,
-          createdAt: existing?.createdAt ?? rumorEvent.createdAt,
+          createdAt: existing?.createdAt ?? rumor.createdAt,
           lastMessageContent: previewContent,
-          lastMessageTimestamp: rumorEvent.createdAt,
-          lastMessageSenderPubkey: rumorEvent.pubkey,
+          lastMessageTimestamp: rumor.createdAt,
+          lastMessageSenderPubkey: rumor.pubkey,
           subject: subject,
           isRead: isSentByMe,
           currentUserHasSent:
@@ -1169,11 +1248,11 @@ class DmRepository {
       // window (NIP-17) so it must not be used for boundary tracking.
       await _syncState?.recordSeen(
         _userPubkey,
-        createdAt: rumorEvent.createdAt,
+        createdAt: rumor.createdAt,
       );
 
       Log.debug(
-        'Persisted DM (kind ${rumorEvent.kind}) in conversation '
+        'Persisted DM (kind ${rumor.kind}) in conversation '
         '$conversationId',
         category: LogCategory.system,
       );
@@ -1187,16 +1266,101 @@ class DmRepository {
     }
   }
 
+  /// Decrypts a page's gift wraps in batches for local-key signers, returning
+  /// a `{giftWrapId: rumor}` map of the SUCCESSFUL decrypts only. One
+  /// [compute] isolate hop covers up to [DmHistoryDrainConfig.decryptBatchSize]
+  /// wraps instead of one spawn per wrap (#5391). Wraps that are already
+  /// persisted, fail to decrypt, or belong to a remote signer are absent from
+  /// the map — the caller routes those through the unchanged per-event path
+  /// (which preserves the isolate→main-isolate fallback and failed-decrypt
+  /// bookkeeping). Runs OFF the [_eventLock].
+  Future<Map<String, Event>> _batchDecryptGiftWraps(
+    List<Event> events,
+  ) async {
+    final signer = _signer;
+    if (signer is! IsolateDecryptSigner || !signer.canDecryptInIsolate) {
+      // Remote / test signer: cannot decrypt in an isolate. Per-event path.
+      return const {};
+    }
+
+    // Only wraps not already persisted, to avoid re-decrypting on resume
+    // drains. The in-transaction hasGiftWrap re-check still protects races.
+    final pending = <Event>[];
+    for (final event in events) {
+      if (event.kind != EventKind.giftWrap) continue;
+      if (await _directMessagesDao.hasGiftWrap(event.id)) continue;
+      pending.add(event);
+    }
+    if (pending.isEmpty) return const {};
+
+    final hex = signer.withPrivateKeyHex((k) => k);
+    final decrypted = <String, Event>{};
+    for (
+      var start = 0;
+      start < pending.length;
+      start += DmHistoryDrainConfig.decryptBatchSize
+    ) {
+      if (_disposed) break;
+      final end = start + DmHistoryDrainConfig.decryptBatchSize;
+      final chunk = pending.sublist(
+        start,
+        end < pending.length ? end : pending.length,
+      );
+      try {
+        final results = await compute(
+          decryptGiftWrapBatch,
+          DecryptBatchRequest(
+            events: [for (final event in chunk) event.toJson()],
+            privateKeyHex: hex,
+          ),
+        );
+        for (var i = 0; i < chunk.length; i++) {
+          final result = results[i];
+          if (result.isSuccess) {
+            decrypted[chunk[i].id] = Event.fromJson(result.rumor!);
+          }
+        }
+      } on Object catch (e, stackTrace) {
+        // Whole-chunk isolate failure: leave these wraps out of the map so
+        // they fall back to the per-event decryptor in the caller.
+        Log.error(
+          'Batch gift-wrap decrypt threw: $e',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+      // WS3: yield an event-loop turn between isolate hops so a large
+      // backfill cannot starve frame rendering. See #5391.
+      await _yieldToEventLoop();
+    }
+    return decrypted;
+  }
+
+  /// Cooperative-scheduling yield (NOT UI timing): a zero-duration delay is a
+  /// real event-loop turn that lets frame rendering run between drain steps;
+  /// a microtask (`await null`) would not. dm_repository is a pure-Dart
+  /// package, so SchedulerBinding is unavailable here. See #5391.
+  Future<void> _yieldToEventLoop() => Future<void>.delayed(Duration.zero);
+
+  /// Yields to the event loop every [DmHistoryDrainConfig.drainYieldInterval]
+  /// events in a serial backfill loop ([index] is the 0-based position), so a
+  /// large history drain cannot starve frame rendering. See #5391.
+  Future<void> _maybeYieldDuringDrain(int index) async {
+    if ((index + 1) % DmHistoryDrainConfig.drainYieldInterval == 0) {
+      await _yieldToEventLoop();
+    }
+  }
+
   /// Decrypts a single gift-wrap rumor, routing through a [compute]
   /// isolate for local signers that can safely expose their private key
   /// bytes, and falling back to the injected [_rumorDecryptor] on the
   /// main isolate for remote signers (Amber, Keycast RPC, NIP-46) and
   /// test-injected decryptors.
   ///
-  /// Single-element isolate batches are intentional for v1: the
-  /// subscription pipeline processes gift wraps one at a time, and the
-  /// goal is to keep the expensive NIP-44 crypto off the UI thread.
-  /// Real backlog batching can come later.
+  /// This single-event path serves the live subscription and the retry
+  /// replay; the high-volume history drain instead batches many wraps per
+  /// isolate hop via [_batchDecryptGiftWraps]. See #5391.
   Future<Event?> _decryptRumor(Nostr nostr, Event giftWrapEvent) async {
     final signer = _signer;
     if (signer is IsolateDecryptSigner && signer.canDecryptInIsolate) {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -12,13 +12,100 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
+import 'package:nostr_sdk/nip44/nip44_v2.dart';
+import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 
 class _MockOutgoingDmsDao extends Mock implements OutgoingDmsDao {}
+
+/// A local-key signer that can decrypt in an isolate, used to drive the
+/// batched history-drain decrypt path (#5391). Delegates the [NostrSigner]
+/// surface to an inner [LocalNostrSigner] and exposes its raw private key.
+class _IsolateLocalSigner implements IsolateDecryptSigner {
+  _IsolateLocalSigner(this._privateKeyHex)
+    : _inner = LocalNostrSigner(_privateKeyHex);
+
+  final String _privateKeyHex;
+  final LocalNostrSigner _inner;
+
+  @override
+  bool get canDecryptInIsolate => true;
+
+  @override
+  T withPrivateKeyHex<T>(T Function(String hex) operation) =>
+      operation(_privateKeyHex);
+
+  @override
+  Future<String?> getPublicKey() => _inner.getPublicKey();
+
+  @override
+  Future<Event?> signEvent(Event event) => _inner.signEvent(event);
+
+  @override
+  Future<Map<dynamic, dynamic>?> getRelays() => _inner.getRelays();
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) =>
+      _inner.encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) =>
+      _inner.decrypt(pubkey, ciphertext);
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) =>
+      _inner.nip44Encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) =>
+      _inner.nip44Decrypt(pubkey, ciphertext);
+
+  @override
+  void close() => _inner.close();
+}
+
+/// Builds a real NIP-17 gift wrap for [rumor] addressed to [recipientPubkey],
+/// sealed and signed by [senderPrivateKey]. Mirrors the production
+/// GiftWrapUtil flow so the batched decrypt worker can unwrap it for real.
+Future<Event> _buildGiftWrap({
+  required Event rumor,
+  required String senderPrivateKey,
+  required String recipientPubkey,
+  required int outerCreatedAt,
+}) async {
+  final senderPubkey = getPublicKey(senderPrivateKey);
+  final rumorMap = rumor.toJson()..remove('sig');
+  final sealKey = NIP44V2.shareSecret(senderPrivateKey, recipientPubkey);
+  final sealContent = await NIP44V2.encrypt(jsonEncode(rumorMap), sealKey);
+  final sealEvent = Event(
+    senderPubkey,
+    EventKind.sealEventKind,
+    <List<String>>[],
+    sealContent,
+  )..sign(senderPrivateKey);
+
+  final ephemeralPrivateKey = generatePrivateKey();
+  final ephemeralPubkey = getPublicKey(ephemeralPrivateKey);
+  final wrapKey = NIP44V2.shareSecret(ephemeralPrivateKey, recipientPubkey);
+  final wrapContent = await NIP44V2.encrypt(
+    jsonEncode(sealEvent.toJson()),
+    wrapKey,
+  );
+  return Event(
+    ephemeralPubkey,
+    EventKind.giftWrap,
+    <List<String>>[
+      ['p', recipientPubkey],
+    ],
+    wrapContent,
+    createdAt: outerCreatedAt,
+  )..sign(ephemeralPrivateKey);
+}
 
 class _MockPendingGiftWrapsDao extends Mock implements PendingGiftWrapsDao {}
 
@@ -273,6 +360,7 @@ void main() {
       OutgoingDmsDao? outgoingDmsDao,
       PendingGiftWrapsDao? pendingGiftWrapsDao,
       DmReactionsRepository? reactionsRepository,
+      NostrSigner? signer,
     }) {
       return DmRepository(
         nostrClient: mockNostrClient,
@@ -282,7 +370,7 @@ void main() {
         outgoingDmsDao: outgoingDmsDao,
         pendingGiftWrapsDao: pendingGiftWrapsDao,
         userPubkey: userPubkey ?? _validPubkeyA,
-        signer: LocalNostrSigner(_validPrivateKey),
+        signer: signer ?? LocalNostrSigner(_validPrivateKey),
         rumorDecryptor: rumorDecryptor,
         nip04Decryptor: nip04Decryptor,
         syncState: syncState,
@@ -3127,6 +3215,347 @@ void main() {
             ),
           );
           expect(syncState.markedCompletePubkeys, [_validPubkeyB]);
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------
+    // History-drain batch decryption + throttle (#5391)
+    // -----------------------------------------------------------------
+
+    group('history drain batch decryption (#5391)', () {
+      // A new recipient keypair per test so the real NIP-44 unwrap in the
+      // batched decrypt worker succeeds (the shared _validPubkey* constants
+      // are not a real keypair).
+      late String recipientPriv;
+      late String recipientPub;
+      late String senderPriv;
+      late String senderPub;
+      late Set<String> persistedGiftWrapIds;
+
+      setUp(() {
+        recipientPriv = generatePrivateKey();
+        recipientPub = getPublicKey(recipientPriv);
+        senderPriv = generatePrivateKey();
+        senderPub = getPublicKey(senderPriv);
+        persistedGiftWrapIds = <String>{};
+
+        // Stateful dedup mirroring production: hasGiftWrap reflects what
+        // insertMessage has persisted, so the inclusive `until` boundary
+        // re-request is deduped instead of re-inserted.
+        when(
+          () => mockDirectMessagesDao.hasGiftWrap(any()),
+        ).thenAnswer(
+          (inv) async =>
+              persistedGiftWrapIds.contains(inv.positionalArguments[0]),
+        );
+        when(
+          () => mockDirectMessagesDao.hasMatchingMessage(
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => false);
+        when(
+          () => mockDirectMessagesDao.insertMessage(
+            id: any(named: 'id'),
+            conversationId: any(named: 'conversationId'),
+            senderPubkey: any(named: 'senderPubkey'),
+            content: any(named: 'content'),
+            createdAt: any(named: 'createdAt'),
+            giftWrapId: any(named: 'giftWrapId'),
+            messageKind: any(named: 'messageKind'),
+            replyToId: any(named: 'replyToId'),
+            subject: any(named: 'subject'),
+            fileType: any(named: 'fileType'),
+            encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+            decryptionKey: any(named: 'decryptionKey'),
+            decryptionNonce: any(named: 'decryptionNonce'),
+            fileHash: any(named: 'fileHash'),
+            originalFileHash: any(named: 'originalFileHash'),
+            fileSize: any(named: 'fileSize'),
+            dimensions: any(named: 'dimensions'),
+            blurhash: any(named: 'blurhash'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            tagsJson: any(named: 'tagsJson'),
+          ),
+        ).thenAnswer((inv) async {
+          persistedGiftWrapIds.add(inv.namedArguments[#giftWrapId] as String);
+        });
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockConversationsDao.upsertConversation(
+            id: any(named: 'id'),
+            participantPubkeys: any(named: 'participantPubkeys'),
+            isGroup: any(named: 'isGroup'),
+            createdAt: any(named: 'createdAt'),
+            lastMessageContent: any(named: 'lastMessageContent'),
+            lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+            lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+            subject: any(named: 'subject'),
+            isRead: any(named: 'isRead'),
+            currentUserHasSent: any(named: 'currentUserHasSent'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            dmProtocol: any(named: 'dmProtocol'),
+          ),
+        ).thenAnswer((_) async {});
+      });
+
+      Event rumorFor(String content, {required int createdAt}) => Event(
+        senderPub,
+        EventKind.privateDirectMessage,
+        <List<String>>[
+          ['p', recipientPub],
+        ],
+        content,
+        createdAt: createdAt,
+      );
+
+      // Returns a queryEvents stub that serves [page] for the gift-wrap drain
+      // filter (p:[self], inclusive `until`) and [] for the NIP-04 recovery
+      // pass (authors:[self]).
+      void stubDrainPage(List<Event> page) {
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer((inv) async {
+          final filters =
+              inv.positionalArguments.first as List<nostr_filter.Filter>;
+          final filter = filters.single;
+          if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+            return const <Event>[];
+          }
+          final until = filter.until ?? (1 << 31);
+          return page.where((e) => e.createdAt <= until).toList();
+        });
+      }
+
+      _FakeDmSyncState drainPending() => _FakeDmSyncState()
+        ..oldestOverride = 1700001000
+        ..drainVersionOverride = DmSyncState.currentDrainVersion;
+
+      test(
+        'batches a drain page of real gift wraps and persists each message '
+        'without a per-event decryptor',
+        () async {
+          final wrap1 = await _buildGiftWrap(
+            rumor: rumorFor('batch hello 1', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          final wrap2 = await _buildGiftWrap(
+            rumor: rumorFor('batch hello 2', createdAt: 1700000600),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000001,
+          );
+          stubDrainPage([wrap1, wrap2]);
+
+          final syncState = drainPending();
+          // No rumorDecryptor injected: the only decrypt path available is the
+          // isolate batch, so persisted messages prove the batch decrypted.
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: _IsolateLocalSigner(recipientPriv),
+            syncState: syncState,
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: senderPub,
+              content: 'batch hello 1',
+              createdAt: 1700000500,
+              giftWrapId: wrap1.id,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: recipientPub,
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: senderPub,
+              content: 'batch hello 2',
+              createdAt: 1700000600,
+              giftWrapId: wrap2.id,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: recipientPub,
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
+
+          // Sync boundaries advance on the rumor's real created_at, and dedup
+          // holds across the inclusive-boundary re-request (no triple insert).
+          expect(
+            syncState.recorded.map((r) => r.createdAt),
+            containsAll(<int>[1700000500, 1700000600]),
+          );
+        },
+      );
+
+      test(
+        'an undecryptable wrap falls back to the per-event path and is queued '
+        'for retry while the valid wrap still persists',
+        () async {
+          final valid = await _buildGiftWrap(
+            rumor: rumorFor('real one', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          // A signed kind-1059 whose content is not valid NIP-44 — passes the
+          // signature gate, fails to decrypt. Higher outer created_at than the
+          // valid wrap so the inclusive boundary re-request is the (deduped)
+          // valid wrap, not this one.
+          final garbageKey = generatePrivateKey();
+          final garbage = Event(
+            getPublicKey(garbageKey),
+            EventKind.giftWrap,
+            <List<String>>[
+              ['p', recipientPub],
+            ],
+            'not-a-real-wrap',
+            createdAt: 1700000001,
+          )..sign(garbageKey);
+          stubDrainPage([valid, garbage]);
+
+          final pendingDao = _MockPendingGiftWrapsDao();
+          when(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              rawJson: any(named: 'rawJson'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => pendingDao.deletePending(
+              giftWrapId: any(named: 'giftWrapId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: _IsolateLocalSigner(recipientPriv),
+            pendingGiftWrapsDao: pendingDao,
+            // Force the per-event fallback for the garbage wrap to also fail.
+            rumorDecryptor: (_, _) async => null,
+            syncState: drainPending(),
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The valid wrap persisted via the batch.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: senderPub,
+              content: 'real one',
+              createdAt: 1700000500,
+              giftWrapId: valid.id,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: recipientPub,
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
+          // The garbage wrap was queued for retry exactly once.
+          verify(
+            () => pendingDao.recordFailedDecrypt(
+              giftWrapId: garbage.id,
+              ownerPubkey: recipientPub,
+              rawJson: any(named: 'rawJson'),
+              createdAt: any(named: 'createdAt'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
+        'throttled drain processes a page larger than the yield interval and '
+        'still completes',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          // 18 tag-less kind-5 deletions (> drainYieldInterval) flow through
+          // the persist loop with no side effects, exercising the WS3 yield
+          // without crypto cost.
+          final page = [
+            for (var i = 0; i < 18; i++)
+              Event(
+                recipientPub,
+                EventKind.eventDeletion,
+                const <List<String>>[],
+                '',
+                createdAt: 1700000000 + i,
+              ),
+          ];
+          stubDrainPage(page);
+
+          final syncState = drainPending();
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: _IsolateLocalSigner(recipientPriv),
+            syncState: syncState,
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The loop ran past the yield boundary and reached relay exhaustion.
+          expect(syncState.drainCompleteOverride, isTrue);
         },
       );
     });


### PR DESCRIPTION
## Description

Completes the remaining work for #5391 — moving session-scoped DM gift-wrap
ingestion off the UI isolate so it no longer janks every screen (including the
Notifications tab, which shares `InboxView`). WS1 for the **db_client** Drift
DB (`NativeDatabase.createInBackground`) already landed via **#5395**; this PR
delivers the rest:

- **cache_sync on a background isolate** — the second native Drift DB
  (`cache_sync.db`, home-feed / liked-video cache) now opens via
  `NativeDatabase.createInBackground` too. `getApplicationSupportDirectory()`
  stays on the main isolate; only the resolved file path crosses to the spawned
  isolate.

- **WS2 — batch gift-wrap decryption on the history-drain path.** A page's
  kind-1059 wraps are decrypted off-lock in one `compute()` hop per
  `DmHistoryDrainConfig.decryptBatchSize` chunk, then persisted in original page
  order under `_eventLock` via the extracted `_persistDecryptedGiftWrap` helper.
  Batching is gated to local `IsolateDecryptSigner` keys; remote signers
  (Keycast NIP-46 / Amber) and undecryptable wraps keep the per-event path and
  its main-isolate fallback + failed-decrypt retry — so dedup, sync-boundary
  tracking and unread counts are unchanged, and remote decrypt stays
  one-RPC-per-ciphertext (Keycast's shared NIP-46 queue is never bursted).

- **WS3 — throttle the serial drain loops.** Yields an event-loop turn between
  decrypt chunks and every `DmHistoryDrainConfig.drainYieldInterval` persisted
  events, placed after the existing `_disposed`/`_userPubkey` re-check so all
  drain-completion guards (#5202, #5304) are preserved.

- **db_client test** — adds the encrypted `createInBackground` open + keyed
  round-trip + plaintext-rejection test. This is the #5391 acceptance criterion
  for the background-isolate encrypted open; #5395 shipped that path without a
  test.

No backend change is required: the relay treats kind-1059 as an opaque
store/serve event (a content-blind kind allowlist), and this PR changes only
client-side CPU/IO scheduling on already-fetched events — it never alters what
is published or queried.

**Related Issue:** Closes #5391

## Out of Scope

- WS1 for the db_client Drift DB — already merged via **#5395** (this PR drops
  the now-redundant hunk and keeps the rest).
- The end-to-end frame-time UX capture (Notifications tab responsive during a
  large remote-signer backfill) — a manual validation to run on-device once
  this lands.

## Verification

- `flutter analyze` on `db_client`, `dm_repository`, `cache_sync` — no issues.
- `flutter test` for `db_client`, `cache_sync`, `dm_repository` — green
  (includes the new batched-decrypt, partial-failure fallback, throttled-drain,
  and encrypted-`createInBackground` tests).
- **On-device (physical iPhone, iOS 26.5.1):** the encrypted Drift DB opens on
  the drift-spawned background isolate with SQLite3MultipleCiphers active
  (`PRAGMA cipher` returns rows on that isolate) and zero cipher/`SQLITE_NOTADB`
  errors across the session; the fail-closed `StateError` guard still holds
  there. Remote-signer DM decryption was observed running strictly serially
  (one NIP-46 RPC per ciphertext).
- **Relay store/serve (local funnelcake relay):** a published kind-1059 is
  served back byte-identical (by id and by `{kinds:[1059], "#p"}`), confirming
  no backend transform.

## Type of Change

- [x] 🧹 Code refactor
