### PR TITLE
fix(video-editor): restore drafts with sticker layers without crashing

### DIFF
--- a/mobile/lib/extensions/complete_parameters_extensions.dart
+++ b/mobile/lib/extensions/complete_parameters_extensions.dart
@@ -2,8 +2,22 @@ import 'package:flutter/foundation.dart';
 import 'package:models/models.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+/// Deserializes [CompleteParameters] from a persisted draft map, rehydrating
+/// sticker [WidgetLayer]s with [videoEditorStickerWidgetLoader].
+///
+/// Without a `widgetLoader`, [CompleteParameters.fromMap] throws "The
+/// `widgetLoader` must be defined when importing the widget layer by id" for
+/// any sticker layer exported with an id, so the loader must be threaded
+/// through here.
+CompleteParameters completeParametersFromDraftMap(Map<String, dynamic> map) =>
+    CompleteParameters.fromMap(
+      map,
+      widgetLoader: videoEditorStickerWidgetLoader,
+    );
 
 /// Deep equality extension for [CompleteParameters].
 ///

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -830,7 +830,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       shareReplyToFeed: draft.shareReplyToFeed,
       expiration: VideoMetadataExpiration.fromDuration(draft.expireTime),
       editorStateHistory: draft.editorStateHistory,
-      editorEditingParameters: CompleteParameters.fromMap(
+      editorEditingParameters: completeParametersFromDraftMap(
         draft.editorEditingParameters,
       ),
       collaboratorPubkeys: draft.collaboratorPubkeys,

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -13,6 +13,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/complete_parameters_extensions.dart';
 import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
@@ -40,7 +41,6 @@ import 'package:openvine/services/native_proofmode_service.dart';
 import 'package:openvine/services/nostr_creator_binding_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_publish/video_publish_service.dart';
-import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -355,7 +355,7 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
           );
 
           final parameters = draft.editorEditingParameters.isNotEmpty
