### PR TITLE
fix(video-editor): recover from stalled draft writes

### DIFF
--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -48,6 +48,13 @@ class VideoEditorConstants {
   /// guards the first, uncached load before the canvas imports the overlays.
   static const textFontLoadTimeout = Duration(seconds: 3);
 
+  /// Maximum time to wait for a draft write to complete before treating it as
+  /// failed. A draft save is a local DB write that normally finishes in
+  /// milliseconds; bounding it ensures a stalled write surfaces as a failure
+  /// the UI can recover from, instead of leaving the save button wedged for
+  /// the rest of the session.
+  static const draftSaveTimeout = Duration(seconds: 15);
+
   /// Primary accent color used in the video editor UI.
   static const primaryColor = Color(0xFFFFF140);
 

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -678,7 +678,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// Save the current video project as a draft.
   ///
   /// Persists clips and metadata to local storage for later editing.
-  /// Returns `true` on success, `false` on failure.
+  /// Returns `true` on success, `false` on failure — including when the write
+  /// exceeds [VideoEditorConstants.draftSaveTimeout]. `isSavingDraft` is always
+  /// cleared before this returns, so a stalled write can never wedge the save
+  /// button for the rest of the editor session.
   Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
     if (state.isSavingDraft) return false;
 
@@ -695,10 +698,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     );
 
     try {
-      await _draftService.saveDraft(getActiveDraft(draftId: draftId));
+      await _draftService
+          .saveDraft(getActiveDraft(draftId: draftId))
+          .timeout(VideoEditorConstants.draftSaveTimeout);
 
-      // Remove the autosaved draft
-      await removeAutosavedDraft();
+      // The new draft is now the durable copy, so drop the autosave recovery
+      // point. Best-effort and fire-and-forget: a stalled cleanup must not
+      // wedge the save flow, and removeAutosavedDraft swallows its own errors.
+      unawaited(removeAutosavedDraft());
 
       Log.info(
         '✅ Draft saved successfully: $draftId',
@@ -706,7 +713,6 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         category: .video,
       );
 
-      state = state.copyWith(isSavingDraft: false);
       return true;
     } catch (e, stackTrace) {
       Log.error(
@@ -716,8 +722,13 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         error: e,
         stackTrace: stackTrace,
       );
-      state = state.copyWith(isSavingDraft: false);
       return false;
+    } finally {
+      // Always clear the flag — a timed-out or failed save must re-enable the
+      // save button. Guard against a dispose that races the timeout.
+      if (ref.mounted) {
+        state = state.copyWith(isSavingDraft: false);
+      }
     }
   }
 

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -701,19 +701,6 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       await _draftService
           .saveDraft(getActiveDraft(draftId: draftId))
           .timeout(VideoEditorConstants.draftSaveTimeout);
-
-      // The new draft is now the durable copy, so drop the autosave recovery
-      // point. Best-effort and fire-and-forget: a stalled cleanup must not
-      // wedge the save flow, and removeAutosavedDraft swallows its own errors.
-      unawaited(removeAutosavedDraft());
-
-      Log.info(
-        '✅ Draft saved successfully: $draftId',
-        name: 'VideoEditorNotifier',
-        category: .video,
-      );
-
-      return true;
     } catch (e, stackTrace) {
       Log.error(
         '❌ Failed to save draft: $e',
@@ -730,6 +717,23 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         state = state.copyWith(isSavingDraft: false);
       }
     }
+
+    // Reached only on success; the button is already re-enabled above. Drop the
+    // now-redundant autosave recovery point. Awaited (bounded) rather than
+    // fire-and-forget so a slow delete can't resolve after the next editor
+    // session wrote a fresh autosave and wipe that session's recovery point.
+    await removeAutosavedDraft().timeout(
+      VideoEditorConstants.draftSaveTimeout,
+      onTimeout: () {},
+    );
+
+    Log.info(
+      '✅ Draft saved successfully: $draftId',
+      name: 'VideoEditorNotifier',
+      category: .video,
+    );
+
+    return true;
   }
 
   /// Restore a draft from local storage.

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -679,9 +679,12 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   ///
   /// Persists clips and metadata to local storage for later editing.
   /// Returns `true` on success, `false` on failure — including when the write
