### PR TITLE
fix(recorder): stop a stuck recording from the button and recover on stop failure

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -795,7 +795,8 @@ class VideoRecorderBloc
       // Anything thrown between setting isStoppingRecording=true and clearing
       // it below would strand the recorder: the flag stays true and every
       // future stop bails at the top of this handler, so the recording could
-      // never be stopped again. Reset to idle so the user can recover.
+      // never be stopped again. Run best-effort cleanup so the user can
+      // recover.
       Log.error(
         '⚠️ Failed to stop recording cleanly - resetting recorder state',
         name: 'VideoRecorderBloc',
@@ -804,7 +805,19 @@ class VideoRecorderBloc
         stackTrace: stackTrace,
       );
       addError(e, stackTrace);
-      _readClipManager().resetRecording();
+      // A throw at _cameraService.stopRecording() skips the clip-manager and
+      // wakelock teardown above. stopRecording() cancels the periodic 60fps
+      // duration timer and stops the stopwatch (resetRecording alone would
+      // leave that timer running); the wakelock release is retried under its
+      // own guard so a wakelock failure can't block state recovery.
+      _readClipManager()
+        ..stopRecording()
+        ..resetRecording();
+      try {
+        await WakelockPlus.disable();
+      } catch (_) {
+        // Best-effort: ignore a secondary wakelock failure during recovery.
+      }
       emit(
         state.copyWith(
           recordingState: VideoRecorderState.idle,

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -782,13 +782,37 @@ class VideoRecorderBloc
 
     unawaited(HapticService.recordingFeedback());
 
-    await _stopSoundPlayback();
-
-    final videoResult = event.result ?? await _cameraService.stopRecording();
-
-    await WakelockPlus.disable();
-    final clipManager = _readClipManager()..stopRecording();
-    final remainingDuration = clipManager.remainingDuration;
+    final EditorVideo? videoResult;
+    final ClipManagerNotifier clipManager;
+    final Duration remainingDuration;
+    try {
+      await _stopSoundPlayback();
+      videoResult = event.result ?? await _cameraService.stopRecording();
+      await WakelockPlus.disable();
+      clipManager = _readClipManager()..stopRecording();
+      remainingDuration = clipManager.remainingDuration;
+    } catch (e, stackTrace) {
+      // Anything thrown between setting isStoppingRecording=true and clearing
+      // it below would strand the recorder: the flag stays true and every
+      // future stop bails at the top of this handler, so the recording could
+      // never be stopped again. Reset to idle so the user can recover.
+      Log.error(
+        '⚠️ Failed to stop recording cleanly - resetting recorder state',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      addError(e, stackTrace);
+      _readClipManager().resetRecording();
+      emit(
+        state.copyWith(
+          recordingState: VideoRecorderState.idle,
+          isStoppingRecording: false,
+        ),
+      );
+      return;
+    }
 
     emit(
       state.copyWith(

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -788,11 +788,19 @@ class VideoRecorderBloc
     try {
       await _stopSoundPlayback();
       videoResult = event.result ?? await _cameraService.stopRecording();
-      await WakelockPlus.disable();
+      // Best-effort: a wakelock teardown failure must not abort the stop and
+      // discard an already-captured clip (videoResult is assigned above), so
+      // it is swallowed rather than thrown into the recovery catch.
+      await _disableWakelockSafely();
       clipManager = _readClipManager()..stopRecording();
       remainingDuration = clipManager.remainingDuration;
     } catch (e, stackTrace) {
-      // Anything thrown between setting isStoppingRecording=true and clearing
+      // Defense-in-depth recovery. Neither production CameraService throws
+      // from stopRecording() (both catch internally and return null),
+      // _stopSoundPlayback() swallows its own errors, and the wakelock
+      // teardown is guarded above — so this is only reached if that
+      // camera/audio/clip-manager contract is violated. If it ever is,
+      // anything thrown between setting isStoppingRecording=true and clearing
       // it below would strand the recorder: the flag stays true and every
       // future stop bails at the top of this handler, so the recording could
       // never be stopped again. Run best-effort cleanup so the user can
@@ -805,19 +813,12 @@ class VideoRecorderBloc
         stackTrace: stackTrace,
       );
       addError(e, stackTrace);
-      // A throw at _cameraService.stopRecording() skips the clip-manager and
-      // wakelock teardown above. stopRecording() cancels the periodic 60fps
-      // duration timer and stops the stopwatch (resetRecording alone would
-      // leave that timer running); the wakelock release is retried under its
-      // own guard so a wakelock failure can't block state recovery.
+      // stopRecording() cancels the periodic 60fps duration timer and stops
+      // the stopwatch (resetRecording alone would leave that timer running).
       _readClipManager()
         ..stopRecording()
         ..resetRecording();
-      try {
-        await WakelockPlus.disable();
-      } catch (_) {
-        // Best-effort: ignore a secondary wakelock failure during recovery.
-      }
+      await _disableWakelockSafely();
       emit(
         state.copyWith(
           recordingState: VideoRecorderState.idle,
@@ -1460,6 +1461,23 @@ class VideoRecorderBloc
     } catch (e) {
       Log.warning(
         'Failed to stop sound playback: $e',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  /// Releases the wakelock without letting a failure abort the caller.
+  ///
+  /// Wakelock teardown is best-effort: a failure only means the screen stays
+  /// awake. It must never strand the recorder state or discard a captured
+  /// clip, so the error is logged and swallowed.
+  Future<void> _disableWakelockSafely() async {
+    try {
+      await WakelockPlus.disable();
+    } catch (e) {
+      Log.warning(
+        'Failed to disable wakelock: $e',
         name: 'VideoRecorderBloc',
         category: LogCategory.video,
       );

--- a/mobile/lib/widgets/video_recorder/shutter_gesture_detector.dart
+++ b/mobile/lib/widgets/video_recorder/shutter_gesture_detector.dart
@@ -8,6 +8,9 @@ import 'package:flutter/widgets.dart';
 ///   must route through this widget.
 /// - A tap-started recording must never be stopped by an incidental
 ///   long-press release.
+/// - In press-down mode, a press on an already-active recording (started by
+///   any other source — volume key, BLE remote, toggle, or a dropped release)
+///   must still stop it, so the button is never a dead control.
 ///
 /// This encodes the issue #4409 regression guard once so new shutter surfaces
 /// inherit the same behavior by default instead of reimplementing it.
@@ -52,7 +55,16 @@ class _ShutterGestureDetectorState extends State<ShutterGestureDetector> {
   }
 
   void _handleTapDown(TapDownDetails _) {
-    if (widget.isRecording) return;
+    if (widget.isRecording) {
+      // A fresh press-down while recording is already active means this
+      // gesture didn't start it (volume key, BLE remote, toggle, or a release
+      // event that never arrived). Without stopping here the press-down button
+      // is a dead control: _handlePressEnd bails on !_startedByPressDown and
+      // tap / long-press handlers are disabled in press-down mode.
+      _startedByPressDown = false;
+      widget.onLongPressStopRecording();
+      return;
+    }
     _startedByPressDown = true;
     widget.onLongPressStartRecording();
   }

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -38,6 +38,19 @@ class _FakeWakelockPlatform extends WakelockPlusPlatformInterface {
   Future<bool> get enabled async => false;
 }
 
+/// Throws when the wakelock is disabled (`WakelockPlus.disable()` →
+/// `toggle(enable: false)`) so the best-effort teardown path can be
+/// exercised. Enabling stays a no-op so a recording can still start.
+class _ThrowingWakelockDisablePlatform extends WakelockPlusPlatformInterface {
+  @override
+  Future<void> toggle({required bool enable}) async {
+    if (!enable) throw Exception('wakelock disable failed');
+  }
+
+  @override
+  Future<bool> get enabled async => false;
+}
+
 void main() {
   late _MockCameraService cameraService;
   late _MockClipManager clipManager;
@@ -759,6 +772,100 @@ void main() {
           // periodic duration timer that resetRecording() leaves running.
           verify(() => clipManager.stopRecording()).called(1);
           verify(() => clipManager.resetRecording()).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a wakelock disable failure is swallowed (best-effort) — the stop '
+        'still completes, no error is surfaced, and the recorder is not '
+        'driven into the recovery path',
+        setUp: () {
+          wakelockPlusPlatformInstance = _ThrowingWakelockDisablePlatform();
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => null);
+        },
+        tearDown: () {
+          wakelockPlusPlatformInstance = _FakeWakelockPlatform();
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStopRequested()),
+        // No error reaches addError: the wakelock failure is logged and
+        // swallowed by _disableWakelockSafely, never the recovery catch.
+        errors: () => const <Object>[],
+        verify: (bloc) {
+          expect(bloc.state.isStoppingRecording, isFalse);
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          // The duration timer is still cancelled even though wakelock threw.
+          verify(() => clipManager.stopRecording()).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'on a clean stop, clipManager.stopRecording() is called so the '
+        'periodic duration timer is cancelled on the normal path',
+        setUp: () {
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => null);
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStopRequested()),
+        errors: () => const <Object>[],
+        verify: (bloc) {
+          expect(bloc.state.isStoppingRecording, isFalse);
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          verify(() => clipManager.stopRecording()).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a new stop is honored after a recovery — isStoppingRecording is '
+        'cleared, not latched, so the recorder is not permanently blocked',
+        setUp: () {
+          var calls = 0;
+          when(() => cameraService.stopRecording()).thenAnswer((_) async {
+            calls++;
+            if (calls == 1) throw Exception('native stop failed');
+            return null;
+          });
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingStopRequested());
+          await Future<void>.delayed(Duration.zero);
+          // Re-arm to recording; the second stop must reach the native call
+          // rather than bail on a latched isStoppingRecording guard.
+          bloc.emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          );
+          bloc.add(const VideoRecorderRecordingStopRequested());
+        },
+        errors: () => [isA<Exception>()],
+        verify: (bloc) {
+          // Both stops reached the native call — the first recovered without
+          // latching isStoppingRecording=true (which would have bailed the
+          // second at the top of the handler).
+          verify(() => cameraService.stopRecording()).called(2);
+          expect(bloc.state.isStoppingRecording, isFalse);
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
         },
       );
     });

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -755,6 +755,9 @@ void main() {
         verify: (bloc) {
           expect(bloc.state.isStoppingRecording, isFalse);
           expect(bloc.state.recordingState, VideoRecorderState.idle);
+          // stopRecording() must run on the recovery path too — it cancels the
+          // periodic duration timer that resetRecording() leaves running.
+          verify(() => clipManager.stopRecording()).called(1);
           verify(() => clipManager.resetRecording()).called(1);
         },
       );

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -711,6 +711,55 @@ void main() {
       );
     });
 
+    group('RecordingStopRequested → failure recovery', () {
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'resets to idle when the native stop throws, so isStoppingRecording '
+        'is never latched true and future stops are not permanently blocked',
+        setUp: () {
+          when(
+            () => cameraService.stopRecording(),
+          ).thenThrow(Exception('native stop failed'));
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStopRequested()),
+        errors: () => [isA<Exception>()],
+        expect: () => [
+          isA<VideoRecorderBlocState>()
+              .having(
+                (s) => s.isStoppingRecording,
+                'isStoppingRecording',
+                isTrue,
+              )
+              .having(
+                (s) => s.recordingState,
+                'recordingState',
+                VideoRecorderState.recording,
+              ),
+          isA<VideoRecorderBlocState>()
+              .having(
+                (s) => s.isStoppingRecording,
+                'isStoppingRecording',
+                isFalse,
+              )
+              .having(
+                (s) => s.recordingState,
+                'recordingState',
+                VideoRecorderState.idle,
+              ),
+        ],
+        verify: (bloc) {
+          expect(bloc.state.isStoppingRecording, isFalse);
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          verify(() => clipManager.resetRecording()).called(1);
+        },
+      );
+    });
+
     group('sequential() transformer contract', () {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'queued RecordingStartRequested events process FIFO, not '

--- a/mobile/test/widgets/video_recorder/shutter_long_press_mixin_test.dart
+++ b/mobile/test/widgets/video_recorder/shutter_long_press_mixin_test.dart
@@ -135,6 +135,39 @@ void main() {
       },
     );
 
+    testWidgets(
+      'press-down mode stops a recording started by another source',
+      (tester) async {
+        var started = 0;
+        var stopped = 0;
+        await pumpHost(
+          tester,
+          isRecording: true,
+          startsRecordingOnPressDown: true,
+          onTapToggle: () {},
+          onLongPressStartRecording: () => started++,
+          onLongPressStopRecording: () => stopped++,
+        );
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(ShutterGestureDetector)),
+        );
+        await tester.pump();
+
+        expect(started, equals(0), reason: 'must not start a second recording');
+        expect(stopped, equals(1), reason: 'press-down must stop it');
+
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        expect(
+          stopped,
+          equals(1),
+          reason: 'release must not stop again after a press-down stop',
+        );
+      },
+    );
+
     testWidgets('release stops only once after a long-press start', (
       tester,
     ) async {


### PR DESCRIPTION
Closes #5490

## Description

Fixes two independent ways the camera record button could end up unable to
stop a recording. Both surface as the same user report: *"the recording just
kept running and I couldn't stop it."*

**1. Press-down button can't stop an externally-started recording (gesture layer).**
In hold-to-record (press-down) mode the shutter button was a dead stop control
whenever recording was started by something *other* than that press — a volume
key, BLE remote, or the toggle event. `onTapDown` bailed on `isRecording`,
`onTapUp` / `onTapCancel` bailed on `!_startedByPressDown`, and `onTap` /
`onLongPress*` are disabled in press-down mode, so nothing could issue a stop.
A fresh press-down on an already-active recording now stops it (and resets the
flag so the following release doesn't double-stop).

**2. Stop handler could latch `isStoppingRecording=true` forever (BLoC layer).**
`_onRecordingStopRequested` set `isStoppingRecording=true` and only cleared it
after several `await`s (audio-session teardown, native `stopRecording()`,
wakelock). If any of those threw, the flag stayed `true` and the guard at the
top of the handler swallowed *every* future stop — the recording kept running
with no way to stop it (matches the pure long-press report). The critical
window is now wrapped so the recorder always resets to `idle` (discarding the
partial clip) on failure, and the error is reported without flooding Crashlytics
(expected platform/IO failure → not wrapped in `Reportable`).

**Related Issue:** 

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/blocs/video_recorder/ test/widgets/video_recorder/` — 243/243 pass, including the two new regression tests:
  - `ShutterGestureDetector › press-down mode stops a recording started by another source`
  - `VideoRecorderBloc › RecordingStopRequested → failure recovery › resets to idle when the native stop throws …`
- pre-push hook (analyze + changed-file tests) green

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore