### PR TITLE
feat(camera): add previewOptimized + lowLatency stabilization modes

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3283,6 +3283,8 @@
     "videoRecorderStabilizationModeStandard": "መደበኛ",
     "videoRecorderStabilizationModeCinematic": "ሲኒማቲክ",
     "videoRecorderStabilizationModeCinematicExtended": "የተራዘመ ሲኒማቲክ",
+    "videoRecorderStabilizationModePreviewOptimized": "ለቅድመ-እይታ የተመቻቸ",
+    "videoRecorderStabilizationModeLowLatency": "ዝቅተኛ መዘግየት",
     "videoRecorderStabilizationModeAuto": "ራስ-ሰር",
     "videoRecorderLibraryEmptyLabel": "ክሊፕ ቤተ-መጽሐፍት፣ ምንም ቅንጥቦች የሉም",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, =1{የክሊፕ ቤተ-መዝገብ ክፈት፣ 1 ክሊፕ} other{የክሊፕ ቤተ-መዝገብ ክፈት፣ {clipCount} ክሊፖች}}",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2982,6 +2982,8 @@
     "videoRecorderStabilizationModeStandard": "قياسي",
     "videoRecorderStabilizationModeCinematic": "سينمائي",
     "videoRecorderStabilizationModeCinematicExtended": "سينمائي موسّع",
+    "videoRecorderStabilizationModePreviewOptimized": "محسّن للمعاينة",
+    "videoRecorderStabilizationModeLowLatency": "زمن استجابة منخفض",
     "videoRecorderStabilizationModeAuto": "تلقائي",
     "videoRecorderToggleFlashLabel": "تبديل الفلاش",
     "videoRecorderToggleGhostFrameLabel": "تبديل الإطار الشبحي",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2973,6 +2973,8 @@
     "videoRecorderStabilizationModeStandard": "Стандартна",
     "videoRecorderStabilizationModeCinematic": "Кинематографична",
     "videoRecorderStabilizationModeCinematicExtended": "Кинематографична разширена",
+    "videoRecorderStabilizationModePreviewOptimized": "Оптимизирана за преглед",
+    "videoRecorderStabilizationModeLowLatency": "Ниска латентност",
     "videoRecorderStabilizationModeAuto": "Авто",
     "videoRecorderLibraryEmptyLabel": "Библиотека с клипове, няма клипове",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Отвори библиотеката с клипове, 1 клип} other{Отвори библиотеката с клипове, {clipCount} клипа}}",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2723,6 +2723,8 @@
     "videoRecorderStabilizationModeStandard": "Standard",
     "videoRecorderStabilizationModeCinematic": "Cinematic",
     "videoRecorderStabilizationModeCinematicExtended": "Cinematic erweitert",
+    "videoRecorderStabilizationModePreviewOptimized": "Vorschau-optimiert",
+    "videoRecorderStabilizationModeLowLatency": "Niedrige Latenz",
     "videoRecorderStabilizationModeAuto": "Auto",
     "videoRecorderLibraryEmptyLabel": "Clip-Mediathek, keine Clips",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Clip-Mediathek öffnen, 1 Clip} other{Clip-Mediathek öffnen, {clipCount} Clips}}",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -4407,6 +4407,8 @@
   "videoRecorderStabilizationModeStandard": "Standard",
   "videoRecorderStabilizationModeCinematic": "Cinematic",
   "videoRecorderStabilizationModeCinematicExtended": "Cinematic Extended",
+  "videoRecorderStabilizationModePreviewOptimized": "Preview Optimized",
+  "videoRecorderStabilizationModeLowLatency": "Low Latency",
   "videoRecorderStabilizationModeAuto": "Auto",
   "videoRecorderLibraryEmptyLabel": "Clip library, no clips",
   "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Open clip library, 1 clip} other{Open clip library, {clipCount} clips}}",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2731,6 +2731,8 @@
     "videoRecorderStabilizationModeStandard": "Estándar",
     "videoRecorderStabilizationModeCinematic": "Cinematográfica",
     "videoRecorderStabilizationModeCinematicExtended": "Cinematográfica ampliada",