-              ? CompleteParameters.fromMap(draft.editorEditingParameters)
+              ? completeParametersFromDraftMap(draft.editorEditingParameters)
               : null;
 
           final result = await VideoEditorRenderService.renderVideoToClip(

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1800,10 +1800,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: c17cc3dd3f7f70c504bff3cc11cbc47dd19f35af7531d14f4bf46d073018d114
+      sha256: afa3593f52b3f75365d9b535b70f709dd35bafc8b4e444a5e8ec2afaeccdfc6f
       url: "https://pub.dev"
     source: hosted
-    version: "12.5.3"
+    version: "12.6.0"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -303,7 +303,7 @@ dependencies:
   convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^1.19.1
-  pro_image_editor: ^12.5.3
+  pro_image_editor: ^12.6.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0

--- a/mobile/test/extensions/complete_parameters_extensions_test.dart
+++ b/mobile/test/extensions/complete_parameters_extensions_test.dart
@@ -418,7 +418,12 @@ void main() {
 
         // The package's own fromMap can't rebuild a widget layer exported by
         // id without a loader — this is the crash the helper exists to prevent.
-        expect(() => CompleteParameters.fromMap(map), throwsA(anything));
+        // (AssertionError in debug; the same site null-check-crashes in
+        // release, where asserts are stripped.)
+        expect(
+          () => CompleteParameters.fromMap(map),
+          throwsA(isA<AssertionError>()),
+        );
 
         final restored = completeParametersFromDraftMap(map);
 

--- a/mobile/test/extensions/complete_parameters_extensions_test.dart
+++ b/mobile/test/extensions/complete_parameters_extensions_test.dart
@@ -1,8 +1,11 @@
+import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show StickerData, StickerPackData;
 import 'package:openvine/extensions/complete_parameters_extensions.dart';
+import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 CompleteParameters _makeParams({
@@ -370,6 +373,95 @@ void main() {
         final fullLength = largeImage.toList().toString().length;
         expect(logStr, contains('$fullLength chars'));
       });
+    });
+  });
+
+  group('completeParametersFromDraftMap', () {
+    WidgetLayer buildStickerLayer(StickerData sticker) {
+      return WidgetLayer(
+        width: 120,
+        widget: VideoEditorSticker(
+          sticker: sticker,
+          enableLimitCacheSize: false,
+        ),
+        meta: sticker.toJson(),
+        exportConfigs: WidgetLayerExportConfigs(
+          id: 'sticker-${sticker.description}',
+          meta: sticker.toJson(),
+        ),
+      );
+    }
+
+    // Mirrors how a draft persists editorEditingParameters: the in-memory
+    // CompleteParameters is serialized via toMap() and round-tripped through
+    // JSON into storage.
+    Map<String, dynamic> persistedMapFor(CompleteParameters params) {
+      return json.decode(json.encode(params.toMap())) as Map<String, dynamic>;
+    }
+
+    test(
+      'rehydrates a sticker widget layer instead of throwing the '
+      'widgetLoader assertion',
+      () {
+        const sticker = StickerData.network(
+          'https://stickers.example.com/heart.png',
+          description: 'Red heart',
+          tags: ['heart'],
+          packData: StickerPackData(
+            packId: 'reactions',
+            packName: 'Reactions',
+          ),
+        );
+        final map = persistedMapFor(
+          _makeParams(layers: [buildStickerLayer(sticker)]),
+        );
+
+        // The package's own fromMap can't rebuild a widget layer exported by
+        // id without a loader — this is the crash the helper exists to prevent.
+        expect(() => CompleteParameters.fromMap(map), throwsA(anything));
+
+        final restored = completeParametersFromDraftMap(map);
+
+        expect(restored.layers, hasLength(1));
+        final layer = restored.layers.single;
+        expect(layer, isA<WidgetLayer>());
+        expect((layer as WidgetLayer).widget, isA<VideoEditorSticker>());
+        expect(
+          (layer.widget as VideoEditorSticker).sticker.props,
+          equals(sticker.props),
+        );
+      },
+    );
+
+    test('returns default parameters for an empty map', () {
+      final restored = completeParametersFromDraftMap(const {});
+
+      expect(restored.layers, isEmpty);
+      expect(restored.blur, equals(0.0));
+    });
+
+    test('preserves non-widget parameters alongside rehydrated layers', () {
+      const sticker = StickerData.asset(
+        'assets/stickers/star.svg',
+        description: 'Gold star',
+        tags: ['star'],
+        packData: StickerPackData.fallback,
+      );
+      final map = persistedMapFor(
+        _makeParams(
+          layers: [buildStickerLayer(sticker)],
+          flipX: true,
+          rotateTurns: 2,
+          cropWidth: 720,
+        ),
+      );
+
+      final restored = completeParametersFromDraftMap(map);
+
+      expect(restored.flipX, isTrue);
+      expect(restored.rotateTurns, equals(2));
+      expect(restored.cropWidth, equals(720));
+      expect(restored.layers, hasLength(1));
     });
   });
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -2,6 +2,9 @@
 // ABOUTME: Tests all EditorNotifier methods and state transitions using ProviderContainer
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui';
 
 import 'package:characters/characters.dart';
 import 'package:fake_async/fake_async.dart';
@@ -20,6 +23,9 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
+import 'package:pro_image_editor/pro_image_editor.dart'
+    show CompleteParameters, WidgetLayer, WidgetLayerExportConfigs;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -1369,6 +1375,96 @@ void main() {
               'independently of finalRenderedClip (#5181)',
         );
       });