-  /// exceeds [VideoEditorConstants.draftSaveTimeout]. `isSavingDraft` is always
-  /// cleared before this returns, so a stalled write can never wedge the save
-  /// button for the rest of the editor session.
+  /// exceeds [VideoEditorConstants.draftSaveTimeout].
+  ///
+  /// The write is bounded so a stalled save can't wedge the button. The
+  /// autosave cleanup that follows is deliberately *not* bounded (see the call
+  /// site): it must run to completion, so a stalled cleanup keeps the save in
+  /// flight — and the button disabled — until it lands.
   Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
     if (state.isSavingDraft) return false;
 
@@ -701,6 +704,20 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       await _draftService
           .saveDraft(getActiveDraft(draftId: draftId))
           .timeout(VideoEditorConstants.draftSaveTimeout);
+
+      // Drop the now-redundant autosave recovery point. This must run to
+      // completion — never timed out or fire-and-forget: the delete targets the
+      // fixed `draft_autosave` id, so an abandoned one that resolved later would
+      // wipe the recovery point of whatever editor session is active by then,
+      // corrupting that session. Blocking here (the button stays disabled until
+      // it lands) is the safe trade-off; only the write above needs a timeout.
+      await removeAutosavedDraft();
+
+      Log.info(
+        '✅ Draft saved successfully: $draftId',
+        name: 'VideoEditorNotifier',
+        category: .video,
+      );
     } catch (e, stackTrace) {
       Log.error(
         '❌ Failed to save draft: $e',
@@ -717,21 +734,6 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         state = state.copyWith(isSavingDraft: false);
       }
     }
-
-    // Reached only on success; the button is already re-enabled above. Drop the
-    // now-redundant autosave recovery point. Awaited (bounded) rather than
-    // fire-and-forget so a slow delete can't resolve after the next editor
-    // session wrote a fresh autosave and wipe that session's recovery point.
-    await removeAutosavedDraft().timeout(
-      VideoEditorConstants.draftSaveTimeout,
-      onTimeout: () {},
-    );
-
-    Log.info(
-      '✅ Draft saved successfully: $draftId',
-      name: 'VideoEditorNotifier',
-      category: .video,
-    );
 
     return true;
   }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1533,7 +1533,7 @@ void main() {
       });
     });
 
