### PR TITLE
fix(db): match local nostr tag filters exactly

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -427,21 +427,21 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
   ) {
     if (values == null || values.isEmpty) return;
 
-    final tagConditions = values.map((value) {
-      variables
-        ..add(Variable.withString(tagName))
-        ..add(Variable.withString(value));
-      return r'''
-        EXISTS (
-          SELECT 1
-          FROM json_each(e.tags) AS tag
-          WHERE json_extract(tag.value, '$[0]') COLLATE BINARY = ?
-            AND json_extract(tag.value, '$[1]') COLLATE BINARY = ?
-        )
-      ''';
-    }).toList();
+    final placeholders = List.filled(values.length, '?').join(', ');
+    variables
+      ..add(Variable.withString(tagName))
+      ..addAll(values.map(Variable.withString));
 
-    conditions.add('(${tagConditions.join(' OR ')})');
+    conditions.add(
+      '''
+      EXISTS (
+        SELECT 1
+        FROM json_each(e.tags) AS tag
+        WHERE json_extract(tag.value, '\$[0]') COLLATE BINARY = ?
+          AND json_extract(tag.value, '\$[1]') COLLATE BINARY IN ($placeholders)
+      )
+      ''',
+    );
   }
 
   /// Get a single event by ID.

--- a/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/nostr_events_dao.dart
@@ -267,7 +267,12 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
   /// - t: List of hashtags to filter by (searches tags JSON)
   /// - e: List of referenced event IDs (e tags)
   /// - p: List of mentioned pubkeys (p tags)
+  /// - h: List of relay-specific values (h tags)
   /// - d: List of addressable event identifiers (d tags)
+  /// - a: List of addressable event references (a tags)
+  /// - uppercaseE: List of root event IDs (E tags)
+  /// - uppercaseA: List of root addressable event references (A tags)
+  /// - uppercaseK: List of root event kind values (K tags)
   /// - search: Full-text search in content (NIP-50)
   /// - since: Minimum created_at timestamp (Unix seconds)
   /// - until: Maximum created_at timestamp (Unix seconds)
@@ -328,89 +333,15 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
       variables.addAll(authors.map(Variable.withString));
     }
 
-    // Hashtags filter (t tags)
-    final hashtags = filter.t;
-    if (hashtags != null && hashtags.isNotEmpty) {
-      final hashtagConditions = hashtags.map((tag) {
-        final lowerTag = tag.toLowerCase();
-        variables.add(Variable.withString('%"t"%"$lowerTag"%'));
-        return 'tags LIKE ?';
-      }).toList();
-      conditions.add('(${hashtagConditions.join(' OR ')})');
-    }
-
-    // Referenced events filter (e tags)
-    final eTags = filter.e;
-    if (eTags != null && eTags.isNotEmpty) {
-      final eTagConditions = eTags.map((eventId) {
-        variables.add(Variable.withString('%"e"%"$eventId"%'));
-        return 'tags LIKE ?';
-      }).toList();
-      conditions.add('(${eTagConditions.join(' OR ')})');
-    }
-
-    // Referenced addressable events filter (a tags)
-    final aTags = filter.a;
-    if (aTags != null && aTags.isNotEmpty) {
-      final aTagConditions = aTags.map((addressableId) {
-        variables.add(Variable.withString('%"a"%"$addressableId"%'));
-        return 'tags LIKE ?';
-      }).toList();
-      conditions.add('(${aTagConditions.join(' OR ')})');
-    }
-
-    // Mentioned pubkeys filter (p tags)
-    final pTags = filter.p;
-    if (pTags != null && pTags.isNotEmpty) {
-      final pTagConditions = pTags.map((pubkey) {
-        variables.add(Variable.withString('%"p"%"$pubkey"%'));
-        return 'tags LIKE ?';
-      }).toList();
-      conditions.add('(${pTagConditions.join(' OR ')})');
-    }
-
-    // Addressable event identifiers filter (d tags)
-    final dTags = filter.d;
-    if (dTags != null && dTags.isNotEmpty) {
-      final dTagConditions = dTags.map((identifier) {
-        variables.add(Variable.withString('%"d"%"$identifier"%'));
-        return 'tags LIKE ?';
-      }).toList();
-      conditions.add('(${dTagConditions.join(' OR ')})');
-    }
-
-    // Uppercase E tags (NIP-22 root event reference)
-    // Use GLOB for case-sensitive matching (LIKE is case-insensitive in SQLite)
-    final uppercaseETags = filter.uppercaseE;
-    if (uppercaseETags != null && uppercaseETags.isNotEmpty) {
-      final eTagConditions = uppercaseETags.map((eventId) {
-        variables.add(Variable.withString('*"E"*"$eventId"*'));
-        return 'tags GLOB ?';
-      }).toList();
-      conditions.add('(${eTagConditions.join(' OR ')})');
-    }
-
-    // Uppercase A tags (NIP-22 root addressable event reference)
-    // Use GLOB for case-sensitive matching (LIKE is case-insensitive in SQLite)
-    final uppercaseATags = filter.uppercaseA;
-    if (uppercaseATags != null && uppercaseATags.isNotEmpty) {
-      final aTagConditions = uppercaseATags.map((addressableId) {
-        variables.add(Variable.withString('*"A"*"$addressableId"*'));
-        return 'tags GLOB ?';
-      }).toList();
-      conditions.add('(${aTagConditions.join(' OR ')})');
-    }
-
-    // Uppercase K tags (NIP-22 root event kind)
-    // Use GLOB for case-sensitive matching (LIKE is case-insensitive in SQLite)
-    final uppercaseKTags = filter.uppercaseK;
-    if (uppercaseKTags != null && uppercaseKTags.isNotEmpty) {
-      final kTagConditions = uppercaseKTags.map((kind) {
-        variables.add(Variable.withString('*"K"*"$kind"*'));
-        return 'tags GLOB ?';
-      }).toList();
-      conditions.add('(${kTagConditions.join(' OR ')})');
-    }
+    _addExactTagCondition('t', filter.t, conditions, variables);
+    _addExactTagCondition('e', filter.e, conditions, variables);
+    _addExactTagCondition('p', filter.p, conditions, variables);
+    _addExactTagCondition('h', filter.h, conditions, variables);
+    _addExactTagCondition('d', filter.d, conditions, variables);
+    _addExactTagCondition('a', filter.a, conditions, variables);
+    _addExactTagCondition('E', filter.uppercaseE, conditions, variables);
+    _addExactTagCondition('A', filter.uppercaseA, conditions, variables);
+    _addExactTagCondition('K', filter.uppercaseK, conditions, variables);
 
     // Content search filter (NIP-50 style, case insensitive)
     final search = filter.search;
