### PR TITLE
perf(dm): one long-lived decrypt isolate per history drain (#5391)

### DIFF
--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -1,4 +1,5 @@
 export 'src/collaborator_invite_recovery.dart';
+export 'src/dm_decrypt_isolate.dart';
 export 'src/dm_decryption_worker.dart';
 export 'src/dm_reactions_repository.dart';
 export 'src/dm_reactions_repository_reportable_sites.dart';

--- a/mobile/packages/dm_repository/lib/src/dm_decrypt_isolate.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_decrypt_isolate.dart
@@ -1,0 +1,143 @@
+// ABOUTME: A single long-lived background isolate for NIP-17 gift-wrap
+// ABOUTME: decryption on the history-drain path. Spawned once per drain, fed
+// ABOUTME: chunks over a port, and killed when the drain ends — so a large
+// ABOUTME: backfill pays one isolate spawn instead of one per chunk (#5391
+// ABOUTME: review follow-up). The recipient private key crosses the boundary
+// ABOUTME: once at spawn and is resident only for the drain's lifetime.
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:dm_repository/src/dm_decryption_worker.dart';
+
+/// A long-lived decrypt isolate that unwraps batches of NIP-17 gift wraps
+/// (kind 1059) off the main isolate.
+///
+/// The per-chunk `compute` path spawned a fresh isolate per
+/// `DmHistoryDrainConfig.decryptBatchSize`-wrap chunk; a ~1000-wrap backfill
+/// therefore paid ~50 isolate spawns. This worker is spawned ONCE (drift-style)
+/// at the start of a history drain and fed one chunk per [decryptBatch] call
+/// over a [SendPort], so the repeated spawn cost is gone.
+///
+/// Key-residency trade (see PR #5405 review): a persistent worker holds the
+/// recipient private key for its whole lifetime rather than for one transient
+/// `compute` isolate. We bound that exposure by scoping the isolate to a single
+/// drain — [close] (which the drain calls in its `finally`) kills the isolate
+/// and reclaims the key. That window equals the one the main isolate already
+/// holds the extracted hex in today's per-chunk path.
+class DmDecryptIsolate {
+  DmDecryptIsolate._({
+    required Isolate isolate,
+    required ReceivePort responses,
+  }) : _isolate = isolate,
+       _responses = responses;
+
+  final Isolate _isolate;
+  final ReceivePort _responses;
+
+  /// The worker's command port, received during the spawn handshake.
+  late final SendPort _commands;
+
+  /// Routes worker responses back to their awaiting [decryptBatch] callers.
+  late final StreamSubscription<dynamic> _subscription;
+
+  /// Outstanding requests keyed by id so concurrent / interleaved
+  /// [decryptBatch] calls each resolve to their own result.
+  final Map<int, Completer<List<DecryptedRumorResult>>> _pending =
+      <int, Completer<List<DecryptedRumorResult>>>{};
+
+  int _nextRequestId = 0;
+  bool _closed = false;
+
+  /// Spawns the worker and completes once it has reported its command port.
+  ///
+  /// [privateKeyHex] is the recipient key used for the two-layer NIP-44 ECDH;
+  /// it is sent into the isolate once here and never retained on the main side.
+  static Future<DmDecryptIsolate> spawn(String privateKeyHex) async {
+    final responses = ReceivePort();
+    final isolate = await Isolate.spawn(
+      _dmDecryptIsolateEntry,
+      (responses.sendPort, privateKeyHex),
+      debugName: 'dm-decrypt-isolate',
+    );
+
+    final ready = Completer<SendPort>();
+    final instance = DmDecryptIsolate._(
+      isolate: isolate,
+      responses: responses,
+    );
+    instance._subscription = responses.listen((dynamic message) {
+      if (!ready.isCompleted) {
+        // First message is the worker's command port (handshake).
+        ready.complete(message as SendPort);
+        return;
+      }
+      // Records survive the isolate copy but the list field can widen to
+      // List<dynamic>; cast the elements (already DecryptedRumorResult) back.
+      final (int id, List<dynamic> raw) = message as (int, List<dynamic>);
+      instance._pending.remove(id)?.complete(raw.cast<DecryptedRumorResult>());
+    });
+
+    final commandPort = await ready.future;
+    instance._commands = commandPort;
+    return instance;
+  }
+
+  /// Decrypts [events] (a chunk of kind-1059 gift wraps as JSON) and returns
+  /// one [DecryptedRumorResult] per event, in order. Never throws for a
+  /// per-event crypto failure (the worker maps those to failure entries);
+  /// throws [StateError] only if called after [close].
+  Future<List<DecryptedRumorResult>> decryptBatch(
+    List<Map<String, dynamic>> events,
+  ) {
+    if (_closed) {
+      throw StateError('DmDecryptIsolate has been closed');
+    }
+    final id = _nextRequestId++;
+    final completer = Completer<List<DecryptedRumorResult>>();
+    _pending[id] = completer;
+    _commands.send((id, events));
+    return completer.future;
+  }
+
+  /// Kills the worker (reclaiming the resident private key), stops listening,
+  /// and fails any still-pending requests so their awaiters never hang.
+  /// Idempotent.
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    unawaited(_subscription.cancel());
+    _responses.close();
+    _isolate.kill(priority: Isolate.immediate);
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          StateError('DmDecryptIsolate closed before the batch completed'),
+        );
+      }
+    }
+    _pending.clear();
+  }
+}
+
+/// Worker entry: handshakes its command port back to the spawner, then
+/// decrypts each `(id, events)` request with the resident key and replies
+/// `(id, results)`. [decryptGiftWrapBatch] never throws, so the loop is
+/// crash-free; the isolate is torn down via [Isolate.kill] from
+/// `DmDecryptIsolate.close`.
+Future<void> _dmDecryptIsolateEntry((SendPort, String) init) async {
+  final (replyTo, privateKeyHex) = init;
+  final commands = ReceivePort();
+  replyTo.send(commands.sendPort);
+
+  await for (final dynamic message in commands) {
+    final (int id, List<dynamic> rawEvents) = message as (int, List<dynamic>);
+    final results = await decryptGiftWrapBatch(
+      DecryptBatchRequest(
+        events: rawEvents.cast<Map<String, dynamic>>(),
+        privateKeyHex: privateKeyHex,
+      ),
+    );
+    replyTo.send((id, results));
+  }
+}

