### PR TITLE
perf: cut UI-isolate CPU (theme lerp, redundant signing, feed rebuilds)

### DIFF
--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -23,6 +23,7 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
+import 'package:openvine/observability/reportable_error.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/local_key_signer.dart';
@@ -81,6 +82,32 @@ enum AuthState {
 
   /// Authentication is in progress (generating/importing keys)
   authenticating,
+}
+
+/// Thrown when a signer returns an event whose author public key does not
+/// match the active identity.
+///
+/// A signing-layer invariant violation: a signer must never produce an event
+/// for a different account than the one that requested signing. Reported to
+/// Crashlytics via [Reportable] (YES on the error-handling matrix), and the
+/// caller fails the publish closed. Carries hex pubkeys only (no npub/nsec),
+/// so it is safe for the [Reportable] sanitizer.
+class EventSignerAccountMismatchException implements Exception {
+  const EventSignerAccountMismatchException({
+    required this.expectedPubkey,
+    required this.actualPubkey,
+  });
+
+  /// The active identity's public key (hex) the event was created with.
+  final String expectedPubkey;
+
+  /// The public key (hex) the signer returned on the signed event.
+  final String actualPubkey;
+
+  @override
+  String toString() =>
+      'EventSignerAccountMismatchException: signer returned an event for '
+      '$actualPubkey but the active identity is $expectedPubkey';
 }
 
 /// Result of authentication operations
@@ -4296,17 +4323,15 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // backend swapped the authorized key). isSigned/isValid only prove
       // the signature and id are self-consistent for the event's own
       // pubkey — not that it is the account we intended to sign as. Cheap
-      // string compare; runs for every signer, local or remote.
+      // string compare; runs for every signer, local or remote. Throwing
+      // (rather than returning null) keeps this off the frozen sentinel
+      // ceiling and surfaces the invariant violation via Reportable in the
+      // catch below. #5450.
       if (signedEvent.pubkey != identity.pubkey) {
-        Log.error(
-          'Event pubkey mismatch! Signer returned a different account. '
-          'eventPubkey=${signedEvent.pubkey}, '
-          'identityPubkey=${identity.pubkey}, '
-          'authSource=${_authSource.name}',
-          name: 'AuthService',
-          category: LogCategory.auth,
+        throw EventSignerAccountMismatchException(
+          expectedPubkey: identity.pubkey,
+          actualPubkey: signedEvent.pubkey,
         );
-        return null;
       }
 
       // Re-verifying a signature we just produced with our own in-process
@@ -4344,12 +4369,24 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       );
 
       return signedEvent;
-    } catch (e) {
+    } catch (e, stackTrace) {
       Log.error(
         'Failed to create or sign event: $e',
         name: 'AuthService',
         category: LogCategory.auth,
       );
+      // An event signed for a different account is an invariant violation
+      // (YES on the Reportable matrix), not an expected domain/network
+      // failure — surface it to Crashlytics. Other errors keep the existing
+      // log-only behavior to avoid flooding the dashboard.
+      if (e is EventSignerAccountMismatchException) {
+        _reportAuthError(
+          Reportable(e, context: 'createAndSignEvent'),
+          stackTrace,
+          reason: 'Signer returned an event for a different account',
+          logMessage: 'Signer account mismatch during createAndSignEvent',
+        );
+      }
       return null;
     }
   }

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -4291,7 +4291,13 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         return null;
       }
 
