### PR TITLE
fix(dm): paint in-chat reaction chips optimistically (#5389)

### DIFF
--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -30,8 +30,10 @@ class ConversationReactionsCubit
   ConversationReactionsCubit({
     required DmReactionsRepository reactionsRepository,
     required String ownerPubkey,
+    DateTime Function()? now,
   }) : _reactionsRepository = reactionsRepository,
        _ownerPubkey = ownerPubkey,
+       _now = now ?? DateTime.now,
        super(const ConversationReactionsState()) {
     on<ConversationReactionsStarted>(_onStarted, transformer: restartable());
     on<ConversationReactionToggled>(_onToggled, transformer: sequential());
@@ -45,8 +47,17 @@ class ConversationReactionsCubit
 
   final DmReactionsRepository _reactionsRepository;
   final String _ownerPubkey;
+
+  /// Clock for the synthetic optimistic row's `created_at`. Injectable so
+  /// tests stay deterministic; defaults to [DateTime.now] in production.
+  final DateTime Function() _now;
+
   StreamSubscription<List<DmReaction>>? _subscription;
   String? _conversationId;
+
+  /// Prefix for the synthetic optimistic row id. Never a valid Nostr event id
+  /// (64-hex), so it can't collide with a real persisted row.
+  static const String _optimisticIdPrefix = 'optimistic:';
 
   @override
   Future<void> close() async {
@@ -80,6 +91,20 @@ class ConversationReactionsCubit
     // Toggle-off: if we already have a live matching reaction, remove it.
     final existing = _ownLiveReaction(event.messageId, event.emoji);
     if (existing != null) {
+      final key = ReactionPublishKey(
+        messageId: event.messageId,
+        emoji: event.emoji,
+      );
+      // Hide the own chip on the same frame as the tap; reconciled away by
+      // the next stream tick once the soft-delete drops the persisted row.
+      emit(
+        state.copyWith(
+          optimistic: {
+            ...state.optimistic,
+            key: const OptimisticReactionRemoved(),
+          },
+        ),
+      );
       try {
         await _reactionsRepository.removeOwn(
           rumorId: existing.id,
@@ -87,6 +112,11 @@ class ConversationReactionsCubit
         );
       } on Object catch (e, st) {
         addError(e, st);
+        // Removal didn't take — restore the chip.
+        final restored = Map<ReactionPublishKey, OptimisticReactionIntent>.from(
+          state.optimistic,
+        )..remove(key);
+        emit(state.copyWith(optimistic: restored));
       }
       return;
     }
@@ -118,6 +148,8 @@ class ConversationReactionsCubit
   }
 
   /// The current account's live reaction with [emoji] on [messageId], or null.
+  /// Reads the persisted rows only (not the optimistic overlay) so toggle-off
+  /// resolves a real rumor id for [DmReactionsRepository.removeOwn].
   DmReaction? _ownLiveReaction(String messageId, String emoji) {
     final list = state.reactionsByMessageId[messageId];
     return list?.firstWhereOrNull(
@@ -125,8 +157,21 @@ class ConversationReactionsCubit
     );
   }
 
-  /// Optimistically mark the publish pending, send, then settle the pending
-  /// map by outcome. Shared by the toggle and set paths.
+  /// The current account's live persisted reaction on [messageId] with ANY
+  /// emoji, or null. Drives the optimistic cap-at-one supersede swap.
+  DmReaction? _ownLivePersistedReaction(String messageId) {
+    final list = state.reactionsByMessageId[messageId];
+    return list?.firstWhereOrNull((r) => r.reactorPubkey == _ownerPubkey);
+  }
+
+  /// Optimistically paint the chip, mark the publish pending, send, then
+  /// settle by outcome. Shared by the toggle and set paths.
+  ///
+  /// The synthetic [DmReaction] is overlaid synchronously (same frame as the
+  /// tap) so the chip never waits on the local Drift round-trip
+  /// (`insertOptimistic` → watch re-emit, which crosses a background isolate
+  /// and SQLCipher). It is reconciled away in [_onSubscriptionTicked] once the
+  /// persisted row lands (#5389).
   Future<void> _publishReaction({
     required String conversationId,
     required String messageId,
@@ -135,10 +180,38 @@ class ConversationReactionsCubit
     required Emitter<ConversationReactionsState> emit,
   }) async {
     final key = ReactionPublishKey(messageId: messageId, emoji: emoji);
+    final synthetic = DmReaction(
+      id: '$_optimisticIdPrefix$messageId:$emoji',
+      conversationId: conversationId,
+      targetMessageId: messageId,
+      targetMessageAuthor: messageAuthorPubkey,
+      reactorPubkey: _ownerPubkey,
+      emoji: emoji,
+      createdAt: _now().millisecondsSinceEpoch ~/ 1000,
+      ownerPubkey: _ownerPubkey,
+      publishStatus: DmReactionPublishStatus.pending,
+    );
+
+    final nextOptimistic =
+        Map<ReactionPublishKey, OptimisticReactionIntent>.from(
+          state.optimistic,
+        );
+    // Cap-at-one supersede: if a different own emoji is live, hide it now so
+    // the swap looks instant (the repository soft-deletes it on the wire).
+    final prior = _ownLivePersistedReaction(messageId);
+    if (prior != null && prior.emoji != emoji) {
+      nextOptimistic[ReactionPublishKey(
+            messageId: messageId,
+            emoji: prior.emoji,
+          )] =
+          const OptimisticReactionRemoved();
+    }
+    nextOptimistic[key] = OptimisticReactionAdded(synthetic);
+
     final nextPending =
         Map<ReactionPublishKey, ReactionPublishLocalStatus>.from(state.pending)
           ..[key] = ReactionPublishLocalStatus.sending;
-    emit(state.copyWith(pending: nextPending));
+    emit(state.copyWith(optimistic: nextOptimistic, pending: nextPending));
 
     try {
       final result = await _reactionsRepository.publish(
@@ -152,15 +225,19 @@ class ConversationReactionsCubit
             state.pending,
           );
       if (result.success) {
-        newPending[key] = ReactionPublishLocalStatus.succeeded;
-        // Best-effort cleanup: drop the key on the next tick. The DAO
-        // stream re-emits with the persisted `sent` row so the chip's
-        // truth source becomes the row itself.
+        // The DAO stream re-emits with the persisted `sent` row; the chip's
+        // truth source becomes the row itself (reconciled in the next tick).
         newPending.remove(key);
+        emit(state.copyWith(pending: newPending));
       } else {
         newPending[key] = ReactionPublishLocalStatus.failed;
+        emit(
+          state.copyWith(
+            pending: newPending,
+            optimistic: _withoutOrphanedAdd(key: key, emoji: emoji),
+          ),
+        );
       }
-      emit(state.copyWith(pending: newPending));
     } on Object catch (e, st) {
       // Network/IO class per error-handling matrix — addError without
       // Reportable wrap. Site identifier carried for log triage.
@@ -175,8 +252,31 @@ class ConversationReactionsCubit
           Map<ReactionPublishKey, ReactionPublishLocalStatus>.from(
             state.pending,
           )..[key] = ReactionPublishLocalStatus.failed;
-      emit(state.copyWith(pending: newPending));
+      emit(
+        state.copyWith(
+          pending: newPending,
+          optimistic: _withoutOrphanedAdd(key: key, emoji: emoji),
+        ),
+      );
     }
+  }
+
+  /// On a publish failure, drop the optimistic add ONLY when the optimistic
+  /// insert never produced a persisted row — otherwise the chip would linger
+  /// forever as a never-settling pending placeholder. When the row exists
+  /// (send-failure), the overlay is left for the stream tick to reconcile and
+  /// the persisted `failed` row drives the retry chip via the [pending] map.
+  Map<ReactionPublishKey, OptimisticReactionIntent> _withoutOrphanedAdd({
+    required ReactionPublishKey key,
+    required String emoji,
+  }) {
+    final persisted =
+        state.reactionsByMessageId[key.messageId] ?? const <DmReaction>[];
+    final hasPersisted = persisted.any((r) => r.isOwn && r.emoji == emoji);
+    if (hasPersisted) return state.optimistic;
+    return Map<ReactionPublishKey, OptimisticReactionIntent>.from(
+      state.optimistic,
+    )..remove(key);
   }
 
   Future<void> _onRetryRequested(
@@ -237,8 +337,30 @@ class ConversationReactionsCubit
       state.copyWith(
         status: ConversationReactionsStatus.loaded,
         reactionsByMessageId: grouped,
+        optimistic: _reconcileOptimistic(grouped),
       ),
     );
+  }
+
+  /// Drop optimistic overlays the freshly-persisted set now satisfies: an
+  /// `Added` whose own row is present, or a `Removed` whose own row is gone.
+  /// Anything still in flight is kept so the chip stays put across the tick.
+  Map<ReactionPublishKey, OptimisticReactionIntent> _reconcileOptimistic(
+    Map<String, List<DmReaction>> persisted,
+  ) {
+    if (state.optimistic.isEmpty) return state.optimistic;
+    final next = Map<ReactionPublishKey, OptimisticReactionIntent>.from(
+      state.optimistic,
+    );
+    next.removeWhere((key, intent) {
+      final rows = persisted[key.messageId] ?? const <DmReaction>[];
+      final ownHasEmoji = rows.any((r) => r.isOwn && r.emoji == key.emoji);
+      return switch (intent) {
+        OptimisticReactionAdded() => ownHasEmoji,
+        OptimisticReactionRemoved() => !ownHasEmoji,
+      };
+    });
+    return next;
   }
 }
 

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
@@ -9,9 +9,10 @@ enum ConversationReactionsStatus { initial, loading, loaded, failure }
 
 /// State of an outgoing reaction publish from this client's perspective.
 /// Distinct from [DmReactionPublishStatus] which is the on-disk shape.
