### PR TITLE
fix(dm): thread real blocklist into DM reaction displays (#5418)

### DIFF
--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -100,6 +100,21 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     final authService = ref.watch(authServiceProvider);
     final currentPubkey = authService.currentPublicKeyHex ?? '';
 
+    // Reactors to hide from the reaction pill + who-reacted sheet: the same
+    // effective block/mute set used app-wide (shouldFilterFromFeeds). Watching
+    // blocklistVersionProvider rebuilds this view — re-passing the set to every
+    // ReactionsRow — on any block/unblock/mute change while the thread is open.
+    ref.watch(blocklistVersionProvider);
+    final blocklistPolicy = ref
+        .read(contentBlocklistRepositoryProvider)
+        .currentState;
+    final blockedReactors = <String>{
+      ...blocklistPolicy.blockedPubkeys,
+      ...blocklistPolicy.mutedPubkeys,
+      ...blocklistPolicy.pubkeysMutingUs,
+      ...blocklistPolicy.pubkeysBlockingUs,
+    };
+
     // Resolve other participant's profile for the app bar + empty state
     final otherPubkey = widget.participantPubkeys.isNotEmpty
         ? widget.participantPubkeys.first
@@ -182,6 +197,7 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
                               currentPubkey: currentPubkey,
                               otherPubkey: otherPubkey,
                               participantPubkeys: widget.participantPubkeys,
+                              blockedPubkeys: blockedReactors,
                               displayName: displayName,
                               imageUrl: profile?.picture,
                               nip05: profile?.shortDisplayNip05,
@@ -296,6 +312,7 @@ class _ConversationContent extends StatelessWidget {
     required this.currentPubkey,
     required this.otherPubkey,
     required this.participantPubkeys,
+    required this.blockedPubkeys,
     required this.displayName,
     this.imageUrl,
     this.nip05,
@@ -305,6 +322,9 @@ class _ConversationContent extends StatelessWidget {
   final String currentPubkey;
   final String otherPubkey;
   final List<String> participantPubkeys;
+
+  /// Effective block/mute set; reactions from these pubkeys are hidden.
+  final Set<String> blockedPubkeys;
   final String displayName;
   final String? imageUrl;
   final String? nip05;
@@ -344,6 +364,7 @@ class _ConversationContent extends StatelessWidget {
                     messages: selected.messages,
                     currentPubkey: currentPubkey,
                     participantPubkeys: participantPubkeys,
+                    blockedPubkeys: blockedPubkeys,
                     senderDisplayName: displayName,
                   ),
         };
@@ -381,12 +402,16 @@ class _MessageList extends StatelessWidget {
     required this.messages,
     required this.currentPubkey,
     required this.participantPubkeys,
+    required this.blockedPubkeys,
     required this.senderDisplayName,
   });
 
   final List<DmMessage> messages;
   final String currentPubkey;
   final List<String> participantPubkeys;
+
+  /// Effective block/mute set; reactions from these pubkeys are hidden.
+  final Set<String> blockedPubkeys;
   final String senderDisplayName;
 
   Future<void> _onMessageLongPress(
@@ -553,6 +578,7 @@ class _MessageList extends StatelessWidget {
                 messageAuthorPubkey: message.senderPubkey,
                 ownerPubkey: currentPubkey,
                 isSentByMe: isSent,
+                blockedPubkeys: blockedPubkeys,
               ),
             ],
           );

