### PR TITLE
fix(upload): retry transient Blossom auth setup failures

### DIFF
--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1286,6 +1286,10 @@ class UploadManager {
       return false;
     }
 
+    if (errorStr.contains('failed to create blossom authentication')) {
+      return true;
+    }
+
     // Network and timeout errors are retriable
     if (errorStr.contains('timeout') ||
         errorStr.contains('cannot connect') ||

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -228,6 +228,14 @@ void main() {
 
         expect(uploadManager.isRetriableError(error), isTrue);
       });
+
+      test('retries Blossom auth creation failures without HTTP status', () {
+        const error = BlossomUploadFailureException(
+          'Failed to create Blossom authentication',
+        );
+
+        expect(uploadManager.isRetriableError(error), isTrue);
+      });
     });
 
     group('generic exceptions (string matching fallback)', () {


### PR DESCRIPTION
Closes #5503

## Summary
- Investigated user video-posting failure from ~/Downloads/Untitled (3).txt
- Found Keycast/Login DNS failures during Blossom auth creation were collapsed to a no-status auth error
- Retry no-status Blossom auth creation failures through UploadManager's existing upload retry budget while keeping HTTP 401/403 non-retryable
- Added regression coverage for the retry classifier

## Log findings
- First publish attempt failed after DNS lookup failures to login.divine.video while creating Blossom auth events
- UploadManager did not retry because the collapsed error text contained auth and no HTTP status
- A second publish attempt later reached the legacy PUT to media.divine.video, but the exported log ended before upload completion or timeout

## Verification
- flutter test test/services/upload_manager_error_handling_test.dart
- dart analyze lib/services/upload_manager.dart test/services/upload_manager_error_handling_test.dart
- flutter analyze
- pre-push analyzer and changed test hook passed
