### PR TITLE
fix(notifications): classify anchored comment replies

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1280,11 +1280,12 @@ class NotificationRepository {
     RelayNotification n,
   ) => switch (mapped) {
     NotificationKind.likeComment || NotificationKind.reply =>
-      // Prefer the referenced (parent) event ID. Fall back to the source
-      // event ID (the reply event itself) when the server omits
-      // referenced_event_id — both carry NIP-22 E-tags the resolver can
-      // walk to find the root video.
-      n.referencedEventId?.isNotEmpty == true
+      // Prefer the explicit parent comment ID. Some Funnelcake reply payloads
+      // carry the root video in referenced_event_id and the actual parent
+      // comment in target_comment_id.
+      n.targetCommentId?.isNotEmpty == true
+          ? n.targetCommentId
+          : n.referencedEventId?.isNotEmpty == true
           ? n.referencedEventId
           : (n.sourceEventId.isNotEmpty ? n.sourceEventId : null),
     NotificationKind.mention =>
@@ -1566,9 +1567,11 @@ class NotificationRepository {
     }
 
     final targetCommentId = n.targetCommentId;
+    if (n.isReferencedVideo && targetCommentId == referencedEventId) {
+      return false;
+    }
     return targetCommentId != null &&
         targetCommentId.isNotEmpty &&
-        !n.isReferencedVideo &&
         n.sourceEventId.isNotEmpty &&
         targetCommentId != n.sourceEventId &&
         targetCommentId != rootEventId;

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1448,6 +1448,28 @@ void main() {
         expect(item.targetEventId, equals('parent_comment_id'));
       });
 
+      test('reply to user comment targets parent comment when '
+          'referencedEventId is the root video', () async {
+        stubNotifications([
+          makeNotification(
+            notificationType: 'reply',
+            sourceKind: 1111,
+            sourceEventId: 'reply_event_id',
+            referencedEventId: 'someone_else_video_id',
+            rootEventId: 'someone_else_video_id',
+            targetCommentId: 'parent_comment_id',
+            content: 'Reply with video anchor',
+          ),
+        ]);
+        stubProfiles({});
+
+        final page = await repository.getNotifications();
+        final item = page.items.single as ActorNotification;
+        expect(item.type, equals(NotificationKind.reply));
+        expect(item.targetEventId, equals('parent_comment_id'));
+        expect(item.commentText, equals('Reply with video anchor'));
+      });
+
       test('comment-typed nested NIP-22 reply maps to reply '
           '($ActorNotification)', () async {
         stubNotifications([
@@ -1649,7 +1671,7 @@ void main() {
           final item = page.items.single as ActorNotification;
           expect(item.id, equals('reply_evt_id'));
           expect(item.type, equals(NotificationKind.reply));
-          expect(item.targetEventId, equals('reply_evt_id'));
+          expect(item.targetEventId, equals('parent_comment_evt_id'));
           expect(item.commentText, equals('Nested reply from staging payload'));
           expect(item.sourceEventIds, equals(['reply_evt_id']));
         },


### PR DESCRIPTION
## Summary
- classify kind 1111 replies with a distinct target_comment_id as comment replies even when referenced_event_id points at the root video
- prefer target_comment_id for reply/like-comment tap targets so reply notifications resolve through the parent comment
- preserve direct comments on referenced video replies when target_comment_id matches referenced_event_id

Fixes #5436

## Tests
- flutter analyze packages/notification_repository
- flutter test packages/notification_repository/test/src/notification_repository_test.dart
- pre-push hook analyzer + changed notification_repository tests