+
+      test(
+        'restores a draft whose editorEditingParameters contain a sticker '
+        'widget layer without crashing on the widgetLoader assertion',
+        () async {
+          const sticker = StickerData.network(
+            'https://stickers.example.com/heart.png',
+            description: 'Red heart',
+            tags: ['heart'],
+            packData: StickerPackData(
+              packId: 'reactions',
+              packName: 'Reactions',
+            ),
+          );
+          final stickerLayer = WidgetLayer(
+            width: 120,
+            widget: const VideoEditorSticker(
+              sticker: sticker,
+              enableLimitCacheSize: false,
+            ),
+            meta: sticker.toJson(),
+            exportConfigs: WidgetLayerExportConfigs(
+              id: 'sticker-${sticker.description}',
+              meta: sticker.toJson(),
+            ),
+          );
+          final params = CompleteParameters(
+            blur: 0,
+            originalImageSize: const Size(1080, 1920),
+            temporaryDecodedImageSize: const Size(1080, 1920),
+            bodySize: const Size(400, 800),
+            editorSize: const Size(400, 800),
+            matrixFilterList: const [],
+            matrixTuneAdjustmentsList: const [],
+            startTime: null,
+            endTime: null,
+            cropWidth: null,
+            cropHeight: null,
+            rotateTurns: 0,
+            cropX: null,
+            cropY: null,
+            flipX: false,
+            flipY: false,
+            image: Uint8List(0),
+            isTransformed: false,
+            layers: [stickerLayer],
+          );
+
+          // Mirror how a draft persists editorEditingParameters: the in-memory
+          // CompleteParameters is serialized via toMap() and round-tripped
+          // through JSON into storage.
+          final persistedParameters =
+              json.decode(json.encode(params.toMap())) as Map<String, dynamic>;
+
+          final draft = DivineVideoDraft.create(
+            id: 'draft-1',
+            clips: [
+              DivineVideoClip(
+                id: 'c1',
+                video: EditorVideo.file('/docs/clip.mp4'),
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+            editorEditingParameters: persistedParameters,
+          );
+          when(
+            () => mockDraftStorage.getDraftById('draft-1'),
+          ).thenAnswer((_) async => draft);
+
+          // restoreDraft rehydrates editorEditingParameters via
+          // completeParametersFromDraftMap, which threads
+          // videoEditorStickerWidgetLoader so the exported-by-id sticker layer
+          // rebuilds into a VideoEditorSticker. Reverting that call site to a
+          // bare CompleteParameters.fromMap would throw the widgetLoader
+          // assertion here, surfacing as a thrown restore rather than a green
+          // test (#5474).
+          final result = await container
+              .read(videoEditorProvider.notifier)
+              .restoreDraft('draft-1');
+
+          expect(result, isTrue);
+        },
+      );
     });
   });
 


### PR DESCRIPTION
Closes #5475

## Description

Restoring a draft whose editor parameters include a sticker `WidgetLayer`
crashed with "The `widgetLoader` must be defined when importing the widget
layer by id". `CompleteParameters.fromMap` rebuilt its layers without a
`widgetLoader`, so any sticker layer exported with an id hit the assertion
(and a null-check crash in release). The publish render path
(`VideoPublishNotifier`) had the same latent crash for the same draft.

The root cause was a missing parameter in `pro_image_editor`'s
`CompleteParameters.fromMap`, which didn't forward a `widgetLoader` to
`Layer.fromMap` — unlike `Layer.fromMap` / `ImportStateHistory.fromMap`, which
both accept one. That is fixed upstream in **pro_image_editor 12.6.0**, which
adds `widgetLoader` (and `widgetRecords`) to `CompleteParameters.fromMap`.

This PR:
- bumps `pro_image_editor` to `^12.6.0`, and
- threads `videoEditorStickerWidgetLoader` through both the editor-restore and
  publish-render paths via a small `completeParametersFromDraftMap` helper.

## Out of Scope

None.

## Verification

- `flutter analyze` (changed files) — no issues
- `flutter test` — `complete_parameters_extensions_test.dart` (incl. new sticker-rehydration tests), `video_editor_provider_test.dart`, `video_publish_provider_test.dart`, and the sticker export round-trip — all green
- New tests: a draft map containing a sticker `WidgetLayer` exported by id rehydrates via the loader instead of throwing; empty-map and non-widget-parameter cases preserved

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)