### PR TITLE
fix(dm): add DB uniqueness guard for live DM self-reactions (#5419)

### DIFF
--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_cubit.dart
@@ -169,9 +169,9 @@ class ConversationReactionsCubit
   ///
   /// The synthetic [DmReaction] is overlaid synchronously (same frame as the
   /// tap) so the chip never waits on the local Drift round-trip
-  /// (`insertOptimistic` → watch re-emit, which crosses a background isolate
-  /// and SQLCipher). It is reconciled away in [_onSubscriptionTicked] once the
-  /// persisted row lands (#5389).
+  /// (`insertOwnReactionSuperseding` → watch re-emit, which crosses a
+  /// background isolate and SQLCipher). It is reconciled away in
+  /// [_onSubscriptionTicked] once the persisted row lands (#5389).
   Future<void> _publishReaction({
     required String conversationId,
     required String messageId,

--- a/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
+++ b/mobile/lib/blocs/dm/reactions/conversation_reactions_state.dart
@@ -30,9 +30,9 @@ class ReactionPublishKey extends Equatable {
 
 /// A synchronous, client-side optimistic overlay applied on top of the
 /// persisted reaction rows so the chip paints on the same frame as the tap —
-/// before the local Drift round-trip (`insertOptimistic` → watch re-emit,
-/// which crosses a background isolate + SQLCipher) settles the row. Mirrors
-/// the in-player reel bar's `_optimisticEmoji` (#5389).
+/// before the local Drift round-trip (`insertOwnReactionSuperseding` → watch
+/// re-emit, which crosses a background isolate + SQLCipher) settles the row.
+/// Mirrors the in-player reel bar's `_optimisticEmoji` (#5389).
 ///
 /// Each entry is reconciled away by [ConversationReactionsCubit] the moment
 /// the persisted stream reflects the intent (an `Added` row appears / a

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -525,7 +525,8 @@ class AppDatabase extends _$AppDatabase {
       ''');
     }
     // Create indexes unconditionally so the runtime path matches Drift's
-    // m.createAll() output (the schema-parity test pins this).
+    // m.createAll() output (the dm_message_reactions schema-parity test in
+    // app_database_test.dart pins this).
     await customStatement('''
       CREATE INDEX IF NOT EXISTS idx_dm_reactions_target_live
       ON dm_message_reactions (conversation_id, target_message_id)
@@ -539,6 +540,37 @@ class AppDatabase extends _$AppDatabase {
     await customStatement('''
       CREATE INDEX IF NOT EXISTS idx_dm_reactions_owner_created
       ON dm_message_reactions (owner_pubkey, created_at)
+    ''');
+
+    // Cap-at-one storage invariant (#5419): at most one LIVE reaction per
+    // (target_message_id, reactor_pubkey, owner_pubkey). The dedup UPDATE
+    // MUST run before CREATE UNIQUE INDEX — SQLite refuses to build a unique
+    // index over rows that already violate it. It soft-deletes every live row
+    // that has a strictly-newer live sibling in its tuple, keeping the single
+    // MAX(created_at, id) row (id tie-break is deterministic and matches the
+    // read-side DmReactionsRepository._collapsePerReactor keep-rule). The
+    // statement is idempotent: once converged (and once the unique index
+    // self-enforces) no row has a newer sibling, so subsequent startups
+    // match nothing.
+    await customStatement('''
+      UPDATE dm_message_reactions
+      SET is_deleted = 1
+      WHERE is_deleted = 0
+        AND EXISTS (
+          SELECT 1 FROM dm_message_reactions AS newer
+          WHERE newer.target_message_id = dm_message_reactions.target_message_id
+            AND newer.reactor_pubkey = dm_message_reactions.reactor_pubkey
+            AND newer.owner_pubkey = dm_message_reactions.owner_pubkey
+            AND newer.is_deleted = 0
+            AND (newer.created_at > dm_message_reactions.created_at
+              OR (newer.created_at = dm_message_reactions.created_at
+                  AND newer.id > dm_message_reactions.id))
+        )
+    ''');
+    await customStatement('''
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_dm_reactions_unique_live
+      ON dm_message_reactions (target_message_id, reactor_pubkey, owner_pubkey)
+      WHERE is_deleted = 0
     ''');
 
     final pendingViewEventsResult = await customSelect(

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -547,11 +547,13 @@ class AppDatabase extends _$AppDatabase {
     // MUST run before CREATE UNIQUE INDEX — SQLite refuses to build a unique
     // index over rows that already violate it. It soft-deletes every live row
     // that has a strictly-newer live sibling in its tuple, keeping the single
-    // MAX(created_at, id) row (id tie-break is deterministic and matches the
-    // read-side DmReactionsRepository._collapsePerReactor keep-rule). The
-    // statement is idempotent: once converged (and once the unique index
-    // self-enforces) no row has a newer sibling, so subsequent startups
-    // match nothing.
+    // MAX(created_at, id) row. The created_at half matches the read-side
+    // DmReactionsRepository._collapsePerReactor keep-rule; the id tie-break is
+    // an extra deterministic guard the read side lacks, and only diverges on
+    // equal-created_at distinct ids — impossible once the unique index caps
+    // each tuple to one live row. The statement is idempotent: once converged
+    // (and once the unique index self-enforces) no row has a newer sibling, so
+    // subsequent startups match nothing.
     await customStatement('''
       UPDATE dm_message_reactions
       SET is_deleted = 1

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -42,6 +42,12 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
   /// crash) instead of a UNIQUE-constraint throw — the dual-cubit race the
   /// issue targets.
   ///
+  /// One narrow path bypasses that ignore: re-reacting the same emoji within
+  /// one wall-clock second of removing it rebuilds a byte-identical rumor id,
+  /// which collides with the row just soft-deleted by `removeOwn`. That row is
+  /// resurrected (flipped live, `publishStatus = 'pending'`) rather than
+  /// dropped, so the re-reaction is not silently lost.
+  ///
   /// Returns the ids of the superseded prior live rows so the caller can emit
   /// NIP-09 kind-5 deletions on the wire (outside this transaction).
   Future<List<String>> insertOwnReactionSuperseding({
@@ -74,6 +80,34 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
             .write(const DmMessageReactionsCompanion(isDeleted: Value(true)));
         superseded.add(prior.id);
       }
+
+      // A react → remove → re-react with the SAME emoji inside one wall-clock
+      // second rebuilds an identical rumor id, so [placeholderId] collides
+      // with the row just soft-deleted by `removeOwn`. That row is excluded
+      // from `priors` (live-only), so the [InsertMode.insertOrIgnore] below
+      // would discard this *wanted* re-reaction against the primary key.
+      // Resurrect it instead. Scoped to `is_deleted = 1` so a still-live
+      // same-id row (idempotent double-tap) keeps its publish status and is
+      // left to the no-op insert.
+      final resurrected =
+          await (update(dmMessageReactions)..where(
+                (t) =>
+                    t.id.equals(placeholderId) &
+                    t.ownerPubkey.equals(ownerPubkey) &
+                    t.isDeleted.equals(true),
+              ))
+              .write(
+                DmMessageReactionsCompanion(
+                  isDeleted: const Value(false),
+                  publishStatus: const Value('pending'),
+                  rumorEventJson: Value(rumorEventJson),
+                  giftWrapId: const Value(null),
+                ),
+              );
+      if (resurrected > 0) {
+        return superseded;
+      }
+
       await into(dmMessageReactions).insert(
         DmMessageReactionsCompanion.insert(
           id: placeholderId,

--- a/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/dm_reactions_dao.dart
@@ -9,26 +9,42 @@ part 'dm_reactions_dao.g.dart';
 
 /// DAO for the `dm_message_reactions` table.
 ///
-/// Two write paths:
-/// - **Outgoing**: [insertOptimistic] writes a row with a placeholder id
-///   plus `publishStatus = 'pending'` and the serialized rumor JSON.
-///   Once the publish lands, [swapPlaceholderId] replaces the placeholder
-///   id with the real rumor id, clears the JSON, and marks `'sent'`.
-/// - **Incoming**: [upsertIncoming] writes (or de-dups) a row keyed on
-///   `(id, owner_pubkey)` — the rumor id is stable across the recipient
-///   and self gift-wraps, so a multi-device account that receives both
-///   collapses to one row.
+/// Two write paths, both enforcing the cap-at-one storage invariant (#5419):
+/// at most one live reaction per `(target_message_id, reactor_pubkey,
+/// owner_pubkey)`, backed by the partial unique index
+/// `idx_dm_reactions_unique_live`.
+/// - **Outgoing**: [insertOwnReactionSuperseding] soft-deletes any prior live
+///   reaction by this reactor on the target, then writes a row with a
+///   placeholder id plus `publishStatus = 'pending'` and the serialized rumor
+///   JSON — all in one transaction. Once the publish lands, [swapPlaceholderId]
+///   marks the row `'sent'` and clears the JSON.
+/// - **Incoming**: [upsertIncoming] de-dups on `(id, owner_pubkey)` (the rumor
+///   id is stable across the recipient and self gift-wraps) and collapses a
+///   new-id same-tuple reaction to the most recent, soft-deleting the loser so
+///   the live set stays capped at one.
 @DriftAccessor(tables: [DmMessageReactions])
 class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     with _$DmReactionsDaoMixin {
   DmReactionsDao(super.attachedDatabase);
 
-  /// Insert an optimistic outgoing row before the publish attempt.
+  /// Insert an optimistic outgoing row before the publish attempt, atomically
+  /// superseding any prior LIVE reactions by this reactor on this target.
   ///
-  /// [placeholderId] is a short unique token (e.g. `pending-<uuid>`) used
-  /// while the real rumor id is in flight. Once the publish succeeds,
-  /// call [swapPlaceholderId] to swap to the real id.
-  Future<void> insertOptimistic({
+  /// [placeholderId] is the rumor id used while the publish is in flight; once
+  /// it lands, call [swapPlaceholderId] to mark the row `sent`.
+  ///
+  /// Enforces the cap-at-one storage invariant (#5419) at the write boundary:
+  /// in one transaction it soft-deletes every prior live row for
+  /// `(targetMessageId, reactorPubkey, ownerPubkey)` and then inserts the new
+  /// pending row. The partial unique index `idx_dm_reactions_unique_live` is
+  /// the backstop. The final insert uses [InsertMode.insertOrIgnore] so a
+  /// concurrent second cubit's racing insert is a silent no-op (cap holds, no
+  /// crash) instead of a UNIQUE-constraint throw — the dual-cubit race the
+  /// issue targets.
+  ///
+  /// Returns the ids of the superseded prior live rows so the caller can emit
+  /// NIP-09 kind-5 deletions on the wire (outside this transaction).
+  Future<List<String>> insertOwnReactionSuperseding({
     required String placeholderId,
     required String conversationId,
     required String targetMessageId,
@@ -38,22 +54,44 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     required int createdAt,
     required String ownerPubkey,
     required String rumorEventJson,
-  }) async {
-    await into(dmMessageReactions).insert(
-      DmMessageReactionsCompanion.insert(
-        id: placeholderId,
-        conversationId: conversationId,
-        targetMessageId: targetMessageId,
-        targetMessageAuthor: targetMessageAuthor,
-        reactorPubkey: reactorPubkey,
-        emoji: emoji,
-        createdAt: createdAt,
-        ownerPubkey: ownerPubkey,
-        giftWrapId: const Value(null),
-        rumorEventJson: Value(rumorEventJson),
-        publishStatus: const Value('pending'),
-      ),
-    );
+  }) {
+    return transaction(() async {
+      final priors =
+          await (select(dmMessageReactions)..where(
+                (t) =>
+                    t.targetMessageId.equals(targetMessageId) &
+                    t.reactorPubkey.equals(reactorPubkey) &
+                    t.ownerPubkey.equals(ownerPubkey) &
+                    t.isDeleted.equals(false),
+              ))
+              .get();
+      final superseded = <String>[];
+      for (final prior in priors) {
+        if (prior.id == placeholderId) continue;
+        await (update(dmMessageReactions)..where(
+              (t) => t.id.equals(prior.id) & t.ownerPubkey.equals(ownerPubkey),
+            ))
+            .write(const DmMessageReactionsCompanion(isDeleted: Value(true)));
+        superseded.add(prior.id);
+      }
+      await into(dmMessageReactions).insert(
+        DmMessageReactionsCompanion.insert(
+          id: placeholderId,
+          conversationId: conversationId,
+          targetMessageId: targetMessageId,
+          targetMessageAuthor: targetMessageAuthor,
+          reactorPubkey: reactorPubkey,
+          emoji: emoji,
+          createdAt: createdAt,
+          ownerPubkey: ownerPubkey,
+          giftWrapId: const Value(null),
+          rumorEventJson: Value(rumorEventJson),
+          publishStatus: const Value('pending'),
+        ),
+        mode: InsertMode.insertOrIgnore,
+      );
+      return superseded;
+    });
   }
 
   /// Swap the placeholder id for the real rumor event id once publish
@@ -127,7 +165,22 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     )..where((t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey))).go();
   }
 
-  /// Upsert an incoming reaction. Idempotent on `(id, owner_pubkey)`.
+  /// Upsert an incoming reaction, enforcing the cap-at-one storage invariant
+  /// (#5419) at the write boundary.
+  ///
+  /// - **Same rumor id** (recipient + self gift-wrap, or relay replay):
+  ///   resolves on the primary key `(id, owner_pubkey)` and updates the stable
+  ///   fields in place. `is_deleted` is deliberately left untouched so a prior
+  ///   kind-5 removal is not resurrected by a replayed wrap.
+  /// - **New rumor id, same `(target, reactor, owner)` tuple**: keeps the most
+  ///   recent by `(created_at, id)`. If the incoming is newest it supersedes
+  ///   (soft-deletes) the prior live rows and lands live; if an existing live
+  ///   row is newer (out-of-order / replayed delivery) the incoming is recorded
+  ///   as already-deleted so gift-wrap dedup and history are preserved without
+  ///   violating the partial unique index `idx_dm_reactions_unique_live`.
+  ///
+  /// The final insert uses [InsertMode.insertOrIgnore] as a race backstop so a
+  /// concurrent writer can never turn this into a UNIQUE-constraint throw.
   Future<void> upsertIncoming({
     required String id,
     required String conversationId,
@@ -138,39 +191,74 @@ class DmReactionsDao extends DatabaseAccessor<AppDatabase>
     required int createdAt,
     required String giftWrapId,
     required String ownerPubkey,
-  }) async {
-    await into(dmMessageReactions).insertOnConflictUpdate(
-      DmMessageReactionsCompanion.insert(
-        id: id,
-        conversationId: conversationId,
-        targetMessageId: targetMessageId,
-        targetMessageAuthor: targetMessageAuthor,
-        reactorPubkey: reactorPubkey,
-        emoji: emoji,
-        createdAt: createdAt,
-        ownerPubkey: ownerPubkey,
-        giftWrapId: Value(giftWrapId),
-      ),
-    );
-  }
+  }) {
+    return transaction(() async {
+      final existing =
+          await (select(dmMessageReactions)
+                ..where(
+                  (t) => t.id.equals(id) & t.ownerPubkey.equals(ownerPubkey),
+                )
+                ..limit(1))
+              .getSingleOrNull();
+      if (existing != null) {
+        // Same rumor id: update stable fields in place, never `is_deleted`.
+        await into(dmMessageReactions).insertOnConflictUpdate(
+          DmMessageReactionsCompanion.insert(
+            id: id,
+            conversationId: conversationId,
+            targetMessageId: targetMessageId,
+            targetMessageAuthor: targetMessageAuthor,
+            reactorPubkey: reactorPubkey,
+            emoji: emoji,
+            createdAt: createdAt,
+            ownerPubkey: ownerPubkey,
+            giftWrapId: Value(giftWrapId),
+          ),
+        );
+        return;
+      }
 
-  /// Returns the existing live (non-deleted) row by this reactor on the
-  /// given target message, if any. Used by the cap-at-one supersede.
-  Future<DmReactionRow?> getOwnLiveReaction({
-    required String targetMessageId,
-    required String reactorPubkey,
-    required String ownerPubkey,
-  }) async {
-    final query = select(dmMessageReactions)
-      ..where(
-        (t) =>
-            t.targetMessageId.equals(targetMessageId) &
-            t.reactorPubkey.equals(reactorPubkey) &
-            t.ownerPubkey.equals(ownerPubkey) &
-            t.isDeleted.equals(false),
-      )
-      ..limit(1);
-    return query.getSingleOrNull();
+      final liveForTuple =
+          await (select(dmMessageReactions)..where(
+                (t) =>
+                    t.targetMessageId.equals(targetMessageId) &
+                    t.reactorPubkey.equals(reactorPubkey) &
+                    t.ownerPubkey.equals(ownerPubkey) &
+                    t.isDeleted.equals(false),
+              ))
+              .get();
+      final hasNewerLive = liveForTuple.any(
+        (r) =>
+            r.createdAt > createdAt ||
+            (r.createdAt == createdAt && r.id.compareTo(id) > 0),
+      );
+      if (!hasNewerLive) {
+        // Incoming is the newest: supersede every prior live row for the tuple.
+        for (final r in liveForTuple) {
+          await (update(dmMessageReactions)..where(
+                (t) => t.id.equals(r.id) & t.ownerPubkey.equals(ownerPubkey),
+              ))
+              .write(
+                const DmMessageReactionsCompanion(isDeleted: Value(true)),
+              );
+        }
+      }
+      await into(dmMessageReactions).insert(
+        DmMessageReactionsCompanion.insert(
+          id: id,
+          conversationId: conversationId,
+          targetMessageId: targetMessageId,
+          targetMessageAuthor: targetMessageAuthor,
+          reactorPubkey: reactorPubkey,
+          emoji: emoji,
+          createdAt: createdAt,
+          ownerPubkey: ownerPubkey,
+          giftWrapId: Value(giftWrapId),
+          isDeleted: Value(hasNewerLive),
+        ),
+        mode: InsertMode.insertOrIgnore,
+      );
+    });
   }
 
   /// Reactive stream of every live reaction in [conversationId] for the

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -879,6 +879,19 @@ class DmMessageReactions extends Table {
       'CREATE INDEX IF NOT EXISTS idx_dm_reactions_owner_created '
           'ON dm_message_reactions (owner_pubkey, created_at)',
     ),
+    // Cap-at-one storage invariant (#5419): at most one LIVE reaction per
+    // (target_message_id, reactor_pubkey, owner_pubkey). Applied at runtime in
+    // app_database._createMissingTables (after a dedup pass); mirrored here for
+    // documentation parity — the getter is not wired through
+    // @DriftDatabase(indexes:), so the runtime customStatement is the source
+    // of truth.
+    Index(
+      'idx_dm_reactions_unique_live',
+      'CREATE UNIQUE INDEX IF NOT EXISTS idx_dm_reactions_unique_live '
+          'ON dm_message_reactions '
+          '(target_message_id, reactor_pubkey, owner_pubkey) '
+          'WHERE is_deleted = 0',
+    ),
   ];
 }
 

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -589,6 +589,113 @@ void main() {
         },
       );
 
+      test(
+        'upgrade path — dedups duplicate live reactions before recreating '
+        'the unique index',
+        () async {
+          final target = '1' * 64;
+          // Drop the unique index so pre-index duplicate live rows can be
+          // seeded (simulating a device that pre-dates #5419).
+          await database.customStatement(
+            'DROP INDEX IF EXISTS idx_dm_reactions_unique_live',
+          );
+          await database.customStatement('''
+            INSERT INTO dm_message_reactions
+              (id, conversation_id, target_message_id, target_message_author,
+               reactor_pubkey, emoji, created_at, owner_pubkey, is_deleted)
+            VALUES
+              ('react_old', 'conv', '$target', 'author', '$testPubkey', 'a',
+               100, '$testPubkey', 0),
+              ('react_new', 'conv', '$target', 'author', '$testPubkey', 'b',
+               200, '$testPubkey', 0)
+          ''');
+
+          await database.close();
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+          // Trigger beforeOpen (dedup then CREATE UNIQUE INDEX). If the dedup
+          // pass did not run first, CREATE UNIQUE INDEX would throw here on the
+          // duplicate live rows.
+          final rows = await database
+              .customSelect(
+                'SELECT id, is_deleted FROM dm_message_reactions '
+                'ORDER BY created_at',
+              )
+              .get();
+          expect(rows, hasLength(2));
+          final live = rows
+              .where((r) => r.read<int>('is_deleted') == 0)
+              .toList();
+          expect(live, hasLength(1));
+          expect(live.single.read<String>('id'), equals('react_new'));
+
+          final indexes = await _collectIndexNames(
+            database,
+            'dm_message_reactions',
+          );
+          expect(indexes, contains('idx_dm_reactions_unique_live'));
+
+          // Idempotency: reopening again keeps exactly one live row, no error.
+          await database.close();
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          final live2 = await database
+              .customSelect(
+                'SELECT id FROM dm_message_reactions WHERE is_deleted = 0',
+              )
+              .get();
+          expect(live2, hasLength(1));
+          expect(live2.single.read<String>('id'), equals('react_new'));
+        },
+      );
+
+      test(
+        'schema parity — dm_message_reactions fresh-install matches runtime '
+        'CREATE-IF-NOT-EXISTS path',
+        () async {
+          final freshColumns = await _collectTableInfo(
+            database,
+            'dm_message_reactions',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'dm_message_reactions',
+          );
+
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason:
+                'precondition: fresh install should have dm_message_reactions',
+          );
+
+          await database.customStatement('DROP TABLE dm_message_reactions');
+          for (final indexName in freshIndexes) {
+            await database.customStatement('DROP INDEX IF EXISTS $indexName');
+          }
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='dm_message_reactions'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'dm_message_reactions',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'dm_message_reactions',
+          );
+
+          expect(recreatedColumns, equals(freshColumns));
+          expect(recreatedIndexes, equals(freshIndexes));
+        },
+      );
+
       test('does not delete non-expired data', () async {
         final eventsDao = database.nostrEventsDao;
         final profileStatsDao = database.profileStatsDao;

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -179,6 +179,105 @@ void main() {
       },
     );
 
+    test(
+      'insertOwnReactionSuperseding resurrects a soft-deleted same-id row so '
+      'a same-second re-react is not silently dropped',
+      () async {
+        // React, remove (soft-delete), then re-react the same emoji within the
+        // same wall-clock second: the rebuilt rumor id is identical, so the
+        // insert collides with the just-deleted row's primary key.
+        await insertPending();
+        await dao.softDelete(id: _pendingId, ownerPubkey: _ownerA);
+        expect(
+          (await dao.getById(id: _pendingId, ownerPubkey: _ownerA))!.isDeleted,
+          isTrue,
+        );
+
+        final superseded = await insertPending();
+
+        expect(superseded, isEmpty);
+        final row = await dao.getById(id: _pendingId, ownerPubkey: _ownerA);
+        expect(row, isNotNull);
+        expect(row!.isDeleted, isFalse);
+        expect(row.publishStatus, equals('pending'));
+        expect(row.rumorEventJson, contains(_pendingId));
+
+        final live = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(live.map((r) => r.emoji), equals(['🔥']));
+      },
+    );
+
+    test(
+      'insertOwnReactionSuperseding leaves a still-live same-id row untouched '
+      'so an idempotent double-tap keeps its publish status',
+      () async {
+        await insertPending();
+        await dao.swapPlaceholderId(
+          placeholderId: _pendingId,
+          realRumorId: _pendingId,
+          ownerPubkey: _ownerA,
+        );
+        expect(
+          (await dao.getById(
+            id: _pendingId,
+            ownerPubkey: _ownerA,
+          ))!.publishStatus,
+          equals('sent'),
+        );
+
+        final superseded = await insertPending();
+
+        expect(superseded, isEmpty);
+        // Resurrect is scoped to deleted rows, so the live 'sent' row is not
+        // regressed to 'pending' and its cleared rumor json stays cleared.
+        final row = await dao.getById(id: _pendingId, ownerPubkey: _ownerA);
+        expect(row!.isDeleted, isFalse);
+        expect(row.publishStatus, equals('sent'));
+        expect(row.rumorEventJson, isNull);
+      },
+    );
+
+    test(
+      'insertOwnReactionSuperseding resurrects a deleted same-id row while a '
+      'different-id live sibling exists, staying capped at one live row',
+      () async {
+        // Deleted same-id row (🔥) coexisting with a live different-id row
+        // (😂): re-reacting 🔥 must supersede the sibling BEFORE resurrecting,
+        // or the partial unique index would reject two live rows for the tuple.
+        await insertPending();
+        await dao.softDelete(id: _pendingId, ownerPubkey: _ownerA);
+        await insertPending(
+          id: _sentId,
+          emoji: '😂',
+          createdAt: 1_700_000_010,
+        );
+
+        final superseded = await insertPending();
+
+        expect(superseded, equals([_sentId]));
+        expect(
+          (await dao.getById(id: _pendingId, ownerPubkey: _ownerA))!.isDeleted,
+          isFalse,
+        );
+        expect(
+          (await dao.getById(id: _sentId, ownerPubkey: _ownerA))!.isDeleted,
+          isTrue,
+        );
+        final live = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(live.map((r) => r.emoji), equals(['🔥']));
+      },
+    );
+
     test('swapPlaceholderId marks row sent and clears stored rumor', () async {
       await insertPending();
 

--- a/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/dm_reactions_dao_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart' hide isNotNull, isNull;
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -54,34 +55,129 @@ void main() {
   });
 
   group('DmReactionsDao', () {
-    Future<void> insertPending({
+    Future<List<String>> insertPending({
       String id = _pendingId,
       String ownerPubkey = _ownerA,
       String reactorPubkey = _reactorA,
       String emoji = '🔥',
+      int createdAt = 1_700_000_000,
     }) {
-      return dao.insertOptimistic(
+      return dao.insertOwnReactionSuperseding(
         placeholderId: id,
         conversationId: _conversationId,
         targetMessageId: _targetMessageId,
         targetMessageAuthor: _targetAuthor,
         reactorPubkey: reactorPubkey,
         emoji: emoji,
-        createdAt: 1_700_000_000,
+        createdAt: createdAt,
         ownerPubkey: ownerPubkey,
         rumorEventJson: '{"id":"$id"}',
       );
     }
 
-    test('insertOptimistic stores pending state and rumor json', () async {
-      await insertPending();
+    test(
+      'insertOwnReactionSuperseding stores pending state and rumor json',
+      () async {
+        final superseded = await insertPending();
+        expect(superseded, isEmpty);
 
-      final row = await dao.getById(id: _pendingId, ownerPubkey: _ownerA);
-      expect(row, isNotNull);
-      expect(row!.publishStatus, equals('pending'));
-      expect(row.rumorEventJson, contains(_pendingId));
-      expect(row.giftWrapId, isNull);
-    });
+        final row = await dao.getById(id: _pendingId, ownerPubkey: _ownerA);
+        expect(row, isNotNull);
+        expect(row!.publishStatus, equals('pending'));
+        expect(row.rumorEventJson, contains(_pendingId));
+        expect(row.giftWrapId, isNull);
+      },
+    );
+
+    test(
+      'insertOwnReactionSuperseding soft-deletes the prior live own reaction '
+      'and returns its id',
+      () async {
+        await insertPending();
+        final superseded = await insertPending(
+          id: _sentId,
+          emoji: '😂',
+          createdAt: 1_700_000_010,
+        );
+
+        expect(superseded, equals([_pendingId]));
+        expect(
+          (await dao.getById(id: _pendingId, ownerPubkey: _ownerA))!.isDeleted,
+          isTrue,
+        );
+        final live = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(live.map((r) => r.emoji), equals(['😂']));
+      },
+    );
+
+    test(
+      'partial unique index rejects a second live reaction for the same '
+      '(target, reactor, owner) tuple',
+      () async {
+        await insertPending();
+
+        Future<void> insertDuplicateLive() {
+          return database
+              .into(database.dmMessageReactions)
+              .insert(
+                DmMessageReactionsCompanion.insert(
+                  id: _sentId,
+                  conversationId: _conversationId,
+                  targetMessageId: _targetMessageId,
+                  targetMessageAuthor: _targetAuthor,
+                  reactorPubkey: _reactorA,
+                  emoji: '😂',
+                  createdAt: 1_700_000_010,
+                  ownerPubkey: _ownerA,
+                ),
+              );
+        }
+
+        await expectLater(insertDuplicateLive(), throwsA(isA<Exception>()));
+      },
+    );
+
+    test(
+      'partial unique index allows unlimited deleted rows for one tuple',
+      () async {
+        Future<void> insertDeleted(String id) {
+          return database
+              .into(database.dmMessageReactions)
+              .insert(
+                DmMessageReactionsCompanion.insert(
+                  id: id,
+                  conversationId: _conversationId,
+                  targetMessageId: _targetMessageId,
+                  targetMessageAuthor: _targetAuthor,
+                  reactorPubkey: _reactorA,
+                  emoji: '🔥',
+                  createdAt: 1_700_000_000,
+                  ownerPubkey: _ownerA,
+                  isDeleted: const Value(true),
+                ),
+              );
+        }
+
+        await insertPending(); // one live
+        await insertDeleted(_sentId); // deleted dup — allowed
+        await insertDeleted(
+          '4444444444444444444444444444444444444444444444444444444444444444',
+        );
+
+        final live = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(live, hasLength(1));
+      },
+    );
 
     test('swapPlaceholderId marks row sent and clears stored rumor', () async {
       await insertPending();
@@ -128,25 +224,25 @@ void main() {
       () async {
         await insertPending(id: _sentId);
 
-        final before = await dao.getOwnLiveReaction(
-          targetMessageId: _targetMessageId,
-          reactorPubkey: _reactorA,
-          ownerPubkey: _ownerA,
-        );
-        expect(before, isNotNull);
+        final before = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(before, hasLength(1));
 
         await dao.softDelete(id: _sentId, ownerPubkey: _ownerA);
 
         final row = await dao.getById(id: _sentId, ownerPubkey: _ownerA);
         expect(row!.isDeleted, isTrue);
-        expect(
-          await dao.getOwnLiveReaction(
-            targetMessageId: _targetMessageId,
-            reactorPubkey: _reactorA,
-            ownerPubkey: _ownerA,
-          ),
-          isNull,
-        );
+        final after = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(after, isEmpty);
       },
     );
 
@@ -196,6 +292,91 @@ void main() {
       expect(rows, hasLength(1));
       expect(rows.single.id, equals(_sentId));
     });
+
+    Future<void> upsertIncoming({
+      required String id,
+      required int createdAt,
+      String reactorPubkey = _reactorB,
+      String emoji = '😂',
+      String giftWrapId = _giftWrapId,
+    }) {
+      return dao.upsertIncoming(
+        id: id,
+        conversationId: _conversationId,
+        targetMessageId: _targetMessageId,
+        targetMessageAuthor: _targetAuthor,
+        reactorPubkey: reactorPubkey,
+        emoji: emoji,
+        createdAt: createdAt,
+        giftWrapId: giftWrapId,
+        ownerPubkey: _ownerA,
+      );
+    }
+
+    test(
+      'upsertIncoming with a newer rumor id supersedes the older live reaction',
+      () async {
+        await upsertIncoming(
+          id: _sentId,
+          createdAt: 1_700_000_000,
+          emoji: '🔥',
+        );
+        await upsertIncoming(id: _pendingId, createdAt: 1_700_000_010);
+
+        expect(
+          (await dao.getById(id: _sentId, ownerPubkey: _ownerA))!.isDeleted,
+          isTrue,
+        );
+        final live = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(live.map((r) => r.id), equals([_pendingId]));
+        expect(live.single.emoji, equals('😂'));
+      },
+    );
+
+    test(
+      'upsertIncoming with an older rumor id is recorded as already-deleted',
+      () async {
+        await upsertIncoming(id: _sentId, createdAt: 1_700_000_010);
+        await upsertIncoming(
+          id: _pendingId,
+          createdAt: 1_700_000_000,
+          emoji: '🔥',
+        );
+
+        // Older reaction is recorded (history + gift-wrap dedup) but deleted.
+        final older = await dao.getById(id: _pendingId, ownerPubkey: _ownerA);
+        expect(older, isNotNull);
+        expect(older!.isDeleted, isTrue);
+        final live = await dao
+            .watchForConversation(
+              conversationId: _conversationId,
+              ownerPubkey: _ownerA,
+            )
+            .first;
+        expect(live.map((r) => r.id), equals([_sentId]));
+      },
+    );
+
+    test(
+      'upsertIncoming re-arrival of a deleted reaction does not resurrect it',
+      () async {
+        await upsertIncoming(id: _sentId, createdAt: 1_700_000_000);
+        await dao.softDelete(id: _sentId, ownerPubkey: _ownerA);
+
+        // Self-wrap / relay replay of the same rumor id arrives again.
+        await upsertIncoming(id: _sentId, createdAt: 1_700_000_000);
+
+        expect(
+          (await dao.getById(id: _sentId, ownerPubkey: _ownerA))!.isDeleted,
+          isTrue,
+        );
+      },
+    );
 
     test('watchForConversation only returns live rows for one owner', () async {
       await insertPending();

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -173,21 +173,6 @@ class DmReactionsRepository {
       );
     }
 
-    final prior = await _reactionsDao.getOwnLiveReaction(
-      targetMessageId: targetMessageId,
-      reactorPubkey: _userPubkey,
-      ownerPubkey: _userPubkey,
-    );
-    if (prior != null) {
-      unawaited(
-        _supersedePrior(
-          priorRow: prior,
-          targetMessageAuthor: targetMessageAuthor,
-          messageService: messageService,
-        ),
-      );
-    }
-
     final additionalTags = <List<String>>[
       ['e', targetMessageId],
       ['p', targetMessageAuthor],
@@ -201,8 +186,12 @@ class DmReactionsRepository {
     );
     final rumorId = rumor.id;
 
+    final List<String> superseded;
     try {
-      await _reactionsDao.insertOptimistic(
+      // Atomic cap-at-one: soft-deletes any prior live own reaction on this
+      // target and inserts the new pending row in one transaction, returning
+      // the superseded ids for the wire-side kind-5 below (#5419).
+      superseded = await _reactionsDao.insertOwnReactionSuperseding(
         placeholderId: rumorId,
         conversationId: conversationId,
         targetMessageId: targetMessageId,
@@ -226,11 +215,25 @@ class DmReactionsRepository {
       );
     }
 
-    try {
-      final recipients = await _resolveWrapRecipients(
-        conversationId: conversationId,
-        targetMessageAuthor: targetMessageAuthor,
+    final recipients = await _resolveWrapRecipients(
+      conversationId: conversationId,
+      targetMessageAuthor: targetMessageAuthor,
+    );
+
+    // Emit a NIP-09 kind-5 deletion on the wire for each superseded prior
+    // reaction. Fire-and-forget and kept OUTSIDE the DAO transaction — a
+    // stalled relay socket must never block the local optimistic write.
+    for (final priorId in superseded) {
+      unawaited(
+        _publishKind5Deletion(
+          reactionEventId: priorId,
+          recipients: recipients,
+          messageService: messageService,
+        ),
       );
+    }
+
+    try {
       final result = await _fanOutRumor(
         messageService: messageService,
         rumor: rumor,
@@ -548,29 +551,6 @@ class DmReactionsRepository {
             '${_publishTimeout.inSeconds}s',
           ),
         );
-  }
-
-  Future<void> _supersedePrior({
-    required DmReactionRow priorRow,
-    required String targetMessageAuthor,
-    required NIP17MessageService messageService,
-  }) async {
-    try {
-      await _reactionsDao.softDelete(id: priorRow.id, ownerPubkey: _userPubkey);
-    } on Object {
-      // Best-effort; the new publish proceeds regardless.
-    }
-    final recipients = await _resolveWrapRecipients(
-      conversationId: priorRow.conversationId,
-      targetMessageAuthor: targetMessageAuthor,
-    );
-    unawaited(
-      _publishKind5Deletion(
-        reactionEventId: priorRow.id,
-        recipients: recipients,
-        messageService: messageService,
-      ),
-    );
   }
 
   /// Resolve the gift-wrap recipient set for a reaction in [conversationId].

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -278,13 +278,6 @@ void main() {
       () async {
         final rumor = reactionRumor();
         when(
-          () => mockDao.getOwnLiveReaction(
-            targetMessageId: _targetMessageId,
-            reactorPubkey: _ownerPubkey,
-            ownerPubkey: _ownerPubkey,
-          ),
-        ).thenAnswer((_) async => null);
-        when(
           () => mockMessageService.buildRumor(
             recipientPubkey: _otherPubkey,
             content: '🔥',
@@ -293,7 +286,7 @@ void main() {
           ),
         ).thenReturn(rumor);
         when(
-          () => mockDao.insertOptimistic(
+          () => mockDao.insertOwnReactionSuperseding(
             placeholderId: rumor.id,
             conversationId: _conversationId,
             targetMessageId: _targetMessageId,
@@ -304,7 +297,7 @@ void main() {
             ownerPubkey: _ownerPubkey,
             rumorEventJson: jsonEncode(rumor.toJson()),
           ),
-        ).thenAnswer((_) async {});
+        ).thenAnswer((_) async => <String>[]);
         when(
           () => mockMessageService.sendRumor(
             rumorEvent: rumor,
@@ -335,7 +328,7 @@ void main() {
 
         expect(result.success, isTrue);
         verify(
-          () => mockDao.insertOptimistic(
+          () => mockDao.insertOwnReactionSuperseding(
             placeholderId: rumor.id,
             conversationId: _conversationId,
             targetMessageId: _targetMessageId,
@@ -357,15 +350,92 @@ void main() {
       },
     );
 
+    test(
+      'publish supersedes a prior reaction and emits a kind-5 deletion for it',
+      () async {
+        const priorReactionId =
+            '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+        final rumor = reactionRumor();
+        final deletionRumor = reactionRumor(
+          id: _giftWrapId,
+          content: '',
+          kind: EventKind.eventDeletion,
+          tags: [
+            ['e', priorReactionId],
+            ['k', EventKind.reaction.toString()],
+          ],
+        );
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: '🔥',
+            eventKind: EventKind.reaction,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(rumor);
+        when(
+          () => mockDao.insertOwnReactionSuperseding(
+            placeholderId: any(named: 'placeholderId'),
+            conversationId: any(named: 'conversationId'),
+            targetMessageId: any(named: 'targetMessageId'),
+            targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            reactorPubkey: any(named: 'reactorPubkey'),
+            emoji: any(named: 'emoji'),
+            createdAt: any(named: 'createdAt'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+            rumorEventJson: any(named: 'rumorEventJson'),
+          ),
+        ).thenAnswer((_) async => <String>[priorReactionId]);
+        when(
+          () => mockMessageService.buildRumor(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            content: '',
+            eventKind: EventKind.eventDeletion,
+            additionalTags: any(named: 'additionalTags'),
+          ),
+        ).thenReturn(deletionRumor);
+        when(
+          () => mockMessageService.sendRumor(
+            rumorEvent: any(named: 'rumorEvent'),
+            recipientPubkey: any(named: 'recipientPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: rumor.id,
+            messageEventId: _giftWrapId,
+            recipientPubkey: _otherPubkey,
+          ),
+        );
+        when(
+          () => mockDao.swapPlaceholderId(
+            placeholderId: any(named: 'placeholderId'),
+            realRumorId: any(named: 'realRumorId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async {});
+
+        final repository = createRepository();
+        final result = await repository.publish(
+          conversationId: _conversationId,
+          targetMessageId: _targetMessageId,
+          targetMessageAuthor: _otherPubkey,
+          emoji: '🔥',
+        );
+        // _publishKind5Deletion fires via unawaited; let it run.
+        await Future<void>.delayed(Duration.zero);
+
+        expect(result.success, isTrue);
+        verify(
+          () => mockMessageService.sendRumor(
+            rumorEvent: deletionRumor,
+            recipientPubkey: any(named: 'recipientPubkey'),
+          ),
+        ).called(1);
+      },
+    );
+
     test('publish marks failed when send returns failure', () async {
       final rumor = reactionRumor();
-      when(
-        () => mockDao.getOwnLiveReaction(
-          targetMessageId: _targetMessageId,
-          reactorPubkey: _ownerPubkey,
-          ownerPubkey: _ownerPubkey,
-        ),
-      ).thenAnswer((_) async => null);
       when(
         () => mockMessageService.buildRumor(
           recipientPubkey: _otherPubkey,
@@ -375,7 +445,7 @@ void main() {
         ),
       ).thenReturn(rumor);
       when(
-        () => mockDao.insertOptimistic(
+        () => mockDao.insertOwnReactionSuperseding(
           placeholderId: rumor.id,
           conversationId: _conversationId,
           targetMessageId: _targetMessageId,
@@ -386,7 +456,7 @@ void main() {
           ownerPubkey: _ownerPubkey,
           rumorEventJson: jsonEncode(rumor.toJson()),
         ),
-      ).thenAnswer((_) async {});
+      ).thenAnswer((_) async => <String>[]);
       when(
         () => mockMessageService.sendRumor(
           rumorEvent: rumor,
@@ -420,13 +490,6 @@ void main() {
     test('publish reports optimistic insert failures', () async {
       final rumor = reactionRumor();
       when(
-        () => mockDao.getOwnLiveReaction(
-          targetMessageId: _targetMessageId,
-          reactorPubkey: _ownerPubkey,
-          ownerPubkey: _ownerPubkey,
-        ),
-      ).thenAnswer((_) async => null);
-      when(
         () => mockMessageService.buildRumor(
           recipientPubkey: _otherPubkey,
           content: '🔥',
@@ -435,7 +498,7 @@ void main() {
         ),
       ).thenReturn(rumor);
       when(
-        () => mockDao.insertOptimistic(
+        () => mockDao.insertOwnReactionSuperseding(
           placeholderId: any(named: 'placeholderId'),
           conversationId: any(named: 'conversationId'),
           targetMessageId: any(named: 'targetMessageId'),
@@ -807,13 +870,6 @@ void main() {
               ownerPubkey: _ownerPubkey,
             ),
           );
-          when(
-            () => mockDao.getOwnLiveReaction(
-              targetMessageId: _targetMessageId,
-              reactorPubkey: _ownerPubkey,
-              ownerPubkey: _ownerPubkey,
-            ),
-          ).thenAnswer((_) async => null);
           final rumor = reactionRumor();
           when(
             () => mockMessageService.buildRumor(
@@ -824,7 +880,7 @@ void main() {
             ),
           ).thenReturn(rumor);
           when(
-            () => mockDao.insertOptimistic(
+            () => mockDao.insertOwnReactionSuperseding(
               placeholderId: any(named: 'placeholderId'),
               conversationId: any(named: 'conversationId'),
               targetMessageId: any(named: 'targetMessageId'),
@@ -835,7 +891,7 @@ void main() {
               ownerPubkey: any(named: 'ownerPubkey'),
               rumorEventJson: any(named: 'rumorEventJson'),
             ),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => <String>[]);
           when(
             () => mockMessageService.sendRumor(
               rumorEvent: any(named: 'rumorEvent'),


### PR DESCRIPTION
## Description

Follow-up from #5403. DM reactions are hard-capped at one live reaction per
reactor per message, but that cap was only enforced in the **render** path
(`DmReactionsRepository._collapsePerReactor`, #5403). Storage could still hold
multiple live rows for the same `(target_message_id, reactor_pubkey,
owner_pubkey)`. This PR makes the **database** own the invariant.

What changed:

- **Partial unique index** `idx_dm_reactions_unique_live` on
  `(target_message_id, reactor_pubkey, owner_pubkey) WHERE is_deleted = 0`.
  Deleted historical rows are unconstrained, so sync/deletion history is
  preserved.
- **Idempotent dedup pass runs before the index is created.** SQLite refuses to
  build a unique index over rows that already violate it, so on any device that
  already holds duplicate live rows the migration first soft-deletes all but the
  most recent (`MAX(created_at, id)`, matching the read-side collapse), then
  creates the index. It converges to a no-op once enforced (the index is
  re-created `IF NOT EXISTS` on every startup, same pattern as the other tables).
- **Write paths are cap-aware and constraint-tolerant** (no user-visible
  crashes):
  - `insertOwnReactionSuperseding` (replaces `insertOptimistic`) soft-deletes any
    prior live own reaction and inserts the new one in one transaction, returning
    the superseded ids; `publish()` then emits the wire-side NIP-09 kind-5
    deletions **outside** the transaction (a stalled relay socket must never hold
    the write lock).
  - `upsertIncoming` collapses a new-rumor-id, same-tuple reaction to the most
    recent. A remote client switching emoji **without** a kind-5 deletion is
    legitimate per NIP-25 (kind-7 is non-replaceable; NIP-09 deletion is
    advisory), so older arrivals are recorded as soft-deleted rather than dropped
    or crashed; same-rumor-id self/recipient wraps still de-dup on the primary
    key and never resurrect a deleted reaction.
- Fixed stale comment that claimed a schema-parity test pinned the reactions
  indexes (none existed); this PR adds that test.

Schema stays at version 1 (runtime `CREATE … IF NOT EXISTS` pattern — no codegen,
no version bump). No backend change: DM reactions are kind-7 rumors sealed inside
NIP-17 gift wraps (kind 1059), opaque to relays.

## Reproducing the duplicate-live-row condition

**Real-world scenario (storage symptom):**
1. In a 1:1 DM, react to a message that is reachable from both the conversation
   screen and the reel reply bar (e.g. a shared reel). Two
   `ConversationReactionsCubit` instances exist for the same `(account,
   conversation)`, sharing the single keep-alive `DmReactionsRepository`; their
   `sequential()` queues are per-instance, so they are not serialized against
   each other.
2. React to the same message near-simultaneously from both surfaces — **or** have
   another device / client switch your emoji on that message without emitting a
   kind-5 deletion.
3. Both writes pass the pre-write "do I already have a live reaction?" check
   before either commits → `dm_message_reactions` ends up with two rows where
   `is_deleted = 0` for the same `(target_message_id, reactor_pubkey,
   owner_pubkey)`. (#5403 hides this at render time; storage stays wrong.)

**Deterministic DB-level reproduction (encoded as tests):**
- Insert two live rows for the same tuple. *Before:* both persist (no
  constraint). *After:* the partial unique index rejects the second
  (`UNIQUE constraint failed`), and the cap-aware write paths supersede the older
  one instead of duplicating.
- Seed two duplicate live rows, drop the new index, reopen the database.
  *Before:* a naive `CREATE UNIQUE INDEX` would throw at startup over the existing
  duplicates. *After:* the dedup pass soft-deletes the older row first, the index
  builds, exactly one live row remains, and re-opening again is a no-op.

## Out of Scope

- Block/mute filtering of DM reactions (#5418) — unchanged.
- Read-side collapse (#5403) stays as defense-in-depth; this PR makes it
  redundant for stored data but does not remove it.

## Verification

From `mobile/`:

- `flutter test packages/db_client` — **677 passing** (new: cap/supersede/index
  enforcement + deleted-dups-allowed DAO tests; dedup-on-reopen migration test;
  `dm_message_reactions` schema-parity test).
- `flutter test packages/dm_repository` — **368 passing** (publish rewired to the
  transactional supersede + a new supersede→kind-5 test).
- `flutter test test/blocs/dm/reactions/conversation_reactions_cubit_test.dart` —
  **12 passing**.
- `flutter analyze packages/db_client packages/dm_repository` — **No issues
  found**.
- `dart format --set-exit-if-changed` on all changed files — clean.
- No generated-file drift; schema version unchanged.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor

Closes #5419
