### PR TITLE
fix(video_editor): prevent text layer shrinking when adding many paint layers

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1800,10 +1800,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: f5fb9940af7e6922dbe154726951a279fbea22549d91b338a15aaa9fe4923caf
+      sha256: c17cc3dd3f7f70c504bff3cc11cbc47dd19f35af7531d14f4bf46d073018d114
       url: "https://pub.dev"
     source: hosted
-    version: "12.5.1"
+    version: "12.5.3"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -303,7 +303,7 @@ dependencies:
   convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^1.19.1
-  pro_image_editor: ^12.5.1
+  pro_image_editor: ^12.5.3
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0


### PR DESCRIPTION
Closes #5460

## Description

Fixes a bug in the video editor where the **text layer** (and the earliest
paint strokes) **shrink** after a single paint session adds many layers
(≥10 drawings/paintings in one go). Adding a single drawing has no visible
effect.

Root cause is in `pro_image_editor`: the paint-editor history loop reused
the same `Layer` instances across every history entry it created (an
O(N²)-avoidance optimization). The engine's per-entry, in-place rescalers
then mutated each shared instance once per entry, compounding `scale` by
`scaleFactor^N` on the oldest layer — the text layer, which is present in
every entry. The more layers added in one session, the stronger the shrink.

The actual fix was made in `pro_image_editor` (the rescalers now dedup
layers by object identity, so each instance is rescaled at most once) and
shipped in **12.5.3**. This PR is therefore only the dependency update
(`^12.5.1` → `^12.5.3`).

**Related Issue:** 

## Out of Scope

None — the fix lives in `pro_image_editor`; this repo only updates the
dependency.

## Verification

- `flutter pub get` — resolves `pro_image_editor` to `12.5.3`
- `flutter analyze lib` — No issues found (no public-API breakage)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change