### PR TITLE
feat(dm): read + publish the user's own kind-10050 DM inbox relays (#4974)

### DIFF
--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -48,6 +48,12 @@ enum FeatureFlag {
         'Changing relays can break publishing and discovery — only turn '
         'this on if you know what you are doing.',
   ),
+  publishDmRelayList(
+    'Publish DM Relay List',
+    'Self-advertise your NIP-17 kind-10050 DM inbox relays on login so '
+        'compliant senders deliver where divine reads. Keep off until the '
+        'backend relay accepts kind-10050.',
+  ),
   ;
 
   const FeatureFlag(

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -48,6 +48,9 @@ class BuildConfiguration {
         );
       case FeatureFlag.advancedRelaySettings:
         return const bool.fromEnvironment('FF_ADVANCED_RELAY_SETTINGS');
+      case FeatureFlag.publishDmRelayList:
+        // Default OFF until the backend relay accepts kind-10050 (#4974 RC3).
+        return const bool.fromEnvironment('FF_PUBLISH_DM_RELAY_LIST');
     }
   }
 
@@ -88,6 +91,8 @@ class BuildConfiguration {
         return 'FF_VIDEO_REPLIES';
       case FeatureFlag.advancedRelaySettings:
         return 'FF_ADVANCED_RELAY_SETTINGS';
+      case FeatureFlag.publishDmRelayList:
+        return 'FF_PUBLISH_DM_RELAY_LIST';
     }
   }
 }

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -544,6 +544,11 @@ DmRepository dmRepository(Ref ref) {
       // session. Bounded by `since: newestSyncedAt - 2d` and isolate
       // decrypt so cold start stays cheap regardless of lifetime DM count.
       unawaited(repository.startListening());
+      // Self-advertise the user's NIP-17 kind-10050 DM inbox relay list once
+      // per (device, pubkey) when absent, so compliant senders deliver where
+      // divine reads. Flag-on-OK, so it no-ops + retries until the relay
+      // accepts the kind — never blocks login. See #4974.
+      unawaited(repository.ensureDmRelayListPublished());
     }
   }
 

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -20,6 +20,8 @@ import 'package:hive_ce/hive_ce.dart';
 import 'package:http/http.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/constants/app_constants.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
