### PR TITLE
feat(feed): filter unavailable videos across all surfaces

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -44,6 +44,16 @@ typedef OnVideoConfirmedUnavailable = void Function(String videoId);
 /// across mutations.
 typedef BlockAuthorFilter = bool Function(String pubkey);
 
+/// Returns `true` when [videoId] has been confirmed unavailable (a persisted
+/// hard 404). Injected so the BLoC stays free of concrete service
+/// dependencies — the launching `ConsumerWidget` resolves it from
+/// `BrokenVideoTracker.isVideoBroken`. The bound method reads live tracker
+/// state on every call, so newly-confirmed-missing videos are filtered from
+/// subsequent source re-pushes. This lets static sources (liked, saved,
+/// reposts, collabs, curated lists) drop videos that 404'd in a *previous*
+/// session, not just the live ones removed via [OnRemoveVideo]. See #5237.
+typedef UnavailableVideoFilter = bool Function(String videoId);
+
 /// Maximum number of concurrent background cache downloads.
 ///
 /// Limiting to 1 prevents background caching from competing with the
@@ -87,6 +97,7 @@ class FullscreenFeedBloc
     OnVideoConfirmedUnavailable? onVideoConfirmedUnavailable,
     MediaAvailabilityChecker? availabilityChecker,
     BlockAuthorFilter? blockFilter,
+    UnavailableVideoFilter? unavailableFilter,
   }) : _videosStream = videosStream,
        _initialVideoId = initialVideoId,
        _initialStableId = initialStableId,
@@ -100,6 +111,7 @@ class FullscreenFeedBloc
        _availabilityChecker =
            availabilityChecker ?? const MediaAvailabilityChecker(),
        _blockFilter = blockFilter,
+       _unavailableFilter = unavailableFilter,
        super(FullscreenFeedState(currentIndex: initialIndex)) {
     on<FullscreenFeedStarted>(_onStarted);
     on<FullscreenFeedHasMoreChanged>(_onHasMoreChanged);
@@ -137,6 +149,7 @@ class FullscreenFeedBloc
   final OnVideoConfirmedUnavailable? _onVideoConfirmedUnavailable;
   final MediaAvailabilityChecker _availabilityChecker;
   final BlockAuthorFilter? _blockFilter;
+  final UnavailableVideoFilter? _unavailableFilter;
   StreamSubscription<bool>? _hasMoreSubscription;
   StreamSubscription<String>? _removedIdsSubscription;
 
@@ -201,7 +214,7 @@ class FullscreenFeedBloc
         // (e.g. the liked-videos like-change subscription / load-more, which
         // never re-filter) can't re-introduce an author who is blocked under
         // the current blocklist. Idempotent for sources that already filter.
-        final videos = _applyBlockFilter(incoming);
+        final videos = _applyUnavailableFilter(_applyBlockFilter(incoming));
 
         Log.debug(
           'FullscreenFeedBloc: Videos updated, count=${videos.length}',
@@ -618,6 +631,17 @@ class FullscreenFeedBloc
     final blockFilter = _blockFilter;
     if (blockFilter == null) return videos;
     return videos.where((v) => !blockFilter(v.pubkey)).toList();
+  }
+
+  /// Returns [videos] with videos confirmed unavailable (persisted hard 404)
+  /// removed, or the same list unchanged when no [UnavailableVideoFilter] was
+  /// injected. Applied at the stream boundary so static sources (liked, saved,
+  /// reposts, collabs, curated lists) drop videos that 404'd in a previous
+  /// session, which their by-id repositories don't filter. See #5237.
+  List<VideoEvent> _applyUnavailableFilter(List<VideoEvent> videos) {
+    final unavailableFilter = _unavailableFilter;
+    if (unavailableFilter == null) return videos;
+    return videos.where((v) => !unavailableFilter(v.id)).toList();
   }
 
   /// Handle a broad blocklist change (`blocklistVersionProvider` bumped).

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -27,6 +27,15 @@ part 'fullscreen_feed_state.dart';
 /// services (matches the existing [FullscreenFeedBloc.onLoadMore] pattern).
 typedef OnRemoveVideo = void Function(String videoId);
 
+/// Callback invoked by [FullscreenFeedBloc] when a video has been confirmed
+/// unavailable (a hard 404 verified via [MediaAvailabilityChecker]).
+///
+/// Unlike [OnRemoveVideo] — which only drops the id from in-memory caches for
+/// the current session — this persists the id so the video stays filtered out
+/// of every list surface across app restarts. A callback keeps the BLoC free
+/// of direct dependencies on concrete services.
+typedef OnVideoConfirmedUnavailable = void Function(String videoId);
+
 /// Returns `true` when [pubkey]'s content must be hidden (blocked / muted /
 /// blocked-us / muted-us). Injected so the BLoC stays free of Riverpod and
 /// repository dependencies — the launching `ConsumerWidget` resolves it from
@@ -75,6 +84,7 @@ class FullscreenFeedBloc
     VoidCallback? onLoadMore,
     BlossomAuthService? blossomAuthService,
     OnRemoveVideo? onRemoveVideo,
+    OnVideoConfirmedUnavailable? onVideoConfirmedUnavailable,
     MediaAvailabilityChecker? availabilityChecker,
     BlockAuthorFilter? blockFilter,
   }) : _videosStream = videosStream,