--- a/mobile/lib/screens/inbox/conversation/conversation_view.dart
+++ b/mobile/lib/screens/inbox/conversation/conversation_view.dart
@@ -100,20 +100,16 @@ class _ConversationViewState extends ConsumerState<ConversationView> {
     final authService = ref.watch(authServiceProvider);
     final currentPubkey = authService.currentPublicKeyHex ?? '';
 
-    // Reactors to hide from the reaction pill + who-reacted sheet: the same
-    // effective block/mute set used app-wide (shouldFilterFromFeeds). Watching
-    // blocklistVersionProvider rebuilds this view — re-passing the set to every
-    // ReactionsRow — on any block/unblock/mute change while the thread is open.
+    // Reactors to hide from the reaction pill + who-reacted sheet: the
+    // repository's canonical feed-hide set (blocked ∪ muted ∪ muted-by ∪
+    // blocked-by), the same union `shouldFilterFromFeeds` enforces app-wide.
+    // Watching blocklistVersionProvider rebuilds this view — re-reading the
+    // set and re-passing it to every ReactionsRow — on any block/unblock/mute
+    // change while the thread is open.
     ref.watch(blocklistVersionProvider);
-    final blocklistPolicy = ref
+    final blockedReactors = ref
         .read(contentBlocklistRepositoryProvider)
-        .currentState;
-    final blockedReactors = <String>{
-      ...blocklistPolicy.blockedPubkeys,
-      ...blocklistPolicy.mutedPubkeys,
-      ...blocklistPolicy.pubkeysMutingUs,
-      ...blocklistPolicy.pubkeysBlockingUs,
-    };
+        .feedHiddenPubkeys;
 
     // Resolve other participant's profile for the app bar + empty state
     final otherPubkey = widget.participantPubkeys.isNotEmpty

--- a/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
+++ b/mobile/packages/content_blocklist_repository/lib/src/content_blocklist_repository.dart
@@ -609,20 +609,47 @@ class ContentBlocklistRepository {
         _runtimeBlocklist.contains(pubkey);
   }
 
-  /// Check if content should be filtered from feeds
-  ///
-  /// Filters content from:
+  /// The buckets whose union is hidden from feeds, held as live references
+  /// to the underlying sets. Every instance is stable for the repository's
+  /// lifetime — the `const` internal list plus four `final` sets that are
+  /// only ever mutated in place — so both [feedHiddenPubkeys] and
+  /// [shouldFilterFromFeeds] derive from this one list and cannot drift. A
+  /// new hide-bucket is added here exactly once.
+  late final List<Set<String>> _hideBuckets = [
+    _internalBlocklist,
+    _runtimeBlocklist,
+    _mutedPubkeys,
+    _mutualMuteBlocklist,
+    _blockedByOthers,
+  ];
+
+  /// The union of every pubkey hidden from feeds:
   /// - Users we blocked (internal + runtime blocklist)
   /// - Users we muted via our own kind 10000 mute list
   /// - Users who mutually muted us (kind 10000)
   /// - Users who blocked us (kind 30000, d=block) — hides our content
   ///   from their feeds and their content from ours
+  ///
+  /// This is the canonical feed-hide set. UI surfaces that need the
+  /// materialized set — e.g. DM reaction filtering in `conversation_view`
+  /// — read this rather than re-deriving the union by hand, so they stay
+  /// in lockstep with [shouldFilterFromFeeds].
+  Set<String> get feedHiddenPubkeys => {
+    for (final bucket in _hideBuckets) ...bucket,
+  };
+
+  /// Whether [pubkey] is in [feedHiddenPubkeys] and so should be filtered
+  /// from feeds.
+  ///
+  /// Implemented as a short-circuiting, allocation-free membership scan
+  /// rather than `feedHiddenPubkeys.contains(...)` because this is a hot
+  /// path — called per item across ~15 feed surfaces — and materializing
+  /// the union on every call would be wasteful.
   bool shouldFilterFromFeeds(String pubkey) {
-    return _internalBlocklist.contains(pubkey) ||
-        _runtimeBlocklist.contains(pubkey) ||
-        _mutedPubkeys.contains(pubkey) ||
-        _mutualMuteBlocklist.contains(pubkey) ||
-        _blockedByOthers.contains(pubkey);
+    for (var i = 0; i < _hideBuckets.length; i++) {
+      if (_hideBuckets[i].contains(pubkey)) return true;
+    }
+    return false;
   }
 
   /// Check if we muted another user via our own kind 10000 mute list.

--- a/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
+++ b/mobile/packages/content_blocklist_repository/test/src/content_blocklist_repository_test.dart
@@ -1992,6 +1992,136 @@ void main() {
     });
   });
 