-      if (!signedEvent.isSigned) {
+      // Re-verifying a signature we just produced with our own in-process
+      // key only exercises the crypto library and costs a full schnorr
+      // verification per event (hot on the feed-scroll signing path). Skip
+      // it for local signers; remote/external signers cross a trust
+      // boundary, so their returned signature is still verified. The cheap
+      // structural check (isValid: id == hash) below always runs.
+      if (!identity.signsWithLocalKey && !signedEvent.isSigned) {
         Log.error(
           'Event signature validation FAILED! '
           'kind=$kind, eventPubkey=${signedEvent.pubkey}, '

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -4291,6 +4291,24 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         return null;
       }
 
+      // Guard against a signer returning an event bound to a different
+      // account than the active identity (e.g. a remote signer whose
+      // backend swapped the authorized key). isSigned/isValid only prove
+      // the signature and id are self-consistent for the event's own
+      // pubkey — not that it is the account we intended to sign as. Cheap
+      // string compare; runs for every signer, local or remote.
+      if (signedEvent.pubkey != identity.pubkey) {
+        Log.error(
+          'Event pubkey mismatch! Signer returned a different account. '
+          'eventPubkey=${signedEvent.pubkey}, '
+          'identityPubkey=${identity.pubkey}, '
+          'authSource=${_authSource.name}',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        return null;
+      }
+
       // Re-verifying a signature we just produced with our own in-process
       // key only exercises the crypto library and costs a full schnorr
       // verification per event (hot on the feed-scroll signing path). Skip

--- a/mobile/lib/services/nostr_identity.dart
+++ b/mobile/lib/services/nostr_identity.dart
@@ -51,6 +51,13 @@ sealed class NostrIdentity implements NostrSigner {
   /// ourselves only exercises the crypto library and costs a full schnorr
   /// verification per event. Structural validation (event id == hash) is
   /// cheap and should still run regardless.
+  ///
+  /// Contract upheld for the caller: when this is true, every event returned
+  /// by [signEvent] carries a signature that needs no external verification.
+  /// [KeycastNostrIdentity] keeps that true even in its rare
+  /// local-sign-fails → RPC fallback by verifying the RPC result before
+  /// returning it, so the flag is a guarantee about the returned event, not
+  /// merely the capability that a local key exists.
   bool get signsWithLocalKey;
 }
 
@@ -153,6 +160,20 @@ class KeycastNostrIdentity extends NostrIdentity
         name: 'KeycastNostrIdentity',
         category: LogCategory.auth,
       );
+      // signsWithLocalKey is true for this identity, so the caller skips its
+      // post-sign verify. This fallback result came from the remote RPC — a
+      // trust boundary — so verify it here to honor that contract; otherwise a
+      // tampered/wrong-key RPC signature would slip through unverified. #5450.
+      final rpcSigned = await _rpcSigner.signEvent(event);
+      if (rpcSigned != null && !rpcSigned.isSigned) {
+        Log.error(
+          'Keycast RPC fallback returned an invalid signature; rejecting',
+          name: 'KeycastNostrIdentity',
+          category: LogCategory.auth,
+        );
+        return null;
+      }
+      return rpcSigned;
     }
     return _rpcSigner.signEvent(event);
   }

--- a/mobile/lib/services/nostr_identity.dart
+++ b/mobile/lib/services/nostr_identity.dart
@@ -38,6 +38,20 @@ sealed class NostrIdentity implements NostrSigner {
   /// signers (NIP-46 bunker, NIP-55 Amber, NIP-07 extension) are human-paced —
   /// the user reads a prompt and approves — so they must NOT be timed out.
   bool get signsRemotelyNonInteractive;
+
+  /// Whether this identity produces signatures in-process with a private key
+  /// it holds directly.
+  ///
+  /// True for local key signers, and for Keycast when a matching local key is
+  /// present. False for external/remote signers (NIP-46 bunker, NIP-55 Amber,
+  /// NIP-07 extension), whose returned signature crosses a trust boundary.
+  ///
+  /// A caller that has just signed an event can skip re-verifying the
+  /// signature when this is true: re-verifying a signature we produced
+  /// ourselves only exercises the crypto library and costs a full schnorr
+  /// verification per event. Structural validation (event id == hash) is
+  /// cheap and should still run regardless.
+  bool get signsWithLocalKey;
 }
 
 /// Identity backed by a local [SecureKeyContainer] with a private key.