--- a/mobile/packages/dm_repository/lib/src/dm_decrypt_isolate.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_decrypt_isolate.dart
@@ -25,12 +25,27 @@ import 'package:dm_repository/src/dm_decryption_worker.dart';
 /// drain — [close] (which the drain calls in its `finally`) kills the isolate
 /// and reclaims the key. That window equals the one the main isolate already
 /// holds the extracted hex in today's per-chunk path.
-class DmDecryptIsolate {
-  DmDecryptIsolate._({
-    required Isolate isolate,
-    required ReceivePort responses,
-  }) : _isolate = isolate,
-       _responses = responses;
+/// Minimal worker contract used by the history drain to decrypt batches and
+/// release any resident key material when the drain exits.
+abstract interface class DmDecryptWorker {
+  /// Decrypts [events] and returns one result per input event, in order.
+  Future<List<DecryptedRumorResult>> decryptBatch(
+    List<Map<String, dynamic>> events,
+  );
+
+  /// Releases worker resources and resident key material.
+  void close();
+}
+
+/// Creates a drain-scoped decrypt worker for [privateKeyHex].
+typedef DmDecryptIsolateSpawner =
+    Future<DmDecryptWorker> Function(String privateKeyHex);
+
+/// Production [DmDecryptWorker] backed by a long-lived Dart isolate.
+class DmDecryptIsolate implements DmDecryptWorker {
+  DmDecryptIsolate._({required Isolate isolate, required ReceivePort responses})
+    : _isolate = isolate,
+      _responses = responses;
 
   final Isolate _isolate;
   final ReceivePort _responses;
@@ -55,17 +70,13 @@ class DmDecryptIsolate {
   /// it is sent into the isolate once here and never retained on the main side.
   static Future<DmDecryptIsolate> spawn(String privateKeyHex) async {
     final responses = ReceivePort();
-    final isolate = await Isolate.spawn(
-      _dmDecryptIsolateEntry,
-      (responses.sendPort, privateKeyHex),
-      debugName: 'dm-decrypt-isolate',
-    );
+    final isolate = await Isolate.spawn(_dmDecryptIsolateEntry, (
+      responses.sendPort,
+      privateKeyHex,
+    ), debugName: 'dm-decrypt-isolate');
 
     final ready = Completer<SendPort>();
-    final instance = DmDecryptIsolate._(
-      isolate: isolate,
-      responses: responses,
-    );
+    final instance = DmDecryptIsolate._(isolate: isolate, responses: responses);
     instance._subscription = responses.listen((dynamic message) {
       if (!ready.isCompleted) {
         // First message is the worker's command port (handshake).
@@ -87,6 +98,7 @@ class DmDecryptIsolate {
   /// one [DecryptedRumorResult] per event, in order. Never throws for a
   /// per-event crypto failure (the worker maps those to failure entries);
   /// throws [StateError] only if called after [close].
+  @override
   Future<List<DecryptedRumorResult>> decryptBatch(
     List<Map<String, dynamic>> events,
   ) {
@@ -103,6 +115,7 @@ class DmDecryptIsolate {
   /// Kills the worker (reclaiming the resident private key), stops listening,
   /// and fails any still-pending requests so their awaiters never hang.
   /// Idempotent.
+  @override
   void close() {
     if (_closed) return;
     _closed = true;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -169,6 +169,7 @@ class DmRepository {
     NostrSigner? signer,
     RumorDecryptor? rumorDecryptor,
     Nip04Decryptor? nip04Decryptor,
+    DmDecryptIsolateSpawner? decryptIsolateSpawner,
     DmRepositoryErrorReporter? errorReporter,
     DmReactionsRepository? reactionsRepository,
   }) : _nostrClient = nostrClient,
@@ -182,6 +183,7 @@ class DmRepository {
        _signer = signer,
        _rumorDecryptor = rumorDecryptor ?? GiftWrapUtil.getRumorEvent,
        _nip04Decryptor = nip04Decryptor,
+       _decryptIsolateSpawner = decryptIsolateSpawner ?? DmDecryptIsolate.spawn,
        _errorReporter = errorReporter,
        _reactionsRepository = reactionsRepository;
 
@@ -211,6 +213,7 @@ class DmRepository {
   NostrSigner? _signer;
   RumorDecryptor _rumorDecryptor;
   Nip04Decryptor? _nip04Decryptor;
+  final DmDecryptIsolateSpawner _decryptIsolateSpawner;
   final DmRepositoryErrorReporter? _errorReporter;
 
   /// Optional sibling repository for NIP-25 reactions on DMs. When wired,
@@ -229,7 +232,7 @@ class DmRepository {
   /// instead of one per chunk and the resident private key is reclaimed when
   /// the drain ends. `null` outside a drain or for remote/test signers. See
   /// PR #5405 review / #5391.
-  DmDecryptIsolate? _drainDecryptIsolate;
+  DmDecryptWorker? _drainDecryptIsolate;
 
   /// Serializes event processing so concurrent subscription events
   /// never race into the dedup/insert path.
@@ -527,9 +530,7 @@ class DmRepository {
       final event = events[i];
       final rumor = preDecrypted[event.id];
       if (rumor != null) {
-        await _withEventLock(
-          () => _persistDecryptedGiftWrap(event, rumor),
-        );
+        await _withEventLock(() => _persistDecryptedGiftWrap(event, rumor));
       } else {
         await _handleIncomingEvent(event);
       }
@@ -823,6 +824,7 @@ class DmRepository {
     );
 
     _beginRecovery();
+    DmDecryptWorker? drainDecryptIsolate;
     try {
       // Spawn one drain-scoped decrypt isolate for local-key signers so the
       // whole backfill pays a single isolate spawn instead of one per chunk
@@ -833,9 +835,15 @@ class DmRepository {
       if (drainSigner is IsolateDecryptSigner &&
           drainSigner.canDecryptInIsolate) {
         try {
-          _drainDecryptIsolate = await DmDecryptIsolate.spawn(
+          final spawned = await _decryptIsolateSpawner(
             drainSigner.withPrivateKeyHex((k) => k),
           );
+          if (_disposed || _userPubkey != pubkey) {
+            spawned.close();
+            return;
+          }
+          drainDecryptIsolate = spawned;
+          _drainDecryptIsolate = spawned;
         } on Object catch (e, stackTrace) {
           Log.error(
             'DM decrypt isolate spawn failed; using per-event decrypt: $e',
@@ -843,7 +851,6 @@ class DmRepository {
             error: e,
             stackTrace: stackTrace,
           );
-          _drainDecryptIsolate = null;
         }
       }
 
@@ -974,8 +981,10 @@ class DmRepository {
       // Kill the drain-scoped decrypt isolate (reclaiming the resident key)
       // before clearing the recovery flag. Runs on every exit path — page
       // cap, exhaustion, user-switch / teardown bail, or error. See #5391.
-      _drainDecryptIsolate?.close();
-      _drainDecryptIsolate = null;
+      drainDecryptIsolate?.close();
+      if (identical(_drainDecryptIsolate, drainDecryptIsolate)) {
+        _drainDecryptIsolate = null;
+      }
       _endRecovery();
     }
   }
@@ -1288,10 +1297,7 @@ class DmRepository {
       // Advance sync boundaries using the rumor's REAL created_at. The
       // outer gift wrap randomizes its own created_at within a ~2 day
       // window (NIP-17) so it must not be used for boundary tracking.
-      await _syncState?.recordSeen(
-        _userPubkey,
-        createdAt: rumor.createdAt,
-      );
+      await _syncState?.recordSeen(_userPubkey, createdAt: rumor.createdAt);
 
       Log.debug(
         'Persisted DM (kind ${rumor.kind}) in conversation '
@@ -1318,9 +1324,7 @@ class DmRepository {
   /// absent) are missing from the map — the caller routes those through the
   /// unchanged per-event path (which preserves the isolate→main-isolate
   /// fallback and failed-decrypt bookkeeping). Runs OFF the [_eventLock].
-  Future<Map<String, Event>> _batchDecryptGiftWraps(
-    List<Event> events,
-  ) async {
+  Future<Map<String, Event>> _batchDecryptGiftWraps(List<Event> events) async {
     final isolate = _drainDecryptIsolate;
     if (isolate == null) {
       // Remote / test signer, or the drain isolate could not spawn: there is

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -11,6 +11,7 @@ import 'dart:convert';
 import 'package:crypto/crypto.dart';
 import 'package:db_client/db_client.dart';
 import 'package:dm_repository/src/collaborator_invite_recovery.dart';
+import 'package:dm_repository/src/dm_decrypt_isolate.dart';
 import 'package:dm_repository/src/dm_decryption_worker.dart';
 import 'package:dm_repository/src/dm_reactions_repository.dart';
 import 'package:dm_repository/src/dm_repository_reportable_sites.dart';
@@ -92,10 +93,10 @@ abstract class DmHistoryDrainConfig {
   /// See #5202.
   static const int maxDecryptRetries = 10;
 
-  /// Gift wraps decrypted per [compute] isolate hop on the history-drain
-  /// path: one hop covers this many wraps instead of one spawn per wrap.
-  /// Sub-chunks a [pageSize] page to bound peak isolate memory and the
-  /// off-lock decrypt duration. See #5391.
+  /// Gift wraps decrypted per hop fed to the drain-scoped long-lived decrypt
+  /// isolate on the history-drain path. Sub-chunks a [pageSize] page to bound
+  /// peak isolate memory, the off-lock decrypt duration, and the per-message
+  /// port payload. See #5391.
   static const int decryptBatchSize = 20;
 
   /// Events processed between cooperative event-loop yields in the serial
@@ -222,6 +223,14 @@ class DmRepository {
   Timer? _reconnectTimer;
   late bool _disposed = false;
 
+  /// A single long-lived decrypt isolate, alive only for the duration of a
+  /// history drain. Spawned in [_runHistoryDrain] for local-key signers and
+  /// killed in its `finally`, so a large backfill pays one isolate spawn
+  /// instead of one per chunk and the resident private key is reclaimed when
+  /// the drain ends. `null` outside a drain or for remote/test signers. See
+  /// PR #5405 review / #5391.
+  DmDecryptIsolate? _drainDecryptIsolate;
+
   /// Serializes event processing so concurrent subscription events
   /// never race into the dedup/insert path.
   Future<void>? _eventLock;
@@ -325,6 +334,11 @@ class DmRepository {
     // user can start fresh; the running loops bail on the _userPubkey change.
     _historyDrain = null;
     _pendingDecryptRetry = null;
+    // Kill any drain-scoped decrypt isolate immediately so the outgoing user's
+    // key is not left resident in a worker while the next user signs in. The
+    // bailing drain's `finally` is idempotent if it also runs.
+    _drainDecryptIsolate?.close();
+    _drainDecryptIsolate = null;
     // Abandon the recovery signal for the outgoing user. The bailing loops'
     // _endRecovery() then no-ops (guarded on the zeroed counter).
     if (_activeRecoveryOps > 0) {
@@ -810,6 +824,29 @@ class DmRepository {
 
     _beginRecovery();
     try {
+      // Spawn one drain-scoped decrypt isolate for local-key signers so the
+      // whole backfill pays a single isolate spawn instead of one per chunk
+      // (#5391 review). Remote / test signers leave it null and the batch path
+      // falls through to the unchanged per-event decryptor. Inside the `try`
+      // so the `finally` always reclaims it. See #5391.
+      final drainSigner = _signer;
+      if (drainSigner is IsolateDecryptSigner &&
+          drainSigner.canDecryptInIsolate) {
+        try {
+          _drainDecryptIsolate = await DmDecryptIsolate.spawn(
+            drainSigner.withPrivateKeyHex((k) => k),
+          );
+        } on Object catch (e, stackTrace) {
+          Log.error(
+            'DM decrypt isolate spawn failed; using per-event decrypt: $e',
+            category: LogCategory.system,
+            error: e,
+            stackTrace: stackTrace,
+          );
+          _drainDecryptIsolate = null;
+        }
+      }
+
       // The relay filters `until:` on the OUTER gift-wrap created_at, which
       // NIP-59 randomizes up to 2 days into the past — so the cursor tracks
       // fetched events' outer timestamps, NOT the rumor times recorded in
@@ -934,6 +971,11 @@ class DmRepository {
         );
       }
     } finally {
+      // Kill the drain-scoped decrypt isolate (reclaiming the resident key)
+      // before clearing the recovery flag. Runs on every exit path — page
+      // cap, exhaustion, user-switch / teardown bail, or error. See #5391.
+      _drainDecryptIsolate?.close();
+      _drainDecryptIsolate = null;
       _endRecovery();
     }
   }
@@ -1266,20 +1308,23 @@ class DmRepository {
     }
   }
 
-  /// Decrypts a page's gift wraps in batches for local-key signers, returning
-  /// a `{giftWrapId: rumor}` map of the SUCCESSFUL decrypts only. One
-  /// [compute] isolate hop covers up to [DmHistoryDrainConfig.decryptBatchSize]
-  /// wraps instead of one spawn per wrap (#5391). Wraps that are already
-  /// persisted, fail to decrypt, or belong to a remote signer are absent from
-  /// the map — the caller routes those through the unchanged per-event path
-  /// (which preserves the isolate→main-isolate fallback and failed-decrypt
-  /// bookkeeping). Runs OFF the [_eventLock].
+  /// Decrypts a page's gift wraps in chunks on the drain-scoped long-lived
+  /// decrypt isolate ([_drainDecryptIsolate]), returning a
+  /// `{giftWrapId: rumor}` map of the SUCCESSFUL decrypts only. Each
+  /// `DmHistoryDrainConfig.decryptBatchSize`-wrap chunk is one hop fed to the
+  /// *same* worker over a port, so the whole backfill pays a single isolate
+  /// spawn instead of one per chunk (#5391 review). Wraps that are already
+  /// persisted, fail to decrypt, or belong to a remote signer (the isolate is
+  /// absent) are missing from the map — the caller routes those through the
+  /// unchanged per-event path (which preserves the isolate→main-isolate
+  /// fallback and failed-decrypt bookkeeping). Runs OFF the [_eventLock].
   Future<Map<String, Event>> _batchDecryptGiftWraps(
     List<Event> events,
   ) async {
-    final signer = _signer;
-    if (signer is! IsolateDecryptSigner || !signer.canDecryptInIsolate) {
-      // Remote / test signer: cannot decrypt in an isolate. Per-event path.
+    final isolate = _drainDecryptIsolate;
+    if (isolate == null) {
+      // Remote / test signer, or the drain isolate could not spawn: there is
+      // no batch worker, so route everything through the per-event path.
       return const {};
     }
 
@@ -1293,7 +1338,6 @@ class DmRepository {
     }
     if (pending.isEmpty) return const {};
 
-    final hex = signer.withPrivateKeyHex((k) => k);
     final decrypted = <String, Event>{};
     for (
       var start = 0;
@@ -1307,13 +1351,9 @@ class DmRepository {
         end < pending.length ? end : pending.length,
       );
       try {
-        final results = await compute(
-          decryptGiftWrapBatch,
-          DecryptBatchRequest(
-            events: [for (final event in chunk) event.toJson()],
-            privateKeyHex: hex,
-          ),
-        );
+        final results = await isolate.decryptBatch([
+          for (final event in chunk) event.toJson(),
+        ]);
         for (var i = 0; i < chunk.length; i++) {
           final result = results[i];
           if (result.isSuccess) {
@@ -1359,8 +1399,12 @@ class DmRepository {
   /// test-injected decryptors.
   ///
   /// This single-event path serves the live subscription and the retry
-  /// replay; the high-volume history drain instead batches many wraps per
-  /// isolate hop via [_batchDecryptGiftWraps]. See #5391.
+  /// replay; the high-volume history drain instead batches many wraps per hop
+  /// on a long-lived isolate via [_batchDecryptGiftWraps]. It intentionally
+  /// stays on per-event [compute] (not the long-lived worker): it fires
+  /// sporadically across the whole session, so a persistent worker here would
+  /// hold the private key resident session-long for no spawn-cost win. See
+  /// #5391.
   Future<Event?> _decryptRumor(Nostr nostr, Event giftWrapEvent) async {
     final signer = _signer;
     if (signer is IsolateDecryptSigner && signer.canDecryptInIsolate) {

--- a/mobile/packages/dm_repository/test/src/dm_decrypt_isolate_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_decrypt_isolate_test.dart
@@ -1,0 +1,172 @@
+// ABOUTME: Tests for DmDecryptIsolate, the long-lived drain-scoped NIP-17
+// ABOUTME: gift-wrap decrypt worker. Covers the real round-trip, per-event
+// ABOUTME: failure handling, concurrent request id-correlation, and close().
+
+import 'dart:convert';
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nip44/nip44_v2.dart';
+
+/// Builds a NIP-17 gift wrap for [content] addressed to [recipientPubkey],
+/// sealed and signed by [senderPrivateKey]. Mirrors the production
+/// GiftWrapUtil flow inline so the worker can unwrap it for real.
+Future<Event> buildGiftWrap({
+  required String content,
+  required String senderPrivateKey,
+  required String recipientPubkey,
+}) async {
+  final senderPubkey = getPublicKey(senderPrivateKey);
+
+  final rumor = Event(
+    senderPubkey,
+    EventKind.privateDirectMessage,
+    <List<String>>[
+      ['p', recipientPubkey],
+    ],
+    content,
+  );
+
+  final rumorMap = rumor.toJson()..remove('sig');
+  final sealKey = NIP44V2.shareSecret(senderPrivateKey, recipientPubkey);
+  final sealContent = await NIP44V2.encrypt(jsonEncode(rumorMap), sealKey);
+  final sealEvent = Event(
+    senderPubkey,
+    EventKind.sealEventKind,
+    <List<String>>[],
+    sealContent,
+  )..sign(senderPrivateKey);
+
+  final ephemeralPrivateKey = generatePrivateKey();
+  final ephemeralPubkey = getPublicKey(ephemeralPrivateKey);
+  final wrapKey = NIP44V2.shareSecret(ephemeralPrivateKey, recipientPubkey);
+  final wrapContent = await NIP44V2.encrypt(
+    jsonEncode(sealEvent.toJson()),
+    wrapKey,
+  );
+  return Event(
+    ephemeralPubkey,
+    EventKind.giftWrap,
+    <List<String>>[
+      ['p', recipientPubkey],
+    ],
+    wrapContent,
+  )..sign(ephemeralPrivateKey);
+}
+
+void main() {
+  group(DmDecryptIsolate, () {
+    late String recipientPriv;
+    late String recipientPub;
+    late String senderPriv;
+    late DmDecryptIsolate isolate;
+
+    setUp(() async {
+      recipientPriv = generatePrivateKey();
+      recipientPub = getPublicKey(recipientPriv);
+      senderPriv = generatePrivateKey();
+      isolate = await DmDecryptIsolate.spawn(recipientPriv);
+    });
+
+    tearDown(() {
+      isolate.close();
+    });
+
+    test('decrypts a real gift wrap to its rumor', () async {
+      final wrap = await buildGiftWrap(
+        content: 'hello isolate',
+        senderPrivateKey: senderPriv,
+        recipientPubkey: recipientPub,
+      );
+
+      final results = await isolate.decryptBatch([wrap.toJson()]);
+
+      expect(results, hasLength(1));
+      expect(results.single.isSuccess, isTrue);
+      expect(Event.fromJson(results.single.rumor!).content, 'hello isolate');
+    });
+
+    test('returns a failure entry for a wrap addressed to another key '
+        'without throwing', () async {
+      final otherRecipientPriv = generatePrivateKey();
+      final otherRecipientPub = getPublicKey(otherRecipientPriv);
+      // Encrypted to someone else: our resident key cannot ECDH-decrypt it.
+      final wrap = await buildGiftWrap(
+        content: 'not for us',
+        senderPrivateKey: senderPriv,
+        recipientPubkey: otherRecipientPub,
+      );
+
+      final results = await isolate.decryptBatch([wrap.toJson()]);
+
+      expect(results, hasLength(1));
+      expect(results.single.isSuccess, isFalse);
+      expect(results.single.error, isNotNull);
+    });
+
+    test('preserves per-event order within a batch', () async {
+      final wraps = <Event>[
+        for (var i = 0; i < 5; i++)
+          await buildGiftWrap(
+            content: 'ordered $i',
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+          ),
+      ];
+
+      final results = await isolate.decryptBatch([
+        for (final wrap in wraps) wrap.toJson(),
+      ]);
+
+      expect(results, hasLength(5));
+      for (var i = 0; i < 5; i++) {
+        expect(Event.fromJson(results[i].rumor!).content, 'ordered $i');
+      }
+    });
+
+    test(
+      'correlates concurrent decryptBatch calls to their own results',
+      () async {
+        // Fire each request without awaiting so they interleave on the shared
+        // port; if ids were mismatched the contents would come back swapped.
+        final futures = <Future<List<DecryptedRumorResult>>>[];
+        for (var i = 0; i < 8; i++) {
+          final wrap = await buildGiftWrap(
+            content: 'concurrent $i',
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+          );
+          futures.add(isolate.decryptBatch([wrap.toJson()]));
+        }
+
+        final results = await Future.wait(futures);
+
+        for (var i = 0; i < 8; i++) {
+          expect(results[i], hasLength(1));
+          expect(
+            Event.fromJson(results[i].single.rumor!).content,
+            'concurrent $i',
+          );
+        }
+      },
+    );
+
+    test('throws StateError when used after close', () async {
+      isolate.close();
+
+      expect(
+        () => isolate.decryptBatch(const [<String, dynamic>{}]),
+        throwsStateError,
+      );
+    });
+
+    test('close is idempotent', () {
+      isolate
+        ..close()
+        ..close();
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -126,6 +126,20 @@ class _MockNostrSigner extends Mock implements NostrSigner {}
 
 class _FakeEvent extends Fake implements Event {}
 
+class _FakeDmDecryptWorker implements DmDecryptWorker {
+  int closeCount = 0;
+
+  @override
+  Future<List<DecryptedRumorResult>> decryptBatch(
+    List<Map<String, dynamic>> events,
+  ) async => const <DecryptedRumorResult>[];
+
+  @override
+  void close() {
+    closeCount++;
+  }
+}
+
 /// Test double for [DmSyncState] that stores values in memory and captures
 /// [recordSeen] calls for assertions.
 class _FakeDmSyncState implements DmSyncState {
@@ -361,6 +375,7 @@ void main() {
       PendingGiftWrapsDao? pendingGiftWrapsDao,
       DmReactionsRepository? reactionsRepository,
       NostrSigner? signer,
+      DmDecryptIsolateSpawner? decryptIsolateSpawner,
     }) {
       return DmRepository(
         nostrClient: mockNostrClient,
@@ -373,6 +388,7 @@ void main() {
         signer: signer ?? LocalNostrSigner(_validPrivateKey),
         rumorDecryptor: rumorDecryptor,
         nip04Decryptor: nip04Decryptor,
+        decryptIsolateSpawner: decryptIsolateSpawner,
         syncState: syncState,
         reactionsRepository: reactionsRepository,
         errorReporter: (error, stackTrace, {required site}) {
@@ -3344,6 +3360,79 @@ void main() {
       _FakeDmSyncState drainPending() => _FakeDmSyncState()
         ..oldestOverride = 1700001000
         ..drainVersionOverride = DmSyncState.currentDrainVersion;
+
+      test(
+        'stale drain spawn cannot close or clear the next drain worker',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+
+          final firstWorker = _FakeDmDecryptWorker();
+          final secondWorker = _FakeDmDecryptWorker();
+          final firstSpawn = Completer<DmDecryptWorker>();
+          final firstSpawnRequested = Completer<void>();
+          final secondSpawnRequested = Completer<void>();
+          var spawnCount = 0;
+
+          Future<DmDecryptWorker> spawner(String privateKeyHex) {
+            spawnCount++;
+            if (spawnCount == 1) {
+              firstSpawnRequested.complete();
+              return firstSpawn.future;
+            }
+            secondSpawnRequested.complete();
+            return Future<DmDecryptWorker>.value(secondWorker);
+          }
+
+          final secondQueryStarted = Completer<void>();
+          final secondQueryResult = Completer<List<Event>>();
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((inv) async {
+            final filters =
+                inv.positionalArguments.first as List<nostr_filter.Filter>;
+            final filter = filters.single;
+            if (filter.p?.contains(senderPub) ?? false) {
+              secondQueryStarted.complete();
+              return secondQueryResult.future;
+            }
+            return const <Event>[];
+          });
+
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: _IsolateLocalSigner(recipientPriv),
+            syncState: drainPending(),
+            decryptIsolateSpawner: spawner,
+          );
+
+          final firstDrain = repository.backfillHistoryIfNeeded();
+          await firstSpawnRequested.future;
+
+          repository.setCredentials(
+            userPubkey: senderPub,
+            signer: _IsolateLocalSigner(senderPriv),
+            messageService: mockMessageService,
+          );
+          final secondDrain = repository.backfillHistoryIfNeeded();
+          await secondSpawnRequested.future;
+          await secondQueryStarted.future;
+
+          firstSpawn.complete(firstWorker);
+          await firstDrain;
+
+          expect(firstWorker.closeCount, 1);
+          expect(secondWorker.closeCount, 0);
+
+          secondQueryResult.complete(const <Event>[]);
+          await secondDrain;
+
+          expect(secondWorker.closeCount, 1);
+        },
+      );
 
       test(
         'batches a drain page of real gift wraps and persists each message '

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3558,6 +3558,74 @@ void main() {
           expect(syncState.drainCompleteOverride, isTrue);
         },
       );
+
+      test(
+        'batches a page larger than decryptBatchSize across multiple isolate '
+        'hops and persists every message with its own content',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          // 25 real wraps => 2 hops fed to the same long-lived isolate
+          // (20 + 5 at decryptBatchSize = 20). Distinct content per wrap, so a
+          // chunk-correlation bug would surface as a missing/duplicated entry.
+          const count = 25;
+          final persistedContents = <String>{};
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).thenAnswer((inv) async {
+            persistedGiftWrapIds.add(
+              inv.namedArguments[#giftWrapId] as String,
+            );
+            persistedContents.add(inv.namedArguments[#content] as String);
+          });
+
+          final wraps = <Event>[
+            for (var i = 0; i < count; i++)
+              await _buildGiftWrap(
+                rumor: rumorFor('multichunk $i', createdAt: 1700000500 + i),
+                senderPrivateKey: senderPriv,
+                recipientPubkey: recipientPub,
+                outerCreatedAt: 1700000000 + i,
+              ),
+          ];
+          stubDrainPage(wraps);
+
+          final syncState = drainPending();
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: _IsolateLocalSigner(recipientPriv),
+            syncState: syncState,
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          expect(
+            persistedContents,
+            {for (var i = 0; i < count; i++) 'multichunk $i'},
+          );
+        },
+      );
     });
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Description

Follow-up to **#5405** (merged), addressing the per-chunk `compute()` respawn that hm21 flagged in the approving review ([#pullrequestreview-4538752602](https://github.com/divinevideo/divine-mobile/pull/5405#pullrequestreview-4538752602)).

The #5391 batch path spawned a fresh `compute()` isolate per `decryptBatchSize`-wrap chunk, so a large gift-wrap backfill (~1000 wraps ~= 50 chunks) paid ~50 isolate spawns over the drain. This replaces that with a single **long-lived, drain-scoped** decrypt isolate:

- **New `DmDecryptIsolate`** (`dm_decrypt_isolate.dart`, pure `dart:isolate`) - spawned once at the start of a history drain, fed one chunk per hop over a `SendPort` (request/response correlated by id), and killed in the drain's `finally`. Reuses the existing pure `decryptGiftWrapBatch` worker.
- **`_runHistoryDrain`** spawns the isolate for local-key signers only and tears it down on every exit path (page cap, exhaustion, user-switch / teardown bail, error). `_resetState` also closes it on user switch.
- **`_batchDecryptGiftWraps`** swaps transport only (`compute(...)` -> `isolate.decryptBatch(...)`); all #5391 pacing semantics - `decryptBatchSize` chunking, `_disposed` checks, the WS3 yield between hops, and the per-event fallback - are unchanged.

This update also hardens ownership after review: each history drain now keeps a drain-local reference to the worker it spawned, re-checks account ownership after the async spawn completes, and only closes/clears that exact worker in `finally`. A stale drain can no longer orphan, clear, or close the next user's drain worker after an account switch.

**Key-residency trade hm21 flagged:** a persistent worker holds the recipient private key for its lifetime rather than for one transient `compute` isolate. Scoping the worker to the **drain** (not the session) bounds that residency to exactly the drain window - the same window the main isolate already holds the extracted hex in today. The single-event `_decryptRumor` path (live subscription + retry replay) intentionally **stays** on per-event `compute()`: it fires session-long, so a persistent worker there would hold the key resident session-long for no spawn-cost win.

Remote/test signers and a failed spawn leave the isolate `null` and fall through to the unchanged per-event path, so dedup, sync-boundary tracking, fallback and failed-decrypt bookkeeping are untouched. No backend/protocol change - this is client-side CPU/IO scheduling only.

Closes #5420.

## Out of Scope

- **On-device responsiveness capture** - the other non-blocking review item (Notifications tab during a large *remote-signer* backfill, which runs the per-event path the batch fast-path doesn't cover). It's a manual on-device measurement; tracked separately in #5413.

## Verification

- `dart format` - clean.
- `flutter analyze packages/dm_repository` - no issues.
- `flutter test packages/dm_repository` - all green, incl. random ordering. The existing `history drain batch decryption (#5391)` group now exercises the new transport end-to-end (real local signer, no injected decryptor). New tests:
  - `dm_decrypt_isolate_test.dart` - real round-trip, per-event failure without throwing, batch order, **concurrent request id-correlation**, post-close `StateError`, idempotent `close`.
  - repo suite - a multi-chunk drain page (25 wraps = 20 + 5 across two hops) persists every message with its own content.
  - repo suite - account-switch interleaving after async worker spawn proves a stale drain closes only its own worker and cannot clear/close the active next-drain worker.

## Type of Change

- [x] Code refactor
