### PR TITLE
fix(dm): stop re-decrypting reaction/deletion gift wraps every launch (#5452)

### DIFF
--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -505,6 +505,7 @@ DmRepository dmRepository(Ref ref) {
     conversationsDao: db.conversationsDao,
     outgoingDmsDao: db.outgoingDmsDao,
     pendingGiftWrapsDao: db.pendingGiftWrapsDao,
+    processedGiftWrapsDao: db.processedGiftWrapsDao,
     syncState: DmSyncState(prefs),
     reactionsRepository: reactionsRepository,
     errorReporter: (error, stackTrace, {required site}) {

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -774,7 +774,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'db555e77673032bf3d1c10788e9b448c363e81e0';
+String _$dmRepositoryHash() => r'598879d7170da09331ed22b5b89bd11f381d41ae';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -361,6 +361,10 @@ UserDataCleanupService userDataCleanupService(Ref ref) {
         // class as direct_messages — wipe them on the same path so they never
         // outlive the account's decrypted DMs. See #5202.
         await db.pendingGiftWrapsDao.clearAll();
+        // Wipe the processed-wrap dedup ledger on the same path: a stale ledger
+        // must never suppress re-population of an account's reactions/deletions
+        // after its DM data is cleared. See #5452.
+        await db.processedGiftWrapsDao.clearAll();
         await db.notificationsDao.clearAll();
         // Clear DM sync cursors so the next login triggers a full re-fetch
         // from relays instead of using stale `since:` boundaries.

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -482,7 +482,7 @@ final class UserDataCleanupServiceProvider
 }
 
 String _$userDataCleanupServiceHash() =>
-    r'd71f520c626677c7120300d8b0739ac2f46e5228';
+    r'dc580b907d795153456bd68fc2fb107593e550cd';
 
 /// Hashtag service depends on Video event service and cache service
 

--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -36,6 +36,7 @@ const _notificationRetentionDays = 7;
     OutgoingDms,
     PendingViewEvents,
     PendingGiftWraps,
+    ProcessedGiftWraps,
   ],
   daos: [
     UserProfilesDao,
@@ -57,6 +58,7 @@ const _notificationRetentionDays = 7;
     OutgoingDmsDao,
     PendingViewEventsDao,
     PendingGiftWrapsDao,
+    ProcessedGiftWrapsDao,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -638,6 +640,27 @@ class AppDatabase extends _$AppDatabase {
       CREATE INDEX IF NOT EXISTS idx_pending_gift_wraps_owner_attempts
       ON pending_gift_wraps (owner_pubkey, attempts)
     ''');
+
+    // Check if processed_gift_wraps table exists, create if missing.
+    // Added for #5452 (dedup ledger so DM reaction/deletion gift wraps are not
+    // re-decrypted on every launch). Schema version stays at 1 — same runtime
+    // CREATE-IF-NOT-EXISTS pattern as pending_gift_wraps above. No index: the
+    // only access is a primary-key lookup on gift_wrap_id.
+    final processedGiftWrapsResult = await customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' "
+      "AND name='processed_gift_wraps'",
+    ).get();
+
+    if (processedGiftWrapsResult.isEmpty) {
+      await customStatement('''
+        CREATE TABLE processed_gift_wraps (
+          gift_wrap_id TEXT NOT NULL,
+          processed_at INTEGER NOT NULL,
+          owner_pubkey TEXT,
+          PRIMARY KEY (gift_wrap_id)
+        )
+      ''');
+    }
 
     // Populate new columns from existing JSON data blobs
     await _backfillFilePathColumns();

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -13738,7 +13738,8 @@ class ProcessedGiftWrap extends DataClass
   final int processedAt;
 
   /// Recipient pubkey this wrap was processed for. Informational only — NOT
-  /// part of the dedup key — used to scope account-cleanup deletes.
+  /// part of the dedup key, and not used to scope deletes: account cleanup
+  /// wipes the whole table via `clearAll()`. Retained for diagnostics.
   final String? ownerPubkey;
   const ProcessedGiftWrap({
     required this.giftWrapId,

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -13609,6 +13609,304 @@ class PendingGiftWrapsCompanion extends UpdateCompanion<PendingGiftWrapRow> {
   }
 }
 
+class $ProcessedGiftWrapsTable extends ProcessedGiftWraps
+    with TableInfo<$ProcessedGiftWrapsTable, ProcessedGiftWrap> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ProcessedGiftWrapsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _giftWrapIdMeta = const VerificationMeta(
+    'giftWrapId',
+  );
+  @override
+  late final GeneratedColumn<String> giftWrapId = GeneratedColumn<String>(
+    'gift_wrap_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _processedAtMeta = const VerificationMeta(
+    'processedAt',
+  );
+  @override
+  late final GeneratedColumn<int> processedAt = GeneratedColumn<int>(
+    'processed_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _ownerPubkeyMeta = const VerificationMeta(
+    'ownerPubkey',
+  );
+  @override
+  late final GeneratedColumn<String> ownerPubkey = GeneratedColumn<String>(
+    'owner_pubkey',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [giftWrapId, processedAt, ownerPubkey];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'processed_gift_wraps';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<ProcessedGiftWrap> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('gift_wrap_id')) {
+      context.handle(
+        _giftWrapIdMeta,
+        giftWrapId.isAcceptableOrUnknown(
+          data['gift_wrap_id']!,
+          _giftWrapIdMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_giftWrapIdMeta);
+    }
+    if (data.containsKey('processed_at')) {
+      context.handle(
+        _processedAtMeta,
+        processedAt.isAcceptableOrUnknown(
+          data['processed_at']!,
+          _processedAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_processedAtMeta);
+    }
+    if (data.containsKey('owner_pubkey')) {
+      context.handle(
+        _ownerPubkeyMeta,
+        ownerPubkey.isAcceptableOrUnknown(
+          data['owner_pubkey']!,
+          _ownerPubkeyMeta,
+        ),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {giftWrapId};
+  @override
+  ProcessedGiftWrap map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ProcessedGiftWrap(
+      giftWrapId: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}gift_wrap_id'],
+      )!,
+      processedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}processed_at'],
+      )!,
+      ownerPubkey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}owner_pubkey'],
+      ),
+    );
+  }
+
+  @override
+  $ProcessedGiftWrapsTable createAlias(String alias) {
+    return $ProcessedGiftWrapsTable(attachedDatabase, alias);
+  }
+}
+
+class ProcessedGiftWrap extends DataClass
+    implements Insertable<ProcessedGiftWrap> {
+  /// The kind 1059 gift-wrap event id (outer). Dedup key.
+  ///
+  /// Intentionally NOT scoped by owner: gift-wrap event ids are globally unique
+  /// per the Nostr protocol, so cross-account dedup prevents re-processing the
+  /// same relay event for multiple local accounts — matching
+  /// [DirectMessages.giftWrapId] dedup semantics.
+  final String giftWrapId;
+
+  /// When the wrap was terminally processed (unix seconds). Informational and
+  /// available for any future time-based retention.
+  final int processedAt;
+
+  /// Recipient pubkey this wrap was processed for. Informational only — NOT
+  /// part of the dedup key — used to scope account-cleanup deletes.
+  final String? ownerPubkey;
+  const ProcessedGiftWrap({
+    required this.giftWrapId,
+    required this.processedAt,
+    this.ownerPubkey,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['gift_wrap_id'] = Variable<String>(giftWrapId);
+    map['processed_at'] = Variable<int>(processedAt);
+    if (!nullToAbsent || ownerPubkey != null) {
+      map['owner_pubkey'] = Variable<String>(ownerPubkey);
+    }
+    return map;
+  }
+
+  ProcessedGiftWrapsCompanion toCompanion(bool nullToAbsent) {
+    return ProcessedGiftWrapsCompanion(
+      giftWrapId: Value(giftWrapId),
+      processedAt: Value(processedAt),
+      ownerPubkey: ownerPubkey == null && nullToAbsent
+          ? const Value.absent()
+          : Value(ownerPubkey),
+    );
+  }
+
+  factory ProcessedGiftWrap.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ProcessedGiftWrap(
+      giftWrapId: serializer.fromJson<String>(json['giftWrapId']),
+      processedAt: serializer.fromJson<int>(json['processedAt']),
+      ownerPubkey: serializer.fromJson<String?>(json['ownerPubkey']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'giftWrapId': serializer.toJson<String>(giftWrapId),
+      'processedAt': serializer.toJson<int>(processedAt),
+      'ownerPubkey': serializer.toJson<String?>(ownerPubkey),
+    };
+  }
+
+  ProcessedGiftWrap copyWith({
+    String? giftWrapId,
+    int? processedAt,
+    Value<String?> ownerPubkey = const Value.absent(),
+  }) => ProcessedGiftWrap(
+    giftWrapId: giftWrapId ?? this.giftWrapId,
+    processedAt: processedAt ?? this.processedAt,
+    ownerPubkey: ownerPubkey.present ? ownerPubkey.value : this.ownerPubkey,
+  );
+  ProcessedGiftWrap copyWithCompanion(ProcessedGiftWrapsCompanion data) {
+    return ProcessedGiftWrap(
+      giftWrapId: data.giftWrapId.present
+          ? data.giftWrapId.value
+          : this.giftWrapId,
+      processedAt: data.processedAt.present
+          ? data.processedAt.value
+          : this.processedAt,
+      ownerPubkey: data.ownerPubkey.present
+          ? data.ownerPubkey.value
+          : this.ownerPubkey,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ProcessedGiftWrap(')
+          ..write('giftWrapId: $giftWrapId, ')
+          ..write('processedAt: $processedAt, ')
+          ..write('ownerPubkey: $ownerPubkey')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(giftWrapId, processedAt, ownerPubkey);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ProcessedGiftWrap &&
+          other.giftWrapId == this.giftWrapId &&
+          other.processedAt == this.processedAt &&
+          other.ownerPubkey == this.ownerPubkey);
+}
+
+class ProcessedGiftWrapsCompanion extends UpdateCompanion<ProcessedGiftWrap> {
+  final Value<String> giftWrapId;
+  final Value<int> processedAt;
+  final Value<String?> ownerPubkey;
+  final Value<int> rowid;
+  const ProcessedGiftWrapsCompanion({
+    this.giftWrapId = const Value.absent(),
+    this.processedAt = const Value.absent(),
+    this.ownerPubkey = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  ProcessedGiftWrapsCompanion.insert({
+    required String giftWrapId,
+    required int processedAt,
+    this.ownerPubkey = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : giftWrapId = Value(giftWrapId),
+       processedAt = Value(processedAt);
+  static Insertable<ProcessedGiftWrap> custom({
+    Expression<String>? giftWrapId,
+    Expression<int>? processedAt,
+    Expression<String>? ownerPubkey,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (giftWrapId != null) 'gift_wrap_id': giftWrapId,
+      if (processedAt != null) 'processed_at': processedAt,
+      if (ownerPubkey != null) 'owner_pubkey': ownerPubkey,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  ProcessedGiftWrapsCompanion copyWith({
+    Value<String>? giftWrapId,
+    Value<int>? processedAt,
+    Value<String?>? ownerPubkey,
+    Value<int>? rowid,
+  }) {
+    return ProcessedGiftWrapsCompanion(
+      giftWrapId: giftWrapId ?? this.giftWrapId,
+      processedAt: processedAt ?? this.processedAt,
+      ownerPubkey: ownerPubkey ?? this.ownerPubkey,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (giftWrapId.present) {
+      map['gift_wrap_id'] = Variable<String>(giftWrapId.value);
+    }
+    if (processedAt.present) {
+      map['processed_at'] = Variable<int>(processedAt.value);
+    }
+    if (ownerPubkey.present) {
+      map['owner_pubkey'] = Variable<String>(ownerPubkey.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ProcessedGiftWrapsCompanion(')
+          ..write('giftWrapId: $giftWrapId, ')
+          ..write('processedAt: $processedAt, ')
+          ..write('ownerPubkey: $ownerPubkey, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -13639,6 +13937,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $PendingGiftWrapsTable pendingGiftWraps = $PendingGiftWrapsTable(
     this,
   );
+  late final $ProcessedGiftWrapsTable processedGiftWraps =
+      $ProcessedGiftWrapsTable(this);
   late final UserProfilesDao userProfilesDao = UserProfilesDao(
     this as AppDatabase,
   );
@@ -13691,6 +13991,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final PendingGiftWrapsDao pendingGiftWrapsDao = PendingGiftWrapsDao(
     this as AppDatabase,
   );
+  late final ProcessedGiftWrapsDao processedGiftWrapsDao =
+      ProcessedGiftWrapsDao(this as AppDatabase);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -13715,6 +14017,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     outgoingDms,
     pendingViewEvents,
     pendingGiftWraps,
+    processedGiftWraps,
   ];
 }
 
@@ -20036,6 +20339,187 @@ typedef $$PendingGiftWrapsTableProcessedTableManager =
       PendingGiftWrapRow,
       PrefetchHooks Function()
     >;
+typedef $$ProcessedGiftWrapsTableCreateCompanionBuilder =
+    ProcessedGiftWrapsCompanion Function({
+      required String giftWrapId,
+      required int processedAt,
+      Value<String?> ownerPubkey,
+      Value<int> rowid,
+    });
+typedef $$ProcessedGiftWrapsTableUpdateCompanionBuilder =
+    ProcessedGiftWrapsCompanion Function({
+      Value<String> giftWrapId,
+      Value<int> processedAt,
+      Value<String?> ownerPubkey,
+      Value<int> rowid,
+    });
+
+class $$ProcessedGiftWrapsTableFilterComposer
+    extends Composer<_$AppDatabase, $ProcessedGiftWrapsTable> {
+  $$ProcessedGiftWrapsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get giftWrapId => $composableBuilder(
+    column: $table.giftWrapId,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get processedAt => $composableBuilder(
+    column: $table.processedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$ProcessedGiftWrapsTableOrderingComposer
+    extends Composer<_$AppDatabase, $ProcessedGiftWrapsTable> {
+  $$ProcessedGiftWrapsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get giftWrapId => $composableBuilder(
+    column: $table.giftWrapId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get processedAt => $composableBuilder(
+    column: $table.processedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$ProcessedGiftWrapsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $ProcessedGiftWrapsTable> {
+  $$ProcessedGiftWrapsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get giftWrapId => $composableBuilder(
+    column: $table.giftWrapId,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<int> get processedAt => $composableBuilder(
+    column: $table.processedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get ownerPubkey => $composableBuilder(
+    column: $table.ownerPubkey,
+    builder: (column) => column,
+  );
+}
+
+class $$ProcessedGiftWrapsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $ProcessedGiftWrapsTable,
+          ProcessedGiftWrap,
+          $$ProcessedGiftWrapsTableFilterComposer,
+          $$ProcessedGiftWrapsTableOrderingComposer,
+          $$ProcessedGiftWrapsTableAnnotationComposer,
+          $$ProcessedGiftWrapsTableCreateCompanionBuilder,
+          $$ProcessedGiftWrapsTableUpdateCompanionBuilder,
+          (
+            ProcessedGiftWrap,
+            BaseReferences<
+              _$AppDatabase,
+              $ProcessedGiftWrapsTable,
+              ProcessedGiftWrap
+            >,
+          ),
+          ProcessedGiftWrap,
+          PrefetchHooks Function()
+        > {
+  $$ProcessedGiftWrapsTableTableManager(
+    _$AppDatabase db,
+    $ProcessedGiftWrapsTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$ProcessedGiftWrapsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$ProcessedGiftWrapsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$ProcessedGiftWrapsTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<String> giftWrapId = const Value.absent(),
+                Value<int> processedAt = const Value.absent(),
+                Value<String?> ownerPubkey = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ProcessedGiftWrapsCompanion(
+                giftWrapId: giftWrapId,
+                processedAt: processedAt,
+                ownerPubkey: ownerPubkey,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String giftWrapId,
+                required int processedAt,
+                Value<String?> ownerPubkey = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => ProcessedGiftWrapsCompanion.insert(
+                giftWrapId: giftWrapId,
+                processedAt: processedAt,
+                ownerPubkey: ownerPubkey,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$ProcessedGiftWrapsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $ProcessedGiftWrapsTable,
+      ProcessedGiftWrap,
+      $$ProcessedGiftWrapsTableFilterComposer,
+      $$ProcessedGiftWrapsTableOrderingComposer,
+      $$ProcessedGiftWrapsTableAnnotationComposer,
+      $$ProcessedGiftWrapsTableCreateCompanionBuilder,
+      $$ProcessedGiftWrapsTableUpdateCompanionBuilder,
+      (
+        ProcessedGiftWrap,
+        BaseReferences<
+          _$AppDatabase,
+          $ProcessedGiftWrapsTable,
+          ProcessedGiftWrap
+        >,
+      ),
+      ProcessedGiftWrap,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -20078,4 +20562,6 @@ class $AppDatabaseManager {
       $$PendingViewEventsTableTableManager(_db, _db.pendingViewEvents);
   $$PendingGiftWrapsTableTableManager get pendingGiftWraps =>
       $$PendingGiftWrapsTableTableManager(_db, _db.pendingGiftWraps);
+  $$ProcessedGiftWrapsTableTableManager get processedGiftWraps =>
+      $$ProcessedGiftWrapsTableTableManager(_db, _db.processedGiftWraps);
 }

--- a/mobile/packages/db_client/lib/src/database/daos/daos.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/daos.dart
@@ -14,6 +14,7 @@ export 'pending_uploads_dao.dart';
 export 'pending_view_events_dao.dart';
 export 'personal_reactions_dao.dart';
 export 'personal_reposts_dao.dart';
+export 'processed_gift_wraps_dao.dart';
 export 'profile_stats_dao.dart';
 export 'user_profiles_dao.dart';
 export 'video_metrics_dao.dart';

--- a/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
@@ -27,7 +27,8 @@ class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
 
   /// Records [giftWrapId] as terminally processed (idempotent — a re-delivered
   /// wrap or a concurrent writer never throws). [ownerPubkey] is informational
-  /// only; it scopes account-cleanup, not the dedup key.
+  /// only — not part of the dedup key, and not used to scope deletes (cleanup
+  /// is global via [clearAll]).
   Future<void> record({
     required String giftWrapId,
     String? ownerPubkey,

--- a/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
@@ -1,0 +1,56 @@
+// ABOUTME: Data Access Object for the processed-gift-wrap dedup ledger.
+// ABOUTME: Records terminally-processed kind-1059 wrap ids so they never
+// ABOUTME: re-decrypt on a later launch. See #5452.
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/drift.dart';
+
+part 'processed_gift_wraps_dao.g.dart';
+
+@DriftAccessor(tables: [ProcessedGiftWraps])
+class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
+    with _$ProcessedGiftWrapsDaoMixin {
+  ProcessedGiftWrapsDao(super.attachedDatabase);
+
+  /// Has the gift wrap [giftWrapId] already been terminally processed?
+  ///
+  /// Global (NOT owner-scoped): gift-wrap event ids are globally unique, so a
+  /// wrap processed under any local account dedups for all of them — matching
+  /// [DirectMessagesDao.hasGiftWrap].
+  Future<bool> hasGiftWrap(String giftWrapId) async {
+    final query = selectOnly(processedGiftWraps)
+      ..addColumns([processedGiftWraps.giftWrapId])
+      ..where(processedGiftWraps.giftWrapId.equals(giftWrapId))
+      ..limit(1);
+    return (await query.get()).isNotEmpty;
+  }
+
+  /// Records [giftWrapId] as terminally processed (idempotent — a re-delivered
+  /// wrap or a concurrent writer never throws). [ownerPubkey] is informational
+  /// only; it scopes account-cleanup, not the dedup key.
+  Future<void> record({
+    required String giftWrapId,
+    String? ownerPubkey,
+  }) async {
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await into(processedGiftWraps).insert(
+      ProcessedGiftWrapsCompanion.insert(
+        giftWrapId: giftWrapId,
+        processedAt: now,
+        ownerPubkey: Value(ownerPubkey),
+      ),
+      mode: InsertMode.insertOrIgnore,
+    );
+  }
+
+  /// Removes every processed-wrap row. Called during account cleanup (switch /
+  /// destructive sign-out) alongside the other DM-table wipes so a stale ledger
+  /// can never suppress re-population of an account's reactions/deletions.
+  Future<int> clearAll() => delete(processedGiftWraps).go();
+
+  /// Total processed-wrap rows (diagnostics / tests).
+  Future<int> count() async {
+    final rows = await select(processedGiftWraps).get();
+    return rows.length;
+  }
+}

--- a/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.g.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'processed_gift_wraps_dao.dart';
+
+// ignore_for_file: type=lint
+mixin _$ProcessedGiftWrapsDaoMixin on DatabaseAccessor<AppDatabase> {
+  $ProcessedGiftWrapsTable get processedGiftWraps =>
+      attachedDatabase.processedGiftWraps;
+  ProcessedGiftWrapsDaoManager get managers =>
+      ProcessedGiftWrapsDaoManager(this);
+}
+
+class ProcessedGiftWrapsDaoManager {
+  final _$ProcessedGiftWrapsDaoMixin _db;
+  ProcessedGiftWrapsDaoManager(this._db);
+  $$ProcessedGiftWrapsTableTableManager get processedGiftWraps =>
+      $$ProcessedGiftWrapsTableTableManager(
+        _db.attachedDatabase,
+        _db.processedGiftWraps,
+      );
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1286,3 +1286,36 @@ class PendingGiftWraps extends Table {
     ),
   ];
 }
+
+/// Ledger of gift-wrap ids that have already been terminally processed, so a
+/// relay re-delivering the same kind-1059 wrap never re-decrypts it.
+///
+/// Text/file messages (kind 14/15) already dedup via
+/// [DirectMessages.giftWrapId]; this table covers the outcomes that write no
+/// message row — reactions (kind 7), reaction/deletion (kind 5), unsupported
+/// kinds, cross-protocol duplicates, and degenerate participant sets — which
+/// otherwise re-decrypted on every launch (a serial remote-signer RPC each).
+/// See #5452.
+class ProcessedGiftWraps extends Table {
+  @override
+  String get tableName => 'processed_gift_wraps';
+
+  /// The kind 1059 gift-wrap event id (outer). Dedup key.
+  ///
+  /// Intentionally NOT scoped by owner: gift-wrap event ids are globally unique
+  /// per the Nostr protocol, so cross-account dedup prevents re-processing the
+  /// same relay event for multiple local accounts — matching
+  /// [DirectMessages.giftWrapId] dedup semantics.
+  TextColumn get giftWrapId => text().named('gift_wrap_id')();
+
+  /// When the wrap was terminally processed (unix seconds). Informational and
+  /// available for any future time-based retention.
+  IntColumn get processedAt => integer().named('processed_at')();
+
+  /// Recipient pubkey this wrap was processed for. Informational only — NOT
+  /// part of the dedup key — used to scope account-cleanup deletes.
+  TextColumn get ownerPubkey => text().nullable().named('owner_pubkey')();
+
+  @override
+  Set<Column> get primaryKey => {giftWrapId};
+}

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -1313,7 +1313,8 @@ class ProcessedGiftWraps extends Table {
   IntColumn get processedAt => integer().named('processed_at')();
 
   /// Recipient pubkey this wrap was processed for. Informational only — NOT
-  /// part of the dedup key — used to scope account-cleanup deletes.
+  /// part of the dedup key, and not used to scope deletes: account cleanup
+  /// wipes the whole table via `clearAll()`. Retained for diagnostics.
   TextColumn get ownerPubkey => text().nullable().named('owner_pubkey')();
 
   @override

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -590,6 +590,95 @@ void main() {
       );
 
       test(
+        'upgrade path recreates processed_gift_wraps when missing',
+        () async {
+          await database.customStatement('DROP TABLE processed_gift_wraps');
+
+          final droppedCheck = await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='processed_gift_wraps'",
+              )
+              .get();
+          expect(
+            droppedCheck,
+            isEmpty,
+            reason: 'precondition: processed_gift_wraps must be missing',
+          );
+
+          await database.close();
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+          final tableCheck = await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='processed_gift_wraps'",
+              )
+              .get();
+          expect(
+            tableCheck,
+            hasLength(1),
+            reason: 'processed_gift_wraps must be re-created on reopen',
+          );
+
+          final dao = database.processedGiftWrapsDao;
+          await dao.record(
+            giftWrapId: 'upgrade-wrap-id',
+            ownerPubkey: testPubkey,
+          );
+          expect(await dao.hasGiftWrap('upgrade-wrap-id'), isTrue);
+        },
+      );
+
+      test(
+        'schema parity — processed_gift_wraps fresh-install matches runtime '
+        'CREATE-IF-NOT-EXISTS path',
+        () async {
+          final freshColumns = await _collectTableInfo(
+            database,
+            'processed_gift_wraps',
+          );
+          final freshIndexes = await _collectIndexNames(
+            database,
+            'processed_gift_wraps',
+          );
+
+          expect(
+            freshColumns,
+            isNotEmpty,
+            reason:
+                'precondition: fresh install should have processed_gift_wraps',
+          );
+
+          await database.customStatement('DROP TABLE processed_gift_wraps');
+          for (final indexName in freshIndexes) {
+            await database.customStatement('DROP INDEX IF EXISTS $indexName');
+          }
+          await database.close();
+
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          await database
+              .customSelect(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='processed_gift_wraps'",
+              )
+              .get();
+
+          final recreatedColumns = await _collectTableInfo(
+            database,
+            'processed_gift_wraps',
+          );
+          final recreatedIndexes = await _collectIndexNames(
+            database,
+            'processed_gift_wraps',
+          );
+
+          expect(recreatedColumns, equals(freshColumns));
+          expect(recreatedIndexes, equals(freshIndexes));
+        },
+      );
+
+      test(
         'upgrade path — dedups duplicate live reactions before recreating '
         'the unique index',
         () async {

--- a/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
@@ -1,0 +1,90 @@
+// ABOUTME: Unit tests for ProcessedGiftWrapsDao — the dedup ledger that stops
+// ABOUTME: DM reaction/deletion gift wraps re-decrypting every launch (#5452).
+
+import 'dart:io';
+
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase database;
+  late ProcessedGiftWrapsDao dao;
+  late String tempDbPath;
+
+  const ownerA =
+      '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+  const ownerB =
+      'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+  const wrap1 =
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+  const wrap2 =
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  setUp(() async {
+    final tempDir = Directory.systemTemp.createTempSync('pgw_ledger_test_');
+    tempDbPath = '${tempDir.path}/test.db';
+    database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+    dao = database.processedGiftWrapsDao;
+  });
+
+  tearDown(() async {
+    await database.close();
+    final file = File(tempDbPath);
+    if (file.existsSync()) file.deleteSync();
+  });
+
+  group(ProcessedGiftWrapsDao, () {
+    test('hasGiftWrap is false before any record', () async {
+      expect(await dao.hasGiftWrap(wrap1), isFalse);
+    });
+
+    test('record then hasGiftWrap returns true', () async {
+      await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+      expect(await dao.hasGiftWrap(wrap1), isTrue);
+      expect(await dao.hasGiftWrap(wrap2), isFalse);
+    });
+
+    test('record is idempotent — re-recording the same wrap does not throw '
+        'and keeps a single row', () async {
+      await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+      await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+      expect(await dao.hasGiftWrap(wrap1), isTrue);
+      expect(await dao.count(), 1);
+    });
+
+    test('dedup is global — a wrap recorded under one owner dedups for '
+        'another account on the device', () async {
+      await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+      // hasGiftWrap takes no owner: a different account sees the same wrap as
+      // already processed.
+      expect(await dao.hasGiftWrap(wrap1), isTrue);
+
+      // A second record under a different owner is ignored (gift-wrap ids are
+      // globally unique), leaving a single row.
+      await dao.record(giftWrapId: wrap1, ownerPubkey: ownerB);
+      expect(await dao.count(), 1);
+    });
+
+    test('record accepts a null owner', () async {
+      await dao.record(giftWrapId: wrap1);
+
+      expect(await dao.hasGiftWrap(wrap1), isTrue);
+    });
+
+    test('clearAll removes every row', () async {
+      await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+      await dao.record(giftWrapId: wrap2, ownerPubkey: ownerB);
+
+      final deleted = await dao.clearAll();
+
+      expect(deleted, 2);
+      expect(await dao.hasGiftWrap(wrap1), isFalse);
+      expect(await dao.hasGiftWrap(wrap2), isFalse);
+      expect(await dao.count(), 0);
+    });
+  });
+}

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -44,6 +44,21 @@ class DmReactionPublishResult {
   final String? errorMessage;
 }
 
+/// Outcome of ingesting an incoming wrapped reaction/deletion rumor, used by
+/// `DmRepository` to decide whether to record the gift wrap in the
+/// processed-wrap dedup ledger (#5452).
+enum DmReactionWrapOutcome {
+  /// The wrap reached a terminal state — persisted, or permanently dropped for
+  /// a reason that will not change (malformed content/tags, no matching row).
+  /// Safe to record so the wrap is never re-decrypted.
+  processed,
+
+  /// The wrap could not be applied yet (signer not ready, or the reaction's
+  /// target message has not synced). Must NOT be recorded so it re-decrypts on
+  /// a later launch once the target exists — preserving eventual consistency.
+  deferred,
+}
+
 /// Repository for DM emoji reactions.
 ///
 /// Public surface:
@@ -420,12 +435,20 @@ class DmReactionsRepository {
 
   /// Persist an incoming kind-7 reaction rumor. Called from
   /// `DmRepository._handleGiftWrapEvent` after rumor extraction.
-  Future<void> persistIncoming({
+  ///
+  /// Returns [DmReactionWrapOutcome.processed] when the wrap reached a terminal
+  /// state (persisted, or permanently dropped for malformed content/tags), and
+  /// [DmReactionWrapOutcome.deferred] when it could not be applied yet (signer
+  /// not ready, or the target message has not synced) so the caller leaves it
+  /// out of the dedup ledger and lets it re-decrypt later. See #5452.
+  Future<DmReactionWrapOutcome> persistIncoming({
     required Event rumorEvent,
     required String giftWrapId,
   }) async {
-    if (_userPubkey.isEmpty) return;
-    if (rumorEvent.kind != EventKind.reaction) return;
+    if (_userPubkey.isEmpty) return DmReactionWrapOutcome.deferred;
+    if (rumorEvent.kind != EventKind.reaction) {
+      return DmReactionWrapOutcome.processed;
+    }
     final content = rumorEvent.content;
     if (content.isEmpty || content.length > _maxReactionContentLength) {
       Log.debug(
@@ -433,7 +456,7 @@ class DmReactionsRepository {
         '(content length: ${content.length})',
         category: LogCategory.system,
       );
-      return;
+      return DmReactionWrapOutcome.processed;
     }
     String? targetMessageId;
     String? targetAuthor;
@@ -452,7 +475,7 @@ class DmReactionsRepository {
         'Dropping reaction rumor ${rumorEvent.id} — missing/invalid e tag',
         category: LogCategory.system,
       );
-      return;
+      return DmReactionWrapOutcome.processed;
     }
     targetAuthor ??= rumorEvent.pubkey;
     final conversationId = await _resolveConversationIdForReaction(
@@ -460,7 +483,9 @@ class DmReactionsRepository {
       targetAuthor: targetAuthor,
       targetMessageId: targetMessageId,
     );
-    if (conversationId == null) return;
+    // Target message not synced yet: leave undecided so a later launch retries
+    // and the reaction lands once the message arrives. See #5452 (D4-terminal).
+    if (conversationId == null) return DmReactionWrapOutcome.deferred;
     try {
       await _reactionsDao.upsertIncoming(
         id: rumorEvent.id,
@@ -473,12 +498,15 @@ class DmReactionsRepository {
         giftWrapId: giftWrapId,
         ownerPubkey: _userPubkey,
       );
+      return DmReactionWrapOutcome.processed;
     } on Object catch (e, st) {
       _errorReporter?.call(
         e,
         st,
         site: DmReactionsRepositoryReportableSites.persistIncomingDaoUpsert,
       );
+      // Transient DAO failure — let it retry rather than cement a skip.
+      return DmReactionWrapOutcome.deferred;
     }
   }
 
@@ -487,13 +515,22 @@ class DmReactionsRepository {
   /// DM message deletions use the top-level kind-5 path in [DmRepository].
   /// This handler is specifically for wrapped deletions emitted by the
   /// reactions feature, which tag the deleted event with `k=7`.
-  Future<void> handleIncomingDeletion({
+  ///
+  /// Returns [DmReactionWrapOutcome.processed] (terminal) in every case except
+  /// when the signer is not ready yet, so the caller records the deletion wrap
+  /// in the dedup ledger and it is not re-decrypted on the next launch. The
+  /// soft-delete is idempotent, so recording it unconditionally is safe. #5452.
+  Future<DmReactionWrapOutcome> handleIncomingDeletion({
     required Event rumorEvent,
     required String giftWrapId,
   }) async {
-    if (_userPubkey.isEmpty) return;
-    if (rumorEvent.kind != EventKind.eventDeletion) return;
-    if (!_targetsReactionKind(rumorEvent.tags)) return;
+    if (_userPubkey.isEmpty) return DmReactionWrapOutcome.deferred;
+    if (rumorEvent.kind != EventKind.eventDeletion) {
+      return DmReactionWrapOutcome.processed;
+    }
+    if (!_targetsReactionKind(rumorEvent.tags)) {
+      return DmReactionWrapOutcome.processed;
+    }
 
     for (final tag in rumorEvent.tags) {
       if (tag.length < 2 || tag[0] != 'e') continue;
@@ -526,6 +563,7 @@ class DmReactionsRepository {
         );
       }
     }
+    return DmReactionWrapOutcome.processed;
   }
 
   // -------------------------------------------------------------------------

--- a/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_reactions_repository.dart
@@ -53,9 +53,10 @@ enum DmReactionWrapOutcome {
   /// Safe to record so the wrap is never re-decrypted.
   processed,
 
-  /// The wrap could not be applied yet (signer not ready, or the reaction's
-  /// target message has not synced). Must NOT be recorded so it re-decrypts on
-  /// a later launch once the target exists — preserving eventual consistency.
+  /// The wrap could not be applied yet (signer not ready, the reaction's
+  /// target message has not synced, or a deletion's target reaction has not
+  /// synced). Must NOT be recorded so it re-decrypts on a later launch once the
+  /// target exists — preserving eventual consistency.
   deferred,
 }
 
@@ -516,10 +517,16 @@ class DmReactionsRepository {
   /// This handler is specifically for wrapped deletions emitted by the
   /// reactions feature, which tag the deleted event with `k=7`.
   ///
-  /// Returns [DmReactionWrapOutcome.processed] (terminal) in every case except
-  /// when the signer is not ready yet, so the caller records the deletion wrap
-  /// in the dedup ledger and it is not re-decrypted on the next launch. The
-  /// soft-delete is idempotent, so recording it unconditionally is safe. #5452.
+  /// Returns [DmReactionWrapOutcome.deferred] — leaving the wrap out of the
+  /// dedup ledger so it re-decrypts on a later launch — when the signer is not
+  /// ready, when a targeted reaction row has not synced yet, or on a transient
+  /// soft-delete failure. Gift wraps carry NIP-59 randomized `created_at`, so a
+  /// deletion can drain before the reaction it removes; recording it as
+  /// terminal then would let the reaction insert live afterwards and never be
+  /// soft-deleted. Otherwise returns [DmReactionWrapOutcome.processed]
+  /// (terminal): the deletion applied, the target was already deleted, or the
+  /// deletion is invalid (author mismatch). The soft-delete is idempotent, so
+  /// re-applying on a benign re-decrypt is safe. #5452.
   Future<DmReactionWrapOutcome> handleIncomingDeletion({
     required Event rumorEvent,
     required String giftWrapId,
@@ -532,6 +539,7 @@ class DmReactionsRepository {
       return DmReactionWrapOutcome.processed;
     }
 
+    var outcome = DmReactionWrapOutcome.processed;
     for (final tag in rumorEvent.tags) {
       if (tag.length < 2 || tag[0] != 'e') continue;
       final rumorId = tag[1];
@@ -539,7 +547,17 @@ class DmReactionsRepository {
         id: rumorId,
         ownerPubkey: _userPubkey,
       );
-      if (row == null || row.isDeleted) continue;
+      // Target reaction not synced yet. Defer so the wrap stays unrecorded and
+      // re-decrypts once the reaction lands — otherwise upsertIncoming would
+      // insert it live afterwards and it would never be soft-deleted (the
+      // deletion-before-reaction drain race; NIP-59 randomizes gift-wrap
+      // created_at). Symmetric with persistIncoming's unsynced-target handling.
+      // #5452.
+      if (row == null) {
+        outcome = DmReactionWrapOutcome.deferred;
+        continue;
+      }
+      if (row.isDeleted) continue;
 
       // NIP-09: only the original reaction author may delete their reaction.
       if (row.reactorPubkey != rumorEvent.pubkey) {
@@ -561,9 +579,11 @@ class DmReactionsRepository {
           site: DmReactionsRepositoryReportableSites
               .handleIncomingDeletionSoftDelete,
         );
+        // Transient DAO failure — let it retry rather than cement a skip.
+        outcome = DmReactionWrapOutcome.deferred;
       }
     }
-    return DmReactionWrapOutcome.processed;
+    return outcome;
   }
 
   // -------------------------------------------------------------------------

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -177,6 +177,7 @@ class DmRepository {
     required ConversationsDao conversationsDao,
     OutgoingDmsDao? outgoingDmsDao,
     PendingGiftWrapsDao? pendingGiftWrapsDao,
+    ProcessedGiftWrapsDao? processedGiftWrapsDao,
     DmSyncState? syncState,
     NIP17MessageService? messageService,
     String? userPubkey,
@@ -192,6 +193,7 @@ class DmRepository {
        _conversationsDao = conversationsDao,
        _outgoingDmsDao = outgoingDmsDao,
        _pendingGiftWrapsDao = pendingGiftWrapsDao,
+       _processedGiftWrapsDao = processedGiftWrapsDao,
        _syncState = syncState,
        _messageService = messageService,
        _userPubkey = userPubkey ?? '',
@@ -222,6 +224,15 @@ class DmRepository {
   /// flaky remote-signer (Keycast RPC) decryption. Nullable to keep older
   /// test fixtures working without rewiring. See #5202.
   final PendingGiftWrapsDao? _pendingGiftWrapsDao;
+
+  /// Optional dedup ledger for gift wraps whose decrypted rumor writes no
+  /// `directMessages` row — reactions (kind 7), deletions (kind 5),
+  /// unsupported kinds, cross-protocol duplicates, degenerate participant
+  /// sets. Consulted alongside [DirectMessagesDao.hasGiftWrap] in the
+  /// pre-decrypt dedup so those wraps are not re-decrypted on every launch
+  /// (a serial remote-signer RPC each). Nullable to keep older test fixtures
+  /// working without rewiring. See #5452.
+  final ProcessedGiftWrapsDao? _processedGiftWrapsDao;
 
   final DmSyncState? _syncState;
   NIP17MessageService? _messageService;
@@ -1157,6 +1168,30 @@ class DmRepository {
     }
   }
 
+  /// Pre-decrypt dedup: has this gift wrap already been processed, by either
+  /// path? Text/file messages (kind 14/15) leave a `directMessages` row; the
+  /// outcomes that write no message row (reactions, deletions, unsupported
+  /// kinds, cross-protocol dups, degenerate participants) leave a
+  /// `processed_gift_wraps` ledger row instead. Checking both means a
+  /// re-delivered wrap of any kind is skipped before paying a decrypt. #5452.
+  Future<bool> _alreadyProcessed(String giftWrapId) async {
+    if (await _directMessagesDao.hasGiftWrap(giftWrapId)) return true;
+    final ledger = _processedGiftWrapsDao;
+    if (ledger == null) return false;
+    return ledger.hasGiftWrap(giftWrapId);
+  }
+
+  /// Records a terminally-processed gift wrap in the dedup ledger so it is not
+  /// re-decrypted on a later launch. No-op when the ledger DAO is absent (older
+  /// test fixtures). Recorded AFTER the outcome write so a crash in between
+  /// only ever costs a benign re-decrypt, never a lost reaction/deletion. #5452.
+  Future<void> _recordProcessedWrap(String giftWrapId) async {
+    await _processedGiftWrapsDao?.record(
+      giftWrapId: giftWrapId,
+      ownerPubkey: _userPubkey,
+    );
+  }
+
   /// Single-event gift-wrap entry (live subscription + retry replay): dedup,
   /// decrypt, then persist. The persist body is shared with the batched
   /// history-drain path via [_persistDecryptedGiftWrap]. Callers must already
@@ -1164,8 +1199,8 @@ class DmRepository {
   Future<void> _handleGiftWrapEvent(Event giftWrapEvent) async {
     final Event? rumorEvent;
     try {
-      // Dedup: skip if already processed
-      if (await _directMessagesDao.hasGiftWrap(giftWrapEvent.id)) {
+      // Dedup: skip if already processed (message row or ledger). #5452.
+      if (await _alreadyProcessed(giftWrapEvent.id)) {
         return;
       }
 
@@ -1232,28 +1267,43 @@ class DmRepository {
       // this feature so the remove path preserves DM privacy. Route both
       // before the DM-only kinds gate below. #4633.
       if (rumor.kind == EventKind.reaction) {
-        await _reactionsRepository?.persistIncoming(
+        final outcome = await _reactionsRepository?.persistIncoming(
           rumorEvent: rumor,
           giftWrapId: giftWrapEvent.id,
         );
+        // Record only terminal outcomes: a reaction whose target message has
+        // not synced is left out so it re-decrypts and lands later. #5452.
+        if (outcome == DmReactionWrapOutcome.processed) {
+          await _recordProcessedWrap(giftWrapEvent.id);
+        }
         return;
       }
       if (rumor.kind == EventKind.eventDeletion) {
-        await _reactionsRepository?.handleIncomingDeletion(
+        final outcome = await _reactionsRepository?.handleIncomingDeletion(
           rumorEvent: rumor,
           giftWrapId: giftWrapEvent.id,
         );
+        if (outcome == DmReactionWrapOutcome.processed) {
+          await _recordProcessedWrap(giftWrapEvent.id);
+        }
         return;
       }
 
-      // Accept kind 14 (text) and kind 15 (file)
-      if (!_supportedDmKinds.contains(rumor.kind)) return;
+      // Accept kind 14 (text) and kind 15 (file). Any other kind is terminally
+      // unsupported — record it so it is not re-decrypted on every launch.
+      if (!_supportedDmKinds.contains(rumor.kind)) {
+        await _recordProcessedWrap(giftWrapEvent.id);
+        return;
+      }
 
       // Extract conversation participants from pubkey + p tags, then
       // resolve against existing conversations to prevent duplicates
       // from non-compliant clients that add extra p-tags.
       final rawParticipants = _extractParticipants(rumor);
-      if (rawParticipants.length < 2) return;
+      if (rawParticipants.length < 2) {
+        await _recordProcessedWrap(giftWrapEvent.id);
+        return;
+      }
 
       final participants = await _resolveConversationParticipants(
         rawParticipants,
@@ -1263,7 +1313,10 @@ class DmRepository {
       // Reject self-conversations (all participants are the same pubkey).
       // Defense-in-depth: should not happen after the self-wrap fix above,
       // but guards against any future code path producing degenerate lists.
-      if (participants.toSet().length < 2) return;
+      if (participants.toSet().length < 2) {
+        await _recordProcessedWrap(giftWrapEvent.id);
+        return;
+      }
 
       final conversationId = computeConversationId(participants);
 
@@ -1283,7 +1336,9 @@ class DmRepository {
           : null;
 
       // Cross-protocol dedup: if a NIP-04 copy of this message was
-      // processed first (network reordering), skip the duplicate.
+      // processed first (network reordering), skip the duplicate. Record the
+      // wrap so the skipped NIP-17 copy is not re-decrypted every launch.
+      // #5452.
       final isDuplicate = await _directMessagesDao.hasMatchingMessage(
         conversationId: conversationId,
         senderPubkey: rumor.pubkey,
@@ -1292,6 +1347,7 @@ class DmRepository {
         ownerPubkey: _userPubkey,
       );
       if (isDuplicate) {
+        await _recordProcessedWrap(giftWrapEvent.id);
         return;
       }
 
@@ -1401,7 +1457,7 @@ class DmRepository {
     final pending = <Event>[];
     for (final event in events) {
       if (event.kind != EventKind.giftWrap) continue;
-      if (await _directMessagesDao.hasGiftWrap(event.id)) continue;
+      if (await _alreadyProcessed(event.id)) continue;
       pending.add(event);
     }
     if (pending.isEmpty) return const {};
@@ -1476,7 +1532,7 @@ class DmRepository {
     final pending = <Event>[];
     for (final event in events) {
       if (event.kind != EventKind.giftWrap) continue;
-      if (await _directMessagesDao.hasGiftWrap(event.id)) continue;
+      if (await _alreadyProcessed(event.id)) continue;
       pending.add(event);
     }
     if (pending.isEmpty) return const {};

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1291,6 +1291,10 @@ class DmRepository {
 
       // Accept kind 14 (text) and kind 15 (file). Any other kind is terminally
       // unsupported — record it so it is not re-decrypted on every launch.
+      // Note: the ledger survives upgrades, so a future version that adds
+      // support for a new kind will not reprocess wraps already recorded here;
+      // such a kind would need a one-off backfill. Acceptable vs. re-decrypting
+      // every unknown wrap on every launch today. #5452.
       if (!_supportedDmKinds.contains(rumor.kind)) {
         await _recordProcessedWrap(giftWrapEvent.id);
         return;

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -872,7 +872,7 @@ void main() {
       ).thenAnswer((_) async => makeRow(reactorPubkey: _otherPubkey));
 
       final repository = createRepository();
-      await repository.handleIncomingDeletion(
+      final outcome = await repository.handleIncomingDeletion(
         rumorEvent: reactionRumor(
           kind: EventKind.eventDeletion,
           content: '',
@@ -884,6 +884,9 @@ void main() {
         giftWrapId: _giftWrapId,
       );
 
+      // An invalid deletion (author mismatch) will never apply — it is
+      // terminal, so the wrap is recorded and not re-decrypted. #5452.
+      expect(outcome, DmReactionWrapOutcome.processed);
       verifyNever(
         () => mockDao.softDelete(
           id: any(named: 'id'),
@@ -891,6 +894,82 @@ void main() {
         ),
       );
     });
+
+    test(
+      'handleIncomingDeletion defers when the target reaction has not synced',
+      () async {
+        // NIP-59 randomizes gift-wrap created_at, so a deletion can drain
+        // before the reaction it removes. With the target row absent, recording
+        // the deletion as terminal would let the reaction insert live later and
+        // never be soft-deleted. Defer instead so the wrap re-decrypts and
+        // applies once the reaction lands. #5452.
+        when(
+          () =>
+              mockDao.getById(id: _reactionRumorId, ownerPubkey: _ownerPubkey),
+        ).thenAnswer((_) async => null);
+
+        final repository = createRepository();
+        final outcome = await repository.handleIncomingDeletion(
+          rumorEvent: reactionRumor(
+            kind: EventKind.eventDeletion,
+            content: '',
+            tags: [
+              ['e', _reactionRumorId],
+              ['k', EventKind.reaction.toString()],
+            ],
+          ),
+          giftWrapId: _giftWrapId,
+        );
+
+        expect(outcome, DmReactionWrapOutcome.deferred);
+        verifyNever(
+          () => mockDao.softDelete(
+            id: any(named: 'id'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'handleIncomingDeletion defers and reports on a soft-delete failure',
+      () async {
+        when(
+          () =>
+              mockDao.getById(id: _reactionRumorId, ownerPubkey: _ownerPubkey),
+        ).thenAnswer((_) async => makeRow());
+        when(
+          () => mockDao.softDelete(
+            id: _reactionRumorId,
+            ownerPubkey: _ownerPubkey,
+          ),
+        ).thenThrow(StateError('boom'));
+
+        final repository = createRepository();
+        final outcome = await repository.handleIncomingDeletion(
+          rumorEvent: reactionRumor(
+            kind: EventKind.eventDeletion,
+            content: '',
+            tags: [
+              ['e', _reactionRumorId],
+              ['k', EventKind.reaction.toString()],
+            ],
+          ),
+          giftWrapId: _giftWrapId,
+        );
+
+        // A transient DAO failure must NOT cement a skip — leave it deferred so
+        // the wrap retries on a later launch. #5452.
+        expect(outcome, DmReactionWrapOutcome.deferred);
+        expect(
+          reporterSites,
+          contains(
+            DmReactionsRepositoryReportableSites
+                .handleIncomingDeletionSoftDelete,
+          ),
+        );
+      },
+    );
 
     group('group reactions', () {
       const thirdPubkey =

--- a/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_reactions_repository_test.dart
@@ -686,11 +686,13 @@ void main() {
     test('persistIncoming validates event shape before upsert', () async {
       final repository = createRepository();
 
-      await repository.persistIncoming(
+      // Malformed content / missing e-tag are permanent drops — terminal, so
+      // the wrap is recorded (processed) and not re-decrypted. #5452.
+      final emptyContentOutcome = await repository.persistIncoming(
         rumorEvent: reactionRumor(content: ''),
         giftWrapId: _giftWrapId,
       );
-      await repository.persistIncoming(
+      final missingTagOutcome = await repository.persistIncoming(
         rumorEvent: reactionRumor(
           tags: [
             ['p', _otherPubkey],
@@ -698,6 +700,9 @@ void main() {
         ),
         giftWrapId: _giftWrapId,
       );
+
+      expect(emptyContentOutcome, DmReactionWrapOutcome.processed);
+      expect(missingTagOutcome, DmReactionWrapOutcome.processed);
 
       verifyNever(
         () => mockDao.upsertIncoming(
@@ -730,11 +735,12 @@ void main() {
       ).thenAnswer((_) async {});
 
       final repository = createRepository();
-      await repository.persistIncoming(
+      final outcome = await repository.persistIncoming(
         rumorEvent: reactionRumor(),
         giftWrapId: _giftWrapId,
       );
 
+      expect(outcome, DmReactionWrapOutcome.processed);
       verify(
         () => mockDao.upsertIncoming(
           id: _reactionRumorId,
@@ -766,11 +772,14 @@ void main() {
       ).thenThrow(StateError('boom'));
 
       final repository = createRepository();
-      await repository.persistIncoming(
+      final outcome = await repository.persistIncoming(
         rumorEvent: reactionRumor(),
         giftWrapId: _giftWrapId,
       );
 
+      // A transient DAO failure must NOT cement a skip — leave it deferred so
+      // the wrap retries on a later launch. #5452.
+      expect(outcome, DmReactionWrapOutcome.deferred);
       expect(
         reporterSites,
         contains(
@@ -778,6 +787,45 @@ void main() {
         ),
       );
     });
+
+    test(
+      'persistIncoming returns deferred when the conversation cannot be '
+      'resolved (target not synced)',
+      () async {
+        // A third-party reaction (neither reactor nor target author is us) with
+        // no synced target message: the conversation cannot be inferred, so the
+        // wrap is left undecided to re-decrypt and land later. #5452.
+        const thirdPubkey =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        final repository = createRepository();
+
+        final outcome = await repository.persistIncoming(
+          rumorEvent: reactionRumor(
+            reactorPubkey: _otherPubkey,
+            tags: [
+              ['e', _targetMessageId],
+              ['p', thirdPubkey],
+            ],
+          ),
+          giftWrapId: _giftWrapId,
+        );
+
+        expect(outcome, DmReactionWrapOutcome.deferred);
+        verifyNever(
+          () => mockDao.upsertIncoming(
+            id: any(named: 'id'),
+            conversationId: any(named: 'conversationId'),
+            targetMessageId: any(named: 'targetMessageId'),
+            targetMessageAuthor: any(named: 'targetMessageAuthor'),
+            reactorPubkey: any(named: 'reactorPubkey'),
+            emoji: any(named: 'emoji'),
+            createdAt: any(named: 'createdAt'),
+            giftWrapId: any(named: 'giftWrapId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      },
+    );
 
     test(
       'handleIncomingDeletion soft-deletes matching reaction rows',
@@ -794,7 +842,7 @@ void main() {
         ).thenAnswer((_) async => 1);
 
         final repository = createRepository();
-        await repository.handleIncomingDeletion(
+        final outcome = await repository.handleIncomingDeletion(
           rumorEvent: reactionRumor(
             kind: EventKind.eventDeletion,
             content: '',
@@ -806,6 +854,9 @@ void main() {
           giftWrapId: _giftWrapId,
         );
 
+        // Terminal: the deletion wrap is recorded so it is not re-decrypted on
+        // every launch. #5452.
+        expect(outcome, DmReactionWrapOutcome.processed);
         verify(
           () => mockDao.softDelete(
             id: _reactionRumorId,

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -153,6 +153,26 @@ Future<Event> _buildForgedSealGiftWrap({
 
 class _MockPendingGiftWrapsDao extends Mock implements PendingGiftWrapsDao {}
 
+/// In-memory [ProcessedGiftWrapsDao] backed by a [Set] of gift-wrap ids, so a
+/// repository test can prove a re-delivered wrap is not re-decrypted without a
+/// real Drift database. Mirrors the global (owner-agnostic) dedup contract.
+class _InMemoryProcessedGiftWrapsDao extends Mock
+    implements ProcessedGiftWrapsDao {
+  final Set<String> recorded = <String>{};
+
+  @override
+  Future<bool> hasGiftWrap(String giftWrapId) async =>
+      recorded.contains(giftWrapId);
+
+  @override
+  Future<void> record({
+    required String giftWrapId,
+    String? ownerPubkey,
+  }) async {
+    recorded.add(giftWrapId);
+  }
+}
+
 class _FakeOutgoingDm extends Fake implements OutgoingDm {}
 
 class _MockNostrClient extends Mock implements NostrClient {}
@@ -443,6 +463,7 @@ void main() {
       DmSyncState? syncState,
       OutgoingDmsDao? outgoingDmsDao,
       PendingGiftWrapsDao? pendingGiftWrapsDao,
+      ProcessedGiftWrapsDao? processedGiftWrapsDao,
       DmReactionsRepository? reactionsRepository,
       NostrSigner? signer,
       DmDecryptIsolateSpawner? decryptIsolateSpawner,
@@ -455,6 +476,7 @@ void main() {
         conversationsDao: mockConversationsDao,
         outgoingDmsDao: outgoingDmsDao,
         pendingGiftWrapsDao: pendingGiftWrapsDao,
+        processedGiftWrapsDao: processedGiftWrapsDao,
         userPubkey: userPubkey ?? _validPubkeyA,
         signer: signer ?? LocalNostrSigner(_validPrivateKey),
         rumorDecryptor: rumorDecryptor,
@@ -8349,7 +8371,7 @@ void main() {
               rumorEvent: any(named: 'rumorEvent'),
               giftWrapId: _giftWrapEventId,
             ),
-          ).thenAnswer((_) async {});
+          ).thenAnswer((_) async => DmReactionWrapOutcome.processed);
 
           final repository = createRepository(
             reactionsRepository: mockReactionsRepository,
@@ -8402,6 +8424,178 @@ void main() {
               thumbnailUrl: any(named: 'thumbnailUrl'),
             ),
           );
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+    });
+
+    group('receive pipeline - processed-wrap dedup ledger (#5452)', () {
+      Event giftWrap() => Event.fromJson({
+        'id': _giftWrapEventId,
+        'pubkey': _validPubkeyC,
+        'created_at': 1700000100,
+        'kind': EventKind.giftWrap,
+        'tags': [
+          ['p', _validPubkeyA],
+        ],
+        'content': 'wrapped',
+        'sig': '',
+      });
+
+      Event reactionRumor() => Event.fromJson({
+        'id': _rumorEventId,
+        'pubkey': _validPubkeyB,
+        'created_at': 1700000000,
+        'kind': EventKind.reaction,
+        'tags': [
+          ['e', _giftWrapEventId2],
+          ['p', _validPubkeyA],
+        ],
+        'content': '❤️',
+        'sig': '',
+      });
+
+      Event deletionRumor() => Event.fromJson({
+        'id': _rumorEventId,
+        'pubkey': _validPubkeyB,
+        'created_at': 1700000000,
+        'kind': EventKind.eventDeletion,
+        'tags': [
+          ['e', _giftWrapEventId2],
+          ['k', EventKind.reaction.toString()],
+        ],
+        'content': '',
+        'sig': '',
+      });
+
+      late StreamController<Event> controller;
+      late _InMemoryProcessedGiftWrapsDao ledger;
+
+      setUp(() {
+        controller = StreamController<Event>();
+        ledger = _InMemoryProcessedGiftWrapsDao();
+        when(
+          () => mockNostrClient.subscribe(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+          ),
+        ).thenAnswer((_) => controller.stream);
+        when(() => mockNostrClient.unsubscribe(any())).thenAnswer((_) async {});
+        // Reactions/deletions never leave a directMessages dedup row, so the
+        // message-table check is always false for these wraps.
+        when(
+          () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+        ).thenAnswer((_) async => false);
+      });
+
+      Future<void> deliverTwice(Event wrap) async {
+        controller.add(wrap);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        controller.add(wrap);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      test(
+        'a re-delivered reaction wrap is decrypted only once (recorded in '
+        'the ledger after the first terminal persist)',
+        () async {
+          when(
+            () => mockReactionsRepository.persistIncoming(
+              rumorEvent: any(named: 'rumorEvent'),
+              giftWrapId: _giftWrapEventId,
+            ),
+          ).thenAnswer((_) async => DmReactionWrapOutcome.processed);
+
+          var decryptCount = 0;
+          final repository = createRepository(
+            processedGiftWrapsDao: ledger,
+            reactionsRepository: mockReactionsRepository,
+            rumorDecryptor: (_, _) async {
+              decryptCount++;
+              return reactionRumor();
+            },
+          );
+          await repository.startListening();
+
+          await deliverTwice(giftWrap());
+
+          expect(decryptCount, 1);
+          expect(ledger.recorded, contains(_giftWrapEventId));
+          verify(
+            () => mockReactionsRepository.persistIncoming(
+              rumorEvent: any(named: 'rumorEvent'),
+              giftWrapId: _giftWrapEventId,
+            ),
+          ).called(1);
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      test(
+        'a re-delivered deletion wrap is decrypted only once',
+        () async {
+          when(
+            () => mockReactionsRepository.handleIncomingDeletion(
+              rumorEvent: any(named: 'rumorEvent'),
+              giftWrapId: _giftWrapEventId,
+            ),
+          ).thenAnswer((_) async => DmReactionWrapOutcome.processed);
+
+          var decryptCount = 0;
+          final repository = createRepository(
+            processedGiftWrapsDao: ledger,
+            reactionsRepository: mockReactionsRepository,
+            rumorDecryptor: (_, _) async {
+              decryptCount++;
+              return deletionRumor();
+            },
+          );
+          await repository.startListening();
+
+          await deliverTwice(giftWrap());
+
+          expect(decryptCount, 1);
+          expect(ledger.recorded, contains(_giftWrapEventId));
+
+          await controller.close();
+          await repository.stopListening();
+        },
+      );
+
+      test(
+        'an unresolved reaction (deferred) is NOT recorded and re-decrypts on '
+        'redelivery — preserving eventual consistency',
+        () async {
+          // conversationId == null in production maps to deferred: the target
+          // message has not synced yet, so the wrap must stay decryptable.
+          when(
+            () => mockReactionsRepository.persistIncoming(
+              rumorEvent: any(named: 'rumorEvent'),
+              giftWrapId: _giftWrapEventId,
+            ),
+          ).thenAnswer((_) async => DmReactionWrapOutcome.deferred);
+
+          var decryptCount = 0;
+          final repository = createRepository(
+            processedGiftWrapsDao: ledger,
+            reactionsRepository: mockReactionsRepository,
+            rumorDecryptor: (_, _) async {
+              decryptCount++;
+              return reactionRumor();
+            },
+          );
+          await repository.startListening();
+
+          await deliverTwice(giftWrap());
+
+          expect(decryptCount, 2);
+          expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
 
           await controller.close();
           await repository.stopListening();


### PR DESCRIPTION
## Description

NIP-17 reaction (kind 7) and deletion (kind 5) gift wraps were re-decrypted on **every app start**. The pre-decrypt dedup check (`_directMessagesDao.hasGiftWrap`) only queries the `directMessages` table, but reactions and deletions return early from the shared persist chokepoint `_persistDecryptedGiftWrap` **without writing a message row**, so they were never recognized as already-processed. On remote-signer (Keycast) accounts each redundant decrypt is two serial network RPCs, making DM startup take minutes. The missing dedup row has been present since reactions shipped (#4633), not a regression.

**Fix — a global `processed_gift_wraps` dedup ledger (Approach A, alongside):**
- New `db_client` table + `ProcessedGiftWrapsDao` (`gift_wrap_id` PRIMARY KEY, global / not owner-scoped — matching `directMessages.hasGiftWrap`'s deliberate global contract), added via the existing idempotent `_createMissingTables` pattern (precedent: `pending_gift_wraps`).
- `dm_repository` records every **terminally-processed** wrap whose rumor writes no message row (reactions, deletions, unsupported kinds, cross-protocol dups, degenerate participants), and OR-checks the ledger alongside the message dedup in all three pre-decrypt paths.
- Text/file messages (kind 14/15) keep their existing `directMessages` dedup untouched — **no backfill, no first-launch re-decrypt of message history**.
- **Eventual-consistency preserved (D4-terminal):** a reaction whose target message hasn't synced yet is left *unrecorded*, so it re-decrypts and lands once the message arrives. `persistIncoming` / `handleIncomingDeletion` now return a `DmReactionWrapOutcome` (`processed` / `deferred`) to drive this.
- The ledger row is written **after** the outcome write, so a crash in between only ever costs a benign re-decrypt — never a lost reaction/deletion.
- The ledger is wiped on the same DM account-cleanup path as `direct_messages` / `pending_gift_wraps`, so a stale ledger can never suppress re-population after a DM-data reset.

**Related Issue:** Closes #5452

## Out of Scope

- Subsuming the kind-14/15 message dedup into the ledger (Approach B) — pure cleanup on top of this fix; intentionally deferred.
- Failed decrypts stay in the `pending_gift_wraps` retry queue (#5202); the ledger records successful/terminal outcomes only.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `db_client` suite (688 tests), `dm_repository` suite (239), `dm_reactions_repository` (23), `user_data_cleanup_service` (25) — all green.
- New tests: `processed_gift_wraps_dao_test.dart` (idempotent / global / clearAll); two schema-parity tests pinning the runtime `CREATE TABLE` against Drift's `createAll()`; repository regression tests proving a re-delivered kind-7 **and** kind-5 wrap is decrypted exactly once, and a deferred (unresolved) reaction re-decrypts and is not recorded; plus outcome-contract assertions on the reactions repo.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
