### PR TITLE
fix(blocking): publish blocks to the NIP-51 kind 10000 mute list

### DIFF
--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -164,8 +164,9 @@ ModerationLabelService moderationLabelService(Ref ref) {
 /// Content blocklist service for filtering unwanted content from feeds
 ///
 /// Injects SharedPreferences for local block persistence across restarts.
-/// Nostr publishing (kind 30000) is initialized via [syncBlockListsInBackground]
-/// during app startup in main.dart.
+/// Nostr publishing (kind 10000 mute list, plus the legacy kind 30000
+/// block list) is initialized via [syncBlockListsInBackground] during app
+/// startup in main.dart.
 ///
 /// keepAlive ensures the relay subscription created by
 /// [syncBlockListsInBackground] survives widget rebuilds. Without it the

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -461,8 +461,9 @@ String _$moderationLabelServiceHash() =>
 /// Content blocklist service for filtering unwanted content from feeds
 ///
 /// Injects SharedPreferences for local block persistence across restarts.
-/// Nostr publishing (kind 30000) is initialized via [syncBlockListsInBackground]
-/// during app startup in main.dart.
+/// Nostr publishing (kind 10000 mute list, plus the legacy kind 30000
+/// block list) is initialized via [syncBlockListsInBackground] during app
+/// startup in main.dart.
 ///
 /// keepAlive ensures the relay subscription created by
 /// [syncBlockListsInBackground] survives widget rebuilds. Without it the
@@ -476,8 +477,9 @@ final contentBlocklistRepositoryProvider =
 /// Content blocklist service for filtering unwanted content from feeds
 ///
 /// Injects SharedPreferences for local block persistence across restarts.
-/// Nostr publishing (kind 30000) is initialized via [syncBlockListsInBackground]
-/// during app startup in main.dart.
+/// Nostr publishing (kind 10000 mute list, plus the legacy kind 30000
+/// block list) is initialized via [syncBlockListsInBackground] during app
+/// startup in main.dart.
 ///
 /// keepAlive ensures the relay subscription created by
 /// [syncBlockListsInBackground] survives widget rebuilds. Without it the
@@ -495,8 +497,9 @@ final class ContentBlocklistRepositoryProvider
   /// Content blocklist service for filtering unwanted content from feeds
   ///
   /// Injects SharedPreferences for local block persistence across restarts.
-  /// Nostr publishing (kind 30000) is initialized via [syncBlockListsInBackground]
-  /// during app startup in main.dart.
+  /// Nostr publishing (kind 10000 mute list, plus the legacy kind 30000
+  /// block list) is initialized via [syncBlockListsInBackground] during app
+  /// startup in main.dart.
   ///
   /// keepAlive ensures the relay subscription created by
   /// [syncBlockListsInBackground] survives widget rebuilds. Without it the

--- a/mobile/packages/content_blocklist_repository/lib/src/block_list_signer.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/block_list_signer.dart
@@ -1,7 +1,8 @@
 import 'package:nostr_sdk/event.dart';
 
 /// Minimal signer interface required by `ContentBlocklistRepository` for
-/// publishing block-list events to Nostr (kind 30000, d=block).
+/// publishing the user's mute/block lists to Nostr — the standard NIP-51
+/// kind 10000 mute list and the legacy kind 30000 (d=block) list.
 ///
 /// In production this is implemented by the app-level `AuthService`. The
 /// interface is kept intentionally narrow so the package has no dependency

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Content blocklist service for filtering unwanted content from feeds
 // ABOUTME: Tracks our blocks, our kind-10000 mutes, and mutual block/mute state
-// ABOUTME: Persists to SharedPreferences and publishes kind 30000
+// ABOUTME: Persists to SharedPreferences and publishes the kind 10000 mute list
 
 import 'dart:async';
 import 'dart:convert';
@@ -29,6 +29,11 @@ const _severedFollowersPrefsKey = 'severed_followers_list';
 /// construction hydrates the right account before auth resolves.
 const _activePubkeyPrefsKey = 'blocklist_active_pubkey';
 
+/// SharedPreferences key prefix recording that the one-time migration of a
+/// legacy kind 30000 (d=block) block list into the standard kind 10000 mute
+/// list has completed for an account. Scoped per account as `base.pubkey`.
+const _blockListMigratedPrefsKeyBase = 'block_list_migrated_to_mute_list';
+
 /// Service for managing content blocklist
 ///
 /// This service maintains an internal blocklist of npubs whose content
@@ -37,7 +42,10 @@ const _activePubkeyPrefsKey = 'blocklist_active_pubkey';
 /// follow them.
 ///
 /// Blocks are persisted to SharedPreferences for survival across restarts,
-/// and published to Nostr as kind 30000 events (d=block) for cross-device sync.
+/// and published to Nostr as the standard NIP-51 kind 10000 mute list so
+/// they interoperate with other clients (Amethyst, Damus, etc.) and the
+/// Divine backend (#4037). A legacy kind 30000 (d=block) event is also
+/// kept in sync for backward compatibility with older Divine clients.
 class ContentBlocklistRepository {
   /// Creates a [ContentBlocklistRepository].
   ///
@@ -84,11 +92,13 @@ class ContentBlocklistRepository {
   // Mutual mute blocklist (populated from kind 10000 events)
   final Set<String> _mutualMuteBlocklist = <String>{};
 
-  // Authors we muted via our own kind 10000 mute list. Read-only mirror of
-  // relay state: this app has no mute-authoring UI, so the newest own
-  // kind 10000 event (published from any Nostr client) replaces this set
-  // wholesale. Only public 'p' tags are read; NIP-51 encrypted (private)
-  // mute entries are not supported.
+  // Authors muted on our own kind 10000 mute list from *other* clients.
+  // Our own in-app blocks live in [_runtimeBlocklist] and are deliberately
+  // excluded from this set (see [_handleOwnMuteListEvent]) so republishing
+  // the merged mute list stays idempotent and unblocking actually removes
+  // the entry. The newest own kind 10000 event replaces this set wholesale.
+  // Only public 'p' tags are read; NIP-51 encrypted (private) mute entries
+  // are not supported.
   final Set<String> _mutedPubkeys = <String>{};
 
   // Latest replaceable kind-10000 mute-list event timestamp per author.
@@ -536,7 +546,97 @@ class ContentBlocklistRepository {
     }
   }
 
-  /// Publish our block list to Nostr as kind 30000 with d=block
+  /// Publish our mute list to Nostr as a NIP-51 kind 10000 event.
+  ///
+  /// Blocking a user adds them to the user's standard Nostr mute list so
+  /// the block interoperates with other clients (Amethyst, Damus, etc.)
+  /// and the Divine backend, all of which key off kind 10000 (#4037).
+  ///
+  /// Kind 10000 is replaceable, so the event must carry the *entire* list.
+  /// We publish the union of our blocks ([_runtimeBlocklist]) and the mutes
+  /// authored from other clients ([_mutedPubkeys]) so republishing never
+  /// clobbers a mute set maintained elsewhere.
+  ///
+  /// Returns `true` when the event was accepted by at least one relay.
+  Future<bool> _publishMuteListToNostr() async {
+    final signer = _signer;
+    final nostrClient = _nostrClient;
+
+    if (signer == null || nostrClient == null) {
+      Log.debug(
+        'Cannot publish mute list - Nostr services not yet injected',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+      return false;
+    }
+
+    if (!signer.isAuthenticated) {
+      Log.warning(
+        'Cannot publish mute list - user not authenticated',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+      return false;
+    }
+
+    try {
+      final mutedAuthors = <String>{..._runtimeBlocklist, ..._mutedPubkeys};
+      final tags = <List<String>>[
+        for (final pubkey in mutedAuthors) ['p', pubkey],
+      ];
+
+      final event = await signer.createAndSignEvent(
+        kind: 10000,
+        content: '',
+        tags: tags,
+      );
+
+      if (event == null) return false;
+
+      // Record our own write as the newest seen event so a stale relay
+      // echo of an older own mute list cannot race back and drop the
+      // mutes we just merged in.
+      final ourPubkey = _ourPubkey;
+      if (ourPubkey != null) {
+        final seen = _latestMuteListEventCreatedAtByAuthor[ourPubkey];
+        if (seen == null || event.createdAt > seen) {
+          _latestMuteListEventCreatedAtByAuthor[ourPubkey] = event.createdAt;
+        }
+      }
+
+      final sentEvent = await nostrClient.publishEvent(event);
+
+      if (sentEvent is PublishSuccess) {
+        Log.info(
+          'Published mute list to Nostr with ${mutedAuthors.length} entries',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+        return true;
+      }
+
+      Log.warning(
+        'Failed to publish mute list event to relays',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+      return false;
+    } on Object catch (e) {
+      Log.error(
+        'Error publishing mute list to Nostr: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+      return false;
+    }
+  }
+
+  /// Publish our legacy block list to Nostr as kind 30000 with d=block.
+  ///
+  /// Retained for backward compatibility with older Divine clients that
+  /// still read kind 30000. New interop goes through the standard kind
+  /// 10000 mute list ([_publishMuteListToNostr]).
   Future<void> _publishBlockListToNostr() async {
     final signer = _signer;
     final nostrClient = _nostrClient;
@@ -673,7 +773,8 @@ class ContentBlocklistRepository {
 
   /// Add a public key to the runtime blocklist
   ///
-  /// Persists to SharedPreferences and publishes to Nostr (kind 30000).
+  /// Persists to SharedPreferences and publishes the user's kind 10000 mute
+  /// list (plus the legacy kind 30000 block list for older Divine clients).
   /// Awaits the local write so the block survives an immediate app kill.
   /// If [ourPubkey] is provided, it will be used to prevent self-blocking.
   /// Otherwise falls back to [_ourPubkey] set during
@@ -695,6 +796,7 @@ class ContentBlocklistRepository {
       await _saveBlockedUsers();
       _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
       _notifyChanged();
+      await _publishMuteListToNostr();
       await _publishBlockListToNostr();
 
       Log.debug(
@@ -714,7 +816,8 @@ class ContentBlocklistRepository {
 
   /// Remove a public key from the runtime blocklist
   ///
-  /// Persists to SharedPreferences and publishes updated list to Nostr.
+  /// Persists to SharedPreferences and republishes the updated kind 10000
+  /// mute list (plus the legacy kind 30000 block list) to Nostr.
   /// Awaits the local write so the change survives an immediate app kill.
   /// Note: Cannot remove users from internal blocklist.
   Future<void> unblockUser(String pubkey) async {
@@ -723,6 +826,7 @@ class ContentBlocklistRepository {
       await _saveBlockedUsers();
       _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unblocked));
       _notifyChanged();
+      await _publishMuteListToNostr();
       await _publishBlockListToNostr();
 
       Log.info(
@@ -939,6 +1043,14 @@ class ContentBlocklistRepository {
 
       _blockListSyncStarted = true;
 
+      // One-time migration (#4037): fold any legacy kind 30000 block list
+      // into the standard kind 10000 mute list so pre-existing blocks
+      // finally interoperate with other clients. Fire-and-forget so it
+      // never blocks startup; guarded by a per-account persisted flag.
+      unawaited(
+        _migrateLegacyBlockListToMuteList(nostrService, signer, ourPubkey),
+      );
+
       Log.info(
         'Block list subscription created (includes own block list restore)',
         name: 'ContentBlocklistRepository',
@@ -947,6 +1059,133 @@ class ContentBlocklistRepository {
     } on Object catch (e) {
       Log.error(
         'Failed to start block list sync: $e',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    }
+  }
+
+  /// One-time migration of a legacy kind 30000 (d=block) block list into the
+  /// standard NIP-51 kind 10000 mute list (#4037).
+  ///
+  /// Older app versions only published blocks to a non-standard kind 30000
+  /// list that no other client honoured. This appends those entries to the
+  /// user's existing kind 10000 mute list and republishes it once, so
+  /// pre-existing blocks finally propagate — without dropping any mutes set
+  /// on other clients (the existing list is fetched and merged, never
+  /// replaced blindly).
+  ///
+  /// Guarded by a per-account SharedPreferences flag so it runs at most once
+  /// per account. The flag is only set after the republish is accepted, so a
+  /// failed publish retries on the next launch. Requires persistence; it is a
+  /// no-op without prefs (the one-time guarantee can't be tracked otherwise).
+  Future<void> _migrateLegacyBlockListToMuteList(
+    NostrClient nostrClient,
+    BlockListSigner signer,
+    String ourPubkey,
+  ) async {
+    final prefs = _prefs;
+    if (prefs == null) return;
+    final flagKey = '$_blockListMigratedPrefsKeyBase.$ourPubkey';
+    if (prefs.getBool(flagKey) ?? false) return;
+    if (!signer.isAuthenticated) return;
+
+    try {
+      // 1. Read the legacy kind 30000 d=block list from cache + relays.
+      final relayBlocks = <String>{};
+      final blockEvents = await nostrClient.queryEvents([
+        Filter(authors: [ourPubkey], kinds: const [30000]),
+      ]);
+      for (final event in blockEvents) {
+        if (event.pubkey != ourPubkey) continue;
+        final hasBlockDTag = event.tags.any(
+          (tag) => tag.length >= 2 && tag[0] == 'd' && tag[1] == 'block',
+        );
+        if (!hasBlockDTag) continue;
+        for (final tag in event.tags) {
+          if (tag.length >= 2 && tag[0] == 'p' && tag[1] != ourPubkey) {
+            relayBlocks.add(tag[1]);
+          }
+        }
+      }
+
+      // Nothing to migrate (no legacy relay blocks and no local blocks):
+      // record completion so we don't re-query on every launch. No publish
+      // happens here, so there is nothing to clobber.
+      if (relayBlocks.isEmpty && _runtimeBlocklist.isEmpty) {
+        await prefs.setBool(flagKey, true);
+        return;
+      }
+
+      // 2. Read the existing kind 10000 mute list (newest replaceable wins)
+      //    so the merge never drops mutes authored on other clients.
+      final muteEvents = await nostrClient.queryEvents([
+        Filter(authors: [ourPubkey], kinds: const [10000]),
+      ]);
+      Event? newestMuteList;
+      for (final event in muteEvents) {
+        if (event.pubkey != ourPubkey) continue;
+        if (newestMuteList == null ||
+            event.createdAt > newestMuteList.createdAt) {
+          newestMuteList = event;
+        }
+      }
+      final existingMutes = <String>{};
+      if (newestMuteList != null) {
+        for (final tag in newestMuteList.tags) {
+          if (tag.length >= 2 && tag[0] == 'p' && tag[1] != ourPubkey) {
+            existingMutes.add(tag[1]);
+          }
+        }
+      }
+
+      // 3. Fold both lists into our in-memory state without removing
+      //    anything. Legacy entries are our blocks; the rest of the relay's
+      //    mute list is preserved as mutes (our own blocks are kept out of
+      //    the mute set, matching [_handleOwnMuteListEvent]).
+      final newlyBlocked = relayBlocks.difference(_runtimeBlocklist);
+      _runtimeBlocklist.addAll(relayBlocks);
+      existingMutes.removeAll(_runtimeBlocklist);
+      final newlyMuted = existingMutes.difference(_mutedPubkeys);
+      _mutedPubkeys.addAll(existingMutes);
+      await _saveBlockedUsers();
+      await _saveMutedUsers();
+
+      // 4. Republish the unified kind 10000 mute list. Only record the
+      //    migration as done once the relay accepts it, so a failure retries.
+      final published = await _publishMuteListToNostr();
+      if (!published) {
+        Log.warning(
+          'Legacy block-list migration publish failed; retrying next launch',
+          name: 'ContentBlocklistRepository',
+          category: LogCategory.system,
+        );
+        return;
+      }
+
+      await prefs.setBool(flagKey, true);
+
+      for (final pubkey in newlyBlocked) {
+        _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
+      }
+      for (final pubkey in newlyMuted) {
+        _emitChange(
+          BlocklistChange(pubkey: pubkey, op: BlocklistOp.mutedByUs),
+        );
+      }
+      if (newlyBlocked.isNotEmpty || newlyMuted.isNotEmpty) {
+        _notifyChanged();
+      }
+
+      Log.info(
+        'Migrated legacy block list into the kind 10000 mute list '
+        '(${_runtimeBlocklist.length} blocks, ${_mutedPubkeys.length} mutes)',
+        name: 'ContentBlocklistRepository',
+        category: LogCategory.system,
+      );
+    } on Object catch (e) {
+      Log.error(
+        'Failed to migrate legacy block list to mute list: $e',
         name: 'ContentBlocklistRepository',
         category: LogCategory.system,
       );
@@ -1031,10 +1270,15 @@ class ContentBlocklistRepository {
 
   /// Replace our muted-authors set from our latest kind 10000 event.
   ///
-  /// Kind 10000 is replaceable and this app never authors mutes, so the
-  /// newest own event is the complete list and replaces [_mutedPubkeys]
-  /// wholesale — unlike [_handleOwnBlockListEvent], which merges to
-  /// protect locally-authored blocks that may not have reached relays.
+  /// Kind 10000 is replaceable, so the newest own event is the complete
+  /// list and replaces [_mutedPubkeys] wholesale — unlike
+  /// [_handleOwnBlockListEvent], which merges to protect locally-authored
+  /// blocks that may not have reached relays.
+  ///
+  /// Our own in-app blocks ([_runtimeBlocklist]) are excluded: this app now
+  /// publishes them onto the same kind 10000 list, so an entry that we
+  /// blocked must be tracked as a block (not duplicated into the mute set),
+  /// otherwise unblocking could never drop it from the republished list.
   /// Our own pubkey is excluded so a malformed self-referential mute list
   /// can never filter the user's own content (#2192).
   void _handleOwnMuteListEvent(Event event) {
@@ -1063,6 +1307,9 @@ class ContentBlocklistRepository {
         relayMuted.add(tag[1]);
       }
     }
+    // Entries we blocked in-app are republished onto this same list; keep
+    // them out of the mute set so they stay tracked as blocks only.
+    relayMuted.removeAll(_runtimeBlocklist);
 
     final added = relayMuted.difference(_mutedPubkeys);
     final removed = _mutedPubkeys.difference(relayMuted);

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -34,6 +34,13 @@ const _activePubkeyPrefsKey = 'blocklist_active_pubkey';
 /// list has completed for an account. Scoped per account as `base.pubkey`.
 const _blockListMigratedPrefsKeyBase = 'block_list_migrated_to_mute_list';
 
+class _MuteListPublishShape {
+  const _MuteListPublishShape({required this.tags, required this.content});
+
+  final List<List<String>> tags;
+  final String content;
+}
+
 /// Service for managing content blocklist
 ///
 /// This service maintains an internal blocklist of npubs whose content
@@ -97,9 +104,14 @@ class ContentBlocklistRepository {
   // excluded from this set (see [_handleOwnMuteListEvent]) so republishing
   // the merged mute list stays idempotent and unblocking actually removes
   // the entry. The newest own kind 10000 event replaces this set wholesale.
-  // Only public 'p' tags are read; NIP-51 encrypted (private) mute entries
-  // are not supported.
+  // Only public 'p' tags are interpreted as authored mutes. Other NIP-51
+  // public mute tags and encrypted private entries are preserved verbatim
+  // from [_latestOwnMuteListEvent] when we republish.
   final Set<String> _mutedPubkeys = <String>{};
+
+  // Full latest own kind-10000 event, retained so republishing Divine blocks
+  // preserves other clients' public t/word/e mutes and encrypted content.
+  Event? _latestOwnMuteListEvent;
 
   // Latest replaceable kind-10000 mute-list event timestamp per author.
   // Prevent stale relay delivery order from resurrecting old mute state.
@@ -240,6 +252,7 @@ class ContentBlocklistRepository {
       _mutedPubkeys.clear();
       _mutualMuteBlocklist.clear();
       _blockedByOthers.clear();
+      _latestOwnMuteListEvent = null;
       _latestMuteListEventCreatedAtByAuthor.clear();
       _latestBlockListEventCreatedAtByAuthor.clear();
       _severedFollowers.clear();
@@ -554,8 +567,9 @@ class ContentBlocklistRepository {
   ///
   /// Kind 10000 is replaceable, so the event must carry the *entire* list.
   /// We publish the union of our blocks ([_runtimeBlocklist]) and the mutes
-  /// authored from other clients ([_mutedPubkeys]) so republishing never
-  /// clobbers a mute set maintained elsewhere.
+  /// authored from other clients ([_mutedPubkeys]) while carrying forward
+  /// other public NIP-51 mute tags and encrypted private list content from
+  /// the latest own kind 10000 event.
   ///
   /// Returns `true` when the event was accepted by at least one relay.
   Future<bool> _publishMuteListToNostr() async {
@@ -581,35 +595,27 @@ class ContentBlocklistRepository {
     }
 
     try {
-      final mutedAuthors = <String>{..._runtimeBlocklist, ..._mutedPubkeys};
-      final tags = <List<String>>[
-        for (final pubkey in mutedAuthors) ['p', pubkey],
-      ];
+      await _refreshLatestOwnMuteList(nostrClient);
+      final publishShape = _buildMuteListPublishShape();
 
       final event = await signer.createAndSignEvent(
         kind: 10000,
-        content: '',
-        tags: tags,
+        content: publishShape.content,
+        tags: publishShape.tags,
       );
 
       if (event == null) return false;
 
-      // Record our own write as the newest seen event so a stale relay
-      // echo of an older own mute list cannot race back and drop the
-      // mutes we just merged in.
-      final ourPubkey = _ourPubkey;
-      if (ourPubkey != null) {
-        final seen = _latestMuteListEventCreatedAtByAuthor[ourPubkey];
-        if (seen == null || event.createdAt > seen) {
-          _latestMuteListEventCreatedAtByAuthor[ourPubkey] = event.createdAt;
-        }
-      }
-
       final sentEvent = await nostrClient.publishEvent(event);
 
       if (sentEvent is PublishSuccess) {
+        // Record our own write as the newest seen event so a stale relay
+        // echo of an older own mute list cannot race back and drop the
+        // mutes we just merged in.
+        _applyOwnMuteListEvent(sentEvent.event);
         Log.info(
-          'Published mute list to Nostr with ${mutedAuthors.length} entries',
+          'Published mute list to Nostr with '
+          '${_runtimeBlocklist.length + _mutedPubkeys.length} pubkey entries',
           name: 'ContentBlocklistRepository',
           category: LogCategory.system,
         );
@@ -632,11 +638,69 @@ class ContentBlocklistRepository {
     }
   }
 
+  Future<void> _refreshLatestOwnMuteList(NostrClient nostrClient) async {
+    final ourPubkey = _ourPubkey;
+    if (ourPubkey == null) return;
+
+    final muteEvents = await nostrClient.queryEvents([
+      Filter(authors: [ourPubkey], kinds: const [10000]),
+    ]);
+
+    var newest = _latestOwnMuteListEvent;
+    for (final event in muteEvents) {
+      if (event.pubkey != ourPubkey) continue;
+      if (newest == null || event.createdAt > newest.createdAt) {
+        newest = event;
+      }
+    }
+
+    if (newest != null && newest != _latestOwnMuteListEvent) {
+      _applyOwnMuteListEvent(newest);
+    }
+  }
+
+  _MuteListPublishShape _buildMuteListPublishShape() {
+    final source = _latestOwnMuteListEvent;
+    final tags = <List<String>>[];
+    final includedPubkeys = <String>{};
+
+    if (source != null) {
+      for (final tag in source.tags) {
+        if (tag.isEmpty || tag[0] != 'p') {
+          tags.add(List<String>.of(tag));
+          continue;
+        }
+
+        if (tag.length < 2) continue;
+        final pubkey = tag[1];
+        if (_mutedPubkeys.contains(pubkey) && includedPubkeys.add(pubkey)) {
+          tags.add(List<String>.of(tag));
+        }
+      }
+    }
+
+    for (final pubkey in _mutedPubkeys) {
+      if (includedPubkeys.add(pubkey)) {
+        tags.add(['p', pubkey]);
+      }
+    }
+
+    for (final pubkey in _runtimeBlocklist) {
+      if (includedPubkeys.add(pubkey)) {
+        tags.add(['p', pubkey]);
+      }
+    }
+
+    return _MuteListPublishShape(tags: tags, content: source?.content ?? '');
+  }
+
   /// Publish our legacy block list to Nostr as kind 30000 with d=block.
   ///
   /// Retained for backward compatibility with older Divine clients that
   /// still read kind 30000. New interop goes through the standard kind
   /// 10000 mute list ([_publishMuteListToNostr]).
+  // TODO(codex): Remove legacy kind 30000 publishing after kind 10000 rollout.
+  // Tracking issue: #5462.
   Future<void> _publishBlockListToNostr() async {
     final signer = _signer;
     final nostrClient = _nostrClient;
@@ -1109,11 +1173,10 @@ class ContentBlocklistRepository {
         }
       }
 
-      // Nothing to migrate (no legacy relay blocks and no local blocks):
-      // record completion so we don't re-query on every launch. No publish
-      // happens here, so there is nothing to clobber.
+      // Nothing to migrate. Leave the flag unset because an empty one-shot
+      // query can also mean a cold relay miss; retrying on a later launch is
+      // safer than permanently skipping a legacy-list migration.
       if (relayBlocks.isEmpty && _runtimeBlocklist.isEmpty) {
-        await prefs.setBool(flagKey, true);
         return;
       }
 
@@ -1130,14 +1193,6 @@ class ContentBlocklistRepository {
           newestMuteList = event;
         }
       }
-      final existingMutes = <String>{};
-      if (newestMuteList != null) {
-        for (final tag in newestMuteList.tags) {
-          if (tag.length >= 2 && tag[0] == 'p' && tag[1] != ourPubkey) {
-            existingMutes.add(tag[1]);
-          }
-        }
-      }
 
       // 3. Fold both lists into our in-memory state without removing
       //    anything. Legacy entries are our blocks; the rest of the relay's
@@ -1145,9 +1200,11 @@ class ContentBlocklistRepository {
       //    the mute set, matching [_handleOwnMuteListEvent]).
       final newlyBlocked = relayBlocks.difference(_runtimeBlocklist);
       _runtimeBlocklist.addAll(relayBlocks);
-      existingMutes.removeAll(_runtimeBlocklist);
-      final newlyMuted = existingMutes.difference(_mutedPubkeys);
-      _mutedPubkeys.addAll(existingMutes);
+      final mutedBeforeMerge = <String>{..._mutedPubkeys};
+      if (newestMuteList != null) {
+        _applyOwnMuteListEvent(newestMuteList, notify: false, persist: false);
+      }
+      final newlyMuted = _mutedPubkeys.difference(mutedBeforeMerge);
       await _saveBlockedUsers();
       await _saveMutedUsers();
 
@@ -1169,9 +1226,7 @@ class ContentBlocklistRepository {
         _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.blocked));
       }
       for (final pubkey in newlyMuted) {
-        _emitChange(
-          BlocklistChange(pubkey: pubkey, op: BlocklistOp.mutedByUs),
-        );
+        _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.mutedByUs));
       }
       if (newlyBlocked.isNotEmpty || newlyMuted.isNotEmpty) {
         _notifyChanged();
@@ -1282,6 +1337,14 @@ class ContentBlocklistRepository {
   /// Our own pubkey is excluded so a malformed self-referential mute list
   /// can never filter the user's own content (#2192).
   void _handleOwnMuteListEvent(Event event) {
+    _applyOwnMuteListEvent(event);
+  }
+
+  void _applyOwnMuteListEvent(
+    Event event, {
+    bool notify = true,
+    bool persist = true,
+  }) {
     final ourPubkey = event.pubkey;
     final createdAt = event.createdAt;
     final latestSeen = _latestMuteListEventCreatedAtByAuthor[ourPubkey];
@@ -1297,6 +1360,7 @@ class ContentBlocklistRepository {
     }
 
     _latestMuteListEventCreatedAtByAuthor[ourPubkey] = createdAt;
+    _latestOwnMuteListEvent = event;
 
     final relayMuted = <String>{};
     for (final tag in event.tags) {
@@ -1318,14 +1382,20 @@ class ContentBlocklistRepository {
     _mutedPubkeys
       ..removeAll(removed)
       ..addAll(added);
-    unawaited(_saveMutedUsers());
-    for (final pubkey in added) {
-      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.mutedByUs));
+    if (persist) {
+      unawaited(_saveMutedUsers());
     }
-    for (final pubkey in removed) {
-      _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.unmutedByUs));
+    if (notify) {
+      for (final pubkey in added) {
+        _emitChange(BlocklistChange(pubkey: pubkey, op: BlocklistOp.mutedByUs));
+      }
+      for (final pubkey in removed) {
+        _emitChange(
+          BlocklistChange(pubkey: pubkey, op: BlocklistOp.unmutedByUs),
+        );
+      }
+      _notifyChanged();
     }
-    _notifyChanged();
 
     Log.info(
       'Synced own mute list: +${added.length} -${removed.length} '

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -711,6 +711,35 @@ void main() {
       expect(service.hasMutedUs(mutedPubkey), isFalse);
     });
 
+    test('own kind 10000 echo does not double-count our own blocks as '
+        'mutes', () async {
+      final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+      await service.syncMuteListsInBackground(mockNostrService, ourPubkey);
+      // We blocked mutedPubkey in-app (no signer wired, so publishing is a
+      // no-op here), then our own kind 10000 echoes back containing both
+      // that block and a mute authored from another client.
+      await service.blockUser(mutedPubkey, ourPubkey: ourPubkey);
+      controller.add(
+        ownMuteListEvent(
+          mutedPubkeys: [mutedPubkey, otherMutedPubkey],
+          createdAt: now,
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Our own block stays tracked as a block, not duplicated into the
+      // mute set — otherwise unblocking could never drop it from the
+      // republished kind 10000 list.
+      expect(service.isBlocked(mutedPubkey), isTrue);
+      expect(service.isMutedByUs(mutedPubkey), isFalse);
+      // The external mute is still recorded.
+      expect(service.isMutedByUs(otherMutedPubkey), isTrue);
+      // Both are filtered from feeds regardless.
+      expect(service.shouldFilterFromFeeds(mutedPubkey), isTrue);
+      expect(service.shouldFilterFromFeeds(otherMutedPubkey), isTrue);
+    });
+
     test('newer own event replaces the muted set (unmute)', () async {
       final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
@@ -2169,7 +2198,7 @@ void main() {
       );
     });
 
-    test('publishes block list with p tag for each blocked user', () async {
+    test('blocking publishes the kind 10000 mute list with a p tag', () async {
       final event = buildEvent();
       when(() => mockSigner.isAuthenticated).thenReturn(true);
       when(
@@ -2192,7 +2221,23 @@ void main() {
 
       await service.blockUser('pubkey1');
 
-      final tagsList =
+      // The interop fix (#4037): the blocked user lands on the standard
+      // NIP-51 kind 10000 mute list, with no parameterized-list tags.
+      final muteTags =
+          verify(
+                () => mockSigner.createAndSignEvent(
+                  kind: 10000,
+                  content: '',
+                  tags: captureAny(named: 'tags'),
+                ),
+              ).captured.last
+              as List<List<String>>;
+      expect(muteTags, contains(equals(['p', 'pubkey1'])));
+      expect(muteTags, isNot(contains(equals(['d', 'block']))));
+
+      // The legacy kind 30000 block list is still kept in sync for older
+      // Divine clients.
+      final blockTags =
           verify(
                 () => mockSigner.createAndSignEvent(
                   kind: 30000,
@@ -2201,10 +2246,46 @@ void main() {
                 ),
               ).captured.last
               as List<List<String>>;
+      expect(blockTags, contains(equals(['d', 'block'])));
+      expect(blockTags, contains(equals(['p', 'pubkey1'])));
 
-      expect(tagsList, contains(equals(['d', 'block'])));
-      expect(tagsList, contains(equals(['p', 'pubkey1'])));
-      verify(() => mockClient.publishEvent(event)).called(1);
+      verify(() => mockClient.publishEvent(event)).called(2);
+    });
+
+    test('unblocking republishes the kind 10000 mute list without the '
+        'user', () async {
+      when(() => mockSigner.isAuthenticated).thenReturn(true);
+      when(
+        () => mockSigner.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => buildEvent());
+      when(
+        () => mockClient.publishEvent(any()),
+      ).thenAnswer((_) async => PublishSuccess(event: buildEvent()));
+
+      final service = ContentBlocklistRepository();
+      await service.syncBlockListsInBackground(
+        mockClient,
+        mockSigner,
+        ourPubkey,
+      );
+
+      await service.blockUser('pubkey1');
+      await service.unblockUser('pubkey1');
+
+      final lastMuteTags =
+          verify(
+                () => mockSigner.createAndSignEvent(
+                  kind: 10000,
+                  content: '',
+                  tags: captureAny(named: 'tags'),
+                ),
+              ).captured.last
+              as List<List<String>>;
+      expect(lastMuteTags, isEmpty);
     });
 
     test('tolerates publishEvent returning null', () async {
@@ -2254,6 +2335,215 @@ void main() {
       await service.blockUser('pubkey1');
 
       expect(service.isBlocked('pubkey1'), isTrue);
+    });
+  });
+
+  group('ContentBlocklistRepository - legacy block list migration', () {
+    const ourPubkey =
+        '0000000000000000000000000000000000000000000000000000000000000001';
+    const blockA =
+        '00000000000000000000000000000000000000000000000000000000000000aa';
+    const blockB =
+        '00000000000000000000000000000000000000000000000000000000000000bb';
+    const muteC =
+        '00000000000000000000000000000000000000000000000000000000000000cc';
+    const flagKey = 'block_list_migrated_to_mute_list.$ourPubkey';
+
+    late _MockNostrClient mockClient;
+    late _MockBlockListSigner mockSigner;
+    late SharedPreferences prefs;
+
+    Event ownBlockEvent(List<String> blocked) =>
+        Event(
+            ourPubkey,
+            30000,
+            [
+              const ['d', 'block'],
+              for (final pk in blocked) ['p', pk],
+            ],
+            'Block list',
+            createdAt: 1000,
+          )
+          ..id = 'own-block-event'
+          ..sig = 'signature';
+
+    Event ownMuteEvent(List<String> muted, {int createdAt = 2000}) =>
+        Event(
+            ourPubkey,
+            10000,
+            [
+              for (final pk in muted) ['p', pk],
+            ],
+            '',
+            createdAt: createdAt,
+          )
+          ..id = 'own-mute-event-$createdAt'
+          ..sig = 'signature';
+
+    Event signedMuteList() =>
+        Event(ourPubkey, 10000, const <List<String>>[], '', createdAt: 3000)
+          ..id = 'signed-mute-list'
+          ..sig = 'signature';
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
+      prefs = await SharedPreferences.getInstance();
+      mockClient = _MockNostrClient();
+      mockSigner = _MockBlockListSigner();
+      when(
+        () => mockClient.subscribe(any()),
+      ).thenAnswer((_) => const Stream.empty());
+      when(() => mockSigner.isAuthenticated).thenReturn(true);
+    });
+
+    test(
+      'appends legacy kind 30000 blocks to the existing kind 10000 mute '
+      'list and publishes once',
+      () async {
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockA, blockB]),
+            ];
+          }
+          if (kinds.contains(10000)) {
+            return [
+              ownMuteEvent([muteC]),
+            ];
+          }
+          return <Event>[];
+        });
+
+        List<List<String>>? publishedMuteTags;
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final kind = invocation.namedArguments[#kind] as int;
+          if (kind == 10000) {
+            publishedMuteTags =
+                invocation.namedArguments[#tags] as List<List<String>>?;
+          }
+          return signedMuteList();
+        });
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenAnswer((_) async => PublishSuccess(event: signedMuteList()));
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // The republished kind 10000 list carries the legacy blocks AND the
+        // mute that already lived on the existing kind 10000 list.
+        expect(publishedMuteTags, isNotNull);
+        final publishedPubkeys = publishedMuteTags!
+            .where((tag) => tag.length >= 2 && tag[0] == 'p')
+            .map((tag) => tag[1])
+            .toSet();
+        expect(publishedPubkeys, containsAll(<String>{blockA, blockB, muteC}));
+
+        expect(service.isBlocked(blockA), isTrue);
+        expect(service.isBlocked(blockB), isTrue);
+        expect(service.isMutedByUs(muteC), isTrue);
+        expect(prefs.getBool(flagKey), isTrue);
+
+        service.dispose();
+      },
+    );
+
+    test(
+      'records completion without publishing when there is no legacy list',
+      () async {
+        when(
+          () => mockClient.queryEvents(any()),
+        ).thenAnswer((_) async => <Event>[]);
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+        expect(prefs.getBool(flagKey), isTrue);
+
+        service.dispose();
+      },
+    );
+
+    test('does not run again once the migration flag is set', () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{flagKey: true});
+      prefs = await SharedPreferences.getInstance();
+
+      final service = ContentBlocklistRepository(prefs: prefs);
+      await service.syncBlockListsInBackground(
+        mockClient,
+        mockSigner,
+        ourPubkey,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      verifyNever(() => mockClient.queryEvents(any()));
+
+      service.dispose();
+    });
+
+    test('keeps the flag unset when the republish is rejected', () async {
+      when(() => mockClient.queryEvents(any())).thenAnswer((invocation) async {
+        final filters = invocation.positionalArguments[0] as List<Filter>;
+        final kinds = filters.first.kinds ?? const <int>[];
+        if (kinds.contains(30000)) {
+          return [
+            ownBlockEvent([blockA]),
+          ];
+        }
+        return <Event>[];
+      });
+      when(
+        () => mockSigner.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer((_) async => signedMuteList());
+      when(
+        () => mockClient.publishEvent(any()),
+      ).thenAnswer((_) async => const PublishFailed());
+
+      final service = ContentBlocklistRepository(prefs: prefs);
+      await service.syncBlockListsInBackground(
+        mockClient,
+        mockSigner,
+        ourPubkey,
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // Migration retries next launch, but the block is real and already
+      // applied locally.
+      expect(prefs.getBool(flagKey), isNull);
+      expect(service.isBlocked(blockA), isTrue);
+
+      service.dispose();
     });
   });
 

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -2093,6 +2093,10 @@ void main() {
         when(
           () => mockBlockClient.subscribe(any()),
         ).thenAnswer((_) => blockController.stream);
+        when(() => mockBlockClient.queryEvents(any())).thenAnswer(
+          (_) async => <Event>[],
+        );
+        when(() => mockSigner.isAuthenticated).thenReturn(false);
         await service.syncBlockListsInBackground(
           mockBlockClient,
           mockSigner,
@@ -2163,18 +2167,32 @@ void main() {
       when(
         () => mockClient.subscribe(any()),
       ).thenAnswer((_) => const Stream.empty());
+      when(() => mockClient.queryEvents(any())).thenAnswer((_) async => []);
     });
 
-    Event buildEvent() {
+    Event buildEvent({
+      int kind = 30000,
+      List<List<String>> tags = const <List<String>>[],
+      String content = 'Block list',
+      int? createdAt,
+    }) {
       return Event(
           ourPubkey,
-          30000,
-          const <List<String>>[],
-          'Block list',
-          createdAt: DateTime.now().millisecondsSinceEpoch ~/ 1000,
+          kind,
+          tags,
+          content,
+          createdAt: createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000,
         )
         ..id = 'test-event-id'
         ..sig = 'signature';
+    }
+
+    Event signedEventFromInvocation(Invocation invocation) {
+      return buildEvent(
+        kind: invocation.namedArguments[#kind] as int,
+        content: invocation.namedArguments[#content] as String,
+        tags: invocation.namedArguments[#tags] as List<List<String>>,
+      );
     }
 
     test('does not publish when signer is not authenticated', () async {
@@ -2199,7 +2217,6 @@ void main() {
     });
 
     test('blocking publishes the kind 10000 mute list with a p tag', () async {
-      final event = buildEvent();
       when(() => mockSigner.isAuthenticated).thenReturn(true);
       when(
         () => mockSigner.createAndSignEvent(
@@ -2207,10 +2224,16 @@ void main() {
           content: any(named: 'content'),
           tags: any(named: 'tags'),
         ),
-      ).thenAnswer((_) async => event);
+      ).thenAnswer(
+        (invocation) async => signedEventFromInvocation(invocation),
+      );
       when(
         () => mockClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: event));
+      ).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
 
       final service = ContentBlocklistRepository();
       await service.syncBlockListsInBackground(
@@ -2249,7 +2272,7 @@ void main() {
       expect(blockTags, contains(equals(['d', 'block'])));
       expect(blockTags, contains(equals(['p', 'pubkey1'])));
 
-      verify(() => mockClient.publishEvent(event)).called(2);
+      verify(() => mockClient.publishEvent(any())).called(2);
     });
 
     test('unblocking republishes the kind 10000 mute list without the '
@@ -2261,10 +2284,16 @@ void main() {
           content: any(named: 'content'),
           tags: any(named: 'tags'),
         ),
-      ).thenAnswer((_) async => buildEvent());
+      ).thenAnswer(
+        (invocation) async => signedEventFromInvocation(invocation),
+      );
       when(
         () => mockClient.publishEvent(any()),
-      ).thenAnswer((_) async => PublishSuccess(event: buildEvent()));
+      ).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
 
       final service = ContentBlocklistRepository();
       await service.syncBlockListsInBackground(
@@ -2287,6 +2316,191 @@ void main() {
               as List<List<String>>;
       expect(lastMuteTags, isEmpty);
     });
+
+    test('blocking preserves existing NIP-51 public tags and encrypted '
+        'content', () async {
+      const existingMute =
+          '00000000000000000000000000000000000000000000000000000000000000cc';
+      const blockedPubkey =
+          '00000000000000000000000000000000000000000000000000000000000000dd';
+      final existingEvent = buildEvent(
+        kind: 10000,
+        content: 'encrypted-private-tags',
+        tags: const [
+          ['p', existingMute, 'wss://relay.example'],
+          ['t', 'spoilers'],
+          ['word', 'spoiler'],
+          ['e', 'event-thread-id'],
+        ],
+        createdAt: 1000,
+      );
+      when(() => mockSigner.isAuthenticated).thenReturn(true);
+      when(
+        () => mockClient.queryEvents(any()),
+      ).thenAnswer((_) async => [existingEvent]);
+      when(
+        () => mockSigner.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer(
+        (invocation) async => signedEventFromInvocation(invocation),
+      );
+      when(
+        () => mockClient.publishEvent(any()),
+      ).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
+
+      final service = ContentBlocklistRepository();
+      await service.syncBlockListsInBackground(
+        mockClient,
+        mockSigner,
+        ourPubkey,
+      );
+
+      await service.blockUser(blockedPubkey);
+
+      final capturedMuteCall = verify(
+        () => mockSigner.createAndSignEvent(
+          kind: 10000,
+          content: captureAny(named: 'content'),
+          tags: captureAny(named: 'tags'),
+        ),
+      ).captured;
+      final content = capturedMuteCall[0] as String;
+      final tags = capturedMuteCall[1] as List<List<String>>;
+
+      expect(content, 'encrypted-private-tags');
+      expect(
+        tags,
+        contains(equals(['p', existingMute, 'wss://relay.example'])),
+      );
+      expect(tags, contains(equals(['p', blockedPubkey])));
+      expect(tags, contains(equals(['t', 'spoilers'])));
+      expect(tags, contains(equals(['word', 'spoiler'])));
+      expect(tags, contains(equals(['e', 'event-thread-id'])));
+    });
+
+    test('blocking appends hydrated external p mutes before the latest source '
+        'event is available', () async {
+      const existingMute =
+          '00000000000000000000000000000000000000000000000000000000000000cc';
+      const blockedPubkey =
+          '00000000000000000000000000000000000000000000000000000000000000dd';
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'muted_users_list': jsonEncode([existingMute]),
+      });
+      final prefs = await SharedPreferences.getInstance();
+      when(() => mockSigner.isAuthenticated).thenReturn(true);
+      when(
+        () => mockSigner.createAndSignEvent(
+          kind: any(named: 'kind'),
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+        ),
+      ).thenAnswer(
+        (invocation) async => signedEventFromInvocation(invocation),
+      );
+      when(
+        () => mockClient.publishEvent(any()),
+      ).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
+
+      final service = ContentBlocklistRepository(prefs: prefs);
+      await service.syncBlockListsInBackground(
+        mockClient,
+        mockSigner,
+        ourPubkey,
+      );
+
+      await service.blockUser(blockedPubkey);
+
+      final tags =
+          verify(
+                () => mockSigner.createAndSignEvent(
+                  kind: 10000,
+                  content: any(named: 'content'),
+                  tags: captureAny(named: 'tags'),
+                ),
+              ).captured.last
+              as List<List<String>>;
+      expect(tags, contains(equals(['p', existingMute])));
+      expect(tags, contains(equals(['p', blockedPubkey])));
+    });
+
+    test(
+      'unblocking preserves non-p mute-list tags and encrypted content',
+      () async {
+        const blockedPubkey =
+            '00000000000000000000000000000000000000000000000000000000000000dd';
+        final existingEvent = buildEvent(
+          kind: 10000,
+          content: 'encrypted-private-tags',
+          tags: const [
+            ['t', 'spoilers'],
+            ['word', 'spoiler'],
+            ['e', 'event-thread-id'],
+          ],
+          createdAt: 1000,
+        );
+        when(() => mockSigner.isAuthenticated).thenReturn(true);
+        when(
+          () => mockClient.queryEvents(any()),
+        ).thenAnswer((_) async => [existingEvent]);
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (invocation) async => signedEventFromInvocation(invocation),
+        );
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenAnswer(
+          (invocation) async => PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          ),
+        );
+
+        final service = ContentBlocklistRepository();
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+
+        await service.blockUser(blockedPubkey);
+        await service.unblockUser(blockedPubkey);
+
+        final capturedMuteCalls = verify(
+          () => mockSigner.createAndSignEvent(
+            kind: 10000,
+            content: captureAny(named: 'content'),
+            tags: captureAny(named: 'tags'),
+          ),
+        ).captured;
+        final lastContent =
+            capturedMuteCalls[capturedMuteCalls.length - 2] as String;
+        final lastTags =
+            capturedMuteCalls[capturedMuteCalls.length - 1]
+                as List<List<String>>;
+
+        expect(lastContent, 'encrypted-private-tags');
+        expect(lastTags, isNot(contains(equals(['p', blockedPubkey]))));
+        expect(lastTags, contains(equals(['t', 'spoilers'])));
+        expect(lastTags, contains(equals(['word', 'spoiler'])));
+        expect(lastTags, contains(equals(['e', 'event-thread-id'])));
+      },
+    );
 
     test('tolerates publishEvent returning null', () async {
       when(() => mockSigner.isAuthenticated).thenReturn(true);
@@ -2367,23 +2581,38 @@ void main() {
           ..id = 'own-block-event'
           ..sig = 'signature';
 
-    Event ownMuteEvent(List<String> muted, {int createdAt = 2000}) =>
+    Event ownMuteEvent(
+      List<String> muted, {
+      int createdAt = 2000,
+      List<List<String>> extraTags = const <List<String>>[],
+      String content = '',
+    }) =>
         Event(
             ourPubkey,
             10000,
             [
               for (final pk in muted) ['p', pk],
+              ...extraTags,
             ],
-            '',
+            content,
             createdAt: createdAt,
           )
           ..id = 'own-mute-event-$createdAt'
           ..sig = 'signature';
 
-    Event signedMuteList() =>
-        Event(ourPubkey, 10000, const <List<String>>[], '', createdAt: 3000)
-          ..id = 'signed-mute-list'
-          ..sig = 'signature';
+    Event signedMuteList({
+      List<List<String>> tags = const <List<String>>[],
+      String content = '',
+    }) => Event(ourPubkey, 10000, tags, content, createdAt: 3000)
+      ..id = 'signed-mute-list'
+      ..sig = 'signature';
+
+    Event signedMuteListFromInvocation(Invocation invocation) {
+      return signedMuteList(
+        content: invocation.namedArguments[#content] as String,
+        tags: invocation.namedArguments[#tags] as List<List<String>>,
+      );
+    }
 
     setUp(() async {
       SharedPreferences.setMockInitialValues(<String, Object>{});
@@ -2430,12 +2659,17 @@ void main() {
           if (kind == 10000) {
             publishedMuteTags =
                 invocation.namedArguments[#tags] as List<List<String>>?;
+            return signedMuteListFromInvocation(invocation);
           }
           return signedMuteList();
         });
         when(
           () => mockClient.publishEvent(any()),
-        ).thenAnswer((_) async => PublishSuccess(event: signedMuteList()));
+        ).thenAnswer(
+          (invocation) async => PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          ),
+        );
 
         final service = ContentBlocklistRepository(prefs: prefs);
         await service.syncBlockListsInBackground(
@@ -2464,7 +2698,7 @@ void main() {
     );
 
     test(
-      'records completion without publishing when there is no legacy list',
+      'leaves the flag unset without publishing when there is no legacy list',
       () async {
         when(
           () => mockClient.queryEvents(any()),
@@ -2485,7 +2719,7 @@ void main() {
             tags: any(named: 'tags'),
           ),
         );
-        expect(prefs.getBool(flagKey), isTrue);
+        expect(prefs.getBool(flagKey), isNull);
 
         service.dispose();
       },
@@ -2584,12 +2818,17 @@ void main() {
           if (kind == 10000) {
             publishedMuteTags =
                 invocation.namedArguments[#tags] as List<List<String>>?;
+            return signedMuteListFromInvocation(invocation);
           }
           return signedMuteList();
         });
         when(
           () => mockClient.publishEvent(any()),
-        ).thenAnswer((_) async => PublishSuccess(event: signedMuteList()));
+        ).thenAnswer(
+          (invocation) async => PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          ),
+        );
 
         final service = ContentBlocklistRepository(prefs: prefs);
         await service.syncBlockListsInBackground(
@@ -2607,6 +2846,81 @@ void main() {
         expect(publishedPubkeys, isNot(contains(muteC)));
         expect(service.isMutedByUs(muteD), isTrue);
         expect(service.isMutedByUs(muteC), isFalse);
+
+        service.dispose();
+      },
+    );
+
+    test(
+      'migration preserves existing non-p mute tags and encrypted content',
+      () async {
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockA]),
+            ];
+          }
+          if (kinds.contains(10000)) {
+            return [
+              ownMuteEvent(
+                [muteC],
+                content: 'encrypted-private-tags',
+                extraTags: const [
+                  ['t', 'spoilers'],
+                  ['word', 'spoiler'],
+                  ['e', 'event-thread-id'],
+                ],
+              ),
+            ];
+          }
+          return <Event>[];
+        });
+
+        List<List<String>>? publishedMuteTags;
+        String? publishedContent;
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final kind = invocation.namedArguments[#kind] as int;
+          if (kind == 10000) {
+            publishedContent = invocation.namedArguments[#content] as String;
+            publishedMuteTags =
+                invocation.namedArguments[#tags] as List<List<String>>?;
+            return signedMuteListFromInvocation(invocation);
+          }
+          return signedMuteList();
+        });
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenAnswer(
+          (invocation) async => PublishSuccess(
+            event: invocation.positionalArguments.first as Event,
+          ),
+        );
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        expect(publishedContent, 'encrypted-private-tags');
+        expect(publishedMuteTags, isNotNull);
+        expect(publishedMuteTags, contains(equals(['p', blockA])));
+        expect(publishedMuteTags, contains(equals(['p', muteC])));
+        expect(publishedMuteTags, contains(equals(['t', 'spoilers'])));
+        expect(publishedMuteTags, contains(equals(['word', 'spoiler'])));
+        expect(publishedMuteTags, contains(equals(['e', 'event-thread-id'])));
 
         service.dispose();
       },

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -2545,6 +2545,101 @@ void main() {
 
       service.dispose();
     });
+
+    test(
+      'merges the newest kind 10000 event when several exist',
+      () async {
+        const muteD =
+            '00000000000000000000000000000000000000000000000000000000000000dd';
+        when(() => mockClient.queryEvents(any())).thenAnswer((
+          invocation,
+        ) async {
+          final filters = invocation.positionalArguments[0] as List<Filter>;
+          final kinds = filters.first.kinds ?? const <int>[];
+          if (kinds.contains(30000)) {
+            return [
+              ownBlockEvent([blockA]),
+            ];
+          }
+          if (kinds.contains(10000)) {
+            // Older event first, newer second: the newest one wins so only
+            // its mutes survive into the republished list.
+            return [
+              ownMuteEvent([muteC], createdAt: 1500),
+              ownMuteEvent([muteD], createdAt: 5000),
+            ];
+          }
+          return <Event>[];
+        });
+
+        List<List<String>>? publishedMuteTags;
+        when(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer((invocation) async {
+          final kind = invocation.namedArguments[#kind] as int;
+          if (kind == 10000) {
+            publishedMuteTags =
+                invocation.namedArguments[#tags] as List<List<String>>?;
+          }
+          return signedMuteList();
+        });
+        when(
+          () => mockClient.publishEvent(any()),
+        ).thenAnswer((_) async => PublishSuccess(event: signedMuteList()));
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        final publishedPubkeys = publishedMuteTags!
+            .where((tag) => tag.length >= 2 && tag[0] == 'p')
+            .map((tag) => tag[1])
+            .toSet();
+        expect(publishedPubkeys, containsAll(<String>{blockA, muteD}));
+        expect(publishedPubkeys, isNot(contains(muteC)));
+        expect(service.isMutedByUs(muteD), isTrue);
+        expect(service.isMutedByUs(muteC), isFalse);
+
+        service.dispose();
+      },
+    );
+
+    test(
+      'swallows errors and leaves the flag unset on query failure',
+      () async {
+        when(
+          () => mockClient.queryEvents(any()),
+        ).thenThrow(Exception('relay unavailable'));
+
+        final service = ContentBlocklistRepository(prefs: prefs);
+        await service.syncBlockListsInBackground(
+          mockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+
+        // The failure is caught; migration retries on the next launch.
+        expect(prefs.getBool(flagKey), isNull);
+        verifyNever(
+          () => mockSigner.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        );
+
+        service.dispose();
+      },
+    );
   });
 
   group('ContentBlocklistRepository - sync edge cases', () {

--- a/mobile/packages/content_policy/lib/src/content_policy_state.dart
+++ b/mobile/packages/content_policy/lib/src/content_policy_state.dart
@@ -32,7 +32,8 @@ class ContentPolicyState {
   /// Authors the user muted via their own kind 10000 event.
   final Set<String> mutedPubkeys;
 
-  /// Authors the user blocked via their own kind 30000 d=block event.
+  /// Authors the user blocked in-app, published onto their own kind 10000
+  /// mute list (and the legacy kind 30000 d=block event).
   final Set<String> blockedPubkeys;
 
   /// Authors whose kind 30000 d=block event names the current user.

--- a/mobile/packages/content_policy/lib/src/rules/pubkey_block_rule.dart
+++ b/mobile/packages/content_policy/lib/src/rules/pubkey_block_rule.dart
@@ -3,7 +3,8 @@ import 'package:content_policy/src/policy_decision.dart';
 import 'package:content_policy/src/policy_input.dart';
 import 'package:content_policy/src/policy_rule.dart';
 
-/// Blocks content from authors the user blocked via kind 30000 d=block.
+/// Blocks content from authors the user blocked in-app (published onto
+/// their kind 10000 mute list, plus the legacy kind 30000 d=block list).
 class PubkeyBlockRule implements PolicyRule {
   /// Creates a [PubkeyBlockRule].
   const PubkeyBlockRule();


### PR DESCRIPTION
## Summary

Fixes #4037.

Blocking a user previously only wrote a non-standard parameterized **kind 30000** "block list". Other Nostr clients (e.g. Amethyst) don't read that list, so blocked users still showed up in their feeds. This PR makes Divine publish blocks to the standard **NIP-51 kind 10000 mute list** while keeping the legacy kind 30000 list in sync for backward compatibility with older Divine clients.

### What changed

- **Publish kind 10000 mute lists** on block/unblock. `_publishMuteListToNostr()` publishes the union of in-app blocks (`_runtimeBlocklist`) and externally-authored public `p` mutes (`_mutedPubkeys`).
- **Preserve the rest of the user's mute list.** Republish now carries forward the latest own kind 10000 event's non-`p` public NIP-51 tags (`t`, `word`, `e`, etc.) and encrypted private `content` instead of replacing the event with only Divine-managed `p` tags.
- **Refresh before replacing.** Before publishing a replaceable kind 10000 event, the repository refreshes the latest own mute list from relays/cache so a block/unblock does not clobber data that arrived before the subscription callback.
- **Keep legacy kind 30000 in sync.** `blockUser()` / `unblockUser()` still publish the kind 30000 list so older Divine clients keep working. Removal is tracked in #5462.
- **Idempotent unblock.** `_handleOwnMuteListEvent()` excludes `_runtimeBlocklist` entries from the external mute set, so unblocking correctly removes a Divine-authored block from the kind 10000 list instead of re-adding it from our own echo.
- **One-time legacy migration (#4037).** `_migrateLegacyBlockListToMuteList()` folds pre-existing kind 30000 blocks into the kind 10000 mute list and republishes once. It preserves existing kind 10000 tags/content and only records completion after a successful relay publish.
- **Safer no-op migration.** Empty legacy-query results no longer mark migration complete, because an empty one-shot relay query can also be a cold relay miss.
- Updated docstrings across `content_policy`, `moderation_providers`, and the signer interface to reflect the kind 10000 (+ legacy 30000) behavior.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart`
- [x] `flutter test packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart`
- [x] `flutter analyze`
- [x] Pre-push hook: merge-conflict check, analyzer, generated files, changed-file tests

## Follow-up

- #5462 tracks removal of the temporary legacy kind 30000 dual-write after the kind 10000 rollout window.
