### PR TITLE
docs(video-editor): explain native log warning default

### DIFF
--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -1060,6 +1060,8 @@ class VideoEditorRenderService {
   static Future<String> renderNativeVideoToFile(
     String outputPath,
     VideoRenderData task, {
+    // Surface native renderer warnings through ProVideoEditorLogForwarder for
+    // #4801 diagnostics while clean renders stay quiet.
     NativeLogLevel? nativeLogLevel = NativeLogLevel.warning,
   }) async {
     await cancelTask(task.id);


### PR DESCRIPTION
## Summary
- Restore the rationale for the `NativeLogLevel.warning` default on `VideoEditorRenderService.renderNativeVideoToFile`.
- Keep the explanation next to the default parameter so future render entry points preserve the #4801 native diagnostic behavior.

## Root cause
PR #5400 moved the native render call behind `renderNativeVideoToFile`, but the inline comment explaining why the app requests warning-level native logs did not move with the `NativeLogLevel.warning` default.

## Impact
This is documentation-only. It does not change render behavior, native logging levels, cancellation tracking, or public APIs.

## Verification
- `flutter analyze` from `mobile/`
- pre-push analyzer hook

Closes #5415