### PR TITLE
fix(divine_ui): keep wider DivineButton padding when not stretched

### DIFF
--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -547,6 +547,24 @@ class _RenderAdaptiveButtonPadding extends RenderShiftedBox {
       _measure(constraints, dry: true);
 
   @override
+  double? computeDryBaseline(
+    BoxConstraints constraints,
+    TextBaseline baseline,
+  ) {
+    // RenderShiftedBox's inherited version omits the top inset; mirror
+    // RenderPadding by shifting the child's dry baseline down by padding.top,
+    // matching the non-dry path (which reads parentData.offset.dy).
+    final child = this.child;
+    if (child == null) return null;
+    final padding = _paddingFor(constraints);
+    final childBaseline = child.getDryBaseline(
+      constraints.deflate(padding),
+      baseline,
+    );
+    return childBaseline == null ? null : childBaseline + padding.top;
+  }
+
+  @override
   void performLayout() {
     size = _measure(constraints, dry: false);
   }

--- a/mobile/packages/divine_ui/lib/src/button/divine_button.dart
+++ b/mobile/packages/divine_ui/lib/src/button/divine_button.dart
@@ -2,6 +2,7 @@ import 'package:divine_ui/src/icon/divine_icon.dart';
 import 'package:divine_ui/src/theme/vine_theme.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
 /// The visual style type of a [DivineButton].
 enum DivineButtonType {
@@ -47,7 +48,8 @@ enum DivineButtonType {
 /// constraint and the surrounding context can absorb the smaller tap
 /// area.
 enum DivineButtonSize {
-  /// Tiny button: no outer tap-padding, 6px symmetric inner padding,
+  /// Tiny button: no outer tap-padding, 12px horizontal / 6px vertical
+  /// inner padding (6px symmetric when stretched or icon-only),
   /// 12.8px border radius (= 32 × 0.4, matches a 32px
   /// `UserAvatar`'s rounded square so the button rhymes visually with
   /// the avatar it usually sits next to), 14px `titleSmallFont` text
@@ -58,12 +60,14 @@ enum DivineButtonSize {
   /// height matches whether the button is present or not).
   tiny,
 
-  /// Small button: 4px outer padding, 8px symmetric inner padding,
+  /// Small button: 4px outer padding, 16px horizontal / 8px vertical
+  /// inner padding (8px symmetric when stretched or icon-only),
   /// 16px border radius, 16px `titleMediumFont` text,
   /// 24px icon. Visual height 40px, tap target 48px.
   small,
 
-  /// Base/medium button: 12px symmetric padding, 20px border radius,
+  /// Base/medium button: 24px horizontal / 12px vertical inner padding
+  /// (12px symmetric when stretched or icon-only), 20px border radius,
   /// 16px `titleMediumFont` text, 24px icon. Total height 48px.
   base,
 }
@@ -132,6 +136,12 @@ class DivineButton extends StatelessWidget {
   final DivineIconName? trailingIcon;
 
   /// Whether the button should expand to fill available width.
+  ///
+  /// You don't need to set this when the button is already forced wider
+  /// than its content by a parent (e.g. wrapped in `Expanded` inside a
+  /// `Row`): that tight-width case is detected automatically and gets the
+  /// same reduced horizontal padding. Set it for the loose-constraint case
+  /// — e.g. to fill a `Column`'s width — where nothing forces the width.
   final bool expanded;
 
   /// Whether the button is in a loading state.
@@ -193,17 +203,27 @@ class _DivineButtonContent extends StatelessWidget {
   /// `DivineIconButton`.
   bool get _noLabel => label.isEmpty;
 
-  /// Symmetric inner padding for every size. Labeled and icon-only
-  /// buttons share the same insets: keeping the horizontal padding equal
-  /// to the (smaller) vertical padding gives a label the most horizontal
-  /// room before it ellipsizes, and for small / base it also matches
-  /// `DivineIconButton`, so a label-less [DivineButton] lines up with a
-  /// `DivineIconButton`.
-  EdgeInsets get _padding => switch (size) {
-    DivineButtonSize.tiny => const EdgeInsets.all(6),
-    DivineButtonSize.small => const EdgeInsets.all(8),
-    DivineButtonSize.base => const EdgeInsets.all(12),
+  /// Vertical inner padding. Fixed per size — it sets the button height
+  /// (32 / 40 / 48px) and never changes with stretch state.
+  double get _verticalPadding => switch (size) {
+    DivineButtonSize.tiny => 6,
+    DivineButtonSize.small => 8,
+    DivineButtonSize.base => 12,
   };
+
+  /// Horizontal inner padding for a content-hugging button (the wider,
+  /// visually-balanced inset). A stretched button instead uses
+  /// [_verticalPadding] for symmetric insets — see [_AdaptiveButtonPadding].
+  double get _looseHorizontalPadding => switch (size) {
+    DivineButtonSize.tiny => 12,
+    DivineButtonSize.small => 16,
+    DivineButtonSize.base => 24,
+  };
+
+  /// Whether the button always uses the narrower symmetric padding,
+  /// regardless of incoming constraints: icon-only buttons (to match
+  /// `DivineIconButton`) and explicitly [expanded] buttons.
+  bool get _forceTightPadding => _noLabel || expanded;
 
   double get _borderRadius => switch (size) {
     // 32 × 0.4 — same factor `UserAvatar` uses for non-tiny avatars, so
@@ -349,8 +369,10 @@ class _DivineButtonContent extends StatelessWidget {
           highlightColor: _foregroundColor.withValues(alpha: 0.05),
           child: Ink(
             decoration: decoration,
-            child: Padding(
-              padding: _padding,
+            child: _AdaptiveButtonPadding(
+              vertical: _verticalPadding,
+              looseHorizontal: _looseHorizontalPadding,
+              forceTight: _forceTightPadding,
               child: content,
             ),
           ),
@@ -367,6 +389,166 @@ class _DivineButtonContent extends StatelessWidget {
     }
 
     return button;
+  }
+}
+
+/// Padding whose horizontal inset adapts to whether the button is stretched.
+///
+/// A button forced wider than its content by its parent receives a tight
+/// width constraint (`minWidth == maxWidth`) — `Expanded` in a `Row`,
+/// `crossAxisAlignment.stretch`, a fixed-width `SizedBox`. In that case (or
+/// when [forceTight] is set, for icon-only / [DivineButton.expanded] buttons)
+/// the horizontal inset collapses to [vertical] so a long label keeps the
+/// most room before it ellipsizes. Otherwise it uses the wider
+/// [looseHorizontal] for visual balance.
+///
+/// This is a render object rather than a `LayoutBuilder` because a
+/// `LayoutBuilder` throws "does not support returning intrinsic dimensions"
+/// when an ancestor (e.g. `IntrinsicHeight`, a stretched `Row`) probes the
+/// button's intrinsic size — which happens widely across the app.
+class _AdaptiveButtonPadding extends SingleChildRenderObjectWidget {
+  const _AdaptiveButtonPadding({
+    required this.vertical,
+    required this.looseHorizontal,
+    required this.forceTight,
+    required Widget super.child,
+  });
+
+  /// Vertical inset, also used as the horizontal inset when tight.
+  final double vertical;
+
+  /// Horizontal inset when the button hugs its content.
+  final double looseHorizontal;
+
+  /// Forces the tight (symmetric) inset regardless of incoming constraints.
+  final bool forceTight;
+
+  @override
+  _RenderAdaptiveButtonPadding createRenderObject(BuildContext context) {
+    return _RenderAdaptiveButtonPadding(
+      vertical: vertical,
+      looseHorizontal: looseHorizontal,
+      forceTight: forceTight,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+    BuildContext context,
+    _RenderAdaptiveButtonPadding renderObject,
+  ) {
+    renderObject
+      ..vertical = vertical
+      ..looseHorizontal = looseHorizontal
+      ..forceTight = forceTight;
+  }
+}
+
+class _RenderAdaptiveButtonPadding extends RenderShiftedBox {
+  _RenderAdaptiveButtonPadding({
+    required double vertical,
+    required double looseHorizontal,
+    required bool forceTight,
+  }) : _vertical = vertical,
+       _looseHorizontal = looseHorizontal,
+       _forceTight = forceTight,
+       super(null);
+
+  double get vertical => _vertical;
+  double _vertical;
+  set vertical(double value) {
+    if (_vertical == value) return;
+    _vertical = value;
+    markNeedsLayout();
+  }
+
+  double get looseHorizontal => _looseHorizontal;
+  double _looseHorizontal;
+  set looseHorizontal(double value) {
+    if (_looseHorizontal == value) return;
+    _looseHorizontal = value;
+    markNeedsLayout();
+  }
+
+  bool get forceTight => _forceTight;
+  bool _forceTight;
+  set forceTight(bool value) {
+    if (_forceTight == value) return;
+    _forceTight = value;
+    markNeedsLayout();
+  }
+
+  /// Horizontal inset used for intrinsic sizing. Intrinsics describe the
+  /// content-hugging width, so they use the loose inset unless the button
+  /// always renders tight.
+  double get _intrinsicHorizontal => forceTight ? vertical : looseHorizontal;
+
+  EdgeInsets _paddingFor(BoxConstraints constraints) {
+    final horizontal = forceTight || constraints.hasTightWidth
+        ? vertical
+        : looseHorizontal;
+    return EdgeInsets.symmetric(horizontal: horizontal, vertical: vertical);
+  }
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    final innerHeight = (height - vertical * 2).clamp(0.0, double.infinity);
+    return child!.getMinIntrinsicWidth(innerHeight) + _intrinsicHorizontal * 2;
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    final innerHeight = (height - vertical * 2).clamp(0.0, double.infinity);
+    return child!.getMaxIntrinsicWidth(innerHeight) + _intrinsicHorizontal * 2;
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    final innerWidth = (width - _intrinsicHorizontal * 2).clamp(
+      0.0,
+      double.infinity,
+    );
+    return child!.getMinIntrinsicHeight(innerWidth) + vertical * 2;
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    final innerWidth = (width - _intrinsicHorizontal * 2).clamp(
+      0.0,
+      double.infinity,
+    );
+    return child!.getMaxIntrinsicHeight(innerWidth) + vertical * 2;
+  }
+
+  Size _measure(BoxConstraints constraints, {required bool dry}) {
+    final padding = _paddingFor(constraints);
+    final innerConstraints = constraints.deflate(padding);
+    final Size childSize;
+    if (dry) {
+      childSize = child!.getDryLayout(innerConstraints);
+    } else {
+      child!.layout(innerConstraints, parentUsesSize: true);
+      (child!.parentData! as BoxParentData).offset = Offset(
+        padding.left,
+        padding.top,
+      );
+      childSize = child!.size;
+    }
+    return constraints.constrain(
+      Size(
+        childSize.width + padding.horizontal,
+        childSize.height + padding.vertical,
+      ),
+    );
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) =>
+      _measure(constraints, dry: true);
+
+  @override
+  void performLayout() {
+    size = _measure(constraints, dry: false);
   }
 }
 

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -727,6 +727,38 @@ void main() {
           );
         }
       });
+
+      testWidgets('dry baseline includes the top inset', (tester) async {
+        // RenderShiftedBox's inherited computeDryBaseline omits padding.top,
+        // so a missing override would report the parent baseline equal to the
+        // child's instead of one inset lower. Assert the inset is added.
+        await tester.pumpWidget(
+          buildTestWidget(label: 'Save', onPressed: () {}),
+        );
+        final box = tester.renderObject<RenderBox>(adaptiveFinder);
+        final child = tester.renderObject<RenderBox>(
+          find.descendant(of: adaptiveFinder, matching: find.byType(Row)),
+        );
+
+        const constraints = BoxConstraints(maxWidth: 400);
+        // Loose width on the base size resolves to the 24/12 inset.
+        const padding = EdgeInsets.symmetric(horizontal: 24, vertical: 12);
+        final parentBaseline = box.getDryBaseline(
+          constraints,
+          TextBaseline.alphabetic,
+        );
+        final childBaseline = child.getDryBaseline(
+          constraints.deflate(padding),
+          TextBaseline.alphabetic,
+        );
+
+        expect(parentBaseline, isNotNull);
+        expect(childBaseline, isNotNull);
+        expect(
+          parentBaseline,
+          moreOrLessEquals(childBaseline! + padding.top, epsilon: 0.5),
+        );
+      });
     });
 
     group('disabled state', () {

--- a/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
+++ b/mobile/packages/divine_ui/test/src/button/divine_button_test.dart
@@ -449,67 +449,140 @@ void main() {
     });
 
     group('label inner padding', () {
-      // The content Row's closest Padding ancestor is the button's inner
-      // padding. Anchoring on the Row skips the EdgeInsets.zero Padding
-      // that Ink wraps its child in internally.
-      Padding innerPaddingOf(WidgetTester tester) {
-        return tester.widget<Padding>(
-          find
-              .ancestor(
-                of: find.byType(Row),
-                matching: find.byType(Padding),
-              )
-              .first,
+      // The inner padding is a render object (_AdaptiveButtonPadding), not a
+      // Padding widget, so measure the resolved inset geometrically: the
+      // content Row's offset within that box is the applied padding.
+      final adaptiveFinder = find.byWidgetPredicate(
+        (w) => w.runtimeType.toString() == '_AdaptiveButtonPadding',
+      );
+
+      EdgeInsets resolvedInnerPadding(WidgetTester tester) {
+        final box = tester.getRect(adaptiveFinder);
+        final content = tester.getRect(
+          find.descendant(of: adaptiveFinder, matching: find.byType(Row)),
+        );
+        return EdgeInsets.fromLTRB(
+          content.left - box.left,
+          content.top - box.top,
+          box.right - content.right,
+          box.bottom - content.bottom,
         );
       }
 
-      testWidgets('base label uses symmetric 12px inner padding', (
+      testWidgets(
+        'base label uses 24px horizontal / 12px vertical inner padding',
+        (tester) async {
+          // A non-expanded labeled button hugs its content, so it keeps the
+          // wider horizontal padding for visual balance.
+          await tester.pumpWidget(
+            buildTestWidget(label: 'Save', onPressed: () {}),
+          );
+
+          expect(
+            resolvedInnerPadding(tester),
+            const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          );
+        },
+      );
+
+      testWidgets(
+        'small label uses 16px horizontal / 8px vertical inner padding',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(
+              label: 'Save',
+              size: DivineButtonSize.small,
+              onPressed: () {},
+            ),
+          );
+
+          expect(
+            resolvedInnerPadding(tester),
+            const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          );
+        },
+      );
+
+      testWidgets(
+        'tiny label uses 12px horizontal / 6px vertical inner padding',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(
+              label: 'Save',
+              size: DivineButtonSize.tiny,
+              onPressed: () {},
+            ),
+          );
+
+          expect(
+            resolvedInnerPadding(tester),
+            const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          );
+        },
+      );
+
+      testWidgets(
+        'expanded label collapses to symmetric inner padding per size',
+        (tester) async {
+          // Expanded buttons are width-constrained by their parent, so the
+          // extra horizontal padding is dropped to give the label the most
+          // room before it ellipsizes.
+          await tester.pumpWidget(
+            buildTestWidget(label: 'Save', expanded: true, onPressed: () {}),
+          );
+          expect(resolvedInnerPadding(tester), const EdgeInsets.all(12));
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              label: 'Save',
+              size: DivineButtonSize.small,
+              expanded: true,
+              onPressed: () {},
+            ),
+          );
+          expect(resolvedInnerPadding(tester), const EdgeInsets.all(8));
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              label: 'Save',
+              size: DivineButtonSize.tiny,
+              expanded: true,
+              onPressed: () {},
+            ),
+          );
+          expect(resolvedInnerPadding(tester), const EdgeInsets.all(6));
+        },
+      );
+
+      testWidgets(
+        'non-expanded label keeps wider horizontal padding than icon-only',
+        (tester) async {
+          await tester.pumpWidget(
+            buildTestWidget(label: 'Save', onPressed: () {}),
+          );
+          final labeledPadding = resolvedInnerPadding(tester);
+
+          await tester.pumpWidget(
+            buildTestWidget(
+              label: '',
+              leadingIcon: DivineIconName.heart,
+              onPressed: () {},
+            ),
+          );
+          final iconOnlyPadding = resolvedInnerPadding(tester);
+
+          expect(labeledPadding.left, greaterThan(iconOnlyPadding.left));
+          expect(labeledPadding.top, equals(iconOnlyPadding.top));
+        },
+      );
+
+      testWidgets('expanded label matches icon-only inner padding', (
         tester,
       ) async {
-        // Symmetric padding keeps the label's full height while giving it
-        // the most horizontal room before the text ellipsizes.
         await tester.pumpWidget(
-          buildTestWidget(label: 'Save', onPressed: () {}),
+          buildTestWidget(label: 'Save', expanded: true, onPressed: () {}),
         );
-
-        expect(innerPaddingOf(tester).padding, const EdgeInsets.all(12));
-      });
-
-      testWidgets('small label uses symmetric 8px inner padding', (
-        tester,
-      ) async {
-        await tester.pumpWidget(
-          buildTestWidget(
-            label: 'Save',
-            size: DivineButtonSize.small,
-            onPressed: () {},
-          ),
-        );
-
-        expect(innerPaddingOf(tester).padding, const EdgeInsets.all(8));
-      });
-
-      testWidgets('tiny label uses symmetric 6px inner padding', (
-        tester,
-      ) async {
-        await tester.pumpWidget(
-          buildTestWidget(
-            label: 'Save',
-            size: DivineButtonSize.tiny,
-            onPressed: () {},
-          ),
-        );
-
-        expect(innerPaddingOf(tester).padding, const EdgeInsets.all(6));
-      });
-
-      testWidgets('labeled and icon-only share the same inner padding', (
-        tester,
-      ) async {
-        await tester.pumpWidget(
-          buildTestWidget(label: 'Save', onPressed: () {}),
-        );
-        final labeledPadding = innerPaddingOf(tester).padding;
+        final labeledPadding = resolvedInnerPadding(tester);
 
         await tester.pumpWidget(
           buildTestWidget(
@@ -518,10 +591,35 @@ void main() {
             onPressed: () {},
           ),
         );
-        final iconOnlyPadding = innerPaddingOf(tester).padding;
+        final iconOnlyPadding = resolvedInnerPadding(tester);
 
         expect(labeledPadding, equals(iconOnlyPadding));
       });
+
+      testWidgets(
+        'parent-forced tight width collapses to symmetric padding without '
+        'the expanded flag',
+        (tester) async {
+          // Expanded inside a Row hands the button a tight width — it is
+          // stretched even though expanded is false, so it should drop the
+          // wider horizontal padding just like an expanded button.
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: Row(
+                  children: [
+                    Expanded(
+                      child: DivineButton(label: 'Save', onPressed: () {}),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+
+          expect(resolvedInnerPadding(tester), const EdgeInsets.all(12));
+        },
+      );
 
       testWidgets('long label ellipsizes instead of overflowing', (
         tester,
@@ -549,6 +647,85 @@ void main() {
         expect(text.maxLines, equals(1));
         expect(text.overflow, equals(TextOverflow.ellipsis));
         expect(tester.takeException(), isNull);
+      });
+
+      testWidgets(
+        'renders inside IntrinsicHeight + stretched Row without errors',
+        (tester) async {
+          // Reproduces the context that throws "LayoutBuilder does not
+          // support returning intrinsic dimensions": an ancestor probes the
+          // button's intrinsic height. The render-object padding answers
+          // intrinsics, so this must not throw.
+          await tester.pumpWidget(
+            MaterialApp(
+              home: Scaffold(
+                body: IntrinsicHeight(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(
+                        child: DivineButton(label: 'Save', onPressed: () {}),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          expect(tester.takeException(), isNull);
+          // Stretched by Expanded → tight width → symmetric inset.
+          expect(resolvedInnerPadding(tester), const EdgeInsets.all(12));
+        },
+      );
+
+      testWidgets('updates inner padding when size and expanded change', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildTestWidget(label: 'Save', onPressed: () {}),
+        );
+        expect(
+          resolvedInnerPadding(tester),
+          const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+        );
+
+        // base → tiny keeps the same tree position (neither size adds the
+        // small-variant outer padding wrapper), so the render object is
+        // updated in place: every inset field changes and its setters fire.
+        await tester.pumpWidget(
+          buildTestWidget(
+            label: 'Save',
+            size: DivineButtonSize.tiny,
+            expanded: true,
+            onPressed: () {},
+          ),
+        );
+        expect(resolvedInnerPadding(tester), const EdgeInsets.all(6));
+      });
+
+      testWidgets('answers intrinsic and dry-layout queries for both states', (
+        tester,
+      ) async {
+        for (final expanded in [false, true]) {
+          await tester.pumpWidget(
+            buildTestWidget(
+              label: 'Save',
+              expanded: expanded,
+              onPressed: () {},
+            ),
+          );
+          final box = tester.renderObject<RenderBox>(adaptiveFinder);
+
+          expect(box.getMinIntrinsicWidth(double.infinity), greaterThan(0));
+          expect(box.getMaxIntrinsicWidth(double.infinity), greaterThan(0));
+          expect(box.getMinIntrinsicHeight(double.infinity), greaterThan(0));
+          expect(box.getMaxIntrinsicHeight(double.infinity), greaterThan(0));
+          expect(
+            box.getDryLayout(const BoxConstraints(maxWidth: 200)).width,
+            lessThanOrEqualTo(200),
+          );
+        }
       });
     });
 


### PR DESCRIPTION
Closes #5470

## Description

Fixes a regression introduced in #5446. That PR switched `DivineButton` to
symmetric inner padding for **every** button so long labels get more room
before truncating — but that was too broad. A labeled, content-hugging button
(not `expanded`, not stretched by its parent) lost the generous horizontal
padding it should keep for visual balance. Because such a button is sized to
its own label, the extra horizontal room can never cause early truncation, so
removing it was the mistake.

This restores the wider horizontal padding for labeled buttons and only
collapses to symmetric insets when the button is actually width-constrained:

- `expanded: true`
- icon-only buttons (matches `DivineIconButton`)
- a parent that forces a tight width — `Expanded` in a `Row`,
  `crossAxisAlignment.stretch`, a fixed-width `SizedBox` — detected
  automatically by a custom render object (`_RenderAdaptiveButtonPadding`,
  which inspects `constraints.hasTightWidth` during layout), so a caller
  inside an `Expanded` doesn't need to set `expanded` manually. A render
  object is used instead of a `LayoutBuilder` because a `LayoutBuilder`
  throws when an ancestor probes intrinsics (e.g. `IntrinsicHeight`).

| Size  | Hugging label (restored) | Stretched / expanded / icon-only |
| ----- | ------------------------ | -------------------------------- |
| base  | 24 / 12                  | 12                               |
| small | 16 / 8                   | 8                                |
| tiny  | 12 / 6                   | 6                                |

Vertical padding is unchanged, so the 32 / 40 / 48px heights stay the same.

## Out of Scope

None.

## Verification

- `flutter analyze` (divine_button.dart + test) — no issues
- `flutter test` for `divine_ui` — **596 passed** (full package incl. strict-coverage gate); `divine_button.dart` fully covered (190/190 lines)
- New tests:
  - non-expanded labeled padding per size (base 24/12, small 16/8, tiny 12/6)
  - expanded label collapses to symmetric per size
  - non-expanded label keeps wider horizontal padding than icon-only
  - parent-forced tight width (`Expanded` in a `Row`) collapses to symmetric **without** the `expanded` flag
  - dry baseline includes the top inset (guards the `computeDryBaseline` override)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