+  group('feedHiddenPubkeys', () {
+    const ourPubkey =
+        '0000000000000000000000000000000000000000000000000000000000000001';
+    const runtimeBlocked =
+        '0000000000000000000000000000000000000000000000000000000000000002';
+    const mutedByUs =
+        '0000000000000000000000000000000000000000000000000000000000000003';
+    const mutualMuter =
+        '0000000000000000000000000000000000000000000000000000000000000004';
+    const blockedByOther =
+        '0000000000000000000000000000000000000000000000000000000000000005';
+    const stranger =
+        '0000000000000000000000000000000000000000000000000000000000000006';
+
+    test('is empty when no hide bucket is populated', () {
+      expect(ContentBlocklistRepository().feedHiddenPubkeys, isEmpty);
+    });
+
+    test(
+      'unions every hide bucket and stays equivalent to shouldFilterFromFeeds',
+      () async {
+        SharedPreferences.setMockInitialValues(<String, Object>{});
+        final prefs = await SharedPreferences.getInstance();
+        final service = ContentBlocklistRepository(prefs: prefs);
+
+        final muteController = StreamController<Event>();
+        final blockController = StreamController<Event>();
+        final mockMuteClient = _MockNostrClient();
+        final mockBlockClient = _MockNostrClient();
+        final mockSigner = _MockBlockListSigner();
+        final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+
+        // Runtime-block bucket.
+        await service.blockUser(runtimeBlocked, ourPubkey: ourPubkey);
+
+        // Own-mute + mutual-mute buckets, both via the kind 10000 stream.
+        when(
+          () => mockMuteClient.subscribe(any()),
+        ).thenAnswer((_) => muteController.stream);
+        await service.syncMuteListsInBackground(mockMuteClient, ourPubkey);
+        muteController
+          ..add(
+            Event(
+                ourPubkey,
+                10000,
+                [
+                  ['p', mutedByUs],
+                ],
+                '',
+                createdAt: now,
+              )
+              ..id = 'own-mute'
+              ..sig = 'sig',
+          )
+          ..add(
+            Event(
+                mutualMuter,
+                10000,
+                [
+                  ['p', ourPubkey],
+                ],
+                '',
+                createdAt: now,
+              )
+              ..id = 'mutual-mute'
+              ..sig = 'sig',
+          );
+
+        // Blocked-by bucket via the kind 30000 d=block stream.
+        when(
+          () => mockBlockClient.subscribe(any()),
+        ).thenAnswer((_) => blockController.stream);
+        await service.syncBlockListsInBackground(
+          mockBlockClient,
+          mockSigner,
+          ourPubkey,
+        );
+        blockController.add(
+          Event(
+              blockedByOther,
+              30000,
+              [
+                ['d', 'block'],
+                ['p', ourPubkey],
+              ],
+              'Block list',
+              createdAt: now,
+            )
+            ..id = 'blocked-by'
+            ..sig = 'sig',
+        );
+
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        final hidden = service.feedHiddenPubkeys;
+        expect(
+          hidden,
+          containsAll(<String>{
+            runtimeBlocked,
+            mutedByUs,
+            mutualMuter,
+            blockedByOther,
+          }),
+        );
+        expect(hidden, isNot(contains(stranger)));
+
+        // The set and the predicate must agree for every pubkey, so a future
+        // sixth bucket added to one cannot silently diverge from the other.
+        for (final pubkey in <String>{
+          runtimeBlocked,
+          mutedByUs,
+          mutualMuter,
+          blockedByOther,
+          stranger,
+        }) {
+          expect(
+            hidden.contains(pubkey),
+            equals(service.shouldFilterFromFeeds(pubkey)),
+            reason:
+                'feedHiddenPubkeys and shouldFilterFromFeeds '
+                'disagree for $pubkey',
+          );
+        }
+
+        await muteController.close();
+        await blockController.close();
+      },
+    );
+  });
+
   group('ContentBlocklistRepository - Nostr publishing', () {
     late _MockNostrClient mockClient;
     late _MockBlockListSigner mockSigner;

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
-import 'package:content_policy/content_policy.dart';
 import 'package:db_client/db_client.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
@@ -109,8 +108,8 @@ void main() {
       mockBlocklist = _MockContentBlocklistRepository();
       // Default: nobody blocked. Reaction-filtering tests re-stub this.
       when(
-        () => mockBlocklist.currentState,
-      ).thenReturn(ContentPolicyState.empty());
+        () => mockBlocklist.feedHiddenPubkeys,
+      ).thenReturn(const <String>{});
 
       whenListen(
         mockReactionsCubit,
@@ -1301,16 +1300,12 @@ void main() {
         );
       }
 
-      ContentPolicyState policyHiding({
+      // The flat feed-hide set the view now reads from the repository
+      // (`feedHiddenPubkeys`), which is itself the union of these buckets.
+      Set<String> hiddenReactors({
         Set<String> blocked = const {},
         Set<String> muted = const {},
-      }) => ContentPolicyState(
-        currentUserPubkey: currentPubkey,
-        mutedPubkeys: muted,
-        blockedPubkeys: blocked,
-        pubkeysBlockingUs: const {},
-        pubkeysMutingUs: const {},
-      );
+      }) => {...blocked, ...muted};
 
       Widget loadedWithReactedMessage() => buildSubject(
         state: ConversationState(
@@ -1342,8 +1337,8 @@ void main() {
             createdAt: 1_700_000_003,
           ),
         ]);
-        when(() => mockBlocklist.currentState).thenReturn(
-          policyHiding(blocked: {blockedReactor}, muted: {mutedReactor}),
+        when(() => mockBlocklist.feedHiddenPubkeys).thenReturn(
+          hiddenReactors(blocked: {blockedReactor}, muted: {mutedReactor}),
         );
 
         await tester.pumpWidget(loadedWithReactedMessage());
@@ -1363,8 +1358,8 @@ void main() {
           reaction(id: 'r-blk', reactor: blockedReactor, emoji: '😂'),
         ]);
         when(
-          () => mockBlocklist.currentState,
-        ).thenReturn(policyHiding(blocked: {blockedReactor}));
+          () => mockBlocklist.feedHiddenPubkeys,
+        ).thenReturn(hiddenReactors(blocked: {blockedReactor}));
 
         await tester.pumpWidget(loadedWithReactedMessage());
         await tester.pump();
@@ -1387,8 +1382,8 @@ void main() {
           ),
         ]);
         when(
-          () => mockBlocklist.currentState,
-        ).thenReturn(policyHiding(blocked: {blockedReactor}));
+          () => mockBlocklist.feedHiddenPubkeys,
+        ).thenReturn(hiddenReactors(blocked: {blockedReactor}));
 
         await tester.pumpWidget(loadedWithReactedMessage());
         await tester.pump();
