### PR TITLE
fix(divine_ui): symmetric DivineButton padding for better label overflow

### DIFF
--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -47,8 +47,8 @@ enum DivineButtonType {
 /// constraint and the surrounding context can absorb the smaller tap
 /// area.
 enum DivineButtonSize {
-  /// Tiny button: no outer tap-padding, 12px horizontal / 6px vertical
-  /// inner padding, 12.8px border radius (= 32 × 0.4, matches a 32px
+  /// Tiny button: no outer tap-padding, 6px symmetric inner padding,
+  /// 12.8px border radius (= 32 × 0.4, matches a 32px
   /// `UserAvatar`'s rounded square so the button rhymes visually with
   /// the avatar it usually sits next to), 14px `titleSmallFont` text
   /// (Bricolage Grotesque 800 — heavier than the Inter `labelLargeFont`
@@ -58,14 +58,13 @@ enum DivineButtonSize {
   /// height matches whether the button is present or not).
   tiny,
 
-  /// Small button: 4px outer padding, 16px horizontal / 8px vertical
-  /// inner padding, 16px border radius, 16px `titleMediumFont` text,
+  /// Small button: 4px outer padding, 8px symmetric inner padding,
+  /// 16px border radius, 16px `titleMediumFont` text,
   /// 24px icon. Visual height 40px, tap target 48px.
   small,
 
-  /// Base/medium button: 24px horizontal / 12px vertical padding, 20px
-  /// border radius, 16px `titleMediumFont` text, 24px icon. Total
-  /// height 48px.
+  /// Base/medium button: 12px symmetric padding, 20px border radius,
+  /// 16px `titleMediumFont` text, 24px icon. Total height 48px.
   base,
 }
 
@@ -194,30 +193,17 @@ class _DivineButtonContent extends StatelessWidget {
   /// `DivineIconButton`.
   bool get _noLabel => label.isEmpty;
 
-  EdgeInsets get _padding {
-    if (_noLabel) {
-      // Match DivineIconButton padding for icon-only mode.
-      return switch (size) {
-        DivineButtonSize.tiny => const EdgeInsets.all(6),
-        DivineButtonSize.small => const EdgeInsets.all(8),
-        DivineButtonSize.base => const EdgeInsets.all(12),
-      };
-    }
-    return switch (size) {
-      DivineButtonSize.tiny => const EdgeInsets.symmetric(
-        horizontal: 12,
-        vertical: 6,
-      ),
-      DivineButtonSize.small => const EdgeInsets.symmetric(
-        horizontal: 16,
-        vertical: 8,
-      ),
-      DivineButtonSize.base => const EdgeInsets.symmetric(
-        horizontal: 24,
-        vertical: 12,
-      ),
-    };
-  }
+  /// Symmetric inner padding for every size. Labeled and icon-only
+  /// buttons share the same insets: keeping the horizontal padding equal
+  /// to the (smaller) vertical padding gives a label the most horizontal
+  /// room before it ellipsizes, and for small / base it also matches
+  /// `DivineIconButton`, so a label-less [DivineButton] lines up with a
+  /// `DivineIconButton`.
+  EdgeInsets get _padding => switch (size) {
+    DivineButtonSize.tiny => const EdgeInsets.all(6),
+    DivineButtonSize.small => const EdgeInsets.all(8),
+    DivineButtonSize.base => const EdgeInsets.all(12),
+  };
 
   double get _borderRadius => switch (size) {
     // 32 × 0.4 — same factor `UserAvatar` uses for non-tiny avatars, so

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -448,6 +448,110 @@ void main() {
       );
     });
 
+    group('label inner padding', () {
+      // The content Row's closest Padding ancestor is the button's inner
+      // padding. Anchoring on the Row skips the EdgeInsets.zero Padding
+      // that Ink wraps its child in internally.
+      Padding innerPaddingOf(WidgetTester tester) {
+        return tester.widget<Padding>(
+          find
+              .ancestor(
+                of: find.byType(Row),
+                matching: find.byType(Padding),
+              )
+              .first,
+        );
+      }
+
+      testWidgets('base label uses symmetric 12px inner padding', (
+        tester,
+      ) async {
+        // Symmetric padding keeps the label's full height while giving it
+        // the most horizontal room before the text ellipsizes.
+        await tester.pumpWidget(
+          buildTestWidget(label: 'Save', onPressed: () {}),
+        );
+
+        expect(innerPaddingOf(tester).padding, const EdgeInsets.all(12));
+      });
+
+      testWidgets('small label uses symmetric 8px inner padding', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'Save',
+            size: DivineButtonSize.small,
+            onPressed: () {},
+          ),
+        );
+
+        expect(innerPaddingOf(tester).padding, const EdgeInsets.all(8));
+      });
+
+      testWidgets('tiny label uses symmetric 6px inner padding', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'Save',
+            size: DivineButtonSize.tiny,
+            onPressed: () {},
+          ),
+        );
+
+        expect(innerPaddingOf(tester).padding, const EdgeInsets.all(6));
+      });
+
+      testWidgets('labeled and icon-only share the same inner padding', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(label: 'Save', onPressed: () {}),
+        );
+        final labeledPadding = innerPaddingOf(tester).padding;
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: '',
+            leadingIcon: DivineIconName.heart,
+            onPressed: () {},
+          ),
+        );
+        final iconOnlyPadding = innerPaddingOf(tester).padding;
+
+        expect(labeledPadding, equals(iconOnlyPadding));
+      });
+
+      testWidgets('long label ellipsizes instead of overflowing', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Center(
+                child: SizedBox(
+                  width: 120,
+                  child: DivineButton(
+                    label: 'A very long label that will not fit the width',
+                    expanded: true,
+                    onPressed: () {},
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        final text = tester.widget<Text>(
+          find.text('A very long label that will not fit the width'),
+        );
+        expect(text.maxLines, equals(1));
+        expect(text.overflow, equals(TextOverflow.ellipsis));
+        expect(tester.takeException(), isNull);
+      });
+    });
+
     group('disabled state', () {
       testWidgets('shows reduced opacity when disabled', (tester) async {
         await tester.pumpWidget(


### PR DESCRIPTION
Closes #5447

## Description

`DivineButton`'s labeled variant used wider horizontal padding than vertical
(base `24/12`, small `16/8`, tiny `12/6`), so longer labels hit the ellipsis
much earlier than necessary. This switches the inner padding to symmetric
insets (base `12`, small `8`, tiny `6`) so a label gets the full chip width
before truncating.

Vertical padding is **unchanged**, so the established `32 / 40 / 48px` heights
and the tiny/small tap-target math all stay the same — only horizontal room
grows.

Because labeled and icon-only padding are now identical, the two duplicated
`switch`es in `_padding` collapse into one, and the size doc comments (which
still quoted the old `24px horizontal / 12px vertical` style values) are
refreshed to match.

| Before | After |
| ------ | ------ |
|       <img width="355" height="71" alt="Bildschirmfoto 2026-06-22 um 10 48 23" src="https://github.com/user-attachments/assets/a0af4bfe-69d8-4a74-9e08-f38e15509c97" />    |        <img width="364" height="74" alt="Bildschirmfoto 2026-06-22 um 10 48 11" src="https://github.com/user-attachments/assets/13d6e3c8-36ef-4ec5-bdcc-9ee0aad28a84" />    |

**Related Issue:** Relates to #

## Out of Scope

None.

## Verification

- `flutter analyze` (divine_button.dart + test) — no issues
- `flutter test` for `divine_ui` — **588 passed** (full package, incl. strict-coverage gate)
- New tests added:
  - symmetric inner padding per size (tiny `6` / small `8` / base `12`)
  - labeled and icon-only buttons share the same inner padding
  - long label ellipsizes (`maxLines: 1`, `TextOverflow.ellipsis`) without overflowing a narrow button

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
- [x] 📝 Documentation