@@ -63,6 +77,9 @@ class LocalNostrIdentity extends NostrIdentity implements IsolateDecryptSigner {
 
   @override
   bool get signsRemotelyNonInteractive => false;
+
+  @override
+  bool get signsWithLocalKey => true;
 
   @override
   bool get canDecryptInIsolate => _signer.canDecryptInIsolate;
@@ -170,6 +187,9 @@ class KeycastNostrIdentity extends NostrIdentity
   bool get signsRemotelyNonInteractive => _localSigner == null;
 
   @override
+  bool get signsWithLocalKey => _localSigner != null;
+
+  @override
   bool get canDecryptInIsolate => _localSigner?.canDecryptInIsolate ?? false;
 
   @override
@@ -257,6 +277,9 @@ class BunkerNostrIdentity extends NostrIdentity {
   bool get signsRemotelyNonInteractive => false;
 
   @override
+  bool get signsWithLocalKey => false;
+
+  @override
   Future<Map?> getRelays() => _remoteSigner.getRelays();
 
   @override
@@ -308,6 +331,9 @@ class AmberNostrIdentity extends NostrIdentity {
   // human-paced and must not be timed out.
   @override
   bool get signsRemotelyNonInteractive => false;
+
+  @override
+  bool get signsWithLocalKey => false;
 
   @override
   Future<Map?> getRelays() => _amberSigner.getRelays();
@@ -363,6 +389,9 @@ class Nip07NostrIdentity extends NostrIdentity {
   // signing is human-paced and must not be timed out.
   @override
   bool get signsRemotelyNonInteractive => false;
+
+  @override
+  bool get signsWithLocalKey => false;
 
   @override
   Future<Map?> getRelays() => _nip07Signer.getRelays();

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -551,20 +551,26 @@ class __OverlayState extends ConsumerState<_Overlay> {
     final repostsRepository = ref.watch(repostsRepositoryProvider);
     final addressableId = video.addressableId;
 
-    final authService = ref.watch(authServiceProvider);
-    final currentUserPubkey = authService.currentPublicKeyHex;
+    final currentUserPubkey = ref.watch(
+      authServiceProvider.select((service) => service.currentPublicKeyHex),
+    );
     final isOwnVideo =
         currentUserPubkey != null && currentUserPubkey == widget.video.pubkey;
 
-    // Subscribe to Auto state so the items rebuild when the rail is
-    // toggled / suppressed / resumed.
-    final autoState = context.watch<FeedAutoAdvanceCubit>().state;
+    // Subscribe only to the Auto flags this overlay renders — the rail being
+    // toggled (enabled) and suppressed/resumed (isEffectivelyActive) — so
+    // unrelated cubit changes (e.g. pendingPaginationAdvance) don't rebuild
+    // every visible feed item while scrolling.
+    final (autoEnabled, autoEffectivelyActive) = context.select(
+      (FeedAutoAdvanceCubit cubit) =>
+          (cubit.state.enabled, cubit.state.isEffectivelyActive),
+    );
 
     // Gate the rail + runtime on both the feature flag and the
     // user's reduced-motion preference. When Auto is unavailable,
     // force it "off" at the view layer regardless of cubit state.
     final autoAdvanceAvailable = !MediaQuery.disableAnimationsOf(context);
-    final effectiveAutoEnabled = autoAdvanceAvailable && autoState.enabled;
+    final effectiveAutoEnabled = autoAdvanceAvailable && autoEnabled;
 
     final overlayLabels = contentWarningOverlayLabels(
       contentWarningLabels: video.contentWarningLabels,
@@ -575,8 +581,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
       warnLabels: video.warnLabels,
     );
 
-    final effectiveAutoActive =
-        autoAdvanceAvailable && autoState.isEffectivelyActive;
+    final effectiveAutoActive = autoAdvanceAvailable && autoEffectivelyActive;
 
     final playbackStatus = context.select(
       (VideoPlaybackStatusCubit cubit) => cubit.state.statusFor(video.id),

--- a/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
+++ b/mobile/packages/divine_ui/lib/src/theme/vine_theme.dart
@@ -586,7 +586,16 @@ class VineTheme {
   static const Color scrim80 = Color(0xCC000000);
 
   /// The complete theme data for the app.
-  static ThemeData get theme => ThemeData(
+  ///
+  /// Kept as a `static final` (not a getter) so its object identity is
+  /// stable across rebuilds. `MaterialApp` wraps the theme in an internal
+  /// `AnimatedTheme`; a fresh `ThemeData` on every access fails its
+  /// `identical`/`==` check — partly because sub-themes here use
+  /// `WidgetStateProperty.resolveWith(...)` closures that never compare
+  /// equal — and triggers a full `ThemeData.lerp` (TextTheme/Typography
+  /// lerp + `Theme` InheritedWidget rebuild cascade) on every rebuild
+  /// above `MaterialApp`.
+  static final ThemeData theme = ThemeData(
     brightness: Brightness.dark,
     primarySwatch: _createMaterialColor(vineGreen),
     primaryColor: vineGreen,

--- a/mobile/packages/divine_ui/test/src/divine_ui_test.dart
+++ b/mobile/packages/divine_ui/test/src/divine_ui_test.dart
@@ -236,6 +236,14 @@ void main() {
     });
 
     group('theme', () {
+      test('returns the same instance across accesses', () {
+        // Referential stability keeps MaterialApp's internal AnimatedTheme
+        // from re-running ThemeData.lerp on every rebuild above it. Reverting
+        // `theme` to a getter would break this and reintroduce the lerp
+        // cascade, so pin the identity here.
+        expect(identical(VineTheme.theme, VineTheme.theme), isTrue);
+      });
+
       test('returns ThemeData with dark brightness', () {
         final theme = VineTheme.theme;
 

--- a/mobile/test/services/auth_service_signing_mismatch_test.dart
+++ b/mobile/test/services/auth_service_signing_mismatch_test.dart
@@ -15,6 +15,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_identity.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -26,6 +27,8 @@ class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
 class _MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+class _MockNostrSigner extends Mock implements NostrSigner {}
 
 // Two known test keypairs
 const _nsecA =
@@ -64,6 +67,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(SecureKeyContainer.fromNsec(_nsecA));
+    registerFallbackValue(Event('0' * 64, 0, const [], ''));
   });
 
   setUp(() {
@@ -334,6 +338,87 @@ void main() {
               'signInForAccount did not restore it.',
         );
         expect(signedEvent!.pubkey, equals(containerA.publicKeyHex));
+      },
+    );
+  });
+
+  group('#5450: pubkey-mismatch guard', () {
+    test(
+      'createAndSignEvent rejects a signer that returns a validly-signed '
+      'event bound to a different account',
+      () async {
+        final npubA = containerA.npub;
+
+        when(
+          () => mockKeyStorage.getIdentityKeyContainer(
+            npubA,
+            biometricPrompt: any(named: 'biometricPrompt'),
+          ),
+        ).thenAnswer((_) async => containerA);
+
+        String? privateKeyAHex;
+        containerA.withPrivateKey<void>((pk) => privateKeyAHex = pk);
+        when(
+          () => mockKeyStorage.withPrivateKey<Event?>(
+            any(),
+            biometricPrompt: any(named: 'biometricPrompt'),
+          ),
+        ).thenAnswer((invocation) async {
+          final operation =
+              invocation.positionalArguments[0] as Event? Function(String);
+          return operation(privateKeyAHex!);
+        });
+
+        await _ignoringDiscoveryErrors(
+          () => authService.signInForAccount(
+            containerA.publicKeyHex,
+            AuthenticationSource.automatic,
+          ),
+        );
+        expect(authService.isAuthenticated, isTrue);
+
+        // A self-consistent event for account B: id == hash and the signature
+        // is valid for B's own pubkey. Only the account itself is "wrong".
+        final wrongAccountEvent = Event(
+          containerB.publicKeyHex,
+          EventKind.textNote,
+          [],
+          'wrong account',
+        );
+        containerB.withPrivateKey<void>(wrongAccountEvent.sign);
+        expect(wrongAccountEvent.isSigned, isTrue);
+        expect(wrongAccountEvent.isValid, isTrue);
+        expect(wrongAccountEvent.pubkey, equals(containerB.publicKeyHex));
+
+        // Inject a remote identity whose pubkey is A but whose signer returns
+        // the wrong-account event. signsWithLocalKey is false, so the isSigned
+        // check still runs and passes — proving the new pubkey guard, not
+        // isSigned, is what rejects it.
+        final mockRpc = _MockNostrSigner();
+        when(
+          () => mockRpc.signEvent(any()),
+        ).thenAnswer((_) async => wrongAccountEvent);
+        authService.debugSetIdentity(
+          KeycastNostrIdentity(
+            pubkey: containerA.publicKeyHex,
+            rpcSigner: mockRpc,
+          ),
+        );
+
+        final signedEvent = await authService.createAndSignEvent(
+          kind: EventKind.textNote,
+          content: 'legitimate content',
+        );
+
+        expect(
+          signedEvent,
+          isNull,
+          reason:
+              'createAndSignEvent must reject an event whose pubkey '
+              '(${containerB.publicKeyHex}) differs from the active identity '
+              '(${containerA.publicKeyHex}), even though its signature and '
+              'structure are internally valid.',
+        );
       },
     );
   });

--- a/mobile/test/services/auth_service_signing_mismatch_test.dart
+++ b/mobile/test/services/auth_service_signing_mismatch_test.dart
@@ -421,5 +421,22 @@ void main() {
         );
       },
     );
+
+    test(
+      'EventSignerAccountMismatchException.toString carries hex pubkeys and '
+      'no npub/nsec identifiers',
+      () {
+        final exception = EventSignerAccountMismatchException(
+          expectedPubkey: containerA.publicKeyHex,
+          actualPubkey: containerB.publicKeyHex,
+        );
+
+        final text = exception.toString();
+        expect(text, contains(containerA.publicKeyHex));
+        expect(text, contains(containerB.publicKeyHex));
+        expect(text, isNot(contains('npub1')));
+        expect(text, isNot(contains('nsec1')));
+      },
+    );
   });
 }

--- a/mobile/test/services/nostr_identity_test.dart
+++ b/mobile/test/services/nostr_identity_test.dart
@@ -633,4 +633,71 @@ void main() {
       expect(identity.signsRemotelyNonInteractive, isFalse);
     });
   });