+    "videoRecorderStabilizationModePreviewOptimized": "Optimizada para vista previa",
+    "videoRecorderStabilizationModeLowLatency": "Baja latencia",
     "videoRecorderStabilizationModeAuto": "Automática",
     "videoRecorderLibraryEmptyLabel": "Biblioteca de clips, sin clips",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Abrir biblioteca de clips, 1 clip} other{Abrir biblioteca de clips, {clipCount} clips}}",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1668,6 +1668,8 @@
     "videoRecorderStabilizationModeStandard": "Standard",
     "videoRecorderStabilizationModeCinematic": "Cinematic",
     "videoRecorderStabilizationModeCinematicExtended": "Cinematic Extended",
+    "videoRecorderStabilizationModePreviewOptimized": "Optimized para sa Preview",
+    "videoRecorderStabilizationModeLowLatency": "Low Latency",
     "videoRecorderStabilizationModeAuto": "Auto",
     "videoRecorderLibraryEmptyLabel": "Clip library, walang clip",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Buksan ang clip library, 1 clip} other{Buksan ang clip library, {clipCount} clip}}",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2723,6 +2723,8 @@
     "videoRecorderStabilizationModeStandard": "Standard",
     "videoRecorderStabilizationModeCinematic": "Cinématique",
     "videoRecorderStabilizationModeCinematicExtended": "Cinématique étendue",
+    "videoRecorderStabilizationModePreviewOptimized": "Optimisée pour l'aperçu",
+    "videoRecorderStabilizationModeLowLatency": "Faible latence",
     "videoRecorderStabilizationModeAuto": "Auto",
     "videoRecorderLibraryEmptyLabel": "Bibliothèque de clips, aucun clip",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Ouvrir la bibliothèque de clips, 1 clip} other{Ouvrir la bibliothèque de clips, {clipCount} clips}}",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2989,6 +2989,8 @@
     "videoRecorderStabilizationModeStandard": "Standar",
     "videoRecorderStabilizationModeCinematic": "Sinematik",
     "videoRecorderStabilizationModeCinematicExtended": "Sinematik Diperluas",
+    "videoRecorderStabilizationModePreviewOptimized": "Dioptimalkan untuk pratinjau",
+    "videoRecorderStabilizationModeLowLatency": "Latensi rendah",
     "videoRecorderStabilizationModeAuto": "Otomatis",
     "videoRecorderToggleFlashLabel": "Ganti flash",
     "videoRecorderToggleGhostFrameLabel": "Ganti frame hantu",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2723,6 +2723,8 @@
     "videoRecorderStabilizationModeStandard": "Standard",
     "videoRecorderStabilizationModeCinematic": "Cinematografica",
     "videoRecorderStabilizationModeCinematicExtended": "Cinematografica estesa",
+    "videoRecorderStabilizationModePreviewOptimized": "Ottimizzata per l'anteprima",
+    "videoRecorderStabilizationModeLowLatency": "Bassa latenza",
     "videoRecorderStabilizationModeAuto": "Automatica",
     "videoRecorderLibraryEmptyLabel": "Libreria clip, nessun clip",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Apri libreria clip, 1 clip} other{Apri libreria clip, {clipCount} clip}}",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2982,6 +2982,8 @@
     "videoRecorderStabilizationModeStandard": "標準",
     "videoRecorderStabilizationModeCinematic": "シネマティック",
     "videoRecorderStabilizationModeCinematicExtended": "シネマティック拡張",
+    "videoRecorderStabilizationModePreviewOptimized": "プレビュー最適化",
+    "videoRecorderStabilizationModeLowLatency": "低遅延",
     "videoRecorderStabilizationModeAuto": "自動",
     "videoRecorderToggleFlashLabel": "フラッシュを切り替え",
     "videoRecorderToggleGhostFrameLabel": "ゴーストフレームを切り替え",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2306,6 +2306,8 @@
     "videoRecorderStabilizationModeStandard": "표준",
     "videoRecorderStabilizationModeCinematic": "시네마틱",
     "videoRecorderStabilizationModeCinematicExtended": "시네마틱 확장",
+    "videoRecorderStabilizationModePreviewOptimized": "미리보기 최적화",
+    "videoRecorderStabilizationModeLowLatency": "낮은 지연 시간",
     "videoRecorderStabilizationModeAuto": "자동",
     "videoRecorderToggleFlashLabel": "플래시 전환",
     "videoRecorderToggleGhostFrameLabel": "고스트 프레임 전환",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2723,6 +2723,8 @@
     "videoRecorderStabilizationModeStandard": "Standaard",
     "videoRecorderStabilizationModeCinematic": "Cinematisch",
     "videoRecorderStabilizationModeCinematicExtended": "Cinematisch uitgebreid",
