### PR TITLE
fix(apps): open verifier in system browser from Apps Directory + standardize spelling

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -3628,11 +3628,11 @@
     },
     "profileEditGetVerifiedCta": "ተረጋግጥ",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "ሰዎች በእርግጥ አንተ መሆንህን እንዲያውቁ የማህበራዊ ሚዲያ መለያዎችህን አገናኝ።",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "blossomServerUrlMustUseHttps": "የBlossom አገልጋይ URL https:// መጠቀም አለበት",
     "@blossomServerUrlMustUseHttps": {

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "وثّق حسابك",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "اربط حساباتك على وسائل التواصل ليعرف الناس أنّك أنت فعلًا.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "صوت بلا عنوان",
     "soundStopPreview": "إيقاف المعاينة",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -3434,11 +3434,11 @@
     },
     "profileEditGetVerifiedCta": "Потвърди се",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Свържи социалните си мрежи, за да знаят хората, че това си наистина ти.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Звук без заглавие",
     "soundStopPreview": "Спри прегледа",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Lass dich verifizieren",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Verknüpfe deine Social-Media-Konten, damit alle wissen, dass du es bist.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Unbenannter Sound",
     "soundStopPreview": "Vorschau stoppen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5194,11 +5194,11 @@
   },
   "profileEditGetVerifiedCta": "Get verified",
   "@profileEditGetVerifiedCta": {
-    "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+    "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
   },
   "profileEditGetVerifiedSubtitle": "Link your social media accounts so people know it's really you.",
   "@profileEditGetVerifiedSubtitle": {
-    "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+    "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
   },
   "profileWebsiteSemanticLabel": "Visit website: {url}",
   "@profileWebsiteSemanticLabel": {

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3307,11 +3307,11 @@
     },
     "profileEditGetVerifiedCta": "Verifícate",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Conecta tus redes sociales para que sepan que eres tú.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Sonido sin título",
     "soundStopPreview": "Parar la vista previa",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Vérifie-toi",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Connecte tes réseaux sociaux pour que les gens sachent que c'est vraiment toi.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Son sans titre",
     "soundStopPreview": "Arrêter l'aperçu",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Verifikasi diri",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Hubungkan akun media sosialmu biar orang tahu ini memang kamu.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Suara tanpa judul",
     "soundStopPreview": "Hentikan pratinjau",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Fatti verificare",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Collega i tuoi profili social così tutti sanno che sei davvero tu.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Audio senza titolo",
     "soundStopPreview": "Ferma anteprima",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "認証を受ける",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "ソーシャルメディアのアカウントをつないで、本物のあなただと伝えよう。",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "無題のサウンド",
     "soundStopPreview": "プレビューを停止",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -2627,11 +2627,11 @@
     },
     "profileEditGetVerifiedCta": "인증 받기",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "소셜 미디어 계정을 연결해서 진짜 너인 걸 알려줘.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "제목 없는 사운드",
     "soundStopPreview": "미리 듣기 중지",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Laat je verifiëren",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Koppel je social-media-accounts zodat mensen weten dat jij het bent.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Geluid zonder titel",
     "soundStopPreview": "Preview stoppen",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Zweryfikuj się",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Połącz swoje konta w mediach społecznościowych, żeby ludzie wiedzieli, że to naprawdę ty.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Dźwięk bez tytułu",
     "soundStopPreview": "Zatrzymaj podgląd",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Verifique-se",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Conecte suas redes sociais para que as pessoas saibam que é você mesmo.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Som sem título",
     "soundStopPreview": "Parar pré-visualização",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Verifică-te",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Conectează-ți conturile de social media ca lumea să știe că ești tu.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Sunet fără titlu",
     "soundStopPreview": "Oprește previzualizarea",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Verifiera dig",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Koppla dina sociala medier-konton så folk vet att det är du.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Namnlöst ljud",
     "soundStopPreview": "Stoppa förhandsvisning",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3303,11 +3303,11 @@
     },
     "profileEditGetVerifiedCta": "Hesabını doğrula",
     "@profileEditGetVerifiedCta": {
-        "description": "Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox."
+        "description": "Primary CTA tile on edit profile that opens the verifier integrated-app sandbox."
     },
     "profileEditGetVerifiedSubtitle": "Sosyal medya hesaplarını bağla ki insanlar gerçekten sen olduğunu bilsin.",
     "@profileEditGetVerifiedSubtitle": {
-        "description": "Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy."
+        "description": "Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy."
     },
     "soundUntitled": "Adsız ses",
     "soundStopPreview": "Ön izlemeyi durdur",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -15666,13 +15666,13 @@ abstract class AppLocalizations {
   /// **'Verified accounts'**
   String get profileEditVerifiedAccountsTitle;
 
-  /// Primary CTA tile on edit profile that opens the verifyer integrated-app sandbox.
+  /// Primary CTA tile on edit profile that opens the verifier integrated-app sandbox.
   ///
   /// In en, this message translates to:
   /// **'Get verified'**
   String get profileEditGetVerifiedCta;
 
-  /// Subtitle under the Get verified tile, harmonized with verifyer.divine.video landing copy.
+  /// Subtitle under the Get verified tile, harmonized with verifier.divine.video landing copy.
   ///
   /// In en, this message translates to:
   /// **'Link your social media accounts so people know it\'s really you.'**

--- a/mobile/lib/models/environment_config.dart
+++ b/mobile/lib/models/environment_config.dart
@@ -112,9 +112,9 @@ class EnvironmentConfig {
   }
 
   /// Base URL for the Divine identity verification service
-  /// (verifyer.divine.video). Single host across all environments — the
+  /// (verifier.divine.video). Single host across all environments — the
   /// service is not part of local_stack.
-  String get verifierBaseUrl => 'https://verifyer.divine.video';
+  String get verifierBaseUrl => 'https://verifier.divine.video';
 
   /// Get blossom media server URL
   String get blossomUrl {

--- a/mobile/lib/screens/apps/app_detail_screen.dart
+++ b/mobile/lib/screens/apps/app_detail_screen.dart
@@ -10,7 +10,7 @@ import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/blocs/app_detail/app_detail_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
+import 'package:openvine/screens/apps/nostr_app_launch_mode.dart';
 
 /// Displays detailed information about a single approved
 /// third-party integration.
@@ -151,12 +151,7 @@ class _AppDetailContent extends StatelessWidget {
                     const SizedBox(height: 8),
                     DivineButton(
                       label: context.l10n.appsDetailOpenButton,
-                      onPressed: () {
-                        context.push(
-                          NostrAppSandboxScreen.pathForAppId(app.id),
-                          extra: app,
-                        );
-                      },
+                      onPressed: () => launchNostrApp(context, app),
                     ),
                   ],
                 ),

--- a/mobile/lib/screens/apps/apps_directory_screen.dart
+++ b/mobile/lib/screens/apps/apps_directory_screen.dart
@@ -10,7 +10,7 @@ import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/blocs/apps_directory/apps_directory_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
+import 'package:openvine/screens/apps/nostr_app_launch_mode.dart';
 import 'package:openvine/utils/nostr_apps_platform_support.dart';
 
 /// Displays the directory of approved third-party apps.
@@ -91,10 +91,7 @@ class _AppsDirectoryContent extends StatelessWidget {
                       final app = state.apps[index - 1];
                       return _AppsDirectoryRow(
                         app: app,
-                        onTap: () => context.push(
-                          NostrAppSandboxScreen.pathForAppId(app.id),
-                          extra: app,
-                        ),
+                        onTap: () => launchNostrApp(context, app),
                       );
                     },
                   ),

