### PR TITLE
fix(video-editor): match transition preview length to export for back-to-back overlaps

### DIFF
--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -63,42 +63,87 @@ class TransitionSeamRenderService {
   bool isRendering(
     DivineVideoClip clipA,
     DivineVideoClip clipB,
-    ClipTransition transition,
-  ) => _inFlight.containsKey(_key(clipA, clipB, transition));
+    ClipTransition transition, {
+    bool clipAHasIncoming = false,
+    bool clipBHasOutgoing = false,
+  }) => _inFlight.containsKey(
+    _key(
+      clipA,
+      clipB,
+      transition,
+      clipAHasIncoming: clipAHasIncoming,
+      clipBHasOutgoing: clipBHasOutgoing,
+    ),
+  );
 
   /// Returns the already-rendered seam for this transition, or `null` if it is
   /// not rendered yet. Pure cache lookup — never triggers a render.
+  ///
+  /// [clipAHasIncoming] / [clipBHasOutgoing] describe whether each clip also
+  /// participates in a *neighbouring* boundary; they bound the per-clip seam
+  /// consumption (see [computeSeamSpans]) and so are part of the cache key —
+  /// callers must pass the same values used when the seam was rendered.
   TransitionSeam? cached(
     DivineVideoClip clipA,
     DivineVideoClip clipB,
-    ClipTransition transition,
-  ) => _cache[_key(clipA, clipB, transition)];
+    ClipTransition transition, {
+    bool clipAHasIncoming = false,
+    bool clipBHasOutgoing = false,
+  }) =>
+      _cache[_key(
+        clipA,
+        clipB,
+        transition,
+        clipAHasIncoming: clipAHasIncoming,
+        clipBHasOutgoing: clipBHasOutgoing,
+      )];
 
   /// Renders (or returns the cached / in-flight) seam for the transition out of
   /// [clipA] into [clipB]. Returns `null` on failure or when either clip is too
   /// short to contribute.
