### PR TITLE
perf(feed): reduce thermal load from video ingestion

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2276,15 +2276,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         paginationState.markEventSeen(event.id);
       }
 
-      // Checkpoint log for profile subscriptions
-      if (subscriptionType == SubscriptionType.profile) {
-        Log.info(
-          'SVC event: id=${event.id}',
-          name: 'Service',
-          category: LogCategory.video,
-        );
-      }
-
       // Use batched logging for repetitive event logs
       // VideoEventLogBatcher.batchVideoEvent(
       //   eventId: event.id,
@@ -2395,11 +2386,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           );
         }
 
-        Log.verbose(
-          'Direct event tags: ${_formatEventTagsForLog(event.tags)}',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
         try {
           var videoEvent = VideoEvent.fromNostrEvent(event);
 

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -42,7 +42,7 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.keepPreviousAlive = true,
     this.keepNextAlive = true,
     this.releaseNeighboursWhenInactive = false,
-    this.prefetchCount = 25,
+    this.prefetchCount = 8,
     this.shouldPortraitExpand = true,
     this.maxLoopDuration,
     this.onActiveVideoChanged,

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -1746,6 +1746,42 @@ void main() {
     });
 
     group('prefetch', () {
+      testWidgets('default disk prefetch window stays bounded', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install();
+        final videos = List.generate(
+          20,
+          (i) => _makeVideo('v$i', videoUrl: 'https://example.com/v$i.mp4'),
+        );
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: videos,
+                cache: cache,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+
+          await tester.pumpAndSettle();
+
+          // The default window starts after the kept-next controller
+          // (index + 2), so a bounded eight-video window downloads 2..8.
+          verify(
+            () => cache.cacheFileCancellable(any(), key: any(named: 'key')),
+          ).called(7);
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
       testWidgets('prefetchCount > 0 exercises _runPrefetch body', (
         tester,
       ) async {

--- a/mobile/test/services/video_event_service_profile_logging_test.dart
+++ b/mobile/test/services/video_event_service_profile_logging_test.dart
@@ -1,0 +1,74 @@
+// ABOUTME: Regression tests for avoiding high-volume profile event log spam.
+// ABOUTME: Keeps hot profile loads from formatting/capturing per-event debug data.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' as sdk;
+import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+void main() {
+  group('VideoEventService profile logging', () {
+    const pubkey =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+    late VideoEventService service;
+
+    setUp(() async {
+      await LogCaptureService().clearAllLogs();
+
+      service = VideoEventService(
+        _MockNostrClient(),
+        subscriptionManager: _MockSubscriptionManager(),
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    sdk.Event makeProfileVideoEvent() => sdk.Event(
+      pubkey,
+      NIP71VideoKinds.addressableShortVideo,
+      const [
+        ['d', 'profile-log-regression'],
+        ['url', 'https://example.com/video.mp4'],
+        ['title', 'Profile log regression'],
+        ['summary', 'A video with enough tags to make eager formatting costly'],
+      ],
+      '',
+      createdAt: 1000,
+    )..id = 'profile-log-regression-event';
+
+    test(
+      'does not capture per-event profile checkpoints or full tag dumps',
+      () {
+        service.handleEventForTesting(
+          makeProfileVideoEvent(),
+          SubscriptionType.profile,
+        );
+
+        final messages = LogCaptureService()
+            .getRecentLogs()
+            .map((entry) => entry.message)
+            .toList();
+
+        expect(
+          messages.where((message) => message.startsWith('SVC event:')),
+          isEmpty,
+        );
+        expect(
+          messages.where((message) => message.startsWith('Direct event tags:')),
+          isEmpty,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #5409

## Summary

Two thermal hot-spots during video-feed scrolling on TestFlight devices:

- **Bounded disk prefetch:** reduce the default `InfiniteVideoFeed.prefetchCount` from 25 to 8, cutting repeated cache scans / download attempts during scrolling. No production caller overrides the default, so this applies everywhere.
- **Drop per-event log work on the hot path** in `VideoEventService._handleNewVideoEvent`:
  - remove the per-profile-event `SVC event: id=…` checkpoint log (fired once per profile event), and
  - remove the eager `Direct event tags: …` verbose log, whose `_formatEventTagsForLog(event.tags)` string was built on **every** event regardless of log level. (`_formatEventTagsForLog` is retained — it's still used in the parse-failure `catch` path, which is cold.)
- **Regression coverage** for both: the bounded default prefetch window and the suppressed profile-event logging.

## Files

- `mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart` — `prefetchCount` default 25 → 8
- `mobile/lib/services/video_event_service.dart` — remove two hot-path log statements
- `mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart` — bounded-window test
- `mobile/test/services/video_event_service_profile_logging_test.dart` — profile log-suppression test (new)

## Verification

- `flutter analyze` on the four touched files — **No issues found**
- `flutter test test/services/video_event_service_profile_logging_test.dart` — pass
- `flutter test packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart` — all 52 tests pass (incl. the new bounded-window test)
- CI: 12/12 green

## Manual QA

- Install on a device and scroll the feed under load; confirm prefetch stays bounded (≤8-video window) and the device runs cooler than before.
- Open a profile feed with many videos and confirm no per-event log spam.

## Notes

- Tradeoff: an 8-video lookahead (vs 25) is a smaller prefetch buffer, which can cause marginally more rebuffering on very fast scrolls. 8 remains a reasonable lookahead for a vertical feed and is the right lever for reducing thermal load.
