### PR TITLE
fix(dm): count followed-but-unreplied unread chats in the Messages badge (#4976)

### DIFF
--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -1,33 +1,106 @@
-// ABOUTME: Cubit that exposes the current unread DM conversation count.
-// ABOUTME: Subscribes to the DmRepository's watchUnreadCount() stream
-// ABOUTME: and emits the latest count as state.
+// ABOUTME: Cubit that exposes the unread "Messages" conversation count.
+// ABOUTME: Mirrors the Messages list composition (accepted union followed,
+// ABOUTME: blocklist-filtered) so the badge matches the visible unread dots.
 
 import 'dart:async';
 
 import 'package:bloc/bloc.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:models/models.dart';
+import 'package:rxdart/rxdart.dart';
 
-/// Cubit that tracks the number of unread DM conversations.
+/// Cubit that tracks the number of unread DM conversations shown in the
+/// Messages tab.
 ///
-/// Subscribes to [DmRepository.watchUnreadAcceptedCount] and emits the
-/// latest count. Only counts conversations where the user has sent at
-/// least one message, excluding message requests from unknown contacts.
-/// Used by the bottom nav badge and inbox tab toggle.
+/// The badge must equal the unread conversations the Messages list actually
+/// renders. That list is **follow-aware**: it shows accepted conversations
+/// (the user has replied) PLUS 1:1 conversations from followed peers the user
+/// has not replied to yet, and it hides blocklisted peers. Counting only
+/// `currentUserHasSent == true` (the previous behaviour) undercounted unread
+/// chats from followed-but-unreplied peers. See #4976.
+///
+/// Parity with the list is structural: this reuses the same static
+/// [DmRepository.classifyPotentialRequests] / [DmRepository.mergeAndSort]
+/// helpers and [ContentBlocklistRepository.filterBlockedConversations] that
+/// [ConversationListBloc] uses, so the count cannot drift from the list. It
+/// intentionally does NOT replicate two list-only concerns:
+///
+/// * **Pagination** — the list renders one page; the badge counts the full
+///   accepted set (unpaginated) so it reflects total unread, not the page.
+/// * **Recovery hold-back (#5304)** — that only delays the *requests* bucket,
+///   which never feeds this count.
+///
+/// Used by the bottom-nav badge and the inbox segmented toggle.
 class DmUnreadCountCubit extends Cubit<int> {
-  DmUnreadCountCubit({required DmRepository dmRepository})
-    : _dmRepository = dmRepository,
-      super(0) {
-    // Drift stream IO errors are expected. Per
-    // .claude/rules/error_handling.md they are NOT Reportable; the
-    // `addError` tear-off keeps them in the unified log.
-    _subscription = _dmRepository.watchUnreadAcceptedCount().listen(
-      emit,
-      onError: addError,
-    );
+  DmUnreadCountCubit({
+    required DmRepository dmRepository,
+    required FollowRepository followRepository,
+    ContentBlocklistRepository? contentBlocklistRepository,
+  }) : _dmRepository = dmRepository,
+       _followRepository = followRepository,
+       _blocklistRepository = contentBlocklistRepository,
+       super(0) {
+    // Recompute the count whenever the accepted conversations, the potential
+    // requests, the following list, or the blocklist change. The blocklist tick
+    // value is unused — `filterBlockedConversations` reads live block state; the
+    // tick only forces a re-filter on block/unblock/mute. Drift / stream IO
+    // errors are expected and NOT Reportable per .claude/rules/error_handling.md;
+    // the `addError` tear-off keeps them in the unified log.
+    final blocklistTicks = _blocklistRepository == null
+        ? Stream<Object?>.value(null)
+        : _blocklistRepository.stateStream
+              .map<Object?>((_) => null)
+              .startWith(null);
+
+    _subscription =
+        Rx.combineLatest4<
+              List<DmConversation>,
+              List<DmConversation>,
+              List<String>,
+              Object?,
+              int
+            >(
+              _dmRepository.watchAcceptedConversations(),
+              _dmRepository.watchPotentialRequests(),
+              _followRepository.followingStream.startWith(const <String>[]),
+              blocklistTicks,
+              (accepted, potentialRequests, _, _) => _countUnread(
+                accepted: accepted,
+                potentialRequests: potentialRequests,
+              ),
+            )
+            .listen(emit, onError: addError);
   }
 
   final DmRepository _dmRepository;
+  final FollowRepository _followRepository;
+  final ContentBlocklistRepository? _blocklistRepository;
   StreamSubscription<int>? _subscription;
+
+  /// Composes the visible Messages list (accepted ∪ followed-but-unreplied,
+  /// blocklist-filtered) and counts the unread ones — the same set the inbox
+  /// renders an unread dot for.
+  int _countUnread({
+    required List<DmConversation> accepted,
+    required List<DmConversation> potentialRequests,
+  }) {
+    final userPubkey = _dmRepository.userPubkey;
+    final split = DmRepository.classifyPotentialRequests(
+      potentialRequests,
+      userPubkey: userPubkey,
+      isFollowing: _followRepository.isFollowing,
+    );
+    final inbox = DmRepository.mergeAndSort(accepted, split.followed);
+    final visible =
+        _blocklistRepository?.filterBlockedConversations(
+          inbox,
+          userPubkey: userPubkey,
+        ) ??
+        inbox;
+    return visible.where((c) => !c.isRead).length;
+  }
 
   @override
   Future<void> close() async {

--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -32,25 +32,74 @@ import 'package:rxdart/rxdart.dart';
 /// * **Recovery hold-back (#5304)** — that only delays the *requests* bucket,
 ///   which never feeds this count.
 ///
+/// The app-shell provides this cubit once via `ref.read`, but
+/// `dmRepositoryProvider` / `followRepositoryProvider` /
+/// `contentBlocklistRepositoryProvider` all `ref.watch(nostrServiceProvider)`
+/// and so rebuild into fresh instances when Nostr/auth becomes ready or the
+/// account switches. A cubit that captured the pre-auth instances would keep
+/// counting against an empty `userPubkey` and a stale stream — diverging from
+/// the inbox list, which is built later from the live repositories. Call
+/// [setRepositories] whenever any of the three provider identities changes so
+/// only this cubit's subscription is swapped (no MaterialApp/AppShell
+/// remount). Mirrors [NotificationBadgeCubit.setRepository].
+///
 /// Used by the bottom-nav badge and the inbox segmented toggle.
 class DmUnreadCountCubit extends Cubit<int> {
   DmUnreadCountCubit({
     required DmRepository dmRepository,
     required FollowRepository followRepository,
     ContentBlocklistRepository? contentBlocklistRepository,
-  }) : _dmRepository = dmRepository,
-       _followRepository = followRepository,
-       _blocklistRepository = contentBlocklistRepository,
-       super(0) {
-    // Recompute the count whenever the accepted conversations, the potential
-    // requests, the following list, or the blocklist change. The blocklist tick
-    // value is unused — `filterBlockedConversations` reads live block state; the
-    // tick only forces a re-filter on block/unblock/mute. Drift / stream IO
-    // errors are expected and NOT Reportable per .claude/rules/error_handling.md;
-    // the `addError` tear-off keeps them in the unified log.
-    final blocklistTicks = _blocklistRepository == null
+  }) : super(0) {
+    setRepositories(
+      dmRepository: dmRepository,
+      followRepository: followRepository,
+      contentBlocklistRepository: contentBlocklistRepository,
+    );
+  }
+
+  DmRepository? _dmRepository;
+  FollowRepository? _followRepository;
+  ContentBlocklistRepository? _blocklistRepository;
+  StreamSubscription<int>? _subscription;
+  int _subscriptionGeneration = 0;
+
+  /// Re-point the count at fresh repository instances and re-subscribe.
+  ///
+  /// No-op when all three identities are unchanged, so redundant
+  /// provider-listener fires are cheap. The generation guard discards any
+  /// late emission from the cancelled subscription so a swap can never
+  /// regress the badge to a stale count.
+  void setRepositories({
+    required DmRepository dmRepository,
+    required FollowRepository followRepository,
+    ContentBlocklistRepository? contentBlocklistRepository,
+  }) {
+    if (identical(_dmRepository, dmRepository) &&
+        identical(_followRepository, followRepository) &&
+        identical(_blocklistRepository, contentBlocklistRepository)) {
+      return;
+    }
+
+    _dmRepository = dmRepository;
+    _followRepository = followRepository;
+    _blocklistRepository = contentBlocklistRepository;
+
+    final generation = ++_subscriptionGeneration;
+    final oldSubscription = _subscription;
+    _subscription = null;
+    if (oldSubscription != null) {
+      unawaited(oldSubscription.cancel());
+    }
+
+    // Recompute whenever the accepted conversations, the potential requests,
+    // the following list, or the blocklist change. The blocklist tick value is
+    // unused — `filterBlockedConversations` reads live block state; the tick
+    // only forces a re-filter on block/unblock/mute. Drift / stream IO errors
+    // are expected and NOT Reportable per .claude/rules/error_handling.md; the
+    // `addError` tear-off keeps them in the unified log.
+    final blocklistTicks = contentBlocklistRepository == null
         ? Stream<Object?>.value(null)
-        : _blocklistRepository.stateStream
+        : contentBlocklistRepository.stateStream
               .map<Object?>((_) => null)
               .startWith(null);
 
@@ -62,22 +111,26 @@ class DmUnreadCountCubit extends Cubit<int> {
               Object?,
               int
             >(
-              _dmRepository.watchAcceptedConversations(),
-              _dmRepository.watchPotentialRequests(),
-              _followRepository.followingStream.startWith(const <String>[]),
+              dmRepository.watchAcceptedConversations(),
+              dmRepository.watchPotentialRequests(),
+              followRepository.followingStream.startWith(const <String>[]),
               blocklistTicks,
               (accepted, potentialRequests, _, _) => _countUnread(
                 accepted: accepted,
                 potentialRequests: potentialRequests,
               ),
             )
-            .listen(emit, onError: addError);
+            .listen(
+              (count) {
+                if (_subscriptionGeneration == generation) emit(count);
+              },
+              onError: (Object error, StackTrace stackTrace) {
+                if (_subscriptionGeneration == generation) {
+                  addError(error, stackTrace);
+                }
+              },
+            );
   }
-
-  final DmRepository _dmRepository;
-  final FollowRepository _followRepository;
-  final ContentBlocklistRepository? _blocklistRepository;
-  StreamSubscription<int>? _subscription;
 
   /// Composes the visible Messages list (accepted ∪ followed-but-unreplied,
   /// blocklist-filtered) and counts the unread ones — the same set the inbox
@@ -86,11 +139,15 @@ class DmUnreadCountCubit extends Cubit<int> {
     required List<DmConversation> accepted,
     required List<DmConversation> potentialRequests,
   }) {
-    final userPubkey = _dmRepository.userPubkey;
+    final dmRepository = _dmRepository;
+    final followRepository = _followRepository;
+    if (dmRepository == null || followRepository == null) return 0;
+
+    final userPubkey = dmRepository.userPubkey;
     final split = DmRepository.classifyPotentialRequests(
       potentialRequests,
       userPubkey: userPubkey,
-      isFollowing: _followRepository.isFollowing,
+      isFollowing: followRepository.isFollowing,
     );
     final inbox = DmRepository.mergeAndSort(accepted, split.followed);
     final visible =
@@ -104,6 +161,7 @@ class DmUnreadCountCubit extends Cubit<int> {
 
   @override
   Future<void> close() async {
+    _subscriptionGeneration += 1;
     await _subscription?.cancel();
     await super.close();
   }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2416,7 +2416,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
           ),
         ),
       ],
-      child: _NotificationBadgeRepositorySync(
+      child: _InboxBadgeRepositorySync(
         child: MultiBlocProvider(
           providers: [
             BlocProvider(
@@ -2546,8 +2546,18 @@ class _DivineAppState extends ConsumerState<DivineApp> {
   }
 }
 
-class _NotificationBadgeRepositorySync extends ConsumerWidget {
-  const _NotificationBadgeRepositorySync({required this.child});
+/// Re-points the app-shell badge cubits at fresh repository instances when
+/// their providers rebuild (Nostr/auth becomes ready, account switch).
+///
+/// Both [NotificationBadgeCubit] and [DmUnreadCountCubit] are provided once
+/// above MaterialApp via `ref.read`, so without this they keep their captured
+/// pre-auth repositories and silently undercount. The DM repositories
+/// (`dmRepositoryProvider` / `followRepositoryProvider` /
+/// `contentBlocklistRepositoryProvider`) all `ref.watch(nostrServiceProvider)`
+/// and so rebuild on auth-ready. Swapping only the cubit subscriptions avoids
+/// remounting MaterialApp/AppShell.
+class _InboxBadgeRepositorySync extends ConsumerWidget {
+  const _InboxBadgeRepositorySync({required this.child});
 
   final Widget child;
 
@@ -2556,6 +2566,22 @@ class _NotificationBadgeRepositorySync extends ConsumerWidget {
     ref.listen(notificationRepositoryProvider, (_, repository) {
       context.read<NotificationBadgeCubit>().setRepository(repository);
     });
+
+    void syncDmUnread() {
+      context.read<DmUnreadCountCubit>().setRepositories(
+        dmRepository: ref.read(dmRepositoryProvider),
+        followRepository: ref.read(followRepositoryProvider),
+        contentBlocklistRepository: ref.read(
+          contentBlocklistRepositoryProvider,
+        ),
+      );
+    }
+
+    ref
+      ..listen(dmRepositoryProvider, (_, _) => syncDmUnread())
+      ..listen(followRepositoryProvider, (_, _) => syncDmUnread())
+      ..listen(contentBlocklistRepositoryProvider, (_, _) => syncDmUnread());
+
     return child;
   }
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2398,8 +2398,13 @@ class _DivineAppState extends ConsumerState<DivineApp> {
           dispose: (client) => client.dispose(),
         ),
         BlocProvider(
-          create: (_) =>
-              DmUnreadCountCubit(dmRepository: ref.read(dmRepositoryProvider)),
+          create: (_) => DmUnreadCountCubit(
+            dmRepository: ref.read(dmRepositoryProvider),
+            followRepository: ref.read(followRepositoryProvider),
+            contentBlocklistRepository: ref.read(
+              contentBlocklistRepositoryProvider,
+            ),
+          ),
         ),
         // Notification badge cubit. Keep the provider identity stable so
         // repository readiness/account switches do not remount MaterialApp

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Inbox page that provides BLoC dependencies for the inbox view.
-// ABOUTME: Sets up ConversationListBloc, DmUnreadCountCubit, and
-// ABOUTME: MyFollowingBloc from Riverpod providers. The DmRepository
+// ABOUTME: Sets up ConversationListBloc and MyFollowingBloc from Riverpod
+// ABOUTME: providers. The DmRepository
 // ABOUTME: gift-wrap subscription is auth-session-scoped via
 // ABOUTME: dmRepositoryProvider, not driven by this screen's lifecycle.
 
@@ -20,8 +20,8 @@ import 'package:openvine/screens/inbox/inbox_view.dart';
 
 /// Inbox page (DM conversation list + notifications).
 ///
-/// Provides [ConversationListBloc], [DmUnreadCountCubit], and
-/// [MyFollowingBloc] to the widget tree. The gift-wrap subscription that
+/// Provides [ConversationListBloc] and [MyFollowingBloc] to the widget
+/// tree. The gift-wrap subscription that
 /// powers DM ingestion is owned by `dmRepositoryProvider` for the entire
 /// authenticated session — this screen does NOT start or stop it (#2931).
 class InboxPage extends ConsumerWidget {

--- a/mobile/lib/screens/inbox/inbox_page.dart
+++ b/mobile/lib/screens/inbox/inbox_page.dart
@@ -11,7 +11,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/dm/conversation_actions/conversation_actions_cubit.dart';
 import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart';
 import 'package:openvine/blocs/dm/conversation_mute/conversation_mute_cubit.dart';
-import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/my_following/my_following_bloc.dart';
 import 'package:openvine/blocs/notifications/badge/notification_badge_cubit.dart';
 import 'package:openvine/notifications/providers/notification_repository_provider.dart';
@@ -54,9 +53,6 @@ class InboxPage extends ConsumerWidget {
               followRepository: followRepository,
               contentBlocklistRepository: blocklistRepository,
             )..add(const ConversationListStarted()),
-          ),
-          BlocProvider(
-            create: (_) => DmUnreadCountCubit(dmRepository: dmRepository),
           ),
           // Inbox-scope NotificationBadgeCubit feeds the segmented
           // toggle's notifications count. Mirrors the app-shell-scope

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_auth_transition_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_auth_transition_test.dart
@@ -1,0 +1,257 @@
+// ABOUTME: Widget-level test for the DmUnreadCountCubit's repository-sync
+// ABOUTME: contract. Mirrors main.dart's wiring: a stable BlocProvider plus a
+// ABOUTME: sync widget that ref.listens the dm/follow/blocklist providers and
+// ABOUTME: forwards new identities to setRepositories, so the Messages badge
+// ABOUTME: stops undercounting after a provider rebuild. See #4976 / #5472.
+
+import 'dart:async';
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
+
+class _MockDmRepository extends Mock implements DmRepository {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+// Full 64-character hex Nostr IDs for test data — never truncate.
+const _me = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+const _alice =
+    'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
+
+// currentUserHasSent defaults to false: an unreplied 1:1 chat from _alice. It
+// only joins the inbox (and the count) once _alice is a followed contact.
+DmConversation _unreadFromAlice() => DmConversation(
+  id: 'alice-convo',
+  participantPubkeys: const [_me, _alice],
+  isGroup: false,
+  createdAt: 1700000000,
+  lastMessageTimestamp: 1700000000,
+  isRead: false,
+);
+
+/// Override targets — tests mutate these to flip the repository instances the
+/// sync widget forwards to the cubit.
+final _dmSelector = StateProvider<DmRepository>((_) {
+  throw StateError('must be overridden');
+});
+final _followSelector = StateProvider<FollowRepository>((_) {
+  throw StateError('must be overridden');
+});
+
+int _mountCount = 0;
+
+class _MountProbe extends StatefulWidget {
+  const _MountProbe({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_MountProbe> createState() => _MountProbeState();
+}
+
+class _MountProbeState extends State<_MountProbe> {
+  @override
+  void initState() {
+    super.initState();
+    _mountCount += 1;
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}
+
+/// Mirrors `main.dart`'s `_InboxBadgeRepositorySync`: forwards new repository
+/// identities to the existing cubit instead of recreating it.
+class _DmRepositorySync extends ConsumerWidget {
+  const _DmRepositorySync({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen(_dmSelector, (_, _) => _sync(context, ref));
+    ref.listen(_followSelector, (_, _) => _sync(context, ref));
+    return child;
+  }
+
+  void _sync(BuildContext context, WidgetRef ref) {
+    context.read<DmUnreadCountCubit>().setRepositories(
+      dmRepository: ref.read(_dmSelector),
+      followRepository: ref.read(_followSelector),
+    );
+  }
+}
+
+/// Probe mirroring `main.dart`'s wiring around the badge cubit: the
+/// [BlocProvider] identity stays stable and repository flips are forwarded to
+/// the existing cubit, so descendants do not remount.
+class _BadgeProbe extends ConsumerWidget {
+  const _BadgeProbe();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return BlocProvider<DmUnreadCountCubit>(
+      create: (_) => DmUnreadCountCubit(
+        dmRepository: ref.read(_dmSelector),
+        followRepository: ref.read(_followSelector),
+      ),
+      child: _DmRepositorySync(
+        child: _MountProbe(
+          child: BlocBuilder<DmUnreadCountCubit, int>(
+            builder: (context, count) =>
+                Text('count=$count', textDirection: TextDirection.ltr),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+({
+  _MockDmRepository dm,
+  StreamController<List<DmConversation>> accepted,
+  StreamController<List<DmConversation>> potential,
+})
+_buildDm() {
+  final dm = _MockDmRepository();
+  final accepted = StreamController<List<DmConversation>>.broadcast();
+  final potential = StreamController<List<DmConversation>>.broadcast();
+  when(() => dm.userPubkey).thenReturn(_me);
+  when(dm.watchAcceptedConversations).thenAnswer((_) => accepted.stream);
+  when(dm.watchPotentialRequests).thenAnswer((_) => potential.stream);
+  return (dm: dm, accepted: accepted, potential: potential);
+}
+
+_MockFollowRepository _buildFollow({required bool followsAlice}) {
+  final follow = _MockFollowRepository();
+  when(
+    () => follow.followingStream,
+  ).thenAnswer((_) => const Stream<List<String>>.empty());
+  when(() => follow.isFollowing(any())).thenAnswer(
+    (inv) => followsAlice && inv.positionalArguments.first == _alice,
+  );
+  return follow;
+}
+
+void main() {
+  setUp(() {
+    _mountCount = 0;
+  });
+
+  testWidgets(
+    'forwarding a fresh follow repository to the existing cubit makes a '
+    'followed-but-unreplied unread chat start counting, without remounting',
+    (tester) async {
+      final dmA = _buildDm();
+      final dmB = _buildDm();
+      addTearDown(() async {
+        await dmA.accepted.close();
+        await dmA.potential.close();
+        await dmB.accepted.close();
+        await dmB.potential.close();
+      });
+      final followStale = _buildFollow(followsAlice: false);
+      final followFresh = _buildFollow(followsAlice: true);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            _dmSelector.overrideWith((ref) => dmA.dm),
+            _followSelector.overrideWith((ref) => followStale),
+          ],
+          child: const _BadgeProbe(),
+        ),
+      );
+
+      dmA.accepted.add(const []);
+      dmA.potential.add([_unreadFromAlice()]);
+      await tester.pump(const Duration(milliseconds: 20));
+
+      // Stale follow repo doesn't know the follow -> _alice is a request -> 0.
+      expect(find.text('count=0'), findsOneWidget);
+      expect(_mountCount, 1);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(_BadgeProbe)),
+      );
+      container.read(_dmSelector.notifier).state = dmB.dm;
+      container.read(_followSelector.notifier).state = followFresh;
+      await tester.pump();
+
+      dmB.accepted.add(const []);
+      dmB.potential.add([_unreadFromAlice()]);
+      await tester.pump(const Duration(milliseconds: 20));
+
+      // The sync widget forwarded the fresh repos to the SAME cubit, which
+      // re-subscribed: _alice is now followed -> counted. The probe did not
+      // remount (the BlocProvider identity stayed stable).
+      expect(find.text('count=1'), findsOneWidget);
+      expect(_mountCount, 1);
+    },
+  );
+
+  testWidgets(
+    'a late emission from the previous repository does not overwrite the count',
+    (tester) async {
+      final dmA = _buildDm();
+      final dmB = _buildDm();
+      addTearDown(() async {
+        await dmA.accepted.close();
+        await dmA.potential.close();
+        await dmB.accepted.close();
+        await dmB.potential.close();
+      });
+      final follow = _buildFollow(followsAlice: false);
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            _dmSelector.overrideWith((ref) => dmA.dm),
+            _followSelector.overrideWith((ref) => follow),
+          ],
+          child: const _BadgeProbe(),
+        ),
+      );
+
+      dmA.accepted.add(const []);
+      dmA.potential.add(const []);
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(find.text('count=0'), findsOneWidget);
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(_BadgeProbe)),
+      );
+      container.read(_dmSelector.notifier).state = dmB.dm;
+      await tester.pump();
+      dmB.accepted.add(const []);
+      dmB.potential.add(const []);
+      await tester.pump(const Duration(milliseconds: 20));
+      expect(find.text('count=0'), findsOneWidget);
+
+      // Old repo emits 3 unread after the swap: must be ignored.
+      dmA.accepted.add([
+        DmConversation(
+          id: 'old1',
+          participantPubkeys: const [_me, _alice],
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000000,
+          isRead: false,
+          currentUserHasSent: true,
+        ),
+      ]);
+      await tester.pump(const Duration(milliseconds: 20));
+
+      expect(find.text('count=0'), findsOneWidget);
+      expect(find.text('count=1'), findsNothing);
+    },
+  );
+}

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
@@ -324,6 +324,67 @@ void main() {
       });
     });
 
+    test(
+      'setRepositories re-points the count at fresh repositories and stops '
+      'counting against the stale ones (app-shell auth-ready rebuild, #4976)',
+      () async {
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        // Pre-auth repository emits one unread accepted conversation.
+        acceptedController.add([
+          _convo('c9', peer: _bob, isRead: false, currentUserHasSent: true),
+        ]);
+        potentialController.add(const []);
+        await _settle();
+        expect(cubit.state, equals(1));
+
+        // Auth becomes ready: the providers rebuild into fresh instances.
+        final dmRepository2 = _MockDmRepository();
+        final followRepository2 = _MockFollowRepository();
+        final acceptedController2 = StreamController<List<DmConversation>>();
+        final potentialController2 = StreamController<List<DmConversation>>();
+        final followingController2 = StreamController<List<String>>();
+        addTearDown(() async {
+          await acceptedController2.close();
+          await potentialController2.close();
+          await followingController2.close();
+        });
+        when(() => dmRepository2.userPubkey).thenReturn(_me);
+        when(
+          dmRepository2.watchAcceptedConversations,
+        ).thenAnswer((_) => acceptedController2.stream);
+        when(
+          dmRepository2.watchPotentialRequests,
+        ).thenAnswer((_) => potentialController2.stream);
+        when(
+          () => followRepository2.followingStream,
+        ).thenAnswer((_) => followingController2.stream);
+        when(
+          () => followRepository2.isFollowing(any()),
+        ).thenReturn(false);
+
+        cubit.setRepositories(
+          dmRepository: dmRepository2,
+          followRepository: followRepository2,
+        );
+
+        // The fresh repository drives the count.
+        acceptedController2.add([
+          _convo('c10', peer: _bob, isRead: false, currentUserHasSent: true),
+          _convo('c11', peer: _carol, isRead: false, currentUserHasSent: true),
+        ]);
+        potentialController2.add(const []);
+        await _settle();
+        expect(cubit.state, equals(2));
+
+        // The stale repository must no longer affect the badge.
+        acceptedController.add(const []);
+        await _settle();
+        expect(cubit.state, equals(2));
+      },
+    );
+
     test('cancels subscription on close', () async {
       final cubit = buildCubit();
       await cubit.close();

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
@@ -1,86 +1,337 @@
 // ABOUTME: Unit tests for DmUnreadCountCubit.
-// ABOUTME: Verifies stream subscription, emission, and cleanup.
+// ABOUTME: Verifies the badge count mirrors the follow-aware, blocklist-filtered
+// ABOUTME: Messages list (accepted union followed-but-unreplied), per #4976.
 
 import 'dart:async';
 
-import 'package:bloc_test/bloc_test.dart';
-import 'package:db_client/db_client.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
+import 'package:content_policy/content_policy.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nostr_client/nostr_client.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 
-class _MockNostrClient extends Mock implements NostrClient {}
+class _MockDmRepository extends Mock implements DmRepository {}
 
-class _MockDirectMessagesDao extends Mock implements DirectMessagesDao {}
+class _MockFollowRepository extends Mock implements FollowRepository {}
 
-class _MockConversationsDao extends Mock implements ConversationsDao {}
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
+
+class _MockContentPolicyState extends Mock implements ContentPolicyState {}
+
+// Full 64-character hex Nostr IDs for test data — never truncate.
+const _me = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+const _alice =
+    'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4';
+const _bob = 'd4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5';
+const _carol =
+    'e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6';
+
+DmConversation _convo(
+  String id, {
+  required String peer,
+  required bool isRead,
+  required bool currentUserHasSent,
+  int timestamp = 1700000000,
+}) {
+  return DmConversation(
+    id: id,
+    participantPubkeys: [_me, peer],
+    isGroup: false,
+    createdAt: timestamp,
+    lastMessageTimestamp: timestamp,
+    isRead: isRead,
+    currentUserHasSent: currentUserHasSent,
+  );
+}
+
+/// Pad an index into a unique 64-char hex conversation id / pubkey.
+String _hex(int i) => i.toRadixString(16).padLeft(64, '0');
+
+Future<void> _settle() =>
+    Future<void>.delayed(const Duration(milliseconds: 10));
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(<DmConversation>[]);
+  });
+
   group(DmUnreadCountCubit, () {
-    late _MockConversationsDao mockConversationsDao;
-    late DmRepository dmRepository;
+    late _MockDmRepository dmRepository;
+    late _MockFollowRepository followRepository;
+    late StreamController<List<DmConversation>> acceptedController;
+    late StreamController<List<DmConversation>> potentialController;
+    late StreamController<List<String>> followingController;
+    late Set<String> followed;
 
     setUp(() {
-      mockConversationsDao = _MockConversationsDao();
+      dmRepository = _MockDmRepository();
+      followRepository = _MockFollowRepository();
+      acceptedController = StreamController<List<DmConversation>>();
+      potentialController = StreamController<List<DmConversation>>();
+      followingController = StreamController<List<String>>();
+      followed = <String>{};
+
+      when(() => dmRepository.userPubkey).thenReturn(_me);
+      // No-arg stub: this matches only a call WITHOUT a limit, locking in that
+      // the badge counts the full (unpaginated) accepted set, not a page.
+      when(
+        () => dmRepository.watchAcceptedConversations(),
+      ).thenAnswer((_) => acceptedController.stream);
+      when(
+        () => dmRepository.watchPotentialRequests(),
+      ).thenAnswer((_) => potentialController.stream);
+      when(
+        () => followRepository.followingStream,
+      ).thenAnswer((_) => followingController.stream);
+      when(
+        () => followRepository.isFollowing(any()),
+      ).thenAnswer((inv) => followed.contains(inv.positionalArguments.first));
     });
 
-    DmUnreadCountCubit buildCubit() {
-      dmRepository = DmRepository(
-        nostrClient: _MockNostrClient(),
-        directMessagesDao: _MockDirectMessagesDao(),
-        conversationsDao: mockConversationsDao,
+    tearDown(() async {
+      await acceptedController.close();
+      await potentialController.close();
+      await followingController.close();
+    });
+
+    DmUnreadCountCubit buildCubit({
+      ContentBlocklistRepository? contentBlocklistRepository,
+    }) {
+      return DmUnreadCountCubit(
+        dmRepository: dmRepository,
+        followRepository: followRepository,
+        contentBlocklistRepository: contentBlocklistRepository,
       );
-      return DmUnreadCountCubit(dmRepository: dmRepository);
     }
 
     test('initial state is 0', () {
-      when(
-        () => mockConversationsDao.watchUnreadAcceptedCount(),
-      ).thenAnswer((_) => const Stream.empty());
-
       final cubit = buildCubit();
-
       expect(cubit.state, equals(0));
-
       cubit.close();
     });
 
-    blocTest<DmUnreadCountCubit, int>(
-      'emits counts from watchUnreadAcceptedCount stream',
-      setUp: () {
-        when(
-          () => mockConversationsDao.watchUnreadAcceptedCount(),
-        ).thenAnswer((_) => Stream.fromIterable([1, 3, 0]));
+    test('stays at 0 when there are no conversations', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      acceptedController.add(const []);
+      potentialController.add(const []);
+      await _settle();
+
+      expect(cubit.state, equals(0));
+    });
+
+    test(
+      'counts an unread conversation from a followed peer the user has '
+      'never replied to (#4976 regression — old follow-blind count returned 0)',
+      () async {
+        followed.add(_alice);
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        acceptedController.add(const []);
+        potentialController.add([
+          _convo('c1', peer: _alice, isRead: false, currentUserHasSent: false),
+        ]);
+        await _settle();
+
+        expect(cubit.state, equals(1));
       },
-      build: buildCubit,
-      expect: () => const [1, 3, 0],
     );
 
-    blocTest<DmUnreadCountCubit, int>(
-      'emits nothing when stream is empty',
-      setUp: () {
-        when(
-          () => mockConversationsDao.watchUnreadAcceptedCount(),
-        ).thenAnswer((_) => const Stream.empty());
+    test('counts an unread accepted conversation', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      acceptedController.add([
+        _convo('c2', peer: _bob, isRead: false, currentUserHasSent: true),
+      ]);
+      potentialController.add(const []);
+      await _settle();
+
+      expect(cubit.state, equals(1));
+    });
+
+    test(
+      'excludes an unread request from a non-followed peer the user has '
+      'never replied to (it is not shown in the Messages list)',
+      () async {
+        // _carol is not in `followed`, never replied -> classifies as a request.
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        acceptedController.add(const []);
+        potentialController.add([
+          _convo('c3', peer: _carol, isRead: false, currentUserHasSent: false),
+        ]);
+        await _settle();
+
+        expect(cubit.state, equals(0));
       },
-      build: buildCubit,
-      expect: () => const <int>[],
     );
+
+    test('excludes read conversations', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      acceptedController.add([
+        _convo('c4', peer: _bob, isRead: true, currentUserHasSent: true),
+      ]);
+      potentialController.add(const []);
+      await _settle();
+
+      expect(cubit.state, equals(0));
+    });
+
+    test('counts the full unpaginated accepted set', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      // More than one inbox page of unread accepted conversations.
+      final many = List.generate(
+        60,
+        (i) => _convo(
+          _hex(i),
+          peer: _hex(1000 + i),
+          isRead: false,
+          currentUserHasSent: true,
+        ),
+      );
+      acceptedController.add(many);
+      potentialController.add(const []);
+      await _settle();
+
+      expect(cubit.state, equals(60));
+      // The badge must subscribe without a limit (full count, not a page).
+      verify(() => dmRepository.watchAcceptedConversations()).called(1);
+    });
+
+    test('recomputes when the following list changes', () async {
+      final cubit = buildCubit();
+      addTearDown(cubit.close);
+
+      acceptedController.add(const []);
+      potentialController.add([
+        _convo('c5', peer: _alice, isRead: false, currentUserHasSent: false),
+      ]);
+      await _settle();
+      // _alice not followed yet -> request -> not counted.
+      expect(cubit.state, equals(0));
+
+      followed.add(_alice);
+      followingController.add([_alice]);
+      await _settle();
+      // Now followed -> appears in the Messages list -> counted.
+      expect(cubit.state, equals(1));
+    });
+
+    group('blocklist-aware', () {
+      late _MockContentBlocklistRepository blocklist;
+      late StreamController<ContentPolicyState> stateController;
+
+      setUp(() {
+        blocklist = _MockContentBlocklistRepository();
+        stateController = StreamController<ContentPolicyState>();
+        when(
+          () => blocklist.stateStream,
+        ).thenAnswer((_) => stateController.stream);
+      });
+
+      tearDown(() async {
+        await stateController.close();
+      });
+
+      test('excludes a blocked unread accepted conversation', () async {
+        // Blocklist drops _bob's conversation, mirroring the list.
+        when(
+          () => blocklist.filterBlockedConversations(
+            any(),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenReturn(const <DmConversation>[]);
+
+        final cubit = buildCubit(contentBlocklistRepository: blocklist);
+        addTearDown(cubit.close);
+
+        acceptedController.add([
+          _convo('c6', peer: _bob, isRead: false, currentUserHasSent: true),
+        ]);
+        potentialController.add(const []);
+        await _settle();
+
+        expect(cubit.state, equals(0));
+      });
+
+      test('counts conversations the blocklist passes through', () async {
+        when(
+          () => blocklist.filterBlockedConversations(
+            any(),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer(
+          (inv) => inv.positionalArguments.first as List<DmConversation>,
+        );
+
+        final cubit = buildCubit(contentBlocklistRepository: blocklist);
+        addTearDown(cubit.close);
+
+        acceptedController.add([
+          _convo('c7', peer: _bob, isRead: false, currentUserHasSent: true),
+        ]);
+        potentialController.add(const []);
+        await _settle();
+
+        expect(cubit.state, equals(1));
+      });
+
+      test('recomputes when the blocklist changes', () async {
+        // Initially passes through -> counted.
+        when(
+          () => blocklist.filterBlockedConversations(
+            any(),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer(
+          (inv) => inv.positionalArguments.first as List<DmConversation>,
+        );
+
+        final cubit = buildCubit(contentBlocklistRepository: blocklist);
+        addTearDown(cubit.close);
+
+        acceptedController.add([
+          _convo('c8', peer: _bob, isRead: false, currentUserHasSent: true),
+        ]);
+        potentialController.add(const []);
+        await _settle();
+        expect(cubit.state, equals(1));
+
+        // Block _bob mid-session: the filter now drops it, and a blocklist
+        // state tick must force the badge to recompute.
+        when(
+          () => blocklist.filterBlockedConversations(
+            any(),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenReturn(const <DmConversation>[]);
+        stateController.add(_MockContentPolicyState());
+        await _settle();
+
+        expect(cubit.state, equals(0));
+      });
+    });
 
     test('cancels subscription on close', () async {
-      final controller = StreamController<int>();
-      when(
-        () => mockConversationsDao.watchUnreadAcceptedCount(),
-      ).thenAnswer((_) => controller.stream);
-
       final cubit = buildCubit();
       await cubit.close();
 
-      // Adding to the controller after close should not throw.
-      controller.add(5);
-      await controller.close();
+      // Emitting after close must not throw (subscription cancelled).
+      acceptedController.add(const []);
+      potentialController.add(const []);
+      await _settle();
     });
   });
 }

--- a/mobile/test/screens/inbox/inbox_page_test.dart
+++ b/mobile/test/screens/inbox/inbox_page_test.dart
@@ -1,6 +1,6 @@
 // ABOUTME: Widget tests for InboxPage, verifying BLoC setup and route constants.
-// ABOUTME: Ensures InboxPage provides ConversationListBloc, DmUnreadCountCubit,
-// ABOUTME: and MyFollowingBloc to InboxView via MultiBlocProvider.
+// ABOUTME: Ensures InboxPage provides ConversationListBloc and MyFollowingBloc
+// ABOUTME: to InboxView; the unread badge cubit is app-shell-scoped (#4976).
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -32,6 +33,9 @@ class _MockContentBlocklistRepository extends Mock
 class _MockInviteStatusCubit extends MockCubit<InviteStatusState>
     implements InviteStatusCubit {}
 
+class _MockDmUnreadCountCubit extends MockCubit<int>
+    implements DmUnreadCountCubit {}
+
 void main() {
   const testPubkey =
       'aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd';
@@ -43,6 +47,7 @@ void main() {
     late _MockContentBlocklistRepository mockBlocklistRepository;
     late MockGoRouter mockGoRouter;
     late _MockInviteStatusCubit mockInviteCubit;
+    late _MockDmUnreadCountCubit mockDmUnreadCountCubit;
 
     setUp(() {
       mockDmRepository = _MockDmRepository();
@@ -51,8 +56,10 @@ void main() {
       mockBlocklistRepository = _MockContentBlocklistRepository();
       mockGoRouter = MockGoRouter();
       mockInviteCubit = _MockInviteStatusCubit();
+      mockDmUnreadCountCubit = _MockDmUnreadCountCubit();
       when(() => mockInviteCubit.state).thenReturn(const InviteStatusState());
       when(mockInviteCubit.load).thenAnswer((_) async {});
+      when(() => mockDmUnreadCountCubit.state).thenReturn(0);
 
       when(
         () => mockDmRepository.watchAcceptedConversations(
@@ -62,9 +69,6 @@ void main() {
       when(
         () => mockDmRepository.watchPotentialRequests(),
       ).thenAnswer((_) => Stream.value(const []));
-      when(
-        () => mockDmRepository.watchUnreadAcceptedCount(),
-      ).thenAnswer((_) => Stream.value(0));
       when(() => mockDmRepository.userPubkey).thenReturn(testPubkey);
 
       when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkey);
@@ -99,8 +103,15 @@ void main() {
         (tester) async {
           await tester.pumpWidget(
             testMaterialApp(
-              home: BlocProvider<InviteStatusCubit>.value(
-                value: mockInviteCubit,
+              home: MultiBlocProvider(
+                providers: [
+                  // App-shell-scoped in production (#4976); provided here so the
+                  // inbox toggle can read it after InboxPage stopped self-scoping.
+                  BlocProvider<DmUnreadCountCubit>.value(
+                    value: mockDmUnreadCountCubit,
+                  ),
+                  BlocProvider<InviteStatusCubit>.value(value: mockInviteCubit),
+                ],
                 child: const InboxPage(),
               ),
               mockAuthService: mockAuthService,
@@ -137,8 +148,15 @@ void main() {
       testWidgets('renders $InboxView', (tester) async {
         await tester.pumpWidget(
           testMaterialApp(
-            home: BlocProvider<InviteStatusCubit>.value(
-              value: mockInviteCubit,
+            home: MultiBlocProvider(
+              providers: [
+                // App-shell-scoped in production (#4976); provided here so the
+                // inbox toggle can read it after InboxPage stopped self-scoping.
+                BlocProvider<DmUnreadCountCubit>.value(
+                  value: mockDmUnreadCountCubit,
+                ),
+                BlocProvider<InviteStatusCubit>.value(value: mockInviteCubit),
+              ],
               child: const InboxPage(),
             ),
             mockAuthService: mockAuthService,


### PR DESCRIPTION
## Description

The "Messages" unread badge (bottom-nav + inbox segmented toggle) counted only conversations where the current user had sent a message (`currentUserHasSent == true`), while the Messages **list** is follow-aware — it also shows unread chats from peers you **follow** but have **never replied to**, and it hides blocklisted peers. So the badge undercounted the visible unread dots (the report: 4 dots, badge 3). It was latent until #4973 backfilled the full conversation list after reinstall, which surfaced followed-but-unreplied conversations.

This makes the badge mirror the list exactly. `DmUnreadCountCubit` now combines the accepted + potential-request + following + blocklist streams and reuses the **same** static helpers the list uses (`DmRepository.classifyPotentialRequests`, `DmRepository.mergeAndSort`, `ContentBlocklistRepository.filterBlockedConversations`), counting unread over `accepted ∪ followed`, blocklist-filtered and unpaginated — so the count can't drift from the list. A pure-SQL count isn't possible because follow state is in-memory (`FollowRepository`), not a DB column.

The two badge surfaces are consolidated onto the single app-shell cubit; the redundant inbox-scoped cubit is removed.

Pure client-side display fix — no backend or Nostr protocol change (NIP-17 defines no read state).

**Related Issue:** Closes #4976

## Out of Scope

- **Account-switch staleness of the unread-count cubit** — the app-shell `DmUnreadCountCubit` captures its repositories via `ref.read` with no identity sync, so the badge can go stale after switching accounts. This is pre-existing (the bottom-nav badge already had it); consolidation makes the inbox toggle share it. Tracked in #5472 (under epic #5178), to be fixed with the `NotificationBadgeCubit`-style `setRepositories()` + sync-widget pattern.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `dart format` — clean.
- New `DmUnreadCountCubit` unit tests (12), including a regression that fails on the old follow-blind count (an unread chat from a followed peer you've never replied to now increments the badge), blocklist exclude/passthrough/reactivity, unpaginated counting, and follow-list-change reactivity.
- Updated `inbox_page_test.dart` to provide the now app-scoped cubit.
- Affected suites (dm blocs + inbox screens + bottom nav + app-shell badge), random ordering: 339 passing. Repo delegation test passing.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore