### PR TITLE
fix(dm): classify message requests with the real pubkey, not the empty cold-start one (#5374)

### DIFF
--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -81,21 +81,34 @@ class ConversationListBloc
     // Combining ensures requests are never truncated by pagination
     // and follow-list changes are handled automatically.
     await emit.forEach(
-      Rx.combineLatest4(
+      Rx.combineLatest5(
         _dmRepository.watchAcceptedConversations(limit: state.currentLimit),
         _dmRepository.watchPotentialRequests(),
         _followRepository.followingStream.startWith(const []),
         _dmRepository.historyRecoveryStream.startWith(
           _dmRepository.isRecoveringHistory,
         ),
-        (accepted, potentialRequests, _, isRestoring) => (
+        // Stream 5: the user's pubkey. The DAO streams emit cached rows before
+        // `setCredentials` populates it at cold start, so classifying with the
+        // empty pre-auth pubkey would misroute every 1:1. This re-fires the
+        // handler once the real identity arrives. See #5374.
+        _dmRepository.userPubkeyStream.startWith(_dmRepository.userPubkey),
+        (accepted, potentialRequests, _, isRestoring, userPubkey) => (
           accepted: accepted,
           potentialRequests: potentialRequests,
           isRestoring: isRestoring,
+          userPubkey: userPubkey,
         ),
       ),
       onData: (data) {
-        final userPubkey = _dmRepository.userPubkey;
+        // Until credentials are set, the pubkey is empty and self cannot be
+        // filtered out of a conversation's participants — classifying now would
+        // make every 1:1 look like a group and land in Message requests. Hold
+        // the current (loading) state; stream 5 re-fires this once the real
+        // identity is available. See #5374.
+        final userPubkey = data.userPubkey;
+        if (userPubkey.isEmpty) return state;
+
         final split = DmRepository.classifyPotentialRequests(
           data.potentialRequests,
           userPubkey: userPubkey,

--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -104,20 +104,27 @@ class DmUnreadCountCubit extends Cubit<int> {
               .startWith(null);
 
     _subscription =
-        Rx.combineLatest4<
+        Rx.combineLatest5<
               List<DmConversation>,
               List<DmConversation>,
               List<String>,
               Object?,
+              String,
               int
             >(
               dmRepository.watchAcceptedConversations(),
               dmRepository.watchPotentialRequests(),
               followRepository.followingStream.startWith(const <String>[]),
               blocklistTicks,
-              (accepted, potentialRequests, _, _) => _countUnread(
+              // Identity stream (#5374): the DAO streams emit cached rows before
+              // setCredentials populates the pubkey at cold start; without it
+              // _countUnread classifies with the empty pubkey and undercounts
+              // followed-but-unreplied 1:1s. Re-fires once the identity lands.
+              dmRepository.userPubkeyStream.startWith(dmRepository.userPubkey),
+              (accepted, potentialRequests, _, _, userPubkey) => _countUnread(
                 accepted: accepted,
                 potentialRequests: potentialRequests,
+                userPubkey: userPubkey,
               ),
             )
             .listen(
@@ -138,12 +145,18 @@ class DmUnreadCountCubit extends Cubit<int> {
   int _countUnread({
     required List<DmConversation> accepted,
     required List<DmConversation> potentialRequests,
+    required String userPubkey,
   }) {
     final dmRepository = _dmRepository;
     final followRepository = _followRepository;
     if (dmRepository == null || followRepository == null) return 0;
 
-    final userPubkey = dmRepository.userPubkey;
+    // Until credentials are set the pubkey is empty and self cannot be filtered
+    // from a conversation's participants — classifying now drops every followed
+    // 1:1 from the count. Keep the current count; the identity stream re-fires
+    // this once the real pubkey arrives. See #5374.
+    if (userPubkey.isEmpty) return state;
+
     final split = DmRepository.classifyPotentialRequests(
       potentialRequests,
       userPubkey: userPubkey,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -300,6 +300,16 @@ class DmRepository {
   final StreamController<bool> _recoveryStateController =
       StreamController<bool>.broadcast();
 
+  /// Broadcasts the user's pubkey whenever credentials change.
+  ///
+  /// Consumers that classify rows by identity (e.g. the conversation-list
+  /// "Message requests" split) must re-run when this fires, otherwise a cold
+  /// start can classify with the pre-auth empty pubkey — which fails to filter
+  /// self out of a conversation's participants, making every 1:1 look like a
+  /// group and land in Message Requests. See #5374.
+  final StreamController<String> _userPubkeyController =
+      StreamController<String>.broadcast();
+
   /// User-scoped subscription ID to prevent collision when the provider
   /// rebuilds during auth transitions (old unsubscribe won't kill new sub).
   String _subscriptionId = 'dm_inbox';
@@ -354,6 +364,13 @@ class DmRepository {
     _messageService = messageService;
     if (rumorDecryptor != null) _rumorDecryptor = rumorDecryptor;
     if (nip04Decryptor != null) _nip04Decryptor = nip04Decryptor;
+
+    // Notify identity-scoped consumers (e.g. the conversation-list classifier)
+    // so a cold-start subscription that first ran with the empty pre-auth
+    // pubkey re-classifies with the real identity. See #5374.
+    if (!_userPubkeyController.isClosed) {
+      _userPubkeyController.add(userPubkey);
+    }
 
     // Run post-auth maintenance sequentially so each step operates on the
     // final state of the previous one (e.g. backfill runs after merge).
@@ -3691,6 +3708,13 @@ class DmRepository {
   ///
   /// Returns an empty string if the repository has not been initialized.
   String get userPubkey => _userPubkey;
+
+  /// Emits the user's pubkey each time credentials are set (see
+  /// [setCredentials]). Seed a listener with the current [userPubkey] via
+  /// `userPubkeyStream.startWith(repo.userPubkey)` so it has a value before the
+  /// first credential change. Drives re-classification of identity-scoped
+  /// streams on cold-start auth. See #5374.
+  Stream<String> get userPubkeyStream => _userPubkeyController.stream;
 
   void _assertInitialized() {
     if (!isInitialized) {

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -75,6 +75,11 @@ void _stubStreams(
   when(
     () => repo.historyRecoveryStream,
   ).thenAnswer((_) => recoveryStream ?? const Stream<bool>.empty());
+  // Identity stream (#5374): seeded via `.startWith(userPubkey)` in the bloc.
+  when(() => repo.userPubkey).thenReturn(_testPubkey1);
+  when(
+    () => repo.userPubkeyStream,
+  ).thenAnswer((_) => const Stream<String>.empty());
 }
 
 void main() {
@@ -92,6 +97,11 @@ void main() {
         () => mockFollowRepository.followingStream,
       ).thenAnswer((_) => const Stream<List<String>>.empty());
       when(() => mockDmRepository.userPubkey).thenReturn(_testPubkey1);
+      // Identity stream (#5374): seeded via `.startWith(userPubkey)` in the
+      // bloc, so an empty stream is enough for the steady-state value to flow.
+      when(
+        () => mockDmRepository.userPubkeyStream,
+      ).thenAnswer((_) => const Stream<String>.empty());
       // Recovery-aware request gate (#5304): default to "recovery complete"
       // so existing split assertions hold; gate tests override to false.
       when(
@@ -1005,6 +1015,76 @@ void main() {
         );
       });
     });
+
+    // -----------------------------------------------------------------
+    // Identity race (#5374)
+    // -----------------------------------------------------------------
+
+    group('identity race (#5374)', () {
+      blocTest<ConversationListBloc, ConversationListState>(
+        'stays loading and does not classify while userPubkey is empty',
+        setUp: () {
+          _stubStreams(
+            mockDmRepository,
+            potentialRequests: [_createConversation(id: 'c1')],
+          );
+          // Cold start: credentials not set yet and the identity stream never
+          // delivers a real pubkey, so classification must be held back.
+          when(() => mockDmRepository.userPubkey).thenReturn('');
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ConversationListStarted()),
+        // Only the loading emit — the empty-pubkey guard prevents a
+        // misclassified "requests" emission (which would leave self in
+        // otherPubkeys, making the 1:1 look like a group).
+        expect: () => [
+          isA<ConversationListState>().having(
+            (s) => s.status,
+            'status',
+            ConversationListStatus.loading,
+          ),
+        ],
+      );
+
+      blocTest<ConversationListBloc, ConversationListState>(
+        'routes a followed 1:1 peer to the inbox once userPubkey arrives, '
+        'not to requests',
+        setUp: () {
+          _stubStreams(
+            mockDmRepository,
+            potentialRequests: [
+              _createConversation(
+                id: 'c1',
+                participantPubkeys: const [_testPubkey1, _testPubkey2],
+              ),
+            ],
+          );
+          // Empty at first; the identity stream then delivers the real pubkey,
+          // mirroring the cold-start race the #5374 diagnostics captured.
+          when(() => mockDmRepository.userPubkey).thenReturn('');
+          when(
+            () => mockDmRepository.userPubkeyStream,
+          ).thenAnswer((_) => Stream.value(_testPubkey1));
+          when(
+            () => mockFollowRepository.isFollowing(_testPubkey2),
+          ).thenReturn(true);
+          when(
+            () => mockFollowRepository.isFollowing(_testPubkey1),
+          ).thenReturn(false);
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(const ConversationListStarted()),
+        verify: (bloc) {
+          // Self (_testPubkey1) is filtered, leaving the single followed peer
+          // _testPubkey2 → inbox. Before the fix the empty pubkey left self in
+          // otherPubkeys (count 2 → treated as a group) → misrouted to
+          // requests.
+          expect(bloc.state.requestConversations, isEmpty);
+          expect(bloc.state.conversations, hasLength(1));
+          expect(bloc.state.conversations.single.id, equals('c1'));
+        },
+      );
+    });
   });
 
   group('$ConversationListState', () {
@@ -1192,7 +1272,6 @@ void main() {
     });
   });
 
-  // -------------------------------------------------------------------
   // Subscription lifecycle (#2931)
   // -------------------------------------------------------------------
 

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_auth_transition_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_auth_transition_test.dart
@@ -125,6 +125,9 @@ _buildDm() {
   final accepted = StreamController<List<DmConversation>>.broadcast();
   final potential = StreamController<List<DmConversation>>.broadcast();
   when(() => dm.userPubkey).thenReturn(_me);
+  when(
+    () => dm.userPubkeyStream,
+  ).thenAnswer((_) => const Stream<String>.empty());
   when(dm.watchAcceptedConversations).thenAnswer((_) => accepted.stream);
   when(dm.watchPotentialRequests).thenAnswer((_) => potential.stream);
   return (dm: dm, accepted: accepted, potential: potential);

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
@@ -76,6 +76,11 @@ void main() {
       followed = <String>{};
 
       when(() => dmRepository.userPubkey).thenReturn(_me);
+      // Identity stream (#5374): seeded via `.startWith(userPubkey)` in the
+      // cubit, so an empty stream suffices for the steady-state value to flow.
+      when(
+        () => dmRepository.userPubkeyStream,
+      ).thenAnswer((_) => const Stream<String>.empty());
       // No-arg stub: this matches only a call WITHOUT a limit, locking in that
       // the badge counts the full (unpaginated) accepted set, not a page.
       when(
@@ -139,6 +144,38 @@ void main() {
         ]);
         await _settle();
 
+        expect(cubit.state, equals(1));
+      },
+    );
+
+    test(
+      'holds the count while userPubkey is empty, then counts the followed '
+      '1:1 once the identity arrives (#5374)',
+      () async {
+        followed.add(_alice);
+        // Cold start: empty pubkey until the identity stream delivers it.
+        when(() => dmRepository.userPubkey).thenReturn('');
+        final pubkeyController = StreamController<String>();
+        addTearDown(pubkeyController.close);
+        when(
+          () => dmRepository.userPubkeyStream,
+        ).thenAnswer((_) => pubkeyController.stream);
+
+        final cubit = buildCubit();
+        addTearDown(cubit.close);
+
+        acceptedController.add(const []);
+        potentialController.add([
+          _convo('c1', peer: _alice, isRead: false, currentUserHasSent: false),
+        ]);
+        await _settle();
+        // Empty pubkey: self cannot be filtered, so the guard holds the count
+        // instead of misclassifying the 1:1 as a group and dropping it.
+        expect(cubit.state, equals(0));
+
+        pubkeyController.add(_me);
+        await _settle();
+        // Identity arrived → the followed-but-unreplied 1:1 is counted.
         expect(cubit.state, equals(1));
       },
     );
@@ -351,6 +388,9 @@ void main() {
           await followingController2.close();
         });
         when(() => dmRepository2.userPubkey).thenReturn(_me);
+        when(
+          () => dmRepository2.userPubkeyStream,
+        ).thenAnswer((_) => const Stream<String>.empty());
         when(
           dmRepository2.watchAcceptedConversations,
         ).thenAnswer((_) => acceptedController2.stream);

--- a/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
+++ b/mobile/test/screens/inbox/message_requests/message_requests_page_test.dart
@@ -55,6 +55,11 @@ void main() {
         () => mockDmRepository.isHistoryRecoveryComplete,
       ).thenReturn(true);
       when(() => mockDmRepository.userPubkey).thenReturn(testPubkey);
+      // Identity stream (#5374): ConversationListBloc subscribes to it via
+      // `.startWith(userPubkey)`; an empty stream suffices for the seed.
+      when(
+        () => mockDmRepository.userPubkeyStream,
+      ).thenAnswer((_) => const Stream<String>.empty());
       when(() => mockDmRepository.startListening()).thenAnswer((_) async {});
       when(() => mockDmRepository.stopListening()).thenAnswer((_) async {});
       when(


### PR DESCRIPTION
## Description

DMs from followed peers intermittently land in **Message requests** at cold start. hm21's on-device `DM_CLASSIFY_DIAGNOSTICS` logs ([#5374 comment](https://github.com/divinevideo/divine-mobile/issues/5374#issuecomment-4780041206)) show the stranded conversations are normal 2-participant 1:1s (`participantCount=2 isGroup=false`), and that `otherPubkeys` transiently contains the user's **own** pubkey:

```
otherPubkeys={04c106a7…(self), 973a531d…(peer)} → request
… (a beat later) …
otherPubkeys={973a531d…(peer)}                  → correct
```

**Root cause.** `classifyPotentialRequests` filters self with `where((pk) => pk != userPubkey)`. The conversation-list bloc read `_dmRepository.userPubkey` at emit time, and its `combineLatest` had no `userPubkey` input. At cold start the DAO streams emit cached rows before `setCredentials` runs (an empty pubkey makes `_ownerPubkey` null, so the owner-scoped query returns all rows), so classification executes with an **empty** pubkey: self isn't filtered, every 1:1 ends up with two "other" participants, is treated as a group, and is routed to Message requests — regardless of follow state. With no pubkey stream feeding the combine there was no guaranteed re-classify, so the wrong split could **stick** (intermittent; clears after reinstall).

**Fix.** Mirror the existing `historyRecoveryStream` pattern: `DmRepository` exposes a `userPubkeyStream` (broadcast, emitted in `setCredentials`); consumers add it to their `combineLatest` via `.startWith(repo.userPubkey)` and guard `if (userPubkey.isEmpty) return <current state>`. This prevents any classification with an empty pubkey and guarantees a re-classify the moment credentials land.

- `conversation_list_bloc.dart` — `combineLatest4 → 5` + empty-pubkey guard. Covers the inbox list **and** the message-requests screen (both build `ConversationListBloc`).
- `dm_unread_count_cubit.dart` — the same race undercounted followed-but-unreplied 1:1s in the Messages badge at cold start; fixed identically.

**Related Issue:** Relates to #5374

## Out of Scope

- The brief follow-list-load flash (a followed peer can show as a request for a moment until the follow list finishes loading) self-heals via the existing `followingStream` input and is not the sticking bug reported here.
- #5478 (legacy inflated-row collapse) is **closed** — these diagnostics refuted that hypothesis; the rows are plain 2-participant 1:1s, not inflated.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test`:
  - `conversation_list_bloc_test.dart` — 52 pass, incl. new "identity race (#5374)" group (guard holds on empty pubkey; followed 1:1 → inbox once pubkey arrives).
  - `dm_unread_count_cubit_test.dart` + auth-transition — pass, incl. new empty-pubkey guard test.
  - `dm_repository` package — 217 pass.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