--- a/mobile/lib/screens/apps/nostr_app_launch_mode.dart
+++ b/mobile/lib/screens/apps/nostr_app_launch_mode.dart
@@ -20,17 +20,20 @@ import 'package:url_launcher/url_launcher.dart';
 /// preloaded ones by slug (see
 /// `NostrAppDirectoryService._mergeWithPreloadedApps`), so the slug is the
 /// identity that survives a remote override — a server-sent flag on the
-/// preloaded entry would not. Both verifier spellings are listed: remote
-/// directory data and older on-device caches may still carry the legacy
-/// `verifyer` slug, which would otherwise survive the merge as its own tile
-/// and dead-end in the sandbox.
+/// preloaded entry would not. Both verifier spellings are accepted on
+/// purpose: remote directory data and on-device caches may carry either
+/// `verifier` or the older `verifyer`, and both resolve to the same worker.
+/// The `verifyer`→`verifier` standardization is tracked in the verifier repo
+/// (divinevideo/divine-identify-verification-service#16, #23); keep both here
+/// regardless, since the alias is harmless and guards stale directory data.
 const Set<String> kSystemBrowserAppSlugs = {'verifier', 'verifyer'};
 
 /// Hosts the system-browser launch is allowed to open. The launch target
 /// comes from directory JSON (`launch_url`), which a remote or cached entry
 /// can override; pinning to these hosts stops a crafted entry from opening an
 /// arbitrary URL under a trusted first-party tile. Both verifier spellings are
