### PR TITLE
perf(dm): decrypt remote-signer history drain in parallel

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -103,6 +103,19 @@ abstract class DmHistoryDrainConfig {
   /// backfill loops, so a large drain cannot starve frame rendering. See
   /// #5391.
   static const int drainYieldInterval = 16;
+
+  /// Remote-signer (Keycast RPC / Amber / NIP-46) gift-wrap decrypts kept in
+  /// flight at once during the history drain.
+  ///
+  /// Remote signers cannot cross the [compute] isolate boundary, so each wrap
+  /// is decrypted by a network round trip to the signer (~250-400 ms each, two
+  /// per wrap: gift→seal, seal→rumor). Draining a large history one RPC at a
+  /// time serializes those into minutes. A bounded worker pool keeps several in
+  /// flight, collapsing the wall-clock to roughly 1/N. Held under Keycast's
+  /// per-connection DB pool (default 10) so parallel calls don't contend, and
+  /// only *decryption* is parallelized — persistence stays serialized under the
+  /// event lock. Local-key signers are unaffected (they use the batch isolate).
+  static const int remoteDecryptConcurrency = 8;
 }
 
 const _relayLoopbackHosts = <String>{
@@ -1327,9 +1340,13 @@ class DmRepository {
   Future<Map<String, Event>> _batchDecryptGiftWraps(List<Event> events) async {
     final isolate = _drainDecryptIsolate;
     if (isolate == null) {
-      // Remote / test signer, or the drain isolate could not spawn: there is
-      // no batch worker, so route everything through the per-event path.
-      return const {};
+      // Remote signer (Keycast RPC / Amber / NIP-46), or the drain isolate
+      // could not spawn: there is no batch worker. Rather than serialize one
+      // network decrypt at a time on the _eventLock, decrypt this page with a
+      // bounded worker pool OFF the lock — persistence still serializes in the
+      // caller. This is the difference between a multi-minute and a few-second
+      // drain for remote-signer accounts.
+      return _parallelDecryptGiftWraps(events);
     }
 
     // Only wraps not already persisted, to avoid re-decrypting on resume
@@ -1378,6 +1395,92 @@ class DmRepository {
       // backfill cannot starve frame rendering. See #5391.
       await _yieldToEventLoop();
     }
+    return decrypted;
+  }
+
+  /// Decrypts a page's gift wraps for a REMOTE signer (Keycast RPC / Amber /
+  /// NIP-46) using a bounded worker pool, OFF the [_eventLock].
+  ///
+  /// Remote signers cannot cross the [compute] isolate boundary, so each wrap
+  /// is decrypted by a network round trip to the signer. Doing that one wrap at
+  /// a time — the previous behaviour, where every wrap fell through to the
+  /// serial per-event path under the lock — serializes hundreds of ~250-400 ms
+  /// RPCs into a multi-minute drain. Keeping
+  /// [DmHistoryDrainConfig.remoteDecryptConcurrency] decrypts in flight
+  /// collapses the wall-clock to roughly 1/N; the Keycast server does not
+  /// serialize per-token decrypts, so the concurrency is real.
+  ///
+  /// Returns a `{giftWrapId: rumor}` map of the SUCCESSFUL decrypts only, with
+  /// the same contract as [_batchDecryptGiftWraps]: wraps that are already
+  /// persisted, undecryptable, or fail are absent and fall through to the
+  /// per-event path in the caller (which preserves failed-decrypt bookkeeping
+  /// for the retry queue, see #5202). Only *decryption* is parallelized here —
+  /// the caller persists each result serially under the [_eventLock], so
+  /// dedup and transaction integrity are unchanged.
+  Future<Map<String, Event>> _parallelDecryptGiftWraps(
+    List<Event> events,
+  ) async {
+    final signer = _signer;
+    if (signer == null) return const {};
+
+    // Probe the dedup index before paying any network decrypt, so a resume
+    // drain over already-persisted history costs DB reads, not RPCs. The
+    // in-transaction hasGiftWrap re-check in the caller still guards races.
+    final pending = <Event>[];
+    for (final event in events) {
+      if (event.kind != EventKind.giftWrap) continue;
+      if (await _directMessagesDao.hasGiftWrap(event.id)) continue;
+      pending.add(event);
+    }
+    if (pending.isEmpty) return const {};
+    if (_disposed) return const {};
+
+    // One signer handle shared across the pool: the public key is refreshed
+    // once up front and the workers only read it. Each decrypt is independent
+    // (pubkey + ciphertext in, plaintext out), so sharing is safe on a single
+    // isolate.
+    final nostr = Nostr(signer, [], _dummyRelay);
+    await nostr.refreshPublicKey();
+
+    final decrypted = <String, Event>{};
+    var next = 0;
+
+    Future<void> worker() async {
+      while (true) {
+        if (_disposed) return;
+        // Read-then-increment with no await in between, so two workers never
+        // claim the same index on a single isolate.
+        final index = next;
+        if (index >= pending.length) return;
+        next = index + 1;
+        final event = pending[index];
+        try {
+          final rumor = await _decryptRumor(nostr, event);
+          if (rumor != null) decrypted[event.id] = rumor;
+        } on Object catch (e, stackTrace) {
+          // Leave the wrap out of the map so it falls through to the per-event
+          // path, which records the failed decrypt for the retry queue. See
+          // #5202.
+          Log.error(
+            'Parallel gift-wrap decrypt threw for ${event.id}: $e',
+            category: LogCategory.system,
+            error: e,
+            stackTrace: stackTrace,
+          );
+        }
+        // Hand back a real event-loop turn between decrypts so the backfill
+        // cannot starve frame rendering — a real remote RPC await yields
+        // anyway, but a fast/synthetic signer would otherwise drain a whole
+        // page in one microtask burst. See #5391.
+        await _yieldToEventLoop();
+      }
+    }
+
+    final workerCount =
+        pending.length < DmHistoryDrainConfig.remoteDecryptConcurrency
+        ? pending.length
+        : DmHistoryDrainConfig.remoteDecryptConcurrency;
+    await Future.wait([for (var i = 0; i < workerCount; i++) worker()]);
     return decrypted;
   }
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -1352,6 +1352,187 @@ void main() {
         await repository.stopListening();
       });
 
+      test(
+        'history drain decrypts a remote-signer page with bounded '
+        'parallelism while persisting serially',
+        () async {
+          // Remote signers (Keycast RPC / Amber / NIP-46) cannot use the batch
+          // decrypt isolate, so before this fix every drained wrap was
+          // decrypted one network round trip at a time under the event lock —
+          // a multi-minute drain for a large history. The drain must now keep
+          // up to DmHistoryDrainConfig.remoteDecryptConcurrency decrypts in
+          // flight, while persistence stays serialized under the lock.
+          const wrapCount = 16;
+
+          String hex64(int seed, String tag) =>
+              (tag * 64).substring(0, 62) +
+              seed.toRadixString(16).padLeft(2, '0');
+
+          final wraps = <Event>[
+            for (var i = 0; i < wrapCount; i++)
+              Event.fromJson({
+                'id': hex64(i, 'a'),
+                'pubkey': hex64(i, 'b'),
+                'created_at': 1700000000 - i,
+                'kind': EventKind.giftWrap,
+                'tags': [
+                  ['p', _validPubkeyA],
+                ],
+                'content': 'wrap-$i',
+                'sig': '',
+              }),
+          ];
+
+          // Each wrap decrypts to a distinct rumor (distinct sender → distinct
+          // conversation) so every wrap produces its own persisted message.
+          Event rumorFor(Event wrap) {
+            final i = wraps.indexOf(wrap);
+            return Event.fromJson({
+              'id': hex64(i, 'c'),
+              'pubkey': hex64(i, 'd'),
+              'created_at': 1700000000 - i,
+              'kind': EventKind.privateDirectMessage,
+              'tags': [
+                ['p', _validPubkeyA],
+              ],
+              'content': 'msg-$i',
+              'sig': '',
+            });
+          }
+
+          // The bounded pool launches all its workers up front, so every
+          // concurrent decrypt increments `active` before the first delay
+          // resolves → maxActive is deterministic.
+          var activeDecrypts = 0;
+          var maxActiveDecrypts = 0;
+
+          // Persistence runs under the event lock, so runInTransaction must
+          // never overlap.
+          var activePersists = 0;
+          var maxActivePersists = 0;
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(any()),
+          ).thenAnswer((_) async => false);
+          stubDaoInserts();
+          // Track persist concurrency on the actual write inside the
+          // transaction. Persists run under the event lock, so a yield here
+          // would expose any overlap — there must be none.
+          when(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).thenAnswer((_) async {
+            activePersists++;
+            if (activePersists > maxActivePersists) {
+              maxActivePersists = activePersists;
+            }
+            await Future<void>.delayed(Duration.zero);
+            activePersists--;
+          });
+
+          var servedGiftWrapPage = false;
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((inv) async {
+            final filters =
+                inv.positionalArguments.first as List<nostr_filter.Filter>;
+            final filter = filters.single;
+            // Outgoing-NIP-04 recovery pass (authors:[self], no p): nothing.
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return const <Event>[];
+            }
+            // One page of wraps, then exhaustion.
+            if (servedGiftWrapPage) return const <Event>[];
+            servedGiftWrapPage = true;
+            return wraps;
+          });
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 1700000000
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(
+            syncState: syncState,
+            rumorDecryptor: (_, wrap) async {
+              activeDecrypts++;
+              if (activeDecrypts > maxActiveDecrypts) {
+                maxActiveDecrypts = activeDecrypts;
+              }
+              await Future<void>.delayed(const Duration(milliseconds: 5));
+              activeDecrypts--;
+              return rumorFor(wrap);
+            },
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          // Decryption ran in parallel...
+          expect(
+            maxActiveDecrypts,
+            DmHistoryDrainConfig.remoteDecryptConcurrency,
+            reason:
+                'remote-signer decrypts should run concurrently, not '
+                'one network round trip at a time',
+          );
+          // ...persistence stayed strictly serial...
+          expect(
+            maxActivePersists,
+            1,
+            reason: 'persistence must stay serialized under the event lock',
+          );
+          // ...and every wrap was persisted exactly once.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(wrapCount);
+        },
+      );
+
       test('successful gift-wrap persist advances sync boundaries', () async {
         const rumorCreatedAt = 1700000500;
         final giftWrap = createGiftWrapEvent();
@@ -3717,18 +3898,20 @@ void main() {
       );
 
       test(
-        'yields the event loop on the remote-signer per-event path so a large '
-        'backfill cannot starve frame rendering',
+        'yields the event loop on the remote-signer bounded-parallel decrypt '
+        'path so a large backfill cannot starve frame rendering',
         () async {
           when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
 
-          // The heaviest #5391 case: a large backfill on the per-event decrypt
-          // path, which the batched fast-path does NOT accelerate. The default
+          // The heaviest #5391 case: a large remote-signer backfill, which the
+          // batched isolate fast-path does NOT accelerate. The default
           // LocalNostrSigner is not an IsolateDecryptSigner, so
-          // _batchDecryptGiftWraps is a no-op and every wrap routes through
-          // _decryptRumor -> the injected per-event decryptor — exactly the
-          // path a remote signer (Keycast NIP-46 / Amber) takes.
-          const wrapCount = 33; // > 2 * drainYieldInterval(16): forces 2 yields
+          // _batchDecryptGiftWraps routes the page through the bounded-parallel
+          // remote decrypt pool (_parallelDecryptGiftWraps) -> _decryptRumor ->
+          // the injected decryptor — exactly the path a remote signer (Keycast
+          // NIP-46 / Amber) takes.
+          // > remoteDecryptConcurrency, so the pool spans several waves.
+          const wrapCount = 33;
           final wraps = <Event>[];
           final rumorByWrapId = <String, Event>{};
           for (var i = 0; i < wrapCount; i++) {
@@ -3774,17 +3957,16 @@ void main() {
           await repository.backfillHistoryIfNeeded();
           ticker.cancel();
 
-          // Every unique wrap routed through the per-event decryptor (the
-          // batch path is a no-op for the non-isolate signer; the inclusive
+          // Every unique wrap routed through the decryptor (the inclusive
           // `until` boundary re-request is deduped by hasGiftWrap before
           // reaching the decryptor).
           expect(ticksAtDecrypt, hasLength(wrapCount));
-          // The opening events run before the first yield; later events run
-          // only after the drain handed back the event loop at least once.
-          // Remove the WS3 yield and the whole page drains in a single
-          // microtask burst with the heartbeat frozen at 0 — so this strict
-          // increase is the regression guard for "the backfill does not
-          // starve frame rendering" on the path the batching never touches.
+          // The opening wave of decrypts runs before the first yield; later
+          // decrypts run only after the pool handed back the event loop at
+          // least once. Remove the per-decrypt yield and the whole page drains
+          // in a single microtask burst with the heartbeat frozen at 0 — so
+          // this strict increase is the regression guard for "the backfill
+          // does not starve frame rendering".
           expect(ticksAtDecrypt.first, 0);
           expect(ticksAtDecrypt.last, greaterThan(0));
         },


### PR DESCRIPTION
## Description

For remote-signer accounts (Keycast NIP-46 / Amber — no on-device key), the DM history drain decrypted every kind-1059 gift wrap **one network round trip at a time under the event lock**. Each wrap is two `nip44_decrypt` RPCs (~250-400 ms each), and the drain spans up to ~5,000 wraps, so the messages list could take **minutes** to populate.

This makes the drain decrypt each page with a **bounded worker pool off the event lock** (`DmHistoryDrainConfig.remoteDecryptConcurrency = 8`). **Persistence stays serialized under the lock**, so dedup and transaction integrity are unchanged — only decryption is parallelized. Local-key signers are untouched (they keep the batched isolate path). A per-decrypt event-loop yield preserves the #5391 frame-rendering guarantee for fast/synthetic signers.

Why concurrency is safe: the Keycast server does not serialize per-token decrypts (multi-threaded runtime, no per-token lock), confirmed by a local HTTP-RPC benchmark. Modeling 100 DMs × 2 sequential decrypts at production-representative ~300 ms/call:

| Mode | Wall-clock (100 DMs) | Speedup |
|------|----------------------|---------|
| Serial (today) | 61.0 s | 1× |
| c=4 | 15.3 s | 4.0× |
| **c=8** | **7.9 s** | **7.7×** |
| c=16 | 4.3 s | 14.2× |

**Related Issue:** Closes #5425

## Out of Scope

- The live first-open subscription (`limit:50`) still decrypts serially as events stream in (~tens of seconds, arrives incrementally). Smaller, separate follow-up.
- A batch `nip44_decrypt` verb on Keycast (would amortize per-call server overhead further) — backend change, separate.

## Verification

- `flutter analyze lib test integration_test` — no issues (pre-commit hook).
- `flutter test` in `packages/dm_repository` — all 358 tests pass, including a new test asserting bounded-parallel decrypt (max 8 in flight) with strictly serial persist and every wrap persisted once.
- Updated the #5391 frame-rendering regression test to cover the new bounded-parallel path (still proves the drain hands back event-loop turns mid-page).
- Mechanism + speedup measured empirically against a local Keycast RPC server.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)