### PR TITLE
feat(video): restrict served video eligibility

### DIFF
--- a/mobile/lib/constants/allowed_classic_vine_pubkeys.dart
+++ b/mobile/lib/constants/allowed_classic_vine_pubkeys.dart
@@ -1,0 +1,10 @@
+// ABOUTME: Curated recovered-Vine account allowlist for the baseline serving policy.
+// ABOUTME: Values must be lowercase 64-character Nostr hex pubkeys.
+
+/// Recovered classic Vine accounts that Divine may serve without ProofMode
+/// certification.
+///
+/// Keep this list in canonical hex form. Human-facing npubs or account labels
+/// can live in review notes, but enforcement should compare only pubkeys from
+/// `VideoEvent.pubkey`.
+const allowedClassicVinePubkeys = <String>{};

--- a/mobile/lib/constants/divine_video_serving_policy.dart
+++ b/mobile/lib/constants/divine_video_serving_policy.dart
@@ -1,0 +1,9 @@
+// ABOUTME: App-level construction of the baseline Divine video serving policy.
+// ABOUTME: Combines ProofMode certification with the curated classic Vine allowlist.
+
+import 'package:models/models.dart';
+import 'package:openvine/constants/allowed_classic_vine_pubkeys.dart';
+
+const divineVideoServingPolicy = VideoServingPolicy(
+  allowedClassicVinePubkeys: allowedClassicVinePubkeys,
+);

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart' show Provider;
 import 'package:http/http.dart' as http;
 import 'package:likes_repository/likes_repository.dart';
+import 'package:openvine/constants/divine_video_serving_policy.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -144,6 +145,7 @@ VideoEventService videoEventService(Ref ref) {
   service.setContentFilterService(ref.watch(contentFilterServiceProvider));
   service.setModerationLabelService(moderationLabelService);
   service.setDivineHostFilterService(divineHostFilterService);
+  service.setVideoServingPolicy(divineVideoServingPolicy);
 
   // Teach the OG Viner badge cache from every video that flows through the
   // service. The cache filters internally (only `isOriginalVine` videos
@@ -397,6 +399,7 @@ VideosRepository videosRepository(Ref ref) {
     localStorage: localStorage,
     blockFilter: createBlockedAuthorFilter(ref),
     contentFilter: (video) =>
+        !divineVideoServingPolicy.allows(video) ||
         nsfwFilter(video) ||
         (divineHostFilterService.showDivineHostedOnly &&
             !video.isFromDivineServer) ||

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -322,7 +322,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'd75c28498b24dfa377024ea650d85160d1948363';
+String _$videoEventServiceHash() => r'cfb27d86fde25bef5a09b96b185ee3a6a1d9829e';
 
 /// Video event publisher for publishing video events to Nostr relays
 
@@ -878,7 +878,7 @@ final class VideosRepositoryProvider
   }
 }
 
-String _$videosRepositoryHash() => r'e4ef1b585f6dc5a957af569cd01f750e60ba5838';
+String _$videosRepositoryHash() => r'8f5359e40d8725afa1931856d2812cbfb2c34b6a';
 
 /// Provider for LikesRepository instance
 ///

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -240,6 +240,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   ContentFilterService? _contentFilterService;
   ModerationLabelService? _moderationLabelService;
   DivineHostFilterService? _divineHostFilterService;
+  VideoServingPolicy? _videoServingPolicy;
   final SubscriptionManager _subscriptionManager;
 
   // Side-channel observers that fire for every video that flows through the
@@ -469,6 +470,10 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   bool get shouldFilterNonDivineVideos =>
       _divineHostFilterService?.showDivineHostedOnly ?? false;
 
+  void setVideoServingPolicy(VideoServingPolicy videoServingPolicy) {
+    _videoServingPolicy = videoServingPolicy;
+  }
+
   /// Returns true when this video should be hidden — either because its author
   /// is blocked/muted (the viewer blocked them, or they blocked the viewer via
   /// kind-30000 `d=block` / muted via kind-10000), or because the viewer's
