### PR TITLE
fix(dm): render flying reaction on one GPU layer (#5389)

### DIFF
--- a/mobile/lib/widgets/video_feed_item/reaction_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/reaction_overlay.dart
@@ -1,10 +1,22 @@
 // ABOUTME: Full-screen TikTok/Instagram-style reaction animation over the reel.
 // ABOUTME: A big emoji springs in at screen center (overshoot), holds, floats
 // ABOUTME: up and fades, garnished by a few floating-particle copies.
+//
+// Rendered on a SINGLE GPU layer: the emoji is rasterized once to a
+// `ui.Image`, then the hero + particles are drawn by one `CustomPainter` via
+// `drawImageRect` (alpha modulated through `paint.color`, transforms through
+// the canvas). This avoids the per-frame `Opacity` save-layers and per-frame
+// widget rebuilds that made the previous `Stack`-of-`Text` version stutter on
+// low-end devices (#5389).
 
 import 'dart:math';
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
+
+/// Font size the hero emoji is rasterized at; particles draw the same image
+/// scaled down.
+const double _heroFontSize = 120;
 
 /// One-shot reaction animation centered over the player. The hero emoji springs
 /// in with an overshoot (`easeOutBack`), holds, then floats up ~70px while
@@ -31,12 +43,25 @@ class _ReactionOverlayState extends State<ReactionOverlay>
   static const Duration _duration = Duration(milliseconds: 1100);
   static const int _particleCount = 5;
 
+  /// Extra resolution headroom so the hero's `easeOutBack` overshoot
+  /// (peak scale ~1.28) never upsamples the rasterized glyph past device
+  /// pixels.
+  static const double _supersample = 1.3;
+
   late final AnimationController _controller;
   late final Animation<double> _heroScale;
   late final Animation<double> _heroGrow;
   late final Animation<double> _heroOpacity;
   late final Animation<double> _heroY;
   late final List<_Particle> _particles;
+
+  /// The emoji rasterized once to a GPU image; null until prepared.
+  ui.Image? _emojiImage;
+
+  /// Logical size of the rasterized glyph at [_heroFontSize] (the draw size
+  /// before any animated scale).
+  Size _baseSize = Size.zero;
+  bool _prepared = false;
 
   @override
   void initState() {
@@ -84,75 +109,177 @@ class _ReactionOverlayState extends State<ReactionOverlay>
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Rasterize the emoji once (needs the device pixel ratio from context).
+    // Runs before the first build, so the first frame paints the image.
+    if (_prepared) return;
+    _prepared = true;
+    _prepareEmojiImage();
+  }
+
+  void _prepareEmojiImage() {
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: widget.emoji,
+        style: const TextStyle(fontSize: _heroFontSize),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    final logicalSize = textPainter.size;
+    final pixelScale = devicePixelRatio * _supersample;
+    final pixelWidth = (logicalSize.width * pixelScale).ceil();
+    final pixelHeight = (logicalSize.height * pixelScale).ceil();
+    if (pixelWidth <= 0 || pixelHeight <= 0) return;
+
+    final recorder = ui.PictureRecorder();
+    final canvas = Canvas(recorder)..scale(pixelScale);
+    textPainter.paint(canvas, Offset.zero);
+    final picture = recorder.endRecording();
+    _emojiImage = picture.toImageSync(pixelWidth, pixelHeight);
+    _baseSize = logicalSize;
+    picture.dispose();
+  }
+
+  @override
   void dispose() {
+    _emojiImage?.dispose();
     _controller.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    final size = MediaQuery.sizeOf(context);
-    final cx = size.width / 2;
-    final cy = size.height / 2;
-
     return IgnorePointer(
-      child: AnimatedBuilder(
-        animation: _controller,
-        builder: (context, _) {
-          final t = _controller.value;
-          return Stack(
-            children: [
-              // Secondary floating-particle layer (garnish).
-              for (final p in _particles)
-                Positioned(
-                  left:
-                      cx +
-                      p.startX +
-                      p.amplitude * sin(p.frequency * t * 2 * pi + p.phase) -
-                      p.size / 2,
-                  top: cy - p.riseHeight * t - p.size / 2,
-                  child: Opacity(
-                    opacity: sin(t * pi).clamp(0.0, 1.0),
-                    child: Transform.rotate(
-                      angle: 0.035 * sin(p.frequency * t * 2 * pi),
-                      child: Transform.scale(
-                        scale: p.scaleAt(t),
-                        child: Text(
-                          widget.emoji,
-                          style: TextStyle(fontSize: p.size * 0.85),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-
-              // Primary hero pop at screen center.
-              Positioned(
-                left: cx - 70,
-                top: cy - 70 + _heroY.value,
-                child: Opacity(
-                  opacity: _heroOpacity.value.clamp(0.0, 1.0),
-                  child: Transform.scale(
-                    scale: _heroScale.value * _heroGrow.value,
-                    child: SizedBox(
-                      width: 140,
-                      height: 140,
-                      child: Center(
-                        child: Text(
-                          widget.emoji,
-                          style: const TextStyle(fontSize: 120),
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          );
-        },
+      child: RepaintBoundary(
+        child: CustomPaint(
+          size: Size.infinite,
+          painter: _ReactionPainter(
+            image: _emojiImage,
+            baseSize: _baseSize,
+            progress: _controller,
+            heroScale: _heroScale,
+            heroGrow: _heroGrow,
+            heroOpacity: _heroOpacity,
+            heroY: _heroY,
+            particles: _particles,
+          ),
+        ),
       ),
     );
   }
+}
+
+/// Paints the hero + particle emoji from a single rasterized [image] on one
+/// canvas. Repaints on every [progress] tick without rebuilding any widget;
+/// opacity is applied via `paint.color` (no save-layer) and position/scale/
+/// rotation via canvas transforms.
+class _ReactionPainter extends CustomPainter {
+  _ReactionPainter({
+    required this.image,
+    required this.baseSize,
+    required this.progress,
+    required this.heroScale,
+    required this.heroGrow,
+    required this.heroOpacity,
+    required this.heroY,
+    required this.particles,
+  }) : super(repaint: progress);
+
+  final ui.Image? image;
+  final Size baseSize;
+  final Animation<double> progress;
+  final Animation<double> heroScale;
+  final Animation<double> heroGrow;
+  final Animation<double> heroOpacity;
+  final Animation<double> heroY;
+  final List<_Particle> particles;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final glyph = image;
+    if (glyph == null) return;
+
+    final t = progress.value;
+    final centerX = size.width / 2;
+    final centerY = size.height / 2;
+    final source = Rect.fromLTWH(
+      0,
+      0,
+      glyph.width.toDouble(),
+      glyph.height.toDouble(),
+    );
+
+    // Secondary floating-particle layer (garnish). All particles share the
+    // same opacity curve, varying only in position, scale and tilt.
+    final particleOpacity = sin(t * pi).clamp(0.0, 1.0);
+    for (final p in particles) {
+      final dx =
+          centerX +
+          p.startX +
+          p.amplitude * sin(p.frequency * t * 2 * pi + p.phase);
+      final dy = centerY - p.riseHeight * t;
+      final scale = (p.size * 0.85 / _heroFontSize) * p.scaleAt(t);
+      final rotation = 0.035 * sin(p.frequency * t * 2 * pi);
+      _paintEmoji(
+        canvas,
+        glyph,
+        source,
+        Offset(dx, dy),
+        scale,
+        rotation,
+        particleOpacity,
+      );
+    }
+
+    // Primary hero pop at screen center.
+    _paintEmoji(
+      canvas,
+      glyph,
+      source,
+      Offset(centerX, centerY + heroY.value),
+      heroScale.value * heroGrow.value,
+      0,
+      heroOpacity.value.clamp(0.0, 1.0),
+    );
+  }
+
+  void _paintEmoji(
+    Canvas canvas,
+    ui.Image glyph,
+    Rect source,
+    Offset center,
+    double scale,
+    double rotation,
+    double opacity,
+  ) {
+    if (opacity <= 0 || scale <= 0) return;
+    final paint = Paint()
+      ..filterQuality = FilterQuality.medium
+      ..isAntiAlias = true
+      ..color = Color.fromRGBO(255, 255, 255, opacity);
+    canvas.save();
+    canvas.translate(center.dx, center.dy);
+    if (rotation != 0) canvas.rotate(rotation);
+    canvas.scale(scale);
+    canvas.drawImageRect(
+      glyph,
+      source,
+      Rect.fromCenter(
+        center: Offset.zero,
+        width: baseSize.width,
+        height: baseSize.height,
+      ),
+      paint,
+    );
+    canvas.restore();
+  }
+
+  @override
+  bool shouldRepaint(_ReactionPainter oldDelegate) =>
+      image != oldDelegate.image || baseSize != oldDelegate.baseSize;
 }
 
 class _Particle {

--- a/mobile/test/widgets/video_feed_item/reaction_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/reaction_overlay_test.dart
@@ -5,7 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/widgets/video_feed_item/reaction_overlay.dart';
 
 void main() {
-  testWidgets('renders the emoji then fires onComplete', (tester) async {
+  testWidgets('paints on a single CustomPaint then fires onComplete', (
+    tester,
+  ) async {
     var completed = false;
     await tester.pumpWidget(
       MaterialApp(
@@ -19,12 +21,23 @@ void main() {
     );
     await tester.pump();
 
-    // Hero glyph + the floating particles all render the emoji.
-    expect(find.text('❤️'), findsWidgets);
+    // The 6 emoji are now drawn by one CustomPainter, not a Stack of Text.
+    expect(
+      find.descendant(
+        of: find.byType(ReactionOverlay),
+        matching: find.byType(CustomPaint),
+      ),
+      findsWidgets,
+    );
+    expect(completed, isFalse);
+
+    // Mid-animation: opacity/scale are non-zero here, so the painter actually
+    // draws the glyph (at t≈0 and t≈1 they are 0). Still animating.
+    await tester.pump(const Duration(milliseconds: 450));
     expect(completed, isFalse);
 
     // Past the 1100ms animation → completes and notifies.
-    await tester.pump(const Duration(milliseconds: 1200));
+    await tester.pump(const Duration(milliseconds: 800));
     await tester.pumpAndSettle();
     expect(completed, isTrue);
   });


### PR DESCRIPTION
## Description

#5389 was first auto-closed by #5421, which made the in-chat reaction **chip** appear optimistically. The reporter reopened it: the chip latency was never the complaint — the **flying reaction animation in the center of the screen** runs at "~10 FPS" on a Galaxy S10. That animation (`ReactionOverlay`) is the facet #5421 explicitly deferred as out of scope.

### Root cause

`ReactionOverlay` rebuilt a `Stack` of **6 color-emoji widgets every frame** for 1100ms — 5 floating particles + a `fontSize: 120` hero — where:

- each emoji was wrapped in a raw `Opacity`, which forces a per-frame compositing offscreen (save-layer) — disproportionately expensive on tiled mobile GPUs (Mali-G76 / Adreno 640 on a 2019 device);
- the `Text` widgets were **re-created every frame** inside `AnimatedBuilder` (no `child:` reuse), re-recording the large color-emoji glyph each frame;
- there was **no `RepaintBoundary`** anywhere, so the overlay's per-frame repaint also re-rastered the surrounding reel chrome.

Stacked over a concurrently-decoding video, this blew the 16.6 ms frame budget.

### Fix

Render the whole animation on **one GPU layer**:

- Rasterize the emoji **once** to a `ui.Image` (`TextPainter` → `PictureRecorder` → `toImageSync`, sized for the device pixel ratio with headroom for the hero's overshoot).
- Replace the 6-widget `Stack` with a single `IgnorePointer` → `RepaintBoundary` → `CustomPaint`. The painter draws the hero + 5 particles from that one image via `canvas.drawImageRect`, applying **opacity through `paint.color` alpha (no save-layer)** and position/scale/rotation through canvas transforms. Repaints are driven by the `AnimationController` with **no per-frame widget rebuild**.

Net effect: per-frame `Opacity` offscreens 6 → 0, per-frame widget allocations ~29 → 0, color-emoji rasterization 60×/sec → once, and the overlay repaint is isolated from the reel chrome. **The visual output and all timing curves are unchanged** — this is a pure rendering optimization. The sibling `double_tap_heart_overlay.dart` already used this lighter pattern; the reaction overlay now matches it.

## How to verify on a real device

This is a timing change with **no static visual difference**, so the evidence is smoothness on a low-end device — best captured as a short screen recording.

> ⚠️ Use a **profile or release** build, not debug. Debug disables Impeller and runs unoptimized, so frame timings there are meaningless.

1. `flutter run --profile` (or install a profile/release APK) on a low-end Android — ideally the Galaxy S10 from the report.
2. Open a DM chat that contains a shared video → tap it to open the full-screen reel.
3. Tap a quick-reaction emoji on the reel reply bar. The big emoji should spring in at center and float up **smoothly**; tap several in a row — it should stay smooth.
4. (Rigor) Toggle the performance overlay (press `P` in `flutter run`, or DevTools → Performance) while firing reactions: the **raster** and **UI** thread bars should stay under the green 16 ms line. Before this change the raster bar spiked.
5. (Optional) DevTools → "Highlight repaints": the overlay is now an isolated repaint region instead of dirtying the whole reel.
6. Reduced motion: enable system "Remove animations" → the flying animation should **not** fire (the reaction chip still appears), confirming the existing reduce-motion gate still holds.

@hm21 — since you have the S10, a quick before/after capture on your device would be the ideal confirmation. 🙏

## Verification done

- `flutter analyze lib test` → No issues.
- `dart format` clean.
- `reaction_overlay_test.dart` updated: the old `find.text(emoji)` assertion no longer applies (the emoji is drawn, not a `Text` widget), so it now asserts the `CustomPaint` renders, `onComplete` fires, and `IgnorePointer` lets taps through — landing mid-animation so the actual draw path runs. 2/2 pass.
- Regression check on the mount/trigger path: `pooled_fullscreen_video_feed_screen_test.dart` + `reel_dm_reply_bar_test.dart` → 40/40 pass (the overlay's public API is unchanged).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

Closes #5389