@@ -86,6 +96,7 @@ class FullscreenFeedBloc
        _mediaCache = mediaCache,
        _blossomAuthService = blossomAuthService,
        _onRemoveVideo = onRemoveVideo,
+       _onVideoConfirmedUnavailable = onVideoConfirmedUnavailable,
        _availabilityChecker =
            availabilityChecker ?? const MediaAvailabilityChecker(),
        _blockFilter = blockFilter,
@@ -123,6 +134,7 @@ class FullscreenFeedBloc
   final MediaCacheManager? _mediaCache;
   final BlossomAuthService? _blossomAuthService;
   final OnRemoveVideo? _onRemoveVideo;
+  final OnVideoConfirmedUnavailable? _onVideoConfirmedUnavailable;
   final MediaAvailabilityChecker _availabilityChecker;
   final BlockAuthorFilter? _blockFilter;
   StreamSubscription<bool>? _hasMoreSubscription;
@@ -509,6 +521,12 @@ class FullscreenFeedBloc
     // Re-check dedupe in case another handler inserted the same id while
     // our HEAD was in flight.
     if (state.removedVideoIds.contains(videoId)) return;
+
+    // Persist the confirmed 404 first so the video stays filtered out of
+    // every list surface (feed, profile, hashtag, grids) across restarts —
+    // not just dropped from this session's in-memory caches via
+    // [_onRemoveVideo].
+    _onVideoConfirmedUnavailable?.call(videoId);
 
     _onRemoveVideo?.call(videoId);
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -145,6 +145,26 @@ VideoEventService videoEventService(Ref ref) {
   service.setModerationLabelService(moderationLabelService);
   service.setDivineHostFilterService(divineHostFilterService);
 
+  // Attach the broken-video tracker (async init) so videos confirmed
+  // unavailable (hard 404) stay filtered out of every list surface across
+  // restarts. Fire-and-forget: the tracker hydrates from SharedPreferences and
+  // is safe to attach once ready. See #5237.
+  unawaited(
+    ref
+        .read(brokenVideoTrackerProvider.future)
+        .then(service.setBrokenVideoTracker)
+        .catchError((Object error, StackTrace stackTrace) {
+          Log.error(
+            'Failed to attach broken video tracker to VideoEventService: '
+            '$error',
+            name: 'VideoEventService',
+            category: LogCategory.system,
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }),
+  );
+
   // Teach the OG Viner badge cache from every video that flows through the
   // service. The cache filters internally (only `isOriginalVine` videos
   // contribute pubkeys), so it's safe to feed it every batch — popular,

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -322,7 +322,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'd75c28498b24dfa377024ea650d85160d1948363';
+String _$videoEventServiceHash() => r'4d5d25bfab30bb44b73e1aa5e6b4f47e6de7b12d';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -232,6 +232,19 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
       );
     }
 
