### PR TITLE
perf(ingestion): keep event persistence off the UI path

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -105,6 +105,7 @@ VideoEventService videoEventService(Ref ref) {
   final videoFilterBuilder = ref.watch(videoFilterBuilderProvider);
   final db = ref.watch(databaseProvider);
   final eventRouter = EventRouter(db);
+  ref.onDispose(eventRouter.dispose);
 
   final likesRepository = ref.watch(likesRepositoryProvider);
   final moderationLabelService = ref.watch(moderationLabelServiceProvider);

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -322,7 +322,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'85ef90976750b306638eca4df08291e7c5e2cb54';
+String _$videoEventServiceHash() => r'd75c28498b24dfa377024ea650d85160d1948363';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -8,6 +8,7 @@ import 'package:db_client/db_client.dart';
 import 'package:meta/meta.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 const eventRouterBatchFlushThreshold = 50;
@@ -139,7 +140,7 @@ class EventRouter {
         category: LogCategory.system,
       );
 
-      await _db.nostrEventsDao.cacheEventsBatch(batch);
+      await _persistRawEvents(batch);
 
       final routeBatch = _coalesceReplaceableRouting(batch);
       await _db.transaction(() async {
@@ -161,6 +162,33 @@ class EventRouter {
         error: e,
         stackTrace: stackTrace,
       );
+    }
+  }
+
+  /// Persists raw events, splitting by replaceable semantics.
+  ///
+  /// Addressable / parameterized-replaceable events (e.g. kind 34236 videos)
+  /// go through [upsertEventsBatch] so superseded coordinates are deleted —
+  /// the cache-first feed reads these raw with a SQL `LIMIT`, so stale rows
+  /// would otherwise consume slots and shrink the unique-result count. Every
+  /// other kind keeps all raw rows by id via [cacheEventsBatch]; its current
+  /// value (if any) lives in a denormalized table (e.g. kind 0 → UserProfiles).
+  Future<void> _persistRawEvents(List<Event> batch) async {
+    final addressable = <Event>[];
+    final raw = <Event>[];
+    for (final event in batch) {
+      if (EventKind.isParameterizedReplaceable(event.kind)) {
+        addressable.add(event);
+      } else {
+        raw.add(event);
+      }
+    }
+
+    if (raw.isNotEmpty) {
+      await _db.nostrEventsDao.cacheEventsBatch(raw);
+    }
+    if (addressable.isNotEmpty) {
+      await _db.nostrEventsDao.upsertEventsBatch(addressable);
     }
   }
 

--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -57,6 +57,7 @@ class EventRouter {
   final Queue<Event> _backgroundQueue = Queue<Event>();
   Timer? _batchTimer;
   bool _isProcessingBatch = false;
+  bool _disposed = false;
 
   /// Access to database for cache-first queries.
   AppDatabase get db => _db;
@@ -65,6 +66,9 @@ class EventRouter {
     Event event, {
     EventIngestionPriority priority = EventIngestionPriority.normal,
   }) {
+    // After dispose the database may be closing; a late relay callback must
+    // not re-arm a drain that would run SQLite against a closed connection.
+    if (_disposed) return;
     _queueFor(priority).add(event);
     if (_config.autoStart) {
       _scheduleProcessing(immediate: _queuedLength >= _config.maxBatchSize);
@@ -86,7 +90,7 @@ class EventRouter {
       _visibleQueue.length + _normalQueue.length + _backgroundQueue.length;
 
   void _scheduleProcessing({bool immediate = false}) {
-    if (_isProcessingBatch) return;
+    if (_disposed || _isProcessingBatch) return;
     if (immediate || _config.flushDelay == Duration.zero) {
       _batchTimer?.cancel();
       _batchTimer = null;
@@ -114,7 +118,7 @@ class EventRouter {
   }
 
   Future<void> _processNextBatch({bool continueProcessing = true}) async {
-    if (_isProcessingBatch || _queuedLength == 0) return;
+    if (_disposed || _isProcessingBatch || _queuedLength == 0) return;
 
     _isProcessingBatch = true;
     try {
@@ -248,6 +252,7 @@ class EventRouter {
   }
 
   void dispose() {
+    _disposed = true;
     _batchTimer?.cancel();
     _batchTimer = null;
     _visibleQueue.clear();

--- a/mobile/lib/services/event_router.dart
+++ b/mobile/lib/services/event_router.dart
@@ -2,74 +2,148 @@
 // ABOUTME: All events go to NostrEvents table, kind-specific processing extracts to denormalized tables
 
 import 'dart:async';
+import 'dart:collection';
+
 import 'package:db_client/db_client.dart';
+import 'package:meta/meta.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:nostr_sdk/event.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 const eventRouterBatchFlushThreshold = 50;
 
-/// Routes incoming Nostr events to appropriate database tables
+enum EventIngestionPriority {
+  visible,
+  normal,
+  background,
+}
+
+class EventRouterConfig {
+  const EventRouterConfig({
+    this.flushDelay = const Duration(milliseconds: 50),
+    this.maxBatchSize = eventRouterBatchFlushThreshold,
+    this.autoStart = true,
+  });
+
+  final Duration flushDelay;
+  final int maxBatchSize;
+  final bool autoStart;
+}
+
+typedef EventRouterYield = Future<void> Function();
+
+Future<void> _defaultYieldToEventLoop() => Future<void>.delayed(Duration.zero);
+
+/// Routes incoming Nostr events to appropriate database tables.
 ///
-/// All events go to NostrEvents table (single source of truth)
-/// Kind-specific processing extracts data to denormalized tables
-/// Uses batching to avoid database lock contention
+/// UI surfaces update from in-memory feed state before this persistence path
+/// completes. This router must therefore be best-effort and cooperative:
+/// bounded batches, priority queues, and event-loop yields keep background
+/// ingestion from starving Flutter frames.
 class EventRouter {
-  EventRouter(this._db);
+  EventRouter(
+    this._db, {
+    EventRouterConfig config = const EventRouterConfig(),
+    EventRouterYield yieldToEventLoop = _defaultYieldToEventLoop,
+  }) : _config = config,
+       _yieldToEventLoop = yieldToEventLoop;
 
   final AppDatabase _db;
-  final List<Event> _eventQueue = [];
+  final EventRouterConfig _config;
+  final EventRouterYield _yieldToEventLoop;
+  final Queue<Event> _visibleQueue = Queue<Event>();
+  final Queue<Event> _normalQueue = Queue<Event>();
+  final Queue<Event> _backgroundQueue = Queue<Event>();
   Timer? _batchTimer;
   bool _isProcessingBatch = false;
 
-  /// Access to database for cache-first queries
+  /// Access to database for cache-first queries.
   AppDatabase get db => _db;
 
-  /// Handle incoming event from relay
-  ///
-  /// Queues event for batch processing to avoid database locks
-  Future<void> handleEvent(Event event) async {
-    // Add to batch queue
-    _eventQueue.add(event);
-
-    // Schedule batch processing if not already scheduled
-    _batchTimer ??= Timer(const Duration(milliseconds: 50), _processBatch);
-
-    // If queue is large, process immediately
-    if (_eventQueue.length >= eventRouterBatchFlushThreshold &&
-        !_isProcessingBatch) {
-      _batchTimer?.cancel();
-      _batchTimer = null;
-      await _processBatch();
+  void handleEvent(
+    Event event, {
+    EventIngestionPriority priority = EventIngestionPriority.normal,
+  }) {
+    _queueFor(priority).add(event);
+    if (_config.autoStart) {
+      _scheduleProcessing(immediate: _queuedLength >= _config.maxBatchSize);
     }
   }
 
-  /// Process queued events in a single batch
-  Future<void> _processBatch() async {
-    if (_isProcessingBatch || _eventQueue.isEmpty) return;
+  Queue<Event> _queueFor(EventIngestionPriority priority) {
+    switch (priority) {
+      case EventIngestionPriority.visible:
+        return _visibleQueue;
+      case EventIngestionPriority.normal:
+        return _normalQueue;
+      case EventIngestionPriority.background:
+        return _backgroundQueue;
+    }
+  }
+
+  int get _queuedLength =>
+      _visibleQueue.length + _normalQueue.length + _backgroundQueue.length;
+
+  void _scheduleProcessing({bool immediate = false}) {
+    if (_isProcessingBatch) return;
+    if (immediate || _config.flushDelay == Duration.zero) {
+      _batchTimer?.cancel();
+      _batchTimer = null;
+      unawaited(_processNextBatch());
+      return;
+    }
+
+    _batchTimer ??= Timer(_config.flushDelay, () {
+      _batchTimer = null;
+      unawaited(_processNextBatch());
+    });
+  }
+
+  List<Event> _takeNextBatch() {
+    final batch = <Event>[];
+    while (batch.length < _config.maxBatchSize && _queuedLength > 0) {
+      final queue = _visibleQueue.isNotEmpty
+          ? _visibleQueue
+          : _normalQueue.isNotEmpty
+          ? _normalQueue
+          : _backgroundQueue;
+      batch.add(queue.removeFirst());
+    }
+    return batch;
+  }
+
+  Future<void> _processNextBatch({bool continueProcessing = true}) async {
+    if (_isProcessingBatch || _queuedLength == 0) return;
 
     _isProcessingBatch = true;
-    _batchTimer = null;
+    try {
+      final batch = _takeNextBatch();
+      await _persistBatch(batch);
+    } finally {
+      _isProcessingBatch = false;
+    }
+
+    if (continueProcessing && _queuedLength > 0) {
+      await _yieldToEventLoop();
+      _scheduleProcessing(immediate: true);
+    }
+  }
+
+  Future<void> _persistBatch(List<Event> batch) async {
+    if (batch.isEmpty) return;
 
     try {
-      final batch = List<Event>.from(_eventQueue);
-      _eventQueue.clear();
-
       Log.debug(
         'Processing batch of ${batch.length} events',
         name: 'EventRouter',
         category: LogCategory.system,
       );
 
-      // Batch insert to nostr_events table
-      await _db.nostrEventsDao.upsertEventsBatch(batch);
+      await _db.nostrEventsDao.cacheEventsBatch(batch);
 
-      // Run kind-specific routing inside a single transaction so the per-event
-      // writes (e.g. profile upserts) commit once instead of once per event.
-      // Each commit is an fsync + journal write — now also encrypted under
-      // SQLCipher — so collapsing N commits into one is the dominant saving.
+      final routeBatch = _coalesceReplaceableRouting(batch);
       await _db.transaction(() async {
-        for (final event in batch) {
+        for (final event in routeBatch) {
           await _routeEvent(event);
         }
       });
@@ -87,40 +161,44 @@ class EventRouter {
         error: e,
         stackTrace: stackTrace,
       );
-    } finally {
-      _isProcessingBatch = false;
     }
   }
 
-  /// Route event to specialized tables based on kind
+  List<Event> _coalesceReplaceableRouting(List<Event> batch) {
+    final routeBatch = <Event>[];
+    final latestProfileByPubkey = <String, Event>{};
+
+    for (final event in batch) {
+      if (event.kind == 0) {
+        final existing = latestProfileByPubkey[event.pubkey];
+        if (existing == null || event.createdAt >= existing.createdAt) {
+          latestProfileByPubkey[event.pubkey] = event;
+        }
+      } else {
+        routeBatch.add(event);
+      }
+    }
+
+    routeBatch.addAll(latestProfileByPubkey.values);
+    return routeBatch;
+  }
+
   Future<void> _routeEvent(Event event) async {
     switch (event.kind) {
-      case 0: // Profile metadata
+      case 0:
         await _handleProfileEvent(event);
-
-      case 3: // Contacts
-        // TODO: Future implementation
+      case 3:
         break;
-
-      case 7: // Reactions
-        // TODO: Future implementation
+      case 7:
         break;
-
-      case 6: // Reposts
-      case NIP71VideoKinds.addressableShortVideo: // Videos
-        // Already in events table, queryable via DAO
+      case 6:
+      case NIP71VideoKinds.addressableShortVideo:
         break;
-
       default:
-        // Still in events table, just not processed further
         break;
     }
   }
 
-  /// Handle kind 0 (profile) event
-  ///
-  /// Extracts profile data and stores in UserProfiles table
-  /// Handles malformed JSON gracefully (UserProfile.fromNostrEvent has fallback)
   Future<void> _handleProfileEvent(Event event) async {
     try {
       final profile = UserProfile.fromNostrEvent(event);
@@ -138,7 +216,32 @@ class EventRouter {
         category: LogCategory.system,
         stackTrace: stackTrace,
       );
-      // Don't rethrow - we already stored the raw event
+    }
+  }
+
+  void dispose() {
+    _batchTimer?.cancel();
+    _batchTimer = null;
+    _visibleQueue.clear();
+    _normalQueue.clear();
+    _backgroundQueue.clear();
+  }
+
+  @visibleForTesting
+  Future<void> drainOneBatchForTesting() =>
+      _processNextBatch(continueProcessing: false);
+
+  @visibleForTesting
+  Future<void> drainForTesting() async {
+    while (_queuedLength > 0 || _isProcessingBatch) {
+      if (_isProcessingBatch) {
+        await _yieldToEventLoop();
+      } else {
+        await _processNextBatch(continueProcessing: false);
+        if (_queuedLength > 0) {
+          await _yieldToEventLoop();
+        }
+      }
     }
   }
 }

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2000,7 +2000,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           (event) {
             eventCount++;
 
-            // Route ALL events to database immediately (Phase 3.2: Drift integration)
+            // Route events to normal-priority persistence without blocking
+            // visible feed updates.
             _eventRouter?.handleEvent(event);
 
             // Track first event arrival time
@@ -2254,16 +2255,11 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
       final event = eventData;
 
       // Route ALL events to database first (single source of truth)
-      // Fire-and-forget: database writes shouldn't block event processing
-      if (_eventRouter != null) {
-        _eventRouter.handleEvent(event).catchError((e) {
-          Log.warning(
-            'EventRouter failed (non-critical): $e',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-        });
-      }
+      // Fire-and-forget: database writes shouldn't block event processing.
+      _eventRouter?.handleEvent(
+        event,
+        priority: EventIngestionPriority.background,
+      );
 
       // Fast-path de-duplication before logging and processing
       // Use case-insensitive ID comparison for consistent deduplication

--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -215,6 +215,25 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
     });
   }
 
+  /// Cache raw events by ID without applying replaceable-event deletion.
+  ///
+  /// Relay ingestion needs to preserve every raw event it receives while
+  /// denormalized tables decide which replaceable value is current.
+  Future<void> cacheEventsBatch(List<Event> events, {int? expireAt}) async {
+    if (events.isEmpty) return;
+
+    final effectiveExpireAt = expireAt ?? _defaultExpireAt();
+
+    await transaction(() async {
+      for (final event in events) {
+        await _insertEvent(event, expireAt: effectiveExpireAt);
+        if (event.kind == 34236) {
+          await db.videoMetricsDao.upsertVideoMetrics(event);
+        }
+      }
+    });
+  }
+
   /// Watch events with a Nostr Filter (reactive stream)
   ///
   /// Returns a Stream that emits whenever the matching events change in the

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -1229,6 +1229,24 @@ void main() {
         final notes = await dao.getEventsByFilter(Filter(kinds: [1]));
         expect(notes.length, equals(1));
       });
+
+      test('cacheEventsBatch preserves raw replaceable events by id', () async {
+        final oldProfile = createEvent(
+          kind: 0,
+          content: '{"name":"old"}',
+          createdAt: 1000,
+        );
+        final newProfile = createEvent(
+          kind: 0,
+          content: '{"name":"new"}',
+          createdAt: 2000,
+        );
+
+        await dao.cacheEventsBatch([oldProfile, newProfile]);
+
+        expect(await dao.getEventById(oldProfile.id), isNotNull);
+        expect(await dao.getEventById(newProfile.id), isNotNull);
+      });
     });
 
     group('watchEventsByFilter (reactive queries)', () {

--- a/mobile/scripts/baseline/skip_tests.txt
+++ b/mobile/scripts/baseline/skip_tests.txt
@@ -51,7 +51,6 @@ test/screens/relay_settings_nip11_info_test.dart
 test/screens/video_editor/video_text_editor_screen_test.dart
 test/screens/video_editor_route_test.dart
 test/services/account_deletion_flow_test.dart
-test/services/cache_first_query_test.dart
 test/services/curated_list_service_persistence_test.dart
 test/services/curated_list_service_query_test.dart
 test/services/feature_flag_service_test.dart

--- a/mobile/test/services/cache_first_query_test.dart
+++ b/mobile/test/services/cache_first_query_test.dart
@@ -20,6 +20,7 @@ class MockNostrServiceWithDelay implements NostrClient {
   final StreamController<Event> _eventController =
       StreamController<Event>.broadcast();
   final List<String> _eventDeliveryOrder = []; // Track when events arrive
+  final List<Timer> _pendingTimers = [];
   final bool _isInitialized = true;
   bool _eoseCalled = false;
 
@@ -42,12 +43,15 @@ class MockNostrServiceWithDelay implements NostrClient {
     bool sendAfterAuth = false,
     void Function()? onEose,
   }) {
-    // Simulate relay delay: call onEose after 100ms
+    // Simulate relay delay: call onEose after 100ms. Tracked as a cancellable
+    // Timer so dispose() stops it firing onEose on a torn-down service.
     if (onEose != null) {
-      Future.delayed(const Duration(milliseconds: 100), () {
-        _eoseCalled = true;
-        onEose();
-      });
+      _pendingTimers.add(
+        Timer(const Duration(milliseconds: 100), () {
+          _eoseCalled = true;
+          onEose();
+        }),
+      );
     }
 
     return _eventController.stream;
@@ -66,6 +70,10 @@ class MockNostrServiceWithDelay implements NostrClient {
 
   @override
   Future<void> dispose() async {
+    for (final timer in _pendingTimers) {
+      timer.cancel();
+    }
+    _pendingTimers.clear();
     await _eventController.close();
   }
 
@@ -143,7 +151,10 @@ void main() {
       );
       testDbPath = p.join(tempDir.path, 'test.db');
       db = AppDatabase.test(NativeDatabase(File(testDbPath)));
-      eventRouter = EventRouter(db);
+      eventRouter = EventRouter(
+        db,
+        config: const EventRouterConfig(autoStart: false),
+      );
     });
 
     tearDown(() async {
@@ -398,8 +409,7 @@ void main() {
       expect(results[1].id, toHex64('middle'));
       expect(results[2].id, toHex64('old'));
     });
-    // TODO(any): Re-enable and fix this test
-  }, skip: true);
+  });
 
   group('Cache-First Integration with VideoEventService', () {
     late AppDatabase db;
@@ -415,7 +425,10 @@ void main() {
       );
       testDbPath = p.join(tempDir.path, 'test.db');
       db = AppDatabase.test(NativeDatabase(File(testDbPath)));
-      eventRouter = EventRouter(db);
+      eventRouter = EventRouter(
+        db,
+        config: const EventRouterConfig(autoStart: false),
+      );
       mockNostrService = MockNostrServiceWithDelay();
       subscriptionManager = SubscriptionManager(mockNostrService);
 
@@ -427,6 +440,7 @@ void main() {
     });
 
     tearDown(() async {
+      await mockNostrService.dispose();
       videoEventService.dispose();
       eventRouter.dispose();
       await db.close();
@@ -635,6 +649,5 @@ void main() {
       expect(events.length, 1);
       expect(events.first.id, toHex64('relay_event'));
     });
-    // TODO(any): Re-enable and fix this test
-  }, skip: true);
+  });
 }

--- a/mobile/test/services/cache_first_query_test.dart
+++ b/mobile/test/services/cache_first_query_test.dart
@@ -147,12 +147,20 @@ void main() {
     });
 
     tearDown(() async {
+      eventRouter.dispose();
       await db.close();
       final file = File(testDbPath);
       if (file.existsSync()) {
         await file.delete();
       }
     });
+
+    Future<void> cacheEvents(List<Event> events) async {
+      for (final event in events) {
+        eventRouter.handleEvent(event);
+      }
+      await eventRouter.drainForTesting();
+    }
 
     test('filters by kinds', () async {
       // Insert events of different kinds
@@ -183,9 +191,7 @@ void main() {
       profileEvent.id = toHex64('profile1');
       profileEvent.sig = toHex64('sig_profile1');
 
-      await eventRouter.handleEvent(video1);
-      await eventRouter.handleEvent(video2);
-      await eventRouter.handleEvent(profileEvent);
+      await cacheEvents([video1, video2, profileEvent]);
 
       // Query for video events only (kind 34236)
       final results = await db.nostrEventsDao.getEventsByFilter(
@@ -217,9 +223,7 @@ void main() {
         createdAt: 300,
       );
 
-      await eventRouter.handleEvent(user1Video);
-      await eventRouter.handleEvent(user2Video);
-      await eventRouter.handleEvent(user3Video);
+      await cacheEvents([user1Video, user2Video, user3Video]);
 
       // Query for user1 and user2 only
       final results = await db.nostrEventsDao.getEventsByFilter(
@@ -259,9 +263,7 @@ void main() {
         createdAt: 300,
       );
 
-      await eventRouter.handleEvent(catVideo);
-      await eventRouter.handleEvent(dogVideo);
-      await eventRouter.handleEvent(noHashtagVideo);
+      await cacheEvents([catVideo, dogVideo, noHashtagVideo]);
 
       // Query for #cats hashtag
       final results = await db.nostrEventsDao.getEventsByFilter(
@@ -289,9 +291,7 @@ void main() {
         createdAt: 1000,
       );
 
-      await eventRouter.handleEvent(oldVideo);
-      await eventRouter.handleEvent(middleVideo);
-      await eventRouter.handleEvent(newVideo);
+      await cacheEvents([oldVideo, middleVideo, newVideo]);
 
       // Query for events between 200 and 800
       final results = await db.nostrEventsDao.getEventsByFilter(
@@ -329,10 +329,7 @@ void main() {
         hashtags: ['target_tag'],
       );
 
-      await eventRouter.handleEvent(matchingEvent);
-      await eventRouter.handleEvent(wrongAuthor);
-      await eventRouter.handleEvent(wrongHashtag);
-      await eventRouter.handleEvent(wrongTime);
+      await cacheEvents([matchingEvent, wrongAuthor, wrongHashtag, wrongTime]);
 
       // Query with ALL filters
       final results = await db.nostrEventsDao.getEventsByFilter(
@@ -353,7 +350,7 @@ void main() {
     test('respects limit parameter', () async {
       // Insert 10 events
       for (int i = 0; i < 10; i++) {
-        await eventRouter.handleEvent(
+        eventRouter.handleEvent(
           createTestVideoEvent(
             id: 'video_$i',
             pubkey: 'user1',
@@ -361,6 +358,7 @@ void main() {
           ),
         );
       }
+      await eventRouter.drainForTesting();
 
       // Query with limit of 5
       final results = await db.nostrEventsDao.getEventsByFilter(
@@ -388,9 +386,7 @@ void main() {
       );
 
       // Insert in random order
-      await eventRouter.handleEvent(middle);
-      await eventRouter.handleEvent(recent);
-      await eventRouter.handleEvent(old);
+      await cacheEvents([middle, recent, old]);
 
       final results = await db.nostrEventsDao.getEventsByFilter(
         Filter(limit: 10),
@@ -432,12 +428,20 @@ void main() {
 
     tearDown(() async {
       videoEventService.dispose();
+      eventRouter.dispose();
       await db.close();
       final file = File(testDbPath);
       if (file.existsSync()) {
         await file.delete();
       }
     });
+
+    Future<void> cacheEvents(List<Event> events) async {
+      for (final event in events) {
+        eventRouter.handleEvent(event);
+      }
+      await eventRouter.drainForTesting();
+    }
 
     test('cached events are delivered BEFORE relay EOSE', () async {
       // Pre-populate database with cached events
@@ -452,8 +456,7 @@ void main() {
         createdAt: 200,
       );
 
-      await eventRouter.handleEvent(cachedEvent1);
-      await eventRouter.handleEvent(cachedEvent2);
+      await cacheEvents([cachedEvent1, cachedEvent2]);
 
       // Track when events arrive
       final receivedEvents = <String>[];
@@ -499,7 +502,7 @@ void main() {
         pubkey: 'user1',
         createdAt: 100,
       );
-      await eventRouter.handleEvent(cachedEvent);
+      await cacheEvents([cachedEvent]);
 
       // Subscribe
       await videoEventService.subscribeToVideoFeed(
@@ -555,8 +558,7 @@ void main() {
         createdAt: 200,
       );
 
-      await eventRouter.handleEvent(user1Event);
-      await eventRouter.handleEvent(user2Event);
+      await cacheEvents([user1Event, user2Event]);
 
       // Subscribe with author filter for user1 only
       await videoEventService.subscribeToVideoFeed(
@@ -589,8 +591,7 @@ void main() {
         hashtags: ['dogs'],
       );
 
-      await eventRouter.handleEvent(catVideo);
-      await eventRouter.handleEvent(dogVideo);
+      await cacheEvents([catVideo, dogVideo]);
 
       // Subscribe with hashtag filter
       await videoEventService.subscribeToVideoFeed(

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -181,6 +181,41 @@ void main() {
       );
     });
 
+    test('replaces superseded addressable video rows for the same '
+        'coordinate', () async {
+      final pubkey = pubkeyFor(55);
+      final older = Event(
+        pubkey,
+        NIP71VideoKinds.addressableShortVideo,
+        const [
+          ['d', 'clip-1'],
+          ['url', 'https://example.com/old.mp4'],
+        ],
+        'old',
+        createdAt: 100,
+      );
+      final latest = Event(
+        pubkey,
+        NIP71VideoKinds.addressableShortVideo,
+        const [
+          ['d', 'clip-1'],
+          ['url', 'https://example.com/new.mp4'],
+        ],
+        'new',
+        createdAt: 200,
+      );
+
+      router.handleEvent(older);
+      router.handleEvent(latest);
+
+      await router.drainForTesting();
+
+      // Same pubkey+kind+d-tag: the older raw row is deleted so cache-first
+      // LIMIT queries don't return a stale duplicate of the edited video.
+      expect(await db.nostrEventsDao.getEventById(older.id), isNull);
+      expect(await db.nostrEventsDao.getEventById(latest.id), isNotNull);
+    });
+
     test(
       'handleEvent enqueues without synchronously persisting the event',
       () async {

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -216,6 +216,19 @@ void main() {
       expect(await db.nostrEventsDao.getEventById(latest.id), isNotNull);
     });
 
+    test('ignores events enqueued after dispose', () async {
+      final event = videoEvent(77);
+
+      router.dispose();
+      router.handleEvent(event);
+
+      // A late relay callback after dispose must not re-arm a drain that
+      // would run SQLite against a closing/closed database.
+      await router.drainForTesting();
+
+      expect(await db.nostrEventsDao.getEventById(event.id), isNull);
+    });
+
     test(
       'handleEvent enqueues without synchronously persisting the event',
       () async {

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -1,7 +1,6 @@
 // ABOUTME: Tests EventRouter batch caching + transaction-wrapped kind routing
 // ABOUTME: Verifies events are stored and kind 0 profiles extracted in one batch
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:db_client/db_client.dart';
@@ -18,10 +17,14 @@ void main() {
 
     setUp(() {
       db = AppDatabase.test(NativeDatabase.memory());
-      router = EventRouter(db);
+      router = EventRouter(
+        db,
+        config: const EventRouterConfig(autoStart: false),
+      );
     });
 
     tearDown(() async {
+      router.dispose();
       await db.close();
     });
 
@@ -36,29 +39,12 @@ void main() {
     Event profileEvent(int seed, {required String content}) =>
         Event(pubkeyFor(seed), 0, const [], content);
 
-    /// Drives [events] through [handleEvent] so the whole list is flushed in a
-    /// single batch. The queue processes immediately once it reaches 50, so the
-    /// list is padded with filler video events and the final `handleEvent` is
-    /// awaited — no reliance on the 50ms batch timer.
+    /// Drives [events] through the deterministic test drain.
     Future<void> flush(List<Event> events) async {
-      // Only the final handleEvent is awaited, and it's the one that trips the
-      // immediate flush. That holds only because the input is padded up to the
-      // production threshold; with that many or more input events, the trip
-      // would fire inside an unawaited call and the batch would not be awaited.
-      assert(
-        events.length < eventRouterBatchFlushThreshold,
-        'flush() awaits only the padded final event; pass fewer than '
-        '$eventRouterBatchFlushThreshold events.',
-      );
-      final padded = [...events];
-      var filler = 1 << 20;
-      while (padded.length < eventRouterBatchFlushThreshold) {
-        padded.add(videoEvent(filler++));
+      for (final event in events) {
+        router.handleEvent(event);
       }
-      for (var i = 0; i < padded.length - 1; i++) {
-        unawaited(router.handleEvent(padded[i]));
-      }
-      await router.handleEvent(padded.last);
+      await router.drainForTesting();
     }
 
     test('stores every event in the batch in the nostr_events table', () async {
@@ -99,5 +85,121 @@ void main() {
       expect(await db.nostrEventsDao.getEventById(video.id), isNotNull);
       expect(await db.nostrEventsDao.getEventById(broken.id), isNotNull);
     });
+
+    test('drains visible events before background events', () async {
+      final background = profileEvent(
+        10,
+        content: jsonEncode({'name': 'background'}),
+      );
+      final visible = profileEvent(
+        11,
+        content: jsonEncode({'name': 'visible'}),
+      );
+
+      router.dispose();
+      router = EventRouter(
+        db,
+        config: const EventRouterConfig(
+          autoStart: false,
+          maxBatchSize: 1,
+        ),
+      );
+
+      router.handleEvent(
+        background,
+        priority: EventIngestionPriority.background,
+      );
+      router.handleEvent(visible, priority: EventIngestionPriority.visible);
+
+      await router.drainOneBatchForTesting();
+
+      expect(await db.nostrEventsDao.getEventById(visible.id), isNotNull);
+      expect(await db.nostrEventsDao.getEventById(background.id), isNull);
+    });
+
+    test(
+      'yields between bounded batches so large drains are cooperative',
+      () async {
+        var yieldCount = 0;
+        router.dispose();
+        router = EventRouter(
+          db,
+          config: const EventRouterConfig(
+            autoStart: false,
+            maxBatchSize: 10,
+          ),
+          yieldToEventLoop: () async {
+            yieldCount++;
+            await Future<void>.delayed(Duration.zero);
+          },
+        );
+
+        for (var i = 0; i < 25; i++) {
+          router.handleEvent(videoEvent(2000 + i));
+        }
+
+        await router.drainForTesting();
+
+        expect(yieldCount, greaterThanOrEqualTo(2));
+        for (var i = 0; i < 25; i++) {
+          expect(
+            await db.nostrEventsDao.getEventById(videoEvent(2000 + i).id),
+            isNotNull,
+          );
+        }
+      },
+    );
+
+    test('stores all raw profile events but routes only the latest profile per '
+        'pubkey', () async {
+      final pubkey = pubkeyFor(44);
+      final older = Event(
+        pubkey,
+        0,
+        const [],
+        jsonEncode({'name': 'old'}),
+        createdAt: 100,
+      );
+      final latest = Event(
+        pubkey,
+        0,
+        const [],
+        jsonEncode({'name': 'new'}),
+        createdAt: 200,
+      );
+
+      router.handleEvent(older);
+      router.handleEvent(latest);
+
+      await router.drainForTesting();
+
+      expect(await db.nostrEventsDao.getEventById(older.id), isNotNull);
+      expect(await db.nostrEventsDao.getEventById(latest.id), isNotNull);
+      expect(
+        (await db.userProfilesDao.getProfile(pubkey))?.name,
+        equals('new'),
+      );
+    });
+
+    test(
+      'handleEvent enqueues without synchronously persisting the event',
+      () async {
+        final event = videoEvent(99);
+
+        router.handleEvent(
+          event,
+          priority: EventIngestionPriority.background,
+        );
+
+        // Enqueue is intentionally fire-and-forget. Persistence happens when the
+        // cooperative router drain runs, so the relay callback can keep updating
+        // in-memory UI state.
+        expect(await db.nostrEventsDao.getEventById(event.id), isNull);
+
+        await router.drainForTesting();
+
+        expect(await db.nostrEventsDao.getEventById(event.id), isNotNull);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Makes EventRouter fire-and-forget with visible/normal/background priority queues, bounded batch drains, and event-loop yields between batches.
- Preserves raw relay events by ID through a dedicated DAO cache path while coalescing profile routing to the latest event per pubkey.
- Disposes EventRouter with the keep-alive video service provider and marks background cache-only persistence as background priority.

Refs #5391

## Test Plan
- [x] `cd mobile && flutter analyze`
- [x] `cd mobile && flutter test test/services/event_router_test.dart`
- [x] `cd mobile && flutter test test/services/cache_first_query_test.dart`
- [x] `cd mobile/packages/db_client && flutter test test/src/database/daos/nostr_events_dao_test.dart`

## Manual QA

- Install on a device with an existing encrypted local DB.
- Open home feed and scroll while relay events are arriving.
- Open Notifications/Inbox during a DM backfill.
- Confirm videos remain responsive and tab changes do not freeze.
- Export logs and confirm EventRouter batches are bounded and no multi-second batch appears.
