### PR TITLE
test(dm): prove the history drain yields on the remote-signer per-event path (#5391)

### DIFF
--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3715,6 +3715,80 @@ void main() {
           );
         },
       );
+
+      test(
+        'yields the event loop on the remote-signer per-event path so a large '
+        'backfill cannot starve frame rendering',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+
+          // The heaviest #5391 case: a large backfill on the per-event decrypt
+          // path, which the batched fast-path does NOT accelerate. The default
+          // LocalNostrSigner is not an IsolateDecryptSigner, so
+          // _batchDecryptGiftWraps is a no-op and every wrap routes through
+          // _decryptRumor -> the injected per-event decryptor — exactly the
+          // path a remote signer (Keycast NIP-46 / Amber) takes.
+          const wrapCount = 33; // > 2 * drainYieldInterval(16): forces 2 yields
+          final wraps = <Event>[];
+          final rumorByWrapId = <String, Event>{};
+          for (var i = 0; i < wrapCount; i++) {
+            final wrapKey = generatePrivateKey();
+            final wrap = Event(
+              getPublicKey(wrapKey),
+              EventKind.giftWrap,
+              <List<String>>[
+                ['p', recipientPub],
+              ],
+              'wrap-$i',
+              createdAt: 1700000100 + i,
+            )..sign(wrapKey);
+            wraps.add(wrap);
+            rumorByWrapId[wrap.id] = rumorFor(
+              'msg $i',
+              createdAt: 1700000100 + i,
+            );
+          }
+          stubDrainPage(wraps);
+
+          // A periodic timer can ONLY fire when the drain surrenders a real
+          // event-loop turn: mocked-DAO and injected-decryptor work runs on
+          // microtasks, which never let a timer fire — only the WS3
+          // _yieldToEventLoop (Future.delayed(Duration.zero)) does. A rising
+          // tick count sampled across the per-event decrypts therefore proves
+          // the drain handed the event loop back mid-page instead of starving
+          // it in one burst.
+          var ticks = 0;
+          final ticker = Timer.periodic(Duration.zero, (_) => ticks++);
+          addTearDown(ticker.cancel);
+
+          final ticksAtDecrypt = <int>[];
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            rumorDecryptor: (_, wrap) async {
+              ticksAtDecrypt.add(ticks);
+              return rumorByWrapId[wrap.id];
+            },
+            syncState: drainPending(),
+          );
+
+          await repository.backfillHistoryIfNeeded();
+          ticker.cancel();
+
+          // Every unique wrap routed through the per-event decryptor (the
+          // batch path is a no-op for the non-isolate signer; the inclusive
+          // `until` boundary re-request is deduped by hasGiftWrap before
+          // reaching the decryptor).
+          expect(ticksAtDecrypt, hasLength(wrapCount));
+          // The opening events run before the first yield; later events run
+          // only after the drain handed back the event loop at least once.
+          // Remove the WS3 yield and the whole page drains in a single
+          // microtask burst with the heartbeat frozen at 0 — so this strict
+          // increase is the regression guard for "the backfill does not
+          // starve frame rendering" on the path the batching never touches.
+          expect(ticksAtDecrypt.first, 0);
+          expect(ticksAtDecrypt.last, greaterThan(0));
+        },
+      );
     });
 
     // -----------------------------------------------------------------


### PR DESCRIPTION
## Description

**Follow-up PR addressing hm21's review of #5405:**
https://github.com/divinevideo/divine-mobile/pull/5405#pullrequestreview-4538752602

In that review hm21 flagged that the WS3 throttle's responsiveness guarantee
was **unproven for the one case the batched fast-path does not accelerate**:
a large backfill on the per-event decrypt path that a remote signer (Keycast
NIP-46 / Amber) takes. He noted the unit tests prove correctness but not that
the jank is gone, and "the heaviest case (a large remote-signer backfill on
the per-event path) is exactly the one the batched fast-path does **not**
cover."

The existing throttle test (`throttled drain processes a page larger than
the yield interval and still completes`) had two gaps against that case:

1. It asserts only that the drain **completes** — it stays green even if
   `_yieldToEventLoop()` is deleted.
2. It runs a **local** signer over kind-5 deletions, not the **remote-signer
   gift-wrap decrypt** path hm21 called out.

This PR adds a regression test that closes both:

- Forces the **per-event** path by using the default non-isolate
  `LocalNostrSigner`, so `_batchDecryptGiftWraps` is a no-op and every wrap
  routes through `_decryptRumor` → the injected per-event decryptor (exactly
  a remote signer's path).
- Drains a page **larger than 2× `drainYieldInterval`** (33 wraps) so the
  loop must yield at least twice.
- Proves the drain **actually surrenders real event-loop turns mid-page**: a
  `Timer.periodic` heartbeat can only advance when the drain yields (the
  mocked-DAO and injected-decryptor work runs on microtasks, which never let
  a timer fire — only the WS3 `Future.delayed(Duration.zero)` does), so a
  rising tick count sampled across the per-event decrypts is a direct guard
  for "the backfill does not starve frame rendering."

**Mutation-verified:** neutralizing `_maybeYieldDuringDrain` turns the new
assertion red (`Expected: a value greater than <0>` / `Actual: <0>` — the
heartbeat frozen at 0), confirming it guards the throttle rather than passing
vacuously.

This is the durable CI half of hm21's note. The on-device frame-time capture
(Notifications tab staying responsive during a large remote-signer backfill)
remains the empirical confirmation and is tracked separately.

**Related Issue:** Relates to #5391

## Out of Scope

- The on-device frame-time / jank capture for a large remote-signer backfill
  — a manual device validation, not a code change. This PR locks the
  yield-on-per-event-path mechanism in CI; the device run confirms it
  empirically.
- The per-chunk `compute()` respawn optimization hm21 flagged inline
  ("not asking for a change") — a deferred trade-off, untouched here.

## Verification

- `flutter analyze lib test` (dm_repository) — No issues found.
- `flutter test` (dm_repository) — all 347 tests green, including the new
  regression test.
- `flutter test --test-randomize-ordering-seed random` — green (no
  order-dependence from the timer-based test).
- Mutation check: removing the WS3 yield turns the new test red, as designed.

## Type of Change

- [x] ✅ Test coverage (regression guard for an already-merged perf change)