-    test('keeps the save in flight until the autosave cleanup completes', () {
+    test('does not abandon autosave cleanup after a successful draft save', () {
       // The autosave delete must run to completion: an abandoned delete could
       // later wipe a new session's recovery point. So a stalled cleanup keeps
       // isSavingDraft true and the save unresolved rather than being dropped.

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -4,6 +4,7 @@
 import 'dart:async';
 
 import 'package:characters/characters.dart';
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -210,20 +211,14 @@ void main() {
         final notifier = container.read(videoEditorProvider.notifier);
 
         notifier.updateMetadata(description: 'short text');
-        expect(
-          container.read(videoEditorProvider).description,
-          'short text',
-        );
+        expect(container.read(videoEditorProvider).description, 'short text');
       });
 
       test('trims whitespace before applying the grapheme limit', () {
         final notifier = container.read(videoEditorProvider.notifier);
 
         notifier.updateMetadata(description: '   hello world   ');
-        expect(
-          container.read(videoEditorProvider).description,
-          'hello world',
-        );
+        expect(container.read(videoEditorProvider).description, 'hello world');
       });
     });
 
@@ -855,10 +850,7 @@ void main() {
             .finalRenderedClip;
         expect(updatedClip, isNotNull);
         expect(updatedClip!.thumbnailPath, '/docs/cover.jpg');
-        expect(
-          updatedClip.thumbnailTimestamp,
-          const Duration(seconds: 2),
-        );
+        expect(updatedClip.thumbnailTimestamp, const Duration(seconds: 2));
       });
 
       test('persists the cover position on state so it survives a '
@@ -1432,6 +1424,113 @@ void main() {
             'the durable cover path must persist so the drafts list keeps '
             'showing the selected cover after finalRenderedClip is cleared',
       );
+    });
+  });
+
+  group('saveAsDraft', () {
+    late _MockDraftStorageService mockDraftStorage;
+    late ProviderContainer container;
+
+    setUpAll(() {
+      registerFallbackValue(
+        DivineVideoDraft.create(
+          id: 'fallback',
+          clips: const [],
+          title: '',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+        ),
+      );
+    });
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      mockDraftStorage = _MockDraftStorageService();
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
+        ],
+      );
+    });
+
+    tearDown(() {
+      container.dispose();
+    });
+
+    test('returns true and clears isSavingDraft on success', () async {
+      when(() => mockDraftStorage.saveDraft(any())).thenAnswer((_) async {});
+      when(() => mockDraftStorage.deleteDraft(any())).thenAnswer((_) async {});
+
+      final result = await container
+          .read(videoEditorProvider.notifier)
+          .saveAsDraft(enforceCreateNewDraft: true);
+
+      expect(result, isTrue);
+      expect(
+        container.read(videoEditorProvider).isSavingDraft,
+        isFalse,
+        reason: 'a successful save must re-enable the save button',
+      );
+    });
+
+    test('clears isSavingDraft and returns false when the write hangs', () {
+      // Reproduces the dead "Save for later" button: a draft write that never
+      // resolves must not leave isSavingDraft stuck true for the session.
+      when(
+        () => mockDraftStorage.saveDraft(any()),
+      ).thenAnswer((_) => Completer<void>().future);
+
+      fakeAsync((async) {
+        final notifier = container.read(videoEditorProvider.notifier);
+        bool? result;
+        notifier
+            .saveAsDraft(enforceCreateNewDraft: true)
+            .then((value) => result = value);
+
+        expect(
+          container.read(videoEditorProvider).isSavingDraft,
+          isTrue,
+          reason: 'the button is disabled while a save is in flight',
+        );
+
+        async.elapse(
+          VideoEditorConstants.draftSaveTimeout + const Duration(seconds: 1),
+        );
+
+        expect(result, isFalse, reason: 'a timed-out save reports failure');
+        expect(
+          container.read(videoEditorProvider).isSavingDraft,
+          isFalse,
+          reason: 'a timed-out save must re-enable the save button',
+        );
+      });
+    });
+
+    test('returns false while a previous save is still in flight', () {
+      when(
+        () => mockDraftStorage.saveDraft(any()),
+      ).thenAnswer((_) => Completer<void>().future);
+
+      fakeAsync((async) {
+        final notifier = container.read(videoEditorProvider.notifier);
+        unawaited(notifier.saveAsDraft(enforceCreateNewDraft: true));
+        async.flushMicrotasks();
+
+        bool? secondResult;
+        notifier
+            .saveAsDraft(enforceCreateNewDraft: true)
+            .then((value) => secondResult = value);
+        async.flushMicrotasks();
+
+        expect(
+          secondResult,
+          isFalse,
+          reason: 'concurrent saves are rejected by the in-flight guard',
+        );
+      });
     });
   });
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1532,5 +1532,45 @@ void main() {
         );
       });
     });
+
+    test('clears isSavingDraft before a slow autosave cleanup completes', () {
+      // The button must re-enable as soon as the save outcome is known, and a
+      // stalled autosave cleanup must not hold it disabled.
+      when(() => mockDraftStorage.saveDraft(any())).thenAnswer((_) async {});
+      when(
+        () => mockDraftStorage.deleteDraft(any()),
+      ).thenAnswer((_) => Completer<void>().future);
+
+      fakeAsync((async) {
+        final notifier = container.read(videoEditorProvider.notifier);
+        bool? result;
+        notifier
+            .saveAsDraft(enforceCreateNewDraft: true)
+            .then((value) => result = value);
+
+        async.flushMicrotasks();
+
+        expect(
+          container.read(videoEditorProvider).isSavingDraft,
+          isFalse,
+          reason: 'the save persisted, so the button is free already',
+        );
+        expect(
+          result,
+          isNull,
+          reason: 'the call is still awaiting the bounded cleanup',
+        );
+
+        async.elapse(
+          VideoEditorConstants.draftSaveTimeout + const Duration(seconds: 1),
+        );
+
+        expect(
+          result,
+          isTrue,
+          reason: 'a stalled cleanup still resolves the save as success',
+        );
+      });
+    });
   });
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1533,42 +1533,52 @@ void main() {
       });
     });
 