+    "videoRecorderStabilizationModePreviewOptimized": "Voorbeeld-geoptimaliseerd",
+    "videoRecorderStabilizationModeLowLatency": "Lage latentie",
     "videoRecorderStabilizationModeAuto": "Automatisch",
     "videoRecorderLibraryEmptyLabel": "Clipbibliotheek, geen clips",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Clipbibliotheek openen, 1 clip} other{Clipbibliotheek openen, {clipCount} clips}}",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2723,6 +2723,8 @@
     "videoRecorderStabilizationModeStandard": "Standardowa",
     "videoRecorderStabilizationModeCinematic": "Filmowa",
     "videoRecorderStabilizationModeCinematicExtended": "Filmowa rozszerzona",
+    "videoRecorderStabilizationModePreviewOptimized": "Zoptymalizowana pod podgląd",
+    "videoRecorderStabilizationModeLowLatency": "Niskie opóźnienie",
     "videoRecorderStabilizationModeAuto": "Automatyczna",
     "videoRecorderLibraryEmptyLabel": "Biblioteka klipów, brak klipów",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Otwórz bibliotekę klipów, 1 klip} other{Otwórz bibliotekę klipów, {clipCount} klipów}}",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2723,6 +2723,8 @@
     "videoRecorderStabilizationModeStandard": "Padrão",
     "videoRecorderStabilizationModeCinematic": "Cinematográfica",
     "videoRecorderStabilizationModeCinematicExtended": "Cinematográfica ampliada",
+    "videoRecorderStabilizationModePreviewOptimized": "Otimizada para visualização",
+    "videoRecorderStabilizationModeLowLatency": "Baixa latência",
     "videoRecorderStabilizationModeAuto": "Automática",
     "videoRecorderLibraryEmptyLabel": "Biblioteca de clipes, sem clipes",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Abrir biblioteca de clipes, 1 clipe} other{Abrir biblioteca de clipes, {clipCount} clipes}}",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2723,6 +2723,8 @@
     "videoRecorderStabilizationModeStandard": "Standard",
     "videoRecorderStabilizationModeCinematic": "Cinematică",
     "videoRecorderStabilizationModeCinematicExtended": "Cinematică extinsă",
+    "videoRecorderStabilizationModePreviewOptimized": "Optimizată pentru previzualizare",
+    "videoRecorderStabilizationModeLowLatency": "Latență redusă",
     "videoRecorderStabilizationModeAuto": "Automată",
     "videoRecorderLibraryEmptyLabel": "Bibliotecă de clipuri, fără clipuri",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Deschide biblioteca de clipuri, 1 clip} other{Deschide biblioteca de clipuri, {clipCount} clipuri}}",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2723,6 +2723,8 @@
     "videoRecorderStabilizationModeStandard": "Standard",
     "videoRecorderStabilizationModeCinematic": "Filmisk",
     "videoRecorderStabilizationModeCinematicExtended": "Filmisk utökad",
+    "videoRecorderStabilizationModePreviewOptimized": "Förhandsoptimerad",
+    "videoRecorderStabilizationModeLowLatency": "Låg latens",
     "videoRecorderStabilizationModeAuto": "Auto",
     "videoRecorderLibraryEmptyLabel": "Klippbibliotek, inga klipp",
     "videoRecorderLibraryOpenLabel": "{clipCount, plural, one{Öppna klippbibliotek, 1 klipp} other{Öppna klippbibliotek, {clipCount} klipp}}",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2989,6 +2989,8 @@
     "videoRecorderStabilizationModeStandard": "Standart",
     "videoRecorderStabilizationModeCinematic": "Sinematik",
     "videoRecorderStabilizationModeCinematicExtended": "Sinematik Genişletilmiş",
