### PR TITLE
fix(quick-actions): cover warm camera-widget resume with the launch splash

### DIFF
--- a/mobile/lib/services/quick_actions_coordinator.dart
+++ b/mobile/lib/services/quick_actions_coordinator.dart
@@ -34,6 +34,8 @@ abstract interface class QuickActionsClient {
 
   Future<bool> clearActions();
 
+  Future<void> dismissLaunchCover();
+
   Future<void> dispose();
 }
 
@@ -61,6 +63,11 @@ class DivineQuickActionsClient implements QuickActionsClient {
   @override
   Future<bool> clearActions() {
     return _quickActions.clearActions();
+  }
+
+  @override
+  Future<void> dismissLaunchCover() {
+    return _quickActions.dismissLaunchCover();
   }
 
   @override
@@ -231,6 +238,9 @@ class QuickActionsCoordinator {
         name: 'QuickActions',
         category: LogCategory.system,
       );
+      // Reveal the route the user actually needs (e.g. login) instead of
+      // leaving a cold-start cover up until the native safety timeout.
+      _dismissLaunchCover();
       unawaited(_client.clearActions());
       return;
     }
@@ -269,6 +279,9 @@ class QuickActionsCoordinator {
       name: 'QuickActions',
       category: LogCategory.system,
     );
+    // Auth resolved without a session — drop the cold-start cover so the user
+    // lands on the screen they need rather than waiting out the safety timeout.
+    _dismissLaunchCover();
   }
 
   bool _isAuthPending(AuthState authState) {
@@ -295,12 +308,25 @@ class QuickActionsCoordinator {
       name: 'QuickActions',
       category: LogCategory.ui,
     );
-    if (_navigator.currentPath == _cameraPath) return;
+    final alreadyOnCamera = _navigator.currentPath == _cameraPath;
+    if (!alreadyOnCamera) {
+      _navigator.suppressAuthenticatedAuthRouteRedirect();
+      _navigator.openCamera();
+    }
 
-    _navigator.suppressAuthenticatedAuthRouteRedirect();
-    _navigator.openCamera();
-    _scheduleRedirectSuppressionClear(
-      _navigator.clearAuthRouteRedirectSuppression,
-    );
+    // Drop the native launch cover only after the recorder frame has rendered,
+    // so it's replaced by the camera rather than the route the user left open.
+    _scheduleRedirectSuppressionClear(() {
+      if (!alreadyOnCamera) {
+        _navigator.clearAuthRouteRedirectSuppression();
+      }
+      _dismissLaunchCover();
+    });
+  }
+
+  void _dismissLaunchCover() {
+    // The cover is only ever drawn natively on Android warm activations.
+    if (!_isAndroid) return;
+    unawaited(_client.dismissLaunchCover());
   }
 }

