### PR TITLE
fix(feed): deduplicate addressable videos

### DIFF
--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -365,14 +365,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           .where((v) => v.videoUrl != null)
           .toList();
 
-      // Deduplicate by event ID. Funnelcake and Nostr can return
-      // overlapping videos when Funnelcake runs out and we fall through
-      // to Nostr. Without dedup, feed-level player dedup can cause a
-      // count mismatch that breaks the pagination trigger.
-      final seenIds = <String>{};
+      // Deduplicate by logical video identity. Addressable videos can be
+      // republished with fresh event IDs, and bare d-tags can collide across
+      // authors, so the key is the full addressable coordinate when present.
+      final seenVideoKeys = <String>{};
       final updatedVideos = <VideoEvent>[];
       for (final video in [...state.videos, ...validNewVideos]) {
-        if (seenIds.add(video.id)) {
+        if (seenVideoKeys.add(video.feedDedupKey)) {
           updatedVideos.add(video);
         }
       }

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -286,9 +286,7 @@ class VideoEvent {
       textTrackRef: textTrackRef,
       textTrackRefs: textTrackRefs.isNotEmpty
           ? textTrackRefs
-          : [
-              if (textTrackRef != null && textTrackRef.isNotEmpty) textTrackRef,
-            ],
+          : [if (textTrackRef != null && textTrackRef.isNotEmpty) textTrackRef],
       textTrackContent: json['textTrackContent'] as String?,
       contentWarningLabels: stringList(json['contentWarningLabels']),
       moderationLabels: stringList(json['moderationLabels']),
@@ -1151,6 +1149,13 @@ class VideoEvent {
           dTag: vineId!,
         ).toAString()
       : null;
+
+  /// Canonical identity for feed/session deduplication.
+  ///
+  /// Addressable short-video events can be republished with a new event id
+  /// while still representing the same logical `kind:pubkey:d-tag` video.
+  /// Falling back to [id] preserves behavior for non-addressable/legacy rows.
+  String get feedDedupKey => (addressableId ?? id).toLowerCase();
 
   /// ProofMode: Check if video has any proof
   bool get hasProofMode {

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -285,7 +285,7 @@ class VideosRepository {
   }) async {
     var cursor = until;
     final visible = <VideoEvent>[];
-    final seenIds = <String>{};
+    final seenVideoKeys = <String>{};
 
     // Intentionally walk until we have enough visible videos or the upstream
     // feed is exhausted. A hard page cap caused premature EOF on reply-dense
@@ -299,7 +299,11 @@ class VideosRepository {
 
       final videos = _transformVideoStats(response.videos);
       final hydratedVideos = await _hydrateVideosWithBulkStats(videos);
-      _appendUniqueVideos(visible, hydratedVideos, seenIds: seenIds);
+      _appendUniqueVideos(
+        visible,
+        hydratedVideos,
+        seenVideoKeys: seenVideoKeys,
+      );
       if (response.videos.length < limit || !response.hasMore) break;
 
       final nextCursor =
@@ -322,7 +326,7 @@ class VideosRepository {
 
     var cursor = until;
     final visible = <VideoEvent>[];
-    final seenIds = <String>{};
+    final seenVideoKeys = <String>{};
 
     while (visible.length < limit) {
       final filter = Filter(
@@ -339,7 +343,7 @@ class VideosRepository {
       _appendUniqueVideos(
         visible,
         await _hydrateVideosWithBulkStats(videos),
-        seenIds: seenIds,
+        seenVideoKeys: seenVideoKeys,
       );
       if (events.length < limit) break;
 
@@ -446,9 +450,12 @@ class VideosRepository {
     required List<VideoEvent> followingVideos,
     required Map<String, List<String>> videoRefs,
   }) async {
-    // Build set of following video IDs for dedup (case-insensitive)
-    final followingVideoIds = <String>{
-      for (final v in followingVideos) v.id.toLowerCase(),
+    // Build set of following video identities for dedup.
+    final followingVideoKeys = <String>{
+      for (final v in followingVideos) v.feedDedupKey,
+    };
+    final followingVideoIdsByKey = <String, String>{
+      for (final v in followingVideos) v.feedDedupKey: v.id,
     };
 
     // Flatten all refs and separate by type
@@ -487,19 +494,8 @@ class VideosRepository {
       resultIndex++;
     }
     if (uniqueAddressableIds.isNotEmpty) {
-      // getVideosByAddressableIds returns videos in the same order as
-      // the input list (omitting not-found). Build a vineId → ref
-      // reverse lookup to map fetched videos back to their refs.
-      final vineIdToRef = <String, String>{};
-      for (final ref in uniqueAddressableIds) {
-        final parsed = AId.fromString(ref);
-        if (parsed != null) {
-          vineIdToRef[parsed.dTag] = ref;
-        }
-      }
       for (final video in results[resultIndex]) {
-        final dTag = video.vineId ?? '';
-        final ref = vineIdToRef[dTag];
+        final ref = video.addressableId;
         if (ref != null) {
           refToVideo[ref] = video;
         }
@@ -510,23 +506,26 @@ class VideosRepository {
     final videoListSources = <String, Set<String>>{};
     final listOnlyVideoIds = <String>{};
     final listOnlyVideos = <VideoEvent>[];
-    final seenListVideoIds = <String>{};
+    final seenListVideoKeys = <String>{};
 
     for (final entry in videoRefs.entries) {
       final listId = entry.key;
       for (final ref in entry.value) {
         final video = refToVideo[ref];
         if (video == null) continue;
+        final displayedVideoId = followingVideoIdsByKey[video.feedDedupKey];
 
         // Track which lists reference this video
-        videoListSources.putIfAbsent(video.id, () => <String>{}).add(listId);
+        videoListSources
+            .putIfAbsent(displayedVideoId ?? video.id, () => <String>{})
+            .add(listId);
 
         // If not from following, it's list-only
-        if (!followingVideoIds.contains(video.id.toLowerCase())) {
+        if (!followingVideoKeys.contains(video.feedDedupKey)) {
           listOnlyVideoIds.add(video.id);
 
           // Add to merge list (dedup across lists)
-          if (seenListVideoIds.add(video.id.toLowerCase())) {
+          if (seenListVideoKeys.add(video.feedDedupKey)) {
             listOnlyVideos.add(video);
           }
         }
@@ -583,16 +582,8 @@ class VideosRepository {
       resultIndex++;
     }
     if (addressableIds.isNotEmpty) {
-      final vineIdToRef = <String, String>{};
-      for (final ref in addressableIds) {
-        final parsed = AId.fromString(ref);
-        if (parsed != null) {
-          vineIdToRef[parsed.dTag] = ref;
-        }
-      }
       for (final video in results[resultIndex]) {
-        final dTag = video.vineId ?? '';
-        final ref = vineIdToRef[dTag];
+        final ref = video.addressableId;
         if (ref != null) {
           refToVideo[ref] = video;
         }
@@ -600,7 +591,9 @@ class VideosRepository {
     }
 
     // Return in ref order, omitting unresolved refs
-    return [for (final ref in videoRefs) ?refToVideo[ref]];
+    return deduplicateVideosPreservingOrder([
+      for (final ref in videoRefs) ?refToVideo[ref],
+    ]);
   }
 
   /// Fetches videos published by a specific author.
@@ -696,7 +689,7 @@ class VideosRepository {
   }) async {
     var cursor = until;
     final visible = <VideoEvent>[];
-    final seenIds = <String>{};
+    final seenVideoKeys = <String>{};
 
     while (visible.length < limit) {
       final videoStats = await _funnelcakeApiClient!.getRecentVideos(
@@ -705,7 +698,7 @@ class VideosRepository {
       );
 
       final videos = _transformVideoStats(videoStats);
-      _appendUniqueVideos(visible, videos, seenIds: seenIds);
+      _appendUniqueVideos(visible, videos, seenVideoKeys: seenVideoKeys);
 
       if (videoStats.length < limit) break;
 
@@ -723,7 +716,7 @@ class VideosRepository {
   }) async {
     var cursor = until;
     final visible = <VideoEvent>[];
-    final seenIds = <String>{};
+    final seenVideoKeys = <String>{};
 
     while (visible.length < limit) {
       final filter = Filter(kinds: [_videoKind], limit: limit, until: cursor);
@@ -731,7 +724,7 @@ class VideosRepository {
       if (events.isEmpty) break;
 
       final videos = _transformAndFilter(events);
-      _appendUniqueVideos(visible, videos, seenIds: seenIds);
+      _appendUniqueVideos(visible, videos, seenVideoKeys: seenVideoKeys);
       if (events.length < limit) break;
 
       final nextCursor = _cursorBeforeOldestEvent(events);
@@ -790,7 +783,7 @@ class VideosRepository {
       var pageCursor = legacyBeforeCursor == null ? cursor : null;
       var before = legacyBeforeCursor ?? (cursor == null ? until : null);
       final visible = <VideoEvent>[];
-      final seenIds = <String>{};
+      final seenVideoKeys = <String>{};
       String? nextPageCursor;
 
       while (visible.length < limit) {
@@ -825,7 +818,7 @@ class VideosRepository {
           ),
           variant,
         );
-        _appendUniqueVideos(visible, pageVideos, seenIds: seenIds);
+        _appendUniqueVideos(visible, pageVideos, seenVideoKeys: seenVideoKeys);
 
         final fallbackBefore = _cursorBeforeOldestStats(stats);
         final fallbackCursor = fallbackBefore == null
@@ -1444,10 +1437,10 @@ class VideosRepository {
   void _appendUniqueVideos(
     List<VideoEvent> target,
     List<VideoEvent> incoming, {
-    required Set<String> seenIds,
+    required Set<String> seenVideoKeys,
   }) {
     for (final video in incoming) {
-      if (!seenIds.add(video.id)) continue;
+      if (!seenVideoKeys.add(video.feedDedupKey)) continue;
       target.add(video);
     }
   }
@@ -1798,7 +1791,8 @@ class VideosRepository {
     return result;
   }
 
-  /// Deduplicates videos by ID and sorts by popularity (loops then time).
+  /// Deduplicates videos by logical feed identity and sorts by popularity
+  /// (loops then time).
   ///
   /// Use this to combine results from [searchVideosLocally] and
   /// [searchVideosOnRelays] into a single ranked list.
@@ -1806,12 +1800,13 @@ class VideosRepository {
       deduplicateVideosPreservingOrder(videos)
         ..sort(VideoEvent.compareByLoopsThenTime);
 
-  /// Deduplicates videos by ID while preserving the first occurrence order.
+  /// Deduplicates videos by logical feed identity while preserving the first
+  /// occurrence order.
   List<VideoEvent> deduplicateVideosPreservingOrder(List<VideoEvent> videos) {
-    final seenIds = <String>{};
+    final seenVideoKeys = <String>{};
     return videos.where((v) {
-      if (seenIds.contains(v.id)) return false;
-      seenIds.add(v.id);
+      if (seenVideoKeys.contains(v.feedDedupKey)) return false;
+      seenVideoKeys.add(v.feedDedupKey);
       return true;
     }).toList();
   }

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -2616,6 +2616,98 @@ void main() {
         expect(result.listOnlyVideoIds, isEmpty);
       });
 
+      test(
+        'deduplicates republished addressable video in following and list',
+        () async {
+          final author = 'a' * 64;
+          final followingEvent = _createVideoEventWithDTag(
+            id: 'following-event-id',
+            pubkey: author,
+            dTag: 'shared-d-tag',
+            videoUrl: 'https://example.com/following.mp4',
+            createdAt: 1704067200,
+          );
+          final listEvent = _createVideoEventWithDTag(
+            id: 'republished-event-id',
+            pubkey: author,
+            dTag: 'shared-d-tag',
+            videoUrl: 'https://example.com/list.mp4',
+            createdAt: 1704067300,
+          );
+
+          var callCount = 0;
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) return [followingEvent];
+            return [listEvent];
+          });
+
+          final result = await repository.getHomeFeedVideos(
+            authors: [author],
+            videoRefs: {
+              'list-a': ['34236:$author:shared-d-tag'],
+            },
+          );
+
+          expect(result.videos, hasLength(1));
+          expect(result.videos.single.id, equals('following-event-id'));
+          expect(
+            result.videoListSources['following-event-id'],
+            contains('list-a'),
+          );
+          expect(result.videoListSources['republished-event-id'], isNull);
+          expect(result.listOnlyVideoIds, isEmpty);
+        },
+      );
+
+      test('keeps same d-tag list videos from different authors', () async {
+        const authorA =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        const authorB =
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+        final videoA = _createVideoEventWithDTag(
+          id: 'author-a-event',
+          pubkey: authorA,
+          dTag: 'shared-d-tag',
+          videoUrl: 'https://example.com/a.mp4',
+          createdAt: 1704067200,
+        );
+        final videoB = _createVideoEventWithDTag(
+          id: 'author-b-event',
+          pubkey: authorB,
+          dTag: 'shared-d-tag',
+          videoUrl: 'https://example.com/b.mp4',
+          createdAt: 1704067300,
+        );
+
+        var callCount = 0;
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer((_) async {
+          callCount++;
+          if (callCount == 1) return <Event>[];
+          return [videoA, videoB];
+        });
+
+        final result = await repository.getHomeFeedVideos(
+          authors: [authorA],
+          videoRefs: {
+            'list-a': [
+              '34236:$authorA:shared-d-tag',
+              '34236:$authorB:shared-d-tag',
+            ],
+          },
+        );
+
+        expect(
+          result.videos.map((v) => v.id),
+          containsAll(['author-a-event', 'author-b-event']),
+        );
+        expect(result.videos, hasLength(2));
+        expect(
+          result.listOnlyVideoIds,
+          containsAll(['author-a-event', 'author-b-event']),
+        );
+      });
+
       test('builds correct videoListSources for multi-list refs', () async {
         final event = _createVideoEvent(
           id: 'multi-list-video',
@@ -2872,6 +2964,78 @@ void main() {
         expect(result, hasLength(1));
         expect(result.first.vineId, equals('my-vine'));
       });
+
+      test(
+        'keeps addressable refs with same d-tag from different authors',
+        () async {
+          final authorA = 'a' * 64;
+          final authorB = 'b' * 64;
+          final videoA = _createVideoEventWithDTag(
+            id: 'author-a-event',
+            pubkey: authorA,
+            dTag: 'same-d-tag',
+            videoUrl: 'https://example.com/a.mp4',
+            createdAt: 1704067200,
+          );
+          final videoB = _createVideoEventWithDTag(
+            id: 'author-b-event',
+            pubkey: authorB,
+            dTag: 'same-d-tag',
+            videoUrl: 'https://example.com/b.mp4',
+            createdAt: 1704067300,
+          );
+
+          when(
+            () => mockNostrClient.queryEvents(any()),
+          ).thenAnswer((_) async => [videoA, videoB]);
+
+          final result = await repository.getVideosForList([
+            '34236:$authorA:same-d-tag',
+            '34236:$authorB:same-d-tag',
+          ]);
+
+          expect(
+            result.map((video) => video.id),
+            equals(['author-a-event', 'author-b-event']),
+          );
+        },
+      );
+
+      test(
+        'deduplicates repeated addressable refs with different event ids',
+        () async {
+          final author = 'a' * 64;
+          final firstCopy = _createVideoEventWithDTag(
+            id: 'first-event-id',
+            pubkey: author,
+            dTag: 'same-d-tag',
+            videoUrl: 'https://example.com/first.mp4',
+            createdAt: 1704067200,
+          );
+          final secondCopy = _createVideoEventWithDTag(
+            id: 'second-event-id',
+            pubkey: author,
+            dTag: 'same-d-tag',
+            videoUrl: 'https://example.com/second.mp4',
+            createdAt: 1704067300,
+          );
+
+          var callCount = 0;
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer((_) async {
+            callCount++;
+            if (callCount == 1) return [firstCopy];
+            return [secondCopy];
+          });
+
+          final result = await repository.getVideosForList([
+            'first-event-id',
+            '34236:$author:same-d-tag',
+          ]);
+
+          expect(result, hasLength(1));
+          expect(result.single.id, equals('first-event-id'));
+        },
+      );
 
       test('fetches mixed ref types in parallel', () async {
         final eventIdVideo = _createVideoEvent(
@@ -7402,6 +7566,63 @@ void main() {
         expect(result.first.id, equals('shared-id'));
       });
 
+      test(
+        'removes republished addressable duplicates by coordinate',
+        () async {
+          final author = 'a' * 64;
+          final video1 = VideoEvent.fromNostrEvent(
+            _createVideoEventWithDTag(
+              id: 'first-event-id',
+              pubkey: author,
+              dTag: 'same-d-tag',
+              videoUrl: 'https://example.com/first.mp4',
+              createdAt: 1704067200,
+            ),
+          );
+          final video2 = VideoEvent.fromNostrEvent(
+            _createVideoEventWithDTag(
+              id: 'second-event-id',
+              pubkey: author,
+              dTag: 'same-d-tag',
+              videoUrl: 'https://example.com/second.mp4',
+              createdAt: 1704067300,
+            ),
+          );
+
+          final result = repository.deduplicateAndSortVideos([video1, video2]);
+
+          expect(result, hasLength(1));
+        },
+      );
+
+      test(
+        'does not collapse same d-tag videos from different authors',
+        () async {
+          final video1 = VideoEvent.fromNostrEvent(
+            _createVideoEventWithDTag(
+              id: 'author-a-event',
+              pubkey: 'a' * 64,
+              dTag: 'same-d-tag',
+              videoUrl: 'https://example.com/a.mp4',
+              createdAt: 1704067200,
+            ),
+          );
+          final video2 = VideoEvent.fromNostrEvent(
+            _createVideoEventWithDTag(
+              id: 'author-b-event',
+              pubkey: 'b' * 64,
+              dTag: 'same-d-tag',
+              videoUrl: 'https://example.com/b.mp4',
+              createdAt: 1704067300,
+            ),
+          );
+
+          final result = repository.deduplicateAndSortVideos([video1, video2]);
+
+          expect(result, hasLength(2));
+        },
+      );
+
       test('sorts by loops then time', () async {
         final videoHighLoops = VideoEvent.fromNostrEvent(
           _createVideoEvent(
@@ -9724,71 +9945,68 @@ void main() {
         },
       );
 
-      test(
-        'raw addressable routes ignore same-d-tag local cache hits from a '
-        'different author before falling back to relay',
-        () async {
-          const eventId =
-              'd695f6b60119d9521934a691347d9f78'
-              'e8770b56da16bb255ee77ac112b4c1f6';
-          const wrongEventId =
-              'e695f6b60119d9521934a691347d9f78'
-              'e8770b56da16bb255ee77ac112b4c1f6';
-          const author =
-              '4bf0c63fcb93463407af97a5e5ee64fa'
-              '883d107ef9e558472c4eb9aaaefa459d';
-          const wrongAuthor =
-              '5bf0c63fcb93463407af97a5e5ee64fa'
-              '883d107ef9e558472c4eb9aaaefa459d';
-          const dTag = 'cached-shared-dtag';
-          const rawAddressableId = '34236:$author:$dTag';
-          final wrongCachedEvent = _createVideoEventWithDTag(
-            id: wrongEventId,
-            pubkey: wrongAuthor,
-            dTag: dTag,
-            videoUrl: 'https://example.com/wrong.mp4',
-            createdAt: 1739350000,
-          );
-          final relayEvent = _createVideoEventWithDTag(
-            id: eventId,
-            pubkey: author,
-            dTag: dTag,
-            videoUrl: 'https://example.com/correct.mp4',
-            createdAt: 1739350100,
-          );
-          final mockLocalStorage = MockVideoLocalStorage();
+      test('raw addressable routes ignore same-d-tag local cache hits from a '
+          'different author before falling back to relay', () async {
+        const eventId =
+            'd695f6b60119d9521934a691347d9f78'
+            'e8770b56da16bb255ee77ac112b4c1f6';
+        const wrongEventId =
+            'e695f6b60119d9521934a691347d9f78'
+            'e8770b56da16bb255ee77ac112b4c1f6';
+        const author =
+            '4bf0c63fcb93463407af97a5e5ee64fa'
+            '883d107ef9e558472c4eb9aaaefa459d';
+        const wrongAuthor =
+            '5bf0c63fcb93463407af97a5e5ee64fa'
+            '883d107ef9e558472c4eb9aaaefa459d';
+        const dTag = 'cached-shared-dtag';
+        const rawAddressableId = '34236:$author:$dTag';
+        final wrongCachedEvent = _createVideoEventWithDTag(
+          id: wrongEventId,
+          pubkey: wrongAuthor,
+          dTag: dTag,
+          videoUrl: 'https://example.com/wrong.mp4',
+          createdAt: 1739350000,
+        );
+        final relayEvent = _createVideoEventWithDTag(
+          id: eventId,
+          pubkey: author,
+          dTag: dTag,
+          videoUrl: 'https://example.com/correct.mp4',
+          createdAt: 1739350100,
+        );
+        final mockLocalStorage = MockVideoLocalStorage();
 
-          when(
-            () => mockLocalStorage.getEventsByDTag(dTag),
-          ).thenAnswer((_) async => [wrongCachedEvent]);
-          when(
-            () => mockNostrClient.queryEvents(any()),
-          ).thenAnswer((_) async => [relayEvent]);
+        when(
+          () => mockLocalStorage.getEventsByDTag(dTag),
+        ).thenAnswer((_) async => [wrongCachedEvent]);
+        when(
+          () => mockNostrClient.queryEvents(any()),
+        ).thenAnswer((_) async => [relayEvent]);
 
-          final repo = VideosRepository(
-            nostrClient: mockNostrClient,
-            localStorage: mockLocalStorage,
-            funnelcakeApiClient: mockFunnelcakeClient,
-          );
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          localStorage: mockLocalStorage,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
 
-          final result = await repo.fetchVideoWithStatsForRouteId(
-            rawAddressableId,
-          );
+        final result = await repo.fetchVideoWithStatsForRouteId(
+          rawAddressableId,
+        );
 
-          expect(result, isNotNull);
-          expect(result!.id, equals(eventId));
-          expect(result.pubkey, equals(author));
-          verify(() => mockLocalStorage.getEventsByDTag(dTag)).called(1);
+        expect(result, isNotNull);
+        expect(result!.id, equals(eventId));
+        expect(result.pubkey, equals(author));
+        verify(() => mockLocalStorage.getEventsByDTag(dTag)).called(1);
 
-          final captured =
-              verify(
-                    () => mockNostrClient.queryEvents(captureAny()),
-                  ).captured.single
-                  as List<Filter>;
-          expect(captured.single.authors, equals([author]));
-          expect(captured.single.d, equals([dTag]));
-        },
-      );
+        final captured =
+            verify(
+                  () => mockNostrClient.queryEvents(captureAny()),
+                ).captured.single
+                as List<Filter>;
+        expect(captured.single.authors, equals([author]));
+        expect(captured.single.d, equals([dTag]));
+      });
 
       test(
         'falls back to relay lookup for stable IDs missing from local cache',
@@ -10750,9 +10968,7 @@ void main() {
             ),
           ).called(2);
           verify(
-            () => mockFunnelcakeClient.getWatchingVideos(
-              limit: 10,
-            ),
+            () => mockFunnelcakeClient.getWatchingVideos(limit: 10),
           ).called(1);
         },
       );

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -120,18 +120,25 @@ void main() {
       curatedListRepository: mockCuratedListRepository,
     );
 
-    VideoEvent createTestVideo(String id, {int? createdAt}) {
+    VideoEvent createTestVideo(
+      String id, {
+      int? createdAt,
+      String pubkey =
+          '0000000000000000000000000000000000000000000000000000000000000000',
+      String? vineId,
+    }) {
       final timestamp =
           createdAt ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
       return VideoEvent(
         id: id,
-        pubkey: '0' * 64,
+        pubkey: pubkey,
         createdAt: timestamp,
         content: '',
         timestamp: DateTime.fromMillisecondsSinceEpoch(timestamp * 1000),
         title: 'Test Video $id',
         videoUrl: 'https://example.com/$id.mp4',
         thumbnailUrl: 'https://example.com/$id.jpg',
+        vineId: vineId,
       );
     }
 
@@ -1832,6 +1839,125 @@ void main() {
           isA<VideoFeedBlocState>()
               .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               .having((s) => s.hasMore, 'hasMore', false)
+              .having((s) => s.videos.length, 'videos count', 2),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'deduplicates republished following videos by addressable identity',
+        setUp: () {
+          const author =
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([author]);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: [
+                createTestVideo(
+                  'republished-event-id',
+                  pubkey: author,
+                  vineId: 'shared-d-tag',
+                  createdAt: 1999,
+                ),
+                createTestVideo('new-video', createdAt: 1998),
+              ],
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          mode: FeedMode.following,
+          videos: [
+            createTestVideo(
+              'original-event-id',
+              pubkey:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              vineId: 'shared-d-tag',
+              createdAt: 2000,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
+              .having(
+                (s) => s.videos.map((v) => v.id),
+                'video ids',
+                equals(['original-event-id', 'new-video']),
+              ),
+        ],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'keeps same d-tag videos from different authors',
+        setUp: () {
+          const authorB =
+              'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+          when(
+            () => mockFollowRepository.followingPubkeys,
+          ).thenReturn([authorB]);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: any(named: 'authors'),
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: [
+                createTestVideo(
+                  'author-b-event',
+                  pubkey: authorB,
+                  vineId: 'shared-d-tag',
+                  createdAt: 1999,
+                ),
+              ],
+            ),
+          );
+        },
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          mode: FeedMode.following,
+          videos: [
+            createTestVideo(
+              'author-a-event',
+              pubkey:
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              vineId: 'shared-d-tag',
+              createdAt: 2000,
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(const VideoFeedLoadMoreRequested()),
+        expect: () => [
+          isA<VideoFeedBlocState>().having(
+            (s) => s.isLoadingMore,
+            'isLoadingMore',
+            true,
+          ),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.isLoadingMore, 'isLoadingMore', false)
               .having((s) => s.videos.length, 'videos count', 2),
         ],
       );


### PR DESCRIPTION
## Summary
- deduplicate feed pagination and repository feed composition by full addressable video identity instead of event id only
- fix addressable list ref matching to use the full kind:pubkey:d-tag coordinate, avoiding same-d-tag cross-author collisions
- add regression coverage for republished addressable videos and same-d-tag videos from different authors

## Root Cause
NIP-33/addressable video events can be republished with a new event id while still representing the same logical video. Several feed paths deduplicated only by event id, so a republished event could appear multiple times in one feed session. A naive bare d-tag key would be unsafe because different authors can reuse the same d-tag.

## Validation
- flutter test test/blocs/video_feed/video_feed_bloc_test.dart
- flutter test test/src/videos_repository_test.dart (from mobile/packages/videos_repository)
- flutter test --coverage (from mobile/packages/videos_repository): 1066/1066 lines, 100.0%
- flutter test (from mobile/packages/models)
- flutter analyze
- pre-push analyzer and changed-file tests

Closes #5437