### PR TITLE
fix(profile): load Kind 0 from relays when Funnelcake hasn't indexed it yet

### DIFF
--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -338,11 +338,15 @@ class ProfileRepository {
             }
             return funnelcakeProfile;
           case UserProfileNotPublished():
-            // User exists but has no Kind 0. Cache stats and skip relay
-            // fallback — the profile genuinely does not exist yet.
+            // Funnelcake reports no Kind 0, but this is NOT authoritative:
+            // it returns NotPublished whenever its indexed profile lacks
+            // name/display_name — which includes "knows the user from a
+            // video event but hasn't pulled their Kind 0 yet", common right
+            // after the user posts their first video. Cache the stats it did
+            // return, then fall through to the relay/indexer path where the
+            // real Kind 0 lives. Only the relay-exhausted path below marks
+            // the pubkey confirmed-missing.
             await _cacheProfileStatsFromResult(pubkey, result);
-            _confirmedMissing.add(pubkey);
-            return null;
           case null:
             // 404 — user not found at all; fall through to relay.
             break;

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -659,8 +659,8 @@ void main() {
           },
         );
 
-        test('marks missing immediately when Funnelcake returns '
-            'UserProfileNotPublished', () async {
+        test('falls back to relay when Funnelcake returns '
+            'UserProfileNotPublished (Kind 0 not yet indexed)', () async {
           when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
           when(
             () => mockFunnelcakeClient.getUserProfile(testPubkey),
@@ -684,17 +684,13 @@ void main() {
             pubkey: testPubkey,
           );
 
-          expect(result, isNull);
-          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isTrue);
-          // Should NOT fall through to relay or indexer
-          verifyNever(() => mockNostrClient.fetchProfile(any()));
-          verifyNever(
-            () => mockNostrClient.queryEvents(
-              any(),
-              tempRelays: any(named: 'tempRelays'),
-              useCache: any(named: 'useCache'),
-            ),
-          );
+          // Funnelcake's "not published" is not authoritative — the real
+          // Kind 0 is on the relay and must still be fetched.
+          expect(result, isNotNull);
+          expect(result!.displayName, equals('Test User'));
+          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isFalse);
+          verify(() => mockNostrClient.fetchProfile(testPubkey)).called(1);
+          // Stats from Funnelcake are still cached on the way through.
           verify(
             () => mockProfileStatsDao.upsertStats(
               pubkey: testPubkey,
@@ -705,6 +701,28 @@ void main() {
               totalViews: 99,
             ),
           ).called(1);
+        });
+
+        test('marks missing only when Funnelcake NotPublished and relays '
+            'are empty', () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getUserProfile(testPubkey),
+          ).thenAnswer(
+            (_) async => const UserProfileNotPublished(pubkey: testPubkey),
+          );
+          // Relay has nothing either → genuinely no Kind 0 anywhere.
+          when(
+            () => mockNostrClient.fetchProfile(testPubkey),
+          ).thenAnswer((_) async => null);
+
+          final result = await repoWithFunnelcake.fetchFreshProfile(
+            pubkey: testPubkey,
+          );
+
+          expect(result, isNull);
+          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isTrue);
+          verify(() => mockNostrClient.fetchProfile(testPubkey)).called(1);
         });
 
         test('uses rounded loops when unified views are unavailable', () async {
@@ -721,12 +739,8 @@ void main() {
             ),
           );
 
-          final result = await repoWithFunnelcake.fetchFreshProfile(
-            pubkey: testPubkey,
-          );
+          await repoWithFunnelcake.fetchFreshProfile(pubkey: testPubkey);
 
-          expect(result, isNull);
-          expect(repoWithFunnelcake.isConfirmedMissing(testPubkey), isTrue);
           verify(
             () => mockProfileStatsDao.upsertStats(
               pubkey: testPubkey,


### PR DESCRIPTION
## Description

A user who recorded and posted a video, then opened their profile, saw the avatar and username as if they were never set (the "Complete your profile" CTA + username placeholder) — while their videos and stats loaded correctly. Only an app restart recovered.

Root cause is in `ProfileRepository._doFetchFreshProfile`. Funnelcake returns `UserProfileNotPublished` whenever its indexed profile lacks `name`/`display_name` — which includes the common case "knows the user from a freshly-posted video event but hasn't pulled their Kind 0 yet". The repository treated this as authoritative and returned `null` **without a relay fallback**, so the real Kind 0 (which lives on the relays) was never fetched and nothing was written to the local cache. Stats were cached from the same response (hence visible). `watchProfile` kept emitting `null`, the identity skeleton timed out after 7s, and the generated-name / "Complete your profile" fallback showed until a restart let Funnelcake/relays catch up.

All three profile-load paths share this `fetchFreshProfile` entry point — `MyProfileBloc`'s fetch, the stats provider self-seed (#5429), and the background video-event `_fetchProfileIfMissing` — so the single short-circuit broke every in-session path at once.

**Fix:** on `UserProfileNotPublished`, cache the stats Funnelcake returned, then fall through to the relay/indexer path (matching the existing 404 branch). The pubkey is marked confirmed-missing only when the relays are also empty. The bulk `fetchBatchProfiles` path keeps its skip-on-NotPublished behaviour intentionally (bulk feed-author loading, not the own-profile path).

**Related Issue:** Relates to # (no tracked issue — reported via user QA)

## Out of Scope

- The 7s identity-skeleton fallback can't distinguish "load failed" from "genuinely no Kind 0" — both render "Complete your profile". A follow-up could emit a distinct failure/retry status from `MyProfileBloc`. Not addressed here.
- A latent `MyProfileBloc` re-keying gap (the `BlocProvider` captures `profileRepository` without a `ValueKey` guard) was identified during investigation but is **not** the cause of this bug; deferred to a separate, clearly-justified change.

## Verification

- `flutter analyze` (`packages/profile_repository` lib + test): no issues
- `flutter test packages/profile_repository` — 191/191 pass, including the updated `UserProfileNotPublished` tests and a new relay-fallback regression test

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)