### PR TITLE
perf(feed): drop eager per-event verbose logging on video parse

### DIFF
--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2399,37 +2399,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             return;
           }
 
-          Log.verbose(
-            'Parsed direct video: hasVideo=${videoEvent.hasVideo}, videoUrl=${videoEvent.videoUrl}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.verbose(
-            'Thumbnail URL: ${videoEvent.thumbnailUrl}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.verbose(
-            'Has thumbnail: ${videoEvent.thumbnailUrl != null && videoEvent.thumbnailUrl!.isNotEmpty}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.verbose(
-            'Video author pubkey: ${videoEvent.pubkey}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.verbose(
-            'Video title: ${videoEvent.title}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-          Log.verbose(
-            'Video hashtags: ${videoEvent.hashtags}',
-            name: 'VideoEventService',
-            category: LogCategory.video,
-          );
-
           // Debug: Special logging for Classic Vines content
           if (videoEvent.pubkey == AppConstants.classicVinesPubkey) {
             Log.info(

--- a/mobile/test/services/video_event_service_profile_logging_test.dart
+++ b/mobile/test/services/video_event_service_profile_logging_test.dart
@@ -70,5 +70,33 @@ void main() {
         );
       },
     );
+
+    test('does not eagerly log per-field dumps for parsed video events', () {
+      service.handleEventForTesting(
+        makeProfileVideoEvent(),
+        SubscriptionType.profile,
+      );
+
+      final messages = LogCaptureService()
+          .getRecentLogs()
+          .map((entry) => entry.message)
+          .toList();
+
+      const eagerPrefixes = [
+        'Parsed direct video:',
+        'Thumbnail URL:',
+        'Has thumbnail:',
+        'Video author pubkey:',
+        'Video title:',
+        'Video hashtags:',
+      ];
+      for (final prefix in eagerPrefixes) {
+        expect(
+          messages.where((message) => message.startsWith(prefix)),
+          isEmpty,
+          reason: 'per-event verbose dump "$prefix" must not be logged',
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
## Summary

Follow-up to #5408 (merged). That PR removed two eager hot-path log statements during video ingestion; this removes the largest remaining one.

`VideoEventService._handleNewVideoEvent` logged **six `Log.verbose` lines per successfully-parsed video event** (`Parsed direct video:`, `Thumbnail URL:`, `Has thumbnail:`, `Video author pubkey:`, `Video title:`, `Video hashtags:`). Two costs, both paid on every event regardless of log level:

- the interpolated strings (incl. `${videoEvent.hashtags}`) are built at the call site before the log call runs, and
- `UnifiedLogger._log` **always** captures a `LogEntry` to the in-memory buffer regardless of level (only console output is level-gated) — so each line allocates and churns the bounded capture buffer in release, evicting more useful entries.

Removing the dump cuts per-event CPU/allocation on the ingestion hot path and reduces log-buffer noise.

## Changes

- `mobile/lib/services/video_event_service.dart` — remove the six per-event verbose field dumps on the parse-success path.
- `mobile/test/services/video_event_service_profile_logging_test.dart` — extend the regression test (added in #5408) to assert these per-field messages are not emitted.

## Verification

- `flutter analyze lib/services/video_event_service.dart test/services/video_event_service_profile_logging_test.dart` — No issues found
- `flutter test test/services/video_event_service_profile_logging_test.dart` — pass (both tests)
- Confirmed the new assertions are non-vacuous: with the original logging restored, the new test fails (the event reaches the success-path dumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