-    test('clears isSavingDraft before a slow autosave cleanup completes', () {
-      // The button must re-enable as soon as the save outcome is known, and a
-      // stalled autosave cleanup must not hold it disabled.
+    test('keeps the save in flight until the autosave cleanup completes', () {
+      // The autosave delete must run to completion: an abandoned delete could
+      // later wipe a new session's recovery point. So a stalled cleanup keeps
+      // isSavingDraft true and the save unresolved rather than being dropped.
       when(() => mockDraftStorage.saveDraft(any())).thenAnswer((_) async {});
-      when(
-        () => mockDraftStorage.deleteDraft(any()),
-      ).thenAnswer((_) => Completer<void>().future);
 
       fakeAsync((async) {
+        // Create the completer inside the fake zone so completing it later is
+        // driven by `async.flushMicrotasks()` rather than the root zone.
+        final cleanup = Completer<void>();
+        when(
+          () => mockDraftStorage.deleteDraft(any()),
+        ).thenAnswer((_) => cleanup.future);
+
         final notifier = container.read(videoEditorProvider.notifier);
         bool? result;
         notifier
             .saveAsDraft(enforceCreateNewDraft: true)
             .then((value) => result = value);
 
+        // Let the write resolve so we are parked on the pending cleanup.
         async.flushMicrotasks();
-
-        expect(
-          container.read(videoEditorProvider).isSavingDraft,
-          isFalse,
-          reason: 'the save persisted, so the button is free already',
+        // Time passing must not abandon the cleanup.
+        async.elapse(
+          VideoEditorConstants.draftSaveTimeout + const Duration(seconds: 5),
         );
+
         expect(
           result,
           isNull,
-          reason: 'the call is still awaiting the bounded cleanup',
+          reason: 'the save stays in flight while the cleanup is pending',
         );
-
-        async.elapse(
-          VideoEditorConstants.draftSaveTimeout + const Duration(seconds: 1),
-        );
-
         expect(
-          result,
+          container.read(videoEditorProvider).isSavingDraft,
           isTrue,
-          reason: 'a stalled cleanup still resolves the save as success',
+          reason: 'the autosave cleanup is not abandoned on a timeout',
+        );
+
+        cleanup.complete();
+        async.flushMicrotasks();
+
+        expect(result, isTrue);
+        expect(
+          container.read(videoEditorProvider).isSavingDraft,
+          isFalse,
+          reason: 'the save resolves once the cleanup lands',
         );
       });
     });


### PR DESCRIPTION
Closes #5441

## Description

A draft DB write that never resolved left `isSavingDraft` permanently `true`, so the **Save for later** / **Save draft** button stayed disabled for the rest of the editor session. Every later save attempt hit the `if (state.isSavingDraft) return false;` guard at the top of `saveAsDraft`, returned `false`, and surfaced repeated `[ERROR] Failed to save draft` logs.

Root cause: `saveAsDraft` reset `isSavingDraft` only inside the try/catch of the same call, and the underlying draft write had no timeout. When the write hung, neither branch ran, so the flag stayed stuck.

This PR narrows the recovery to the draft write itself:
- Bound the draft write with `VideoEditorConstants.draftSaveTimeout` (15s), so a hung/slow write surfaces as a recoverable failure instead of an infinite hang.
- Always clear `isSavingDraft` in a `finally` (guarded by `ref.mounted`) so success, failure, or write timeout all re-enable the UI.
- Keep autosave-recovery cleanup (`removeAutosavedDraft`) awaited and unbounded after a successful save. That cleanup deletes the fixed `draft_autosave` id, so abandoning it could later wipe a future editor session's recovery point. If cleanup stalls, the save remains in flight by design; that is the integrity-first trade-off.

## Out of Scope

- Masking every possible draft-storage stall. This PR recovers from stalled draft writes; cleanup remains blocking to avoid deleting a newer autosave session.
- The deeper DB-stall root cause (why a local draft DB operation may stall under contention).
- Coupling the button's opacity to `isSaving` so it visibly fades during a save.

## Verification

- `dart analyze lib/constants/video_editor_constants.dart lib/providers/video_editor_provider.dart test/providers/video_editor_provider_test.dart` - No issues found
- `flutter test test/providers/video_editor_provider_test.dart` - 65/65
- Dependent widget tests (capture bottom bar, main overlay actions, recorder navigation) - 37/37

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