-enum ReactionPublishLocalStatus { sending, succeeded, failed }
+enum ReactionPublishLocalStatus { sending, failed }
 
-/// Identity for an outgoing publish, used as the key in [pending].
+/// Identity for an outgoing publish, used as the key in [pending] and
+/// [ConversationReactionsState.optimistic].
 @immutable
 class ReactionPublishKey extends Equatable {
   /// Construct a publish key.
@@ -27,6 +28,42 @@ class ReactionPublishKey extends Equatable {
   List<Object?> get props => [messageId, emoji];
 }
 
+/// A synchronous, client-side optimistic overlay applied on top of the
+/// persisted reaction rows so the chip paints on the same frame as the tap —
+/// before the local Drift round-trip (`insertOptimistic` → watch re-emit,
+/// which crosses a background isolate + SQLCipher) settles the row. Mirrors
+/// the in-player reel bar's `_optimisticEmoji` (#5389).
+///
+/// Each entry is reconciled away by [ConversationReactionsCubit] the moment
+/// the persisted stream reflects the intent (an `Added` row appears / a
+/// `Removed` row disappears).
+sealed class OptimisticReactionIntent extends Equatable {
+  const OptimisticReactionIntent();
+}
+
+/// The current account just added [reaction]; show its chip immediately.
+class OptimisticReactionAdded extends OptimisticReactionIntent {
+  /// Construct an optimistic-add intent carrying the synthetic chip row.
+  const OptimisticReactionAdded(this.reaction);
+
+  /// Synthetic placeholder row (`publishStatus: pending`) rendered until the
+  /// persisted row arrives on the next stream tick.
+  final DmReaction reaction;
+
+  @override
+  List<Object?> get props => [reaction];
+}
+
+/// The current account just removed their reaction for this `(message, emoji)`;
+/// hide the own chip immediately.
+class OptimisticReactionRemoved extends OptimisticReactionIntent {
+  /// Construct an optimistic-remove intent.
+  const OptimisticReactionRemoved();
+
+  @override
+  List<Object?> get props => [];
+}
+
 /// Snapshot of the cubit's reactive view.
 @immutable
 class ConversationReactionsState extends Equatable {
@@ -35,14 +72,17 @@ class ConversationReactionsState extends Equatable {
     this.status = ConversationReactionsStatus.initial,
     this.reactionsByMessageId = const <String, List<DmReaction>>{},
     this.pending = const <ReactionPublishKey, ReactionPublishLocalStatus>{},
+    this.optimistic = const <ReactionPublishKey, OptimisticReactionIntent>{},
   });
 
   /// Lifecycle status of the cubit.
   final ConversationReactionsStatus status;
 
-  /// Live (non-deleted) reactions grouped by `target_message_id`. Empty
-  /// when no reactions exist for a message. The cubit uses an empty
-  /// outer map between initialization and the first stream tick.
+  /// Live (non-deleted) reactions grouped by `target_message_id`, exactly as
+  /// the DAO stream delivered them (the *persisted* truth). Empty when no
+  /// reactions exist for a message. The cubit uses an empty outer map between
+  /// initialization and the first stream tick. The render path reads
+  /// [reactionsFor], which overlays [optimistic] on top of this.
   final Map<String, List<DmReaction>> reactionsByMessageId;
 
   /// In-flight publish state per (messageId, emoji). Cleared on the
@@ -50,9 +90,38 @@ class ConversationReactionsState extends Equatable {
   /// the real status.
   final Map<ReactionPublishKey, ReactionPublishLocalStatus> pending;
 
-  /// Live reactions for [messageId]. Returns `const []` if none.
-  List<DmReaction> reactionsFor(String messageId) =>
-      reactionsByMessageId[messageId] ?? const <DmReaction>[];
+  /// Synchronous optimistic overlay per (messageId, emoji), bridging the gap
+  /// between a tap and the persisted row arriving on the DAO stream (#5389).
+  /// Reconciled away by the cubit once the persisted set reflects the intent.
+  final Map<ReactionPublishKey, OptimisticReactionIntent> optimistic;
+
+  /// Live reactions for [messageId] as the chips should render them: the
+  /// persisted rows with [optimistic] applied. Returns `const []` if none.
+  ///
+  /// Fast path: when no optimistic overlay touches [messageId], the persisted
+  /// list is returned by reference, preserving identity for `identical`-based
+  /// `buildWhen` guards. A merged copy is allocated only while an optimistic
+  /// add/remove for this message is in flight.
+  List<DmReaction> reactionsFor(String messageId) {
+    final persisted = reactionsByMessageId[messageId] ?? const <DmReaction>[];
+    if (optimistic.isEmpty) return persisted;
+    final overlays = optimistic.entries
+        .where((e) => e.key.messageId == messageId)
+        .toList(growable: false);
+    if (overlays.isEmpty) return persisted;
+    final merged = List<DmReaction>.of(persisted);
+    for (final entry in overlays) {
+      final emoji = entry.key.emoji;
+      switch (entry.value) {
+        case OptimisticReactionAdded(:final reaction):
+          final present = merged.any((r) => r.isOwn && r.emoji == emoji);
+          if (!present) merged.add(reaction);
+        case OptimisticReactionRemoved():
+          merged.removeWhere((r) => r.isOwn && r.emoji == emoji);
+      }
+    }
+    return merged;
+  }
 
   /// Did the current account author a live reaction with [emoji] on
   /// the message [messageId]?
@@ -77,14 +146,21 @@ class ConversationReactionsState extends Equatable {
     ConversationReactionsStatus? status,
     Map<String, List<DmReaction>>? reactionsByMessageId,
     Map<ReactionPublishKey, ReactionPublishLocalStatus>? pending,
+    Map<ReactionPublishKey, OptimisticReactionIntent>? optimistic,
   }) {
     return ConversationReactionsState(
       status: status ?? this.status,
       reactionsByMessageId: reactionsByMessageId ?? this.reactionsByMessageId,
       pending: pending ?? this.pending,
+      optimistic: optimistic ?? this.optimistic,
     );
   }
 
   @override
-  List<Object?> get props => [status, reactionsByMessageId, pending];
+  List<Object?> get props => [
+    status,
+    reactionsByMessageId,
+    pending,
+    optimistic,
+  ];
 }

