### PR TITLE
fix(metadata): open mentioned user profiles from video text

### DIFF
--- a/mobile/lib/widgets/linkified_text/linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text.dart
@@ -17,6 +17,8 @@ class LinkifiedText extends ConsumerStatefulWidget {
     this.overflow,
     this.onVideoStateChange,
     this.onUrlTap,
+    this.mentionProfilePubkeys = const [],
+    this.dismissModalBeforeNavigation = false,
   });
 
   final String text;
@@ -27,6 +29,8 @@ class LinkifiedText extends ConsumerStatefulWidget {
   final TextOverflow? overflow;
   final VoidCallback? onVideoStateChange;
   final Future<void> Function(String rawUrl)? onUrlTap;
+  final List<String> mentionProfilePubkeys;
+  final bool dismissModalBeforeNavigation;
 
   @override
   ConsumerState<LinkifiedText> createState() => _LinkifiedTextState();
@@ -65,6 +69,7 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
         AppLocalizations,
       )?.clickableTextViewVideoLink,
       profileLabelForHex: _profileDisplayText,
+      profilePubkeyForMention: _profilePubkeyForMention,
       onHashtagTap: (hashtag) => _navigateToHashtagFeed(context, hashtag),
       onProfileTap: (hexPubkey) => _navigateToProfile(context, hexPubkey),
       onVideoTap: (routeReference) => _navigateToVideo(context, routeReference),
@@ -94,7 +99,24 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
     return LinkifiedTextSupport.profileDisplayText(ref, hexPubkey);
   }
 