+    "videoRecorderStabilizationModePreviewOptimized": "Önizleme için optimize",
+    "videoRecorderStabilizationModeLowLatency": "Düşük gecikme",
     "videoRecorderStabilizationModeAuto": "Otomatik",
     "videoRecorderToggleFlashLabel": "Flaşı değiştir",
     "videoRecorderToggleGhostFrameLabel": "Hayalet kareyi değiştir",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -13358,6 +13358,18 @@ abstract class AppLocalizations {
   /// **'Cinematic Extended'**
   String get videoRecorderStabilizationModeCinematicExtended;
 
+  /// No description provided for @videoRecorderStabilizationModePreviewOptimized.
+  ///
+  /// In en, this message translates to:
+  /// **'Preview Optimized'**
+  String get videoRecorderStabilizationModePreviewOptimized;
+
+  /// No description provided for @videoRecorderStabilizationModeLowLatency.
+  ///
+  /// In en, this message translates to:
+  /// **'Low Latency'**
+  String get videoRecorderStabilizationModeLowLatency;
+
   /// No description provided for @videoRecorderStabilizationModeAuto.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -7538,6 +7538,12 @@ class AppLocalizationsAm extends AppLocalizations {
   String get videoRecorderStabilizationModeCinematicExtended => 'የተራዘመ ሲኒማቲክ';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized => 'ለቅድመ-እይታ የተመቻቸ';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'ዝቅተኛ መዘግየት';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'ራስ-ሰር';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -7607,6 +7607,12 @@ class AppLocalizationsAr extends AppLocalizations {
   String get videoRecorderStabilizationModeCinematicExtended => 'سينمائي موسّع';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized => 'محسّن للمعاينة';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'زمن استجابة منخفض';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'تلقائي';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -7739,6 +7739,13 @@ class AppLocalizationsBg extends AppLocalizations {
       'Кинематографична разширена';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Оптимизирана за преглед';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Ниска латентност';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Авто';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -7753,6 +7753,13 @@ class AppLocalizationsDe extends AppLocalizations {
       'Cinematic erweitert';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Vorschau-optimiert';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Niedrige Latenz';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Auto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -7667,6 +7667,13 @@ class AppLocalizationsEn extends AppLocalizations {
       'Cinematic Extended';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Preview Optimized';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Low Latency';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Auto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -7736,6 +7736,13 @@ class AppLocalizationsEs extends AppLocalizations {
       'Cinematográfica ampliada';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Optimizada para vista previa';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Baja latencia';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Automática';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -7755,6 +7755,13 @@ class AppLocalizationsFil extends AppLocalizations {
       'Cinematic Extended';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Optimized para sa Preview';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Low Latency';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Auto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -7766,6 +7766,13 @@ class AppLocalizationsFr extends AppLocalizations {
       'Cinématique étendue';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Optimisée pour l\'aperçu';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Faible latence';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Auto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -7645,6 +7645,13 @@ class AppLocalizationsId extends AppLocalizations {
       'Sinematik Diperluas';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Dioptimalkan untuk pratinjau';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Latensi rendah';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Otomatis';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -7734,6 +7734,13 @@ class AppLocalizationsIt extends AppLocalizations {
       'Cinematografica estesa';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Ottimizzata per l\'anteprima';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Bassa latenza';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Automatica';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -7403,6 +7403,12 @@ class AppLocalizationsJa extends AppLocalizations {
   String get videoRecorderStabilizationModeCinematicExtended => 'シネマティック拡張';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized => 'プレビュー最適化';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => '低遅延';
+
+  @override
   String get videoRecorderStabilizationModeAuto => '自動';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -7425,6 +7425,12 @@ class AppLocalizationsKo extends AppLocalizations {
   String get videoRecorderStabilizationModeCinematicExtended => '시네마틱 확장';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized => '미리보기 최적화';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => '낮은 지연 시간';
+
+  @override
   String get videoRecorderStabilizationModeAuto => '자동';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -7705,6 +7705,13 @@ class AppLocalizationsNl extends AppLocalizations {
       'Cinematisch uitgebreid';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Voorbeeld-geoptimaliseerd';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Lage latentie';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Automatisch';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -7821,6 +7821,13 @@ class AppLocalizationsPl extends AppLocalizations {
       'Filmowa rozszerzona';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Zoptymalizowana pod podgląd';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Niskie opóźnienie';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Automatyczna';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -7715,6 +7715,13 @@ class AppLocalizationsPt extends AppLocalizations {
       'Cinematográfica ampliada';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Otimizada para visualização';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Baixa latência';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Automática';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -7834,6 +7834,13 @@ class AppLocalizationsRo extends AppLocalizations {
       'Cinematică extinsă';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Optimizată pentru previzualizare';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Latență redusă';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Automată';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -7676,6 +7676,13 @@ class AppLocalizationsSv extends AppLocalizations {
       'Filmisk utökad';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Förhandsoptimerad';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Låg latens';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Auto';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -7645,6 +7645,13 @@ class AppLocalizationsTr extends AppLocalizations {
       'Sinematik Genişletilmiş';
 
   @override
+  String get videoRecorderStabilizationModePreviewOptimized =>
+      'Önizleme için optimize';
+
+  @override
+  String get videoRecorderStabilizationModeLowLatency => 'Düşük gecikme';
+
+  @override
   String get videoRecorderStabilizationModeAuto => 'Otomatik';
 
   @override

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_actions.dart
@@ -150,6 +150,8 @@ String _stabilizationModeLabel(
     .standard => l10n.videoRecorderStabilizationModeStandard,
     .cinematic => l10n.videoRecorderStabilizationModeCinematic,
     .cinematicExtended => l10n.videoRecorderStabilizationModeCinematicExtended,
+    .previewOptimized => l10n.videoRecorderStabilizationModePreviewOptimized,
+    .lowLatency => l10n.videoRecorderStabilizationModeLowLatency,
     .auto => l10n.videoRecorderStabilizationModeAuto,
   };
 }

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -205,6 +205,8 @@ class CameraController(
         const val STABILIZATION_STANDARD = "standard"
         const val STABILIZATION_CINEMATIC = "cinematic"
         const val STABILIZATION_CINEMATIC_EXTENDED = "cinematicExtended"
+        const val STABILIZATION_PREVIEW_OPTIMIZED = "previewOptimized"
+        const val STABILIZATION_LOW_LATENCY = "lowLatency"
         const val STABILIZATION_AUTO = "auto"
 
         private val CANONICAL_STABILIZATION_MODES = setOf(
@@ -212,6 +214,8 @@ class CameraController(
             STABILIZATION_STANDARD,
             STABILIZATION_CINEMATIC,
             STABILIZATION_CINEMATIC_EXTENDED,
+            STABILIZATION_PREVIEW_OPTIMIZED,
+            STABILIZATION_LOW_LATENCY,
             STABILIZATION_AUTO,
         )
 
@@ -238,8 +242,9 @@ class CameraController(
          * `CONTROL_VIDEO_STABILIZATION_MODE_ON`, basic) and "cinematic"
          * ([previewStabilizationSupported] → `PREVIEW_STABILIZATION`, strong,
          * preview AND recording). The finer iOS tiers (`cinematicExtended`,
-         * `auto`) would map to the identical underlying mode, so they're omitted
-         * here to avoid duplicate-looking menu entries.
+         * `previewOptimized`, `lowLatency`, `auto`) would map to the identical
+         * underlying mode, so they're omitted here to avoid duplicate-looking
+         * menu entries.
          */
         fun buildStabilizationModeList(
             onSupported: Boolean,
@@ -750,6 +755,8 @@ class CameraController(
             STABILIZATION_STANDARD -> if (onSupported) on else off
             STABILIZATION_CINEMATIC,
             STABILIZATION_CINEMATIC_EXTENDED,
+            STABILIZATION_PREVIEW_OPTIMIZED,
+            STABILIZATION_LOW_LATENCY,
             STABILIZATION_AUTO -> when {
                 previewSupported -> preview
                 onSupported -> on

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
@@ -175,6 +175,10 @@ internal class VideoStabilizationTest {
         assertTrue(
             CameraController.isCanonicalStabilizationMode("cinematicExtended")
         )
+        assertTrue(
+            CameraController.isCanonicalStabilizationMode("previewOptimized")
+        )
+        assertTrue(CameraController.isCanonicalStabilizationMode("lowLatency"))
         assertTrue(CameraController.isCanonicalStabilizationMode("auto"))
         assertFalse(CameraController.isCanonicalStabilizationMode("bogus"))
     }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -1634,6 +1634,16 @@ class CameraController: NSObject {
                 return .cinematicExtended
             }
             return .cinematic
+        case "previewOptimized":
+            if #available(iOS 17.0, *) {
+                return .previewOptimized
+            }
+            return nil
+        case "lowLatency":
+            if #available(iOS 26.0, *) {
+                return .lowLatency
+            }
+            return nil
         case "auto":
             return .auto
         default:
@@ -1656,6 +1666,12 @@ class CameraController: NSObject {
         case .auto:
             return "auto"
         default:
+            if #available(iOS 26.0, *), mode == .lowLatency {
+                return "lowLatency"
+            }
+            if #available(iOS 17.0, *), mode == .previewOptimized {
+                return "previewOptimized"
+            }
             if #available(iOS 13.0, *), mode == .cinematicExtended {
                 return "cinematicExtended"
             }
@@ -1738,13 +1754,30 @@ class CameraController: NSObject {
         if #available(iOS 13.0, *) {
             candidates.append((.cinematicExtended, "cinematicExtended"))
         }
-        for (mode, name) in candidates
-        where format.isVideoStabilizationModeSupported(mode) {
-            modes.append(name)
+        // previewOptimized is a low-latency tier; the system only engages it
+        // on connections backed by a preview layer or preview-sized data
+        // output, so the format probe may surface it while the active video
+        // connection falls back to a nearby mode at apply time.
+        if #available(iOS 17.0, *) {
+            candidates.append((.previewOptimized, "previewOptimized"))
+        }
+        if #available(iOS 26.0, *) {
+            candidates.append((.lowLatency, "lowLatency"))
+        }
+        var probed: [String] = []
+        for (mode, name) in candidates {
+            let supported = format.isVideoStabilizationModeSupported(mode)
+            probed.append("\(name)=\(supported)")
+            if supported { modes.append(name) }
         }
         if modes.count > 1 {
             modes.append("auto")
         }
+        DivineCameraLog.shared.debug(
+            "Available stabilization modes: [\(modes.joined(separator: ", "))] "
+                + "(probed \(probed.joined(separator: ", ")))",
+            name: "DivineCamera.Stabilization"
+        )
         return modes
     }
 

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -1679,6 +1679,15 @@ class CameraController: NSObject {
         }
     }
 
+    private static func isPreviewOptimized(
+        _ mode: AVCaptureVideoStabilizationMode
+    ) -> Bool {
+        if #available(iOS 17.0, *) {
+            return mode == .previewOptimized
+        }
+        return false
+    }
+
     /// Sets the requested video stabilization mode and applies it to the
     /// active video connection. Returns true if the mode was applied.
     func setVideoStabilizationMode(_ mode: String) -> Bool {
@@ -1689,8 +1698,13 @@ class CameraController: NSObject {
             )
             return false
         }
+        let previous = requestedStabilizationMode
         requestedStabilizationMode = parsed
-        return applyVideoStabilization()
+        let applied = applyVideoStabilization()
+        if !applied {
+            requestedStabilizationMode = previous
+        }
+        return applied
     }
 
     /// Applies `requestedStabilizationMode` to the video connection. The
@@ -1710,6 +1724,15 @@ class CameraController: NSObject {
                 )
             }
             return requestedStabilizationMode == .off
+        }
+        if Self.isPreviewOptimized(requestedStabilizationMode) {
+            DivineCameraLog.shared.warning(
+                "Preview optimized stabilization requires a preview layer or "
+                    + "preview-sized AVCaptureVideoDataOutput; the recorder "
+                    + "uses a full-resolution data output",
+                name: "DivineCamera.Stabilization"
+            )
+            return false
         }
         // .auto lets AVFoundation pick a supported mode; for explicit modes
         // verify the active format actually supports the request.
@@ -1754,13 +1777,10 @@ class CameraController: NSObject {
         if #available(iOS 13.0, *) {
             candidates.append((.cinematicExtended, "cinematicExtended"))
         }
-        // previewOptimized is a low-latency tier; the system only engages it
-        // on connections backed by a preview layer or preview-sized data
-        // output, so the format probe may surface it while the active video
-        // connection falls back to a nearby mode at apply time.
-        if #available(iOS 17.0, *) {
-            candidates.append((.previewOptimized, "previewOptimized"))
-        }
+        // previewOptimized is intentionally omitted for this recorder. Apple
+        // only supports it on connections with a preview layer or preview-sized
+        // AVCaptureVideoDataOutput, while this controller records from the
+        // full-resolution data output that backs the Flutter texture.
         if #available(iOS 26.0, *) {
             candidates.append((.lowLatency, "lowLatency"))
         }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -1781,6 +1781,29 @@ class CameraController: NSObject {
         return modes
     }
 