--- a/mobile/packages/divine_quick_actions/android/src/main/kotlin/co/openvine/divine_quick_actions/CameraLaunchCover.kt
+++ b/mobile/packages/divine_quick_actions/android/src/main/kotlin/co/openvine/divine_quick_actions/CameraLaunchCover.kt
@@ -1,0 +1,127 @@
+package co.openvine.divine_quick_actions
+
+import android.app.Activity
+import android.graphics.drawable.Drawable
+import android.os.Handler
+import android.os.Looper
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
+
+/**
+ * Covers a warm-resumed activity with the launch splash (the divine wordmark
+ * centered on the brand background) while a camera quick action navigates to
+ * the recorder.
+ *
+ * Only used for warm resumes: `launchMode="singleTask"` reuses the activity via
+ * `onNewIntent`, and the OS composites the activity's last rendered frame — the
+ * route the user left open (e.g. their profile) — before Flutter receives the
+ * intent and navigates to the recorder. Dart can't paint before the OS shows
+ * that cached surface, so the cover must be native. Cold starts are left alone:
+ * the OS already shows the launch splash (the same logo a normal app-icon
+ * launch shows), so there is nothing to cover.
+ *
+ * The wordmark is drawn with a real [ImageView] rather than by setting the
+ * `launch_background` layer-list as a View background: a layer-list's centered
+ * `<bitmap>` frequently fails to render as a View background, leaving only the
+ * flat colour — which showed as a bare green cover. The brand background colour
+ * is applied directly (no resource-name lookup) so the cover can never collapse
+ * to the wrong colour, and the app icon is used as a last-resort glyph if the
+ * wordmark drawable can't be resolved.
+ */
+internal interface CameraLaunchCover {
+  fun show(activity: Activity)
+
+  fun dismiss()
+}
+
+internal class WindowCameraLaunchCover(
+  private val autoDismissMs: Long = DEFAULT_AUTO_DISMISS_MS,
+) : CameraLaunchCover {
+  private val mainHandler = Handler(Looper.getMainLooper())
+  private val autoDismiss = Runnable { dismiss() }
+  private var coverView: View? = null
+
+  override fun show(activity: Activity) {
+    if (coverView != null) {
+      restartSafetyTimeout()
+      return
+    }
+    val root = activity.window?.decorView as? ViewGroup ?: return
+    coverView = buildCoverView(activity).also(root::addView)
+    restartSafetyTimeout()
+  }
+
+  override fun dismiss() {
+    mainHandler.removeCallbacks(autoDismiss)
+    val view = coverView ?: return
+    (view.parent as? ViewGroup)?.removeView(view)
+    coverView = null
+  }
+
+  private fun restartSafetyTimeout() {
+    mainHandler.removeCallbacks(autoDismiss)
+    mainHandler.postDelayed(autoDismiss, autoDismissMs)
+  }
+
+  private fun buildCoverView(activity: Activity): View {
+    val container = FrameLayout(activity).apply {
+      layoutParams = ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT,
+      )
+      // Swallow taps so the covered route can't be interacted with.
+      isClickable = true
+      setBackgroundColor(SPLASH_BACKGROUND_COLOR)
+    }
+
+    resolveLogo(activity)?.let { logo ->
+      container.addView(
+        ImageView(activity).apply {
+          setImageDrawable(logo)
+          adjustViewBounds = true
+          layoutParams = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.CENTER,
+          )
+        },
+      )
+    }
+
+    return container
+  }
+
+  /** The wordmark splash image, falling back to the app launcher icon. */
+  private fun resolveLogo(activity: Activity): Drawable? {
+    val wordmarkId = activity.resources.getIdentifier(
+      LAUNCH_IMAGE_NAME,
+      "drawable",
+      activity.packageName,
+    )
+    if (wordmarkId != 0) {
+      runCatching { activity.getDrawable(wordmarkId) }.getOrNull()?.let { return it }
+    }
+    // PackageManager always resolves the launcher icon, even when resource-name
+    // lookup is unavailable (e.g. shrunk builds).
+    return runCatching {
+      activity.packageManager.getApplicationIcon(activity.packageName)
+    }.getOrNull()
+  }
+
+  companion object {
+    // Pure safety net for a wedged engine. Dart deterministically drops the
+    // cover in every terminal state (recorder opened, action ignored/dropped);
+    // this only fires if Dart never responds at all.
+    private const val DEFAULT_AUTO_DISMISS_MS = 2000L
+
+    // @color/splash_background — applied directly so the cover never depends on
+    // a resource-name lookup for its background.
+    private const val SPLASH_BACKGROUND_COLOR = 0xFF00150D.toInt()
+
+    // Flutter's conventional full-screen splash wordmark in the host app.
+    private const val LAUNCH_IMAGE_NAME = "launch_image"
+  }
+}

--- a/mobile/packages/divine_quick_actions/android/src/main/kotlin/co/openvine/divine_quick_actions/DivineQuickActionsPlugin.kt
+++ b/mobile/packages/divine_quick_actions/android/src/main/kotlin/co/openvine/divine_quick_actions/DivineQuickActionsPlugin.kt
@@ -18,11 +18,16 @@ import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry
 
 /** DivineQuickActionsPlugin */
-class DivineQuickActionsPlugin :
+class DivineQuickActionsPlugin internal constructor(
+    private val launchCover: CameraLaunchCover,
+) :
     FlutterPlugin,
     MethodCallHandler,
     ActivityAware,
     PluginRegistry.NewIntentListener {
+
+    constructor() : this(WindowCameraLaunchCover())
+
     // The MethodChannel that will the communication between Flutter and native Android
     //
     // This local reference serves to register the plugin with the Flutter Engine and unregister it
@@ -51,6 +56,10 @@ class DivineQuickActionsPlugin :
             "consumeLaunchAction" -> {
                 result.success(pendingLaunchAction)
                 pendingLaunchAction = null
+            }
+            "dismissLaunchCover" -> {
+                launchCover.dismiss()
+                result.success(null)
             }
             else -> result.notImplemented()
         }
@@ -81,8 +90,20 @@ class DivineQuickActionsPlugin :
         val action = QuickActionContract.actionFromIntent(intent) ?: return false
         QuickActionContract.clearShortcutIntent(intent)
         activity?.intent = intent
+        handleLaunchCover(action, activity)
         channel.invokeMethod("onQuickAction", action)
         return true
+    }
+
+    /**
+     * Shows the launch cover for a warm camera activation so the previously
+     * visible route never flashes before Flutter navigates to the recorder.
+     * Dart removes the cover via the `dismissLaunchCover` method once the
+     * recorder frame is rendered.
+     */
+    internal fun handleLaunchCover(action: Map<String, Any>, activity: Activity?) {
+        if (action["type"] != QuickActionContract.TYPE_CAMERA) return
+        activity?.let { launchCover.show(it) }
     }
 
     private fun attachActivity(binding: ActivityPluginBinding) {
@@ -93,10 +114,16 @@ class DivineQuickActionsPlugin :
         if (launchAction != null) {
             pendingLaunchAction = launchAction
             QuickActionContract.clearShortcutIntent(binding.activity.intent)
+            // No cover on cold start: the OS already shows the launch splash
+            // (the same logo a normal app-icon launch shows) until the first
+            // Flutter frame. Covering it would only hide that splash. The cover
+            // is for warm resumes (onNewIntent), where there is no OS splash and
+            // the last route (e.g. the profile) would otherwise flash.
         }
     }
 
     private fun detachActivity() {
+        launchCover.dismiss()
         activityBinding?.removeOnNewIntentListener(this)
         activityBinding = null
         activity = null

--- a/mobile/packages/divine_quick_actions/android/src/test/kotlin/co/openvine/divine_quick_actions/DivineQuickActionsPluginTest.kt
+++ b/mobile/packages/divine_quick_actions/android/src/test/kotlin/co/openvine/divine_quick_actions/DivineQuickActionsPluginTest.kt
@@ -1,5 +1,6 @@
 package co.openvine.divine_quick_actions
 
+import android.app.Activity
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import org.mockito.Mockito
@@ -42,5 +43,40 @@ internal class DivineQuickActionsPluginTest {
         plugin.onMethodCall(call, mockResult)
 
         Mockito.verify(mockResult).success(false)
+    }
+
+    @Test
+    fun handleLaunchCover_cameraAction_showsCover() {
+        val cover = Mockito.mock(CameraLaunchCover::class.java)
+        val plugin = DivineQuickActionsPlugin(cover)
+        val activity = Mockito.mock(Activity::class.java)
+
+        plugin.handleLaunchCover(mapOf("type" to "camera"), activity)
+
+        Mockito.verify(cover).show(activity)
+    }
+
+    @Test
+    fun handleLaunchCover_nonCameraAction_doesNotShowCover() {
+        val cover = Mockito.mock(CameraLaunchCover::class.java)
+        val plugin = DivineQuickActionsPlugin(cover)
+        val activity = Mockito.mock(Activity::class.java)
+
+        plugin.handleLaunchCover(mapOf("type" to "notifications"), activity)
+
+        Mockito.verify(cover, Mockito.never()).show(activity)
+    }
+
+    @Test
+    fun onMethodCall_dismissLaunchCover_dismissesCover() {
+        val cover = Mockito.mock(CameraLaunchCover::class.java)
+        val plugin = DivineQuickActionsPlugin(cover)
+
+        val call = MethodCall("dismissLaunchCover", null)
+        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
+        plugin.onMethodCall(call, mockResult)
+
+        Mockito.verify(cover).dismiss()
+        Mockito.verify(mockResult).success(null)
     }
 }

--- a/mobile/packages/divine_quick_actions/lib/divine_quick_actions.dart
+++ b/mobile/packages/divine_quick_actions/lib/divine_quick_actions.dart
@@ -71,6 +71,15 @@ class DivineQuickActions {
     return _platform.clearActions();
   }
 