@@ -499,6 +501,17 @@ DmRepository dmRepository(Ref ref) {
   final prefs = ref.watch(sharedPreferencesProvider);
   final reactionsRepository = ref.watch(dmReactionsRepositoryProvider);
 
+  // #4974 RC3: gate self-publishing the user's kind-10050 behind the feature
+  // flag (default OFF until the backend relay accepts the kind), and advertise
+  // the environment's stable DM relay (same source as the kind-10002
+  // bootstrap), not the volatile connected-relay getter. Read, not watch, so a
+  // flag flip doesn't churn the live DM subscription — the provider body
+  // re-runs (and re-reads the flag) on each auth change.
+  final publishDmRelayListEnabled = ref.read(
+    isFeatureEnabledProvider(FeatureFlag.publishDmRelayList),
+  );
+  final dmInboxRelayUrl = ref.read(currentEnvironmentProvider).relayUrl;
+
   final repository = DmRepository(
     nostrClient: nostrService,
     directMessagesDao: db.directMessagesDao,
@@ -508,6 +521,8 @@ DmRepository dmRepository(Ref ref) {
     processedGiftWrapsDao: db.processedGiftWrapsDao,
     syncState: DmSyncState(prefs),
     reactionsRepository: reactionsRepository,
+    publishDmRelayListEnabled: publishDmRelayListEnabled,
+    dmInboxRelayUrl: dmInboxRelayUrl,
     errorReporter: (error, stackTrace, {required site}) {
       unawaited(
         CrashReportingService.instance.recordError(

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -774,7 +774,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'a1f331195d4579f19a8bf4e7a2f2641d6a011a8b';
+String _$dmRepositoryHash() => r'f95c82dff0f5dccd48648c7e6037f06d10362b24';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -774,7 +774,7 @@ final class DmRepositoryProvider
   }
 }
 
-String _$dmRepositoryHash() => r'598879d7170da09331ed22b5b89bd11f381d41ae';
+String _$dmRepositoryHash() => r'a1f331195d4579f19a8bf4e7a2f2641d6a011a8b';
 
 /// Provider for CommentsRepository instance
 ///

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -136,6 +136,14 @@ const _relayLoopbackHosts = <String>{
 const bool _classifyDiagnostics =
     bool.fromEnvironment('DM_CLASSIFY_DIAGNOSTICS') && !kReleaseMode;
 
+/// Caps how long `ensureDmRelayListPublished` waits for the
+/// signer when self-publishing the user's kind-10050 DM inbox relay list.
+/// A hung remote signer (Keycast RPC) must not block login; on timeout the
+/// publish is abandoned with the persistence flag left unset so the next
+/// login retries. Mirrors AuthService's kind-10002 bootstrap discipline.
+/// See #4974.
+const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
+
 bool _isAllowedDmRelayUrl(String url) {
   final uri = Uri.tryParse(url.trim());
   if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return false;
@@ -253,6 +261,21 @@ class DmRepository {
   StreamSubscription<Event>? _giftWrapSubscription;
   Timer? _reconnectTimer;
   late bool _disposed = false;
+
+  /// Guards against a double-subscribe race: [startListening] now awaits the
+  /// user's own kind-10050 resolution before opening the live subscription,
+  /// so a concurrent call could otherwise slip past the
+  /// `_giftWrapSubscription == null` check during that await. See #4974.
+  bool _subscribing = false;
+
+  /// Memoized resolution of the CURRENT user's own kind-10050 DM inbox
+  /// relays (#4974 RC2). Resolved at most once per session and shared by the
+  /// live subscription and the history drain; `null` until first requested.
+  /// Cleared in [_resetState] so it never leaks across an account switch and
+  /// is re-resolved for the new `_userPubkey`. The resolved value may itself
+  /// be `null` (user has no kind-10050 → fall back to the default pool),
+  /// which is cached too so reconnects do not re-query.
+  Future<List<String>?>? _ownInboxRelaysFuture;
 
   /// A single long-lived decrypt isolate, alive only for the duration of a
   /// history drain. Spawned in [_runHistoryDrain] for local-key signers and
@@ -412,6 +435,9 @@ class DmRepository {
     _reconnectTimer = null;
     unawaited(_giftWrapSubscription?.cancel());
     _giftWrapSubscription = null;
+    // Drop the outgoing user's resolved own-inbox relays so the next user
+    // re-resolves their own kind-10050 (never reuses a stale set). #4974.
+    _ownInboxRelaysFuture = null;
     final subId = _subscriptionId;
     try {
       unawaited(_nostrClient.unsubscribe(subId));
@@ -467,7 +493,7 @@ class DmRepository {
     // fresh subscription we're about to establish.
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
-    if (_giftWrapSubscription != null || !isInitialized) return;
+    if (_giftWrapSubscription != null || _subscribing || !isInitialized) return;
 
     // Count-based windowing: first open fetches a bounded backlog
     // (limit:50), later opens fetch only recent events via a `since:`
@@ -496,47 +522,83 @@ class DmRepository {
       category: LogCategory.system,
     );
 
-    _subscriptionId = 'dm_inbox_$_userPubkey';
-    final stream = _nostrClient.subscribe([
-      filter,
-    ], subscriptionId: _subscriptionId);
+    // Resolve the user's OWN kind-10050 inbox relays and target the live
+    // subscription at them — as BOTH tempRelays (to add connections outside
+    // the default pool) AND targetRelays — so gift wraps a NIP-17 sender
+    // delivered to relays outside divine's default pool are read. A `null`
+    // result (no kind-10050 / resolve failure) preserves the prior
+    // default-pool behavior. Memoized per session, so the up-to-5s resolve
+    // only delays the FIRST open. _subscribing guards the await window
+    // against a concurrent startListening opening a duplicate subscription.
+    // See #4974.
+    _subscribing = true;
+    try {
+      final ownInbox = await _resolveOwnInboxRelays();
+      // A teardown (stopListening / account switch) or a competing call may
+      // have run during the await — bail rather than open a stale or
+      // duplicate subscription.
+      if (_disposed || !isInitialized || _giftWrapSubscription != null) {
+        return;
+      }
 
-    _giftWrapSubscription = stream.listen(
-      _handleIncomingEvent,
-      onError: (Object error) {
-        Log.error(
-          'DM subscription error: $error',
-          category: LogCategory.system,
-        );
-        // Cancel the failed subscription so its onDone callback never fires
-        // after a later stopListening() call (which leaves _disposed false).
-        // Without this, the orphaned subscription's onDone would schedule a
-        // reconnect timer that leaks past the current lifecycle.
-        unawaited(_giftWrapSubscription?.cancel());
-        _giftWrapSubscription = null;
-        if (!_disposed) {
-          _scheduleReconnect();
-        }
-      },
-      onDone: () {
-        // Stream closed (relay disconnect, NostrClient rebuild, etc.)
-        // Clear the subscription so startListening() can re-subscribe.
-        _giftWrapSubscription = null;
-        if (!_disposed) {
-          Log.info(
-            'DM subscription stream closed, re-subscribing '
-            'in ${_reconnectDelay.inSeconds}s',
+      _subscriptionId = 'dm_inbox_$_userPubkey';
+      final stream = _nostrClient.subscribe(
+        [filter],
+        subscriptionId: _subscriptionId,
+        tempRelays: ownInbox,
+        targetRelays: ownInbox,
+      );
+
+      _giftWrapSubscription = stream.listen(
+        _handleIncomingEvent,
+        onError: (Object error) {
+          Log.error(
+            'DM subscription error: $error',
             category: LogCategory.system,
           );
-          _scheduleReconnect();
-        }
-      },
-    );
+          // Cancel the failed subscription so its onDone callback never fires
+          // after a later stopListening() call (which leaves _disposed false).
+          // Without this, the orphaned subscription's onDone would schedule a
+          // reconnect timer that leaks past the current lifecycle.
+          unawaited(_giftWrapSubscription?.cancel());
+          _giftWrapSubscription = null;
+          if (!_disposed) {
+            _scheduleReconnect();
+          }
+        },
+        onDone: () {
+          // Stream closed (relay disconnect, NostrClient rebuild, etc.)
+          // Clear the subscription so startListening() can re-subscribe.
+          _giftWrapSubscription = null;
+          if (!_disposed) {
+            Log.info(
+              'DM subscription stream closed, re-subscribing '
+              'in ${_reconnectDelay.inSeconds}s',
+              category: LogCategory.system,
+            );
+            _scheduleReconnect();
+          }
+        },
+      );
+    } finally {
+      _subscribing = false;
+    }
 
     // No poll timer: the live WebSocket subscription is the sole event
     // source for the entire authenticated session. Poller was removed
     // because it re-fetched duplicate events every 10s forever on the UI
     // isolate. See docs/plans/2026-04-05-dm-scaling-fix-design.md and #2931.
+  }
+
+  /// Resolves and memoizes the CURRENT user's own kind-10050 DM inbox
+  /// relays for the session (#4974 RC2).
+  ///
+  /// Shared by the live subscription and the history drain so the relay is
+  /// queried at most once per session; the result (which may be `null` when
+  /// the user has no kind-10050) is cached so reconnects and drain pages do
+  /// not re-query. [_resetState] clears the memo on account switch.
+  Future<List<String>?> _resolveOwnInboxRelays() {
+    return _ownInboxRelaysFuture ??= resolveDmInboxRelays(_userPubkey);
   }
 
   /// Fetches a single older page of DM events (gift wraps, NIP-04,
@@ -552,6 +614,7 @@ class DmRepository {
     required int limit,
     required String subscriptionId,
     required String pubkey,
+    List<String>? tempRelays,
   }) async {
     final filter = nostr_filter.Filter(
       kinds: [
@@ -564,10 +627,15 @@ class DmRepository {
       limit: limit,
     );
 
+    // Target the user's OWN kind-10050 inbox relays (in addition to the
+    // default pool) so the #4953/#4973 history drain reads gift wraps a
+    // sender delivered outside the default pool. `null` keeps the prior
+    // default-pool-only behavior. See #4974.
     final events = await _nostrClient.queryEvents(
       [filter],
       subscriptionId: subscriptionId,
       useCache: false,
+      tempRelays: tempRelays,
     );
     if (_disposed || _userPubkey != pubkey) return null;
 
@@ -950,6 +1018,13 @@ class DmRepository {
           syncState.oldestSyncedAt(pubkey) ??
           DateTime.now().millisecondsSinceEpoch ~/ 1000;
 
+      // Resolve the user's OWN kind-10050 inbox relays once for the whole
+      // drain (memoized, shared with the live subscription) and target every
+      // page at them so the backfill reads gift wraps delivered outside the
+      // default pool. `null` keeps default-pool-only behavior. See #4974.
+      final ownInbox = await _resolveOwnInboxRelays();
+      if (_disposed || _userPubkey != pubkey) return;
+
       var reachedEnd = false;
       var pagesRun = 0;
       var totalEvents = 0;
@@ -961,6 +1036,7 @@ class DmRepository {
           limit: DmHistoryDrainConfig.pageSize,
           subscriptionId: 'dm_drain_${pubkey}_$page',
           pubkey: pubkey,
+          tempRelays: ownInbox,
         );
         if (events == null) return;
         pagesRun++;
@@ -1838,10 +1914,15 @@ class DmRepository {
       if (events.isEmpty) return null;
       // Newest wins for a replaceable event served from multiple relays.
       events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      // Accept both `relay` (the kind-10050 spec tag) and `r` tags. The
+      // whole point of #4974 is reading a 10050 a user advertised from
+      // ANOTHER client, and some clients write `r` tags; within a
+      // kind-10050 event both unambiguously denote DM inbox relays. Matches
+      // divine-web's resolveDmReadRelays.
       final relays = <String>{
         for (final tag in events.first.tags)
           if (tag.length >= 2 &&
-              tag[0] == 'relay' &&
+              (tag[0] == 'relay' || tag[0] == 'r') &&
               tag[1].isNotEmpty &&
               _isAllowedDmRelayUrl(tag[1]))
             tag[1],
@@ -1853,6 +1934,97 @@ class DmRepository {
         category: LogCategory.system,
       );
       return null;
+    }
+  }
+
+  /// Publishes a minimal NIP-17 kind-10050 DM inbox relay list for the
+  /// current user when they don't already advertise one, so compliant
+  /// senders deliver gift-wrapped DMs to the relay where divine receives
+  /// them (#4974 RC3).
+  ///
+  /// Publish-when-absent: a kind-10050 the user advertised from any client
+  /// is left untouched — divine reads it on the receive side (RC2) rather
+  /// than risk overwriting a richer list. Idempotent per (device, pubkey)
+  /// via `DmSyncState.dmRelayListPublished`, with the flag set ONLY on a
+  /// confirmed relay `OK`. So a relay that rejects kind-10050 (e.g. the kind
+  /// is not yet in its allowed-kinds) or a slow/failed signer simply leaves
+  /// the flag unset and the next login retries — the publish never blocks
+  /// login and self-heals once the backend accepts the kind.
+  ///
+  /// No-op when uninitialized, when no signer / sync state is wired, or when
+  /// the advertised relay URL is not a valid `wss://` relay.
+  Future<void> ensureDmRelayListPublished() async {
+    if (!isInitialized) return;
+    final syncState = _syncState;
+    final signer = _signer;
+    if (syncState == null || signer == null) return;
+    final pubkey = _userPubkey;
+    try {
+      if (syncState.dmRelayListPublished(pubkey)) return;
+
+      // Never overwrite a kind-10050 the user advertised from another
+      // client — it may list inbox relays divine doesn't know. Record the
+      // flag so we stop re-checking every login.
+      final existing = await resolveDmInboxRelays(pubkey);
+      if (_disposed || _userPubkey != pubkey) return;
+      if (existing != null) {
+        await syncState.markDmRelayListPublished(pubkey);
+        return;
+      }
+
+      final relayUrl = _nostrClient.primaryRelay;
+      if (!_isAllowedDmRelayUrl(relayUrl)) return;
+
+      final unsigned = Event(
+        pubkey,
+        EventKind.dmRelaysList,
+        <List<String>>[
+          <String>['relay', relayUrl],
+        ],
+        '',
+      );
+
+      final Event? signed;
+      try {
+        signed = await signer
+            .signEvent(unsigned)
+            .timeout(_dmRelayListSignTimeout);
+      } on TimeoutException {
+        Log.warning(
+          'kind-10050 publish: signer timed out after '
+          '${_dmRelayListSignTimeout.inSeconds}s — will retry next login',
+          category: LogCategory.system,
+        );
+        return;
+      }
+      if (signed == null || signed.sig.isEmpty) return;
+      if (_disposed || _userPubkey != pubkey) return;
+
+      final outcome = await _nostrClient.publishEventAwaitOk(
+        signed,
+        targetRelays: <String>[relayUrl],
+      );
+      if (_disposed || _userPubkey != pubkey) return;
+      if (outcome.acceptedBy.isEmpty) {
+        Log.warning(
+          'kind-10050 publish: no relay accepted — will retry next login',
+          category: LogCategory.system,
+        );
+        return;
+      }
+
+      await syncState.markDmRelayListPublished(pubkey);
+      Log.info(
+        'Published kind-10050 DM inbox relay list for $pubkey -> $relayUrl',
+        category: LogCategory.system,
+      );
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'kind-10050 publish failed: $e — will retry next login',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
     }
   }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -454,8 +454,11 @@ class DmRepository {
   void _resetState() {
     // Bump the session-identity token first so any in-flight `await` started
     // under the outgoing session detects the switch on resume and bails
-    // instead of acting on the new `_userPubkey`. See #4974.
+    // instead of acting on the new `_userPubkey`. Release `_subscribing` too,
+    // so the incoming user's startListening() is not blocked at its entry
+    // guard by the outgoing user's still-resolving subscribe. See #4974.
     _resetGeneration++;
+    _subscribing = false;
     _disposed = true;
     _eventLock = null;
     // Drop the in-flight history drain and decrypt-retry pass so the next
@@ -1240,6 +1243,13 @@ class DmRepository {
     // startListening() call a silent no-op, breaking re-open flows such
     // as the post-signOut cleanup in UserDataCleanupService that may be
     // followed by a fresh sign-in on the same repository instance.
+    //
+    // But DO bump the session token: an intentional stop must invalidate any
+    // startListening()/ensureDmRelayListPublished() resolve already in flight,
+    // so its post-await continuation bails instead of re-opening the
+    // subscription (or completing a publish) after the stop. _disposed stays
+    // false so a later startListening() re-opens cleanly. See #4974.
+    _resetGeneration++;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     _eventLock = null;

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -144,6 +144,24 @@ const bool _classifyDiagnostics =
 /// See #4974.
 const Duration _dmRelayListSignTimeout = Duration(seconds: 10);
 
+/// Outcome of resolving a user's own kind-10050 DM inbox relay list (#4974).
+///
+/// Distinguishes a genuine absence from a transient query failure so callers
+/// don't conflate them: the live subscription / drain fall back to the
+/// default pool on either, but RC3 must only publish-when-`absent` and never
+/// overwrite a real list when the lookup merely `failed`.
+enum _OwnDmInboxState {
+  /// The user advertises a kind-10050 with at least one allowed relay.
+  found,
+
+  /// The query succeeded but the user has no kind-10050 (or none with an
+  /// allowed relay) — safe for RC3 to self-publish.
+  absent,
+
+  /// The query threw / timed out — outcome unknown; do not publish, retry.
+  failed,
+}
+
 bool _isAllowedDmRelayUrl(String url) {
   final uri = Uri.tryParse(url.trim());
   if (uri == null || !uri.hasAuthority || uri.host.isEmpty) return false;
@@ -196,6 +214,8 @@ class DmRepository {
     DmVerifyIsolateSpawner? verifyIsolateSpawner,
     DmRepositoryErrorReporter? errorReporter,
     DmReactionsRepository? reactionsRepository,
+    bool publishDmRelayListEnabled = false,
+    String? dmInboxRelayUrl,
   }) : _nostrClient = nostrClient,
        _directMessagesDao = directMessagesDao,
        _conversationsDao = conversationsDao,
@@ -211,7 +231,9 @@ class DmRepository {
        _decryptIsolateSpawner = decryptIsolateSpawner ?? DmDecryptIsolate.spawn,
        _verifyIsolateSpawner = verifyIsolateSpawner ?? DmVerifyIsolate.spawn,
        _errorReporter = errorReporter,
-       _reactionsRepository = reactionsRepository;
+       _reactionsRepository = reactionsRepository,
+       _publishDmRelayListEnabled = publishDmRelayListEnabled,
+       _dmInboxRelayUrl = dmInboxRelayUrl;
 
   final NostrClient _nostrClient;
   final DirectMessagesDao _directMessagesDao;
@@ -258,6 +280,19 @@ class DmRepository {
   /// without rewiring; production injects it via `dmRepositoryProvider`.
   final DmReactionsRepository? _reactionsRepository;
 
+  /// Feature gate for #4974 RC3 (self-publishing the user's own kind-10050 DM
+  /// inbox relay list on login). Defaults to `false` so the publish stays
+  /// inert until the backend relay accepts the kind; the app flips it on via
+  /// `FeatureFlag.publishDmRelayList`. While `false`,
+  /// [ensureDmRelayListPublished] is a no-op — no signer round-trip fires.
+  final bool _publishDmRelayListEnabled;
+
+  /// The stable relay URL advertised by the RC3 kind-10050 publish (the
+  /// environment's canonical DM relay, mirroring the kind-10002 bootstrap).
+  /// `null` in fixtures that don't exercise RC3; when `null`,
+  /// [ensureDmRelayListPublished] is a no-op (nothing to advertise).
+  final String? _dmInboxRelayUrl;
+
   StreamSubscription<Event>? _giftWrapSubscription;
   Timer? _reconnectTimer;
   late bool _disposed = false;
@@ -268,14 +303,23 @@ class DmRepository {
   /// `_giftWrapSubscription == null` check during that await. See #4974.
   bool _subscribing = false;
 
+  /// Monotonic session-identity token. Bumped at the start of [_resetState]
+  /// (account switch / logout) so any `await` that began under the previous
+  /// session can detect the switch on resume and bail instead of acting on a
+  /// stale `_userPubkey` (e.g. opening the live subscription with the old
+  /// user's filter, or completing an RC3 publish for the wrong session).
+  /// See #4974.
+  int _resetGeneration = 0;
+
   /// Memoized resolution of the CURRENT user's own kind-10050 DM inbox
   /// relays (#4974 RC2). Resolved at most once per session and shared by the
-  /// live subscription and the history drain; `null` until first requested.
-  /// Cleared in [_resetState] so it never leaks across an account switch and
-  /// is re-resolved for the new `_userPubkey`. The resolved value may itself
-  /// be `null` (user has no kind-10050 → fall back to the default pool),
-  /// which is cached too so reconnects do not re-query.
-  Future<List<String>?>? _ownInboxRelaysFuture;
+  /// live subscription, the history drain, and the RC3 existence check;
+  /// `null` until first requested. Cleared in [_resetState] so it never leaks
+  /// across an account switch. A `found`/`absent` outcome is cached so
+  /// reconnects don't re-query; a `failed` (transient relay error) outcome is
+  /// NOT cached — the memo is cleared once it resolves so the next caller
+  /// re-queries, and RC3 never overwrites a real list on a transient failure.
+  Future<({_OwnDmInboxState state, List<String>? relays})>? _ownInboxFuture;
 
   /// A single long-lived decrypt isolate, alive only for the duration of a
   /// history drain. Spawned in [_runHistoryDrain] for local-key signers and
@@ -408,6 +452,10 @@ class DmRepository {
   /// is fire-and-forget — the old subscription filtered by the old pubkey
   /// so any late arrivals are harmless (dedup rejects them).
   void _resetState() {
+    // Bump the session-identity token first so any in-flight `await` started
+    // under the outgoing session detects the switch on resume and bails
+    // instead of acting on the new `_userPubkey`. See #4974.
+    _resetGeneration++;
     _disposed = true;
     _eventLock = null;
     // Drop the in-flight history drain and decrypt-retry pass so the next
@@ -437,7 +485,7 @@ class DmRepository {
     _giftWrapSubscription = null;
     // Drop the outgoing user's resolved own-inbox relays so the next user
     // re-resolves their own kind-10050 (never reuses a stale set). #4974.
-    _ownInboxRelaysFuture = null;
+    _ownInboxFuture = null;
     final subId = _subscriptionId;
     try {
       unawaited(_nostrClient.unsubscribe(subId));
@@ -527,17 +575,24 @@ class DmRepository {
     // the default pool) AND targetRelays — so gift wraps a NIP-17 sender
     // delivered to relays outside divine's default pool are read. A `null`
     // result (no kind-10050 / resolve failure) preserves the prior
-    // default-pool behavior. Memoized per session, so the up-to-5s resolve
-    // only delays the FIRST open. _subscribing guards the await window
-    // against a concurrent startListening opening a duplicate subscription.
-    // See #4974.
+    // default-pool behavior. Memoized per session, so the resolve (bounded by
+    // the queryEvents ~5s timeout) only delays the FIRST open. `_subscribing`
+    // guards the await window against a concurrent startListening opening a
+    // duplicate subscription. See #4974.
     _subscribing = true;
     try {
-      final ownInbox = await _resolveOwnInboxRelays();
-      // A teardown (stopListening / account switch) or a competing call may
-      // have run during the await — bail rather than open a stale or
-      // duplicate subscription.
-      if (_disposed || !isInitialized || _giftWrapSubscription != null) {
+      // Capture the session token before the await: `filter` was built with
+      // the current `_userPubkey`, so if an account switch lands during the
+      // resolve we must NOT open a subscription targeting the previous user.
+      final gen = _resetGeneration;
+      final ownInbox = await _ownInboxTargetRelays();
+      // A teardown (stopListening), account switch (generation bumped), or a
+      // competing call may have run during the await — bail rather than open
+      // a stale or duplicate subscription.
+      if (_disposed ||
+          _resetGeneration != gen ||
+          !isInitialized ||
+          _giftWrapSubscription != null) {
         return;
       }
 
@@ -591,14 +646,39 @@ class DmRepository {
   }
 
   /// Resolves and memoizes the CURRENT user's own kind-10050 DM inbox
-  /// relays for the session (#4974 RC2).
+  /// resolution for the session (#4974 RC2).
   ///
-  /// Shared by the live subscription and the history drain so the relay is
-  /// queried at most once per session; the result (which may be `null` when
-  /// the user has no kind-10050) is cached so reconnects and drain pages do
-  /// not re-query. [_resetState] clears the memo on account switch.
-  Future<List<String>?> _resolveOwnInboxRelays() {
-    return _ownInboxRelaysFuture ??= resolveDmInboxRelays(_userPubkey);
+  /// Shared by the live subscription, the history drain, and the RC3
+  /// existence check, so the relay is queried at most once per login. A
+  /// `found`/`absent` outcome is cached; a `failed` (transient) outcome is
+  /// NOT — the memo clears itself once it resolves `failed` so the next
+  /// caller re-queries instead of degrading the whole session to the default
+  /// pool. [_resetState] clears the memo on account switch.
+  Future<({_OwnDmInboxState state, List<String>? relays})>
+  _resolveOwnDmInbox() {
+    final cached = _ownInboxFuture;
+    if (cached != null) return cached;
+    final future = _queryOwnDmInbox(_userPubkey);
+    _ownInboxFuture = future;
+    unawaited(
+      future.then((res) {
+        // Don't strand the session on a transient failure: drop the memo so
+        // a later reconnect / login re-queries. Guard with `identical` so a
+        // concurrent _resetState (which nulls or replaces the memo) wins.
+        if (res.state == _OwnDmInboxState.failed &&
+            identical(_ownInboxFuture, future)) {
+          _ownInboxFuture = null;
+        }
+      }),
+    );
+    return future;
+  }
+
+  /// The relays to target the live read at: the user's own kind-10050 relays
+  /// when `found`, else `null` (default pool) on `absent`/`failed`.
+  Future<List<String>?> _ownInboxTargetRelays() async {
+    final res = await _resolveOwnDmInbox();
+    return res.state == _OwnDmInboxState.found ? res.relays : null;
   }
 
   /// Fetches a single older page of DM events (gift wraps, NIP-04,
@@ -1022,7 +1102,7 @@ class DmRepository {
       // drain (memoized, shared with the live subscription) and target every
       // page at them so the backfill reads gift wraps delivered outside the
       // default pool. `null` keeps default-pool-only behavior. See #4974.
-      final ownInbox = await _resolveOwnInboxRelays();
+      final ownInbox = await _ownInboxTargetRelays();
       if (_disposed || _userPubkey != pubkey) return;
 
       var reachedEnd = false;
@@ -1903,6 +1983,19 @@ class DmRepository {
   /// who have not advertised a DM inbox. Resolution failures degrade to
   /// `null` rather than throwing, so a relay hiccup never blocks a send.
   Future<List<String>?> resolveDmInboxRelays(String pubkey) async {
+    return (await _queryOwnDmInbox(pubkey)).relays;
+  }
+
+  /// Queries [pubkey]'s kind-10050 DM inbox relay list and reports a
+  /// found / absent / failed outcome (#4974).
+  ///
+  /// Collapsing absent and failed to `null` (as the public
+  /// [resolveDmInboxRelays] does) is safe for the send path and the live
+  /// read (both fall back to the default pool either way), but RC3 must tell
+  /// them apart — see [ensureDmRelayListPublished].
+  Future<({_OwnDmInboxState state, List<String>? relays})> _queryOwnDmInbox(
+    String pubkey,
+  ) async {
     try {
       final events = await _nostrClient.queryEvents([
         nostr_filter.Filter(
@@ -1911,14 +2004,17 @@ class DmRepository {
           limit: 1,
         ),
       ]);
-      if (events.isEmpty) return null;
+      if (events.isEmpty) {
+        return (state: _OwnDmInboxState.absent, relays: null);
+      }
       // Newest wins for a replaceable event served from multiple relays.
       events.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       // Accept both `relay` (the kind-10050 spec tag) and `r` tags. The
       // whole point of #4974 is reading a 10050 a user advertised from
       // ANOTHER client, and some clients write `r` tags; within a
       // kind-10050 event both unambiguously denote DM inbox relays. Matches
-      // divine-web's resolveDmReadRelays.
+      // divine-web's resolveDmReadRelays. Shared with the send path via
+      // resolveDmInboxRelays, so it also widens recipient resolution there.
       final relays = <String>{
         for (final tag in events.first.tags)
           if (tag.length >= 2 &&
@@ -1927,13 +2023,15 @@ class DmRepository {
               _isAllowedDmRelayUrl(tag[1]))
             tag[1],
       };
-      return relays.isEmpty ? null : relays.toList();
+      return relays.isEmpty
+          ? (state: _OwnDmInboxState.absent, relays: null)
+          : (state: _OwnDmInboxState.found, relays: relays.toList());
     } on Object catch (e) {
       Log.warning(
         'Failed to resolve DM inbox relays for $pubkey: $e',
         category: LogCategory.system,
       );
-      return null;
+      return (state: _OwnDmInboxState.failed, relays: null);
     }
   }
 
@@ -1942,38 +2040,53 @@ class DmRepository {
   /// senders deliver gift-wrapped DMs to the relay where divine receives
   /// them (#4974 RC3).
   ///
-  /// Publish-when-absent: a kind-10050 the user advertised from any client
-  /// is left untouched — divine reads it on the receive side (RC2) rather
-  /// than risk overwriting a richer list. Idempotent per (device, pubkey)
-  /// via `DmSyncState.dmRelayListPublished`, with the flag set ONLY on a
-  /// confirmed relay `OK`. So a relay that rejects kind-10050 (e.g. the kind
-  /// is not yet in its allowed-kinds) or a slow/failed signer simply leaves
-  /// the flag unset and the next login retries — the publish never blocks
-  /// login and self-heals once the backend accepts the kind.
+  /// Gated behind the injected `publishDmRelayListEnabled` flag: while it is
+  /// off (the default, until the backend relay accepts kind-10050) this is a
+  /// no-op — no signer round-trip fires on login.
   ///
-  /// No-op when uninitialized, when no signer / sync state is wired, or when
-  /// the advertised relay URL is not a valid `wss://` relay.
+  /// Publish-when-absent: a kind-10050 the user advertised from any client is
+  /// left untouched. The own-inbox lookup distinguishes `found` / `absent` /
+  /// `failed`, so a transient relay failure (`failed`) NEVER triggers a
+  /// publish that could overwrite a real list divine simply couldn't fetch —
+  /// it retries next login. The lookup is the shared session memo, so it
+  /// reuses the live subscription's resolve rather than issuing a second
+  /// query. Idempotent per (device, pubkey) via
+  /// `DmSyncState.dmRelayListPublished`, with the flag set ONLY on a confirmed
+  /// relay `OK`. A relay that rejects kind-10050 or a slow/failed signer
+  /// leaves the flag unset and the next login retries — the publish never
+  /// blocks login and self-heals once the backend accepts the kind.
+  ///
+  /// No-op when the feature is off, when uninitialized, when no signer / sync
+  /// state is wired, or when no valid advertised relay URL is configured.
   Future<void> ensureDmRelayListPublished() async {
-    if (!isInitialized) return;
+    if (!_publishDmRelayListEnabled || !isInitialized) return;
     final syncState = _syncState;
     final signer = _signer;
+    final relayUrl = _dmInboxRelayUrl;
     if (syncState == null || signer == null) return;
+    if (relayUrl == null || !_isAllowedDmRelayUrl(relayUrl)) return;
     final pubkey = _userPubkey;
+    // Session-identity token: bail after any await if an account switch /
+    // logout (or other teardown) bumped it while we were in flight.
+    final gen = _resetGeneration;
     try {
       if (syncState.dmRelayListPublished(pubkey)) return;
 
-      // Never overwrite a kind-10050 the user advertised from another
-      // client — it may list inbox relays divine doesn't know. Record the
-      // flag so we stop re-checking every login.
-      final existing = await resolveDmInboxRelays(pubkey);
-      if (_disposed || _userPubkey != pubkey) return;
-      if (existing != null) {
+      // Shared session memo — dedupes with the live subscription's resolve.
+      final resolution = await _resolveOwnDmInbox();
+      if (_disposed || _resetGeneration != gen) return;
+      if (resolution.state == _OwnDmInboxState.found) {
+        // Already advertising an inbox — never overwrite a richer list.
+        // Record the flag so we stop re-checking every login.
         await syncState.markDmRelayListPublished(pubkey);
         return;
       }
-
-      final relayUrl = _nostrClient.primaryRelay;
-      if (!_isAllowedDmRelayUrl(relayUrl)) return;
+      if (resolution.state == _OwnDmInboxState.failed) {
+        // Outcome unknown: do NOT publish (could clobber an existing list)
+        // and do NOT set the flag — retry on the next login.
+        return;
+      }
+      // _OwnDmInboxState.absent — safe to self-advertise.
 
       final unsigned = Event(
         pubkey,
@@ -1998,13 +2111,13 @@ class DmRepository {
         return;
       }
       if (signed == null || signed.sig.isEmpty) return;
-      if (_disposed || _userPubkey != pubkey) return;
+      if (_disposed || _resetGeneration != gen) return;
 
       final outcome = await _nostrClient.publishEventAwaitOk(
         signed,
         targetRelays: <String>[relayUrl],
       );
-      if (_disposed || _userPubkey != pubkey) return;
+      if (_disposed || _resetGeneration != gen) return;
       if (outcome.acceptedBy.isEmpty) {
         Log.warning(
           'kind-10050 publish: no relay accepted — will retry next login',

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -161,6 +161,7 @@ class DmSyncState {
     await _prefs.remove('$_drainCompletePrefix$pubkey');
     await _prefs.remove('$_drainCursorPrefix$pubkey');
     await _prefs.remove('$_drainVersionPrefix$pubkey');
+    await _prefs.remove('$_dmRelayListPublishedPrefix$pubkey');
   }
 
   /// Removes all DM sync state entries for every pubkey.
@@ -176,7 +177,8 @@ class DmSyncState {
               key.startsWith(_oldestPrefix) ||
               key.startsWith(_drainCompletePrefix) ||
               key.startsWith(_drainCursorPrefix) ||
-              key.startsWith(_drainVersionPrefix),
+              key.startsWith(_drainVersionPrefix) ||
+              key.startsWith(_dmRelayListPublishedPrefix),
         )
         .toList();
     for (final key in keysToRemove) {

--- a/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_sync_state.dart
@@ -25,6 +25,7 @@ class DmSyncState {
   static const _drainCompletePrefix = 'dm.historyDrainComplete.';
   static const _drainCursorPrefix = 'dm.historyDrainCursor.';
   static const _drainVersionPrefix = 'dm.historyDrainVersion.';
+  static const _dmRelayListPublishedPrefix = 'dm.dmRelayListPublished.';
 
   /// Current history-drain logic version. Installs whose persisted
   /// [drainVersion] is below this re-run the drain once, even if
@@ -134,6 +135,23 @@ class DmSyncState {
   /// from it.
   Future<void> setHistoryDrainCursor(String pubkey, int cursor) async {
     await _prefs.setInt('$_drainCursorPrefix$pubkey', cursor);
+  }
+
+  /// Whether a NIP-17 kind-10050 DM inbox relay list has been published for
+  /// [pubkey] from this device.
+  ///
+  /// Gates #4974's publish-on-login so it runs at most once per
+  /// (device, pubkey). Set only on a confirmed relay `OK` (see
+  /// [markDmRelayListPublished]); a reinstall wipes SharedPreferences and a
+  /// fresh install should re-advertise, so this correctly reads `false`
+  /// again then.
+  bool dmRelayListPublished(String pubkey) =>
+      _prefs.getBool('$_dmRelayListPublishedPrefix$pubkey') ?? false;
+
+  /// Records that a kind-10050 DM inbox relay list has been published for
+  /// [pubkey] (or that one already exists). See [dmRelayListPublished].
+  Future<void> markDmRelayListPublished(String pubkey) async {
+    await _prefs.setBool('$_dmRelayListPublishedPrefix$pubkey', true);
   }
 
   /// Removes all sync state for [pubkey]. Called on account switch.

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -480,6 +480,10 @@ void main() {
       NostrSigner? signer,
       DmDecryptIsolateSpawner? decryptIsolateSpawner,
       DmVerifyIsolateSpawner? verifyIsolateSpawner,
+      // #4974 RC3: default the feature on + inject a stable relay so the
+      // existing RC3 tests exercise the publish path; gating tests override.
+      bool publishDmRelayListEnabled = true,
+      String? dmInboxRelayUrl = 'wss://relay.divine.video',
     }) {
       return DmRepository(
         nostrClient: mockNostrClient,
@@ -502,6 +506,8 @@ void main() {
             verifyIsolateSpawner ?? () async => _RecordingVerifyWorker(),
         syncState: syncState,
         reactionsRepository: reactionsRepository,
+        publishDmRelayListEnabled: publishDmRelayListEnabled,
+        dmInboxRelayUrl: dmInboxRelayUrl,
         errorReporter: (error, stackTrace, {required site}) {
           reporterCalls.add(_ReporterCall(error, stackTrace, site));
         },
@@ -3041,15 +3047,9 @@ void main() {
         noResponseFrom: const [],
       );
 
-      setUp(() {
-        when(
-          () => mockNostrClient.primaryRelay,
-        ).thenReturn('wss://relay.divine.video');
-      });
-
       test(
-        'publishes a kind-10050 advertising the primary relay when absent and '
-        'records the flag on a confirmed OK',
+        'publishes a kind-10050 advertising the injected stable relay when '
+        'absent and records the flag on a confirmed OK',
         () async {
           // setUp default queryEvents -> [] : user has no existing kind-10050.
           when(
@@ -3187,6 +3187,152 @@ void main() {
           ),
         );
       });
+
+      test('is a no-op when the feature flag is off', () async {
+        final syncState = _FakeDmSyncState();
+        final repository = createRepository(
+          syncState: syncState,
+          publishDmRelayListEnabled: false,
+        );
+        await repository.ensureDmRelayListPublished();
+
+        // Gated before any work — no relay query, no signer round-trip.
+        verifyNever(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        );
+        verifyNever(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+        expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+      });
+
+      test(
+        'does NOT publish or set the flag when the own-inbox lookup fails '
+        '(transient) — never overwrites a real list',
+        () async {
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenThrow(Exception('relay down'));
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(syncState: syncState);
+          await repository.ensureDmRelayListPublished();
+
+          verifyNever(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+          expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+        },
+      );
+
+      test(
+        'a transient lookup failure is not cached — a later call re-queries '
+        'and can publish',
+        () async {
+          var queries = 0;
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((_) async {
+            queries++;
+            if (queries == 1) throw Exception('relay down');
+            return const <Event>[]; // absent on the retry
+          });
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => outcome(accepted: true));
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(syncState: syncState);
+
+          // First login: lookup fails -> no publish, flag unset.
+          await repository.ensureDmRelayListPublished();
+          expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+
+          // Next login: the failure was not memoized, so it re-queries,
+          // resolves absent, and publishes.
+          await repository.ensureDmRelayListPublished();
+          expect(queries, 2);
+          verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).called(1);
+          expect(
+            syncState.dmRelayListPublishedPubkeys,
+            contains(_validPubkeyA),
+          );
+        },
+      );
+
+      test(
+        'reuses the live subscription own-inbox resolve — one kind-10050 '
+        'query shared at login',
+        () async {
+          var resolveQueries = 0;
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
+              resolveQueries++;
+            }
+            return const <Event>[];
+          });
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => outcome(accepted: true));
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(syncState: syncState);
+          await repository.startListening();
+          await repository.ensureDmRelayListPublished();
+
+          expect(resolveQueries, 1);
+
+          await repository.stopListening();
+          await controller.close();
+        },
+      );
     });
 
     group('backfillHistoryIfNeeded', () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3025,6 +3025,81 @@ void main() {
           await controller.close();
         },
       );
+
+      // NOTE: the analogous "stopListening() during the resolve" case shares
+      // the identical session-token guard (stopListening bumps _resetGeneration
+      // exactly as _resetState does), so the account-switch test below covers
+      // the during-resolve invalidation mechanism for both paths.
+      test(
+        'an account switch during the own-inbox resolve bails the old '
+        "user's subscription and frees the new user to subscribe",
+        () async {
+          final resolveA = Completer<List<Event>>();
+          final resolveB = Completer<List<Event>>();
+          var resolveCalls = 0;
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((_) {
+            resolveCalls++;
+            return resolveCalls == 1 ? resolveA.future : resolveB.future;
+          });
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          when(
+            () => mockNostrClient.unsubscribe(any()),
+          ).thenAnswer((_) async {});
+
+          final repository = createRepository(); // user A
+          final pendingA = repository.startListening(); // suspends at resolve
+
+          // Switch A -> B while A's resolve is still in flight.
+          repository.setCredentials(
+            userPubkey: _validPubkeyB,
+            signer: LocalNostrSigner(_validPrivateKey),
+            messageService: mockMessageService,
+          );
+
+          resolveA.complete(const <Event>[]);
+          await pendingA;
+
+          // A's continuation bailed — no subscription opened under A's id.
+          verifyNever(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: 'dm_inbox_$_validPubkeyA',
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+
+          // _subscribing was released, so B opens its own subscription.
+          final pendingB = repository.startListening();
+          resolveB.complete(const <Event>[]);
+          await pendingB;
+          verify(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: 'dm_inbox_$_validPubkeyB',
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).called(1);
+
+          await repository.stopListening();
+          await controller.close();
+        },
+      );
     });
 
     group('ensureDmRelayListPublished (#4974 RC3)', () {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -18,6 +18,7 @@ import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
 import 'package:nostr_sdk/nip44/nip44_v2.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
+import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
@@ -284,6 +285,17 @@ class _FakeDmSyncState implements DmSyncState {
   Future<void> setHistoryDrainCursor(String pubkey, int cursor) async {
     drainCursorOverride = cursor;
     persistedDrainCursors.add(cursor);
+  }
+
+  final Set<String> dmRelayListPublishedPubkeys = <String>{};
+
+  @override
+  bool dmRelayListPublished(String pubkey) =>
+      dmRelayListPublishedPubkeys.contains(pubkey);
+
+  @override
+  Future<void> markDmRelayListPublished(String pubkey) async {
+    dmRelayListPublishedPubkeys.add(pubkey);
   }
 
   @override
@@ -2577,14 +2589,16 @@ void main() {
         // Wait well beyond any former poll interval.
         await Future<void>.delayed(const Duration(milliseconds: 100));
 
-        // queryEvents must never be called — no background poller.
-        verifyNever(
+        // queryEvents is called EXACTLY once — the one-shot #4974 own
+        // kind-10050 inbox-relay resolve at subscription open — and never
+        // again: no background poller re-fetches events on a timer.
+        verify(
           () => mockNostrClient.queryEvents(
             any(),
             subscriptionId: any(named: 'subscriptionId'),
             useCache: any(named: 'useCache'),
           ),
-        );
+        ).called(1);
 
         await repository.stopListening();
         await controller.close();
@@ -2792,6 +2806,387 @@ void main() {
         final repository = createRepository();
         expect(await repository.resolveDmInboxRelays(_validPubkeyB), isNull);
       });
+
+      test('accepts both `relay` and `r` tags (#4974 cross-client)', () async {
+        // Some clients write `r` tags into a kind-10050; within a 10050 event
+        // both denote DM inbox relays, so both must be read. See divine-web.
+        when(
+          () => mockNostrClient.queryEvents(
+            any(),
+            subscriptionId: any(named: 'subscriptionId'),
+            useCache: any(named: 'useCache'),
+          ),
+        ).thenAnswer(
+          (_) async => [
+            Event(
+              _validPubkeyB,
+              EventKind.dmRelaysList,
+              [
+                ['relay', 'wss://relay-tag.example'],
+                ['r', 'wss://r-tag.example'],
+              ],
+              '',
+              createdAt: 1700000000,
+            ),
+          ],
+        );
+        final repository = createRepository();
+        expect(
+          await repository.resolveDmInboxRelays(_validPubkeyB),
+          ['wss://relay-tag.example', 'wss://r-tag.example'],
+        );
+      });
+    });
+
+    group('own kind-10050 receive targeting (#4974 RC2)', () {
+      Event ownInbox(List<String> relays) => Event(
+        _validPubkeyA,
+        EventKind.dmRelaysList,
+        [
+          for (final r in relays) ['relay', r],
+        ],
+        '',
+        createdAt: 1700000000,
+      );
+
+      test(
+        'live subscription targets the own kind-10050 inbox relays as BOTH '
+        'tempRelays and targetRelays',
+        () async {
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              ownInbox(['wss://own.example']),
+            ],
+          );
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository();
+          await repository.startListening();
+
+          final captured = verify(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: captureAny(named: 'tempRelays'),
+              targetRelays: captureAny(named: 'targetRelays'),
+            ),
+          ).captured;
+          expect(captured, [
+            ['wss://own.example'],
+            ['wss://own.example'],
+          ]);
+
+          await repository.stopListening();
+          await controller.close();
+        },
+      );
+
+      test(
+        'live subscription falls back to the default pool (null targeting) '
+        'when the user has no kind-10050',
+        () async {
+          // setUp default queryEvents -> [] : no kind-10050.
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository();
+          await repository.startListening();
+
+          final captured = verify(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: captureAny(named: 'tempRelays'),
+              targetRelays: captureAny(named: 'targetRelays'),
+            ),
+          ).captured;
+          expect(captured, [isNull, isNull]);
+
+          await repository.stopListening();
+          await controller.close();
+        },
+      );
+
+      test(
+        'history drain targets the own kind-10050 inbox relays as tempRelays',
+        () async {
+          final capturedDrainTempRelays = <List<String>?>[];
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
+              return [
+                ownInbox(['wss://own.example']),
+              ];
+            }
+            // Only the gift-wrap drain pages carry p:[self]; capture their
+            // tempRelays (the NIP-04 recovery uses authors:[self] with no p
+            // and is intentionally not 10050-targeted).
+            if (filter.p?.isNotEmpty ?? false) {
+              capturedDrainTempRelays.add(
+                inv.namedArguments[#tempRelays] as List<String>?,
+              );
+            }
+            return const <Event>[];
+          });
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+          await repository.backfillHistoryIfNeeded();
+
+          expect(
+            capturedDrainTempRelays,
+            contains(equals(['wss://own.example'])),
+          );
+        },
+      );
+
+      test(
+        'resolves the own kind-10050 once per session, reused across the live '
+        'subscription and the drain',
+        () async {
+          var resolveQueries = 0;
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+              tempRelays: any(named: 'tempRelays'),
+            ),
+          ).thenAnswer((inv) async {
+            final filter =
+                (inv.positionalArguments.first as List<nostr_filter.Filter>)
+                    .single;
+            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
+              resolveQueries++;
+              return [
+                ownInbox(['wss://own.example']),
+              ];
+            }
+            return const <Event>[];
+          });
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+          await repository.startListening();
+          await repository.backfillHistoryIfNeeded();
+
+          expect(resolveQueries, 1);
+
+          await repository.stopListening();
+          await controller.close();
+        },
+      );
+    });
+
+    group('ensureDmRelayListPublished (#4974 RC3)', () {
+      Event existingInbox(List<String> relays) => Event(
+        _validPubkeyA,
+        EventKind.dmRelaysList,
+        [
+          for (final r in relays) ['relay', r],
+        ],
+        '',
+        createdAt: 1700000000,
+      );
+
+      PublishOutcome outcome({required bool accepted}) => PublishOutcome(
+        eventId: 'eid',
+        acceptedBy: accepted ? const ['wss://relay.divine.video'] : const [],
+        rejectedBy: accepted
+            ? const <String, String>{}
+            : const {'wss://relay.divine.video': 'blocked: kind not allowed'},
+        noResponseFrom: const [],
+      );
+
+      setUp(() {
+        when(
+          () => mockNostrClient.primaryRelay,
+        ).thenReturn('wss://relay.divine.video');
+      });
+
+      test(
+        'publishes a kind-10050 advertising the primary relay when absent and '
+        'records the flag on a confirmed OK',
+        () async {
+          // setUp default queryEvents -> [] : user has no existing kind-10050.
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => outcome(accepted: true));
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(syncState: syncState);
+          await repository.ensureDmRelayListPublished();
+
+          final captured = verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              captureAny(),
+              targetRelays: captureAny(named: 'targetRelays'),
+            ),
+          ).captured;
+          final event = captured[0] as Event;
+          expect(event.kind, EventKind.dmRelaysList);
+          expect(event.tags, [
+            ['relay', 'wss://relay.divine.video'],
+          ]);
+          expect(captured[1], ['wss://relay.divine.video']);
+          expect(
+            syncState.dmRelayListPublishedPubkeys,
+            contains(_validPubkeyA),
+          );
+        },
+      );
+
+      test(
+        'does NOT record the flag when no relay accepts — retries next login',
+        () async {
+          when(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).thenAnswer((_) async => outcome(accepted: false));
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(syncState: syncState);
+          await repository.ensureDmRelayListPublished();
+
+          verify(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).called(1);
+          expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+        },
+      );
+
+      test(
+        'skips publishing and records the flag when the user already '
+        'advertises a kind-10050',
+        () async {
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              existingInbox(['wss://own.example']),
+            ],
+          );
+
+          final syncState = _FakeDmSyncState();
+          final repository = createRepository(syncState: syncState);
+          await repository.ensureDmRelayListPublished();
+
+          verifyNever(
+            () => mockNostrClient.publishEventAwaitOk(
+              any(),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+          expect(
+            syncState.dmRelayListPublishedPubkeys,
+            contains(_validPubkeyA),
+          );
+        },
+      );
+
+      test('is a no-op when already published this device/pubkey', () async {
+        final syncState = _FakeDmSyncState()
+          ..dmRelayListPublishedPubkeys.add(_validPubkeyA);
+        final repository = createRepository(syncState: syncState);
+        await repository.ensureDmRelayListPublished();
+
+        verifyNever(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+
+      test('does not publish when the signer returns null', () async {
+        final mockSigner = _MockNostrSigner();
+        when(() => mockSigner.signEvent(any())).thenAnswer((_) async => null);
+        final syncState = _FakeDmSyncState();
+        final repository = createRepository(
+          signer: mockSigner,
+          syncState: syncState,
+        );
+        await repository.ensureDmRelayListPublished();
+
+        verifyNever(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+        expect(syncState.dmRelayListPublishedPubkeys, isEmpty);
+      });
+
+      test('is a no-op when uninitialized', () async {
+        final syncState = _FakeDmSyncState();
+        final repository = createRepository(
+          userPubkey: '',
+          syncState: syncState,
+        );
+        await repository.ensureDmRelayListPublished();
+
+        verifyNever(
+          () => mockNostrClient.publishEventAwaitOk(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
     });
 
     group('backfillHistoryIfNeeded', () {
@@ -2982,6 +3377,12 @@ void main() {
             final filter =
                 (inv.positionalArguments.first as List<nostr_filter.Filter>)
                     .single;
+            // The #4974 own kind-10050 inbox-relay resolve (authors:[self],
+            // kinds:[10050]) also matches authors-with-no-p; skip it so it is
+            // not mistaken for a NIP-04 recovery page.
+            if (filter.kinds?.contains(EventKind.dmRelaysList) ?? false) {
+              return const <Event>[];
+            }
             final isNip04Recovery =
                 filter.authors != null && (filter.p?.isEmpty ?? true);
             if (!isNip04Recovery) return const <Event>[];
@@ -3279,9 +3680,15 @@ void main() {
               useCache: any(named: 'useCache'),
             ),
           ).thenAnswer((inv) async {
-            calls++;
             final filters =
                 inv.positionalArguments.first as List<nostr_filter.Filter>;
+            // Skip the #4974 own kind-10050 inbox-relay resolve so it is not
+            // counted as a drain page.
+            if (filters.single.kinds?.contains(EventKind.dmRelaysList) ??
+                false) {
+              return const <Event>[];
+            }
+            calls++;
             final until = filters.single.until!;
             // Infinite descending supply: only the maxPages cap can stop it.
             return [deletion(until - 1)];
@@ -3345,9 +3752,15 @@ void main() {
               useCache: any(named: 'useCache'),
             ),
           ).thenAnswer((inv) async {
-            calls++;
             final filters =
                 inv.positionalArguments.first as List<nostr_filter.Filter>;
+            // Skip the #4974 own kind-10050 inbox-relay resolve so it is not
+            // counted as a drain page.
+            if (filters.single.kinds?.contains(EventKind.dmRelaysList) ??
+                false) {
+              return const <Event>[];
+            }
+            calls++;
             final until = filters.single.until!;
             // Page 0 advances + persists the cursor; page 1 fails.
             if (calls == 1) return [deletion(until - 1)];

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -296,6 +296,28 @@ void main() {
         expect(state.dmRelayListPublished(pkA), isTrue);
         expect(state.dmRelayListPublished(pkB), isFalse);
       });
+
+      test('clear removes only the selected pubkey marker', () async {
+        await state.markDmRelayListPublished(pkA);
+        await state.markDmRelayListPublished(pkB);
+
+        await state.clear(pkA);
+
+        expect(state.dmRelayListPublished(pkA), isFalse);
+        expect(state.dmRelayListPublished(pkB), isTrue);
+      });
+
+      test('clearAll removes all markers and leaves unrelated keys', () async {
+        await state.markDmRelayListPublished(pkA);
+        await state.markDmRelayListPublished(pkB);
+        await prefs.setString('unrelated_key', 'keep_me');
+
+        await state.clearAll();
+
+        expect(state.dmRelayListPublished(pkA), isFalse);
+        expect(state.dmRelayListPublished(pkB), isFalse);
+        expect(prefs.getString('unrelated_key'), equals('keep_me'));
+      });
     });
   });
 }

--- a/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_sync_state_test.dart
@@ -283,5 +283,19 @@ void main() {
         expect(state.drainVersion(pkB), equals(0));
       });
     });
+
+    group('dmRelayListPublished (#4974)', () {
+      test('defaults to false and flips to true after marking', () async {
+        expect(state.dmRelayListPublished(pkA), isFalse);
+        await state.markDmRelayListPublished(pkA);
+        expect(state.dmRelayListPublished(pkA), isTrue);
+      });
+
+      test('is per-pubkey — marking one does not affect another', () async {
+        await state.markDmRelayListPublished(pkA);
+        expect(state.dmRelayListPublished(pkA), isTrue);
+        expect(state.dmRelayListPublished(pkB), isFalse);
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

Implements the NIP-17 **receive side** for direct messages. divine-mobile already routed *sends* to the recipient's kind-10050 DM inbox relays, but it never read from — or advertised — the **user's own** kind-10050. As a result, DMs that a compliant sender delivered to inbox relays outside divine's default pool were silently missing.

**RC2 — read the user's own kind-10050 (the core fix):**
- Resolve the user's own kind-10050 once per session (memoized in `DmRepository`, cleared in `_resetState` so it never leaks across an account switch).
- Target both the live gift-wrap subscription and the #4953 history drain at those relays via `tempRelays` + `targetRelays` (mirrors the proven send-side plumbing), falling back to the default pool when the user has no kind-10050.
- `resolveDmInboxRelays` now accepts both `relay` and `r` tags, so a kind-10050 advertised by another client is read (matches `divine-web`). This shared resolver also widens recipient relay resolution on the send path.

**RC3 — publish the user's own kind-10050 on login:**
- Gated behind `FeatureFlag.publishDmRelayList` / `FF_PUBLISH_DM_RELAY_LIST` (default OFF until the backend relay accepts kind-10050), so no signer round-trip fires in production until the rollout flag is enabled.
- When enabled and the user has no kind-10050, self-advertise a minimal one pointing at the environment's stable relay URL.
- Publish-when-absent (never overwrites a richer list the user advertised elsewhere), once per (device, pubkey), with the persistence flag set only when an existing list is found or on a confirmed relay `OK`. A relay that rejects the kind or a slow/timed-out signer leaves the flag unset and retries next login — it never blocks login.
- The publish marker is cleared by `DmSyncState.clear` / `clearAll` with the rest of DM sync state so database/account cleanup does not leave stale RC3 state behind.

### Backend dependency (RC3)

The production funnelcake relay does **not yet accept** kind-10050 writes: both the prod relay and migrate images are pinned below migration `000168` (which adds 10050 to `allowed_kinds`). This was confirmed by reproducing the prod image state locally and exercising the relay's own integration test (accepts with the migration, rejects without it). RC3 is gated default-off until that backend rollout happens; once enabled, the flag-on-OK design lets it self-heal.

**RC2 (read) is unaffected and effective immediately** — the prod relay already serves kind-10050 reads.

Backend follow-up (separate, owned by the funnelcake team): bump the prod `funnelcake-migrate` + relay images to a tag at/after `73ac7b0` and let the schema sync-hook re-run.

**Related Issue:** Closes #4974

## Out of Scope

- **RC4** (re-subscribe on mid-session `addRelays`): dropped — the SDK's `autoSubscribe` already replays the live DM REQ to relays joining the pool, so the failure mode is effectively absent.
- **NIP-04 outgoing-recovery path** (`_recoverOutgoingNip04`): left untargeted — kind-4 belongs to NIP-65 *write* relays, not kind-10050 (which advertises kind-1059 gift-wrap inbox relays).
- **Self-wrap routing to the user's own 10050** (NIP-17 Client Behavior #4): deferred as a separate follow-up.

## Verification

- `dart format` / repo pre-push format check passed.
- `dart analyze` from `mobile/packages/dm_repository` passed.
- Full `dm_repository` test suite green with coverage (**394 tests**), including coverage for live-subscription targeting, default-pool fallback, history-drain targeting, once-per-session memoization, `r`/`relay` tag parity, all RC3 paths, and cleanup of the new `DmSyncState` flag.
- Pre-push hook passed: merge-conflict check, analyzer, generated-files check, and changed-file tests.
- GitHub checks green: Analyze, Format, Generated Files, Tests, VGV Tag Gate, Mobile CI, Build Flutter Web Preview, build, semantic PR, CLA, and mergeability.
- RC3 backend behavior validated empirically against a local funnelcake relay (accept with migration 000168, reject without).

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
