### PR TITLE
fix(db): honor lowercase #a tag filter in event cache query

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -349,6 +349,16 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
       conditions.add('(${eTagConditions.join(' OR ')})');
     }
 
+    // Referenced addressable events filter (a tags)
+    final aTags = filter.a;
+    if (aTags != null && aTags.isNotEmpty) {
+      final aTagConditions = aTags.map((addressableId) {
+        variables.add(Variable.withString('%"a"%"$addressableId"%'));
+        return 'tags LIKE ?';
+      }).toList();
+      conditions.add('(${aTagConditions.join(' OR ')})');
+    }
+
     // Mentioned pubkeys filter (p tags)
     final pTags = filter.p;
     if (pTags != null && pTags.isNotEmpty) {

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -350,6 +350,33 @@ void main() {
         expect(results.first.id, equals(event1.id));
       });
 
+      test('filters by a tags (referenced addressable events)', () async {
+        const referencedAddress = '34236:author_pubkey_hex:video_d_tag';
+        final event1 = createEvent(
+          kind: 6,
+          tags: [
+            ['a', referencedAddress],
+          ],
+          createdAt: 1000,
+        );
+        final event2 = createEvent(
+          kind: 6,
+          tags: [
+            ['a', '34236:author_pubkey_hex:other_d_tag'],
+          ],
+          createdAt: 2000,
+        );
+
+        await dao.upsertEventsBatch([event1, event2]);
+
+        final results = await dao.getEventsByFilter(
+          Filter(kinds: [6], a: [referencedAddress]),
+        );
+
+        expect(results.length, equals(1));
+        expect(results.first.id, equals(event1.id));
+      });
+
       test('filters by p tags (mentioned pubkeys)', () async {
         const mentionedPubkey = 'mentioned_pubkey_123';
         final event1 = createEvent(


### PR DESCRIPTION
Closes #5432

## What

`NostrEventsDao._buildFilterQuery` (the SQL builder for the local Nostr event cache) handled `#e`, `#p`, `#d`, `#t` and the uppercase `#A`/`#E`/`#K` tag filters — but had **no case for the lowercase `#a`** addressable-coordinate filter. The constraint was silently dropped, so any `Filter(a: [...])` against the cache ignored the address and returned **every cached event of the matching kinds**.

## User-visible symptom

The video metadata ("About") sheet's **"Reposted by"** section listed the current user on essentially **every addressable video** — including others' videos the user never reposted.

### Why

1. `RepostsRepository.fetchEventReposters()` queries reposts for addressable videos (all kind-34236 Divine videos) by `#a`: `Filter(kinds:[6,16], a:[addressableId])`.
2. `NostrClient.queryEvents()` merges the **relay** result with the **local cache** result (`getEventsByFilter`).
3. The relay filtered `#a` correctly and returned nothing for the user. The cache **dropped** the `#a` constraint and returned all cached kind-6/16 reposts — prominently the user's **own reposts of other videos** (always synced into the cache by the persistent repost subscription).
4. Those leaked into the merged list → the user appeared under "Reposted by" everywhere.

The relay data was correct; the local cache filter was the leak. The same gap affected any `#a`-based cache query (reactions / comments / zaps on addressable events), and the reactive `watchEventsByFilter` path too (it shares `_buildFilterQuery`).

## Fix

Add an `#a` handler mirroring the existing `#e` handler in `_buildFilterQuery`.

## Tests

Added a regression test: `Filter(kinds:[6], a:[address])` returns only the event tagged with that coordinate (not a sibling repost of a different coordinate). Verified it **fails without the fix** (returns 2 instead of 1) and **passes with it**. Full `nostr_events_dao_test.dart` suite (75 tests) green; `flutter analyze` clean.

## Test plan

- [x] `flutter test packages/db_client/test/src/database/daos/nostr_events_dao_test.dart`
- [x] `flutter analyze lib test` (db_client)
- [ ] Manual: open the metadata sheet on an addressable video you didn't repost → you no longer appear under "Reposted by"

🤖 Generated with [Claude Code](https://claude.com/claude-code)