+
+  group('signsWithLocalKey', () {
+    late _MockNostrSigner mockSigner;
+
+    setUp(() {
+      mockSigner = _MockNostrSigner();
+    });
+
+    test('LocalNostrIdentity signs in-process — true', () {
+      final mockKeyContainer = _MockSecureKeyContainer();
+      when(() => mockKeyContainer.publicKeyHex).thenReturn(testPublicKey);
+      when(() => mockKeyContainer.isDisposed).thenReturn(false);
+
+      final identity = LocalNostrIdentity(keyContainer: mockKeyContainer);
+
+      expect(identity.signsWithLocalKey, isTrue);
+    });
+
+    test('KeycastNostrIdentity with a local signer — true', () {
+      final identity = KeycastNostrIdentity(
+        pubkey: testPublicKey,
+        rpcSigner: mockSigner,
+        localSigner: _MockLocalKeySigner(),
+      );
+
+      expect(identity.signsWithLocalKey, isTrue);
+    });
+
+    test(
+      'KeycastNostrIdentity without a local signer (OAuth-only) — false',
+      () {
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockSigner,
+        );
+
+        expect(identity.signsWithLocalKey, isFalse);
+      },
+    );
+
+    test('BunkerNostrIdentity signs remotely — false', () {
+      final identity = BunkerNostrIdentity(
+        pubkey: testPublicKey,
+        remoteSigner: mockSigner,
+      );
+
+      expect(identity.signsWithLocalKey, isFalse);
+    });
+
+    test('AmberNostrIdentity signs remotely — false', () {
+      final identity = AmberNostrIdentity(
+        pubkey: testPublicKey,
+        amberSigner: mockSigner,
+      );
+
+      expect(identity.signsWithLocalKey, isFalse);
+    });
+
+    test('Nip07NostrIdentity signs remotely — false', () {
+      final identity = Nip07NostrIdentity(
+        pubkey: testPublicKey,
+        nip07Signer: mockSigner,
+      );
+
+      expect(identity.signsWithLocalKey, isFalse);
+    });
+  });
 }