@@ -1400,15 +1395,19 @@ void main() {
         await tester.pump(const Duration(milliseconds: 400));
 
         expect(find.text(l10n.dmReactionsSheetTitle), findsOneWidget);
-        // The blocked reactor's emoji must not appear in the pill or the sheet.
+        // The owner's reaction now renders twice — the pill glyph plus the
+        // sheet's reactor row — proving the sheet lists reactions; the blocked
+        // reactor's emoji appears in neither, proving the sheet itself filters
+        // it out rather than the absence just reflecting the collapsed pill.
+        expect(find.text('🔥'), findsNWidgets(2));
         expect(find.text('😂'), findsNothing);
       });
 
       testWidgets('refilters live when the blocklist changes mid-thread', (
         tester,
       ) async {
-        var policy = ContentPolicyState.empty();
-        when(() => mockBlocklist.currentState).thenAnswer((_) => policy);
+        var hidden = <String>{};
+        when(() => mockBlocklist.feedHiddenPubkeys).thenAnswer((_) => hidden);
         primeReactions([
           reaction(id: 'r-own', reactor: currentPubkey, emoji: '🔥'),
           reaction(
@@ -1427,7 +1426,7 @@ void main() {
         expect(find.text('😂'), findsOneWidget);
 
         // Block the reactor elsewhere → the version bump rebuilds the view.
-        policy = policyHiding(blocked: {blockedReactor});
+        hidden = hiddenReactors(blocked: {blockedReactor});
         final container = ProviderScope.containerOf(
           tester.element(find.byType(ConversationView)),
         );

--- a/mobile/test/screens/inbox/conversation/conversation_view_test.dart
+++ b/mobile/test/screens/inbox/conversation/conversation_view_test.dart
@@ -3,11 +3,14 @@
 // ABOUTME: plus the app bar and input bar rendering.
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:db_client/db_client.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -41,6 +44,9 @@ class _MockConversationReactionsCubit
     implements ConversationReactionsCubit {}
 
 class _MockVideoEventService extends Mock implements VideoEventService {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 class _MockAuthService extends MockAuthService {
   _MockAuthService(this._pubkey);
@@ -76,6 +82,7 @@ void main() {
     late _MockVideoEventService mockVideoEventService;
     late MockNostrClient mockNostrClient;
     late _MockAuthService mockAuthService;
+    late _MockContentBlocklistRepository mockBlocklist;
 
     setUpAll(() {
       registerFallbackValue(fallbackInvite);
@@ -99,6 +106,11 @@ void main() {
       mockVideoEventService = _MockVideoEventService();
       mockNostrClient = createMockNostrService();
       mockAuthService = _MockAuthService(currentPubkey);
+      mockBlocklist = _MockContentBlocklistRepository();
+      // Default: nobody blocked. Reaction-filtering tests re-stub this.
+      when(
+        () => mockBlocklist.currentState,
+      ).thenReturn(ContentPolicyState.empty());
 
       whenListen(
         mockReactionsCubit,
@@ -146,6 +158,9 @@ void main() {
           fetchUserProfileProvider(
             otherPubkey,
           ).overrideWith((ref) async => otherProfile),
+          // The view now reads the blocklist eagerly in build() to filter
+          // reaction reactors, so every pump needs a stubbed repository.
+          contentBlocklistRepositoryProvider.overrideWithValue(mockBlocklist),
         ],
         home: BlocProvider<ConversationBloc>.value(
           value: mockBloc,
@@ -1229,6 +1244,199 @@ void main() {
           expect(find.byType(EmojiEditor), findsOneWidget);
         },
       );
+    });
+
+    // #5418 — the reaction pill + who-reacted sheet must hide reactions from
+    // blocked/muted accounts. ConversationView builds the effective set
+    // (shouldFilterFromFeeds semantics) from the blocklist and threads it into
+    // every ReactionsRow, reactively via blocklistVersionProvider.
+    group('blocked reaction filtering (#5418)', () {
+      const blockedReactor =
+          '1111111111111111111111111111111111111111111111111111111111111111';
+      const mutedReactor =
+          '2222222222222222222222222222222222222222222222222222222222222222';
+      const visibleReactor =
+          '3333333333333333333333333333333333333333333333333333333333333333';
+      const reactionMessageId =
+          'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+      const reactionConversationId =
+          'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff';
+
+      DmMessage reactedMessage() => DmMessage(
+        id: reactionMessageId,
+        conversationId: reactionConversationId,
+        senderPubkey: otherPubkey,
+        content: 'Hello there!',
+        createdAt: now.millisecondsSinceEpoch ~/ 1000,
+        giftWrapId:
+            'aaaaaaaabbbbbbbbccccccccddddddddaaaaaaaabbbbbbbbccccccccdddddddd',
+      );
+
+      DmReaction reaction({
+        required String id,
+        required String reactor,
+        required String emoji,
+        int createdAt = 1_700_000_000,
+      }) => DmReaction(
+        id: id,
+        conversationId: reactionConversationId,
+        targetMessageId: reactionMessageId,
+        targetMessageAuthor: otherPubkey,
+        reactorPubkey: reactor,
+        emoji: emoji,
+        createdAt: createdAt,
+        ownerPubkey: currentPubkey,
+        publishStatus: DmReactionPublishStatus.received,
+      );
+
+      void primeReactions(List<DmReaction> reactions) {
+        final state = ConversationReactionsState(
+          status: ConversationReactionsStatus.loaded,
+          reactionsByMessageId: {reactionMessageId: reactions},
+        );
+        whenListen(
+          mockReactionsCubit,
+          Stream<ConversationReactionsState>.value(state),
+          initialState: state,
+        );
+      }
+
+      ContentPolicyState policyHiding({
+        Set<String> blocked = const {},
+        Set<String> muted = const {},
+      }) => ContentPolicyState(
+        currentUserPubkey: currentPubkey,
+        mutedPubkeys: muted,
+        blockedPubkeys: blocked,
+        pubkeysBlockingUs: const {},
+        pubkeysMutingUs: const {},
+      );
+
+      Widget loadedWithReactedMessage() => buildSubject(
+        state: ConversationState(
+          status: ConversationStatus.loaded,
+          messages: [reactedMessage()],
+        ),
+      );
+
+      testWidgets('hides reactions from blocked and muted reactors in the '
+          'pill', (tester) async {
+        primeReactions([
+          reaction(id: 'r-own', reactor: currentPubkey, emoji: '🔥'),
+          reaction(
+            id: 'r-vis',
+            reactor: visibleReactor,
+            emoji: '🎉',
+            createdAt: 1_700_000_001,
+          ),
+          reaction(
+            id: 'r-blk',
+            reactor: blockedReactor,
+            emoji: '😂',
+            createdAt: 1_700_000_002,
+          ),
+          reaction(
+            id: 'r-mut',
+            reactor: mutedReactor,
+            emoji: '👍',
+            createdAt: 1_700_000_003,
+          ),
+        ]);
+        when(() => mockBlocklist.currentState).thenReturn(
+          policyHiding(blocked: {blockedReactor}, muted: {mutedReactor}),
+        );
+
+        await tester.pumpWidget(loadedWithReactedMessage());
+        await tester.pump();
+
+        // Owner + unblocked reactor remain; blocked and muted are gone.
+        expect(find.text('🔥'), findsOneWidget);
+        expect(find.text('🎉'), findsOneWidget);
+        expect(find.text('😂'), findsNothing);
+        expect(find.text('👍'), findsNothing);
+      });
+
+      testWidgets('renders no pill when every reactor is blocked', (
+        tester,
+      ) async {
+        primeReactions([
+          reaction(id: 'r-blk', reactor: blockedReactor, emoji: '😂'),
+        ]);
+        when(
+          () => mockBlocklist.currentState,
+        ).thenReturn(policyHiding(blocked: {blockedReactor}));
+
+        await tester.pumpWidget(loadedWithReactedMessage());
+        await tester.pump();
+
+        // The bubble still renders; only its fully-blocked pill collapses.
+        expect(find.byType(MessageBubble), findsOneWidget);
+        expect(find.text('😂'), findsNothing);
+      });
+
+      testWidgets('excludes a blocked reactor from the who-reacted sheet', (
+        tester,
+      ) async {
+        primeReactions([
+          reaction(id: 'r-own', reactor: currentPubkey, emoji: '🔥'),
+          reaction(
+            id: 'r-blk',
+            reactor: blockedReactor,
+            emoji: '😂',
+            createdAt: 1_700_000_002,
+          ),
+        ]);
+        when(
+          () => mockBlocklist.currentState,
+        ).thenReturn(policyHiding(blocked: {blockedReactor}));
+
+        await tester.pumpWidget(loadedWithReactedMessage());
+        await tester.pump();
+
+        await tester.tap(find.text('🔥'));
+        // Avoid pumpAndSettle: the view's async profile providers can schedule
+        // continuous micro-tasks. Pump the bottom-sheet enter animation.
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 400));
+
+        expect(find.text(l10n.dmReactionsSheetTitle), findsOneWidget);
+        // The blocked reactor's emoji must not appear in the pill or the sheet.
+        expect(find.text('😂'), findsNothing);
+      });
+
+      testWidgets('refilters live when the blocklist changes mid-thread', (
+        tester,
+      ) async {
+        var policy = ContentPolicyState.empty();
+        when(() => mockBlocklist.currentState).thenAnswer((_) => policy);
+        primeReactions([
+          reaction(id: 'r-own', reactor: currentPubkey, emoji: '🔥'),
+          reaction(
+            id: 'r-blk',
+            reactor: blockedReactor,
+            emoji: '😂',
+            createdAt: 1_700_000_002,
+          ),
+        ]);
+
+        await tester.pumpWidget(loadedWithReactedMessage());
+        await tester.pump();
+
+        // Nobody blocked yet: both reactions show.
+        expect(find.text('🔥'), findsOneWidget);
+        expect(find.text('😂'), findsOneWidget);
+
+        // Block the reactor elsewhere → the version bump rebuilds the view.
+        policy = policyHiding(blocked: {blockedReactor});
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(ConversationView)),
+        );
+        container.read(blocklistVersionProvider.notifier).increment();
+        await tester.pump();
+
+        expect(find.text('🔥'), findsOneWidget);
+        expect(find.text('😂'), findsNothing);
+      });
     });
   });
 }

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_row_test.dart
@@ -57,17 +57,21 @@ void main() {
     );
   }
 
-  Widget buildSubject(_MockConversationReactionsCubit cubit) {
+  Widget buildSubject(
+    _MockConversationReactionsCubit cubit, {
+    Set<String> blockedPubkeys = const <String>{},
+  }) {
     return testMaterialApp(
       home: Scaffold(
         body: BlocProvider<ConversationReactionsCubit>.value(
           value: cubit,
-          child: const ReactionsRow(
+          child: ReactionsRow(
             conversationId: conversationId,
             messageId: messageId,
             messageAuthorPubkey: otherPubkey,
             ownerPubkey: ownerPubkey,
             isSentByMe: false,
+            blockedPubkeys: blockedPubkeys,
           ),
         ),
       ),
@@ -179,6 +183,54 @@ void main() {
       await tester.pump();
 
       expect(find.text('🔥'), findsNothing);
+      expect(find.byType(UserAvatar), findsNothing);
+    });
+
+    testWidgets(
+      'filters reactions from blockedPubkeys out of the pill (#5418)',
+      (
+        tester,
+      ) async {
+        primeState(
+          stateWith([
+            makeReaction(id: '1', reactorPubkey: ownerPubkey, emoji: '🔥'),
+            makeReaction(
+              id: '2',
+              reactorPubkey: otherPubkey,
+              emoji: '😂',
+              createdAt: 1_700_000_001,
+              publishStatus: DmReactionPublishStatus.received,
+            ),
+          ]),
+        );
+
+        await tester.pumpWidget(
+          buildSubject(cubit, blockedPubkeys: const {otherPubkey}),
+        );
+        await tester.pump();
+
+        // The blocked reactor's glyph and avatar are gone; the owner's remain.
+        expect(find.text('🔥'), findsOneWidget);
+        expect(find.text('😂'), findsNothing);
+        expect(find.byType(UserAvatar), findsOneWidget);
+      },
+    );
+
+    testWidgets('renders nothing when every reactor is blocked (#5418)', (
+      tester,
+    ) async {
+      primeState(
+        stateWith([
+          makeReaction(id: '1', reactorPubkey: otherPubkey, emoji: '😂'),
+        ]),
+      );
+
+      await tester.pumpWidget(
+        buildSubject(cubit, blockedPubkeys: const {otherPubkey}),
+      );
+      await tester.pump();
+
+      expect(find.text('😂'), findsNothing);
       expect(find.byType(UserAvatar), findsNothing);
     });
 


### PR DESCRIPTION
## Description

`ReactionsRow` and `ReactionsDetailSheet` already accept a `blockedPubkeys` set and filter reactors against it, but the conversation call site passed the default **empty** set — so reactions from blocked/muted accounts still appeared in the combined reaction pill (emoji glyphs, avatar stack, overflow counts) and the who-reacted sheet. This is the follow-up wiring deferred by #5403.

This builds the current account's **effective block/mute set** in `ConversationView.build` and threads it down to every `ReactionsRow`:

- **Set semantics:** the same `shouldFilterFromFeeds` union used app-wide (and by the DM inbox via `filterBlockedConversations`) — the account's blocked, muted, muted-by, and blocked-by pubkeys, read from `ContentBlocklistRepository.currentState`.
- **Reactive:** `ConversationView.build` watches `blocklistVersionProvider`, so blocking/unblocking/muting while a thread is open re-passes the set and the pill refilters live (empties collapse to no pill, since `ReactionsRow` already shrinks when the filtered list is empty).
- **Threading only:** the set flows `ConversationView` → `_ConversationContent` → `_MessageList` → `ReactionsRow`, which already forwards it into `ReactionsDetailSheet.show`. No change to the widget internals, the cubit, or the repository.

The in-player `reel_dm_reply_bar` reaction surface is write-only (it shows your own reaction highlight, never other reactors), so it needs no change. The only `ReactionsRow` render site is `conversation_view.dart`.

**Related Issue:** Closes #5418

## Out of Scope

- DB write-side reaction-uniqueness hardening — tracked by #5419.
- Relocating the reactor `.where` filter out of `ReactionsRow` into the cubit/repository — the filter shipped inside the widget in #5403; this PR only supplies its input set, adding no new widget-level logic.

## Verification

- `dart format` — clean (0 changed)
- `flutter analyze lib test integration_test` — **No issues found**
- `flutter test test/screens/inbox/conversation/` — **159 pass** (incl. 4 new `ConversationView` view-boundary tests: blocked+muted reactor hidden from pill, all-blocked collapses, blocked reactor excluded from the who-reacted sheet, live refilter on `blocklistVersionProvider` bump)
- `flutter test test/screens/inbox/conversation/widgets/reactions_row_test.dart` — **9 pass** (incl. 2 new: `blockedPubkeys` filters the glyph/avatar, collapses when all reactors blocked)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)