-/// listed for the same directory-data transition as [kSystemBrowserAppSlugs].
+/// accepted for the same reason as [kSystemBrowserAppSlugs] — move the two
+/// sets together.
 const Set<String> _systemBrowserAppHosts = {
   'verifier.divine.video',
   'verifyer.divine.video',
@@ -43,7 +46,8 @@ bool appRequiresSystemBrowser(NostrAppDirectoryEntry app) =>
 
 /// Whether [rawUrl] is a safe system-browser target: an `https` URL on a
 /// pinned verifier host. Guards against a crafted directory `launch_url`.
-bool _isAllowedSystemBrowserTarget(String rawUrl) {
+@visibleForTesting
+bool isAllowedSystemBrowserTarget(String rawUrl) {
   final uri = Uri.tryParse(rawUrl);
   return uri != null &&
       uri.scheme == 'https' &&
@@ -75,7 +79,7 @@ Future<void> launchNostrApp(
 
   final messenger = ScaffoldMessenger.of(context);
   final errorText = context.l10n.relaySettingsCouldNotOpenBrowser;
-  if (!_isAllowedSystemBrowserTarget(app.launchUrl)) {
+  if (!isAllowedSystemBrowserTarget(app.launchUrl)) {
     messenger.showSnackBar(
       SnackBar(content: Text(errorText), backgroundColor: VineTheme.error),
     );

--- a/mobile/lib/screens/apps/nostr_app_launch_mode.dart
+++ b/mobile/lib/screens/apps/nostr_app_launch_mode.dart
@@ -20,13 +20,35 @@ import 'package:url_launcher/url_launcher.dart';
 /// preloaded ones by slug (see
 /// `NostrAppDirectoryService._mergeWithPreloadedApps`), so the slug is the
 /// identity that survives a remote override — a server-sent flag on the
-/// preloaded entry would not. If the verifier slug changes, update this set.
-const Set<String> kSystemBrowserAppSlugs = {'verifier'};
+/// preloaded entry would not. Both verifier spellings are listed: remote
+/// directory data and older on-device caches may still carry the legacy
+/// `verifyer` slug, which would otherwise survive the merge as its own tile
+/// and dead-end in the sandbox.
+const Set<String> kSystemBrowserAppSlugs = {'verifier', 'verifyer'};
+
+/// Hosts the system-browser launch is allowed to open. The launch target
+/// comes from directory JSON (`launch_url`), which a remote or cached entry
+/// can override; pinning to these hosts stops a crafted entry from opening an
+/// arbitrary URL under a trusted first-party tile. Both verifier spellings are
+/// listed for the same directory-data transition as [kSystemBrowserAppSlugs].
+const Set<String> _systemBrowserAppHosts = {
+  'verifier.divine.video',
+  'verifyer.divine.video',
+};
 
 /// Whether [app] must be opened in the system browser rather than the
 /// in-app sandbox.
 bool appRequiresSystemBrowser(NostrAppDirectoryEntry app) =>
     kSystemBrowserAppSlugs.contains(app.slug);
+
+/// Whether [rawUrl] is a safe system-browser target: an `https` URL on a
+/// pinned verifier host. Guards against a crafted directory `launch_url`.
+bool _isAllowedSystemBrowserTarget(String rawUrl) {
+  final uri = Uri.tryParse(rawUrl);
+  return uri != null &&
+      uri.scheme == 'https' &&
+      _systemBrowserAppHosts.contains(uri.host);
+}
 
 /// Opens [app] from the directory.
 ///
@@ -53,6 +75,13 @@ Future<void> launchNostrApp(
 
   final messenger = ScaffoldMessenger.of(context);
   final errorText = context.l10n.relaySettingsCouldNotOpenBrowser;
+  if (!_isAllowedSystemBrowserTarget(app.launchUrl)) {
+    messenger.showSnackBar(
+      SnackBar(content: Text(errorText), backgroundColor: VineTheme.error),
+    );
+    return;
+  }
+
   var launched = false;
   try {
     launched = await launchUrl(

--- a/mobile/lib/screens/apps/nostr_app_launch_mode.dart
+++ b/mobile/lib/screens/apps/nostr_app_launch_mode.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
+import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 /// Slugs of first-party apps that perform cross-origin login / OAuth
@@ -32,7 +33,12 @@ bool appRequiresSystemBrowser(NostrAppDirectoryEntry app) =>
 /// Apps that need cross-origin login/OAuth ([appRequiresSystemBrowser])
 /// launch in the system browser, where cookies and provider redirects
 /// work; everything else opens in the in-app sandbox. Shows a snackbar
-/// when a system-browser launch fails.
+/// when a system-browser launch fails or throws.
+///
+/// The directory entry points that call this are native-only — the Apps
+/// Directory renders an unsupported message on web (`supportsNostrAppsSandbox`)
+/// — so the system-browser branch always runs on a device, where
+/// `LaunchMode.externalApplication` is correct.
 Future<void> launchNostrApp(
   BuildContext context,
   NostrAppDirectoryEntry app,
@@ -47,10 +53,18 @@ Future<void> launchNostrApp(
 
   final messenger = ScaffoldMessenger.of(context);
   final errorText = context.l10n.relaySettingsCouldNotOpenBrowser;
-  final launched = await launchUrl(
-    Uri.parse(app.launchUrl),
-    mode: LaunchMode.externalApplication,
-  );
+  var launched = false;
+  try {
+    launched = await launchUrl(
+      Uri.parse(app.launchUrl),
+      mode: LaunchMode.externalApplication,
+    );
+  } catch (error) {
+    UnifiedLogger.warning(
+      'Failed to open ${app.name}: $error',
+      name: 'launchNostrApp',
+    );
+  }
   if (!launched) {
     messenger.showSnackBar(
       SnackBar(content: Text(errorText), backgroundColor: VineTheme.error),

--- a/mobile/lib/screens/apps/nostr_app_launch_mode.dart
+++ b/mobile/lib/screens/apps/nostr_app_launch_mode.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Decides whether a directory app opens in the system browser or the
+// ABOUTME: in-app sandbox, and launches it accordingly.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
+import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+/// Slugs of first-party apps that perform cross-origin login / OAuth
+/// hand-offs and therefore cannot run inside the locked-down in-app
+/// WebView sandbox — its origin allowlist blocks those navigations
+/// (the verifyer dead-ends at `login.divine.video` and the OAuth
+/// providers). These open in the system browser instead.
+///
+/// Keyed by slug because the directory merges remote/cached entries over
+/// preloaded ones by slug (see
+/// `NostrAppDirectoryService._mergeWithPreloadedApps`), so the slug is the
+/// identity that survives a remote override — a server-sent flag on the
+/// preloaded entry would not. If the verifyer slug changes, update this set.
+const Set<String> kSystemBrowserAppSlugs = {'verifyer'};
+
+/// Whether [app] must be opened in the system browser rather than the
+/// in-app sandbox.
+bool appRequiresSystemBrowser(NostrAppDirectoryEntry app) =>
+    kSystemBrowserAppSlugs.contains(app.slug);
+
+/// Opens [app] from the directory.
+///
+/// Apps that need cross-origin login/OAuth ([appRequiresSystemBrowser])
+/// launch in the system browser, where cookies and provider redirects
+/// work; everything else opens in the in-app sandbox. Shows a snackbar
+/// when a system-browser launch fails.
+Future<void> launchNostrApp(
+  BuildContext context,
+  NostrAppDirectoryEntry app,
+) async {
+  if (!appRequiresSystemBrowser(app)) {
+    await context.push(
+      NostrAppSandboxScreen.pathForAppId(app.id),
+      extra: app,
+    );
+    return;
+  }
+
+  final messenger = ScaffoldMessenger.of(context);
+  final errorText = context.l10n.relaySettingsCouldNotOpenBrowser;
+  final launched = await launchUrl(
+    Uri.parse(app.launchUrl),
+    mode: LaunchMode.externalApplication,
+  );
+  if (!launched) {
+    messenger.showSnackBar(
+      SnackBar(content: Text(errorText), backgroundColor: VineTheme.error),
+    );
+  }
+}

--- a/mobile/lib/screens/apps/nostr_app_launch_mode.dart
+++ b/mobile/lib/screens/apps/nostr_app_launch_mode.dart
@@ -12,15 +12,15 @@ import 'package:url_launcher/url_launcher.dart';
 /// Slugs of first-party apps that perform cross-origin login / OAuth
 /// hand-offs and therefore cannot run inside the locked-down in-app
 /// WebView sandbox — its origin allowlist blocks those navigations
-/// (the verifyer dead-ends at `login.divine.video` and the OAuth
+/// (the verifier dead-ends at `login.divine.video` and the OAuth
 /// providers). These open in the system browser instead.
 ///
 /// Keyed by slug because the directory merges remote/cached entries over
 /// preloaded ones by slug (see
 /// `NostrAppDirectoryService._mergeWithPreloadedApps`), so the slug is the
 /// identity that survives a remote override — a server-sent flag on the
-/// preloaded entry would not. If the verifyer slug changes, update this set.
-const Set<String> kSystemBrowserAppSlugs = {'verifyer'};
+/// preloaded entry would not. If the verifier slug changes, update this set.
+const Set<String> kSystemBrowserAppSlugs = {'verifier'};
 
 /// Whether [app] must be opened in the system browser rather than the
 /// in-app sandbox.

--- a/mobile/lib/screens/apps/web_iframe_sandbox_screen_web.dart
+++ b/mobile/lib/screens/apps/web_iframe_sandbox_screen_web.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Flutter web iframe screen that hosts a first-party Divine integrated
-// ABOUTME: app (verifyer.divine.video, badges.divine.video) inline. The embedded
+// ABOUTME: app (verifier.divine.video, badges.divine.video) inline. The embedded
 // ABOUTME: app's window.nostr is proxied to Divine's WebSigner via postMessage,
 // ABOUTME: so users don't have to log in twice.
 

--- a/mobile/lib/screens/profile_setup_screen.dart
+++ b/mobile/lib/screens/profile_setup_screen.dart
@@ -1874,10 +1874,10 @@ class _VerifiedAccountsSection extends StatelessWidget {
 typedef VerifierRoutePusher =
     Future<void> Function(String location, {Object? extra});
 
-/// Opens the Divine verifyer.
+/// Opens the Divine verifier.
 ///
-/// Native in-app WebViews cannot complete the verifyer's login flow because it
-/// leaves `verifyer.divine.video` for `login.divine.video` and OAuth providers.
+/// Native in-app WebViews cannot complete the verifier's login flow because it
+/// leaves `verifier.divine.video` for `login.divine.video` and OAuth providers.
 /// Those hand-offs need real browser tabs, cookies, and redirects, so native
 /// platforms launch the system browser. Flutter web keeps the existing iframe
 /// signer bridge because it runs in the browser and does not use
@@ -1890,27 +1890,27 @@ Future<bool> launchVerifierFlow({
   VerifierRoutePusher? pushVerifierRoute,
   bool isWeb = kIsWeb,
 }) async {
-  final verifyer = preloadedNostrApps.firstWhere(
-    (app) => app.slug == 'verifyer',
+  final verifier = preloadedNostrApps.firstWhere(
+    (app) => app.slug == 'verifier',
   );
 
   var launched = false;
   try {
     if (isWeb && pushVerifierRoute != null) {
       await pushVerifierRoute(
-        WebIframeSandboxScreen.pathForAppId(verifyer.id),
-        extra: verifyer,
+        WebIframeSandboxScreen.pathForAppId(verifier.id),
+        extra: verifier,
       );
       launched = true;
     } else {
       launched = await launchUrl(
-        Uri.parse(verifyer.launchUrl),
+        Uri.parse(verifier.launchUrl),
         mode: LaunchMode.externalApplication,
       );
     }
   } catch (error) {
     UnifiedLogger.warning(
-      'Failed to open Divine verifyer: $error',
+      'Failed to open Divine verifier: $error',
       name: 'ProfileSetupScreen',
     );
   }

--- a/mobile/lib/services/web_iframe_nostr_bridge.dart
+++ b/mobile/lib/services/web_iframe_nostr_bridge.dart
@@ -31,7 +31,7 @@ class _EmbedRequest {
 /// Listens for `divine:nostr.request` messages from a single child iframe of
 /// a known origin and routes them through a [WebSigner] from
 /// [WebAuthService]. Construct with [allowedParentOrigin] set to the
-/// iframe's origin (e.g. `https://verifyer.divine.video`); only messages
+/// iframe's origin (e.g. `https://verifier.divine.video`); only messages
 /// whose `event.origin` matches that string are honored.
 ///
 /// Lifecycle: call [start] when the iframe mounts and [stop] before it

--- a/mobile/lib/widgets/profile/verified_account_chip.dart
+++ b/mobile/lib/widgets/profile/verified_account_chip.dart
@@ -97,7 +97,7 @@ String _platformUrl(IdentityClaim claim) {
     case 'discord':
     case 'telegram':
     default:
-      return 'https://verifyer.divine.video/u'
+      return 'https://verifier.divine.video/u'
           '?platform=${claim.platform}'
           '&identity=${Uri.encodeComponent(claim.identity)}';
   }

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/preloaded_nostr_apps.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/preloaded_nostr_apps.dart
@@ -216,15 +216,15 @@ final List<NostrAppDirectoryEntry> preloadedNostrApps = List.unmodifiable([
     sortOrder: 15,
   ),
   _buildPreloadedApp(
-    id: 'bundled-verifyer',
-    slug: 'verifyer',
-    name: 'Divine Verifyer',
+    id: 'bundled-verifier',
+    slug: 'verifier',
+    name: 'Divine Verifier',
     tagline: 'Link your social accounts so people know it is really you.',
     description:
         'A first-party Divine Nostr app for verifying ownership of '
         'external accounts (GitHub, Twitter, Bluesky, etc.) and '
         'attaching them to your profile via NIP-39 i tags.',
-    launchUrl: 'https://verifyer.divine.video/',
+    launchUrl: 'https://verifier.divine.video/',
     allowedMethods: const [
       'getPublicKey',
       'getRelays',

--- a/mobile/packages/nostr_app_bridge_repository/test/nostr_app_directory_service_test.dart
+++ b/mobile/packages/nostr_app_bridge_repository/test/nostr_app_directory_service_test.dart
@@ -395,7 +395,7 @@ const List<String> _starterSlugs = [
   'jumble',
   'divine-space',
   'badges',
-  'verifyer',
+  'verifier',
 ];
 
 void _expectBundledApp({

--- a/mobile/packages/verifier_client/README.md
+++ b/mobile/packages/verifier_client/README.md
@@ -1,7 +1,7 @@
 # verifier_client
 
 HTTP client for the Divine identity verification service at
-`https://verifyer.divine.video`.
+`https://verifier.divine.video`.
 
 This is a thin Dart client. It has no Nostr knowledge and no BLoC knowledge —
 upper layers (`profile_repository`'s `IdentityClaimsRepository`, the profile

--- a/mobile/packages/verifier_client/lib/src/verifier_client.dart
+++ b/mobile/packages/verifier_client/lib/src/verifier_client.dart
@@ -1,4 +1,4 @@
-// ABOUTME: VerifierClient — HTTP client over verifyer.divine.video.
+// ABOUTME: VerifierClient — HTTP client over verifier.divine.video.
 // ABOUTME: Stateless: every call hits the network; server owns freshness.
 
 import 'dart:async';
@@ -11,7 +11,7 @@ import 'package:verifier_client/src/exceptions.dart';
 import 'package:verifier_client/src/models/identity_claim.dart';
 import 'package:verifier_client/src/models/verification_result.dart';
 
-/// HTTP client for `https://verifyer.divine.video`.
+/// HTTP client for `https://verifier.divine.video`.
 ///
 /// Stateless: every call hits the network. The verifier owns freshness via
 /// Cloudflare KV; intentionally no client-side cache, no retry, no rechecking.

--- a/mobile/packages/verifier_client/lib/verifier_client.dart
+++ b/mobile/packages/verifier_client/lib/verifier_client.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Public surface for the verifier_client package.
-// ABOUTME: HTTP client over https://verifyer.divine.video.
+// ABOUTME: HTTP client over https://verifier.divine.video.
 
 export 'src/exceptions.dart';
 export 'src/models/identity_claim.dart';

--- a/mobile/packages/verifier_client/pubspec.yaml
+++ b/mobile/packages/verifier_client/pubspec.yaml
@@ -1,5 +1,5 @@
 name: verifier_client
-description: HTTP client for the Divine identity verification service (verifyer.divine.video).
+description: HTTP client for the Divine identity verification service (verifier.divine.video).
 version: 0.1.0+1
 publish_to: none
 

--- a/mobile/test/models/environment_config_test.dart
+++ b/mobile/test/models/environment_config_test.dart
@@ -221,7 +221,7 @@ void main() {
         const config = EnvironmentConfig(
           environment: AppEnvironment.production,
         );
-        expect(config.verifierBaseUrl, equals('https://verifyer.divine.video'));
+        expect(config.verifierBaseUrl, equals('https://verifier.divine.video'));
       });
 
       test('is the same across environments (no local stub)', () {
@@ -229,7 +229,7 @@ void main() {
           final config = EnvironmentConfig(environment: env);
           expect(
             config.verifierBaseUrl,
-            equals('https://verifyer.divine.video'),
+            equals('https://verifier.divine.video'),
           );
         }
       });

--- a/mobile/test/screens/apps/app_detail_screen_test.dart
+++ b/mobile/test/screens/apps/app_detail_screen_test.dart
@@ -140,12 +140,7 @@ void main() {
           'https://verifier.divine.video/',
         );
         expect(launcher.launched.single.useExternalApplication, isTrue);
-        verifyNever(
-          () => mockGoRouter.push(
-            NostrAppSandboxScreen.pathForAppId('bundled-verifier'),
-            extra: any(named: 'extra'),
-          ),
-        );
+        verifyNever(() => mockGoRouter.push(any(), extra: any(named: 'extra')));
       },
     );
   });

--- a/mobile/test/screens/apps/app_detail_screen_test.dart
+++ b/mobile/test/screens/apps/app_detail_screen_test.dart
@@ -92,7 +92,7 @@ void main() {
     );
 
     testWidgets(
-      'opens the verifyer in the system browser instead of the sandbox',
+      'opens the verifier in the system browser instead of the sandbox',
       (tester) async {
         final originalPlatform = UrlLauncherPlatform.instance;
         final launcher = UrlLauncherTestDouble();
@@ -117,8 +117,8 @@ void main() {
                 localizationsDelegates: AppLocalizations.localizationsDelegates,
                 supportedLocales: AppLocalizations.supportedLocales,
                 home: AppDetailScreen(
-                  slug: 'verifyer',
-                  initialEntry: _verifyerFixtureApp(),
+                  slug: 'verifier',
+                  initialEntry: _verifierFixtureApp(),
                 ),
               ),
             ),
@@ -137,12 +137,12 @@ void main() {
         expect(launcher.launched, hasLength(1));
         expect(
           launcher.launched.single.url,
-          'https://verifyer.divine.video/',
+          'https://verifier.divine.video/',
         );
         expect(launcher.launched.single.useExternalApplication, isTrue);
         verifyNever(
           () => mockGoRouter.push(
-            NostrAppSandboxScreen.pathForAppId('bundled-verifyer'),
+            NostrAppSandboxScreen.pathForAppId('bundled-verifier'),
             extra: any(named: 'extra'),
           ),
         );
@@ -151,16 +151,16 @@ void main() {
   });
 }
 
-NostrAppDirectoryEntry _verifyerFixtureApp() {
+NostrAppDirectoryEntry _verifierFixtureApp() {
   return const NostrAppDirectoryEntry(
-    id: 'bundled-verifyer',
-    slug: 'verifyer',
-    name: 'Divine Verifyer',
+    id: 'bundled-verifier',
+    slug: 'verifier',
+    name: 'Divine Verifier',
     tagline: 'Link your social accounts.',
     description: 'Verify ownership of external accounts.',
-    iconUrl: 'https://verifyer.divine.video/favicon.ico',
-    launchUrl: 'https://verifyer.divine.video/',
-    allowedOrigins: ['https://verifyer.divine.video'],
+    iconUrl: 'https://verifier.divine.video/favicon.ico',
+    launchUrl: 'https://verifier.divine.video/',
+    allowedOrigins: ['https://verifier.divine.video'],
     allowedMethods: ['getPublicKey', 'signEvent'],
     allowedSignEventKinds: [0],
     promptRequiredFor: [],

--- a/mobile/test/screens/apps/app_detail_screen_test.dart
+++ b/mobile/test/screens/apps/app_detail_screen_test.dart
@@ -8,8 +8,10 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/apps/app_detail_screen.dart';
 import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import '../../helpers/go_router.dart';
+import '../../helpers/url_launcher_test_double.dart';
 
 class _MockNostrAppDirectoryService extends Mock
     implements NostrAppDirectoryService {}
@@ -88,7 +90,85 @@ void main() {
         expect(pushedApp.slug, 'primal');
       },
     );
+
+    testWidgets(
+      'opens the verifyer in the system browser instead of the sandbox',
+      (tester) async {
+        final originalPlatform = UrlLauncherPlatform.instance;
+        final launcher = UrlLauncherTestDouble();
+        UrlLauncherPlatform.instance = launcher;
+        addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+        final mockGoRouter = MockGoRouter();
+        when(
+          () => mockGoRouter.push(any(), extra: any(named: 'extra')),
+        ).thenAnswer((_) async => null);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              nostrAppDirectoryServiceProvider.overrideWithValue(
+                mockDirectoryService,
+              ),
+            ],
+            child: MockGoRouterProvider(
+              goRouter: mockGoRouter,
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                home: AppDetailScreen(
+                  slug: 'verifyer',
+                  initialEntry: _verifyerFixtureApp(),
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        await tester.scrollUntilVisible(
+          find.text(l10n.appsDetailOpenButton),
+          300,
+        );
+        await tester.tap(find.byType(DivineButton));
+        await tester.pumpAndSettle();
+
+        expect(launcher.launched, hasLength(1));
+        expect(
+          launcher.launched.single.url,
+          'https://verifyer.divine.video/',
+        );
+        expect(launcher.launched.single.useExternalApplication, isTrue);
+        verifyNever(
+          () => mockGoRouter.push(
+            NostrAppSandboxScreen.pathForAppId('bundled-verifyer'),
+            extra: any(named: 'extra'),
+          ),
+        );
+      },
+    );
   });
+}
+
+NostrAppDirectoryEntry _verifyerFixtureApp() {
+  return const NostrAppDirectoryEntry(
+    id: 'bundled-verifyer',
+    slug: 'verifyer',
+    name: 'Divine Verifyer',
+    tagline: 'Link your social accounts.',
+    description: 'Verify ownership of external accounts.',
+    iconUrl: 'https://verifyer.divine.video/favicon.ico',
+    launchUrl: 'https://verifyer.divine.video/',
+    allowedOrigins: ['https://verifyer.divine.video'],
+    allowedMethods: ['getPublicKey', 'signEvent'],
+    allowedSignEventKinds: [0],
+    promptRequiredFor: [],
+    status: 'approved',
+    sortOrder: 16,
+    createdAt: null,
+    updatedAt: null,
+  );
 }
 
 NostrAppDirectoryEntry _fixtureApp() {

--- a/mobile/test/screens/apps/apps_directory_screen_test.dart
+++ b/mobile/test/screens/apps/apps_directory_screen_test.dart
@@ -123,7 +123,7 @@ void main() {
     });
 
     testWidgets(
-      'tapping the verifyer opens the system browser, not the sandbox',
+      'tapping the verifier opens the system browser, not the sandbox',
       (tester) async {
         final originalPlatform = UrlLauncherPlatform.instance;
         final launcher = UrlLauncherTestDouble();
@@ -136,23 +136,23 @@ void main() {
         ).thenAnswer((_) async => null);
         when(
           () => mockDirectoryService.fetchApprovedApps(),
-        ).thenAnswer((_) async => [_verifyerFixture()]);
+        ).thenAnswer((_) async => [_verifierFixture()]);
 
         await tester.pumpWidget(buildSubject(goRouter: mockGoRouter));
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Divine Verifyer'));
+        await tester.tap(find.text('Divine Verifier'));
         await tester.pumpAndSettle();
 
         expect(launcher.launched, hasLength(1));
         expect(
           launcher.launched.single.url,
-          'https://verifyer.divine.video/',
+          'https://verifier.divine.video/',
         );
         expect(launcher.launched.single.useExternalApplication, isTrue);
         verifyNever(
           () => mockGoRouter.push(
-            NostrAppSandboxScreen.pathForAppId('bundled-verifyer'),
+            NostrAppSandboxScreen.pathForAppId('bundled-verifier'),
             extra: any(named: 'extra'),
           ),
         );
@@ -176,16 +176,16 @@ void main() {
   });
 }
 
-NostrAppDirectoryEntry _verifyerFixture() {
+NostrAppDirectoryEntry _verifierFixture() {
   return const NostrAppDirectoryEntry(
-    id: 'bundled-verifyer',
-    slug: 'verifyer',
-    name: 'Divine Verifyer',
+    id: 'bundled-verifier',
+    slug: 'verifier',
+    name: 'Divine Verifier',
     tagline: 'Link your social accounts.',
     description: 'Verify ownership of external accounts.',
-    iconUrl: 'https://verifyer.divine.video/favicon.ico',
-    launchUrl: 'https://verifyer.divine.video/',
-    allowedOrigins: ['https://verifyer.divine.video'],
+    iconUrl: 'https://verifier.divine.video/favicon.ico',
+    launchUrl: 'https://verifier.divine.video/',
+    allowedOrigins: ['https://verifier.divine.video'],
     allowedMethods: ['getPublicKey', 'signEvent'],
     allowedSignEventKinds: [0],
     promptRequiredFor: [],

--- a/mobile/test/screens/apps/apps_directory_screen_test.dart
+++ b/mobile/test/screens/apps/apps_directory_screen_test.dart
@@ -8,8 +8,10 @@ import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/apps/apps_directory_screen.dart';
 import 'package:openvine/screens/apps/nostr_app_sandbox_screen.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 import '../../helpers/go_router.dart';
+import '../../helpers/url_launcher_test_double.dart';
 
 class _MockNostrAppDirectoryService extends Mock
     implements NostrAppDirectoryService {}
@@ -120,6 +122,43 @@ void main() {
       ).called(1);
     });
 
+    testWidgets(
+      'tapping the verifyer opens the system browser, not the sandbox',
+      (tester) async {
+        final originalPlatform = UrlLauncherPlatform.instance;
+        final launcher = UrlLauncherTestDouble();
+        UrlLauncherPlatform.instance = launcher;
+        addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+        final mockGoRouter = MockGoRouter();
+        when(
+          () => mockGoRouter.push(any(), extra: any(named: 'extra')),
+        ).thenAnswer((_) async => null);
+        when(
+          () => mockDirectoryService.fetchApprovedApps(),
+        ).thenAnswer((_) async => [_verifyerFixture()]);
+
+        await tester.pumpWidget(buildSubject(goRouter: mockGoRouter));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Divine Verifyer'));
+        await tester.pumpAndSettle();
+
+        expect(launcher.launched, hasLength(1));
+        expect(
+          launcher.launched.single.url,
+          'https://verifyer.divine.video/',
+        );
+        expect(launcher.launched.single.useExternalApplication, isTrue);
+        verifyNever(
+          () => mockGoRouter.push(
+            NostrAppSandboxScreen.pathForAppId('bundled-verifyer'),
+            extra: any(named: 'extra'),
+          ),
+        );
+      },
+    );
+
     testWidgets('shows an empty state when there are no approved apps', (
       tester,
     ) async {
@@ -135,6 +174,26 @@ void main() {
       expect(find.text(l10n.appsDirectoryEmptySubtitle), findsOneWidget);
     });
   });
+}
+
+NostrAppDirectoryEntry _verifyerFixture() {
+  return const NostrAppDirectoryEntry(
+    id: 'bundled-verifyer',
+    slug: 'verifyer',
+    name: 'Divine Verifyer',
+    tagline: 'Link your social accounts.',
+    description: 'Verify ownership of external accounts.',
+    iconUrl: 'https://verifyer.divine.video/favicon.ico',
+    launchUrl: 'https://verifyer.divine.video/',
+    allowedOrigins: ['https://verifyer.divine.video'],
+    allowedMethods: ['getPublicKey', 'signEvent'],
+    allowedSignEventKinds: [0],
+    promptRequiredFor: [],
+    status: 'approved',
+    sortOrder: 16,
+    createdAt: null,
+    updatedAt: null,
+  );
 }
 
 NostrAppDirectoryEntry _fixture() {

--- a/mobile/test/screens/apps/apps_directory_screen_test.dart
+++ b/mobile/test/screens/apps/apps_directory_screen_test.dart
@@ -150,11 +150,36 @@ void main() {
           'https://verifier.divine.video/',
         );
         expect(launcher.launched.single.useExternalApplication, isTrue);
-        verifyNever(
-          () => mockGoRouter.push(
-            NostrAppSandboxScreen.pathForAppId('bundled-verifier'),
-            extra: any(named: 'extra'),
+        verifyNever(() => mockGoRouter.push(any(), extra: any(named: 'extra')));
+      },
+    );
+
+    testWidgets(
+      'shows an error snackbar when the verifier browser launch throws',
+      (tester) async {
+        final originalPlatform = UrlLauncherPlatform.instance;
+        final launcher = UrlLauncherTestDouble(launchError: Exception('boom'));
+        UrlLauncherPlatform.instance = launcher;
+        addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+        when(
+          () => mockDirectoryService.fetchApprovedApps(),
+        ).thenAnswer((_) async => [_verifierFixture()]);
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Divine Verifier'));
+        await tester.pumpAndSettle();
+
+        expect(launcher.launched, hasLength(1));
+        expect(
+          find.text(
+            lookupAppLocalizations(
+              const Locale('en'),
+            ).relaySettingsCouldNotOpenBrowser,
           ),
+          findsOneWidget,
         );
       },
     );

--- a/mobile/test/screens/apps/apps_directory_screen_test.dart
+++ b/mobile/test/screens/apps/apps_directory_screen_test.dart
@@ -184,6 +184,38 @@ void main() {
       },
     );
 
+    testWidgets(
+      'does not launch a system-browser app with an off-host launch_url',
+      (tester) async {
+        final originalPlatform = UrlLauncherPlatform.instance;
+        final launcher = UrlLauncherTestDouble();
+        UrlLauncherPlatform.instance = launcher;
+        addTearDown(() => UrlLauncherPlatform.instance = originalPlatform);
+
+        when(
+          () => mockDirectoryService.fetchApprovedApps(),
+        ).thenAnswer(
+          (_) async => [_verifierFixtureWithUrl('https://evil.test/')],
+        );
+
+        await tester.pumpWidget(buildSubject());
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Divine Verifier'));
+        await tester.pumpAndSettle();
+
+        expect(launcher.launched, isEmpty);
+        expect(
+          find.text(
+            lookupAppLocalizations(
+              const Locale('en'),
+            ).relaySettingsCouldNotOpenBrowser,
+          ),
+          findsOneWidget,
+        );
+      },
+    );
+
     testWidgets('shows an empty state when there are no approved apps', (
       tester,
     ) async {
@@ -214,6 +246,26 @@ NostrAppDirectoryEntry _verifierFixture() {
     allowedMethods: ['getPublicKey', 'signEvent'],
     allowedSignEventKinds: [0],
     promptRequiredFor: [],
+    status: 'approved',
+    sortOrder: 16,
+    createdAt: null,
+    updatedAt: null,
+  );
+}
+
+NostrAppDirectoryEntry _verifierFixtureWithUrl(String launchUrl) {
+  return NostrAppDirectoryEntry(
+    id: 'bundled-verifier',
+    slug: 'verifier',
+    name: 'Divine Verifier',
+    tagline: 'Link your social accounts.',
+    description: 'Verify ownership of external accounts.',
+    iconUrl: 'https://verifier.divine.video/favicon.ico',
+    launchUrl: launchUrl,
+    allowedOrigins: const ['https://verifier.divine.video'],
+    allowedMethods: const ['getPublicKey', 'signEvent'],
+    allowedSignEventKinds: const [0],
+    promptRequiredFor: const [],
     status: 'approved',
     sortOrder: 16,
     createdAt: null,

--- a/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
+++ b/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
@@ -36,7 +36,7 @@ void main() {
     });
 
     test(
-      'returns true for the legacy verifyer slug (directory transition)',
+      'returns true for the older verifyer slug (directory data may carry it)',
       () {
         final app = _entry(
           slug: 'verifyer',
@@ -56,6 +56,66 @@ void main() {
         (app) => app.id == 'bundled-verifier',
       );
       expect(appRequiresSystemBrowser(verifier), isTrue);
+    });
+  });
+
+  group('isAllowedSystemBrowserTarget', () {
+    test(
+      'accepts the real preloaded verifier launch_url (guards host drift)',
+      () {
+        final verifier = preloadedNostrApps.firstWhere(
+          (app) => app.id == 'bundled-verifier',
+        );
+        expect(isAllowedSystemBrowserTarget(verifier.launchUrl), isTrue);
+      },
+    );
+
+    test('accepts both verifier host spellings over https', () {
+      expect(
+        isAllowedSystemBrowserTarget('https://verifier.divine.video/'),
+        isTrue,
+      );
+      expect(
+        isAllowedSystemBrowserTarget('https://verifyer.divine.video/'),
+        isTrue,
+      );
+    });
+
+    test('rejects the pinned host over a non-https scheme', () {
+      expect(
+        isAllowedSystemBrowserTarget('http://verifier.divine.video/'),
+        isFalse,
+      );
+    });
+
+    test('rejects non-web schemes', () {
+      expect(isAllowedSystemBrowserTarget('tel:12345'), isFalse);
+      expect(
+        isAllowedSystemBrowserTarget('intent://verifier.divine.video'),
+        isFalse,
+      );
+    });
+
+    test('rejects a userinfo-spoofed host', () {
+      expect(
+        isAllowedSystemBrowserTarget(
+          'https://verifier.divine.video@evil.test/',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects a subdomain-suffix-spoofed host', () {
+      expect(
+        isAllowedSystemBrowserTarget(
+          'https://verifier.divine.video.evil.test/',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects an off-host https url', () {
+      expect(isAllowedSystemBrowserTarget('https://evil.test/'), isFalse);
     });
   });
 }

--- a/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
+++ b/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
+import 'package:openvine/screens/apps/nostr_app_launch_mode.dart';
+
+NostrAppDirectoryEntry _entry({
+  required String slug,
+  required String launchUrl,
+}) {
+  return NostrAppDirectoryEntry(
+    id: 'id-$slug',
+    slug: slug,
+    name: slug,
+    tagline: '',
+    description: '',
+    iconUrl: '',
+    launchUrl: launchUrl,
+    allowedOrigins: [Uri.parse(launchUrl).origin],
+    allowedMethods: const [],
+    allowedSignEventKinds: const [],
+    promptRequiredFor: const [],
+    status: 'approved',
+    sortOrder: 0,
+    createdAt: null,
+    updatedAt: null,
+  );
+}
+
+void main() {
+  group('appRequiresSystemBrowser', () {
+    test('returns true for the verifyer app (cross-origin OAuth)', () {
+      final app = _entry(
+        slug: 'verifyer',
+        launchUrl: 'https://verifyer.divine.video/',
+      );
+      expect(appRequiresSystemBrowser(app), isTrue);
+    });
+
+    test('returns false for an ordinary sandbox app', () {
+      final app = _entry(slug: 'primal', launchUrl: 'https://primal.net/');
+      expect(appRequiresSystemBrowser(app), isFalse);
+    });
+  });
+}

--- a/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
+++ b/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
@@ -39,5 +39,12 @@ void main() {
       final app = _entry(slug: 'primal', launchUrl: 'https://primal.net/');
       expect(appRequiresSystemBrowser(app), isFalse);
     });
+
+    test('matches the real preloaded verifier app (guards slug drift)', () {
+      final verifier = preloadedNostrApps.firstWhere(
+        (app) => app.id == 'bundled-verifier',
+      );
+      expect(appRequiresSystemBrowser(verifier), isTrue);
+    });
   });
 }

--- a/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
+++ b/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
@@ -27,10 +27,10 @@ NostrAppDirectoryEntry _entry({
 
 void main() {
   group('appRequiresSystemBrowser', () {
-    test('returns true for the verifyer app (cross-origin OAuth)', () {
+    test('returns true for the verifier app (cross-origin OAuth)', () {
       final app = _entry(
-        slug: 'verifyer',
-        launchUrl: 'https://verifyer.divine.video/',
+        slug: 'verifier',
+        launchUrl: 'https://verifier.divine.video/',
       );
       expect(appRequiresSystemBrowser(app), isTrue);
     });

--- a/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
+++ b/mobile/test/screens/apps/nostr_app_launch_mode_test.dart
@@ -35,6 +35,17 @@ void main() {
       expect(appRequiresSystemBrowser(app), isTrue);
     });
 
+    test(
+      'returns true for the legacy verifyer slug (directory transition)',
+      () {
+        final app = _entry(
+          slug: 'verifyer',
+          launchUrl: 'https://verifyer.divine.video/',
+        );
+        expect(appRequiresSystemBrowser(app), isTrue);
+      },
+    );
+
     test('returns false for an ordinary sandbox app', () {
       final app = _entry(slug: 'primal', launchUrl: 'https://primal.net/');
       expect(appRequiresSystemBrowser(app), isFalse);

--- a/mobile/test/screens/profile_setup_screen_test.dart
+++ b/mobile/test/screens/profile_setup_screen_test.dart
@@ -929,7 +929,7 @@ void main() {
     });
 
     test(
-      'opens the verifyer in the external browser without immediate refresh',
+      'opens the verifier in the external browser without immediate refresh',
       () async {
         final launched = await launchVerifierFlow(
           editorBloc: editorBloc,
@@ -939,7 +939,7 @@ void main() {
 
         expect(launched, isTrue);
         expect(launcher.launched, hasLength(1));
-        expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
+        expect(launcher.launched.single.url, 'https://verifier.divine.video/');
         expect(launcher.launched.single.useExternalApplication, isTrue);
         verify(
           () => editorBloc.add(const VerifierLaunchHandled()),
@@ -969,7 +969,7 @@ void main() {
         expect(pushedRoutes, hasLength(1));
         expect(
           pushedRoutes.single.location,
-          '/apps/bundled-verifyer/web-sandbox',
+          '/apps/bundled-verifier/web-sandbox',
         );
         verify(
           () => editorBloc.add(const VerifierLaunchHandled()),
@@ -994,7 +994,7 @@ void main() {
 
         expect(launched, isFalse);
         expect(launcher.launched, hasLength(1));
-        expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
+        expect(launcher.launched.single.url, 'https://verifier.divine.video/');
         verify(
           () => editorBloc.add(const VerifierLaunchHandled()),
         ).called(1);
@@ -1020,7 +1020,7 @@ void main() {
 
         expect(launched, isFalse);
         expect(launcher.launched, hasLength(1));
-        expect(launcher.launched.single.url, 'https://verifyer.divine.video/');
+        expect(launcher.launched.single.url, 'https://verifier.divine.video/');
         verify(
           () => editorBloc.add(const VerifierLaunchHandled()),
         ).called(1);

--- a/mobile/test/services/web_iframe_nostr_bridge_test.dart
+++ b/mobile/test/services/web_iframe_nostr_bridge_test.dart
@@ -13,7 +13,7 @@ class _MockWebSigner extends Mock implements WebSigner {}
 
 void main() {
   group(WebIframeNostrBridge, () {
-    const allowedOrigin = 'https://verifyer.divine.video';
+    const allowedOrigin = 'https://verifier.divine.video';
     const fakePubkey =
         'aaaa11111111111111111111111111111111111111111111111111111111aaaa';
 
@@ -27,12 +27,12 @@ void main() {
       auth = _MockWebAuthService();
       signer = _MockWebSigner();
       app = const NostrAppDirectoryEntry(
-        id: 'verifyer',
-        slug: 'verifyer',
-        name: 'Verifyer',
+        id: 'verifier',
+        slug: 'verifier',
+        name: 'Verifier',
         tagline: 'tagline',
         description: 'description',
-        iconUrl: 'https://verifyer.divine.video/favicon.ico',
+        iconUrl: 'https://verifier.divine.video/favicon.ico',
         launchUrl: '$allowedOrigin/',
         allowedOrigins: [allowedOrigin],
         allowedMethods: ['getPublicKey', 'getRelays', 'signEvent'],

--- a/mobile/test/widgets/profile/verified_account_chip_test.dart
+++ b/mobile/test/widgets/profile/verified_account_chip_test.dart
@@ -84,7 +84,7 @@ void main() {
       await tester.tap(find.byType(InkWell));
       await tester.pumpAndSettle();
       expect(launched, isNotNull);
-      expect(launched!.host, equals('verifyer.divine.video'));
+      expect(launched!.host, equals('verifier.divine.video'));
       expect(launched!.queryParameters['platform'], equals('mastodon'));
       expect(
         launched!.queryParameters['identity'],


### PR DESCRIPTION
## Description

Two related changes to the in-app verifier, in separate commits.

**1. `fix(apps)` — open the verifier in the system browser from the Apps Directory.** The verifier needs cross-origin login/OAuth hand-offs (login.divine.video, then external providers and the verifier callback) that the in-app WebView sandbox's origin allowlist blocks, so in-app verification dead-ends at "Blocked for safety." #5372 moved the Edit Profile → Get verified entry point to the system browser but left the Apps Directory + App Detail entry points still pushing the sandbox route. This adds `appRequiresSystemBrowser` (keyed on the app slug so it survives the remote-directory merge) and a shared `launchNostrApp` that opens such apps in the system browser; both Apps surfaces now route the verifier there while ordinary apps keep using the sandbox.

**2. `refactor(verifier)` — standardize on the "verifier" spelling.** The service is reachable at both `verifyer.divine.video` (misspelled) and `verifier.divine.video` (correct), serving the same worker, and the rest of the system already treats "verifier" as canonical (OAuth redirect base, provider callbacks, all return_urls). This flips the social-verifier host, the preloaded app slug/id, and the display name to "verifier" across environment config, the preloaded catalog, profile setup, the verified-account chip, the web iframe bridge, the verifier_client package, the system-browser slug set, and translator metadata (regenerated l10n). Behavior-neutral today since both hosts serve the same worker.

**Related Issue:** Closes #5481. Relates to divinevideo/divine-identify-verification-service#16.

## Out of Scope

- **CAWG / C2PA identity-verifier subsystem** (`cawg_verifier_client`, `CAWG_VERIFIER_BASE_URL`, the `identity_verifier` bundle issuer) is intentionally left on "verifyer": it is a separate service whose `/v1/claims/verify` endpoint is served elsewhere and whose issuer value is echoed from the native proof bundle, so its canonical host must be confirmed and flipped with that service, not from mobile.
- **Verifier-repo cleanup** (drop `verifyer` from `ALLOWED_RETURN_ORIGINS`, rename KV keys, 301) — separate PR on divinevideo/divine-identify-verification-service, gated on installed-build migration. When the apps-directory worker is eventually deployed, it must also serve the verifier under slug `verifier` to match this app (the routing decision is keyed on slug).
- **Broken `/u` profile link** in the verified-account chip: it builds `https://verifier.divine.video/u?platform=…&identity=…` for mastodon/discord/telegram claims, but the verifier worker serves no `/u` route, so it 404s on both `verifyer` and `verifier`. Pre-existing (not introduced or regressed here); the spelling flip leaves it functionally unchanged. Documenting it here rather than fixing in this PR — needs either a `/u` page on the verifier or a different chip link target.
- A raw deep link to `/apps/bundled-verifier/sandbox` would still render the sandbox; no such in-app link exists today. Noted for a possible chokepoint guard.

## Verification

- `flutter analyze lib test` — clean
- Affected suites green: `test/screens/apps/`, `environment_config_test`, `profile_setup_screen_test`, `web_iframe_nostr_bridge_test`, `verified_account_chip_test`, `nostr_app_directory_service_test`, `verifier_client`
- CAWG suites re-run green to confirm no shared-code breakage: `cawg_verifier_client_test`, `video_event_publisher_cawg_identity_test`, `c2pa_identity_manifest_service_test`, `creator_identity_claim_test`
- New tests: `appRequiresSystemBrowser` unit test; Apps Directory + App Detail widget tests asserting the verifier opens the system browser (not the sandbox)

Manual device verification (tap "Divine Verifier" in the Apps Directory, confirm it opens the system browser and the verification flow completes) and screenshots to be attached before this leaves draft.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor
