### PR TITLE
fix(video-editor): restrict clip transitions to debug builds

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -647,7 +648,15 @@ class _VideoEditorTimelineClipStripState
                 /// Transition buttons on each internal clip boundary. Hidden
                 /// during reorder/trim/volume/multi-select so they never
                 /// overlap those interactions.
-                if (!shouldAnimate &&
+                ///
+                /// Temporarily restricted to debug builds: clip transitions
+                /// currently mishandle audio when adjacent clips overlap, so
+                /// the entry point stays out of release builds until that is
+                /// fixed.
+                // TODO(#5497): Remove the kDebugMode guard once overlapping
+                // clip transitions handle audio correctly.
+                if (kDebugMode &&
+                    !shouldAnimate &&
                     widget.trimmingClipId == null &&
                     !isVolumeEditMode &&
                     !widget.isMultiSelectMode &&


### PR DESCRIPTION
Closes #5499

## Description

Clip transitions currently mishandle audio when adjacent clips overlap.
As a stopgap, this gates the transition boundary buttons (`_TransitionButtonsLayer`)
behind `kDebugMode`, so the entry point — and the picker flow behind it — stays
out of release builds until the audio handling is fixed. Widget tests run in debug
mode, so they are unaffected.

**Related Issue:**  — Relates to #5497 (tracks the audio fix + removing this guard)

## Out of Scope

- Fixing the overlapping-clip transition audio bug itself. Tracked in #5497.

## Verification

- `flutter analyze` on the changed file — no issues.
- `flutter test test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart` — all passing.
- Pre-push hook (analyze + changed-file tests) — green.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)