+  /// Removes the native launch cover shown during a warm camera activation.
+  ///
+  /// Call once the app has navigated to the camera so the cover is replaced by
+  /// the recorder rather than the route the user left open. No-op on platforms
+  /// that draw no cover.
+  Future<void> dismissLaunchCover() {
+    return _platform.dismissLaunchCover();
+  }
+
   /// Removes the callback installed by [initialize].
   Future<void> dispose() async {
     await _actionSubscription?.cancel();

--- a/mobile/packages/divine_quick_actions/lib/divine_quick_actions_method_channel.dart
+++ b/mobile/packages/divine_quick_actions/lib/divine_quick_actions_method_channel.dart
@@ -81,4 +81,13 @@ class MethodChannelDivineQuickActions extends DivineQuickActionsPlatform {
     if (result == null) return null;
     return DivineQuickActionEvent.tryFromMap(result, isLaunchAction: true);
   }
+
+  @override
+  Future<void> dismissLaunchCover() async {
+    try {
+      await methodChannel.invokeMethod<void>('dismissLaunchCover');
+    } on MissingPluginException {
+      // Platform draws no launch cover; nothing to dismiss.
+    }
+  }
 }

--- a/mobile/packages/divine_quick_actions/lib/divine_quick_actions_platform_interface.dart
+++ b/mobile/packages/divine_quick_actions/lib/divine_quick_actions_platform_interface.dart
@@ -60,4 +60,11 @@ abstract class DivineQuickActionsPlatform extends PlatformInterface {
   Future<DivineQuickActionEvent?> consumeLaunchAction() {
     throw UnimplementedError('consumeLaunchAction() has not been implemented.');
   }
+
+  /// Removes the native launch cover drawn during a warm camera activation.
+  ///
+  /// No-op on platforms that do not draw a cover.
+  Future<void> dismissLaunchCover() {
+    throw UnimplementedError('dismissLaunchCover() has not been implemented.');
+  }
 }

--- a/mobile/packages/divine_quick_actions/test/divine_quick_actions_method_channel_test.dart
+++ b/mobile/packages/divine_quick_actions/test/divine_quick_actions_method_channel_test.dart
@@ -96,6 +96,21 @@ void main() {
     expect(action?.isLaunchAction, isTrue);
   });
 