@@ -479,6 +484,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// blocklist filter, so the blocklist check lives here at the shared
   /// chokepoint rather than at each call site.
   bool shouldHideVideo(VideoEvent video) {
+    if (!(_videoServingPolicy?.allows(video) ?? true)) {
+      return true;
+    }
     if (_blocklistRepository?.shouldFilterFromFeeds(video.pubkey) ?? false) {
       return true;
     }

--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -49,6 +49,7 @@ export 'src/video_editor/sticker_data.dart';
 export 'src/video_event.dart';
 export 'src/video_event_filters.dart';
 export 'src/video_reply_visibility.dart';
+export 'src/video_serving_policy.dart';
 export 'src/video_state.dart';
 export 'src/video_stats.dart';
 export 'src/video_url_resolver.dart';

--- a/mobile/packages/models/lib/src/video_serving_policy.dart
+++ b/mobile/packages/models/lib/src/video_serving_policy.dart
@@ -1,0 +1,60 @@
+import 'package:models/src/video_event.dart';
+
+/// The minimum ProofMode signal a video must carry to pass the serving policy.
+enum ProofModeServingLevel {
+  /// Require a backend/user-verifiable certified ProofMode level.
+  certified,
+
+  /// Allow any usable ProofMode evidence, including the basic proof tier.
+  anyProof,
+}
+
+/// Decides whether a video may be shown by Divine feed and lookup surfaces.
+///
+/// The policy is intentionally independent from user preferences such as
+/// blocklists, content labels, host filters, and aspect-ratio filters. Those
+/// filters still apply after this baseline serving eligibility check.
+class VideoServingPolicy {
+  const VideoServingPolicy({
+    required Set<String> allowedClassicVinePubkeys,
+    this.proofModeLevel = ProofModeServingLevel.certified,
+  }) : _allowedClassicVinePubkeys = allowedClassicVinePubkeys;
+
+  /// No-op policy for tests and contexts that do not want serving restriction.
+  static const VideoServingPolicy unrestricted =
+      _UnrestrictedVideoServingPolicy();
+
+  final Set<String> _allowedClassicVinePubkeys;
+  final ProofModeServingLevel proofModeLevel;
+
+  /// Returns true when [video] is eligible for Divine to serve/display.
+  bool allows(VideoEvent video) {
+    return isAllowedProofModeVideo(video) || isAllowedClassicVine(video);
+  }
+
+  /// Returns true when [video] satisfies the configured ProofMode threshold.
+  bool isAllowedProofModeVideo(VideoEvent video) {
+    return switch (proofModeLevel) {
+      ProofModeServingLevel.certified =>
+        video.isVerifiedMobile || video.isVerifiedWeb,
+      ProofModeServingLevel.anyProof => video.hasProofMode,
+    };
+  }
+
+  /// Returns true when [video] is a recovered Vine from a curated account.
+  bool isAllowedClassicVine(VideoEvent video) {
+    return video.isOriginalVine &&
+        _allowedClassicVinePubkeys.contains(video.pubkey.toLowerCase());
+  }
+}
+
+class _UnrestrictedVideoServingPolicy extends VideoServingPolicy {
+  const _UnrestrictedVideoServingPolicy()
+    : super(
+        allowedClassicVinePubkeys: const {},
+        proofModeLevel: ProofModeServingLevel.anyProof,
+      );
+
+  @override
+  bool allows(VideoEvent video) => true;
+}

--- a/mobile/packages/models/test/src/video_serving_policy_test.dart
+++ b/mobile/packages/models/test/src/video_serving_policy_test.dart
@@ -1,0 +1,98 @@
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+const allowedClassicPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const otherPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+void main() {
+  group('VideoServingPolicy', () {
+    const policy = VideoServingPolicy(
+      allowedClassicVinePubkeys: {allowedClassicPubkey},
+    );
+
+    test('allows certified mobile ProofMode videos', () {
+      final video = _video(
+        pubkey: otherPubkey,
+        rawTags: const {'verification': 'verified_mobile'},
+      );
+
+      expect(policy.allows(video), isTrue);
+      expect(policy.isAllowedProofModeVideo(video), isTrue);
+    });
+
+    test('allows certified web ProofMode videos', () {
+      final video = _video(
+        pubkey: otherPubkey,
+        rawTags: const {'verification': 'verified_web'},
+      );
+
+      expect(policy.allows(video), isTrue);
+      expect(policy.isAllowedProofModeVideo(video), isTrue);
+    });
+
+    test('rejects basic proof when certification is required', () {
+      final video = _video(
+        pubkey: otherPubkey,
+        rawTags: const {'verification': 'basic_proof'},
+      );
+
+      expect(video.hasBasicProof, isTrue);
+      expect(policy.allows(video), isFalse);
+    });
+
+    test('allows basic proof when configured for any proof', () {
+      const anyProofPolicy = VideoServingPolicy(
+        allowedClassicVinePubkeys: {},
+        proofModeLevel: ProofModeServingLevel.anyProof,
+      );
+      final video = _video(
+        pubkey: otherPubkey,
+        rawTags: const {'verification': 'basic_proof'},
+      );
+
+      expect(anyProofPolicy.allows(video), isTrue);
+    });
+
+    test('allows recovered classic Vines from curated accounts', () {
+      final video = _video(
+        pubkey: allowedClassicPubkey.toUpperCase(),
+        rawTags: const {'platform': 'vine'},
+      );
+
+      expect(video.isOriginalVine, isTrue);
+      expect(policy.allows(video), isTrue);
+      expect(policy.isAllowedClassicVine(video), isTrue);
+    });
+
+    test('rejects recovered classic Vines from non-curated accounts', () {
+      final video = _video(
+        pubkey: otherPubkey,
+        rawTags: const {'platform': 'vine'},
+      );
+
+      expect(video.isOriginalVine, isTrue);
+      expect(policy.allows(video), isFalse);
+    });
+
+    test('rejects unverified non-classic videos', () {
+      expect(policy.allows(_video(pubkey: otherPubkey)), isFalse);
+    });
+  });
+}
+
+VideoEvent _video({
+  required String pubkey,
+  Map<String, String> rawTags = const {},
+}) {
+  return VideoEvent(
+    id: 'video-id',
+    pubkey: pubkey,
+    createdAt: 1000,
+    content: '',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true),
+    videoUrl: 'https://cdn.example.com/video.mp4',
+    rawTags: rawTags,
+  );
+}

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -11010,6 +11010,7 @@ void main() {
         List<String> moderationLabels = const [],
         List<String> contentWarningLabels = const [],
         List<String> warnLabels = const [],
+        Map<String, String> rawTags = const {},
       }) {
         return VideoEvent(
           id: id,
@@ -11021,6 +11022,7 @@ void main() {
           moderationLabels: moderationLabels,
           contentWarningLabels: contentWarningLabels,
           warnLabels: warnLabels,
+          rawTags: rawTags,
         );
       }
 
@@ -11101,6 +11103,47 @@ void main() {
 
         expect(result, hasLength(1));
         expect(result.single.warnLabels, isEmpty);
+      });
+
+      test('can enforce baseline serving eligibility as content filter', () {
+        const allowedClassicPubkey =
+            'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+        const policy = VideoServingPolicy(
+          allowedClassicVinePubkeys: {allowedClassicPubkey},
+        );
+        final repo = VideosRepository(
+          nostrClient: mockNostrClient,
+          contentFilter: (video) => !policy.allows(video),
+        );
+
+        final unverified = buildVideo(id: 'plain', pubkey: goodPubkey);
+        final certified = buildVideo(
+          id: 'certified',
+          pubkey: goodPubkey,
+          rawTags: const {'verification': 'verified_web'},
+        );
+        final nonAllowlistedClassic = buildVideo(
+          id: 'classic-other',
+          pubkey: blockedPubkey,
+          rawTags: const {'platform': 'vine'},
+        );
+        final allowlistedClassic = buildVideo(
+          id: 'classic-allowed',
+          pubkey: allowedClassicPubkey,
+          rawTags: const {'platform': 'vine'},
+        );
+
+        final result = repo.applyContentPreferences([
+          unverified,
+          certified,
+          nonAllowlistedClassic,
+          allowlistedClassic,
+        ]);
+
+        expect(
+          result.map((video) => video.id),
+          equals(['certified', 'classic-allowed']),
+        );
       });
     });
 

