### PR TITLE
fix(notifications): enrich cached refresh failures

### DIFF
--- a/mobile/lib/notifications/providers/notification_repository_provider.dart
+++ b/mobile/lib/notifications/providers/notification_repository_provider.dart
@@ -62,7 +62,12 @@ final notificationRepositoryProvider = Provider<NotificationRepository?>((ref) {
         method: httpMethod,
         payload: body,
       );
-      if (token == null) return <String, String>{};
+      if (token == null) {
+        throw const Nip98AuthException(
+          'Unable to sign notifications request',
+          code: 'token_unavailable',
+        );
+      }
       return {'Authorization': token.authorizationHeader};
     },
   );

--- a/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_mode_selector.dart
@@ -188,6 +188,9 @@ class _VideoRecorderModeSelectorWheelState
                               ),
                               child: Text(
                                 modes[i].label,
+                                maxLines: 1,
+                                overflow: TextOverflow.visible,
+                                softWrap: false,
                                 textScaler: textScaler,
                               ),
                             ),

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -232,10 +232,8 @@ class NotificationRepository {
   Future<NotificationPage> getNotifications({
     String? cursor,
     String? cursorId,
-  }) async => (await _getNotificationsResult(
-    cursor: cursor,
-    cursorId: cursorId,
-  )).page;
+  }) async =>
+      (await _getNotificationsResult(cursor: cursor, cursorId: cursorId)).page;
 
   Future<({NotificationPage page, bool applied})> _getNotificationsResult({
     String? cursor,
@@ -431,6 +429,7 @@ class NotificationRepository {
           hasMore: true,
         ),
       );
+      unawaited(_enrichCachedPlaceholders(items));
     } on Exception catch (e, s) {
       Log.error(
         'Failed to hydrate notifications cache: $e',
@@ -440,6 +439,82 @@ class NotificationRepository {
         stackTrace: s,
       );
     }
+  }
+
+  Future<void> _enrichCachedPlaceholders(
+    List<NotificationItem> placeholders,
+  ) async {
+    try {
+      final pubkeys = placeholders
+          .map(
+            (item) => switch (item) {
+              VideoNotification(:final actors) => actors.first.pubkey,
+              ActorNotification(:final actor) => actor.pubkey,
+            },
+          )
+          .where((pubkey) => pubkey.isNotEmpty)
+          .toSet()
+          .toList();
+      final eventIds = placeholders
+          .whereType<VideoNotification>()
+          .map((item) => item.videoEventId)
+          .where((id) => id.isNotEmpty)
+          .toSet()
+          .toList();
+
+      if (pubkeys.isEmpty && eventIds.isEmpty) return;
+
+      final profilesFuture = pubkeys.isEmpty
+          ? Future.value(<String, UserProfile>{})
+          : _profileRepository.fetchBatchProfiles(pubkeys: pubkeys);
+      final videosFuture = _fetchVideoMetadata(eventIds);
+      final (profiles, videosById) = await (profilesFuture, videosFuture).wait;
+
+      final current = _snapshot.value;
+      if (!_sameNotificationIds(current.items, placeholders)) return;
+
+      final enriched = placeholders.map((item) {
+        return switch (item) {
+          VideoNotification(:final actors, :final videoEventId) => () {
+            final actor = actors.first;
+            final video = videosById[videoEventId];
+            return item.copyWith(
+              actors: [_buildActor(actor.pubkey, profiles)],
+              videoThumbnailUrl:
+                  item.videoThumbnailUrl ?? _nonEmpty(video?.thumbnail),
+              videoTitle: item.videoTitle ?? _nonEmpty(video?.title),
+              videoAddressableId:
+                  item.videoAddressableId ??
+                  _recipientScopedVideoAddressableId(dTag: null, video: video),
+            );
+          }(),
+          ActorNotification(:final actor) => item.copyWith(
+            actor: _buildActor(actor.pubkey, profiles),
+          ),
+        };
+      }).toList();
+
+      _snapshot.add(current.copyWith(items: enriched));
+    } on Object catch (e, s) {
+      Log.error(
+        'Failed to enrich cached notifications: $e',
+        name: 'NotificationRepository._enrichCachedPlaceholders',
+        category: LogCategory.storage,
+        error: e,
+        stackTrace: s,
+      );
+    }
+  }
+
+  static bool _sameNotificationIds(
+    List<NotificationItem> current,
+    List<NotificationItem> expected,
+  ) {
+    if (current.length != expected.length) return false;
+    for (var i = 0; i < current.length; i++) {
+      if (current[i].id != expected[i].id) return false;
+    }
+    return true;
   }
 
   /// Maps a [NotificationRow] into a placeholder [NotificationItem].

--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -444,6 +444,7 @@ class NotificationRepository {
   Future<void> _enrichCachedPlaceholders(
     List<NotificationItem> placeholders,
   ) async {
+    final generation = _fetchGeneration;
     try {
       final pubkeys = placeholders
           .map(
@@ -470,16 +471,20 @@ class NotificationRepository {
       final videosFuture = _fetchVideoMetadata(eventIds);
       final (profiles, videosById) = await (profilesFuture, videosFuture).wait;
 
+      if (generation != _fetchGeneration) return;
+
       final current = _snapshot.value;
       if (!_sameNotificationIds(current.items, placeholders)) return;
 
-      final enriched = placeholders.map((item) {
+      final enriched = current.items.map((item) {
         return switch (item) {
           VideoNotification(:final actors, :final videoEventId) => () {
             final actor = actors.first;
             final video = videosById[videoEventId];
             return item.copyWith(
-              actors: [_buildActor(actor.pubkey, profiles)],
+              actors: _isCachedVideoPlaceholder(item)
+                  ? [_buildActor(actor.pubkey, profiles)]
+                  : actors,
               videoThumbnailUrl:
                   item.videoThumbnailUrl ?? _nonEmpty(video?.thumbnail),
               videoTitle: item.videoTitle ?? _nonEmpty(video?.title),
@@ -495,7 +500,7 @@ class NotificationRepository {
       }).toList();
 
       _snapshot.add(current.copyWith(items: enriched));
-    } on Object catch (e, s) {
+    } on Exception catch (e, s) {
       Log.error(
         'Failed to enrich cached notifications: $e',
         name: 'NotificationRepository._enrichCachedPlaceholders',
@@ -505,6 +510,11 @@ class NotificationRepository {
       );
     }
   }
+
+  static bool _isCachedVideoPlaceholder(VideoNotification item) =>
+      item.actors.length == 1 &&
+      item.totalCount == 1 &&
+      item.sourceEventIds.isEmpty;
 
   static bool _sameNotificationIds(
     List<NotificationItem> current,

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1899,6 +1899,121 @@ void main() {
         },
       );
 
+      test(
+        'cached video placeholders are enriched with actor and video metadata',
+        () async {
+          when(
+            () => notificationsDao.getAllNotifications(
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              NotificationRow(
+                id: 'cached_like_1',
+                type: 'like',
+                fromPubkey: 'actor_pub',
+                timestamp: 1700000000,
+                targetEventId: 'video_evt_1',
+                isRead: false,
+                cachedAt: DateTime(2026),
+              ),
+            ],
+          );
+          stubProfiles({
+            'actor_pub': makeProfile(
+              'actor_pub',
+              displayName: 'Alice',
+              picture: 'https://example.com/alice.jpg',
+            ),
+          });
+          stubVideoStats(
+            'video_evt_1',
+            makeVideoStats(
+              id: 'video_evt_1',
+              title: 'Cached clip',
+              thumbnail: 'https://example.com/thumb.jpg',
+            ),
+          );
+
+          final hydrated = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+          );
+          addTearDown(hydrated.close);
+
+          await expectLater(
+            hydrated.watchSnapshot(),
+            emitsThrough(
+              predicate<NotificationPage>((p) {
+                if (p.items.length != 1) return false;
+                final item = p.items.single;
+                return item is VideoNotification &&
+                    item.actors.single.displayName == 'Alice' &&
+                    item.actors.single.pictureUrl ==
+                        'https://example.com/alice.jpg' &&
+                    item.videoTitle == 'Cached clip' &&
+                    item.videoThumbnailUrl == 'https://example.com/thumb.jpg' &&
+                    item.videoAddressableId ==
+                        '34236:$userPubkey:d_video_evt_1';
+              }, 'cached placeholder is enriched after hydration'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'cached actor placeholders are enriched with profile metadata',
+        () async {
+          when(
+            () => notificationsDao.getAllNotifications(
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              NotificationRow(
+                id: 'cached_follow_1',
+                type: 'follow',
+                fromPubkey: 'follower_pub',
+                timestamp: 1700000000,
+                targetPubkey: 'follower_pub',
+                isRead: false,
+                cachedAt: DateTime(2026),
+              ),
+            ],
+          );
+          stubProfiles({
+            'follower_pub': makeProfile(
+              'follower_pub',
+              displayName: 'Bob',
+              picture: 'https://example.com/bob.jpg',
+            ),
+          });
+
+          final hydrated = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+          );
+          addTearDown(hydrated.close);
+
+          await expectLater(
+            hydrated.watchSnapshot(),
+            emitsThrough(
+              predicate<NotificationPage>((p) {
+                if (p.items.length != 1) return false;
+                final item = p.items.single;
+                return item is ActorNotification &&
+                    item.actor.displayName == 'Bob' &&
+                    item.actor.pictureUrl == 'https://example.com/bob.jpg';
+              }, 'cached actor placeholder is enriched after hydration'),
+            ),
+          );
+        },
+      );
+
       test('cached "comment" row becomes $VideoNotification placeholder '
           'with commentText preserved', () async {
         when(
@@ -2113,10 +2228,7 @@ void main() {
 
           staleGate.completeError(const FunnelcakeException('stale'));
 
-          await expectLater(
-            staleFetch,
-            throwsA(isA<FunnelcakeException>()),
-          );
+          await expectLater(staleFetch, throwsA(isA<FunnelcakeException>()));
           final snapshot = await repository.watchSnapshot().first;
           expect(snapshot.lastRefreshError, isFalse);
           expect(
@@ -2738,6 +2850,38 @@ void main() {
       });
 
       test(
+        'does not call notifications API when auth header creation fails',
+        () async {
+          final authRepo = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+            authHeadersProvider: (url, method, {body}) async {
+              throw const FunnelcakeException('auth unavailable');
+            },
+            hydrateOnStart: false,
+          );
+          addTearDown(authRepo.close);
+
+          await expectLater(
+            authRepo.getNotifications(),
+            throwsA(isA<FunnelcakeException>()),
+          );
+
+          verifyNever(
+            () => funnelcakeApiClient.getNotifications(
+              pubkey: any(named: 'pubkey'),
+              cursor: any(named: 'cursor'),
+              requestUri: any(named: 'requestUri'),
+              authHeaders: any(named: 'authHeaders'),
+              limit: any(named: 'limit'),
+            ),
+          );
+        },
+      );
+
+      test(
         'markAllAsRead signs the full mark-read URL and empty body',
         () async {
           // NIP-98 requires the auth event's `u` tag to match the
@@ -3060,10 +3204,7 @@ void main() {
         expect(repository.hasPaginatedBeyondFirstPage, isFalse);
 
         markGate.completeError(const FunnelcakeException('boom'));
-        await expectLater(
-          markFuture,
-          throwsA(isA<FunnelcakeException>()),
-        );
+        await expectLater(markFuture, throwsA(isA<FunnelcakeException>()));
 
         expect(repository.hasPaginatedBeyondFirstPage, isTrue);
       });
@@ -3166,10 +3307,7 @@ void main() {
         expect(repository.hasPaginatedBeyondFirstPage, isFalse);
 
         markGate.completeError(const FunnelcakeException('boom'));
-        await expectLater(
-          markFuture,
-          throwsA(isA<FunnelcakeException>()),
-        );
+        await expectLater(markFuture, throwsA(isA<FunnelcakeException>()));
 
         expect(repository.hasPaginatedBeyondFirstPage, isTrue);
       });

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -87,6 +87,10 @@ void main() {
     when(
       () => funnelcakeApiClient.getVideoStats(any()),
     ).thenThrow(const FunnelcakeException('no stats'));
+    when(
+      () =>
+          profileRepository.fetchBatchProfiles(pubkeys: any(named: 'pubkeys')),
+    ).thenAnswer((_) async => <String, UserProfile>{});
     // Default DAO stubs cover the new hydrate / write-through paths so
     // existing tests don't need to know about them. Tests exercising the
     // cache override these explicitly.
@@ -116,6 +120,8 @@ void main() {
     String? targetCommentId,
     String? content,
     bool isReferencedVideo = true,
+    String? referencedVideoTitle,
+    String? referencedVideoThumbnail,
   }) {
     return RelayNotification(
       id: id,
@@ -131,6 +137,8 @@ void main() {
       targetCommentId: targetCommentId,
       content: content,
       isReferencedVideo: isReferencedVideo,
+      referencedVideoTitle: referencedVideoTitle,
+      referencedVideoThumbnail: referencedVideoThumbnail,
     );
   }
 
@@ -2011,6 +2019,189 @@ void main() {
               }, 'cached actor placeholder is enriched after hydration'),
             ),
           );
+        },
+      );
+
+      test(
+        'cached enrichment does not overwrite a completed refresh snapshot',
+        () async {
+          final pendingProfiles = Completer<Map<String, UserProfile>>();
+          var profileFetchCount = 0;
+          when(
+            () => profileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) {
+            profileFetchCount++;
+            if (profileFetchCount == 1) {
+              return pendingProfiles.future;
+            }
+            return Future.value({
+              'actor_pub': makeProfile('actor_pub', displayName: 'Alice'),
+              'pubkey_bob': makeProfile('pubkey_bob', displayName: 'Bob'),
+            });
+          });
+          when(
+            () => notificationsDao.getAllNotifications(
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              NotificationRow(
+                id: 'cached_like_1',
+                type: 'like',
+                fromPubkey: 'actor_pub',
+                timestamp: 1700000000,
+                targetEventId: 'video_evt_1',
+                isRead: false,
+                cachedAt: DateTime(2026),
+              ),
+            ],
+          );
+
+          final hydrated = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+          );
+          addTearDown(hydrated.close);
+
+          await expectLater(
+            hydrated.watchSnapshot(),
+            emitsThrough(
+              predicate<NotificationPage>((p) {
+                if (p.items.length != 1) return false;
+                final item = p.items.single;
+                return item is VideoNotification && item.id == 'cached_like_1';
+              }, 'snapshot contains cached placeholder'),
+            ),
+          );
+
+          stubNotifications([
+            makeNotification(
+              id: 'older_server_notification',
+              sourcePubkey: 'actor_pub',
+              sourceEventId: 'older_source_event',
+              referencedEventId: 'video_evt_1',
+              createdAt: DateTime(2025),
+              referencedVideoTitle: 'Server title',
+              referencedVideoThumbnail: 'https://example.com/server.jpg',
+            ),
+            makeNotification(
+              id: 'cached_like_1',
+              sourcePubkey: 'pubkey_bob',
+              sourceEventId: 'newer_source_event',
+              referencedEventId: 'video_evt_1',
+              createdAt: DateTime(2025, 1, 2),
+              referencedVideoTitle: 'Server title',
+              referencedVideoThumbnail: 'https://example.com/server.jpg',
+            ),
+          ], unreadCount: 2);
+
+          await hydrated.refresh();
+          pendingProfiles.complete({
+            'actor_pub': makeProfile('actor_pub', displayName: 'Alice'),
+          });
+          await Future<void>.delayed(Duration.zero);
+
+          final item =
+              (await hydrated.watchSnapshot().first).items.single
+                  as VideoNotification;
+          expect(item.id, equals('cached_like_1'));
+          expect(item.actors.map((a) => a.pubkey), [
+            'pubkey_bob',
+            'actor_pub',
+          ]);
+          expect(item.totalCount, equals(2));
+          expect(item.videoTitle, equals('Server title'));
+          expect(
+            item.videoThumbnailUrl,
+            equals('https://example.com/server.jpg'),
+          );
+          expect(item.sourceEventIds, [
+            'newer_source_event',
+            'older_source_event',
+          ]);
+          expect(item.notificationIds, [
+            'cached_like_1',
+            'older_server_notification',
+          ]);
+          expect(item.isRead, isFalse);
+        },
+      );
+
+      test(
+        'cached enrichment preserves an interim markAsRead update',
+        () async {
+          final pendingProfiles = Completer<Map<String, UserProfile>>();
+          when(
+            () => profileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
+            ),
+          ).thenAnswer((_) => pendingProfiles.future);
+          when(
+            () => notificationsDao.getAllNotifications(
+              limit: any(named: 'limit'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              NotificationRow(
+                id: 'cached_like_1',
+                type: 'like',
+                fromPubkey: 'actor_pub',
+                timestamp: 1700000000,
+                targetEventId: 'video_evt_1',
+                isRead: false,
+                cachedAt: DateTime(2026),
+              ),
+            ],
+          );
+          when(
+            () => funnelcakeApiClient.markNotificationsRead(
+              pubkey: any(named: 'pubkey'),
+              notificationIds: any(named: 'notificationIds'),
+              authHeaders: any(named: 'authHeaders'),
+            ),
+          ).thenAnswer(
+            (_) async => const MarkReadResponse(success: true, markedCount: 1),
+          );
+          when(
+            () => notificationsDao.markAsRead(any()),
+          ).thenAnswer((_) async => true);
+
+          final hydrated = NotificationRepository(
+            funnelcakeApiClient: funnelcakeApiClient,
+            profileRepository: profileRepository,
+            notificationsDao: notificationsDao,
+            userPubkey: userPubkey,
+          );
+          addTearDown(hydrated.close);
+
+          await expectLater(
+            hydrated.watchSnapshot(),
+            emitsThrough(
+              predicate<NotificationPage>((p) {
+                if (p.items.length != 1) return false;
+                final item = p.items.single;
+                return item is VideoNotification &&
+                    item.id == 'cached_like_1' &&
+                    !item.isRead;
+              }, 'snapshot contains unread cached placeholder'),
+            ),
+          );
+
+          await hydrated.markAsRead(['cached_like_1']);
+          pendingProfiles.complete({
+            'actor_pub': makeProfile('actor_pub', displayName: 'Alice'),
+          });
+          await Future<void>.delayed(Duration.zero);
+
+          final item =
+              (await hydrated.watchSnapshot().first).items.single
+                  as VideoNotification;
+          expect(item.isRead, isTrue);
+          expect(item.actors.single.displayName, equals('Alice'));
         },
       );
 


### PR DESCRIPTION
## Summary

Closes #5433

This fixes the actionable notification-side failure mode shown in the Zendesk screenshots: when the notifications REST refresh fails, cached notification rows were shown but stayed as placeholders with `Loading...` actors and missing thumbnails/titles. The change keeps the existing cached-first behavior, then performs a best-effort background enrichment of cached notification placeholders from profile and video metadata.

It also tightens the NIP-98 auth path for notification REST calls. If auth token creation returns null, the repository now receives an explicit auth failure instead of sending an unsigned request to Funnelcake and surfacing it later as a generic refresh/network problem.

During CI verification, Flutter 3.44 exposed a text-paint assertion in the video recorder mode selector under an existing didUpdateWidget test. This PR also constrains those fixed-width mode labels to one line, which matches the selector layout and removes that rendering instability without changing behavior.

## Changes

- Enrich cached video notification placeholders with actor profile, title, thumbnail, and recipient-scoped addressable id when metadata is available.
- Enrich cached actor/follow placeholders with profile metadata.
- Guard enrichment so it cannot overwrite a newer successful refresh snapshot.
- Throw `Nip98AuthException` when notification auth header creation fails, preventing unsigned notification API calls.
- Constrain video recorder mode selector labels to a stable one-line layout to avoid Flutter text paint assertions during animated selection updates.
- Add regression coverage for cached video enrichment, cached actor enrichment, and auth-header failures not reaching the notifications API.

## Verification

- `flutter test test/src/notification_repository_test.dart` from `mobile/packages/notification_repository`
- `flutter test test/notifications` from `mobile`
- `flutter test test/widgets/video_recorder/video_recorder_mode_selector_test.dart` from `mobile`
- `flutter analyze` from `mobile`
- `flutter test` from `mobile`
- Push hook changed-file analyzer and affected tests passed