### PR TITLE
fix(profile): fetch missing profile stats

### DIFF
--- a/mobile/lib/providers/user_profile_providers.dart
+++ b/mobile/lib/providers/user_profile_providers.dart
@@ -12,13 +12,21 @@ part 'user_profile_providers.g.dart';
 
 // ignore: specify_nonobvious_property_types
 final userProfileStatsReactiveProvider =
-    StreamProvider.family<ProfileStats?, String>((ref, pubkey) {
+    StreamProvider.family<ProfileStats?, String>((ref, pubkey) async* {
       final repo = ref.watch(profileRepositoryProvider);
       if (repo == null) {
-        return const Stream<ProfileStats?>.empty();
+        return;
       }
 
-      return repo.watchProfileStats(pubkey: pubkey);
+      unawaited(
+        repo
+            .fetchFreshProfile(pubkey: pubkey)
+            .catchError((Object _, StackTrace _) => null),
+      );
+
+      await for (final stats in repo.watchProfileStats(pubkey: pubkey)) {
+        yield stats;
+      }
     });
 
 /// Reactive profile provider backed by Drift's watchProfile stream.

--- a/mobile/test/providers/user_profile_providers_test.dart
+++ b/mobile/test/providers/user_profile_providers_test.dart
@@ -1,0 +1,75 @@
+// ABOUTME: Tests for user profile Riverpod providers.
+// ABOUTME: Verifies profile stats self-seed when the local cache is empty.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:profile_repository/profile_repository.dart';
+
+class _MockProfileRepository extends Mock implements ProfileRepository {}
+
+void main() {
+  group('userProfileStatsReactiveProvider', () {
+    const pubkey =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+    late _MockProfileRepository profileRepository;
+    late StreamController<ProfileStats?> statsController;
+    late ProviderContainer container;
+
+    setUp(() {
+      profileRepository = _MockProfileRepository();
+      statsController = StreamController<ProfileStats?>();
+      container = ProviderContainer(
+        overrides: [
+          profileRepositoryProvider.overrideWithValue(profileRepository),
+        ],
+      );
+      addTearDown(container.dispose);
+      addTearDown(statsController.close);
+
+      when(
+        () => profileRepository.watchProfileStats(pubkey: pubkey),
+      ).thenAnswer((_) => statsController.stream);
+      when(
+        () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+      ).thenAnswer((_) async => null);
+    });
+
+    test('fetches a fresh profile as soon as stats are watched', () async {
+      final emitted = <AsyncValue<ProfileStats?>>[];
+      final sub = container.listen(
+        userProfileStatsReactiveProvider(pubkey),
+        (_, next) => emitted.add(next),
+        fireImmediately: true,
+      );
+      addTearDown(sub.close);
+
+      await Future<void>.delayed(Duration.zero);
+
+      verify(
+        () => profileRepository.fetchFreshProfile(pubkey: pubkey),
+      ).called(1);
+
+      statsController.add(null);
+      await Future<void>.delayed(Duration.zero);
+
+      const stats = ProfileStats(
+        pubkey: pubkey,
+        followers: 12,
+        following: 34,
+        totalLikes: 56,
+        totalViews: 78,
+      );
+      statsController.add(stats);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(emitted.last.value, stats);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- start a REST-backed profile fetch as soon as profile stats are watched
- keep the UI subscribed to the local profile stats stream so cached stats still render immediately and REST updates flow through
- add a provider regression test for the REST-first stats trigger

## Verification
- flutter test test/providers/user_profile_providers_test.dart test/widgets/profile/profile_header_widget_test.dart
- flutter analyze lib/providers/user_profile_providers.dart test/providers/user_profile_providers_test.dart
- flutter analyze
- pre-push hook: analyzer, generated file check, changed provider test

Closes #5430