+  test('dismissLaunchCover invokes the native method', () async {
+    await platform.dismissLaunchCover();
+
+    expect(calls.single.method, 'dismissLaunchCover');
+  });
+
+  test('dismissLaunchCover ignores a missing native implementation', () async {
+    // No handler registered → the channel reports the method as unimplemented;
+    // dismissLaunchCover must swallow that rather than surfacing an error.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+
+    await expectLater(platform.dismissLaunchCover(), completes);
+  });
+
   test('native callbacks are emitted on the action stream', () async {
     final action = expectLater(
       platform.actionStream,

--- a/mobile/packages/divine_quick_actions/test/divine_quick_actions_test.dart
+++ b/mobile/packages/divine_quick_actions/test/divine_quick_actions_test.dart
@@ -15,6 +15,7 @@ class MockDivineQuickActionsPlatform
   DivineQuickActionEvent? launchAction;
   List<DivineQuickAction> actions = const <DivineQuickAction>[];
   bool supported = true;
+  int dismissLaunchCoverCount = 0;
 
   @override
   Stream<DivineQuickActionEvent> get actionStream => _controller.stream;
@@ -42,6 +43,11 @@ class MockDivineQuickActionsPlatform
   Future<bool> setActions(List<DivineQuickAction> actions) async {
     this.actions = actions;
     return supported;
+  }
+
+  @override
+  Future<void> dismissLaunchCover() async {
+    dismissLaunchCoverCount += 1;
   }
 
   void addAction(DivineQuickActionEvent action) {
@@ -103,6 +109,16 @@ void main() {
     expect(launchAction?.isLaunchAction, isTrue);
     expect(received, contains(launchAction));
     expect(await plugin.initialize(), isNull);
+  });
+
+  test('dismissLaunchCover delegates to the platform', () async {
+    final plugin = DivineQuickActions.instance;
+    final fakePlatform = MockDivineQuickActionsPlatform();
+    DivineQuickActionsPlatform.instance = fakePlatform;
+
+    await plugin.dismissLaunchCover();
+
+    expect(fakePlatform.dismissLaunchCoverCount, 1);
   });
 
   test('initialize subscribes to runtime action stream', () async {

--- a/mobile/test/services/quick_actions_coordinator_test.dart
+++ b/mobile/test/services/quick_actions_coordinator_test.dart
@@ -127,6 +127,132 @@ void main() {
       expect(navigator.clearSuppressionCount, 1);
     });
 
+    test(
+      'dismisses the launch cover after the camera frame settles on Android',
+      () {
+        final client = _FakeQuickActionsClient();
+        final navigator = _FakeQuickActionsNavigator();
+        void Function()? scheduled;
+        final coordinator = _coordinator(
+          client: client,
+          navigator: navigator,
+          readAuthState: () => AuthState.authenticated,
+          isAndroid: true,
+          scheduleRedirectSuppressionClear: (callback) => scheduled = callback,
+        );
+
+        coordinator.handleAction(
+          const DivineQuickActionEvent(type: quickActionCameraType),
+        );
+
+        // Cover stays up until the post-frame callback confirms navigation.
+        expect(client.dismissLaunchCoverCount, isZero);
+
+        scheduled!();
+
+        expect(client.dismissLaunchCoverCount, 1);
+        expect(navigator.openedRoutes, equals(<String>['camera']));
+      },
+    );
+
+    test('does not dismiss a launch cover off Android', () {
+      final client = _FakeQuickActionsClient();
+      final navigator = _FakeQuickActionsNavigator();
+      void Function()? scheduled;
+      final coordinator = _coordinator(
+        client: client,
+        navigator: navigator,
+        readAuthState: () => AuthState.authenticated,
+        scheduleRedirectSuppressionClear: (callback) => scheduled = callback,
+      );
+
+      coordinator.handleAction(
+        const DivineQuickActionEvent(type: quickActionCameraType),
+      );
+      scheduled!();
+
+      expect(client.dismissLaunchCoverCount, isZero);
+    });
+
+    test(
+      'dismisses the launch cover even when already on the camera route',
+      () {
+        final client = _FakeQuickActionsClient();
+        final navigator = _FakeQuickActionsNavigator()
+          ..currentPath = '/video-recorder';
+        void Function()? scheduled;
+        final coordinator = _coordinator(
+          client: client,
+          navigator: navigator,
+          readAuthState: () => AuthState.authenticated,
+          isAndroid: true,
+          scheduleRedirectSuppressionClear: (callback) => scheduled = callback,
+        );
+
+        coordinator.handleAction(
+          const DivineQuickActionEvent(type: quickActionCameraType),
+        );
+
+        expect(navigator.openedRoutes, isEmpty);
+        expect(navigator.suppressCount, isZero);
+
+        scheduled!();
+
+        // The cover was drawn natively before the action reached Dart, so it
+        // must still be dropped even though no navigation was needed.
+        expect(client.dismissLaunchCoverCount, 1);
+        expect(navigator.clearSuppressionCount, isZero);
+      },
+    );
+
+    test('dismisses the launch cover when ignoring an unauthenticated action '
+        'on Android', () {
+      final client = _FakeQuickActionsClient();
+      final navigator = _FakeQuickActionsNavigator();
+      final coordinator = _coordinator(
+        client: client,
+        navigator: navigator,
+        readAuthState: () => AuthState.unauthenticated,
+        isAndroid: true,
+      );
+
+      coordinator.handleAction(
+        const DivineQuickActionEvent(type: quickActionCameraType),
+      );
+
+      expect(client.dismissLaunchCoverCount, 1);
+      expect(navigator.openedRoutes, isEmpty);
+    });
+
+    test(
+      'dismisses the launch cover when dropping a deferred action on Android',
+      () {
+        final client = _FakeQuickActionsClient();
+        final navigator = _FakeQuickActionsNavigator();
+        var authState = AuthState.checking;
+        final coordinator = _coordinator(
+          client: client,
+          navigator: navigator,
+          readAuthState: () => authState,
+          isAndroid: true,
+        );
+
+        coordinator.handleAction(
+          const DivineQuickActionEvent(
+            type: quickActionCameraType,
+            isLaunchAction: true,
+          ),
+        );
+        expect(client.dismissLaunchCoverCount, isZero);
+
+        authState = AuthState.unauthenticated;
+        coordinator.handleAuthStateChanged(authState);
+
+        expect(client.dismissLaunchCoverCount, 1);
+        expect(navigator.openedRoutes, isEmpty);
+      },
+    );
+
     test('does not reopen camera when already on the camera route', () {
       final client = _FakeQuickActionsClient();
       final navigator = _FakeQuickActionsNavigator()
@@ -198,6 +324,7 @@ Future<void> _flushAsyncWork() async {
 class _FakeQuickActionsClient implements QuickActionsClient {
   bool supported = true;
   int clearCount = 0;
+  int dismissLaunchCoverCount = 0;
   List<DivineQuickAction> actions = const <DivineQuickAction>[];
   void Function(DivineQuickActionEvent action)? onAction;
 
@@ -222,6 +349,11 @@ class _FakeQuickActionsClient implements QuickActionsClient {
   Future<bool> clearActions() async {
     clearCount += 1;
     return true;
+  }
+
+  @override
+  Future<void> dismissLaunchCover() async {
+    dismissLaunchCoverCount += 1;
   }
 
   @override


### PR DESCRIPTION
Closes #5444

## Description

Opening the camera from the Android home-screen widget could flash the wrong
UI before the recorder.

**Warm resume (app already running in the background)** is the case this PR
fixes. `launchMode="singleTask"` reuses the launcher activity via
`onNewIntent`, so the OS composites the activity's last rendered frame — the
route the user left open (e.g. their **profile**) — before Flutter receives
the intent and navigates to the recorder. Dart can't paint before the OS
shows that cached surface, so the cover must be native.

Fix:
- New native `CameraLaunchCover` (`divine_quick_actions`) draws the launch
  splash — the divine wordmark centered on the brand background — above the
  FlutterView on a **warm** camera `onNewIntent`. The wordmark is drawn with a
  real `ImageView`; setting the `launch_background` layer-list as a View
  background fails to render its centered bitmap (that left a bare green
  cover). The brand colour is applied directly (no resource-name lookup) and
  the app icon is a last-resort glyph fallback. The cover swallows taps.
- `QuickActionsCoordinator` drops the cover deterministically via the new
  `dismissLaunchCover` method: post-frame after navigating to the recorder,
  and immediately if the action is dropped/ignored (e.g. session expired). A
  native 2s timeout is a last-resort fallback only.

**Cold start is intentionally left untouched.** When the app was closed, the
OS already shows the launch splash (the same logo a normal app-icon launch
shows) until the first Flutter frame — exactly like tapping the app icon.
Covering it natively was what produced the green-only screen, so the cold
path now simply relies on the OS splash. (An earlier revision changed the
Android 12 `values-v31` splash icon; that has been reverted — no app-wide
splash change ships here.)

**Related Issue:** 

## Out of Scope

- Cold start still briefly shows welcome/feed between the OS splash and the
  recorder. Hiding that requires holding the OS splash past the first frame,
  which can't be done without changing the normal-launch splash look on older
  Android — deferred.
- iOS: the camera widget opens via `divine://quick-action/camera`, which
  `DeepLinkService.parseDeepLink` currently classifies as a NIP-46
  `signerCallback`. Unaffected here; looks like a separate bug.
- The notifications quick action is intentionally not covered.

## Verification

- `dart format` (clean) and `flutter analyze` on the changed Dart files — no issues.
- `flutter test test/services/quick_actions_coordinator_test.dart` — 12/12 pass (incl. dismiss-after-frame on Android, no-dismiss off Android, dismiss-when-already-on-camera, dismiss-on-ignore-unauthenticated, dismiss-on-drop-deferred).
- `flutter test` in `packages/divine_quick_actions` — all pass (method-channel invoke + MissingPluginException-swallow + platform delegation tests).
- Kotlin tests added for `handleLaunchCover` (camera shows / non-camera doesn't) and the `dismissLaunchCover` method path. **Not executed locally**: the plugin has no example-app gradle harness here (standalone gradle can't resolve `com.android.library`), so verified by review against existing test patterns.
- **Pending manual device check**: warm widget tap (app backgrounded on the profile) shows the wordmark splash, not the profile, then the recorder; cold widget tap shows the OS logo splash exactly like the app-icon launch.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)