### PR TITLE
perf(subtitle): rebuild caption pill only on cue change

### DIFF
--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -819,24 +819,49 @@ class _FeedItemOverlayActions extends StatelessWidget {
 }
 
 /// Streams player position and renders subtitle text for fullscreen feed.
-class _SubtitleLayer extends StatelessWidget {
+class _SubtitleLayer extends StatefulWidget {
   const _SubtitleLayer({required this.video, required this.controller});
 
   final VideoEvent video;
   final DivineVideoPlayerController controller;
 
   @override
+  State<_SubtitleLayer> createState() => _SubtitleLayerState();
+}
+
+class _SubtitleLayerState extends State<_SubtitleLayer> {
+  late Stream<Duration> _positionStream;
+
+  @override
+  void initState() {
+    super.initState();
+    _positionStream = _createPositionStream(widget.controller);
+  }
+
+  @override
+  void didUpdateWidget(covariant _SubtitleLayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      _positionStream = _createPositionStream(widget.controller);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 24),
       child: SubtitleCueStreamPill(
-        video: video,
-        positionStream: controller.stateStream
-            .map((s) => s.position)
-            .distinct(),
-        initialPosition: controller.state.position,
+        video: widget.video,
+        positionStream: _positionStream,
+        initialPosition: widget.controller.state.position,
       ),
     );
+  }
+
+  Stream<Duration> _createPositionStream(
+    DivineVideoPlayerController controller,
+  ) {
+    return controller.stateStream.map((s) => s.position).distinct();
   }
 }
 

--- a/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
@@ -9,7 +9,7 @@ import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/services/subtitle_service.dart';
 
 /// Streams playback position into the shared caption pill renderer.
