### PR TITLE
perf(dm): move remote-signer gift-wrap validation off the main isolate

### DIFF
--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -6,4 +6,5 @@ export 'src/dm_reactions_repository_reportable_sites.dart';
 export 'src/dm_repository.dart';
 export 'src/dm_repository_reportable_sites.dart';
 export 'src/dm_sync_state.dart';
+export 'src/dm_verify_isolate.dart';
 export 'src/nip17_message_service.dart' hide GiftWrapBuilder;

--- a/mobile/packages/dm_repository/lib/src/dm_decryption_worker.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_decryption_worker.dart
@@ -9,6 +9,7 @@ import 'dart:convert';
 
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/nip44/nip44_v2.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 
 /// Input payload for [decryptGiftWrapBatch].
 ///
@@ -95,7 +96,7 @@ Future<DecryptedRumorResult> _decryptOne(
   // C16/NIP-44: validate the outer gift wrap (kind 1059) signature before
   // decrypting. Defense-in-depth — diVine relays verify on publish, but an
   // untrusted relay or local cache could serve a forged/tampered wrap.
-  if (!giftWrap.isValid || !giftWrap.isSigned) {
+  if (!verifyGiftWrapPart(giftWrap)) {
     return DecryptedRumorResult.failure(
       'gift wrap signature invalid for ${giftWrap.id}',
     );
@@ -123,7 +124,7 @@ Future<DecryptedRumorResult> _decryptOne(
     );
   }
 
-  if (!sealEvent.isValid || !sealEvent.isSigned) {
+  if (!verifyGiftWrapPart(sealEvent)) {
     return DecryptedRumorResult.failure(
       'seal signature invalid for gift wrap ${giftWrap.id}',
     );

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1590,13 +1590,19 @@ class DmRepository {
         // Fall through to main-isolate decryptor.
       }
     }
-    // Remote-signer history drain: when a key-less verify isolate is active,
-    // route the production decryptor's id + Schnorr verification through it so
-    // the CPU-bound work leaves the main isolate. Only
+    // When a key-less verify isolate is live (spawned for a remote-signer
+    // history drain), route the production decryptor's id + Schnorr
+    // verification through it so the CPU-bound work leaves the main isolate.
+    // The gate is "verify isolate alive", not "drain batch path only": a
+    // live-subscription wrap arriving mid-drain routes here too, which is
+    // correct (its verify also leaves the main isolate). Only
     // GiftWrapUtil.getRumorEvent accepts a verifier; a test-injected decryptor
     // is used unchanged. If the isolate is torn down mid-flight (account
-    // switch), verifyPart throws StateError which the parallel-decrypt worker's
-    // catch turns into a fall-through to the per-event retry path. See #5424.
+    // switch) verifyPart throws StateError — the parallel-decrypt drain worker
+    // catches it and falls through to the per-event retry queue; the live
+    // _handleGiftWrapEvent path catches it and drops that one wrap, which the
+    // switch re-recovers (drain completion is deferred and the live
+    // subscription re-subscribes on switch-back). See #5424.
     final verifyWorker = _drainVerifyIsolate;
     if (verifyWorker != null &&
         identical(_rumorDecryptor, GiftWrapUtil.getRumorEvent)) {

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -17,6 +17,7 @@ import 'package:dm_repository/src/dm_reactions_repository.dart';
 import 'package:dm_repository/src/dm_repository_reportable_sites.dart';
 import 'package:dm_repository/src/dm_shared_video_citation.dart';
 import 'package:dm_repository/src/dm_sync_state.dart';
+import 'package:dm_repository/src/dm_verify_isolate.dart';
 import 'package:dm_repository/src/nip17_message_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:models/models.dart';
@@ -183,6 +184,7 @@ class DmRepository {
     RumorDecryptor? rumorDecryptor,
     Nip04Decryptor? nip04Decryptor,
     DmDecryptIsolateSpawner? decryptIsolateSpawner,
+    DmVerifyIsolateSpawner? verifyIsolateSpawner,
     DmRepositoryErrorReporter? errorReporter,
     DmReactionsRepository? reactionsRepository,
   }) : _nostrClient = nostrClient,
@@ -197,6 +199,7 @@ class DmRepository {
        _rumorDecryptor = rumorDecryptor ?? GiftWrapUtil.getRumorEvent,
        _nip04Decryptor = nip04Decryptor,
        _decryptIsolateSpawner = decryptIsolateSpawner ?? DmDecryptIsolate.spawn,
+       _verifyIsolateSpawner = verifyIsolateSpawner ?? DmVerifyIsolate.spawn,
        _errorReporter = errorReporter,
        _reactionsRepository = reactionsRepository;
 
@@ -227,6 +230,7 @@ class DmRepository {
   RumorDecryptor _rumorDecryptor;
   Nip04Decryptor? _nip04Decryptor;
   final DmDecryptIsolateSpawner _decryptIsolateSpawner;
+  final DmVerifyIsolateSpawner _verifyIsolateSpawner;
   final DmRepositoryErrorReporter? _errorReporter;
 
   /// Optional sibling repository for NIP-25 reactions on DMs. When wired,
@@ -246,6 +250,15 @@ class DmRepository {
   /// the drain ends. `null` outside a drain or for remote/test signers. See
   /// PR #5405 review / #5391.
   DmDecryptWorker? _drainDecryptIsolate;
+
+  /// A single long-lived, KEY-LESS verify isolate, alive only for the duration
+  /// of a REMOTE-signer history drain. Spawned in [_runHistoryDrain] when there
+  /// is no decrypt isolate (remote signers, whose decrypt stays on the main
+  /// isolate) and killed in its `finally`, so the per-event id + Schnorr
+  /// verification in `GiftWrapUtil.getRumorEvent` runs off the main isolate.
+  /// `null` outside a drain, for local-key signers (they validate inside the
+  /// decrypt isolate), or when the verify isolate could not spawn. See #5424.
+  DmVerifyWorker? _drainVerifyIsolate;
 
   /// Serializes event processing so concurrent subscription events
   /// never race into the dedup/insert path.
@@ -355,6 +368,10 @@ class DmRepository {
     // bailing drain's `finally` is idempotent if it also runs.
     _drainDecryptIsolate?.close();
     _drainDecryptIsolate = null;
+    // Likewise kill any drain-scoped verify isolate (key-less, but still a live
+    // worker). The bailing drain's idempotent `finally` is a no-op if it runs.
+    _drainVerifyIsolate?.close();
+    _drainVerifyIsolate = null;
     // Abandon the recovery signal for the outgoing user. The bailing loops'
     // _endRecovery() then no-ops (guarded on the zeroed counter).
     if (_activeRecoveryOps > 0) {
@@ -838,6 +855,7 @@ class DmRepository {
 
     _beginRecovery();
     DmDecryptWorker? drainDecryptIsolate;
+    DmVerifyWorker? drainVerifyIsolate;
     try {
       // Spawn one drain-scoped decrypt isolate for local-key signers so the
       // whole backfill pays a single isolate spawn instead of one per chunk
@@ -860,6 +878,31 @@ class DmRepository {
         } on Object catch (e, stackTrace) {
           Log.error(
             'DM decrypt isolate spawn failed; using per-event decrypt: $e',
+            category: LogCategory.system,
+            error: e,
+            stackTrace: stackTrace,
+          );
+        }
+      }
+
+      // Remote signers (no decrypt isolate) validate each gift wrap on the main
+      // isolate inside GiftWrapUtil.getRumorEvent. Spawn one key-less verify
+      // isolate for the drain so that id + Schnorr work moves off the main
+      // isolate; local-key signers already validate inside their decrypt
+      // isolate, so they skip this. On spawn failure, leave it null and fall
+      // back to inline main-isolate validation. See #5424.
+      if (drainDecryptIsolate == null) {
+        try {
+          final spawnedVerify = await _verifyIsolateSpawner();
+          if (_disposed || _userPubkey != pubkey) {
+            spawnedVerify.close();
+            return;
+          }
+          drainVerifyIsolate = spawnedVerify;
+          _drainVerifyIsolate = spawnedVerify;
+        } on Object catch (e, stackTrace) {
+          Log.error(
+            'DM verify isolate spawn failed; validating on main isolate: $e',
             category: LogCategory.system,
             error: e,
             stackTrace: stackTrace,
@@ -997,6 +1040,10 @@ class DmRepository {
       drainDecryptIsolate?.close();
       if (identical(_drainDecryptIsolate, drainDecryptIsolate)) {
         _drainDecryptIsolate = null;
+      }
+      drainVerifyIsolate?.close();
+      if (identical(_drainVerifyIsolate, drainVerifyIsolate)) {
+        _drainVerifyIsolate = null;
       }
       _endRecovery();
     }
@@ -1542,6 +1589,22 @@ class DmRepository {
         );
         // Fall through to main-isolate decryptor.
       }
+    }
+    // Remote-signer history drain: when a key-less verify isolate is active,
+    // route the production decryptor's id + Schnorr verification through it so
+    // the CPU-bound work leaves the main isolate. Only
+    // GiftWrapUtil.getRumorEvent accepts a verifier; a test-injected decryptor
+    // is used unchanged. If the isolate is torn down mid-flight (account
+    // switch), verifyPart throws StateError which the parallel-decrypt worker's
+    // catch turns into a fall-through to the per-event retry path. See #5424.
+    final verifyWorker = _drainVerifyIsolate;
+    if (verifyWorker != null &&
+        identical(_rumorDecryptor, GiftWrapUtil.getRumorEvent)) {
+      return GiftWrapUtil.getRumorEvent(
+        nostr,
+        giftWrapEvent,
+        verifyPart: verifyWorker.verifyPart,
+      );
     }
     return _rumorDecryptor(nostr, giftWrapEvent);
   }

--- a/mobile/packages/dm_repository/lib/src/dm_verify_isolate.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_verify_isolate.dart
@@ -1,0 +1,137 @@
+// ABOUTME: A single long-lived, KEY-LESS background isolate that runs NIP-17
+// ABOUTME: gift-wrap id + Schnorr verification off the main isolate on the
+// ABOUTME: remote-signer history drain. The decrypt for remote signers
+// ABOUTME: (Keycast RPC / Amber IPC / NIP-46) must stay on the main isolate
+// ABOUTME: (the signer cannot cross a SendPort), but the pure verification
+// ABOUTME: can — and needs no private key, so nothing secret is ever sent in.
+// ABOUTME: Spawned once per drain, fed events over a port, killed when the
+// ABOUTME: drain ends. See #5424 (sibling of #5412's DmDecryptIsolate).
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
+
+/// Minimal worker contract used by the history drain to verify gift-wrap-layer
+/// events off the main isolate and release the worker when the drain exits.
+abstract interface class DmVerifyWorker {
+  /// Returns `true` iff [event] recomputes its own id (sha256) and carries a
+  /// valid Schnorr signature ([verifyGiftWrapPart]). Never throws for a
+  /// verification result; throws [StateError] only if called after [close].
+  Future<bool> verifyPart(Event event);
+
+  /// Releases worker resources. Idempotent.
+  void close();
+}
+
+/// Creates a drain-scoped verify worker.
+typedef DmVerifyIsolateSpawner = Future<DmVerifyWorker> Function();
+
+/// Production [DmVerifyWorker] backed by a long-lived, KEY-LESS Dart isolate.
+///
+/// Mirrors `DmDecryptIsolate` but for the remote-signer history drain, whose
+/// per-event validation otherwise runs on the main isolate inside
+/// `GiftWrapUtil.getRumorEvent`. The decrypt must stay on the main isolate (a
+/// remote signer's RPC/IPC cannot cross a `SendPort`); only the pure id +
+/// Schnorr verification moves here. Unlike the decrypt worker this needs NO
+/// private key — verification reads only the event's own fields — so the
+/// key-residency trade that scopes the decrypt isolate to one drain does not
+/// apply. Spawned once per drain and killed in the drain's `finally`.
+class DmVerifyIsolate implements DmVerifyWorker {
+  DmVerifyIsolate._({required Isolate isolate, required ReceivePort responses})
+    : _isolate = isolate,
+      _responses = responses;
+
+  final Isolate _isolate;
+  final ReceivePort _responses;
+
+  /// The worker's command port, received during the spawn handshake.
+  late final SendPort _commands;
+
+  /// Routes worker responses back to their awaiting [verifyPart] callers.
+  late final StreamSubscription<dynamic> _subscription;
+
+  /// Outstanding requests keyed by id so concurrent / interleaved [verifyPart]
+  /// calls (the drain runs many wraps in flight) each resolve to their own
+  /// result.
+  final Map<int, Completer<bool>> _pending = <int, Completer<bool>>{};
+
+  int _nextRequestId = 0;
+  bool _closed = false;
+
+  /// Spawns the worker and completes once it has reported its command port.
+  /// No key or other secret crosses the boundary.
+  static Future<DmVerifyIsolate> spawn() async {
+    final responses = ReceivePort();
+    final isolate = await Isolate.spawn(
+      _dmVerifyIsolateEntry,
+      responses.sendPort,
+      debugName: 'dm-verify-isolate',
+    );
+
+    final ready = Completer<SendPort>();
+    final instance = DmVerifyIsolate._(isolate: isolate, responses: responses);
+    instance._subscription = responses.listen((dynamic message) {
+      if (!ready.isCompleted) {
+        // First message is the worker's command port (handshake).
+        ready.complete(message as SendPort);
+        return;
+      }
+      final (int id, bool result) = message as (int, bool);
+      instance._pending.remove(id)?.complete(result);
+    });
+
+    final commandPort = await ready.future;
+    instance._commands = commandPort;
+    return instance;
+  }
+
+  @override
+  Future<bool> verifyPart(Event event) {
+    if (_closed) {
+      throw StateError('DmVerifyIsolate has been closed');
+    }
+    final id = _nextRequestId++;
+    final completer = Completer<bool>();
+    _pending[id] = completer;
+    _commands.send((id, event.toJson()));
+    return completer.future;
+  }
+
+  /// Kills the worker, stops listening, and fails any still-pending requests so
+  /// their awaiters never hang. Idempotent.
+  @override
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    unawaited(_subscription.cancel());
+    _responses.close();
+    _isolate.kill(priority: Isolate.immediate);
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(
+          StateError('DmVerifyIsolate closed before the verify completed'),
+        );
+      }
+    }
+    _pending.clear();
+  }
+}
+
+/// Worker entry: handshakes its command port back to the spawner, then verifies
+/// each `(id, eventJson)` request with [verifyGiftWrapPartJson] and replies
+/// `(id, result)`. The helper never throws (malformed JSON → `false`), so the
+/// loop is crash-free; the isolate is torn down via [Isolate.kill] from
+/// [DmVerifyIsolate.close].
+Future<void> _dmVerifyIsolateEntry(SendPort replyTo) async {
+  final commands = ReceivePort();
+  replyTo.send(commands.sendPort);
+
+  await for (final dynamic message in commands) {
+    final (int id, Map<dynamic, dynamic> rawEvent) =
+        message as (int, Map<dynamic, dynamic>);
+    final result = verifyGiftWrapPartJson(Map<String, dynamic>.from(rawEvent));
+    replyTo.send((id, result));
+  }
+}

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -17,6 +17,7 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
 import 'package:nostr_sdk/nip44/nip44_v2.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
@@ -107,6 +108,49 @@ Future<Event> _buildGiftWrap({
   )..sign(ephemeralPrivateKey);
 }
 
+/// Like [_buildGiftWrap] but corrupts the seal signature after sealing, so the
+/// outer wrap still verifies while the inner seal fails verification — exactly
+/// the impersonation shape the seal verify exists to reject.
+Future<Event> _buildForgedSealGiftWrap({
+  required Event rumor,
+  required String senderPrivateKey,
+  required String recipientPubkey,
+  required int outerCreatedAt,
+}) async {
+  final senderPubkey = getPublicKey(senderPrivateKey);
+  final rumorMap = rumor.toJson()..remove('sig');
+  final sealKey = NIP44V2.shareSecret(senderPrivateKey, recipientPubkey);
+  final sealContent = await NIP44V2.encrypt(jsonEncode(rumorMap), sealKey);
+  final sealEvent =
+      Event(
+          senderPubkey,
+          EventKind.sealEventKind,
+          const <List<String>>[],
+          sealContent,
+        )
+        ..sign(senderPrivateKey)
+        // Corrupt the seal signature; the id still matches (content
+        // unchanged) so isValid passes but isSigned fails.
+        ..sig = '0' * 128;
+
+  final ephemeralPrivateKey = generatePrivateKey();
+  final ephemeralPubkey = getPublicKey(ephemeralPrivateKey);
+  final wrapKey = NIP44V2.shareSecret(ephemeralPrivateKey, recipientPubkey);
+  final wrapContent = await NIP44V2.encrypt(
+    jsonEncode(sealEvent.toJson()),
+    wrapKey,
+  );
+  return Event(
+    ephemeralPubkey,
+    EventKind.giftWrap,
+    <List<String>>[
+      ['p', recipientPubkey],
+    ],
+    wrapContent,
+    createdAt: outerCreatedAt,
+  )..sign(ephemeralPrivateKey);
+}
+
 class _MockPendingGiftWrapsDao extends Mock implements PendingGiftWrapsDao {}
 
 class _FakeOutgoingDm extends Fake implements OutgoingDm {}
@@ -136,6 +180,32 @@ class _FakeDmDecryptWorker implements DmDecryptWorker {
 
   @override
   void close() {
+    closeCount++;
+  }
+}
+
+/// Test double for [DmVerifyWorker] that runs the real verification inline (no
+/// isolate), records the kinds it verified, and tracks teardown — so drain
+/// tests assert the verify worker was used and closed without spawning a real
+/// isolate. Behaviour-equivalent to the inline main-isolate check, so it does
+/// not change any existing drain test's outcome.
+class _RecordingVerifyWorker implements DmVerifyWorker {
+  final List<int> verifiedKinds = <int>[];
+  int closeCount = 0;
+  bool closed = false;
+
+  @override
+  Future<bool> verifyPart(Event event) async {
+    if (closed) {
+      throw StateError('DmVerifyWorker has been closed');
+    }
+    verifiedKinds.add(event.kind);
+    return verifyGiftWrapPart(event);
+  }
+
+  @override
+  void close() {
+    closed = true;
     closeCount++;
   }
 }
@@ -376,6 +446,7 @@ void main() {
       DmReactionsRepository? reactionsRepository,
       NostrSigner? signer,
       DmDecryptIsolateSpawner? decryptIsolateSpawner,
+      DmVerifyIsolateSpawner? verifyIsolateSpawner,
     }) {
       return DmRepository(
         nostrClient: mockNostrClient,
@@ -389,6 +460,12 @@ void main() {
         rumorDecryptor: rumorDecryptor,
         nip04Decryptor: nip04Decryptor,
         decryptIsolateSpawner: decryptIsolateSpawner,
+        // Default to an inline (no-isolate) verify worker so drain tests never
+        // spawn a real verify isolate; it runs the same check inline, so it is
+        // behaviour-equivalent. Tests that assert verify routing inject their
+        // own recording worker. See #5424.
+        verifyIsolateSpawner:
+            verifyIsolateSpawner ?? () async => _RecordingVerifyWorker(),
         syncState: syncState,
         reactionsRepository: reactionsRepository,
         errorReporter: (error, stackTrace, {required site}) {
@@ -3541,6 +3618,131 @@ void main() {
       _FakeDmSyncState drainPending() => _FakeDmSyncState()
         ..oldestOverride = 1700001000
         ..drainVersionOverride = DmSyncState.currentDrainVersion;
+
+      test(
+        'remote-signer drain verifies gift wraps off the main isolate and '
+        'closes the verify isolate when the drain ends (#5424)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+
+          final wrap = await _buildGiftWrap(
+            rumor: rumorFor('off-isolate verify', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          stubDrainPage([wrap]);
+
+          final verifyWorker = _RecordingVerifyWorker();
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            // A non-isolate signer takes the per-event getRumorEvent path the
+            // verify isolate serves (an IsolateDecryptSigner would instead
+            // validate inside its decrypt isolate).
+            signer: LocalNostrSigner(recipientPriv),
+            syncState: drainPending(),
+            verifyIsolateSpawner: () async => verifyWorker,
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The wrap decrypted and persisted as a message...
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: senderPub,
+              content: 'off-isolate verify',
+              createdAt: 1700000500,
+              giftWrapId: wrap.id,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: recipientPub,
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
+
+          // ...with both the outer wrap and the seal verified via the worker
+          // (i.e. off the main isolate), and the worker torn down afterwards.
+          expect(
+            verifyWorker.verifiedKinds,
+            containsAllInOrder(<int>[
+              EventKind.giftWrap,
+              EventKind.sealEventKind,
+            ]),
+          );
+          expect(verifyWorker.closed, isTrue);
+        },
+      );
+
+      test(
+        'remote-signer drain drops a wrap whose seal fails verification '
+        '(#5424)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+
+          final forged = await _buildForgedSealGiftWrap(
+            rumor: rumorFor('should be dropped', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          stubDrainPage([forged]);
+
+          final verifyWorker = _RecordingVerifyWorker();
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: LocalNostrSigner(recipientPriv),
+            syncState: drainPending(),
+            verifyIsolateSpawner: () async => verifyWorker,
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The seal was verified (off-isolate) and rejected, so the wrap is
+          // never persisted as a message.
+          expect(
+            verifyWorker.verifiedKinds,
+            contains(EventKind.sealEventKind),
+          );
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          );
+        },
+      );
 
       test(
         'stale drain spawn cannot close or clear the next drain worker',

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3745,6 +3745,65 @@ void main() {
       );
 
       test(
+        'remote-signer drain verifies through a real DmVerifyIsolate '
+        'end-to-end (toJson/SendPort round-trip) (#5424)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+
+          final wrap = await _buildGiftWrap(
+            rumor: rumorFor('real verify isolate', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          stubDrainPage([wrap]);
+
+          // Inject the production spawner so the outer-wrap + seal verification
+          // crosses a real SendPort (event.toJson() out, bool back) on the
+          // actual drain path — the recording worker the other drain tests use
+          // runs inline, so the isolate's port round-trip is otherwise only
+          // covered by dm_verify_isolate_test.dart in isolation. See #5424.
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: LocalNostrSigner(recipientPriv),
+            syncState: drainPending(),
+            verifyIsolateSpawner: DmVerifyIsolate.spawn,
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The wrap survived the real-isolate verification round-trip (both
+          // the outer wrap and the seal returned true across the port) and
+          // persisted as a message.
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: senderPub,
+              content: 'real verify isolate',
+              createdAt: 1700000500,
+              giftWrapId: wrap.id,
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: recipientPub,
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
         'stale drain spawn cannot close or clear the next drain worker',
         () async {
           when(() => mockNostrClient.connectedRelayCount).thenReturn(2);

--- a/mobile/packages/dm_repository/test/src/dm_verify_isolate_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_verify_isolate_test.dart
@@ -1,0 +1,79 @@
+// ABOUTME: Tests for DmVerifyIsolate — the key-less verify isolate that runs
+// ABOUTME: gift-wrap id + Schnorr verification off the main isolate on the
+// ABOUTME: remote-signer history drain. Covers valid/invalid verification,
+// ABOUTME: interleaved concurrent requests, and use-after-close. See #5424.
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+Event _signed(int kind, {String content = 'hi'}) {
+  final privateKey = generatePrivateKey();
+  return Event(getPublicKey(privateKey), kind, const <List<String>>[], content)
+    ..sign(privateKey);
+}
+
+void main() {
+  group(DmVerifyIsolate, () {
+    late DmVerifyIsolate worker;
+
+    setUp(() async {
+      worker = await DmVerifyIsolate.spawn();
+    });
+
+    tearDown(() {
+      worker.close();
+    });
+
+    test('verifies a self-valid signed event as true', () async {
+      expect(await worker.verifyPart(_signed(EventKind.textNote)), isTrue);
+    });
+
+    test('rejects an event whose signature does not verify', () async {
+      final event = _signed(EventKind.textNote)..sig = '0' * 128;
+      expect(await worker.verifyPart(event), isFalse);
+    });
+
+    test('rejects an event whose id no longer matches its content', () async {
+      final event = _signed(EventKind.textNote)..content = 'tampered';
+      expect(await worker.verifyPart(event), isFalse);
+    });
+
+    test(
+      'resolves many interleaved concurrent requests independently',
+      () async {
+        final valid = [
+          for (var i = 0; i < 8; i++)
+            _signed(EventKind.textNote, content: 'valid-$i'),
+        ];
+        final invalid = [
+          for (var i = 0; i < 8; i++)
+            _signed(EventKind.textNote, content: 'invalid-$i')..sig = '0' * 128,
+        ];
+
+        final results = await Future.wait(<Future<bool>>[
+          for (final event in valid) worker.verifyPart(event),
+          for (final event in invalid) worker.verifyPart(event),
+        ]);
+
+        expect(results.sublist(0, 8), everyElement(isTrue));
+        expect(results.sublist(8), everyElement(isFalse));
+      },
+    );
+
+    test('throws StateError when verifyPart is called after close', () {
+      worker.close();
+      expect(
+        () => worker.verifyPart(_signed(EventKind.textNote)),
+        throwsStateError,
+      );
+    });
+
+    test('close is idempotent', () {
+      worker
+        ..close()
+        ..close();
+      expect(worker.close, returnsNormally);
+    });
+  });
+}

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
@@ -8,6 +8,34 @@ import '../event_kind.dart';
 import '../nip44/nip44_v2.dart';
 import '../nostr.dart';
 
+/// Verifies one gift-wrap-layer event's integrity and signature: it recomputes
+/// the event id (sha256, [Event.isValid]) and verifies the Schnorr signature
+/// ([Event.isSigned]). This is the single shared definition of "this gift-wrap
+/// part is well-formed and authentically signed", used by
+/// [GiftWrapUtil.getRumorEvent] (inline and via an injected
+/// [GiftWrapPartVerifier]) and by the off-isolate DM history-drain verifier.
+///
+/// Pure (no I/O, no private key), so it is safe to run inside an isolate.
+bool verifyGiftWrapPart(Event event) => event.isValid && event.isSigned;
+
+/// [verifyGiftWrapPart] over an [Event.toJson] map, so the check can cross an
+/// isolate boundary. Returns `false` for malformed JSON rather than throwing.
+bool verifyGiftWrapPartJson(Map<String, dynamic> eventJson) {
+  try {
+    return verifyGiftWrapPart(Event.fromJson(eventJson));
+  } on Object {
+    return false;
+  }
+}
+
+/// Asynchronously verifies a single gift-wrap-layer [Event]. Injected into
+/// [GiftWrapUtil.getRumorEvent] so the (CPU-bound, pure-Dart) id + Schnorr
+/// verification can be moved off the main isolate on the high-volume remote-
+/// signer history drain — where the decrypt itself must stay on the main
+/// isolate (a remote signer cannot cross a `SendPort`). When omitted,
+/// `getRumorEvent` verifies inline on the calling isolate, unchanged.
+typedef GiftWrapPartVerifier = Future<bool> Function(Event event);
+
 class GiftWrapUtil {
   static final math.Random _secureRandom = math.Random.secure();
 
@@ -20,11 +48,27 @@ class GiftWrapUtil {
   static int _randomizedPastTimestamp(int base) =>
       base - _secureRandom.nextInt(_maxBackdateSeconds);
 
-  static Future<Event?> getRumorEvent(Nostr nostr, Event e) async {
+  /// Unwraps a NIP-17 gift wrap (kind 1059) → seal (kind 13) → rumor and
+  /// returns the inner rumor, or `null` if any layer fails.
+  ///
+  /// The two id + Schnorr verifications (outer wrap and seal) are run via
+  /// [verifyPart] when provided, so a caller can move that CPU-bound work off
+  /// the main isolate (the remote-signer history drain does this). When
+  /// [verifyPart] is `null` they run inline on the calling isolate, unchanged.
+  /// The two `nip44Decrypt` calls always stay on the calling isolate — a remote
+  /// signer's RPC/IPC cannot cross a `SendPort`.
+  static Future<Event?> getRumorEvent(
+    Nostr nostr,
+    Event e, {
+    GiftWrapPartVerifier? verifyPart,
+  }) async {
     // C16/NIP-44: validate the outer gift wrap (kind 1059) signature before
     // decrypting. Defense-in-depth — diVine relays already verify, but an
     // untrusted relay or local cache could serve a forged/tampered wrap.
-    if (!e.isValid || !e.isSigned) {
+    final outerValid = verifyPart != null
+        ? await verifyPart(e)
+        : verifyGiftWrapPart(e);
+    if (!outerValid) {
       log('GiftWrap outer event invalid or unsigned, id: ${e.id}');
       return null;
     }
@@ -37,7 +81,13 @@ class GiftWrapUtil {
     var rumorJson = jsonDecode(rumorText);
     var rumorEvent = Event.fromJson(rumorJson);
 
-    if (!rumorEvent.isValid || !rumorEvent.isSigned) {
+    // C16/NIP-44: validate the seal (kind 13). Unlike the outer wrap, the seal
+    // is NIP-44-encrypted so no relay can ever verify it — this is the sole
+    // cryptographic anchor of sender identity, so it is always enforced.
+    final sealValid = verifyPart != null
+        ? await verifyPart(rumorEvent)
+        : verifyGiftWrapPart(rumorEvent);
+    if (!sealValid) {
       log(
         "GiftWrap rumorEvent sign check result fail, id: ${e.id}, from: ${e.pubkey}",
       );
@@ -55,15 +105,9 @@ class GiftWrapUtil {
     var jsonObj = jsonDecode(sourceText);
     var innerEvent = Event.fromJson(jsonObj);
 
-    // C15/NIP-59: the inner rumor MUST be unsigned. A signed rumor is a
-    // non-compliant (or malicious) peer — its signature is never trusted for
-    // identity (the seal pubkey is authoritative below), but flag it.
-    if (innerEvent.isSigned) {
-      log(
-        'GiftWrap inner rumor is unexpectedly signed (NIP-59 requires '
-        'unsigned), gift wrap id: ${e.id}',
-      );
-    }
+    // The inner rumor is intentionally NOT signature-checked: NIP-59 requires
+    // it to be unsigned, and its claimed authorship is never trusted for
+    // identity — the seal pubkey (authenticated above) is authoritative below.
 
     // NIP-17 sender verification: the seal's pubkey should match the rumor's
     // pubkey. When they differ, the rumor's claimed author is unverified while

--- a/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip59/gift_wrap_util_test.dart
@@ -1,0 +1,207 @@
+// ABOUTME: Tests for GiftWrapUtil.getRumorEvent's injectable off-isolate
+// ABOUTME: verifier (verifyPart) and the shared verifyGiftWrapPart helper.
+// ABOUTME: Covers: the inline (null-verifier) path is unchanged, the injected
+// ABOUTME: verifier gates both the outer wrap and the seal, and the inner
+// ABOUTME: rumor is intentionally not signature-checked. See #5424.
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+void main() {
+  Relay dummyRelay(String url) => RelayBase(url, RelayStatus(url));
+
+  Event signedEvent(
+    String privateKey,
+    int kind, {
+    String content = 'hi',
+    List<List<String>> tags = const <List<String>>[],
+  }) {
+    return Event(getPublicKey(privateKey), kind, tags, content)
+      ..sign(privateKey);
+  }
+
+  /// Builds a real NIP-17 gift wrap for [rumor] addressed to [recipientPubkey],
+  /// sealed and signed by [senderPrivateKey]. When [keepRumorSig] is true the
+  /// rumor's signature is left intact (a non-compliant, signed inner rumor).
+  Future<Event> buildGiftWrap({
+    required Event rumor,
+    required String senderPrivateKey,
+    required String recipientPubkey,
+    bool keepRumorSig = false,
+  }) async {
+    final senderPubkey = getPublicKey(senderPrivateKey);
+    final rumorMap = rumor.toJson();
+    if (!keepRumorSig) rumorMap.remove('sig');
+    final sealKey = NIP44V2.shareSecret(senderPrivateKey, recipientPubkey);
+    final sealContent = await NIP44V2.encrypt(jsonEncode(rumorMap), sealKey);
+    final sealEvent = Event(
+      senderPubkey,
+      EventKind.sealEventKind,
+      const <List<String>>[],
+      sealContent,
+    )..sign(senderPrivateKey);
+
+    final ephemeralPrivateKey = generatePrivateKey();
+    final ephemeralPubkey = getPublicKey(ephemeralPrivateKey);
+    final wrapKey = NIP44V2.shareSecret(ephemeralPrivateKey, recipientPubkey);
+    final wrapContent = await NIP44V2.encrypt(
+      jsonEncode(sealEvent.toJson()),
+      wrapKey,
+    );
+    return Event(ephemeralPubkey, EventKind.giftWrap, <List<String>>[
+      ['p', recipientPubkey],
+    ], wrapContent)..sign(ephemeralPrivateKey);
+  }
+
+  group('verifyGiftWrapPart', () {
+    test('returns true for a self-valid signed event', () {
+      final event = signedEvent(generatePrivateKey(), EventKind.textNote);
+      expect(verifyGiftWrapPart(event), isTrue);
+    });
+
+    test('returns false when the signature does not verify', () {
+      final event = signedEvent(generatePrivateKey(), EventKind.textNote)
+        ..sig = '0' * 128;
+      expect(verifyGiftWrapPart(event), isFalse);
+    });
+
+    test('returns false when the id no longer matches the content', () {
+      final event = signedEvent(generatePrivateKey(), EventKind.textNote)
+        ..content = 'tampered after signing';
+      expect(verifyGiftWrapPart(event), isFalse);
+    });
+  });
+
+  group('verifyGiftWrapPartJson', () {
+    test('true for a valid event toJson round-trip', () {
+      final event = signedEvent(generatePrivateKey(), EventKind.textNote);
+      expect(verifyGiftWrapPartJson(event.toJson()), isTrue);
+    });
+
+    test('false for malformed json rather than throwing', () {
+      expect(verifyGiftWrapPartJson(<String, dynamic>{}), isFalse);
+    });
+  });
+
+  group('getRumorEvent', () {
+    late String recipientPrivateKey;
+    late String senderPrivateKey;
+    late String senderPubkey;
+    late Nostr recipientNostr;
+
+    setUp(() {
+      recipientPrivateKey = generatePrivateKey();
+      senderPrivateKey = generatePrivateKey();
+      senderPubkey = getPublicKey(senderPrivateKey);
+      recipientNostr = Nostr(
+        LocalNostrSigner(recipientPrivateKey),
+        const [],
+        dummyRelay,
+      );
+    });
+
+    Future<Event> validWrap() async {
+      final rumor = Event(
+        senderPubkey,
+        EventKind.privateDirectMessage,
+        const <List<String>>[],
+        'secret message',
+      );
+      return buildGiftWrap(
+        rumor: rumor,
+        senderPrivateKey: senderPrivateKey,
+        recipientPubkey: getPublicKey(recipientPrivateKey),
+      );
+    }
+
+    test('inline path (no verifier) unwraps a valid wrap', () async {
+      final rumor = await GiftWrapUtil.getRumorEvent(
+        recipientNostr,
+        await validWrap(),
+      );
+      expect(rumor, isNotNull);
+      expect(rumor!.content, equals('secret message'));
+      expect(rumor.pubkey, equals(senderPubkey));
+    });
+
+    test(
+      'injected verifier is invoked for the outer wrap then the seal',
+      () async {
+        final verifiedKinds = <int>[];
+        Future<bool> verifier(Event event) async {
+          verifiedKinds.add(event.kind);
+          return verifyGiftWrapPart(event);
+        }
+
+        final rumor = await GiftWrapUtil.getRumorEvent(
+          recipientNostr,
+          await validWrap(),
+          verifyPart: verifier,
+        );
+
+        expect(rumor, isNotNull);
+        expect(rumor!.content, equals('secret message'));
+        expect(
+          verifiedKinds,
+          orderedEquals(<int>[EventKind.giftWrap, EventKind.sealEventKind]),
+        );
+      },
+    );
+
+    test(
+      'returns null when the injected verifier rejects the outer wrap',
+      () async {
+        final verifiedKinds = <int>[];
+        Future<bool> rejectOuter(Event event) async {
+          verifiedKinds.add(event.kind);
+          return event.kind != EventKind.giftWrap;
+        }
+
+        final rumor = await GiftWrapUtil.getRumorEvent(
+          recipientNostr,
+          await validWrap(),
+          verifyPart: rejectOuter,
+        );
+
+        expect(rumor, isNull);
+        // Rejected at the outer wrap — the seal is never reached/verified.
+        expect(verifiedKinds, equals(<int>[EventKind.giftWrap]));
+      },
+    );
+
+    test('returns null when the injected verifier rejects the seal', () async {
+      Future<bool> rejectSeal(Event event) async =>
+          event.kind != EventKind.sealEventKind;
+
+      final rumor = await GiftWrapUtil.getRumorEvent(
+        recipientNostr,
+        await validWrap(),
+        verifyPart: rejectSeal,
+      );
+
+      expect(rumor, isNull);
+    });
+
+    test('a signed inner rumor still unwraps (3rd verify removed)', () async {
+      final signedRumor = signedEvent(
+        senderPrivateKey,
+        EventKind.privateDirectMessage,
+        content: 'still delivered',
+      );
+      final wrap = await buildGiftWrap(
+        rumor: signedRumor,
+        senderPrivateKey: senderPrivateKey,
+        recipientPubkey: getPublicKey(recipientPrivateKey),
+        keepRumorSig: true,
+      );
+
+      final rumor = await GiftWrapUtil.getRumorEvent(recipientNostr, wrap);
+
+      expect(rumor, isNotNull);
+      expect(rumor!.content, equals('still delivered'));
+      expect(rumor.pubkey, equals(senderPubkey));
+    });
+  });
+}


### PR DESCRIPTION
## Description

For remote signers (Keycast RPC / Amber IPC / NIP-46 bunker), the NIP-17 gift-wrap **validation** — `Event.isValid` (sha256 id recompute) + `Event.isSigned` (pure-Dart `bip340` Schnorr verify), on the outer kind-1059 wrap and the decrypted kind-13 seal — ran synchronously on the **main isolate** inside `GiftWrapUtil.getRumorEvent`. The *decrypt* is an off-device RPC the signer can't send across an isolate boundary, but the pure-Dart *validation* can. Local-key signers already validate inside their decrypt isolate; only the remote per-event path ran the verify on the main isolate. After #5426's c=8 parallel drain landed, up to eight Schnorr verifies could concentrate on the main isolate close together with no per-frame guard — a follow-up #5413 flagged.

This moves the (pure, key-less) verification off the main isolate while keeping the decrypt on it:

- **`getRumorEvent` gains an optional `GiftWrapPartVerifier`.** When `null` it verifies inline exactly as before, so the live-subscription and retry-replay paths are byte-unchanged. The remote history drain injects an isolate-backed verifier.
- **New `DmVerifyIsolate`** — a long-lived, **key-less** verify isolate mirroring the #5412 `DmDecryptIsolate` lifecycle: spawned once per remote drain, torn down in the drain `finally` and on account switch. Verification needs no private key, so nothing secret ever crosses the boundary (strictly safer than the decrypt isolate).
- **The wiring is a field read in `_decryptRumor`**, gated on the production decryptor, so #5426's `_parallelDecryptGiftWraps` worker pool is untouched — minimal blast radius.
- **The inner seal verify is preserved.** No relay can verify the NIP-44-*encrypted* seal, so the client-side seal Schnorr verify is the sole anchor of sender identity — it is moved off-isolate, never dropped. (The "the relay already verified on publish" rationale is correct only for the outer kind-1059 wrap, which the relay re-checks; it does not apply to the encrypted seal.)
- **The redundant inner-rumor signature check is removed** — it only gated a log line (NIP-59 requires the rumor unsigned; the seal pubkey is authoritative). The verify logic is de-duplicated into a shared `verifyGiftWrapPart` used by the inline path, the verify isolate, and the local-key decrypt worker.

## Out of Scope

- **Dropping the outer kind-1059 verify on a trusted-relay basis** (the issue's "Option 2"). The drain queries the whole connected relay pool (including user-added relays) and replays from local cache, so provenance can't be guaranteed at validation time — this stays a separately-gated follow-up, not done here. The seal verify is deliberately kept regardless.
- The #5413 perf measurement harnesses (`integration_test/perf/dm_remote_signer_backfill_*`) are left unchanged: they are synthetic models that document the motivating main-isolate cost. The off-isolate routing is proven instead by a new `dm_repository` drain test.

## Verification

- `flutter analyze` (both packages, lib + test): no issues. Pre-commit + pre-push hooks (whole-project format + analyzer + changed tests) passed.
- `flutter test` in `packages/nostr_sdk`: 292 pass (incl. new `gift_wrap_util_test`: injected verifier gates the outer wrap and the seal; inline path unchanged; a signed inner rumor still unwraps).
- `flutter test` in `packages/dm_repository`: 366 pass (incl. new `dm_verify_isolate_test`: valid/invalid/interleaved-concurrent/after-close; and two remote-drain tests: validation routed off-isolate then the worker closed, and a forged-seal wrap rejected and never persisted).

**Related Issue:** Closes #5424

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor