### PR TITLE
fix(videos_repository): fall back when recommendations fail

### DIFF
--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -2452,22 +2452,36 @@ class VideosRepository {
     }
 
     final recommendationCursor = cursor ?? until?.toString();
-    final response = recommendationCursor == null
-        ? await _funnelcakeApiClient.getRecommendations(
-            pubkey: effectiveUserPubkey,
-            limit: limit,
-            seed: requestSeed,
-            preferredLanguages: preferredLanguages,
-            viewerCountry: viewerCountry,
-          )
-        : await _funnelcakeApiClient.getRecommendations(
-            pubkey: effectiveUserPubkey,
-            limit: limit,
-            cursor: recommendationCursor,
-            seed: requestSeed,
-            preferredLanguages: preferredLanguages,
-            viewerCountry: viewerCountry,
-          );
+    late final RecommendationsResponse response;
+    try {
+      response = recommendationCursor == null
+          ? await _funnelcakeApiClient.getRecommendations(
+              pubkey: effectiveUserPubkey,
+              limit: limit,
+              seed: requestSeed,
+              preferredLanguages: preferredLanguages,
+              viewerCountry: viewerCountry,
+            )
+          : await _funnelcakeApiClient.getRecommendations(
+              pubkey: effectiveUserPubkey,
+              limit: limit,
+              cursor: recommendationCursor,
+              seed: requestSeed,
+              preferredLanguages: preferredLanguages,
+              viewerCountry: viewerCountry,
+            );
+    } on FunnelcakeException {
+      if (recommendationCursor != null) rethrow;
+      return HomeFeedResult(
+        videos: await getPopularVideos(
+          limit: limit,
+          until: until,
+          skipCache: skipCache,
+          preferredLanguages: preferredLanguages,
+          viewerCountry: viewerCountry,
+        ),
+      );
+    }
     final videos = _transformVideoStats(response.videos);
     if (videos.isEmpty) {
       return HomeFeedResult(

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -10103,6 +10103,12 @@ void main() {
         'does not commit refreshed session seed when first page fails',
         () async {
           final requestedSeeds = <String?>[];
+          final popular = _createVideoStats(
+            id: 'popular-video',
+            pubkey: 'popular-pubkey',
+            dTag: 'popular-dtag',
+            videoUrl: 'https://example.com/popular.mp4',
+          );
           var callCount = 0;
           when(
             () => mockFunnelcakeClient.getRecommendations(
@@ -10135,6 +10141,12 @@ void main() {
               hasMore: true,
             );
           });
+          when(
+            () => mockFunnelcakeClient.getWatchingVideos(
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer((_) async => [popular]);
 
           final repo = VideosRepository(
             nostrClient: mockNostrClient,
@@ -10145,18 +10157,16 @@ void main() {
           final firstPage = await repo.getRecommendedVideos(
             userPubkey: 'user-pubkey',
           );
-          await expectLater(
-            repo.getRecommendedVideos(
-              userPubkey: 'user-pubkey',
-              skipCache: true,
-            ),
-            throwsA(isA<FunnelcakeException>()),
+          final fallback = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            skipCache: true,
           );
           await repo.getRecommendedVideos(
             userPubkey: 'user-pubkey',
             cursor: firstPage.paginationCursor,
           );
 
+          expect(fallback.videos.single.id, equals('popular-video'));
           expect(requestedSeeds, hasLength(3));
           expect(requestedSeeds[0], isNotNull);
           expect(requestedSeeds[0], isNotEmpty);
@@ -10673,8 +10683,21 @@ void main() {
       );
 
       test(
-        'propagates recommendation errors without popular fallback',
+        'falls back to popular videos when recommendations throw on first page',
         () async {
+          final popular = _createVideoStats(
+            id: 'popular-video',
+            pubkey: 'popular-pubkey',
+            dTag: 'popular-dtag',
+            videoUrl: 'https://example.com/popular.mp4',
+          );
+          final recommended = _createVideoStats(
+            id: 'recommended-video',
+            pubkey: 'recommended-pubkey',
+            dTag: 'recommended-dtag',
+            videoUrl: 'https://example.com/recommended.mp4',
+          );
+          var recommendationCallCount = 0;
           when(
             () => mockFunnelcakeClient.getRecommendations(
               seed: any(named: 'seed'),
@@ -10682,24 +10705,55 @@ void main() {
               limit: any(named: 'limit'),
               fallback: any(named: 'fallback'),
               category: any(named: 'category'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
             ),
-          ).thenThrow(const FunnelcakeException('recommendations failed'));
-
-          final repo = VideosRepository(
-            nostrClient: mockNostrClient,
-            funnelcakeApiClient: mockFunnelcakeClient,
-          );
-
-          expect(
-            () => repo.getRecommendedVideos(userPubkey: 'user-pubkey'),
-            throwsA(isA<FunnelcakeException>()),
-          );
-          verifyNever(
+          ).thenAnswer((_) async {
+            recommendationCallCount += 1;
+            if (recommendationCallCount == 1) {
+              throw const FunnelcakeException('recommendations failed');
+            }
+            return RecommendationsResponse(
+              videos: [recommended],
+              source: 'personalized',
+            );
+          });
+          when(
             () => mockFunnelcakeClient.getWatchingVideos(
               limit: any(named: 'limit'),
               before: any(named: 'before'),
             ),
+          ).thenAnswer((_) async => [popular]);
+
+          final repo = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            inMemoryFeedCache: InMemoryFeedCache(),
           );
+
+          final fallback = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+          final recovered = await repo.getRecommendedVideos(
+            userPubkey: 'user-pubkey',
+            limit: 10,
+          );
+
+          expect(fallback.videos.single.id, equals('popular-video'));
+          expect(recovered.videos.single.id, equals('recommended-video'));
+          verify(
+            () => mockFunnelcakeClient.getRecommendations(
+              seed: any(named: 'seed'),
+              pubkey: 'user-pubkey',
+              limit: 10,
+            ),
+          ).called(2);
+          verify(
+            () => mockFunnelcakeClient.getWatchingVideos(
+              limit: 10,
+            ),
+          ).called(1);
         },
       );
     });

--- a/mobile/test/services/event_router_test.dart
+++ b/mobile/test/services/event_router_test.dart
@@ -134,16 +134,17 @@ void main() {
           },
         );
 
-        for (var i = 0; i < 25; i++) {
-          router.handleEvent(videoEvent(2000 + i));
+        final events = List.generate(25, (i) => videoEvent(2000 + i));
+        for (final event in events) {
+          router.handleEvent(event);
         }
 
         await router.drainForTesting();
 
         expect(yieldCount, greaterThanOrEqualTo(2));
-        for (var i = 0; i < 25; i++) {
+        for (final event in events) {
           expect(
-            await db.nostrEventsDao.getEventById(videoEvent(2000 + i).id),
+            await db.nostrEventsDao.getEventById(event.id),
             isNotNull,
           );
         }


### PR DESCRIPTION
## Description

For You recommendations now fall back to the popular feed when the first recommendations request throws a `FunnelcakeException`, instead of surfacing `VideoFeedError.loadFailed` on cold start. The fallback is not cached as personalized recommendations, so later recovery still fetches real recommendations and preserves the existing recommendation session seed behavior.

Root-cause evidence from Martin log: the home feed failed at `getRecommendations` with `CERTIFICATE_VERIFY_FAILED: certificate has expired` against the production API path; other feed surfaces with fallback behavior continued to load content.

While taking over the red CI, this PR also fixes the pre-existing `event_router_test` nondeterminism by asserting persisted IDs from the exact queued events instead of re-creating new `Event` objects during verification.

Closes #5428

## Out of Scope

Server certificate renewal/ops remediation. This PR only hardens the client feed fallback behavior and fixes the existing test debt that blocked CI.

## Verification

- `flutter test test/services/event_router_test.dart --plain-name "EventRouter yields between bounded batches so large drains are cooperative"`
- `flutter test test/services/event_router_test.dart`
- `flutter test` from `mobile/packages/videos_repository`
- `flutter analyze` from `mobile/packages/videos_repository`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore