### PR TITLE
test(perf): trace remote-signer DM backfill main-isolate cost + frames (#5413)

### DIFF
--- a/mobile/integration_test/perf/dm_remote_signer_backfill_cost_test.dart
+++ b/mobile/integration_test/perf/dm_remote_signer_backfill_cost_test.dart
@@ -1,0 +1,264 @@
+// ABOUTME: #5413 — measures the MAIN-ISOLATE CPU a large remote-signer DM
+// ABOUTME: backfill imposes per gift wrap (event validation) and per Drift
+// ABOUTME: emission (conversation-list projection), on real device hardware.
+//
+// Context: a remote signer (Keycast NIP-46 / Amber NIP-55) takes the per-event
+// decrypt path (the batch fast-path does not cover it). The symmetric decrypt
+// itself runs OFF the main isolate (network RPC / IPC), but `getRumorEvent`
+// runs 2x Event.isValid (sha256) + 2x Event.isSigned (Schnorr verify) per wrap
+// ON the main isolate, and `ConversationListBloc` re-runs an un-throttled
+// projection (mergeAndSort + classifyPotentialRequests) per persisted wrap.
+// This test puts a real device-CPU number on both, so we can reason about the
+// per-frame budget (8.33ms @120Hz / 16.67ms @60Hz) and the WS3 yield interval
+// of 16 wraps. See tasks/findings_5413.md (E1, E3) and PR #5405/#5412/#5417.
+//
+// This is the CPU half of the trace. The frame build/raster half is in
+// dm_remote_signer_backfill_frame_test.dart.
+
+import 'dart:convert';
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:models/models.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+
+String _randomBase64(Random rng, int bytes) {
+  final b = List<int>.generate(bytes, (_) => rng.nextInt(256));
+  return base64.encode(b);
+}
+
+/// Builds a real signed event whose `content` is a realistic NIP-44-ciphertext-
+/// sized base64 blob, so `isValid` (sha256 over the serialized event) and
+/// `isSigned` (Schnorr verify over the 32-byte id) cost what they cost in the
+/// real gift-wrap / seal validation.
+Event _signedEvent(Random rng, int kind, int contentBytes) {
+  final priv = generatePrivateKey();
+  final pub = getPublicKey(priv);
+  final e = Event(pub, kind, const [], _randomBase64(rng, contentBytes));
+  e.sign(priv);
+  return e;
+}
+
+DmConversation _conversation(Random rng, int i, {required bool group}) {
+  final me = 'a' * 64;
+  final peer = i.toRadixString(16).padLeft(64, '0');
+  return DmConversation(
+    id: 'conv_$i',
+    participantPubkeys: group ? [me, peer, '${'b' * 63}c'] : [me, peer],
+    isGroup: group,
+    createdAt: 1700000000 + i,
+    lastMessageContent: _randomBase64(rng, 24),
+    lastMessageTimestamp: 1700000000 + i * 7,
+    lastMessageSenderPubkey: peer,
+  );
+}
+
+double _median(List<int> micros) {
+  final s = [...micros]..sort();
+  return s[s.length ~/ 2] / 1000.0; // ms
+}
+
+double _p99(List<int> micros) {
+  final s = [...micros]..sort();
+  return s[(s.length * 0.99).floor().clamp(0, s.length - 1)] / 1000.0;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    '#5413 remote-signer backfill: main-isolate CPU per wrap + per emission',
+    () async {
+      final rng = Random(5413);
+
+      // Refresh rate / frame budget for the device under test.
+      final view = PlatformDispatcher.instance.views.first;
+      final refreshHz = view.display.refreshRate;
+      final frameBudgetMs = refreshHz > 0 ? 1000.0 / refreshHz : 16.67;
+
+      // --- Component 1: per-wrap main-isolate VALIDATION cost (H1b) ---
+      // Two nested events per wrap: outer gift wrap (kind 1059, ~encrypted seal)
+      // and seal (kind 13, ~encrypted rumor). getRumorEvent validates BOTH:
+      // isValid (sha256) + isSigned (Schnorr verify) on each.
+      const wrapCount = 400;
+      final outers = [
+        for (var i = 0; i < wrapCount; i++)
+          _signedEvent(rng, EventKind.giftWrap, 900),
+      ];
+      final seals = [
+        for (var i = 0; i < wrapCount; i++)
+          _signedEvent(rng, EventKind.sealEventKind, 600),
+      ];
+
+      // perWrap = both nested validations (reference total). The TRUE per-frame
+      // risk, though, is the largest CONTIGUOUS main-isolate burst between two
+      // off-isolate awaits: in getRumorEvent that is ONE isValid (sha256) + ONE
+      // isSigned (Schnorr verify) — the outer verify runs, an awaited
+      // nip44Decrypt RPC yields the loop, THEN the seal verify runs. A single
+      // frame never sees both verifies.
+      final perWrapMicros = <int>[];
+      final perBurstMicros = <int>[];
+      final singleVerifyMicros = <int>[];
+      final singleSha256Micros = <int>[];
+      final sw = Stopwatch();
+      for (var i = 0; i < wrapCount; i++) {
+        sw
+          ..reset()
+          ..start();
+        final ok =
+            outers[i].isValid &&
+            outers[i].isSigned &&
+            seals[i].isValid &&
+            seals[i].isSigned;
+        sw.stop();
+        expect(ok, isTrue, reason: 'generated events must self-validate');
+        perWrapMicros.add(sw.elapsedMicroseconds);
+
+        sw
+          ..reset()
+          ..start();
+        final v = outers[i].isValid;
+        sw.stop();
+        expect(v, isTrue);
+        singleSha256Micros.add(sw.elapsedMicroseconds);
+
+        sw
+          ..reset()
+          ..start();
+        final s = outers[i].isSigned;
+        sw.stop();
+        expect(s, isTrue);
+        singleVerifyMicros.add(sw.elapsedMicroseconds);
+
+        sw
+          ..reset()
+          ..start();
+        final b = seals[i].isValid && seals[i].isSigned;
+        sw.stop();
+        expect(b, isTrue);
+        perBurstMicros.add(sw.elapsedMicroseconds);
+      }
+
+      // --- Component 2: per-emission projection cost (H2) ---
+      // ConversationListBloc re-runs mergeAndSort + classifyPotentialRequests on
+      // every Drift emission (~once per persisted wrap). watchPotentialRequests
+      // is UNPAGINATED, so after a reinstall N grows toward the full history.
+      final projectionByN = <int, ({double median, double p99})>{};
+      bool isFollowing(String _) => false; // worst case: nothing followed
+      for (final n in const [200, 500, 1000]) {
+        final accepted = [
+          for (var i = 0; i < (n * 0.1).round(); i++)
+            _conversation(rng, i, group: false),
+        ];
+        final potential = [
+          for (var i = 0; i < n; i++)
+            _conversation(rng, 100000 + i, group: i % 25 == 0),
+        ];
+        final micros = <int>[];
+        for (var rep = 0; rep < 50; rep++) {
+          sw
+            ..reset()
+            ..start();
+          final split = DmRepository.classifyPotentialRequests(
+            potential,
+            userPubkey: 'a' * 64,
+            isFollowing: isFollowing,
+          );
+          DmRepository.mergeAndSort(accepted, split.followed);
+          sw.stop();
+          micros.add(sw.elapsedMicroseconds);
+        }
+        projectionByN[n] = (median: _median(micros), p99: _p99(micros));
+      }
+
+      final perWrapMedian = _median(perWrapMicros);
+      final perWrapP99 = _p99(perWrapMicros);
+      final verifyMedian = _median(singleVerifyMicros);
+      final verifyP99 = _p99(singleVerifyMicros);
+      final sha256Median = _median(singleSha256Micros);
+      final burstMedian = _median(perBurstMicros);
+      final burstP99 = _p99(perBurstMicros);
+      // The realistic per-frame main-isolate cost: one inter-await burst
+      // (1 verify + 1 sha256) + one projection recompute at the largest N.
+      final worstProjectionMs = projectionByN[1000]!.p99;
+      final perFrameP99 = burstP99 + worstProjectionMs;
+
+      final summary = StringBuffer()
+        ..writeln(
+          '================ #5413 BACKFILL MAIN-ISOLATE COST ================',
+        )
+        ..writeln(
+          'device refreshRate=${refreshHz.toStringAsFixed(1)}Hz '
+          'frameBudget=${frameBudgetMs.toStringAsFixed(2)}ms',
+        )
+        ..writeln(
+          'single Schnorr verify (isSigned): '
+          'median=${verifyMedian.toStringAsFixed(3)}ms '
+          'p99=${verifyP99.toStringAsFixed(3)}ms',
+        )
+        ..writeln(
+          'single sha256 (isValid): '
+          'median=${sha256Median.toStringAsFixed(3)}ms',
+        )
+        ..writeln(
+          'full per-wrap validation (2x verify + 2x sha256): '
+          'median=${perWrapMedian.toStringAsFixed(3)}ms '
+          'p99=${perWrapP99.toStringAsFixed(3)}ms',
+        )
+        ..writeln('projection (classify+mergeAndSort) per emission:');
+      for (final n in const [200, 500, 1000]) {
+        final p = projectionByN[n]!;
+        summary.writeln(
+          '  N=$n: median=${p.median.toStringAsFixed(3)}ms '
+          'p99=${p.p99.toStringAsFixed(3)}ms',
+        );
+      }
+      summary
+        ..writeln(
+          'REALISTIC per-frame main-isolate cost (the decision metric):',
+        )
+        ..writeln(
+          '  one inter-await burst (1 verify + 1 sha256), p99 = '
+          '${burstP99.toStringAsFixed(2)}ms (median '
+          '${burstMedian.toStringAsFixed(2)}ms)',
+        )
+        ..writeln(
+          '  + projection @N=1000 (p99) = '
+          '${worstProjectionMs.toStringAsFixed(2)}ms',
+        )
+        ..writeln(
+          '  = ${perFrameP99.toStringAsFixed(2)}ms vs budget '
+          '${frameBudgetMs.toStringAsFixed(2)}ms '
+          '(${perFrameP99 <= frameBudgetMs ? "WITHIN" : "OVER"})',
+        )
+        ..writeln(
+          'WHY one burst, not 16: getRumorEvent splits the two verifies with an '
+          'awaited off-isolate nip44Decrypt RPC (~235ms observed), and the WS3 '
+          'yield fires every 16 wraps — so verifies never accumulate within a '
+          'frame. The Schnorr verify, not the projection (~0.06ms), is the '
+          'dominant main-isolate cost. Numbers are for THIS device class; a '
+          'low-end Android verify is materially slower (extrapolate up).',
+        )
+        ..writeln(
+          '=================================================================',
+        );
+      // ignore: avoid_print
+      print(summary);
+
+      // The realistic per-frame unit (one inter-await burst) must fit a frame
+      // on this device class. (We report, not gate, the low-end extrapolation.)
+      expect(
+        burstP99,
+        lessThan(frameBudgetMs),
+        reason:
+            'one inter-await validation burst must fit the frame budget '
+            'on this device class',
+      );
+    },
+  );
+}

