### PR TITLE
fix(dm): collapse legacy inflated 1:1 conversations out of message requests (#5374)

### DIFF
--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -3332,6 +3332,55 @@ class DmRepository {
     return (followed: followed, requests: requests);
   }
 
+  /// Decides whether an `is_group` conversation row is actually a 1:1 that was
+  /// stored with spurious extra participant(s), and returns the single real
+  /// peer to collapse it onto — or `null` to leave the row untouched.
+  ///
+  /// Legacy rows created before [_resolveConversationParticipants] existed
+  /// (the 2026-03 → 2026-04 window) stored the raw `p`-tag set of inbound
+  /// rumors, so a non-compliant client that added an extra `p` tag to a 1:1
+  /// produced a 3-distinct-participant `is_group=true` row that
+  /// [classifyPotentialRequests] then strands under "Message requests"
+  /// regardless of follow state (#5374). [_resolveConversationParticipants]
+  /// stops minting such rows going forward but does not repair existing ones.
+  ///
+  /// The signal is the set of **actual message senders**, never the stored
+  /// participant list: the spurious pubkey only ever appears as an extra `p`
+  /// tag, never as a message author, so a logical 1:1 has exactly one non-self
+  /// sender while a genuine group has two or more. The rumor `p` tags are
+  /// deliberately ignored — they are the source of the inflation. Returns
+  /// `null` for genuine groups (≥2 distinct senders), self-initiated groups
+  /// (no inbound sender), already-1:1 rows, and any inconsistent row.
+  @visibleForTesting
+  static String? spuriousGroupPeer({
+    required List<String> participantPubkeys,
+    required Set<String> messageSenderPubkeys,
+    required String userPubkey,
+  }) {
+    final nonSelfParticipants = participantPubkeys
+        .where((pk) => pk != userPubkey)
+        .toSet();
+    // Only inflated rows (≥2 stored non-self participants) are candidates; a
+    // real 1:1 already has a single non-self participant and is handled by the
+    // participant-count classifier.
+    if (nonSelfParticipants.length < 2) return null;
+
+    final nonSelfSenders = messageSenderPubkeys
+        .where((pk) => pk != userPubkey)
+        .toSet();
+    // Exactly one peer ever spoke ⇒ a 1:1 inflated with extra p-tags. Zero
+    // senders (self-initiated group) or two-plus senders (genuine group) are
+    // left untouched.
+    if (nonSelfSenders.length != 1) return null;
+
+    final peer = nonSelfSenders.first;
+    // The speaker must be one of the stored participants; otherwise the row is
+    // inconsistent and unsafe to rewrite.
+    if (!nonSelfParticipants.contains(peer)) return null;
+
+    return peer;
+  }
+
   /// Merges accepted conversations with followed-but-unreplied ones
   /// and sorts by timestamp descending.
   static List<DmConversation> mergeAndSort(
@@ -3578,6 +3627,100 @@ class DmRepository {
     }
   }
 
+  /// Collapses legacy inflated 1:1 conversation rows back to their canonical
+  /// 1:1 form so they stop being treated as groups and stranded under
+  /// "Message requests" (#5374).
+  ///
+  /// A row is collapsed only when its actual message senders prove it is a
+  /// 1:1 (see [spuriousGroupPeer]); genuine groups, self-initiated groups,
+  /// and ambiguous rows are left untouched. Mirrors
+  /// [_mergeDuplicateConversations]'s reassign/delete/create-if-missing flow.
+  ///
+  /// Idempotent — safe to call on every init. Becomes a no-op once all
+  /// inflated rows are collapsed. Deleting the inflated row also breaks the
+  /// re-perpetuation in [_resolveConversationParticipants]: a later inbound
+  /// message for the same peer no longer matches the deleted `existingFull`
+  /// row and is routed to the canonical 1:1 instead.
+  Future<void> _backfillCollapseInflatedOneToOneConversations() async {
+    try {
+      final allConversations = await _conversationsDao.getAllConversations(
+        ownerPubkey: _ownerPubkey,
+      );
+
+      for (final conv in allConversations) {
+        if (!conv.isGroup) continue;
+
+        final participants = (jsonDecode(conv.participantPubkeys) as List)
+            .cast<String>();
+        final messages = await _directMessagesDao.getMessagesForConversation(
+          conv.id,
+          ownerPubkey: _ownerPubkey,
+        );
+        final senders = messages.map((m) => m.senderPubkey).toSet();
+
+        final peer = spuriousGroupPeer(
+          participantPubkeys: participants,
+          messageSenderPubkeys: senders,
+          userPubkey: _userPubkey,
+        );
+        if (peer == null) continue;
+
+        final canonicalParticipants = [_userPubkey, peer]..sort();
+        final canonicalId = computeConversationId(canonicalParticipants);
+        if (canonicalId == conv.id) continue;
+
+        final existingCanonical = await _conversationsDao.getConversation(
+          canonicalId,
+          ownerPubkey: _ownerPubkey,
+        );
+
+        await _conversationsDao.runInTransaction(() async {
+          await _directMessagesDao.reassignConversation(
+            fromConversationId: conv.id,
+            toConversationId: canonicalId,
+            ownerPubkey: _userPubkey,
+          );
+          await _conversationsDao.deleteConversation(
+            conv.id,
+            ownerPubkey: _ownerPubkey,
+          );
+
+          // If the canonical 1:1 row didn't exist, create it from the
+          // inflated row's metadata (preserving currentUserHasSent).
+          if (existingCanonical == null) {
+            await _conversationsDao.upsertConversation(
+              id: canonicalId,
+              participantPubkeys: jsonEncode(canonicalParticipants),
+              isGroup: false,
+              createdAt: conv.createdAt,
+              lastMessageContent: conv.lastMessageContent,
+              lastMessageTimestamp: conv.lastMessageTimestamp,
+              lastMessageSenderPubkey: conv.lastMessageSenderPubkey,
+              currentUserHasSent: conv.currentUserHasSent,
+              ownerPubkey: conv.ownerPubkey,
+              dmProtocol: conv.dmProtocol,
+            );
+          }
+        });
+
+        // Refresh preview from the actual (reassigned) messages.
+        await _refreshConversationPreview(canonicalId);
+
+        Log.info(
+          'Collapsed inflated 1:1 conversation to canonical form (#5374)',
+          category: LogCategory.system,
+        );
+      }
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to collapse inflated 1:1 conversations: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
   /// Removes phantom self-conversations created by the self-wrap bug where
   /// `_resolveConversationParticipants` produced `[self, self]`.
   ///
@@ -3622,6 +3765,7 @@ class DmRepository {
   Future<void> _runPostAuthMaintenance() async {
     await _mergeDuplicateConversations();
     await _cleanupSelfConversations();
+    await _backfillCollapseInflatedOneToOneConversations();
     await _backfillCurrentUserHasSent();
     await _backfillConversationPreviews();
   }

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -2553,6 +2553,209 @@ void main() {
         ).called(1);
       });
 
+      test(
+        'setCredentials collapses an inflated 1:1 group row to canonical 1:1 '
+        '(#5374)',
+        () async {
+          final inflated = [_validPubkeyA, _validPubkeyB, _validPubkeyC]
+            ..sort();
+          final inflatedId = DmRepository.computeConversationId(inflated);
+          final canonical = [_validPubkeyA, _validPubkeyB]..sort();
+          final canonicalId = DmRepository.computeConversationId(canonical);
+
+          when(
+            () => mockConversationsDao.getAllConversations(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              ConversationRow(
+                id: inflatedId,
+                participantPubkeys: jsonEncode(inflated),
+                isGroup: true,
+                isRead: true,
+                currentUserHasSent: false,
+                createdAt: 1700000000,
+              ),
+            ],
+          );
+          // Only B ever spoke ⇒ a 1:1 inflated with the spurious C p-tag.
+          when(
+            () => mockDirectMessagesDao.getMessagesForConversation(
+              any(),
+              limit: any(named: 'limit'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              DirectMessageRow(
+                id: 'm1',
+                conversationId: inflatedId,
+                senderPubkey: _validPubkeyB,
+                content: 'hi',
+                createdAt: 1700000000,
+                giftWrapId: 'g1',
+                messageKind: 14,
+                isDeleted: false,
+              ),
+            ],
+          );
+          when(
+            () => mockConversationsDao.getConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockDirectMessagesDao.reassignConversation(
+              fromConversationId: any(named: 'fromConversationId'),
+              toConversationId: any(named: 'toConversationId'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => 1);
+          when(
+            () => mockConversationsDao.deleteConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => 1);
+          when(
+            () => mockConversationsDao.upsertConversation(
+              id: any(named: 'id'),
+              participantPubkeys: any(named: 'participantPubkeys'),
+              isGroup: any(named: 'isGroup'),
+              createdAt: any(named: 'createdAt'),
+              lastMessageContent: any(named: 'lastMessageContent'),
+              lastMessageTimestamp: any(named: 'lastMessageTimestamp'),
+              lastMessageSenderPubkey: any(named: 'lastMessageSenderPubkey'),
+              subject: any(named: 'subject'),
+              isRead: any(named: 'isRead'),
+              currentUserHasSent: any(named: 'currentUserHasSent'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              dmProtocol: any(named: 'dmProtocol'),
+            ),
+          ).thenAnswer((_) async {});
+
+          DmRepository(
+            nostrClient: mockNostrClient,
+            directMessagesDao: mockDirectMessagesDao,
+            conversationsDao: mockConversationsDao,
+          ).setCredentials(
+            userPubkey: _validPubkeyA,
+            signer: LocalNostrSigner(_validPrivateKey),
+            messageService: mockMessageService,
+          );
+
+          await Future<void>.delayed(Duration.zero);
+
+          verify(
+            () => mockDirectMessagesDao.reassignConversation(
+              fromConversationId: inflatedId,
+              toConversationId: canonicalId,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).called(1);
+          verify(
+            () => mockConversationsDao.deleteConversation(
+              inflatedId,
+              ownerPubkey: _validPubkeyA,
+            ),
+          ).called(1);
+        },
+      );
+
+      test('setCredentials does not collapse a genuine group row', () async {
+        final group = [_validPubkeyA, _validPubkeyB, _validPubkeyC]..sort();
+        final groupId = DmRepository.computeConversationId(group);
+
+        when(
+          () => mockConversationsDao.getAllConversations(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            ConversationRow(
+              id: groupId,
+              participantPubkeys: jsonEncode(group),
+              isGroup: true,
+              isRead: true,
+              currentUserHasSent: false,
+              createdAt: 1700000000,
+            ),
+          ],
+        );
+        when(
+          () => mockConversationsDao.getConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => null);
+        // Two distinct peers spoke ⇒ a genuine group, must be left untouched.
+        when(
+          () => mockDirectMessagesDao.getMessagesForConversation(
+            any(),
+            limit: any(named: 'limit'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            DirectMessageRow(
+              id: 'm1',
+              conversationId: groupId,
+              senderPubkey: _validPubkeyB,
+              content: 'hi',
+              createdAt: 1700000000,
+              giftWrapId: 'g1',
+              messageKind: 14,
+              isDeleted: false,
+            ),
+            DirectMessageRow(
+              id: 'm2',
+              conversationId: groupId,
+              senderPubkey: _validPubkeyC,
+              content: 'yo',
+              createdAt: 1700000001,
+              giftWrapId: 'g2',
+              messageKind: 14,
+              isDeleted: false,
+            ),
+          ],
+        );
+        when(
+          () => mockDirectMessagesDao.reassignConversation(
+            fromConversationId: any(named: 'fromConversationId'),
+            toConversationId: any(named: 'toConversationId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => 0);
+        when(
+          () => mockConversationsDao.deleteConversation(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => 0);
+
+        DmRepository(
+          nostrClient: mockNostrClient,
+          directMessagesDao: mockDirectMessagesDao,
+          conversationsDao: mockConversationsDao,
+        ).setCredentials(
+          userPubkey: _validPubkeyA,
+          signer: LocalNostrSigner(_validPrivateKey),
+          messageService: mockMessageService,
+        );
+
+        await Future<void>.delayed(Duration.zero);
+
+        verifyNever(
+          () => mockDirectMessagesDao.reassignConversation(
+            fromConversationId: any(named: 'fromConversationId'),
+            toConversationId: any(named: 'toConversationId'),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+      });
+
       test('startListening does not poll the relay', () async {
         // Regression guard: the 10s gift-wrap poll timer was removed
         // because it re-fetched the last 20 events forever on the UI
@@ -7663,6 +7866,86 @@ void main() {
 
         expect(result.followed, isEmpty);
         expect(result.requests, isEmpty);
+      });
+    });
+
+    group('spuriousGroupPeer', () {
+      test('returns the sole speaker for an inflated 1:1 (one sender)', () {
+        // [self, B, C] stored as a group, but only B ever spoke ⇒ B was the
+        // real 1:1 peer and C is a spurious extra p-tag (#5374).
+        final peer = DmRepository.spuriousGroupPeer(
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+          messageSenderPubkeys: {_validPubkeyB},
+          userPubkey: _validPubkeyA,
+        );
+        expect(peer, equals(_validPubkeyB));
+      });
+
+      test('ignores self among the senders', () {
+        // The user replied, so self is also a sender; only B is non-self.
+        final peer = DmRepository.spuriousGroupPeer(
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+          messageSenderPubkeys: {_validPubkeyA, _validPubkeyB},
+          userPubkey: _validPubkeyA,
+        );
+        expect(peer, equals(_validPubkeyB));
+      });
+
+      test('returns null for a genuine group (two distinct senders)', () {
+        final peer = DmRepository.spuriousGroupPeer(
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+          messageSenderPubkeys: {_validPubkeyB, _validPubkeyC},
+          userPubkey: _validPubkeyA,
+        );
+        expect(peer, isNull);
+      });
+
+      test('returns null for a self-initiated group (no inbound sender)', () {
+        final peer = DmRepository.spuriousGroupPeer(
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+          messageSenderPubkeys: {_validPubkeyA},
+          userPubkey: _validPubkeyA,
+        );
+        expect(peer, isNull);
+      });
+
+      test('returns null when there are no messages', () {
+        final peer = DmRepository.spuriousGroupPeer(
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+          messageSenderPubkeys: const {},
+          userPubkey: _validPubkeyA,
+        );
+        expect(peer, isNull);
+      });
+
+      test(
+        'returns null for an already-1:1 row (one non-self peer)',
+        () {
+          final peer = DmRepository.spuriousGroupPeer(
+            participantPubkeys: [_validPubkeyA, _validPubkeyB],
+            messageSenderPubkeys: {_validPubkeyB},
+            userPubkey: _validPubkeyA,
+          );
+          expect(peer, isNull);
+        },
+      );
+
+      test('returns null when the sole sender is not a participant', () {
+        final peer = DmRepository.spuriousGroupPeer(
+          participantPubkeys: [_validPubkeyA, _validPubkeyB, _validPubkeyC],
+          messageSenderPubkeys: {_validPubkeyD},
+          userPubkey: _validPubkeyA,
+        );
+        expect(peer, isNull);
+      });
+
+      test('returns null for empty participants', () {
+        final peer = DmRepository.spuriousGroupPeer(
+          participantPubkeys: const [],
+          messageSenderPubkeys: {_validPubkeyB},
+          userPubkey: _validPubkeyA,
+        );
+        expect(peer, isNull);
       });
     });
 


### PR DESCRIPTION
## Description

Legacy 1:1 DM conversations can be stranded under **Message requests** even when the peer is followed, because the conversation row was physically stored with an extra participant.

Conversations ingested before `_resolveConversationParticipants` existed (the 2026-03-11 → 2026-04-04 window) stored the raw `p`-tag set of inbound rumors. A non-compliant client that added an extra `p` tag (e.g. a reply mention) to a 1:1 produced a **3-distinct-participant row flagged `is_group=true`**. `classifyPotentialRequests` derives 1:1-ness from the deduped non-self participant count, so it treats such a row as a group and routes it to Requests regardless of follow state.

#5387 fixed the cases whose non-self set dedups to a single peer (a stale `is_group` flag on a 2-entry row, or a duplicate-entry row). But the **receive path cannot produce those shapes** — it co-writes `is_group = participants.length > 2` from a `Set`-clean participant list — so a received `is_group=true` row always has ≥3 distinct participants. #5387 therefore does not touch these legacy rows, and nothing on `main` collapses a *lone* inflated row (`_mergeDuplicateConversations` only merges peer-groups of size > 1; `_resolveConversationParticipants` re-perpetuates the inflated row on re-ingest).

This PR adds an idempotent post-auth maintenance pass that:

- Detects an inflated 1:1 by its **actual message senders** — exactly one non-self sender means the extra participant never authored a message and is a spurious `p` tag. (The rumor `p` tags are deliberately ignored: they are the source of the inflation.)
- Reassigns the conversation's messages to the canonical 1:1 id, deletes the inflated row, and creates the canonical row if missing (mirrors `_mergeDuplicateConversations`).
- Deleting the inflated row also breaks the re-perpetuation in `_resolveConversationParticipants`, so later inbound messages for that peer resolve to the canonical 1:1.

Genuine groups (≥2 distinct senders) and self-initiated groups (no inbound sender) are left untouched. The decision is a pure, `@visibleForTesting` static helper (`spuriousGroupPeer`) so the logic is unit-testable in isolation.

**Related Issue:** Relates to #5374

## Out of Scope

- **Durable NIP-51 accepted-peers list** (cross-device / reinstall durability, and the *unfollowed*-replied-to-peer case) — secondary, forward-looking; a separate follow-up. It does not retroactively heal existing inflated rows, which is what this PR targets.
- **Send-path hardening** (`sendGroupMessage` does not dedup recipients) — currently inert for this issue, since self-authored group rows carry `currentUserHasSent=true` and are classified as accepted, never requests. Tracked separately.
- A single benign edge: a genuine group in which only one member ever spoke would collapse to a 1:1. This is rare and indistinguishable from a 1:1 from the user's perspective.

## Verification

- `flutter analyze` (dm_repository package) — clean.
- `flutter analyze lib test integration_test` (mobile app) — clean.
- `flutter test packages/dm_repository/test/src/dm_repository_test.dart` — 227 passed, including 8 `spuriousGroupPeer` matrix tests and 2 wiring tests (collapses an inflated 1:1 via `setCredentials`; leaves a genuine two-speaker group untouched).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