+  ///
+  /// See [cached] for [clipAHasIncoming] / [clipBHasOutgoing].
   Future<TransitionSeam?> render({
     required DivineVideoClip clipA,
     required DivineVideoClip clipB,
     required ClipTransition transition,
+    bool clipAHasIncoming = false,
+    bool clipBHasOutgoing = false,
   }) {
-    final key = _key(clipA, clipB, transition);
+    final key = _key(
+      clipA,
+      clipB,
+      transition,
+      clipAHasIncoming: clipAHasIncoming,
+      clipBHasOutgoing: clipBHasOutgoing,
+    );
     final cached = _cache[key];
     if (cached != null) return Future.value(cached);
-    return _inFlight[key] ??= _render(clipA, clipB, transition, key);
+    return _inFlight[key] ??= _render(
+      clipA,
+      clipB,
+      transition,
+      key,
+      clipAHasIncoming: clipAHasIncoming,
+      clipBHasOutgoing: clipBHasOutgoing,
+    );
   }
 
   Future<TransitionSeam?> _render(
     DivineVideoClip clipA,
     DivineVideoClip clipB,
     ClipTransition transition,
-    String key,
-  ) async {
+    String key, {
+    required bool clipAHasIncoming,
+    required bool clipBHasOutgoing,
+  }) async {
     try {
       final (:consumed, :blend, :seamTransition) = computeSeamSpans(
         clipA,
         clipB,
         transition,
+        clipAHasIncoming: clipAHasIncoming,
+        clipBHasOutgoing: clipBHasOutgoing,
       );
       if (consumed <= Duration.zero) return null;
 
@@ -252,24 +297,44 @@ class TransitionSeamRenderService {
   /// the visible blend at a quarter of it. For overlaps the blend is always
   /// half the consumed span, guaranteeing a solo lead-in/out on each side (a
   /// segment equal to the blend degenerates into a hard cut).
+  ///
+  /// A clip that sits on *two* boundaries must share its body between both
+  /// seams. [clipAHasIncoming] / [clipBHasOutgoing] say whether each clip also
+  /// feeds a neighbouring seam; when so, that clip's contribution here is capped
+  /// at half its length, so its head + tail consumption can't exceed the clip
+  /// (mirroring the export's per-boundary "half the shorter clip" clamp). This
+  /// drops the solo lead-in/out first — the blend itself always fits, since each
+  /// boundary's blend is ≤ half the clip — so an over-consumed short clip no
+  /// longer gets played twice or stretches the preview past the export length.
   @visibleForTesting
   ({Duration consumed, Duration blend, ClipTransition seamTransition})
   computeSeamSpans(
     DivineVideoClip clipA,
     DivineVideoClip clipB,
-    ClipTransition transition,
-  ) {
+    ClipTransition transition, {
+    bool clipAHasIncoming = false,
+    bool clipBHasOutgoing = false,
+  }) {
     final maxSpan = _min(clipA.playbackDuration, clipB.playbackDuration);
+    final availA = clipAHasIncoming
+        ? _half(clipA.playbackDuration)
+        : clipA.playbackDuration;
+    final availB = clipBHasOutgoing
+        ? _half(clipB.playbackDuration)
+        : clipB.playbackDuration;
+    final budget = _min(availA, availB);
     if (_isOverlap(transition.type)) {
-      final consumed = _min(transition.duration * 2, maxSpan);
-      final blend = _half(consumed);
+      // blend stays the faithful overlap; only the solo padding (the gap
+      // between `blend` and `consumed`) is given up when the budget is tight.
+      final blend = _half(_min(transition.duration * 2, maxSpan));
+      final consumed = _min(_min(transition.duration * 2, maxSpan), budget);
       return (
         consumed: consumed,
         blend: blend,
         seamTransition: transition.copyWith(duration: blend),
       );
     }
-    final consumed = _min(_half(transition.duration), maxSpan);
+    final consumed = _min(_min(_half(transition.duration), maxSpan), budget);
     final dip = _min(transition.duration, consumed * 2);
     return (
       consumed: consumed,
@@ -306,13 +371,15 @@ class TransitionSeamRenderService {
   /// rendered by an older algorithm under `transition_seams/` are no longer
   /// key-matched and get re-rendered after an app upgrade instead of replayed
   /// stale (the keyed files live in the documents dir and survive upgrades).
-  static const _seamCacheVersion = 1;
+  static const _seamCacheVersion = 2;
 
   String _key(
     DivineVideoClip clipA,
     DivineVideoClip clipB,
-    ClipTransition transition,
-  ) {
+    ClipTransition transition, {
+    required bool clipAHasIncoming,
+    required bool clipBHasOutgoing,
+  }) {
     // The played file path is part of the key: reversing a clip swaps `video`
     // to the physically-reversed file (and any crop/transform re-render swaps
     // it too), so this invalidates the seam even when the trims are symmetric
@@ -329,7 +396,12 @@ class TransitionSeamRenderService {
     final t =
         '${transition.type.name}:${transition.duration.inMicroseconds}:'
         '${transition.curve.name}:${transition.direction.name}';
-    return 'v$_seamCacheVersion|${clipKey(clipA)}|${clipKey(clipB)}|$t';
+    // The neighbour-sharing flags change how much of each clip the seam
+    // consumes, so two boundaries with the same clip pair but different
+    // neighbours must not collide on one cached seam.
+    final neighbours = '$clipAHasIncoming:$clipBHasOutgoing';
+    return 'v$_seamCacheVersion|${clipKey(clipA)}|${clipKey(clipB)}|$t'
+        '|$neighbours';
   }
 
   bool _isOverlap(ClipTransitionType type) =>
@@ -366,9 +438,18 @@ class TransitionSeamRenderService {
     DivineVideoClip clipA,
     DivineVideoClip clipB,
     ClipTransition transition,
-    TransitionSeam seam,
-  ) {
-    _cache[_key(clipA, clipB, transition)] = seam;
+    TransitionSeam seam, {
+    bool clipAHasIncoming = false,
+    bool clipBHasOutgoing = false,
+  }) {
+    _cache[_key(
+          clipA,
+          clipB,
+          transition,
+          clipAHasIncoming: clipAHasIncoming,
+          clipBHasOutgoing: clipBHasOutgoing,
+        )] =
+        seam;
     _version++;
   }
 }
@@ -397,7 +478,14 @@ class SeamTimeline {
       var headPb = Duration.zero;
       final prevTransition = i > 0 ? clips[i - 1].transition : null;
       if (prevTransition != null) {
-        final seam = seams.cached(clips[i - 1], clip, prevTransition);
+        final sharing = seamBoundarySharing(clips, i - 1);
+        final seam = seams.cached(
+          clips[i - 1],
+          clip,
+          prevTransition,
+          clipAHasIncoming: sharing.leftHasIncoming,
+          clipBHasOutgoing: sharing.rightHasOutgoing,
+        );
         if (seam != null) {
           headPb = clip.sourceDurationToPlaybackDuration(seam.headConsumed);
         }
@@ -407,7 +495,14 @@ class SeamTimeline {
       var tailPb = Duration.zero;
       final transition = clip.transition;
       if (i + 1 < clips.length && transition != null) {
-        outgoing = seams.cached(clip, clips[i + 1], transition);
+        final sharing = seamBoundarySharing(clips, i);
+        outgoing = seams.cached(
+          clip,
+          clips[i + 1],
+          transition,
+          clipAHasIncoming: sharing.leftHasIncoming,
+          clipBHasOutgoing: sharing.rightHasOutgoing,
+        );
         if (outgoing != null) {
           tailPb = clip.sourceDurationToPlaybackDuration(outgoing.tailConsumed);
         }
@@ -512,6 +607,19 @@ class _Segment {
 
 Duration _maxDur(Duration a, Duration b) => a > b ? a : b;
 
+/// Whether each side of the boundary between clips [i] and `i + 1` also feeds a
+/// *neighbouring* seam, so that side must share its body across two boundaries.
+/// Drives the per-clip consumption cap in
+/// [TransitionSeamRenderService.computeSeamSpans] and is part of the seam cache
+/// key — callers must derive it the same way on render and on lookup.
+({bool leftHasIncoming, bool rightHasOutgoing}) seamBoundarySharing(
+  List<DivineVideoClip> clips,
+  int i,
+) => (
+  leftHasIncoming: i > 0 && clips[i - 1].transition != null,
+  rightHasOutgoing: i + 2 < clips.length && clips[i + 1].transition != null,
+);
+
 /// Builds the preview player's clip list for [clips], splicing in any
 /// already-rendered transition seams. Each clip plays only its body (minus the
 /// tail/head consumed by adjacent rendered seams), with the seam clip inserted
@@ -528,8 +636,17 @@ List<player.VideoClip> buildSeamAwarePlayerClips(
     var headConsumed = Duration.zero;
     final prevTransition = i > 0 ? clips[i - 1].transition : null;
     if (prevTransition != null) {
+      final sharing = seamBoundarySharing(clips, i - 1);
       headConsumed =
-          seams.cached(clips[i - 1], clip, prevTransition)?.headConsumed ??
+          seams
+              .cached(
+                clips[i - 1],
+                clip,
+                prevTransition,
+                clipAHasIncoming: sharing.leftHasIncoming,
+                clipBHasOutgoing: sharing.rightHasOutgoing,
+              )
+              ?.headConsumed ??
           Duration.zero;
     }
 
@@ -537,7 +654,14 @@ List<player.VideoClip> buildSeamAwarePlayerClips(
     var tailConsumed = Duration.zero;
     final transition = clip.transition;
     if (i + 1 < clips.length && transition != null) {
-      outgoingSeam = seams.cached(clip, clips[i + 1], transition);
+      final sharing = seamBoundarySharing(clips, i);
+      outgoingSeam = seams.cached(
+        clip,
+        clips[i + 1],
+        transition,
+        clipAHasIncoming: sharing.leftHasIncoming,
+        clipBHasOutgoing: sharing.rightHasOutgoing,
+      );
       tailConsumed = outgoingSeam?.tailConsumed ?? Duration.zero;
     }
 

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -265,17 +265,37 @@ class _VideoEditorState extends ConsumerState<_VideoEditor> {
     for (var i = 0; i < clips.length - 1; i++) {
       final transition = clips[i].transition;
       if (transition == null) continue;
-      if (_seamService.cached(clips[i], clips[i + 1], transition) != null) {
+      final sharing = seamBoundarySharing(clips, i);
+      if (_seamService.cached(
+            clips[i],
+            clips[i + 1],
+            transition,
+            clipAHasIncoming: sharing.leftHasIncoming,
+            clipBHasOutgoing: sharing.rightHasOutgoing,
+          ) !=
+          null) {
         continue;
       }
       // Already counted by an earlier pass whose render is still in flight —
       // skip so the pending counter (and overlay) is not double-incremented.
-      if (_seamService.isRendering(clips[i], clips[i + 1], transition)) {
+      if (_seamService.isRendering(
+        clips[i],
+        clips[i + 1],
+        transition,
+        clipAHasIncoming: sharing.leftHasIncoming,
+        clipBHasOutgoing: sharing.rightHasOutgoing,
+      )) {
         continue;
       }
       _pendingSeamRenders.value++;
       _seamService
-          .render(clipA: clips[i], clipB: clips[i + 1], transition: transition)
+          .render(
+            clipA: clips[i],
+            clipB: clips[i + 1],
+            transition: transition,
+            clipAHasIncoming: sharing.leftHasIncoming,
+            clipBHasOutgoing: sharing.rightHasOutgoing,
+          )
           .then((seam) {
             if (!mounted) return;
             _pendingSeamRenders.value--;

--- a/mobile/test/services/video_editor/transition_seam_render_service_test.dart
+++ b/mobile/test/services/video_editor/transition_seam_render_service_test.dart
@@ -166,6 +166,41 @@ void main() {
       expect(spans.blend, lessThan(spans.consumed));
       expect(spans.seamTransition.duration, equals(spans.blend));
     });
+
+    test('caps a shared clip so its head + tail fit its length (#5487)', () {
+      final long = sized('a', const Duration(seconds: 1));
+      final short = sized('b', const Duration(seconds: 1));
+
+      // Unshared, each boundary consumes the whole 1s clip.
+      expect(
+        service.computeSeamSpans(long, short, dissolve).consumed,
+        equals(const Duration(seconds: 1)),
+      );
+
+      // B sits on two boundaries: the right side of A->B (clipBHasOutgoing) and
+      // the left side of B->C (clipAHasIncoming). Each side is capped to half of
+      // B so head + tail == B's length, while the 500ms blend is preserved.
+      final ab = service.computeSeamSpans(
+        long,
+        short,
+        dissolve,
+        clipBHasOutgoing: true,
+      );
+      final bc = service.computeSeamSpans(
+        short,
+        long,
+        dissolve,
+        clipAHasIncoming: true,
+      );
+      expect(ab.consumed, equals(const Duration(milliseconds: 500)));
+      expect(bc.consumed, equals(const Duration(milliseconds: 500)));
+      expect(
+        ab.consumed + bc.consumed,
+        lessThanOrEqualTo(const Duration(seconds: 1)),
+      );
+      expect(ab.blend, equals(const Duration(milliseconds: 500)));
+      expect(bc.blend, equals(const Duration(milliseconds: 500)));
+    });
   });
 
   group('cached', () {
@@ -359,9 +394,24 @@ void main() {
         tailConsumed: Duration(milliseconds: 600),
         headConsumed: Duration(milliseconds: 600),
       );
+      // Seed with the same neighbour-sharing flags SeamTimeline derives: B is
+      // the right side of A->B (has an outgoing seam) and the left side of
+      // B->C (has an incoming seam).
       final service = TransitionSeamRenderService()
-        ..cacheSeamForTest(clipA, clipB, dissolve, seamSpan)
-        ..cacheSeamForTest(clipB, clipC, dissolve, seamSpan);
+        ..cacheSeamForTest(
+          clipA,
+          clipB,
+          dissolve,
+          seamSpan,
+          clipBHasOutgoing: true,
+        )
+        ..cacheSeamForTest(
+          clipB,
+          clipC,
+          dissolve,
+          seamSpan,
+          clipAHasIncoming: true,
+        );
       final timeline = SeamTimeline([clipA, clipB, clipC], service);
 
       // Sweep the whole composite axis; the mapped editor position must never
@@ -386,6 +436,72 @@ void main() {
           timeline.compositeToTimeline(const Duration(milliseconds: 5299)),
         ),
       );
+    });
+
+    test('preview length matches the export for back-to-back overlaps on a '
+        'short clip (#5487)', () {
+      DivineVideoClip sized(
+        String id,
+        Duration duration, {
+        editor.ClipTransition? transition,
+      }) => DivineVideoClip(
+        id: id,
+        video: editor.EditorVideo.file(File('/tmp/$id.mp4')),
+        duration: duration,
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.square,
+        originalAspectRatio: 1,
+        transition: transition,
+      );
+
+      // Three 1s clips, 500ms dissolve on A->B and B->C. The native export is
+      // 3000 - 500 - 500 = 2000ms, with B fully consumed by the two overlaps.
+      final clipA = sized(
+        'a',
+        const Duration(seconds: 1),
+        transition: dissolve,
+      );
+      final clipB = sized(
+        'b',
+        const Duration(seconds: 1),
+        transition: dissolve,
+      );
+      final clipC = sized('c', const Duration(seconds: 1));
+
+      // Boundary-aware seams consume 500ms/side (half of the shared B), so each
+      // seam duration is 2*500 - 500 = 500ms.
+      const seam = TransitionSeam(
+        path: '/tmp/seam.mp4',
+        duration: Duration(milliseconds: 500),
+        tailConsumed: Duration(milliseconds: 500),
+        headConsumed: Duration(milliseconds: 500),
+      );
+      final service = TransitionSeamRenderService()
+        ..cacheSeamForTest(clipA, clipB, dissolve, seam, clipBHasOutgoing: true)
+        ..cacheSeamForTest(
+          clipB,
+          clipC,
+          dissolve,
+          seam,
+          clipAHasIncoming: true,
+        );
+
+      // The full 3000ms editor timeline maps to a 2000ms composite — matching
+      // the export, not the 3000ms the old per-boundary budgeting produced.
+      final timeline = SeamTimeline([clipA, clipB, clipC], service);
+      expect(
+        timeline.timelineToComposite(const Duration(seconds: 3)),
+        equals(const Duration(seconds: 2)),
+      );
+
+      // B is never played as a standalone body: only A's head, the two seams,
+      // and C's tail appear — no duplicated B frames.
+      final players = buildSeamAwarePlayerClips([clipA, clipB, clipC], service);
+      expect(players, hasLength(4));
+      expect(players[0].uri, equals('/tmp/a.mp4'));
+      expect(players[1].uri, equals('/tmp/seam.mp4'));
+      expect(players[2].uri, equals('/tmp/seam.mp4'));
+      expect(players[3].uri, equals('/tmp/c.mp4'));
     });
   });
 }


### PR DESCRIPTION
## Description

Follow-up to #5479. Fixes the transition **live preview** diverging from the native export when a short clip sits between two near-max overlap transitions.

Per-boundary seam budgeting consumed each clip's full `playbackDuration` from *both* its incoming and outgoing boundary, so a short middle clip was consumed twice — the preview played it back-to-back across two seams, diverging from the export in length and frames. Repro: three 1s clips with a 500ms dissolve on both boundaries → preview ≈ 3000ms, native export = 2000ms (B's body played twice).

Seam consumption is now **boundary-aware**: when a clip also feeds a neighbouring seam, its contribution is capped at half its length, so a clip's head + tail consumption can never exceed it. Only the solo lead-in/out padding is dropped — the blend itself always fits (each boundary's blend is ≤ half the clip) — so the preview tracks the export length and never replays the shared clip.

- `computeSeamSpans` takes `clipAHasIncoming` / `clipBHasOutgoing` and caps the per-clip budget.
- Those flags are part of the seam cache key (bumped to `v2`) and derived consistently via `seamBoundarySharing()` at every render and lookup site (canvas, `SeamTimeline`, `buildSeamAwarePlayerClips`).
- The `editorCursor` monotonic clamp from #5479 stays as a belt-and-suspenders floor.

**Related Issue:** Closes #5487

## Out of Scope

A perfectly faithful preview is inherently impossible for two near-max overlaps on one short clip (the seam would need ~2× duration of solo content per side, which the clip can't supply). This trades the solo padding for matching length/content — as the issue notes, the goal is to track the export "as closely as the math allows."

## Verification

- `flutter analyze` (changed files) — no issues.
- `transition_seam_render_service_test.dart` (incl. two new #5487 tests: the per-clip budget cap, and an end-to-end three-1s dual-dissolve repro asserting preview length == export and no duplicated body), `video_editor_canvas_test.dart`, and the transition suite — all green.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)