--- a/mobile/test/services/video_event_service_serving_policy_test.dart
+++ b/mobile/test/services/video_event_service_serving_policy_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+
+const allowedClassicPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const otherPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+void main() {
+  group('VideoEventService serving policy', () {
+    late VideoEventService service;
+
+    setUp(() {
+      service =
+          VideoEventService(
+            _MockNostrClient(),
+            subscriptionManager: _MockSubscriptionManager(),
+          )..setVideoServingPolicy(
+            const VideoServingPolicy(
+              allowedClassicVinePubkeys: {allowedClassicPubkey},
+            ),
+          );
+    });
+
+    tearDown(() => service.dispose());
+
+    test('hides unverified non-classic videos', () {
+      expect(service.shouldHideVideo(_video(pubkey: otherPubkey)), isTrue);
+    });
+
+    test('keeps certified ProofMode videos', () {
+      final video = _video(
+        pubkey: otherPubkey,
+        rawTags: const {'verification': 'verified_mobile'},
+      );
+
+      expect(service.shouldHideVideo(video), isFalse);
+    });
+
+    test('keeps allowlisted recovered classic Vines', () {
+      final video = _video(
+        pubkey: allowedClassicPubkey,
+        rawTags: const {'platform': 'vine'},
+      );
+
+      expect(service.shouldHideVideo(video), isFalse);
+    });
+
+    test('hides non-allowlisted recovered classic Vines', () {
+      final video = _video(
+        pubkey: otherPubkey,
+        rawTags: const {'platform': 'vine'},
+      );
+
+      expect(service.shouldHideVideo(video), isTrue);
+    });
+  });
+}
+
+VideoEvent _video({
+  required String pubkey,
+  Map<String, String> rawTags = const {},
+}) {
+  return VideoEvent(
+    id: 'video-id',
+    pubkey: pubkey,
+    createdAt: 1000,
+    content: '',
+    timestamp: DateTime.fromMillisecondsSinceEpoch(1000 * 1000, isUtc: true),
+    videoUrl: 'https://cdn.example.com/video.mp4',
+    rawTags: rawTags,
+  );
+}


### PR DESCRIPTION
## Summary
- Add a shared VideoServingPolicy that serves only certified ProofMode videos or recovered classic Vine videos from allowlisted pubkeys.
- Wire the policy through the mobile feed repository filter and VideoEventService hide logic.
- Add focused coverage for the shared policy, repository filtering, and service-level hiding.

## Linked Issue
Closes #5467

## Draft Status
This PR is intentionally in draft until it can be discussed and reviewed by @rabble.

## Notes
- The recovered classic Vine allowlist is currently empty until the exact account npubs/pubkeys are supplied and reviewed.
- Allowlist entries are lowercase 64-character Nostr hex pubkeys; npubs can be converted before adding them.
- Funnelcake/server-side serving should mirror this same eligibility rule so filtered content is not sent to clients unnecessarily.

## Validation
- mobile/packages/models: flutter analyze
- mobile/packages/models: flutter test test/src/video_serving_policy_test.dart
- mobile/packages/videos_repository: flutter analyze
- mobile/packages/videos_repository: flutter test test/src/videos_repository_test.dart --plain-name "can enforce baseline serving eligibility as content filter"
- mobile: flutter analyze
- mobile: flutter test test/services/video_event_service_serving_policy_test.dart
- pre-push changed-file checks passed