### PR TITLE
fix(auth): break /welcome login loop on silent restore failure

### DIFF
--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -252,6 +252,29 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
       await _authService.acceptTerms();
       emit(state.copyWith(status: WelcomeStatus.navigatingToLoginOptions));
       emit(state.copyWith(status: WelcomeStatus.loaded));
+    } on AccountRestoreFailedException catch (e, stackTrace) {
+      // The account's credentials could not be restored (e.g. missing local
+      // identity keys, or session setup failed). Previously this returned
+      // silently and the user was pinned to /welcome with no feedback — the
+      // login loop in #5195. Route to the full login flow so the user can
+      // re-import their key or pick another account.
+      Log.warning(
+        'WelcomeBloc: restore failed for ${account.pubkeyHex} '
+        '(${e.resolvedState}) — redirecting to login options',
+        name: 'WelcomeBloc',
+        category: LogCategory.auth,
+      );
+      // Recoverable auth-flow failure — matrix-NO (Auth/session row).
+      addError(e, stackTrace);
+      emit(
+        state.copyWith(
+          status: WelcomeStatus.sessionExpired,
+          clearSigningIn: true,
+        ),
+      );
+      await _authService.acceptTerms();
+      emit(state.copyWith(status: WelcomeStatus.navigatingToLoginOptions));
+      emit(state.copyWith(status: WelcomeStatus.loaded));
     } catch (e, stackTrace) {
       Log.error(
         'WelcomeBloc: failed to log back in as ${account.pubkeyHex}: $e',

--- a/mobile/lib/blocs/welcome/welcome_bloc.dart
+++ b/mobile/lib/blocs/welcome/welcome_bloc.dart
@@ -240,41 +240,25 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
         name: 'WelcomeBloc',
         category: LogCategory.auth,
       );
-      // Session expiry — matrix-NO (Auth/session row). Raw addError.
-      addError(e, stackTrace);
-      emit(
-        state.copyWith(
-          status: WelcomeStatus.sessionExpired,
-          clearSigningIn: true,
-        ),
+      await _recoverToLoginOptions(
+        emit,
+        e,
+        stackTrace,
+        emitSessionExpiredStatus: true,
       );
-      // Session cannot be restored silently — redirect to full login flow.
-      await _authService.acceptTerms();
-      emit(state.copyWith(status: WelcomeStatus.navigatingToLoginOptions));
-      emit(state.copyWith(status: WelcomeStatus.loaded));
     } on AccountRestoreFailedException catch (e, stackTrace) {
-      // The account's credentials could not be restored (e.g. missing local
-      // identity keys, or session setup failed). Previously this returned
-      // silently and the user was pinned to /welcome with no feedback — the
-      // login loop in #5195. Route to the full login flow so the user can
-      // re-import their key or pick another account.
       Log.warning(
         'WelcomeBloc: restore failed for ${account.pubkeyHex} '
         '(${e.resolvedState}) — redirecting to login options',
         name: 'WelcomeBloc',
         category: LogCategory.auth,
       );
-      // Recoverable auth-flow failure — matrix-NO (Auth/session row).
-      addError(e, stackTrace);
-      emit(
-        state.copyWith(
-          status: WelcomeStatus.sessionExpired,
-          clearSigningIn: true,
-        ),
+      await _recoverToLoginOptions(
+        emit,
+        e,
+        stackTrace,
+        emitSessionExpiredStatus: true,
       );
-      await _authService.acceptTerms();
-      emit(state.copyWith(status: WelcomeStatus.navigatingToLoginOptions));
-      emit(state.copyWith(status: WelcomeStatus.loaded));
     } catch (e, stackTrace) {
       Log.error(
         'WelcomeBloc: failed to log back in as ${account.pubkeyHex}: $e',
@@ -287,6 +271,32 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
       addError(e, stackTrace);
       emit(state.copyWith(status: WelcomeStatus.error, clearSigningIn: true));
     }
+  }
+
+  Future<void> _recoverToLoginOptions(
+    Emitter<WelcomeState> emit,
+    Object error,
+    StackTrace stackTrace, {
+    required bool emitSessionExpiredStatus,
+  }) async {
+    // Recoverable auth-flow failure — matrix-NO (Auth/session row).
+    addError(error, stackTrace);
+    if (emitSessionExpiredStatus) {
+      emit(
+        state.copyWith(
+          status: WelcomeStatus.sessionExpired,
+          clearSigningIn: true,
+        ),
+      );
+    }
+    await _authService.acceptTerms();
+    emit(
+      state.copyWith(
+        status: WelcomeStatus.navigatingToLoginOptions,
+        clearSigningIn: true,
+      ),
+    );
+    emit(state.copyWith(status: WelcomeStatus.loaded));
   }
 
   /// Cancels an account switch and restores the previous (most-recently-used)
@@ -319,16 +329,26 @@ class WelcomeBloc extends Bloc<WelcomeEvent, WelcomeState> {
         previous.authSource,
       );
     } on SessionExpiredException catch (e, stackTrace) {
-      // Session expiry — matrix-NO (Auth/session row). Raw addError.
-      addError(e, stackTrace);
-      await _authService.acceptTerms();
-      emit(
-        state.copyWith(
-          status: WelcomeStatus.navigatingToLoginOptions,
-          clearSigningIn: true,
-        ),
+      await _recoverToLoginOptions(
+        emit,
+        e,
+        stackTrace,
+        emitSessionExpiredStatus: false,
       );
-      emit(state.copyWith(status: WelcomeStatus.loaded));
+    } on AccountRestoreFailedException catch (e, stackTrace) {
+      Log.warning(
+        'WelcomeBloc: restore failed while cancelling account switch for '
+        '${previous.pubkeyHex} (${e.resolvedState}) — redirecting to '
+        'login options',
+        name: 'WelcomeBloc',
+        category: LogCategory.auth,
+      );
+      await _recoverToLoginOptions(
+        emit,
+        e,
+        stackTrace,
+        emitSessionExpiredStatus: false,
+      );
     } catch (e, stackTrace) {
       // Same auth/network/IO failure surface as `_onLogBackIn` —
       // matrix-NO. YES-narrowing deferred per #4592.

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -111,28 +111,38 @@ class EventSignerAccountMismatchException implements Exception {
 }
 
 /// Thrown by [AuthService.signInForAccount] when a returning-user sign-in
-/// resolves WITHOUT reaching [AuthState.authenticated] — for example when an
+/// does not restore the requested account — for example when an
 /// `importedKeys`/`automatic` account's identity keys are missing from secure
-/// storage, or when [AuthService] lands in [AuthState.awaitingTosAcceptance]
-/// after an internal session-setup failure.
+/// storage, when a fallback authenticates a different primary account, or when
+/// [AuthService] lands in [AuthState.awaitingTosAcceptance] after an internal
+/// session-setup failure.
 ///
 /// Previously these paths returned normally, leaving the caller (WelcomeBloc)
 /// believing the sign-in succeeded while the router kept the user pinned to
 /// `/welcome` — an invisible login loop. Throwing lets the caller route the
 /// user to the full login flow instead. See #5195.
 class AccountRestoreFailedException implements Exception {
-  const AccountRestoreFailedException(this.pubkeyHex, this.resolvedState);
+  const AccountRestoreFailedException(
+    this.pubkeyHex,
+    this.resolvedState, {
+    this.resolvedPubkeyHex,
+  });
 
   /// The account (hex pubkey) whose restore was attempted.
   final String pubkeyHex;
 
-  /// The non-authenticated [AuthState] the service resolved to.
+  /// The [AuthState] the service resolved to.
   final AuthState resolvedState;
+
+  /// The account (hex pubkey) that became active, if any.
+  final String? resolvedPubkeyHex;
 
   @override
   String toString() =>
       'AccountRestoreFailedException: sign-in for $pubkeyHex resolved to '
-      '$resolvedState instead of authenticated';
+      '$resolvedState'
+      '${resolvedPubkeyHex == null ? '' : ' as $resolvedPubkeyHex'} '
+      'instead of the requested account';
 }
 
 /// Result of authentication operations
@@ -2304,14 +2314,47 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           await _keyStorage.switchToIdentity(npub);
           await _setupUserSession(container, authSource);
         } else {
-          // Fall back to current primary keys
+          // Fall back to current PRIMARY keys only when they belong to the
+          // requested account. `_checkExistingAuth` intentionally restores
+          // whatever PRIMARY account is present, which is correct for app
+          // startup but unsafe for an explicit account-switch request.
           Log.warning(
             'signInForAccount: no saved identity keys for $npub — '
-            'falling back to _checkExistingAuth',
+            'checking PRIMARY key for same-account fallback',
             name: 'AuthService',
             category: LogCategory.auth,
           );
-          await _checkExistingAuth();
+          SecureKeyContainer? primary;
+          try {
+            if (await _keyStorage.hasKeys()) {
+              primary = await _keyStorage.getKeyContainer();
+            }
+          } catch (e, stack) {
+            Log.error(
+              'signInForAccount: failed to inspect PRIMARY key fallback: $e',
+              name: 'AuthService',
+              category: LogCategory.auth,
+            );
+            _reportStorageError(e, stack, 'signInForAccount primary fallback');
+          }
+
+          if (primary?.publicKeyHex == pubkeyHex) {
+            Log.info(
+              'signInForAccount: PRIMARY key matches requested account — '
+              'using same-account fallback',
+              name: 'AuthService',
+              category: LogCategory.auth,
+            );
+            await _setupUserSession(primary!, authSource);
+          } else {
+            Log.warning(
+              'signInForAccount: no restorable local keys for $pubkeyHex '
+              '(primaryPubkey=${primary?.publicKeyHex})',
+              name: 'AuthService',
+              category: LogCategory.auth,
+            );
+            _setAuthState(AuthState.unauthenticated);
+          }
         }
 
       case AuthenticationSource.none:
@@ -2323,24 +2366,31 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         throw Exception('Cannot sign in with auth source "none"');
     }
 
-    // Guard against silent restore failures. Several branches above can
-    // resolve normally WITHOUT reaching `authenticated`:
-    //   - importedKeys/automatic whose identity keys are missing fall back to
-    //     `_checkExistingAuth`, which sets `unauthenticated` and returns.
+    // Guard against silent restore failures. Several branches above can resolve
+    // normally without restoring the requested account:
+    //   - importedKeys/automatic whose identity keys are missing and no
+    //     matching PRIMARY key exists resolve unauthenticated.
     //   - `_setupUserSession` swallows internal failures into
     //     `awaitingTosAcceptance`.
-    // Both previously left the caller believing the sign-in succeeded while
-    // the router kept the user on `/welcome` (an invisible loop). Surface the
-    // failure so the caller can route to the full login flow instead. See
-    // #5195.
-    if (_authState != AuthState.authenticated) {
+    // These previously left the caller believing the sign-in succeeded while
+    // the router kept the user on `/welcome`, or worse, authenticated the wrong
+    // local account. Surface the failure so the caller can route to the full
+    // login flow instead. See #5195.
+    final resolvedPubkeyHex = currentPublicKeyHex;
+    if (_authState != AuthState.authenticated ||
+        resolvedPubkeyHex != pubkeyHex) {
       Log.warning(
-        'signInForAccount: resolved to $_authState (not authenticated) for '
+        'signInForAccount: resolved to $_authState '
+        '(resolvedPubkey=$resolvedPubkeyHex) for '
         '$pubkeyHex — surfacing AccountRestoreFailedException',
         name: 'AuthService',
         category: LogCategory.auth,
       );
-      throw AccountRestoreFailedException(pubkeyHex, _authState);
+      throw AccountRestoreFailedException(
+        pubkeyHex,
+        _authState,
+        resolvedPubkeyHex: resolvedPubkeyHex,
+      );
     }
   }
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -110,6 +110,31 @@ class EventSignerAccountMismatchException implements Exception {
       '$actualPubkey but the active identity is $expectedPubkey';
 }
 
+/// Thrown by [AuthService.signInForAccount] when a returning-user sign-in
+/// resolves WITHOUT reaching [AuthState.authenticated] — for example when an
+/// `importedKeys`/`automatic` account's identity keys are missing from secure
+/// storage, or when [AuthService] lands in [AuthState.awaitingTosAcceptance]
+/// after an internal session-setup failure.
+///
+/// Previously these paths returned normally, leaving the caller (WelcomeBloc)
+/// believing the sign-in succeeded while the router kept the user pinned to
+/// `/welcome` — an invisible login loop. Throwing lets the caller route the
+/// user to the full login flow instead. See #5195.
+class AccountRestoreFailedException implements Exception {
+  const AccountRestoreFailedException(this.pubkeyHex, this.resolvedState);
+
+  /// The account (hex pubkey) whose restore was attempted.
+  final String pubkeyHex;
+
+  /// The non-authenticated [AuthState] the service resolved to.
+  final AuthState resolvedState;
+
+  @override
+  String toString() =>
+      'AccountRestoreFailedException: sign-in for $pubkeyHex resolved to '
+      '$resolvedState instead of authenticated';
+}
+
 /// Result of authentication operations
 class AuthResult {
   const AuthResult({
@@ -2296,6 +2321,26 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           category: LogCategory.auth,
         );
         throw Exception('Cannot sign in with auth source "none"');
+    }
+
+    // Guard against silent restore failures. Several branches above can
+    // resolve normally WITHOUT reaching `authenticated`:
+    //   - importedKeys/automatic whose identity keys are missing fall back to
+    //     `_checkExistingAuth`, which sets `unauthenticated` and returns.
+    //   - `_setupUserSession` swallows internal failures into
+    //     `awaitingTosAcceptance`.
+    // Both previously left the caller believing the sign-in succeeded while
+    // the router kept the user on `/welcome` (an invisible loop). Surface the
+    // failure so the caller can route to the full login flow instead. See
+    // #5195.
+    if (_authState != AuthState.authenticated) {
+      Log.warning(
+        'signInForAccount: resolved to $_authState (not authenticated) for '
+        '$pubkeyHex — surfacing AccountRestoreFailedException',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
+      throw AccountRestoreFailedException(pubkeyHex, _authState);
     }
   }
 

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -449,6 +449,50 @@ void main() {
         },
         errors: () => [isA<SessionExpiredException>()],
       );
+
+      blocTest<WelcomeBloc, WelcomeState>(
+        'navigates to login options on $AccountRestoreFailedException '
+        '(missing keys) instead of looping silently',
+        setUp: () {
+          when(
+            () => mockAuthService.signInForAccount(any(), any()),
+          ).thenThrow(
+            const AccountRestoreFailedException(
+              _testPubkeyHex,
+              AuthState.unauthenticated,
+            ),
+          );
+        },
+        build: buildBloc,
+        seed: () => const WelcomeState(
+          status: WelcomeStatus.loaded,
+          previousAccounts: [_testPreviousAccount],
+        ),
+        act: (bloc) => bloc.add(const WelcomeLogBackInRequested()),
+        expect: () => [
+          const WelcomeState(
+            status: WelcomeStatus.accepting,
+            previousAccounts: [_testPreviousAccount],
+            signingInPubkeyHex: _testPubkeyHex,
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.sessionExpired,
+            previousAccounts: [_testPreviousAccount],
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.navigatingToLoginOptions,
+            previousAccounts: [_testPreviousAccount],
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.loaded,
+            previousAccounts: [_testPreviousAccount],
+          ),
+        ],
+        verify: (_) {
+          verify(() => mockAuthService.acceptTerms()).called(1);
+        },
+        errors: () => [isA<AccountRestoreFailedException>()],
+      );
     });
 
     group('$WelcomeCancelSwitchRequested', () {

--- a/mobile/test/blocs/welcome/welcome_bloc_test.dart
+++ b/mobile/test/blocs/welcome/welcome_bloc_test.dart
@@ -563,6 +563,50 @@ void main() {
       );
 
       blocTest<WelcomeBloc, WelcomeState>(
+        'records addError and redirects to login options on '
+        '$AccountRestoreFailedException',
+        setUp: () {
+          when(
+            () => mockAuthService.signInForAccount(any(), any()),
+          ).thenThrow(
+            const AccountRestoreFailedException(
+              _testPubkeyHex,
+              AuthState.unauthenticated,
+            ),
+          );
+        },
+        build: buildBloc,
+        seed: () => const WelcomeState(
+          status: WelcomeStatus.loaded,
+          previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+          selectedPubkeyHex: _testPubkeyHex2,
+        ),
+        act: (bloc) => bloc.add(const WelcomeCancelSwitchRequested()),
+        expect: () => [
+          const WelcomeState(
+            status: WelcomeStatus.accepting,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+            signingInPubkeyHex: _testPubkeyHex,
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.navigatingToLoginOptions,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+          ),
+          const WelcomeState(
+            status: WelcomeStatus.loaded,
+            previousAccounts: [_testPreviousAccount, _testPreviousAccount2],
+            selectedPubkeyHex: _testPubkeyHex2,
+          ),
+        ],
+        verify: (_) {
+          verify(() => mockAuthService.acceptTerms()).called(1);
+        },
+        errors: () => [isA<AccountRestoreFailedException>()],
+      );
+
+      blocTest<WelcomeBloc, WelcomeState>(
         'records addError and emits error on restore failure',
         setUp: () {
           when(

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -1129,27 +1129,43 @@ void main() {
     );
 
     test(
-      'falls back to _checkExistingAuth when identity keys not found',
+      'throws AccountRestoreFailedException when identity keys not found '
+      'and _checkExistingAuth cannot authenticate',
       () async {
         final pubkeyHex = testKeyContainer.publicKeyHex;
 
-        // Return null for identity key lookup
+        // Return null for identity key lookup, and ensure the
+        // _checkExistingAuth fallback also finds no usable keys so the
+        // service resolves to unauthenticated rather than authenticated.
         when(
           () => mockKeyStorage.getIdentityKeyContainer(
             any(),
             biometricPrompt: any(named: 'biometricPrompt'),
           ),
         ).thenAnswer((_) async => null);
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
 
-        await _ignoringDiscoveryErrors(
-          () => authService.signInForAccount(
-            pubkeyHex,
-            AuthenticationSource.automatic,
+        await expectLater(
+          _ignoringDiscoveryErrors(
+            () => authService.signInForAccount(
+              pubkeyHex,
+              AuthenticationSource.automatic,
+            ),
+          ),
+          throwsA(
+            isA<AccountRestoreFailedException>()
+                .having((e) => e.pubkeyHex, 'pubkeyHex', pubkeyHex)
+                .having(
+                  (e) => e.resolvedState,
+                  'resolvedState',
+                  AuthState.unauthenticated,
+                ),
           ),
         );
 
-        // _checkExistingAuth should fall back to the unauthenticated flow
+        // The fallback path was exercised before the guard threw.
         verify(() => mockKeyStorage.hasKeys()).called(1);
+        expect(authService.authState, equals(AuthState.unauthenticated));
       },
     );
 

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -31,6 +31,8 @@ class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
 // Test nsec from a known keypair (same one used in other auth_service tests)
 const _testNsec =
     'nsec1vl029mgpspedva04g90vltkh6fvh240zqtv9k0t9af8935ke9laqsnlfe5';
+const _otherNsec =
+    'nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsmhltgl';
 
 /// Runs [body] while silencing unhandled async errors from `_performDiscovery`.
 ///
@@ -1130,13 +1132,13 @@ void main() {
 
     test(
       'throws AccountRestoreFailedException when identity keys not found '
-      'and _checkExistingAuth cannot authenticate',
+      'and no primary keys can authenticate',
       () async {
         final pubkeyHex = testKeyContainer.publicKeyHex;
 
-        // Return null for identity key lookup, and ensure the
-        // _checkExistingAuth fallback also finds no usable keys so the
-        // service resolves to unauthenticated rather than authenticated.
+        // Return null for identity key lookup, and ensure no same-account
+        // PRIMARY fallback exists so the service resolves to unauthenticated
+        // rather than silently succeeding.
         when(
           () => mockKeyStorage.getIdentityKeyContainer(
             any(),
@@ -1163,9 +1165,62 @@ void main() {
           ),
         );
 
-        // The fallback path was exercised before the guard threw.
+        // The same-account fallback path was exercised before the guard threw.
         verify(() => mockKeyStorage.hasKeys()).called(1);
         expect(authService.authState, equals(AuthState.unauthenticated));
+      },
+    );
+
+    test(
+      'throws AccountRestoreFailedException when missing identity keys would '
+      'otherwise fall back to a different primary account',
+      () async {
+        final requestedPubkeyHex = testKeyContainer.publicKeyHex;
+        final primaryKeyContainer = SecureKeyContainer.fromNsec(_otherNsec);
+
+        when(
+          () => mockKeyStorage.getIdentityKeyContainer(
+            any(),
+            biometricPrompt: any(named: 'biometricPrompt'),
+          ),
+        ).thenAnswer((_) async => null);
+        when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => true);
+        when(
+          () => mockKeyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => primaryKeyContainer);
+
+        await expectLater(
+          _ignoringDiscoveryErrors(
+            () => authService.signInForAccount(
+              requestedPubkeyHex,
+              AuthenticationSource.automatic,
+            ),
+          ),
+          throwsA(
+            isA<AccountRestoreFailedException>()
+                .having((e) => e.pubkeyHex, 'pubkeyHex', requestedPubkeyHex)
+                .having(
+                  (e) => e.resolvedState,
+                  'resolvedState',
+                  AuthState.unauthenticated,
+                )
+                .having(
+                  (e) => e.resolvedPubkeyHex,
+                  'resolvedPubkeyHex',
+                  isNull,
+                ),
+          ),
+        );
+
+        expect(authService.authState, equals(AuthState.unauthenticated));
+        expect(authService.currentPublicKeyHex, isNull);
+        verify(() => mockKeyStorage.getKeyContainer()).called(1);
+        verifyNever(
+          () => mockKeyStorage.switchToIdentity(
+            any(),
+            biometricPrompt: any(named: 'biometricPrompt'),
+          ),
+        );
       },
     );
 


### PR DESCRIPTION
## Description

Closes #5195.

A returning user whose persisted account was `importedKeys`/`automatic` but whose identity keys were missing from secure storage could hit an invisible login loop: `signInForAccount` fell back to a non-restored auth path and returned normally, so `WelcomeBloc` believed sign-in succeeded while the router kept the user on `/welcome`.

This PR makes returning-account restore explicit and fail-closed:

- **`AuthService`**: adds `AccountRestoreFailedException` for restore attempts that do not end on the requested account.
- **Local-key fallback**: only uses the PRIMARY key slot when it belongs to the requested pubkey. A missing identity container can no longer silently authenticate a different primary account.
- **End guard**: verifies both `AuthState.authenticated` and `currentPublicKeyHex == requestedPubkeyHex`, covering internal setup failures and wrong-account resolutions.
- **`WelcomeBloc`**: handles restore failure like expired sessions, routing users to the full login flow so they can re-import a key, pick another account, or create a new account.
- **Cleanup**: extracts the duplicated session-expiry/login-options recovery path and applies the same recoverable behavior to cancel-switch restore failures.

This complements #5295, which handled minor-account-review redirect behavior but did not address the `/welcome` auth-state loop.

## Verification

- `flutter test test/blocs/welcome/welcome_bloc_test.dart test/services/auth_service_multi_account_test.dart` — 135 passed.
- `flutter test test/services/auth_service_signing_mismatch_test.dart test/services/auth_service_bunker_lifecycle_test.dart test/screens/welcome_screen_test.dart` — 49 passed.
- `flutter analyze lib/services/auth_service.dart lib/blocs/welcome/welcome_bloc.dart` — clean.
- `flutter analyze` from `mobile/` — clean.
- Pre-push hook reran analyzer and changed-file tests successfully before pushing `545592a`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