--- a/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
+++ b/mobile/test/blocs/dm/reactions/conversation_reactions_cubit_test.dart
@@ -337,5 +337,243 @@ void main() {
         expect(list.first.emoji, '👍');
       },
     );
+
+    group('optimistic chip (#5389)', () {
+      bool ownPending(ConversationReactionsState s, String emoji) => s
+          .reactionsFor(_msgId)
+          .any(
+            (r) =>
+                r.reactorPubkey == _owner &&
+                r.emoji == emoji &&
+                r.publishStatus == DmReactionPublishStatus.pending,
+          );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'paints the own chip synchronously, before the publish resolves',
+        build: () {
+          when(
+            () => repo.publish(
+              conversationId: any(named: 'conversationId'),
+              targetMessageId: any(named: 'targetMessageId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              emoji: any(named: 'emoji'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                const DmReactionPublishResult(success: true, rumorId: 'r-1'),
+          );
+          return ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          );
+        },
+        act: (cubit) => cubit.add(
+          const ConversationReactionToggled(
+            conversationId: _convo,
+            messageId: _msgId,
+            messageAuthorPubkey: _peer,
+            emoji: '❤️',
+          ),
+        ),
+        expect: () => [
+          // FIRST emit already carries the chip — no stream tick, no DB wait.
+          isA<ConversationReactionsState>()
+              .having(
+                (s) => ownPending(s, '❤️'),
+                'optimistic chip present',
+                isTrue,
+              )
+              .having(
+                (s) =>
+                    s.pending[const ReactionPublishKey(
+                      messageId: _msgId,
+                      emoji: '❤️',
+                    )],
+                'pending sending',
+                ReactionPublishLocalStatus.sending,
+              ),
+          // After publish: pending cleared, overlay still bridges until a tick.
+          isA<ConversationReactionsState>()
+              .having((s) => s.pending.isEmpty, 'pending cleared', isTrue)
+              .having((s) => ownPending(s, '❤️'), 'chip still present', isTrue),
+        ],
+      );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'reconciles the optimistic add when the persisted row arrives (no dupe)',
+        build: () {
+          when(
+            () => repo.publish(
+              conversationId: any(named: 'conversationId'),
+              targetMessageId: any(named: 'targetMessageId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              emoji: any(named: 'emoji'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                const DmReactionPublishResult(success: true, rumorId: 'r-1'),
+          );
+          return ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          );
+        },
+        act: (cubit) async {
+          cubit.add(const ConversationReactionsStarted(conversationId: _convo));
+          await Future<void>.delayed(Duration.zero);
+          cubit.add(
+            const ConversationReactionToggled(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '❤️',
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+          streamController.add([ownReaction('❤️')]);
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (cubit) {
+          expect(cubit.state.optimistic, isEmpty);
+          final chips = cubit.state
+              .reactionsFor(_msgId)
+              .where((r) => r.emoji == '❤️')
+              .toList();
+          expect(chips, hasLength(1));
+          expect(chips.first.publishStatus, DmReactionPublishStatus.sent);
+        },
+      );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'toggle-off hides the own chip synchronously',
+        build: () {
+          when(
+            () => repo.removeOwn(
+              rumorId: any(named: 'rumorId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            ),
+          ).thenAnswer((_) async {});
+          return ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          );
+        },
+        act: (cubit) async {
+          cubit.add(const ConversationReactionsStarted(conversationId: _convo));
+          await Future<void>.delayed(Duration.zero);
+          streamController.add([ownReaction('❤️')]);
+          await Future<void>.delayed(Duration.zero);
+          cubit.add(
+            const ConversationReactionToggled(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '❤️',
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (cubit) {
+          expect(
+            cubit.state.reactionsFor(_msgId).any((r) => r.isOwn),
+            isFalse,
+          );
+          verify(
+            () => repo.removeOwn(
+              rumorId: 'own-❤️',
+              targetMessageAuthor: _peer,
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'set with a different emoji optimistically swaps the chip',
+        build: () {
+          when(
+            () => repo.publish(
+              conversationId: any(named: 'conversationId'),
+              targetMessageId: any(named: 'targetMessageId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              emoji: any(named: 'emoji'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                const DmReactionPublishResult(success: true, rumorId: 'r-new'),
+          );
+          return ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          );
+        },
+        act: (cubit) async {
+          cubit.add(const ConversationReactionsStarted(conversationId: _convo));
+          await Future<void>.delayed(Duration.zero);
+          streamController.add([ownReaction('❤️')]);
+          await Future<void>.delayed(Duration.zero);
+          cubit.add(
+            const ConversationReactionSet(
+              conversationId: _convo,
+              messageId: _msgId,
+              messageAuthorPubkey: _peer,
+              emoji: '😂',
+            ),
+          );
+          await Future<void>.delayed(Duration.zero);
+        },
+        verify: (cubit) {
+          final emojis = cubit.state
+              .reactionsFor(_msgId)
+              .where((r) => r.isOwn)
+              .map((r) => r.emoji)
+              .toSet();
+          expect(emojis, contains('😂'));
+          expect(emojis, isNot(contains('❤️')));
+        },
+      );
+
+      blocTest<ConversationReactionsCubit, ConversationReactionsState>(
+        'drops the optimistic add when the insert never persisted',
+        build: () {
+          when(
+            () => repo.publish(
+              conversationId: any(named: 'conversationId'),
+              targetMessageId: any(named: 'targetMessageId'),
+              targetMessageAuthor: any(named: 'targetMessageAuthor'),
+              emoji: any(named: 'emoji'),
+            ),
+          ).thenAnswer(
+            (_) async => const DmReactionPublishResult(
+              success: false,
+              rumorId: 'r-x',
+              errorMessage: 'Optimistic insert failed',
+            ),
+          );
+          return ConversationReactionsCubit(
+            reactionsRepository: repo,
+            ownerPubkey: _owner,
+          );
+        },
+        act: (cubit) => cubit.add(
+          const ConversationReactionToggled(
+            conversationId: _convo,
+            messageId: _msgId,
+            messageAuthorPubkey: _peer,
+            emoji: '🔥',
+          ),
+        ),
+        verify: (cubit) {
+          expect(cubit.state.optimistic, isEmpty);
+          expect(cubit.state.reactionsFor(_msgId), isEmpty);
+          expect(
+            cubit.state.pending[const ReactionPublishKey(
+              messageId: _msgId,
+              emoji: '🔥',
+            )],
+            ReactionPublishLocalStatus.failed,
+          );
+        },
+      );
+    });
   });
 }

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -201,5 +201,40 @@ void main() {
       // The sheet (re-providing the same cubit via contentWrapper) is shown.
       expect(find.text(l10n.dmReactionsSheetTitle), findsOneWidget);
     });
+
+    testWidgets(
+      'renders the own optimistic pill with NO persisted rows (#5389)',
+      (tester) async {
+        // No persisted reactions; the chip exists only because of the
+        // synchronous optimistic overlay — i.e. before any Drift round-trip.
+        final state = ConversationReactionsState(
+          optimistic: {
+            const ReactionPublishKey(
+              messageId: messageId,
+              emoji: '🔥',
+            ): OptimisticReactionAdded(
+              makeReaction(
+                id: 'optimistic:$messageId:🔥',
+                reactorPubkey: ownerPubkey,
+                emoji: '🔥',
+                publishStatus: DmReactionPublishStatus.pending,
+              ),
+            ),
+          },
+        );
+        when(() => cubit.state).thenReturn(state);
+        whenListen(cubit, Stream.value(state), initialState: state);
+
+        await tester.pumpWidget(buildSubject(cubit));
+        await tester.pump();
+
+        expect(find.text('🔥'), findsOneWidget);
+        expect(find.byType(UserAvatar), findsOneWidget);
+        expect(
+          find.bySemanticsLabel(l10n.dmReactionsViewA11yLabel),
+          findsOneWidget,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Description

In a chat, tapping a reaction on a shared video showed **no chip until a fully-local Drift round-trip finished** (`getOwnLiveReaction` SELECT → `insertOptimistic` INSERT → `watchForConversation` watch re-emit). That round-trip now crosses a background isolate (#5395) and SQLCipher (#4981), so on low-end devices (the reporter's Galaxy S10) the chip appeared perceptibly late. The in-player reel reaction bar already showed a synchronous optimistic emoji; the in-chat bubble never got parity.

This adds a **cubit-owned optimistic overlay** that paints the chip on the *same frame as the tap* — for add, toggle-off, and supersede — then reconciles against the next Drift stream tick by `(messageId, emoji, owner)`.

**How it works (BLoC-only):**
- `OptimisticReactionIntent` (sealed: `Added(synthetic DmReaction)` / `Removed`) is held in `ConversationReactionsState.optimistic`.
- `reactionsFor(messageId)` — the render-path getter — merges the overlay on top of the persisted rows, with a **fast path that returns the persisted list by reference** when no overlay touches that message, preserving `identical()`-based `buildWhen` guards. The chip widgets (`ReactionsRow`, `PerPersonReactionsRow`) are **unchanged**: a synthetic `DmReaction(publishStatus: pending)` flows through the existing pending-chip path.
- `reactionsByMessageId` stays raw-persisted, so the in-player reel bar's reads are untouched.
- Failure paths preserve the existing `pending = failed` retry affordance; an insert-failure (no persisted row) drops the overlay so it can't linger as a never-settling placeholder.

Root cause was investigated to 1.0 on the causal claim (in-chat chips were structurally non-optimistic; signing/relay/Keycast/funnelcake all ruled out of the chip-appearance path). The absolute on-device latency is now moot since tap→chip is synchronous.

**Related Issue:** Closes #5389

## Out of Scope

Two separate "feels laggy / smooth animations" facets, deliberately split to follow-ups:
- Picker friction (long-press → modal bottom-sheet open).
- The in-player flying `ReactionOverlay` jank (Surface-B-only: no `RepaintBoundary`, per-frame relayout of 6 emoji over a playing video).

Also removed a now-dead `ReactionPublishLocalStatus.succeeded` enum value (its only use was a set-then-remove dance this change replaced).

## Verification

- `flutter analyze lib test integration_test` → No issues.
- New tests (6): synchronous chip presence *before the publish future resolves*, reconcile-on-tick (no dupe), toggle-off hide, supersede swap, insert-failure cleanup, and the group per-person surface. The `reactions_row` "renders the own optimistic chip with NO persisted rows" test is the one that would have caught this bug.
- 340 DM-bloc + inbox-conversation tests pass; in-player reel bar (Surface B) test passes.
- `dart format` clean; pre-commit + pre-push hooks green.
- Rebased onto fresh `origin/main` (conflict-free; no file overlap with the incoming #5412).

> Note: this is a timing/perf change with no static visual delta, so there's no before/after screenshot. Best validated by tapping a reaction in a chat on a low-end Android and observing the chip appear instantly. Happy to attach a screen recording from a device if useful.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)