-class SubtitleCueStreamPill extends ConsumerWidget {
+class SubtitleCueStreamPill extends ConsumerStatefulWidget {
   const SubtitleCueStreamPill({
     required this.video,
     required this.positionStream,
@@ -22,21 +22,44 @@ class SubtitleCueStreamPill extends ConsumerWidget {
   final Duration initialPosition;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final visible = ref.watch(subtitleVisibilityProvider);
-    if (!visible || !video.hasSubtitles) return const SizedBox.shrink();
+  ConsumerState<SubtitleCueStreamPill> createState() =>
+      _SubtitleCueStreamPillState();
+}
 
-    final cuesAsync = ref.watch(_subtitleCuesProvider(video));
+class _SubtitleCueStreamPillState extends ConsumerState<SubtitleCueStreamPill> {
+  Stream<_SubtitleCueDisplay>? _displayStream;
+  List<SubtitleCue>? _displayStreamCues;
+  Stream<Duration>? _displayStreamSource;
+  String? _displayStreamVideoId;
+
+  @override
+  void didUpdateWidget(covariant SubtitleCueStreamPill oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.video.id != widget.video.id ||
+        oldWidget.positionStream != widget.positionStream) {
+      _clearDisplayStream();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = ref.watch(subtitleVisibilityProvider);
+    if (!visible || !widget.video.hasSubtitles) {
+      _clearDisplayStream();
+      return const SizedBox.shrink();
+    }
+
+    final cuesAsync = ref.watch(_subtitleCuesProvider(widget.video));
 
     return cuesAsync.when(
       data: (cues) {
-        final initialPositionMs = initialPosition.inMilliseconds;
+        final initialPositionMs = widget.initialPosition.inMilliseconds;
         final initialDisplay = _SubtitleCueDisplayTracker(
           cues,
         ).displayFor(initialPositionMs);
 
         return StreamBuilder<_SubtitleCueDisplay>(
-          stream: _displayStream(cues, initialPositionMs),
+          stream: _displayStreamFor(cues, initialPositionMs),
           initialData: initialDisplay,
           builder: (context, snapshot) {
             final display = snapshot.data ?? const _SubtitleCueDisplay.hidden();
@@ -45,14 +68,43 @@ class SubtitleCueStreamPill extends ConsumerWidget {
           },
         );
       },
-      loading: SizedBox.shrink,
-      error: (_, _) => const SizedBox.shrink(),
+      loading: () {
+        _clearDisplayStream();
+        return const SizedBox.shrink();
+      },
+      error: (_, _) {
+        _clearDisplayStream();
+        return const SizedBox.shrink();
+      },
     );
   }
 
-  Stream<_SubtitleCueDisplay> _displayStream(
+  Stream<_SubtitleCueDisplay> _displayStreamFor(
     List<SubtitleCue> cues,
     int initialPositionMs,
+  ) {
+    final existing = _displayStream;
+    if (existing != null &&
+        identical(_displayStreamCues, cues) &&
+        _displayStreamSource == widget.positionStream &&
+        _displayStreamVideoId == widget.video.id) {
+      return existing;
+    }
+
+    _displayStreamCues = cues;
+    _displayStreamSource = widget.positionStream;
+    _displayStreamVideoId = widget.video.id;
+    return _displayStream = _createDisplayStream(
+      cues,
+      initialPositionMs,
+      widget.positionStream,
+    );
+  }
+
+  Stream<_SubtitleCueDisplay> _createDisplayStream(
+    List<SubtitleCue> cues,
+    int initialPositionMs,
+    Stream<Duration> positionStream,
   ) async* {
     final tracker = _SubtitleCueDisplayTracker(cues);
     var previousDisplay = tracker.displayFor(initialPositionMs);
@@ -64,6 +116,13 @@ class SubtitleCueStreamPill extends ConsumerWidget {
       previousDisplay = display;
       yield display;
     }
+  }
+
+  void _clearDisplayStream() {
+    _displayStream = null;
+    _displayStreamCues = null;
+    _displayStreamSource = null;
+    _displayStreamVideoId = null;
   }
 }
 

--- a/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/subtitle_overlay.dart
@@ -9,7 +9,7 @@ import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/services/subtitle_service.dart';
 
 /// Streams playback position into the shared caption pill renderer.
-class SubtitleCueStreamPill extends StatelessWidget {
+class SubtitleCueStreamPill extends ConsumerWidget {
   const SubtitleCueStreamPill({
     required this.video,
     required this.positionStream,
@@ -22,91 +22,105 @@ class SubtitleCueStreamPill extends StatelessWidget {
   final Duration initialPosition;
 
   @override
-  Widget build(BuildContext context) {
-    return StreamBuilder<Duration>(
-      stream: positionStream,
-      initialData: initialPosition,
-      builder: (context, snapshot) {
-        return SubtitleCuePositionPill(
-          video: video,
-          positionMs: snapshot.data?.inMilliseconds ?? 0,
-        );
-      },
-    );
-  }
-}
-
-/// Layout-neutral caption pill that retains short inter-cue gaps.
-class SubtitleCuePositionPill extends ConsumerStatefulWidget {
-  const SubtitleCuePositionPill({
-    required this.video,
-    required this.positionMs,
-    super.key,
-  });
-
-  final VideoEvent video;
-  final int positionMs;
-
-  @override
-  ConsumerState<SubtitleCuePositionPill> createState() =>
-      _SubtitleCuePositionPillState();
-}
-
-class _SubtitleCuePositionPillState
-    extends ConsumerState<SubtitleCuePositionPill> {
-  SubtitleCue? _lastCue;
-  int _prevPositionMs = 0;
-  static const _gapBridgeMs = 300;
-
-  @override
-  void didUpdateWidget(covariant SubtitleCuePositionPill oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.video.id != widget.video.id) {
-      _lastCue = null;
-      _prevPositionMs = 0;
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final visible = ref.watch(subtitleVisibilityProvider);
-    if (!visible || !widget.video.hasSubtitles) return const SizedBox.shrink();
+    if (!visible || !video.hasSubtitles) return const SizedBox.shrink();
 
-    final cuesAsync = ref.watch(
-      subtitleCuesProvider(
-        videoId: widget.video.id,
-        textTrackRef: widget.video.textTrackRef,
-        textTrackRefs: widget.video.textTrackRefs,
-        textTrackContent: widget.video.textTrackContent,
-        sha256: widget.video.sha256,
-      ),
-    );
+    final cuesAsync = ref.watch(_subtitleCuesProvider(video));
 
     return cuesAsync.when(
       data: (cues) {
-        final currentCue = _findCurrentCue(cues, widget.positionMs);
-        final didSeekBackward = widget.positionMs < _prevPositionMs;
-        _prevPositionMs = widget.positionMs;
+        final initialPositionMs = initialPosition.inMilliseconds;
+        final initialDisplay = _SubtitleCueDisplayTracker(
+          cues,
+        ).displayFor(initialPositionMs);
 
-        if (currentCue != null) {
-          _lastCue = currentCue;
-        } else if (_lastCue != null &&
-            (didSeekBackward ||
-                widget.positionMs > _lastCue!.end + _gapBridgeMs)) {
-          _lastCue = null;
-        }
-
-        final displayCue = _lastCue;
-        if (displayCue == null) return const SizedBox.shrink();
-        return _CaptionPill(text: displayCue.text);
+        return StreamBuilder<_SubtitleCueDisplay>(
+          stream: _displayStream(cues, initialPositionMs),
+          initialData: initialDisplay,
+          builder: (context, snapshot) {
+            final display = snapshot.data ?? const _SubtitleCueDisplay.hidden();
+            if (display.text == null) return const SizedBox.shrink();
+            return _CaptionPill(text: display.text!);
+          },
+        );
       },
       loading: SizedBox.shrink,
       error: (_, _) => const SizedBox.shrink(),
     );
   }
 
-  SubtitleCue? _findCurrentCue(List<SubtitleCue> cues, int positionMs) {
-    for (final cue in cues) {
+  Stream<_SubtitleCueDisplay> _displayStream(
+    List<SubtitleCue> cues,
+    int initialPositionMs,
+  ) async* {
+    final tracker = _SubtitleCueDisplayTracker(cues);
+    var previousDisplay = tracker.displayFor(initialPositionMs);
+
+    await for (final position in positionStream) {
+      final display = tracker.displayFor(position.inMilliseconds);
+      if (display == previousDisplay) continue;
+
+      previousDisplay = display;
+      yield display;
+    }
+  }
+}
+
+SubtitleCuesProvider _subtitleCuesProvider(VideoEvent video) {
+  return subtitleCuesProvider(
+    videoId: video.id,
+    textTrackRef: video.textTrackRef,
+    textTrackRefs: video.textTrackRefs,
+    textTrackContent: video.textTrackContent,
+    sha256: video.sha256,
+  );
+}
+
+class _SubtitleCueDisplay {
+  const _SubtitleCueDisplay(this.text);
+
+  const _SubtitleCueDisplay.hidden() : text = null;
+
+  final String? text;
+
+  @override
+  bool operator ==(Object other) {
+    return other is _SubtitleCueDisplay && other.text == text;
+  }
+
+  @override
+  int get hashCode => text.hashCode;
+}
+
+class _SubtitleCueDisplayTracker {
+  _SubtitleCueDisplayTracker(this._cues);
+
+  final List<SubtitleCue> _cues;
+  SubtitleCue? _lastCue;
+  int _prevPositionMs = 0;
+
+  static const _gapBridgeMs = 300;
+
+  _SubtitleCueDisplay displayFor(int positionMs) {
+    final currentCue = _findCurrentCue(positionMs);
+    final didSeekBackward = positionMs < _prevPositionMs;
+    _prevPositionMs = positionMs;
+
+    if (currentCue != null) {
+      _lastCue = currentCue;
+    } else if (_lastCue != null &&
+        (didSeekBackward || positionMs > _lastCue!.end + _gapBridgeMs)) {
+      _lastCue = null;
+    }
+
+    final displayCue = _lastCue;
+    if (displayCue == null) return const _SubtitleCueDisplay.hidden();
+    return _SubtitleCueDisplay(displayCue.text);
+  }
+
+  SubtitleCue? _findCurrentCue(int positionMs) {
+    for (final cue in _cues) {
       if (positionMs >= cue.start && positionMs <= cue.end) {
         return cue;
       }

--- a/mobile/lib/widgets/video_feed_item/video_player_subtitle_layer.dart
+++ b/mobile/lib/widgets/video_feed_item/video_player_subtitle_layer.dart
@@ -1,12 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
-import 'package:openvine/providers/subtitle_providers.dart';
 import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
 import 'package:video_player/video_player.dart';
 
 /// Renders subtitles for a [VideoPlayerController]-backed video.
-class VideoPlayerSubtitleLayer extends ConsumerWidget {
+class VideoPlayerSubtitleLayer extends StatefulWidget {
   const VideoPlayerSubtitleLayer({
     required this.video,
     required this.controller,
@@ -17,22 +17,61 @@ class VideoPlayerSubtitleLayer extends ConsumerWidget {
   final VideoPlayerController controller;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final subtitlesVisible = ref.watch(subtitleVisibilityProvider);
-    if (!subtitlesVisible) return const SizedBox.shrink();
+  State<VideoPlayerSubtitleLayer> createState() =>
+      _VideoPlayerSubtitleLayerState();
+}
 
-    return ValueListenableBuilder<VideoPlayerValue>(
-      valueListenable: controller,
-      builder: (context, value, _) {
-        if (!value.isInitialized) {
-          return const SizedBox.shrink();
-        }
+class _VideoPlayerSubtitleLayerState extends State<VideoPlayerSubtitleLayer> {
+  final _positionController = StreamController<Duration>.broadcast();
+  late bool _isInitialized = widget.controller.value.isInitialized;
 
-        return SubtitleCuePositionPill(
-          video: video,
-          positionMs: value.position.inMilliseconds,
-        );
-      },
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_handleControllerValue);
+  }
+
+  @override
+  void didUpdateWidget(covariant VideoPlayerSubtitleLayer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller == widget.controller) return;
+
+    oldWidget.controller.removeListener(_handleControllerValue);
+    _isInitialized = widget.controller.value.isInitialized;
+    widget.controller.addListener(_handleControllerValue);
+    _emitPositionIfReady(widget.controller.value);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_handleControllerValue);
+    _positionController.close();
+    super.dispose();
+  }
+
+  void _handleControllerValue() {
+    final value = widget.controller.value;
+    if (_isInitialized != value.isInitialized) {
+      setState(() {
+        _isInitialized = value.isInitialized;
+      });
+    }
+    _emitPositionIfReady(value);
+  }
+
+  void _emitPositionIfReady(VideoPlayerValue value) {
+    if (!value.isInitialized || _positionController.isClosed) return;
+    _positionController.add(value.position);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isInitialized) return const SizedBox.shrink();
+
+    return SubtitleCueStreamPill(
+      video: widget.video,
+      positionStream: _positionController.stream,
+      initialPosition: widget.controller.value.position,
     );
   }
 }

--- a/mobile/test/widgets/video_feed_item/subtitle_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/subtitle_overlay_test.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/widgets/video_feed_item/subtitle_overlay.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+VideoEvent _makeVideo() => VideoEvent(
+  id: 'a1b2c3d4e5f6789012345678901234567890abcdef123456789012345678901234',
+  pubkey: 'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3',
+  createdAt: 1700000000,
+  content: 'Test video',
+  timestamp: DateTime.fromMillisecondsSinceEpoch(1700000000 * 1000),
+  videoUrl: 'https://example.com/video.mp4',
+  textTrackContent: '''
+WEBVTT
+
+1
+00:00:00.100 --> 00:00:01.000
+Hello there
+
+2
+00:00:01.100 --> 00:00:02.000
+Second line
+''',
+);
+
+void main() {
+  testWidgets('does not rebuild the caption pill for ticks within one cue', (
+    tester,
+  ) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final positions = StreamController<Duration>.broadcast();
+    addTearDown(positions.close);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SubtitleCueStreamPill(
+                video: _makeVideo(),
+                positionStream: positions.stream,
+                initialPosition: const Duration(milliseconds: 300),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('Hello there'), findsOneWidget);
+    final initialTextWidget = tester.widget<Text>(find.text('Hello there'));
+
+    positions.add(const Duration(milliseconds: 500));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Hello there'), findsOneWidget);
+    expect(
+      identical(
+        initialTextWidget,
+        tester.widget<Text>(find.text('Hello there')),
+      ),
+      isTrue,
+    );
+
+    positions.add(const Duration(milliseconds: 1200));
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Second line'), findsOneWidget);
+  });
+}

--- a/mobile/test/widgets/video_feed_item/subtitle_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/subtitle_overlay_test.dart
@@ -28,6 +28,40 @@ Second line
 ''',
 );
 
+class _RebuildingSubtitleHost extends StatefulWidget {
+  const _RebuildingSubtitleHost({
+    required this.video,
+    required this.positions,
+    super.key,
+  });
+
+  final VideoEvent video;
+  final Stream<Duration> positions;
+
+  @override
+  State<_RebuildingSubtitleHost> createState() =>
+      _RebuildingSubtitleHostState();
+}
+
+class _RebuildingSubtitleHostState extends State<_RebuildingSubtitleHost> {
+  Duration initialPosition = const Duration(milliseconds: 500);
+
+  void rebuildAt(Duration position) {
+    setState(() {
+      initialPosition = position;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SubtitleCueStreamPill(
+      video: widget.video,
+      positionStream: widget.positions,
+      initialPosition: initialPosition,
+    );
+  }
+}
+
 void main() {
   testWidgets('does not rebuild the caption pill for ticks within one cue', (
     tester,
@@ -77,5 +111,43 @@ void main() {
     await tester.pump();
 
     expect(find.text('Second line'), findsOneWidget);
+  });
+
+  testWidgets('keeps bridged cue state across parent rebuilds', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final positions = StreamController<Duration>.broadcast();
+    addTearDown(positions.close);
+    final hostKey = GlobalKey<_RebuildingSubtitleHostState>();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [sharedPreferencesProvider.overrideWithValue(prefs)],
+        child: MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: _RebuildingSubtitleHost(
+                key: hostKey,
+                video: _makeVideo(),
+                positions: positions.stream,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.text('Hello there'), findsOneWidget);
+
+    positions.add(const Duration(milliseconds: 1050));
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('Hello there'), findsOneWidget);
+
+    hostKey.currentState!.rebuildAt(const Duration(milliseconds: 1050));
+    await tester.pump();
+
+    expect(find.text('Hello there'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #5455

**Related Issue:** 

## Description

The subtitle overlay rebuilt the caption pill on **every** player position
tick (many times per second) — reconstructing the `Container` + `Text`
each frame even when the visible cue text was unchanged.

This decouples the high-frequency ticks from the widget rebuild:

- `VideoPlayerSubtitleLayer` is now a plain `StatefulWidget`. It pushes the
  controller position into a broadcast `StreamController<Duration>` and only
  calls `setState` when `isInitialized` flips — no per-tick rebuild.
- New `SubtitleCueStreamPill` watches visibility + cues once, then runs a
  `StreamBuilder` over a display stream that **only yields when the cue text
  actually changes** (`if (display == previousDisplay) continue;`). So
  `_CaptionPill` rebuilds on cue transitions instead of every frame.
- Cue-tracking logic (gap-bridge, seek-back) is extracted into
  `_SubtitleCueDisplayTracker`; `_SubtitleCueDisplay` is a value type with
  `==`/`hashCode` for the dedup compare.
- The now-unused `SubtitleCuePositionPill` is removed — both call sites
  (`feed_videos.dart`, `video_player_subtitle_layer.dart`) use the
  stream-based pill.

## Out of Scope

The display stream is currently re-created inside the `cuesAsync.when` data
builder, so a rebuild of `SubtitleCueStreamPill` resubscribes the
`StreamBuilder`. This is harmless today (the widget only rebuilds on
visibility/cue changes) and was left as-is to keep the change focused.

## Verification

- `flutter analyze` on the changed lib + test files — no issues
- `flutter test test/widgets/video_feed_item/subtitle_overlay_test.dart test/widgets/video_feed_item/video_player_subtitle_layer_test.dart` — all green
- New widget test asserts the caption `Text` instance is **identical** across
  a position tick within one cue, and switches text across a cue boundary

## Type of Change

- [x] 🧹 Code refactor
- [x] ✅ Performance