--- a/mobile/test/services/nostr_identity_test.dart
+++ b/mobile/test/services/nostr_identity_test.dart
@@ -143,9 +143,11 @@ void main() {
     });
 
     test(
-      'signEvent falls back to RPC when local signer returns null',
+      'signEvent falls back to RPC when local signer returns null and the '
+      'RPC signature is valid',
       () async {
-        final event = Event(testPublicKey, EventKind.textNote, [], 'test');
+        final event = Event(testPublicKey, EventKind.textNote, [], 'test')
+          ..sign(testPrivateKey);
         final mockLocal = _MockLocalKeySigner();
         when(() => mockLocal.signEvent(any())).thenAnswer((_) async => null);
         when(() => mockRpc.signEvent(any())).thenAnswer((_) async => event);
@@ -159,6 +161,34 @@ void main() {
         final signed = await identity.signEvent(event);
 
         expect(signed, equals(event));
+        verify(() => mockLocal.signEvent(any())).called(1);
+        verify(() => mockRpc.signEvent(any())).called(1);
+      },
+    );
+
+    test(
+      'signEvent rejects an invalid RPC fallback signature (#5450) so a remote '
+      'result cannot bypass verification when signsWithLocalKey is true',
+      () async {
+        // signsWithLocalKey is true (local signer present), so AuthService
+        // skips its post-sign verify. The local sign fails and the RPC
+        // fallback returns an UNSIGNED event — it must be rejected, not
+        // returned, or the remote result would slip through unverified.
+        final unsigned = Event(testPublicKey, EventKind.textNote, [], 'test');
+        final mockLocal = _MockLocalKeySigner();
+        when(() => mockLocal.signEvent(any())).thenAnswer((_) async => null);
+        when(() => mockRpc.signEvent(any())).thenAnswer((_) async => unsigned);
+
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockRpc,
+          localSigner: mockLocal,
+        );
+
+        expect(identity.signsWithLocalKey, isTrue);
+        final signed = await identity.signEvent(unsigned);
+
+        expect(signed, isNull);
         verify(() => mockLocal.signEvent(any())).called(1);
         verify(() => mockRpc.signEvent(any())).called(1);
       },


### PR DESCRIPTION
Closes #5451

## Description

Three independent CPU optimizations identified from DevTools profiling. Earlier sessions flagged three major UI-isolate hotspots — Theme rebuild cascades, large-scale widget rebuilds, and Nostr cryptography. This PR addresses all three:

1. **`perf(theme)`** — `VineTheme.theme` was a getter, allocating a fresh `ThemeData` on every access. `MaterialApp` wraps the theme in an internal `AnimatedTheme`, so a new (non-`==`-equal) `ThemeData` on each rebuild above `MaterialApp` triggered a full `ThemeData.lerp` animation (`TextTheme`/`Typography` lerp + `Theme` `InheritedWidget` rebuild cascade). Caching it as a `static final` gives a stable identity so `AnimatedTheme`'s `identical`/`==` check short-circuits and never animates.

2. **`perf(auth)`** — `createAndSignEvent` ran a full schnorr verify (`Event.isSigned`) on every event right after signing it. For local-key signers that only re-exercises the crypto library — we just produced the signature with our own in-process key. Adds `signsWithLocalKey` to the sealed `NostrIdentity` and gates the verify on it. Remote/external signatures (bunker/amber/nip07) cross a trust boundary and are still verified; the cheap structural check (`isValid`: id == hash) still runs for all signers, preserving the #2233 guard.

3. **`perf(feed)`** — the video feed item overlay watched the whole `FeedAutoAdvanceCubit` state and the whole `AuthService`, so every visible item rebuilt on any cubit emission (including `pendingPaginationAdvance`, which it never renders). Narrowed to the two flags it uses (`enabled`, `isEffectivelyActive`) and only `currentPublicKeyHex`. The three repository `ref.watch` calls feeding `videoInteractionsBlocKey` (#3503) are left untouched.

**Related Issue:** 

## Performance Impact

Before this change, CPU profiles were dominated by Theme rebuild cascades:

```
_AnimatedThemeState.build → ThemeDataTween.lerp → ThemeData.lerp →
TextTheme.lerp → TextStyle.lerp → Typography.lerp
InheritedElement.notifyClients → InheritedElement.updated → ProxyElement.update
```

These propagated rebuilds across the whole widget tree. In the latest profile these Theme hotspots are gone, and the remaining UI-isolate work is mostly legitimate secp256k1/BIP340 cryptography:

```
AuthService.createAndSignEvent → Event.isSigned → verify → verifyWithPoint → ECPointBase.*
ECPoint.twice / ECPoint.+ / _BigIntImpl.modInverse / _BigIntImpl.modPow
```

The `perf(auth)` change additionally removes the `isSigned → verify` step from that path for local-key signers (the common case), so each locally-signed event (view events, NIP-98 tokens, likes, reposts) no longer pays a full schnorr verification on the main isolate.

Exact percentages can't be derived from profile snapshots (they show distribution, not total device CPU), but comparing before/after suggests roughly a **~30% reduction in UI-isolate workload**. Because Flutter is frame-budget-constrained (16.6 ms/frame @ 60 FPS, 8.3 ms @ 120 FPS), the practical effect on stutter is larger than the raw CPU number: the UI thread now spends a far higher share of its budget on useful work rather than Theme-driven rebuild cascades.

## Out of Scope

Two further crypto-reduction ideas were investigated and intentionally deferred:

- **Batching/debounce of view-event signing** — already largely implemented: `view_end` only signs at `>= 1s` dwell, views are deduped, and a durable `PendingViewEventsDao` queue + retry sweep already coalesces delivery. The only remaining lever (raising the dwell threshold) changes analytics semantics and is a product decision, not a perf fix.
- **Moving signing off the main isolate** — the naive per-call `compute` would be a net CPU regression (isolate-spawn overhead > a single ~1–3 ms `schnorr.sign`, per `rules/performance.md`). The correct version is a batch + drain-scoped signing isolate following the `DmDecryptIsolate` key-residency convention. Gated on a fresh profile first, since `perf(auth)` already removed the more expensive verify for local signers.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `divine_ui`: `divine_ui_test.dart` (incl. new `VineTheme.theme` identity regression test) — green
- `nostr_identity_test.dart` (new `signsWithLocalKey` group), `auth_service_signing_mismatch_test.dart` (#2233 guards), `feed_videos_test.dart`, `pooled_video_feed_item_repo_swap_test.dart` (#3503 contract) — green
- `dart format` — clean

## Type of Change

- [x] 🧹 Code refactor
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)