--- a/mobile/integration_test/perf/dm_remote_signer_backfill_frame_test.dart
+++ b/mobile/integration_test/perf/dm_remote_signer_backfill_frame_test.dart
@@ -1,0 +1,297 @@
+// ABOUTME: #5413 — captures real frame build/raster times while a large
+// ABOUTME: remote-signer DM backfill runs the per-event path concurrently,
+// ABOUTME: proving the visible UI stays within frame budget (no sustained jank).
+//
+// A continuously-animating canary widget stands in for the active Notifications
+// tab (the surface the user watches while the drain runs). During
+// `watchPerformance`, a backfill loop reproduces the REAL main-isolate work the
+// remote per-event path does — for each wrap: one Event validation burst
+// (sha256 + Schnorr verify), an awaited off-isolate decrypt RPC (emulated as a
+// delay, since Keycast=network / Amber=IPC), a second validation burst, a
+// second awaited RPC, an un-throttled ConversationListBloc-style projection,
+// and the WS3 yield every 16 wraps. If that main-isolate work starves frame
+// rendering, the canary drops frames and the summary shows it.
+//
+// Two latencies: realistic (~235ms, observed for remote nip44_decrypt) and a
+// fast stress (~10ms, Keycast-HTTP-like, where bursts arrive far more often).
+// See tasks/findings_5413.md and the CPU half in
+// dm_remote_signer_backfill_cost_test.dart.
+
+import 'dart:convert';
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:models/models.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+
+const int _drainYieldInterval = 16;
+
+String _randomBase64(Random rng, int bytes) =>
+    base64.encode(List<int>.generate(bytes, (_) => rng.nextInt(256)));
+
+Event _signedEvent(Random rng, int kind, int contentBytes) {
+  final priv = generatePrivateKey();
+  final e = Event(
+    getPublicKey(priv),
+    kind,
+    const [],
+    _randomBase64(rng, contentBytes),
+  );
+  e.sign(priv);
+  return e;
+}
+
+DmConversation _conversation(Random rng, int i) {
+  return DmConversation(
+    id: 'conv_$i',
+    participantPubkeys: ['a' * 64, i.toRadixString(16).padLeft(64, '0')],
+    isGroup: false,
+    createdAt: 1700000000 + i,
+    lastMessageContent: _randomBase64(rng, 24),
+    lastMessageTimestamp: 1700000000 + i * 7,
+    lastMessageSenderPubkey: i.toRadixString(16).padLeft(64, '0'),
+  );
+}
+
+/// Reproduces the main-isolate work of one remote-signer gift-wrap drain step:
+/// validate outer (burst) -> await off-isolate decrypt -> validate seal (burst)
+/// -> await off-isolate decrypt -> project. Mirrors getRumorEvent +
+/// ConversationListBloc.onData. Yields every [_drainYieldInterval] wraps (WS3).
+Future<void> _runBackfill({
+  required Random rng,
+  required int wraps,
+  required Duration decryptLatency,
+  required List<DmConversation> potential,
+}) async {
+  bool isFollowing(String _) => false;
+  for (var i = 0; i < wraps; i++) {
+    final outer = _signedEvent(rng, EventKind.giftWrap, 900);
+    final seal = _signedEvent(rng, EventKind.sealEventKind, 600);
+
+    // Burst 1: outer validation (sha256 + Schnorr verify) on the main isolate.
+    if (!(outer.isValid && outer.isSigned)) {
+      throw StateError('outer self-validate failed');
+    }
+    // Off-isolate decrypt RPC (Keycast network / Amber IPC) — frames render.
+    await Future<void>.delayed(decryptLatency);
+
+    // Burst 2: seal validation on the main isolate.
+    if (!(seal.isValid && seal.isSigned)) {
+      throw StateError('seal self-validate failed');
+    }
+    await Future<void>.delayed(decryptLatency);
+
+    // Per-emission projection (un-throttled ConversationListBloc recompute).
+    final visible = potential.sublist(0, min(potential.length, (i + 1) * 3));
+    final split = DmRepository.classifyPotentialRequests(
+      visible,
+      userPubkey: 'a' * 64,
+      isFollowing: isFollowing,
+    );
+    DmRepository.mergeAndSort(const [], split.followed);
+
+    // WS3 yield.
+    if ((i + 1) % _drainYieldInterval == 0) {
+      await Future<void>.delayed(Duration.zero);
+    }
+  }
+}
+
+/// Always-animating canary: forces a build + repaint every frame, like the
+/// active Notifications tab the user is watching while the drain runs.
+class _Canary extends StatefulWidget {
+  const _Canary();
+  @override
+  State<_Canary> createState() => _CanaryState();
+}
+
+class _CanaryState extends State<_Canary> with SingleTickerProviderStateMixin {
+  late final AnimationController _c = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 900),
+  )..repeat();
+
+  @override
+  void dispose() {
+    _c.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: Scaffold(
+        backgroundColor: Colors.black,
+        body: AnimatedBuilder(
+          animation: _c,
+          builder: (context, _) {
+            return ListView.builder(
+              itemCount: 40,
+              itemBuilder: (context, i) => Opacity(
+                opacity: 0.3 + 0.7 * ((_c.value + i / 40) % 1.0),
+                child: Container(
+                  height: 56,
+                  margin: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 4,
+                  ),
+                  color: Color.lerp(
+                    Colors.indigo,
+                    Colors.teal,
+                    (_c.value + i / 40) % 1.0,
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('#5413 frame build/raster during a remote-signer backfill', (
+    tester,
+  ) async {
+    final rng = Random(5413);
+    final view = PlatformDispatcher.instance.views.first;
+    final refreshHz = view.display.refreshRate;
+    final frameBudgetMs = refreshHz > 0 ? 1000.0 / refreshHz : 16.67;
+
+    final potential = [for (var i = 0; i < 1000; i++) _conversation(rng, i)];
+
+    // Free-run frames in real time so the canary animation renders continuously
+    // and any concurrent main-isolate work shows up as delayed/janky frames.
+    binding.framePolicy = LiveTestWidgetsFlutterBindingFramePolicy.fullyLive;
+
+    await tester.pumpWidget(const _Canary());
+    await tester.pump(const Duration(milliseconds: 16));
+
+    final report = StringBuffer()
+      ..writeln('================ #5413 BACKFILL FRAME TRACE ================')
+      ..writeln(
+        'device refreshRate=${refreshHz.toStringAsFixed(1)}Hz '
+        'frameBudget=${frameBudgetMs.toStringAsFixed(2)}ms',
+      );
+
+    final overBudgetByLabel = <String, int>{};
+    final frameCountByLabel = <String, int>{};
+
+    Future<void> measure(
+      String label, {
+      required Future<void> Function() action,
+    }) async {
+      final raw = <FrameTiming>[];
+      void cb(List<FrameTiming> t) => raw.addAll(t);
+      binding.addTimingsCallback(cb);
+      // With fullyLive frame policy + a repeating animation, frames free-run in
+      // real time during this await, so a concurrent main-isolate backfill
+      // burst genuinely competes for the UI thread (watchPerformance hangs on a
+      // passive await — it needs an action that itself drives frames).
+      await action();
+      // FrameTimings are flushed by the engine ~once/sec — drain the tail.
+      await Future<void>.delayed(const Duration(seconds: 2));
+      binding.removeTimingsCallback(cb);
+
+      double ms(int micros) => micros / 1000.0;
+      final build = raw.map((t) => ms(t.buildDuration.inMicroseconds)).toList()
+        ..sort();
+      final raster =
+          raw.map((t) => ms(t.rasterDuration.inMicroseconds)).toList()..sort();
+      double p(List<double> xs, double q) =>
+          xs.isEmpty ? 0 : xs[(xs.length * q).floor().clamp(0, xs.length - 1)];
+      final jankyBuild = build.where((d) => d > frameBudgetMs).length;
+      final jankyRaster = raster.where((d) => d > frameBudgetMs).length;
+      overBudgetByLabel[label] = jankyBuild + jankyRaster;
+      frameCountByLabel[label] = raw.length;
+
+      report
+        ..writeln('--- $label (${raw.length} frames) ---')
+        ..writeln(
+          '  build  p50=${p(build, 0.5).toStringAsFixed(2)} '
+          'p90=${p(build, 0.9).toStringAsFixed(2)} '
+          'p99=${p(build, 0.99).toStringAsFixed(2)} '
+          'max=${(build.isEmpty ? 0 : build.last).toStringAsFixed(2)}ms',
+        )
+        ..writeln(
+          '  raster p50=${p(raster, 0.5).toStringAsFixed(2)} '
+          'p90=${p(raster, 0.9).toStringAsFixed(2)} '
+          'p99=${p(raster, 0.99).toStringAsFixed(2)} '
+          'max=${(raster.isEmpty ? 0 : raster.last).toStringAsFixed(2)}ms',
+        )
+        ..writeln(
+          '  over-budget frames: build=$jankyBuild raster=$jankyRaster '
+          '(budget ${frameBudgetMs.toStringAsFixed(2)}ms)',
+        );
+    }
+
+    // Baseline: animation only, no backfill.
+    await measure(
+      'baseline',
+      action: () async {
+        await Future<void>.delayed(const Duration(seconds: 3));
+      },
+    );
+
+    // Realistic remote latency (~235ms): the common Keycast NIP-46 / Amber case.
+    await measure(
+      'backfill_realistic_235ms',
+      action: () async {
+        await _runBackfill(
+          rng: rng,
+          wraps: 40,
+          decryptLatency: const Duration(milliseconds: 235),
+          potential: potential,
+        );
+      },
+    );
+
+    // Fast stress (~10ms): Keycast-HTTP-like, bursts arrive ~20x more often.
+    await measure(
+      'backfill_fast_10ms',
+      action: () async {
+        await _runBackfill(
+          rng: rng,
+          wraps: 300,
+          decryptLatency: const Duration(milliseconds: 10),
+          potential: potential,
+        );
+      },
+    );
+
+    report.writeln(
+      '===========================================================',
+    );
+    // ignore: avoid_print
+    print(report);
+
+    // The backfill windows must render real frames and stay within budget. The
+    // observed result is 0 over-budget frames; allow a small slack for harness
+    // noise. (The idle baseline's startup frame is intentionally excluded.)
+    for (final label in const [
+      'backfill_realistic_235ms',
+      'backfill_fast_10ms',
+    ]) {
+      expect(
+        frameCountByLabel[label],
+        greaterThan(50),
+        reason: '$label must actually render frames during the backfill',
+      );
+      expect(
+        overBudgetByLabel[label],
+        lessThanOrEqualTo(3),
+        reason: '$label must not produce sustained over-budget frames',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Description

The empirical half of hm21's review of #5405 (the #5391 perf effort): does a large **remote-signer**
(Keycast NIP-46 / Amber NIP-55) DM history backfill keep the inbox within frame budget on the
**per-event decrypt path** the batched fast-path does not cover? The CI yield-guard landed in #5417;
this adds the on-device frame + CPU measurement.

Two integration tests under `mobile/integration_test/perf/` (no production code touched):

- **`dm_remote_signer_backfill_cost_test.dart`** — measures the main-isolate CPU the per-event path
  imposes: `getRumorEvent`'s per-wrap validation (2× `Event.isValid` sha256 + 2× `isSigned` Schnorr
  verify) and the `ConversationListBloc` projection (`mergeAndSort` + `classifyPotentialRequests`).
- **`dm_remote_signer_backfill_frame_test.dart`** — captures real build/raster (`fullyLive` frame
  policy + a free-running canary UI) while a faithful backfill runs concurrently: real validation
  bursts + emulated off-isolate decrypt latency + projection + the WS3 yield, at 235 ms and 10 ms
  decrypt latencies.

### Results

**Real iPhone (A19 Pro, iOS 26.5.1, 120 Hz → 8.33 ms budget):**
- one inter-await burst (1 verify + 1 sha256) + projection = **7.10 ms p99 → within the 8.33 ms budget**
- projection alone @ N=1000: **0.07 ms** — the Schnorr verify, not the projection, is the cost
- frame trace: realistic backfill **1 over-budget frame / 2525** (same rate as the idle baseline);
  fast 10 ms stress **0 / 1432**

**iOS simulator (60 Hz → 16.67 ms budget):** per-frame 5.97 ms; 0 over-budget frames in both windows.

**Conclusion: no sustained jank.** The two verifies per wrap never share a frame — `getRumorEvent`
splits them with the off-isolate `nip44Decrypt` RPC, and the WS3 yield fires every 16 wraps, so the
longest the UI thread is held is one verify.

## Out of Scope

- The literal real-account DevTools trace (a manual run on a real Keycast/Amber account) — these tests
  reproduce the heaviest case faithfully without one.
- Moving the remote-path validation off the main isolate / dropping the redundant drain-time verify:
  the 120 Hz headroom is thin (one verify ≈ 85% of the frame budget), so this is worth a follow-up.
  Tracked separately; no production code is changed here.

## Verification

- `flutter analyze integration_test/perf/...` — No issues found.
- `flutter test integration_test/perf/dm_remote_signer_backfill_cost_test.dart` — passed on iOS sim + real iPhone.
- `flutter test integration_test/perf/dm_remote_signer_backfill_frame_test.dart` — passed on iOS sim + real iPhone.

## Type of Change

- [x] 🗑️ Chore (on-device perf measurement / test coverage; no production code change)

**Related Issue:** Relates to #5413