@@ -486,6 +417,31 @@ class NostrEventsDao extends DatabaseAccessor<AppDatabase>
       variables: variables,
       readsFrom: needsMetricsJoin ? {nostrEvents, videoMetrics} : {nostrEvents},
     );
+  }
+
+  void _addExactTagCondition(
+    String tagName,
+    List<String>? values,
+    List<String> conditions,
+    List<Variable> variables,
+  ) {
+    if (values == null || values.isEmpty) return;
+
+    final tagConditions = values.map((value) {
+      variables
+        ..add(Variable.withString(tagName))
+        ..add(Variable.withString(value));
+      return r'''
+        EXISTS (
+          SELECT 1
+          FROM json_each(e.tags) AS tag
+          WHERE json_extract(tag.value, '$[0]') COLLATE BINARY = ?
+            AND json_extract(tag.value, '$[1]') COLLATE BINARY = ?
+        )
+      ''';
+    }).toList();
+
+    conditions.add('(${tagConditions.join(' OR ')})');
   }
 
   /// Get a single event by ID.

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -325,6 +325,27 @@ void main() {
         expect(results.first.id, equals(event1.id));
       });
 
+      test('filters by multiple hashtags with OR logic', () async {
+        final flutterEvent = createVideoEvent(
+          hashtags: ['flutter'],
+          createdAt: 1000,
+        );
+        final dartEvent = createVideoEvent(hashtags: ['dart'], createdAt: 2000);
+        final rustEvent = createVideoEvent(hashtags: ['rust'], createdAt: 3000);
+
+        await dao.upsertEventsBatch([flutterEvent, dartEvent, rustEvent]);
+
+        final results = await dao.getEventsByFilter(
+          Filter(t: ['flutter', 'dart']),
+        );
+
+        expect(results.length, equals(2));
+        expect(
+          results.map((event) => event.id).toSet(),
+          equals({flutterEvent.id, dartEvent.id}),
+        );
+      });
+
       test('filters by e tags (referenced events)', () async {
         const referencedEventId = 'abc123def456';
         final event1 = createEvent(

--- a/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
@@ -402,6 +402,29 @@ void main() {
         expect(results.first.id, equals(event1.id));
       });
 
+      test('filters by h tags (relay-specific values)', () async {
+        const relayValue = 'vine.hol.is';
+        final event1 = createEvent(
+          tags: [
+            ['h', relayValue],
+          ],
+          createdAt: 1000,
+        );
+        final event2 = createEvent(
+          tags: [
+            ['h', 'other-relay-value'],
+          ],
+          createdAt: 2000,
+        );
+
+        await dao.upsertEventsBatch([event1, event2]);
+
+        final results = await dao.getEventsByFilter(Filter(h: [relayValue]));
+
+        expect(results.length, equals(1));
+        expect(results.first.id, equals(event1.id));
+      });
+
       test('filters by d tags (addressable event identifiers)', () async {
         const dTagValue = 'my-unique-identifier';
         final event1 = createEvent(
@@ -638,6 +661,114 @@ void main() {
           results.map((e) => e.id).toSet(),
           equals({event1.id, event2.id}),
         );
+      });
+
+      test('tag filters require exact case-sensitive tag names', () async {
+        const eventId = 'root_video_event_id_123';
+        final lowercaseE = createEvent(
+          tags: [
+            ['e', eventId],
+          ],
+          content: 'lowercase e',
+          createdAt: 1000,
+        );
+        final uppercaseE = createEvent(
+          tags: [
+            ['E', eventId],
+          ],
+          content: 'uppercase E',
+          createdAt: 2000,
+        );
+
+        await dao.upsertEventsBatch([lowercaseE, uppercaseE]);
+
+        final lowercaseResults = await dao.getEventsByFilter(
+          Filter(e: [eventId]),
+        );
+        final uppercaseResults = await dao.getEventsByFilter(
+          Filter(uppercaseE: [eventId]),
+        );
+
+        expect(lowercaseResults.map((event) => event.id), [lowercaseE.id]);
+        expect(uppercaseResults.map((event) => event.id), [uppercaseE.id]);
+      });
+
+      test('tag filters only match the second tag element', () async {
+        const eventId = 'referenced_event_123';
+        final matchingEvent = createEvent(
+          tags: [
+            ['e', eventId],
+          ],
+          content: 'matching second element',
+          createdAt: 1000,
+        );
+        final wrongPosition = createEvent(
+          tags: [
+            ['e', 'different_event', eventId],
+          ],
+          content: 'matching value in third element',
+          createdAt: 2000,
+        );
+
+        await dao.upsertEventsBatch([matchingEvent, wrongPosition]);
+
+        final results = await dao.getEventsByFilter(Filter(e: [eventId]));
+
+        expect(results.map((event) => event.id), [matchingEvent.id]);
+      });
+
+      test('tag filters do not match values across serialized JSON', () async {
+        const eventId = 'referenced_event_456';
+        final matchingEvent = createEvent(
+          tags: [
+            ['e', eventId],
+          ],
+          content: 'matching e tag',
+          createdAt: 1000,
+        );
+        final splitAcrossTags = createEvent(
+          tags: [
+            ['e', 'different_event'],
+            ['p', eventId],
+          ],
+          content: 'e tag name and value in separate tags',
+          createdAt: 2000,
+        );
+
+        await dao.upsertEventsBatch([matchingEvent, splitAcrossTags]);
+
+        final results = await dao.getEventsByFilter(Filter(e: [eventId]));
+
+        expect(results.map((event) => event.id), [matchingEvent.id]);
+      });
+
+      test('tag values are matched case-sensitively', () async {
+        final lowercaseTag = createEvent(
+          tags: [
+            ['t', 'flutter'],
+          ],
+          content: 'lowercase hashtag',
+          createdAt: 1000,
+        );
+        final uppercaseTag = createEvent(
+          tags: [
+            ['t', 'Flutter'],
+          ],
+          content: 'uppercase hashtag',
+          createdAt: 2000,
+        );
+
+        await dao.upsertEventsBatch([lowercaseTag, uppercaseTag]);
+
+        final lowercaseResults = await dao.getEventsByFilter(
+          Filter(t: ['flutter']),
+        );
+        final uppercaseResults = await dao.getEventsByFilter(
+          Filter(t: ['Flutter']),
+        );
+
+        expect(lowercaseResults.map((event) => event.id), [lowercaseTag.id]);
+        expect(uppercaseResults.map((event) => event.id), [uppercaseTag.id]);
       });
 
       test(


### PR DESCRIPTION
## Summary
- Replace serialized JSON LIKE/GLOB tag filtering with exact SQLite JSON1 tag predicates.
- Share one helper across #t, #e, #p, #h, #d, #a, #E, #A, and #K cache filters.
- Add regressions for lowercase/uppercase collisions, wrong tag element matches, cross-tag false positives, case-sensitive values, and #h support.

## Root Cause
Local cache queries searched the JSON-encoded tags column with broad string patterns. SQLite LIKE is case-insensitive by default, and both LIKE and GLOB could match a tag name and value from different positions in the serialized JSON instead of requiring tag[0] and tag[1] to match the Nostr filter.

## Verification
- flutter analyze
- flutter test packages/db_client/test/src/database/daos/nostr_events_dao_test.dart
- pre-push hook: analyzer, generated-file verification, changed-file test

Closes #5461