+  String? _profilePubkeyForMention(String username) {
+    return LinkifiedTextSupport.profilePubkeyForMention(
+      ref,
+      username,
+      widget.mentionProfilePubkeys,
+    );
+  }
+
   void _navigateToHashtagFeed(BuildContext context, String hashtag) {
+    if (widget.dismissModalBeforeNavigation) {
+      LinkifiedTextNavigation.navigateToHashtagFeedFromModal(
+        context,
+        hashtag,
+        beforeNavigate: widget.onVideoStateChange,
+      );
+      return;
+    }
+
     LinkifiedTextNavigation.navigateToHashtagFeed(
       context,
       hashtag,
@@ -103,6 +125,15 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
   }
 
   void _navigateToProfile(BuildContext context, String hexPubkey) {
+    if (widget.dismissModalBeforeNavigation) {
+      LinkifiedTextNavigation.navigateToProfileFromModal(
+        context,
+        hexPubkey,
+        beforeNavigate: widget.onVideoStateChange,
+      );
+      return;
+    }
+
     LinkifiedTextNavigation.navigateToProfile(
       context,
       hexPubkey,
@@ -111,6 +142,15 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
   }
 
   void _navigateToVideo(BuildContext context, String routeReference) {
+    if (widget.dismissModalBeforeNavigation) {
+      LinkifiedTextNavigation.navigateToVideoFromModal(
+        context,
+        routeReference,
+        beforeNavigate: widget.onVideoStateChange,
+      );
+      return;
+    }
+
     LinkifiedTextNavigation.navigateToVideo(
       context,
       routeReference,
@@ -119,6 +159,15 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
   }
 
   void _navigateToSearch(BuildContext context, String username) {
+    if (widget.dismissModalBeforeNavigation) {
+      LinkifiedTextNavigation.navigateToSearchFromModal(
+        context,
+        username,
+        beforeNavigate: widget.onVideoStateChange,
+      );
+      return;
+    }
+
     LinkifiedTextNavigation.navigateToSearch(
       context,
       username,

--- a/mobile/lib/widgets/linkified_text/linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_navigation.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
@@ -73,7 +76,7 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
       onHashtagTap: (hashtag) => _navigateToHashtagFeed(context, hashtag),
       onProfileTap: (hexPubkey) => _navigateToProfile(context, hexPubkey),
       onVideoTap: (routeReference) => _navigateToVideo(context, routeReference),
-      onMentionTap: (username) => _navigateToSearch(context, username),
+      onMentionTap: (username) => _navigateToMention(context, username),
       onUrlTap: _handleUrlTap,
     ).build();
 
@@ -158,7 +161,22 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
     );
   }
 
-  void _navigateToSearch(BuildContext context, String username) {
+  void _navigateToMention(BuildContext context, String username) {
+    unawaited(_resolveAndNavigateToMention(context, username));
+  }
+
+  Future<void> _resolveAndNavigateToMention(
+    BuildContext context,
+    String username,
+  ) async {
+    final resolvedPubkey = await _resolveMentionPubkey(username);
+    if (!context.mounted) return;
+
+    if (resolvedPubkey != null) {
+      _navigateToProfile(context, resolvedPubkey);
+      return;
+    }
+
     if (widget.dismissModalBeforeNavigation) {
       LinkifiedTextNavigation.navigateToSearchFromModal(
         context,
@@ -172,6 +190,13 @@ class _LinkifiedTextState extends ConsumerState<LinkifiedText> {
       context,
       username,
       beforeNavigate: widget.onVideoStateChange,
+    );
+  }
+
+  Future<String?> _resolveMentionPubkey(String username) async {
+    return LinkifiedTextSupport.resolveProfilePubkeyForMention(
+      ref.read(profileRepositoryProvider),
+      username,
     );
   }
 

--- a/mobile/lib/widgets/linkified_text/linkified_text_navigation.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_navigation.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// Shared navigation and URL handling for linkified text renderers.
@@ -19,6 +21,18 @@ final class LinkifiedTextNavigation {
     context.push(HashtagScreenRouter.pathForTag(hashtag));
   }
 
+  static void navigateToHashtagFeedFromModal(
+    BuildContext context,
+    String hashtag, {
+    VoidCallback? beforeNavigate,
+  }) {
+    _pushAfterModalPop(
+      context,
+      HashtagScreenRouter.pathForTag(hashtag),
+      beforeNavigate: beforeNavigate,
+    );
+  }
+
   static void navigateToProfile(
     BuildContext context,
     String hexPubkey, {
@@ -26,6 +40,19 @@ final class LinkifiedTextNavigation {
   }) {
     beforeNavigate?.call();
     context.pushOtherProfile(hexPubkey);
+  }
+
+  static void navigateToProfileFromModal(
+    BuildContext context,
+    String hexPubkey, {
+    VoidCallback? beforeNavigate,
+  }) {
+    final npub = NostrKeyUtils.encodePubKey(hexPubkey);
+    _pushAfterModalPop(
+      context,
+      OtherProfileScreen.pathForNpub(npub),
+      beforeNavigate: beforeNavigate,
+    );
   }
 
   static void navigateToVideo(
@@ -37,6 +64,18 @@ final class LinkifiedTextNavigation {
     context.push(VideoDetailScreen.pathForId(routeReference));
   }
 
+  static void navigateToVideoFromModal(
+    BuildContext context,
+    String routeReference, {
+    VoidCallback? beforeNavigate,
+  }) {
+    _pushAfterModalPop(
+      context,
+      VideoDetailScreen.pathForId(routeReference),
+      beforeNavigate: beforeNavigate,
+    );
+  }
+
   static void navigateToSearch(
     BuildContext context,
     String username, {
@@ -45,6 +84,18 @@ final class LinkifiedTextNavigation {
     beforeNavigate?.call();
     context.push(
       SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
+    );
+  }
+
+  static void navigateToSearchFromModal(
+    BuildContext context,
+    String username, {
+    VoidCallback? beforeNavigate,
+  }) {
+    _pushAfterModalPop(
+      context,
+      SearchResultsPage.pathForQuery(username, requestFocusOnMount: false),
+      beforeNavigate: beforeNavigate,
     );
   }
 
@@ -78,6 +129,20 @@ final class LinkifiedTextNavigation {
         ? rawUrl
         : 'https://$rawUrl';
     return Uri.tryParse(normalizedUrl);
+  }
+
+  static void _pushAfterModalPop(
+    BuildContext context,
+    String location, {
+    VoidCallback? beforeNavigate,
+  }) {
+    final hostContext = Navigator.of(context, rootNavigator: true).context;
+    beforeNavigate?.call();
+    Navigator.of(context).pop();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!hostContext.mounted) return;
+      hostContext.push(location);
+    });
   }
 }
 

--- a/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_span_builder.dart
@@ -35,6 +35,7 @@ class LinkifiedTextSpanBuilder {
     this.onMentionTap,
     this.onUrlTap,
     this.profileLabelForHex,
+    this.profilePubkeyForMention,
     this.videoLabel,
   });
 
@@ -74,6 +75,10 @@ class LinkifiedTextSpanBuilder {
 
   /// Resolves a profile label for a decoded hex public key.
   final String Function(String hexPubkey)? profileLabelForHex;
+
+  /// Resolves a plain typed @mention to a hex public key when the caller has
+  /// surrounding event metadata that identifies the mentioned user.
+  final String? Function(String username)? profilePubkeyForMention;
 
   /// Display label for video/event references.
   final String? videoLabel;
@@ -208,7 +213,14 @@ class LinkifiedTextSpanBuilder {
     text: '@$username',
     style: mentionStyle ?? linkStyle,
     recognizer: TapGestureRecognizer()
-      ..onTap = () => onMentionTap?.call(username),
+      ..onTap = () {
+        final hexPubkey = profilePubkeyForMention?.call(username);
+        if (hexPubkey != null) {
+          onProfileTap?.call(hexPubkey);
+        } else {
+          onMentionTap?.call(username);
+        }
+      },
   );
 
   bool _hexReferenceLooksLikeProfile(int start) {

--- a/mobile/lib/widgets/linkified_text/linkified_text_support.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_support.dart
@@ -2,6 +2,8 @@ import 'package:flutter/painting.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' show UserProfile;
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:profile_repository/profile_repository.dart';
 
 /// Shared helpers for linkified-text renderers.
 final class LinkifiedTextSupport {
@@ -40,12 +42,7 @@ final class LinkifiedTextSupport {
       if (profile == null) continue;
 
       final values = <String?>[
-        profile.name,
-        profile.displayName,
-        profile.divineUsername,
-        profile.shortDisplayNip05,
-        profile.displayNip05,
-        profile.nip05,
+        ..._profileMentionValues(profile),
         pubkey,
       ];
 
@@ -57,6 +54,61 @@ final class LinkifiedTextSupport {
     }
 
     return null;
+  }
+
+  /// Returns the unique exact profile match for a typed mention.
+  ///
+  /// A contains-style search result is not enough to open a profile directly:
+  /// `@ann` should not pick `@annie`. This helper only returns a pubkey when
+  /// exactly one searched profile has a name, NIP-05, hex key, or npub matching
+  /// the typed token after mention normalization.
+  static String? exactProfilePubkeyForMention(
+    String username,
+    Iterable<UserProfile> profiles,
+  ) {
+    final normalizedUsername = _normalizeMentionValue(username);
+    if (normalizedUsername.isEmpty) return null;
+
+    final matches = <String>{};
+    for (final profile in profiles) {
+      final pubkey = _normalizedHexPubkey(profile.pubkey);
+      if (pubkey == null) continue;
+
+      final values = <String?>[
+        ..._profileMentionValues(profile),
+        pubkey,
+        NostrKeyUtils.encodePubKey(pubkey),
+      ];
+
+      final isMatch = values
+          .whereType<String>()
+          .map(_normalizeMentionValue)
+          .any((value) => value == normalizedUsername);
+      if (isMatch) matches.add(pubkey);
+    }
+
+    return matches.length == 1 ? matches.single : null;
+  }
+
+  /// Resolves a typed mention through profile search before search navigation.
+  ///
+  /// Local cache is tried first so cached exact matches open instantly. The
+  /// broader repository search is only used when local cache has no unique
+  /// exact match.
+  static Future<String?> resolveProfilePubkeyForMention(
+    ProfileRepository? profileRepository,
+    String username,
+  ) async {
+    if (profileRepository == null) return null;
+
+    final localPubkey = await _exactMentionSearch(
+      profileRepository,
+      username,
+      localOnly: true,
+    );
+    if (localPubkey != null) return localPubkey;
+
+    return _exactMentionSearch(profileRepository, username);
   }
 
   /// Recursively disposes gesture recognizers owned by inline spans.
@@ -75,5 +127,54 @@ final class LinkifiedTextSupport {
         ? trimmed.substring(1)
         : trimmed;
     return withoutPrefix.replaceAll(RegExp('[^a-z0-9]'), '');
+  }
+
+  static List<String?> _profileMentionValues(UserProfile profile) => [
+    profile.name,
+    profile.displayName,
+    profile.divineUsername,
+    profile.shortDisplayNip05,
+    profile.displayNip05,
+    profile.nip05,
+    _nip05LocalPart(profile.nip05),
+  ];
+
+  static String? _normalizedHexPubkey(String value) {
+    final normalized = value.trim().toLowerCase();
+    return NostrKeyUtils.isValidKey(normalized) ? normalized : null;
+  }
+
+  static String? _nip05LocalPart(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+
+    if (trimmed.startsWith('_@')) {
+      return trimmed.substring(2).split('.').first;
+    }
+    if (trimmed.startsWith('@')) {
+      return trimmed.substring(1).split('.').first;
+    }
+    if (trimmed.contains('@')) {
+      return trimmed.split('@').first;
+    }
+    return null;
+  }
+
+  static Future<String?> _exactMentionSearch(
+    ProfileRepository profileRepository,
+    String username, {
+    bool localOnly = false,
+  }) async {
+    try {
+      final profiles = localOnly
+          ? await profileRepository.searchUsersLocally(
+              query: username,
+              limit: 10,
+            )
+          : await profileRepository.searchUsers(query: username, limit: 10);
+      return exactProfilePubkeyForMention(username, profiles);
+    } on Object {
+      return null;
+    }
   }
 }

--- a/mobile/lib/widgets/linkified_text/linkified_text_support.dart
+++ b/mobile/lib/widgets/linkified_text/linkified_text_support.dart
@@ -22,6 +22,43 @@ final class LinkifiedTextSupport {
     return profileText.startsWith('@') ? profileText : '@$profileText';
   }
 
+  /// Matches a plain typed mention against known mentioned profile pubkeys.
+  ///
+  /// Nostr `p` tags identify mentioned users but do not carry the visible
+  /// username. The renderer can still resolve common cases once profiles are
+  /// cached by comparing the typed token with the profile's known names.
+  static String? profilePubkeyForMention(
+    WidgetRef ref,
+    String username,
+    Iterable<String> profilePubkeys,
+  ) {
+    final normalizedUsername = _normalizeMentionValue(username);
+    if (normalizedUsername.isEmpty) return null;
+
+    for (final pubkey in profilePubkeys) {
+      final profile = ref.watch(userProfileReactiveProvider(pubkey)).value;
+      if (profile == null) continue;
+
+      final values = <String?>[
+        profile.name,
+        profile.displayName,
+        profile.divineUsername,
+        profile.shortDisplayNip05,
+        profile.displayNip05,
+        profile.nip05,
+        pubkey,
+      ];
+
+      final matches = values
+          .whereType<String>()
+          .map(_normalizeMentionValue)
+          .any((value) => value == normalizedUsername);
+      if (matches) return pubkey;
+    }
+
+    return null;
+  }
+
   /// Recursively disposes gesture recognizers owned by inline spans.
   static void disposeSpans(List<InlineSpan> spans) {
     for (final span in spans) {
@@ -30,5 +67,13 @@ final class LinkifiedTextSupport {
       final children = span.children;
       if (children != null) disposeSpans(children);
     }
+  }
+
+  static String _normalizeMentionValue(String value) {
+    final trimmed = value.trim().toLowerCase();
+    final withoutPrefix = trimmed.startsWith('@')
+        ? trimmed.substring(1)
+        : trimmed;
+    return withoutPrefix.replaceAll(RegExp('[^a-z0-9]'), '');
   }
 }

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -1,7 +1,10 @@
+import 'dart:async';
+
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_navigation.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_span_builder.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
@@ -67,7 +70,7 @@ class _SelectableLinkifiedTextState
       onHashtagTap: (hashtag) => _navigateToHashtagFeed(context, hashtag),
       onProfileTap: (hexPubkey) => _navigateToProfile(context, hexPubkey),
       onVideoTap: (routeReference) => _navigateToVideo(context, routeReference),
-      onMentionTap: (username) => _navigateToSearch(context, username),
+      onMentionTap: (username) => _navigateToMention(context, username),
       onUrlTap: _handleUrlTap,
     ).build();
 
@@ -104,8 +107,30 @@ class _SelectableLinkifiedTextState
     LinkifiedTextNavigation.navigateToVideo(context, routeReference);
   }
 
-  void _navigateToSearch(BuildContext context, String username) {
+  void _navigateToMention(BuildContext context, String username) {
+    unawaited(_resolveAndNavigateToMention(context, username));
+  }
+
+  Future<void> _resolveAndNavigateToMention(
+    BuildContext context,
+    String username,
+  ) async {
+    final resolvedPubkey = await _resolveMentionPubkey(username);
+    if (!context.mounted) return;
+
+    if (resolvedPubkey != null) {
+      _navigateToProfile(context, resolvedPubkey);
+      return;
+    }
+
     LinkifiedTextNavigation.navigateToSearch(context, username);
+  }
+
+  Future<String?> _resolveMentionPubkey(String username) async {
+    return LinkifiedTextSupport.resolveProfilePubkeyForMention(
+      ref.read(profileRepositoryProvider),
+      username,
+    );
   }
 
   Future<void> _handleUrlTap(String rawUrl) async {

--- a/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
+++ b/mobile/lib/widgets/linkified_text/selectable_linkified_text.dart
@@ -14,6 +14,7 @@ class SelectableLinkifiedText extends ConsumerStatefulWidget {
     this.linkStyle,
     this.mentionStyle,
     this.onUrlTap,
+    this.mentionProfilePubkeys = const [],
   });
 
   final String text;
@@ -21,6 +22,7 @@ class SelectableLinkifiedText extends ConsumerStatefulWidget {
   final TextStyle? linkStyle;
   final TextStyle? mentionStyle;
   final Future<void> Function(String rawUrl)? onUrlTap;
+  final List<String> mentionProfilePubkeys;
 
   @override
   ConsumerState<SelectableLinkifiedText> createState() =>
@@ -61,6 +63,7 @@ class _SelectableLinkifiedTextState
         AppLocalizations,
       )?.clickableTextViewVideoLink,
       profileLabelForHex: _profileDisplayText,
+      profilePubkeyForMention: _profilePubkeyForMention,
       onHashtagTap: (hashtag) => _navigateToHashtagFeed(context, hashtag),
       onProfileTap: (hexPubkey) => _navigateToProfile(context, hexPubkey),
       onVideoTap: (routeReference) => _navigateToVideo(context, routeReference),
@@ -79,6 +82,14 @@ class _SelectableLinkifiedTextState
 
   String _profileDisplayText(String hexPubkey) {
     return LinkifiedTextSupport.profileDisplayText(ref, hexPubkey);
+  }
+
+  String? _profilePubkeyForMention(String username) {
+    return LinkifiedTextSupport.profilePubkeyForMention(
+      ref,
+      username,
+      widget.mentionProfilePubkeys,
+    );
   }
 
   void _navigateToHashtagFeed(BuildContext context, String hashtag) {

--- a/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/video_description_overlay.dart
@@ -62,6 +62,7 @@ class VideoDescriptionOverlay extends StatelessWidget {
                     Shadow(offset: Offset(2, 2), blurRadius: 4),
                   ],
                 ),
+                mentionProfilePubkeys: video.mentionedPubkeys,
                 maxLines: 3,
                 overflow: TextOverflow.ellipsis,
               ),

--- a/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
+++ b/mobile/lib/widgets/video_feed_item/metadata/metadata_expanded_sheet.dart
@@ -159,12 +159,22 @@ class _OverviewSection extends StatelessWidget {
     final hasTags = video.categories.isNotEmpty || video.allHashtags.isNotEmpty;
 
     final titleCluster = <Widget>[
-      if (hasTitle) Text(title, style: VineTheme.headlineSmallFont()),
+      if (hasTitle)
+        LinkifiedText(
+          text: title,
+          style: VineTheme.headlineSmallFont(),
+          linkStyle: VineTheme.headlineSmallFont(color: VineTheme.info),
+          mentionStyle: VineTheme.headlineSmallFont(color: VineTheme.info),
+          mentionProfilePubkeys: video.mentionedPubkeys,
+          dismissModalBeforeNavigation: true,
+        ),
       if (hasBadges) MetadataBadgesRow(video: video),
       if (hasDescription)
         LinkifiedText(
           text: description,
           style: VineTheme.bodyLargeFont(color: VineTheme.onSurfaceVariant),
+          mentionProfilePubkeys: video.mentionedPubkeys,
+          dismissModalBeforeNavigation: true,
         ),
     ];
 

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -847,6 +847,28 @@ class VideoEvent {
   /// Compact proof verification summary returned by Funnelcake REST feeds.
   final ProofVerificationSummary? proofSummary;
 
+  /// Generic `p` tags that mark users mentioned by this video.
+  ///
+  /// Collaborator `p` tags are intentionally excluded; those are rendered by
+  /// [collaboratorPubkeys] and have separate confirmation semantics.
+  List<String> get mentionedPubkeys {
+    final seen = <String>{};
+    final pubkeys = <String>[];
+
+    for (final tag in nostrEventTags) {
+      if (tag.length < 4 || tag[0] != 'p') continue;
+      if (tag[3].toLowerCase() != 'mention') continue;
+
+      final pubkey = tag[1].trim().toLowerCase();
+      if (pubkey.isEmpty || pubkey == this.pubkey.toLowerCase()) continue;
+      if (!seen.add(pubkey)) continue;
+
+      pubkeys.add(pubkey);
+    }
+
+    return pubkeys;
+  }
+
   /// Whether this video has any content warnings.
   bool get hasContentWarning => contentWarningLabels.isNotEmpty;
 

--- a/mobile/packages/models/test/src/video_event_parsing_test.dart
+++ b/mobile/packages/models/test/src/video_event_parsing_test.dart
@@ -472,6 +472,30 @@ void main() {
       expect(videoEvent.collaboratorPubkeys, equals([collabPubkey1]));
     });
 
+    test(
+      'should expose generic mention p-tags separately from collaborators',
+      () {
+        const mentionPubkey =
+            'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+        final nostrEvent = Event(
+          authorPubkey,
+          34236,
+          [
+            ['url', 'https://example.com/video.mp4'],
+            ['p', collabPubkey1, 'wss://relay.divine.video', 'collaborator'],
+            ['p', mentionPubkey, 'wss://relay.divine.video', 'mention'],
+          ],
+          '@shutupphia FOLLOW HER',
+          createdAt: 1757385263,
+        );
+
+        final videoEvent = VideoEvent.fromNostrEvent(nostrEvent);
+
+        expect(videoEvent.collaboratorPubkeys, equals([collabPubkey1]));
+        expect(videoEvent.mentionedPubkeys, equals([mentionPubkey]));
+      },
+    );
+
     test('should accept historical capitalized collaborator markers', () {
       final nostrEvent = Event(
         authorPubkey,

--- a/mobile/test/widgets/clickable_hashtag_text_test.dart
+++ b/mobile/test/widgets/clickable_hashtag_text_test.dart
@@ -2,13 +2,20 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_sdk/nip19/nip19_tlv.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
+import 'package:openvine/screens/search_results/view/search_results_page.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
+import 'package:openvine/widgets/linkified_text/linkified_text_support.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+import 'package:profile_repository/profile_repository.dart';
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
@@ -37,8 +44,13 @@ class _FakeUrlLauncherPlatform extends UrlLauncherPlatform {
   LinkDelegate? get linkDelegate => null;
 }
 
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
 const _testHexPubkey =
     '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const _mentionedHexPubkey =
+    'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
 
 void main() {
   group('LinkifiedText', () {
@@ -327,6 +339,129 @@ void main() {
 
       expect(fakeUrlLauncherPlatform.launchedUrl, 'https://example.com/docs');
     });
+
+    testWidgets('opens exact profile match for plain mention before search', (
+      tester,
+    ) async {
+      const mention = 'shutupphia';
+      final profile = UserProfile(
+        pubkey: _mentionedHexPubkey,
+        name: mention,
+        displayName: 'Sophia',
+        rawData: const {'name': mention, 'display_name': 'Sophia'},
+        createdAt: DateTime.utc(2026, 6, 21),
+        eventId:
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+      );
+      final profileRepository = _MockProfileRepository();
+      when(
+        () => profileRepository.searchUsersLocally(
+          query: mention,
+          limit: 10,
+        ),
+      ).thenAnswer((_) async => [profile]);
+      when(
+        () => profileRepository.searchUsers(query: mention, limit: 10),
+      ).thenAnswer((_) async => const []);
+
+      final expectedNpub = NostrKeyUtils.encodePubKey(_mentionedHexPubkey);
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => const Scaffold(
+              body: LinkifiedText(text: '@shutupphia FOLLOW HER.'),
+            ),
+          ),
+          GoRoute(
+            path: OtherProfileScreen.pathWithNpub,
+            builder: (context, state) =>
+                Text('profile:${state.pathParameters['npub']}'),
+          ),
+          GoRoute(
+            path: SearchResultsPage.path,
+            builder: (context, state) =>
+                Text('search:${state.pathParameters['query']}'),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            profileRepositoryProvider.overrideWithValue(profileRepository),
+          ],
+          child: MaterialApp.router(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: router,
+          ),
+        ),
+      );
+
+      final text = tester.widget<Text>(find.byType(Text));
+      final textSpan = text.textSpan! as TextSpan;
+      final spans = textSpan.children!.cast<TextSpan>();
+      final mentionSpan = spans.firstWhere((span) => span.text == '@$mention');
+
+      final recognizer = mentionSpan.recognizer! as TapGestureRecognizer;
+      recognizer.onTap!();
+      await tester.pumpAndSettle();
+
+      expect(find.text('profile:$expectedNpub'), findsOneWidget);
+      expect(find.text('search:$mention'), findsNothing);
+      verify(
+        () => profileRepository.searchUsersLocally(
+          query: mention,
+          limit: 10,
+        ),
+      ).called(1);
+      verifyNever(
+        () => profileRepository.searchUsers(query: mention, limit: 10),
+      );
+    });
+
+    test(
+      'resolves remote exact profile match when local cache misses',
+      () async {
+        const mention = 'shutupphia';
+        final profile = UserProfile(
+          pubkey: _mentionedHexPubkey,
+          name: mention,
+          rawData: const {'name': mention},
+          createdAt: DateTime.utc(2026, 6, 21),
+          eventId:
+              'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+        );
+        final profileRepository = _MockProfileRepository();
+        when(
+          () => profileRepository.searchUsersLocally(
+            query: mention,
+            limit: 10,
+          ),
+        ).thenAnswer((_) async => const []);
+        when(
+          () => profileRepository.searchUsers(query: mention, limit: 10),
+        ).thenAnswer((_) async => [profile]);
+
+        final pubkey =
+            await LinkifiedTextSupport.resolveProfilePubkeyForMention(
+              profileRepository,
+              mention,
+            );
+
+        expect(pubkey, _mentionedHexPubkey);
+        verify(
+          () => profileRepository.searchUsersLocally(
+            query: mention,
+            limit: 10,
+          ),
+        ).called(1);
+        verify(
+          () => profileRepository.searchUsers(query: mention, limit: 10),
+        ).called(1);
+      },
+    );
 
     testWidgets('parses bare npub mentions as tappable profile spans', (
       tester,

--- a/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
+++ b/mobile/test/widgets/linkified_text/linkified_text_span_builder_test.dart
@@ -126,6 +126,34 @@ void main() {
       );
     });
 
+    test('routes plain mentions to profile when a mention pubkey matches', () {
+      const alicePubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      String? tappedProfile;
+      String? tappedMention;
+
+      final spans = LinkifiedTextSpanBuilder(
+        text: '@alice FOLLOW HER',
+        defaultStyle: defaultStyle,
+        linkStyle: linkStyle,
+        mentionStyle: mentionStyle,
+        profilePubkeyForMention: (username) =>
+            username == 'alice' ? alicePubkey : null,
+        onProfileTap: (hexPubkey) => tappedProfile = hexPubkey,
+        onMentionTap: (username) => tappedMention = username,
+      ).build();
+
+      expect(
+        spans.map((span) => span.text).join(),
+        equals('@alice FOLLOW HER'),
+      );
+
+      spans.tappableSpans.single.tap();
+
+      expect(tappedProfile, equals(alicePubkey));
+      expect(tappedMention, isNull);
+    });
+
     test('routes note1 references to normalized event ids', () {
       const eventId =
           '1111111111111111111111111111111111111111111111111111111111111111';

--- a/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
+++ b/mobile/test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
@@ -259,6 +259,19 @@ void main() {
       );
 
       expect(find.text('Who knew?'), findsOneWidget);
+      expect(find.byType(LinkifiedText), findsNWidgets(2));
+    });
+
+    testWidgetsWithSurfaceSize('renders title with clickable rich text', (
+      tester,
+    ) async {
+      final video = _makeVideo(title: '@shutupphia FOLLOW HER');
+
+      await tester.pumpWidget(
+        buildSubject(child: MetadataExpandedSheet(video: video)),
+      );
+
+      expect(find.text('@shutupphia FOLLOW HER'), findsOneWidget);
       expect(find.byType(LinkifiedText), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary
- link metadata titles/descriptions with the same rich text renderer used elsewhere
- resolve plain @mentions to profile taps when the video carries matching Nostr mention p-tags
- dismiss the metadata sheet before navigating from inline links

## Verification
- flutter test test/widgets/linkified_text/linkified_text_span_builder_test.dart
- flutter test test/widgets/video_feed_item/metadata/metadata_expanded_sheet_test.dart
- flutter test packages/models/test/src/video_event_parsing_test.dart
- (cd mobile/packages/models && flutter test test/src/video_event_parsing_test.dart)
- flutter analyze
- pre-push hook: analyzer + changed-file tests (95 passed)