### PR TITLE
docs: add CLAUDE.md importing AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+<!-- Canonical guidance lives in AGENTS.md, imported below. Add Claude-only notes after the import. -->
+
+@AGENTS.md


### PR DESCRIPTION
Closes #5492

## Summary
Adds a `CLAUDE.md` that imports the existing `AGENTS.md` via `@AGENTS.md`, so Claude Code picks up this repo's agent guidance.

## Motivation
Claude Code reads only `CLAUDE.md` and never reads `AGENTS.md` automatically. This repo had `AGENTS.md` but no `CLAUDE.md`, so Claude Code loaded none of the guidance. The one-line `@AGENTS.md` import (Anthropic's recommended pattern) bridges them with zero duplication; other agents keep reading `AGENTS.md` directly.

## Changes
- New `CLAUDE.md`: a comment + `@AGENTS.md` import.

No code or functional change.