+    /// The stabilization mode to surface in the camera state.
+    ///
+    /// For explicit modes we report the connection's actual
+    /// `activeVideoStabilizationMode`, not the requested one, so a silent
+    /// system fallback is reflected honestly — e.g. `previewOptimized`
+    /// requested on the recorder's full-resolution data output resolves to a
+    /// nearby mode. `auto` is reported verbatim because it expresses intent
+    /// ("let the system pick") rather than a concrete target, and an idle
+    /// session falls back to the requested value to avoid surfacing a
+    /// transient `.off` before the connection has configured.
+    private func reportedStabilizationString() -> String {
+        guard requestedStabilizationMode != .auto,
+            captureSession?.isRunning == true,
+            let connection = videoOutput?.connection(with: .video),
+            connection.isVideoStabilizationSupported
+        else {
+            return Self.stabilizationString(from: requestedStabilizationMode)
+        }
+        return Self.stabilizationString(
+            from: connection.activeVideoStabilizationMode
+        )
+    }
+
     /// Starts video recording using AVAssetWriter.
     /// - Parameters:
     ///   - maxDurationMs: Optional maximum duration in milliseconds. Recording stops automatically when reached.
@@ -2143,9 +2166,7 @@ class CameraController: NSObject {
             "textureId": textureId,
             "availableLenses": getAvailableLenses(),
             "currentLensMetadata": getCurrentLensMetadata() as Any,
-            "videoStabilizationMode": Self.stabilizationString(
-                from: requestedStabilizationMode
-            ),
+            "videoStabilizationMode": reportedStabilizationString(),
             "availableVideoStabilizationModes": availableStabilizationModes,
             // Mirror Android: "supported" means the active format offers at
             // least one mode beyond "off", so the UI affordance matches the

--- a/mobile/packages/divine_camera/lib/src/models/video_stabilization_mode.dart
+++ b/mobile/packages/divine_camera/lib/src/models/video_stabilization_mode.dart
@@ -19,6 +19,19 @@ enum DivineVideoStabilizationMode {
   /// The strongest cinematic stabilization tier available.
   cinematicExtended,
 
+  /// Low-latency, low-power stabilization tuned for the preview path.
+  ///
+  /// iOS 17+ only (`AVCaptureVideoStabilizationMode.previewOptimized`); other
+  /// platforms never report it.
+  previewOptimized,
+
+  /// Stabilization that adds no latency to the capture pipeline, at the cost
+  /// of a reduced field of view.
+  ///
+  /// iOS 26+ only (`AVCaptureVideoStabilizationMode.lowLatency`); other
+  /// platforms never report it.
+  lowLatency,
+
   /// Let the platform pick the best supported mode automatically.
   auto;
 
@@ -33,6 +46,10 @@ enum DivineVideoStabilizationMode {
         return 'cinematic';
       case DivineVideoStabilizationMode.cinematicExtended:
         return 'cinematicExtended';
+      case DivineVideoStabilizationMode.previewOptimized:
+        return 'previewOptimized';
+      case DivineVideoStabilizationMode.lowLatency:
+        return 'lowLatency';
       case DivineVideoStabilizationMode.auto:
         return 'auto';
     }
@@ -48,6 +65,10 @@ enum DivineVideoStabilizationMode {
         return DivineVideoStabilizationMode.cinematic;
       case 'cinematicExtended':
         return DivineVideoStabilizationMode.cinematicExtended;
+      case 'previewOptimized':
+        return DivineVideoStabilizationMode.previewOptimized;
+      case 'lowLatency':
+        return DivineVideoStabilizationMode.lowLatency;
       case 'auto':
         return DivineVideoStabilizationMode.auto;
       case 'off':

--- a/mobile/packages/divine_camera/test/ios_stabilization_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_stabilization_contract_test.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Static guards for iOS video stabilization recorder constraints.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('iOS stabilization recorder contract', () {
+    late final String controllerSource;
+
+    setUpAll(() {
+      final controllerFile = [
+        File('ios/Classes/CameraController.swift'),
+        File('packages/divine_camera/ios/Classes/CameraController.swift'),
+      ].firstWhere((file) => file.existsSync());
+
+      controllerSource = controllerFile.readAsStringSync();
+    });
+
+    test('does not advertise previewOptimized for full-resolution output', () {
+      expect(
+        controllerSource,
+        isNot(contains('candidates.append((.previewOptimized')),
+      );
+      expect(
+        controllerSource,
+        contains('previewOptimized is intentionally omitted for this recorder'),
+      );
+    });
+
+    test('rejects previewOptimized requests before saving native intent', () {
+      expect(
+        controllerSource,
+        contains('let previous = requestedStabilizationMode'),
+      );
+      expect(
+        controllerSource,
+        contains('requestedStabilizationMode = previous'),
+      );
+      expect(
+        controllerSource,
+        contains('Self.isPreviewOptimized(requestedStabilizationMode)'),
+      );
+    });
+  });
+}

--- a/mobile/packages/divine_camera/test/models/video_stabilization_mode_test.dart
+++ b/mobile/packages/divine_camera/test/models/video_stabilization_mode_test.dart
@@ -17,6 +17,14 @@ void main() {
         DivineVideoStabilizationMode.cinematicExtended.toNativeString(),
         'cinematicExtended',
       );
+      expect(
+        DivineVideoStabilizationMode.previewOptimized.toNativeString(),
+        'previewOptimized',
+      );
+      expect(
+        DivineVideoStabilizationMode.lowLatency.toNativeString(),
+        'lowLatency',
+      );
       expect(DivineVideoStabilizationMode.auto.toNativeString(), 'auto');
     });
 
@@ -36,6 +44,14 @@ void main() {
       expect(
         DivineVideoStabilizationMode.fromNativeString('cinematicExtended'),
         DivineVideoStabilizationMode.cinematicExtended,
+      );
+      expect(
+        DivineVideoStabilizationMode.fromNativeString('previewOptimized'),
+        DivineVideoStabilizationMode.previewOptimized,
+      );
+      expect(
+        DivineVideoStabilizationMode.fromNativeString('lowLatency'),
+        DivineVideoStabilizationMode.lowLatency,
       );
       expect(
         DivineVideoStabilizationMode.fromNativeString('auto'),


### PR DESCRIPTION
Closes #5477

## Description

Adds the newer iOS video stabilization vocabulary to the camera recorder while keeping the visible menu limited to modes the current recording pipeline can honestly apply.

- **Low Latency** (`lowLatency`, iOS 26+) is probed from the active capture format and surfaced when the OS and format both support it.
- **Preview Optimized** (`previewOptimized`, iOS 17+) is parsed and serialized for native vocabulary compatibility, but is intentionally not advertised by this recorder. Apple's contract limits it to preview-layer connections or preview-sized `AVCaptureVideoDataOutput`; Divine currently records from the full-resolution data output that backs the Flutter texture.
- `getCameraState()` reports the connection's actual `activeVideoStabilizationMode` for explicit modes instead of the requested mode, so native fallback is reflected honestly. `auto` is still reported as intent.
- Failed iOS stabilization requests now restore the previous requested native mode, avoiding stale requested-mode state after a rejected apply.

Android keeps its existing visible two-rung stabilization menu (`off` / `standard` / `cinematic`) but recognizes the newer strings defensively and maps them to the closest existing preview-stabilization behavior when received.

New l10n keys `videoRecorderStabilizationModePreviewOptimized` and `videoRecorderStabilizationModeLowLatency` are translated across all 18 offered locales and generated files are committed.

## Out of Scope

- `cinematicExtendedEnhanced` (iOS 18+) is intentionally not added.
- Surfacing `previewOptimized` in the recorder menu requires changing the capture pipeline to use a preview-layer or preview-sized data-output path. This PR prevents that mode from being offered until the pipeline can actually honor it.

## Verification

- `dart format test/ios_stabilization_contract_test.dart test/models/video_stabilization_mode_test.dart`
- `flutter test test/models/video_stabilization_mode_test.dart test/ios_stabilization_contract_test.dart` from `mobile/packages/divine_camera`
- `flutter analyze lib test` from `mobile/packages/divine_camera`
- `flutter test` from `mobile/packages/divine_camera`
- CI will run full mobile analyze/tests, generated-file checks, camera build, linked-issue gate, semantic PR, and preview build after push.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes incorrect capability reporting)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