+    // Filter videos confirmed unavailable (persisted hard 404) out of the
+    // fullscreen list at the stream boundary. This covers static / by-id
+    // sources (liked, saved, reposts, collabs, curated lists) whose
+    // repositories don't run the central feed filters, so a video that 404'd
+    // in a previous session won't reappear when opened fullscreen. The
+    // predicate reads live tracker state on each call; before the tracker's
+    // async init completes it filters nothing (matching grid behaviour). See
+    // #5237.
+    final brokenTracker = ref
+        .watch(brokenVideoTrackerProvider)
+        .maybeWhen(data: (tracker) => tracker, orElse: () => null);
+    final unavailableFilter = brokenTracker?.isVideoBroken;
+
     return MultiBlocProvider(
       providers: [
         BlocProvider(
@@ -247,6 +260,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             mediaCache: mediaCache,
             blossomAuthService: blossomAuthService,
             blockFilter: blockFilter,
+            unavailableFilter: unavailableFilter,
           )..add(const FullscreenFeedStarted()),
         ),
         BlocProvider(create: (_) => VideoPlaybackStatusCubit()),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -209,6 +209,29 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
         .read(videoEventServiceProvider)
         .removedVideoIds;
 
+    // Persist confirmed-404 ids so the video stays filtered out of every list
+    // surface (feed, profile, hashtag, grids) across restarts. The bloc only
+    // fires this after a HEAD request confirms a hard 404 (#5237).
+    void persistConfirmedUnavailable(String videoId) {
+      unawaited(
+        ref
+            .read(brokenVideoTrackerProvider.future)
+            .then(
+              (tracker) => tracker.markVideoBroken(
+                videoId,
+                'Confirmed 404 in fullscreen feed',
+              ),
+            )
+            .catchError((Object error) {
+              Log.warning(
+                'Failed to persist confirmed-unavailable video: $error',
+                name: 'PooledFullscreenVideoFeedScreen',
+                category: LogCategory.video,
+              );
+            }),
+      );
+    }
+
     return MultiBlocProvider(
       providers: [
         BlocProvider(
@@ -220,6 +243,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             hasMoreStream: feedRepository.watchHasMore(source),
             removedIdsStream: removedIdsStream,
             onLoadMore: () => unawaited(feedRepository.loadMore(source)),
+            onVideoConfirmedUnavailable: persistConfirmedUnavailable,
             mediaCache: mediaCache,
             blossomAuthService: blossomAuthService,
             blockFilter: blockFilter,

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -236,14 +236,18 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
     // fullscreen list at the stream boundary. This covers static / by-id
     // sources (liked, saved, reposts, collabs, curated lists) whose
     // repositories don't run the central feed filters, so a video that 404'd
-    // in a previous session won't reappear when opened fullscreen. The
-    // predicate reads live tracker state on each call; before the tracker's
-    // async init completes it filters nothing (matching grid behaviour). See
-    // #5237.
-    final brokenTracker = ref
-        .watch(brokenVideoTrackerProvider)
-        .maybeWhen(data: (tracker) => tracker, orElse: () => null);
-    final unavailableFilter = brokenTracker?.isVideoBroken;
+    // in a previous session won't reappear when opened fullscreen. Reads live
+    // tracker state on every call via the provider (rather than capturing a
+    // snapshot in `create:`, which would stay `null` if the tracker's async
+    // init hadn't resolved by first build and never recover): before init
+    // resolves it filters nothing; once it resolves, every subsequent source
+    // re-push is filtered. See #5237.
+    bool unavailableFilter(String videoId) => ref
+        .read(brokenVideoTrackerProvider)
+        .maybeWhen(
+          data: (tracker) => tracker.isVideoBroken(videoId),
+          orElse: () => false,
+        );
 
     return MultiBlocProvider(
       providers: [

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -34,6 +34,7 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/constants/nip71_migration.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/models/content_label.dart';
+import 'package:openvine/services/broken_video_tracker.dart';
 import 'package:openvine/services/connection_status_service.dart';
 import 'package:openvine/services/content_filter_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
@@ -240,6 +241,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   ContentFilterService? _contentFilterService;
   ModerationLabelService? _moderationLabelService;
   DivineHostFilterService? _divineHostFilterService;
+  BrokenVideoTracker? _brokenVideoTracker;
   final SubscriptionManager _subscriptionManager;
 
   // Side-channel observers that fire for every video that flows through the
@@ -466,6 +468,19 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
+  /// Set the broken-video tracker used to filter videos confirmed unavailable
+  /// (hard 404). Marked entries are persisted by the tracker, so this keeps
+  /// videos that 404'd in the fullscreen player out of every list surface
+  /// (home, profile, hashtag, grids) across app restarts. See #5237.
+  void setBrokenVideoTracker(BrokenVideoTracker tracker) {
+    _brokenVideoTracker = tracker;
+    Log.debug(
+      'Broken video tracker attached to VideoEventService',
+      name: 'VideoEventService',
+      category: LogCategory.video,
+    );
+  }
+
   bool get shouldFilterNonDivineVideos =>
       _divineHostFilterService?.showDivineHostedOnly ?? false;
 
@@ -614,8 +629,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// noisy and would otherwise block autoplay on ordinary videos.
   List<VideoEvent> filterVideoList(List<VideoEvent> videos) {
     final service = _contentFilterService;
+    final tracker = _brokenVideoTracker;
     final baseVideos = videos
-        .where((video) => !shouldHideVideo(video))
+        .where(
+          (video) =>
+              !shouldHideVideo(video) &&
+              !(tracker?.isVideoBroken(video.id) ?? false),
+        )
         .toList();
     if (service == null) {
       _notifyVideoObservers(baseVideos);
@@ -4305,6 +4325,18 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         category: LogCategory.video,
       );
       return; // Don't resurrect deleted videos
+    }
+
+    // Filter out videos confirmed unavailable (hard 404) so they don't
+    // resurface on any list surface after being skipped in the player. See
+    // #5237.
+    if (_brokenVideoTracker?.isVideoBroken(videoEvent.id) == true) {
+      Log.debug(
+        'Filtering out unavailable (404) video ${videoEvent.id} from $subscriptionType feed',
+        name: 'VideoEventService',
+        category: LogCategory.video,
+      );
+      return;
     }
 
     // NIP-40: Filter out expired events

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -81,6 +81,7 @@ void main() {
       OnVideoConfirmedUnavailable? onVideoConfirmedUnavailable,
       MediaAvailabilityChecker? availabilityChecker,
       BlockAuthorFilter? blockFilter,
+      UnavailableVideoFilter? unavailableFilter,
     }) => FullscreenFeedBloc(
       videosStream: videosController.stream,
       initialIndex: initialIndex,
@@ -94,6 +95,7 @@ void main() {
       onVideoConfirmedUnavailable: onVideoConfirmedUnavailable,
       availabilityChecker: availabilityChecker,
       blockFilter: blockFilter,
+      unavailableFilter: unavailableFilter,
     );
 
     test('initial state has correct values', () {
@@ -1281,6 +1283,65 @@ void main() {
             ),
           ).called(1);
         },
+      );
+    });
+
+    group('unavailableFilter (persisted 404)', () {
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'filters known-unavailable videos from incoming stream lists',
+        build: () => createBloc(unavailableFilter: (id) => id == 'broken'),
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('broken'),
+            createTestVideo('c'),
+          ]);
+        },
+        wait: const Duration(milliseconds: 100),
+        expect: () => [
+          isA<FullscreenFeedState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'video ids',
+            ['a', 'c'],
+          ),
+        ],
+      );
+
+      // Static sources (liked / saved / reposts / curated lists) re-emit
+      // unfiltered by-id lists, so a known-unavailable video must stay out
+      // across a re-push — the gap this filter closes for #5237.
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'keeps known-unavailable videos out across a source re-push',
+        build: () => createBloc(unavailableFilter: (id) => id == 'broken'),
+        act: (bloc) async {
+          bloc.add(const FullscreenFeedStarted());
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('broken'),
+          ]);
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          videosController.add([
+            createTestVideo('a'),
+            createTestVideo('broken'),
+            createTestVideo('c'),
+          ]);
+        },
+        wait: const Duration(milliseconds: 150),
+        expect: () => [
+          isA<FullscreenFeedState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'video ids',
+            ['a'],
+          ),
+          isA<FullscreenFeedState>().having(
+            (s) => s.videos.map((v) => v.id).toList(),
+            'video ids',
+            ['a', 'c'],
+          ),
+        ],
       );
     });
 

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -78,6 +78,7 @@ void main() {
       MediaCacheManager? mediaCache,
       BlossomAuthService? blossomAuthService,
       OnRemoveVideo? onRemoveVideo,
+      OnVideoConfirmedUnavailable? onVideoConfirmedUnavailable,
       MediaAvailabilityChecker? availabilityChecker,
       BlockAuthorFilter? blockFilter,
     }) => FullscreenFeedBloc(
@@ -90,6 +91,7 @@ void main() {
       mediaCache: mediaCache ?? mockMediaCache,
       blossomAuthService: blossomAuthService,
       onRemoveVideo: onRemoveVideo,
+      onVideoConfirmedUnavailable: onVideoConfirmedUnavailable,
       availabilityChecker: availabilityChecker,
       blockFilter: blockFilter,
     );
@@ -1366,6 +1368,54 @@ void main() {
             availabilityChecker: throwingChecker(),
           );
         },
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [createTestVideo('video1')],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedVideoUnavailable('video1')),
+        wait: const Duration(milliseconds: 100),
+        expect: () => <FullscreenFeedState>[],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'calls onVideoConfirmedUnavailable when HEAD confirms 404',
+        build: () => createBloc(
+          onVideoConfirmedUnavailable: expectAsync1<void, String>((id) {
+            expect(id, equals('video1'));
+          }),
+          availabilityChecker: checkerReturning(404),
+        ),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [createTestVideo('video1')],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedVideoUnavailable('video1')),
+        wait: const Duration(milliseconds: 100),
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'does not call onVideoConfirmedUnavailable on transient error (200)',
+        build: () => createBloc(
+          onVideoConfirmedUnavailable: (_) =>
+              fail('should not persist on non-404'),
+          availabilityChecker: checkerReturning(200),
+        ),
+        seed: () => FullscreenFeedState(
+          status: FullscreenFeedStatus.ready,
+          videos: [createTestVideo('video1')],
+        ),
+        act: (bloc) => bloc.add(const FullscreenFeedVideoUnavailable('video1')),
+        wait: const Duration(milliseconds: 100),
+        expect: () => <FullscreenFeedState>[],
+      );
+
+      blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+        'does not call onVideoConfirmedUnavailable when HEAD throws',
+        build: () => createBloc(
+          onVideoConfirmedUnavailable: (_) =>
+              fail('should not persist on network error'),
+          availabilityChecker: throwingChecker(),
+        ),
         seed: () => FullscreenFeedState(
           status: FullscreenFeedStatus.ready,
           videos: [createTestVideo('video1')],

--- a/mobile/test/services/video_event_service_broken_filter_test.dart
+++ b/mobile/test/services/video_event_service_broken_filter_test.dart
@@ -1,0 +1,121 @@
+// ABOUTME: Tests that VideoEventService filters videos confirmed unavailable
+// ABOUTME: (hard 404) via the attached BrokenVideoTracker across list surfaces.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/broken_video_tracker.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+VideoEvent _videoEvent({required String id}) {
+  final event =
+      Event(
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          34236,
+          [
+            ['d', 'd-$id'],
+            ['url', 'https://example.com/$id.mp4'],
+          ],
+          'test video',
+          createdAt: 1000,
+        )
+        ..id = id
+        ..sig = 'sig-$id';
+  return VideoEvent.fromNostrEvent(event);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('VideoEventService broken-video filtering', () {
+    late VideoEventService service;
+    late _MockNostrClient nostrClient;
+    late _MockSubscriptionManager subscriptionManager;
+    late BrokenVideoTracker tracker;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      nostrClient = _MockNostrClient();
+      subscriptionManager = _MockSubscriptionManager();
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.publicKey).thenReturn(
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      );
+      when(
+        () => nostrClient.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+
+      service = VideoEventService(
+        nostrClient,
+        subscriptionManager: subscriptionManager,
+      );
+
+      tracker = BrokenVideoTracker();
+      await tracker.initialize();
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test(
+      'filterVideoList drops videos marked broken by the tracker',
+      () async {
+        await tracker.markVideoBroken('broken1', 'Confirmed 404');
+        service.setBrokenVideoTracker(tracker);
+
+        final videos = [
+          _videoEvent(id: 'good1'),
+          _videoEvent(id: 'broken1'),
+          _videoEvent(id: 'good2'),
+        ];
+
+        final filtered = service.filterVideoList(videos);
+
+        expect(
+          filtered.map((v) => v.id),
+          equals(['good1', 'good2']),
+        );
+      },
+    );
+
+    test(
+      'filterVideoList keeps all videos when no tracker attached',
+      () {
+        final videos = [_videoEvent(id: 'a'), _videoEvent(id: 'b')];
+
+        final filtered = service.filterVideoList(videos);
+
+        expect(filtered.map((v) => v.id), equals(['a', 'b']));
+      },
+    );
+
+    test(
+      'filterVideoList keeps videos that become broken only after attach',
+      () async {
+        service.setBrokenVideoTracker(tracker);
+
+        final videos = [_videoEvent(id: 'x'), _videoEvent(id: 'y')];
+        expect(service.filterVideoList(videos).map((v) => v.id), ['x', 'y']);
+
+        // Tracker reads live state, so a later mark is reflected immediately.
+        await tracker.markVideoBroken('x', 'Confirmed 404');
+        expect(service.filterVideoList(videos).map((v) => v.id), ['y']);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Description

Videos confirmed unavailable (hard 404) in the player were only dropped from the current session's in-memory caches, and only on the fullscreen surface. They reappeared after restart and were never filtered out of the home feed, profile, hashtag, lists/playlists, or favorites.

The app already had the pieces: a persisted `BrokenVideoTracker` (used by grids) and a HEAD-verified 404 signal in `FullscreenFeedBloc` (`MediaAvailabilityChecker.isConfirmedMissing`). They just weren't connected, and the central feed pipeline never applied the tracker. This wires the existing pieces together rather than adding a parallel store.

**Write path (only on confirmed 404, never transient network/5xx):**
- `FullscreenFeedBloc` gains `onVideoConfirmedUnavailable`, fired after the HEAD check confirms a hard 404.
- `PooledFullscreenVideoFeedScreen` persists the id to `BrokenVideoTracker`.

**Apply path — relay-backed surfaces (home, explore, profile, hashtag):**
- `VideoEventService` filters the tracker at the central ingest gate (`_addVideoToSubscription`) and in `filterVideoList`.

**Apply path — static by-id surfaces (favorites/liked, saved, reposts, collabs, curated lists/playlists):**
- These load via `getVideosByIds` and never run the central filters. `FullscreenFeedBloc` gains an injectable `UnavailableVideoFilter` (wired to `BrokenVideoTracker.isVideoBroken`) applied at the stream boundary, so a video that 404'd in a previous session is dropped from the initial fullscreen list and across source re-pushes — not only when the player re-confirms a 404 live.

Note on "history": there is no published-video watch-history/recently-viewed list surface in the app (the library screen is local clips/drafts), so there is nothing to filter there.

**Related Issue:** Closes #5237

## Out of Scope

- No proactive HEAD-checking of whole lists — filtering remains driven solely by playback-confirmed 404s (conservative; avoids hiding content on transient 5xx).
- Thumbnail grids for liked/saved/reposts already coexist with the fullscreen filter; the playback surface (where a 404 actually breaks UX) is fully covered.

## Verification

- `flutter analyze` on all touched files — clean.
- `flutter test test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart` (87 pass, incl. 5 new: persist only on confirmed 404; `unavailableFilter` drops known-broken at boundary and across re-push).
- `flutter test test/services/video_event_service_broken_filter_test.dart` (new, 3 pass).
- `flutter test test/services/video_event_service_deletion_test.dart`, `test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` — no regressions.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
