### PR TITLE
fix(upload): retry uploads when the signer is briefly unreachable

### DIFF
--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -200,6 +200,9 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
   ) {
     return switch (failureReason ?? BlossomUploadFailureReason.unknown) {
       BlossomUploadFailureReason.network => AvatarUploadError.network,
+      // Signer briefly unreachable while building the auth header — a
+      // connectivity problem from the user's view, so reuse the network copy.
+      BlossomUploadFailureReason.authUnavailable => AvatarUploadError.network,
       BlossomUploadFailureReason.auth => AvatarUploadError.auth,
       BlossomUploadFailureReason.fileTooLarge => AvatarUploadError.fileTooLarge,
       BlossomUploadFailureReason.server => AvatarUploadError.server,
@@ -364,6 +367,9 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
   ) {
     return switch (failureReason ?? BlossomUploadFailureReason.unknown) {
       BlossomUploadFailureReason.network => BannerUploadError.network,
+      // Signer briefly unreachable while building the auth header — a
+      // connectivity problem from the user's view, so reuse the network copy.
+      BlossomUploadFailureReason.authUnavailable => BannerUploadError.network,
       BlossomUploadFailureReason.auth => BannerUploadError.auth,
       BlossomUploadFailureReason.fileTooLarge => BannerUploadError.fileTooLarge,
       BlossomUploadFailureReason.server => BannerUploadError.server,

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1409,8 +1409,16 @@ class UploadManager {
       return 'NO_INTERNET';
     }
 
-    // Use structured status code when available
+    // Use structured classification when available.
     if (error is BlossomUploadFailureException) {
+      // A failure to *produce* the signed auth header (the signer was briefly
+      // unreachable) is a connectivity problem, not a server rejection. It
+      // carries no HTTP status, so classify it on the typed reason and surface
+      // the retry-friendly network copy instead of the generic UNKNOWN message.
+      if (error.failureReason == BlossomUploadFailureReason.authUnavailable) {
+        return 'NETWORK_ERROR';
+      }
+
       final code = error.statusCode;
       if (code != null) {
         if (code == 408) return 'TIMEOUT';

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1310,10 +1310,6 @@ class UploadManager {
       return false;
     }
 
-    if (errorStr.contains('failed to create blossom authentication')) {
-      return true;
-    }
-
     // Network and timeout errors are retriable
     if (errorStr.contains('timeout') ||
         errorStr.contains('cannot connect') ||

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -39,14 +39,23 @@ String _getPlatformName() {
 
 /// Exception thrown when a [BlossomUploadResult] indicates failure.
 ///
-/// Carries the HTTP [statusCode] so that [categorizeError] and
-/// [isRetriableError] can branch on it directly instead of parsing
-/// error-message strings.
+/// Carries the HTTP [statusCode] and the typed [failureReason] so that
+/// [categorizeError] and [isRetriableError] can branch on them directly
+/// instead of parsing error-message strings. The [failureReason]
+/// distinguishes a transient inability to *produce* a signed auth header
+/// ([BlossomUploadFailureReason.authUnavailable]) from a permanent
+/// server-side auth rejection ([BlossomUploadFailureReason.auth]) — a
+/// distinction the bare error string cannot carry.
 class BlossomUploadFailureException implements Exception {
-  const BlossomUploadFailureException(this.message, {this.statusCode});
+  const BlossomUploadFailureException(
+    this.message, {
+    this.statusCode,
+    this.failureReason,
+  });
 
   final String message;
   final int? statusCode;
+  final BlossomUploadFailureReason? failureReason;
 
   @override
   String toString() => message;
@@ -1121,6 +1130,7 @@ class UploadManager {
       throw BlossomUploadFailureException(
         (result.errorMessage as String?) ?? 'Upload failed with unknown error',
         statusCode: result.statusCode as int?,
+        failureReason: result.failureReason as BlossomUploadFailureReason?,
       );
     }
   }
@@ -1258,8 +1268,22 @@ class UploadManager {
       return false;
     }
 
-    // Use structured status code when available
+    // Use structured classification when available.
     if (error is BlossomUploadFailureException) {
+      // A transient inability to *produce* a signed auth header (the remote
+      // signer or its network path was briefly unreachable) is retriable —
+      // distinct from a permanent 401/403 rejection handled below. This is
+      // the fix for uploads that died on a momentary signer DNS blip.
+      final reason = error.failureReason;
+      if (reason == BlossomUploadFailureReason.authUnavailable ||
+          reason == BlossomUploadFailureReason.network) {
+        return true;
+      }
+      if (reason == BlossomUploadFailureReason.auth ||
+          reason == BlossomUploadFailureReason.fileTooLarge) {
+        return false;
+      }
+
       final code = error.statusCode;
       if (code != null) {
         // 408 request timeout — retriable
@@ -1305,10 +1329,12 @@ class UploadManager {
       return false;
     }
 
-    // Authentication / permission errors are not retriable
-    if (errorStr.contains('auth') ||
-        errorStr.contains('permission') ||
-        errorStr.contains('cancelled')) {
+    // Permission and cancellation failures are permanent. Authentication is
+    // classified structurally above (failureReason / 401-403 statusCode): a
+    // failed auth-header *creation* is transient while a server *rejection*
+    // is not, and the bare substring 'auth' cannot tell them apart — so it
+    // no longer gates retries here.
+    if (errorStr.contains('permission') || errorStr.contains('cancelled')) {
       return false;
     }
 

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -29,10 +29,19 @@ enum BlossomUploadFailureReason {
   /// connectivity loss. Caller may show "check your connection".
   network,
 
-  /// Authentication failure: HTTP 401 / 403, or the service was unable
-  /// to produce a signed Blossom auth header. Caller may prompt the
-  /// user to sign in again.
+  /// Server-side authentication rejection: HTTP 401 / 403. Permanent —
+  /// retrying the same request will be rejected again. Caller may prompt
+  /// the user to sign in again. Does NOT cover a failure to *produce* the
+  /// auth header — that is the transient [authUnavailable] below.
   auth,
+
+  /// The service could not *produce* a signed Blossom auth header before
+  /// the request was sent, because the remote signer (or the network path
+  /// to it — e.g. a momentary `Failed host lookup` for the signer host)
+  /// was briefly unreachable. Transient: once connectivity returns the
+  /// same upload succeeds, so the caller should retry. Distinct from
+  /// [auth], which is a permanent server-side rejection.
+  authUnavailable,
 
   /// Server rejected the upload because the file exceeds size limits
   /// (HTTP 413 "payload too large"). Caller may suggest a smaller file.
@@ -200,13 +209,24 @@ class BlossomHealthCheckResult {
 /// Exception thrown when a resumable upload operation fails.
 class BlossomResumableUploadException implements Exception {
   /// Creates a [BlossomResumableUploadException].
-  const BlossomResumableUploadException(this.message, {this.statusCode});
+  const BlossomResumableUploadException(
+    this.message, {
+    this.statusCode,
+    this.failureReason,
+  });
 
   /// The error message.
   final String message;
 
   /// HTTP status code, if applicable.
   final int? statusCode;
+
+  /// Typed classification when the throw site already knows it — e.g. an
+  /// auth-header-creation failure sets
+  /// [BlossomUploadFailureReason.authUnavailable] so the boundary can tell
+  /// it apart from a missing-field/malformed-response throw. `null` lets
+  /// the classifier fall back to [statusCode].
+  final BlossomUploadFailureReason? failureReason;
 
   @override
   String toString() => message;
@@ -613,9 +633,11 @@ class BlossomUploadService {
   ///   * [BlossomResumableUploadException] with a retriable status code —
   ///     thrown when chunk PUT exhausts its internal retry budget on a 5xx
   ///     and the resumable session bubbles up. An outer retry rebuilds the
-  ///     session via `_initResumableUpload`. 404/410 (session expired) and
-  ///     null statusCode (auth or malformed-response) are intentionally not
-  ///     transient.
+  ///     session via `_initResumableUpload`. It is also transient when the
+  ///     throw tagged itself [BlossomUploadFailureReason.authUnavailable]
+  ///     (the signer was briefly unreachable while building the auth
+  ///     header). 404/410 (session expired) and an otherwise null
+  ///     statusCode (malformed-response) are intentionally not transient.
   bool _isTransientUploadError(Object error) {
     if (error is DioException) {
       final statusCode = error.response?.statusCode;
@@ -632,6 +654,9 @@ class BlossomUploadService {
       };
     }
     if (error is BlossomResumableUploadException) {
+      if (error.failureReason == BlossomUploadFailureReason.authUnavailable) {
+        return true;
+      }
       final statusCode = error.statusCode;
       return statusCode != null &&
           _retriableUploadStatusCodes.contains(statusCode);
@@ -646,12 +671,12 @@ class BlossomUploadService {
   ///
   ///   * [DioException] — delegated to
   ///     [BlossomUploadFailureReason.fromDioException].
-  ///   * [BlossomResumableUploadException] — classified by its
-  ///     `statusCode` when present. Throws without a status (auth-header
-  ///     build failure, malformed init response) fall through to
-  ///     [BlossomUploadFailureReason.unknown] — the boundary can't tell
-  ///     them apart from the typed exception alone, and surfacing
-  ///     "authentication error" for a missing init field would mislead.
+  ///   * [BlossomResumableUploadException] — its own `failureReason` wins
+  ///     when set (an auth-header build failure tags itself
+  ///     [BlossomUploadFailureReason.authUnavailable]); otherwise it is
+  ///     classified by `statusCode`. A throw with neither (e.g. a
+  ///     malformed init response) falls through to
+  ///     [BlossomUploadFailureReason.unknown].
   ///
   /// Anything else falls through to [BlossomUploadFailureReason.unknown].
   static BlossomUploadFailureReason _classifyUploadException(Object error) {
@@ -659,7 +684,8 @@ class BlossomUploadService {
       return BlossomUploadFailureReason.fromDioException(error);
     }
     if (error is BlossomResumableUploadException) {
-      return BlossomUploadFailureReason.fromStatusCode(error.statusCode) ??
+      return error.failureReason ??
+          BlossomUploadFailureReason.fromStatusCode(error.statusCode) ??
           BlossomUploadFailureReason.unknown;
     }
     return BlossomUploadFailureReason.unknown;
@@ -676,10 +702,16 @@ class BlossomUploadService {
   ///   * `isTransientNetworkFailure` is `true` — set by [_uploadToServer]
   ///     when it caught a [DioException] of type connection / send /
   ///     receive timeout or connection error and converted it to a result
-  ///     (these have no HTTP status to classify on).
+  ///     (these have no HTTP status to classify on), or
+  ///   * `failureReason` is [BlossomUploadFailureReason.authUnavailable] —
+  ///     the signer was briefly unreachable while building the auth header
+  ///     ([_uploadToServer] returns this instead of throwing).
   bool _isTransientUploadResult(BlossomUploadResult result) {
     if (result.success) return false;
     if (result.isTransientNetworkFailure) return true;
+    if (result.failureReason == BlossomUploadFailureReason.authUnavailable) {
+      return true;
+    }
     final statusCode = result.statusCode;
     return statusCode != null &&
         _retriableUploadStatusCodes.contains(statusCode);
@@ -969,6 +1001,7 @@ class BlossomUploadService {
     if (authHeader == null) {
       throw const BlossomResumableUploadException(
         'Failed to create Blossom authentication for resumable upload init',
+        failureReason: BlossomUploadFailureReason.authUnavailable,
       );
     }
 
@@ -1249,6 +1282,7 @@ class BlossomUploadService {
       throw const BlossomResumableUploadException(
         'Failed to create Blossom authentication for '
         'resumable upload completion',
+        failureReason: BlossomUploadFailureReason.authUnavailable,
       );
     }
 
@@ -1462,7 +1496,7 @@ class BlossomUploadService {
         return const BlossomUploadResult(
           success: false,
           errorMessage: 'Failed to create Blossom authentication',
-          failureReason: BlossomUploadFailureReason.auth,
+          failureReason: BlossomUploadFailureReason.authUnavailable,
         );
       }
 

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -2196,6 +2196,77 @@ void main() {
           equals(BlossomUploadFailureReason.unknown),
         );
       });
+
+      test(
+        'returns authUnavailable (not auth) when the signer cannot produce '
+        'the auth header',
+        () async {
+          // Authenticated, but the remote signer is briefly unreachable so
+          // createAndSignEvent yields null. This is transient — it must NOT
+          // be classified as a permanent `auth` rejection.
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          final service = BlossomUploadService(authProvider: mockAuthProvider);
+
+          final result = await service.uploadSubtitleVtt(
+            bytes: Uint8List.fromList(utf8.encode('WEBVTT\n')),
+          );
+
+          expect(result.success, isFalse);
+          expect(
+            result.failureReason,
+            equals(BlossomUploadFailureReason.authUnavailable),
+          );
+        },
+      );
+
+      test('returns auth when the server rejects the PUT with 403', () async {
+        final mockDio = _MockDio();
+        final mockResponse = _MockResponse();
+        when(() => mockResponse.statusCode).thenReturn(403);
+        when(() => mockResponse.headers).thenReturn(Headers());
+        when(() => mockResponse.data).thenReturn(<String, dynamic>{
+          'message': 'forbidden',
+        });
+        when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+        when(
+          () => mockAuthProvider.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => _signedEvent(_testPublicKey, 24242, const [], ''),
+        );
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((_) async => mockResponse);
+
+        final service = BlossomUploadService(
+          authProvider: mockAuthProvider,
+          dio: mockDio,
+        );
+
+        final result = await service.uploadSubtitleVtt(
+          bytes: Uint8List.fromList(utf8.encode('WEBVTT\n')),
+        );
+
+        expect(result.success, isFalse);
+        expect(result.statusCode, equals(403));
+        expect(result.failureReason, equals(BlossomUploadFailureReason.auth));
+      });
     });
 
     group('Model classes', () {
@@ -2254,6 +2325,23 @@ void main() {
           );
           expect(exception.toString(), equals('upload failed'));
           expect(exception.statusCode, equals(500));
+        });
+
+        test('carries failureReason when provided', () {
+          const exception = BlossomResumableUploadException(
+            'Failed to create Blossom authentication for resumable upload init',
+            failureReason: BlossomUploadFailureReason.authUnavailable,
+          );
+          expect(
+            exception.failureReason,
+            equals(BlossomUploadFailureReason.authUnavailable),
+          );
+          expect(exception.statusCode, isNull);
+        });
+
+        test('failureReason defaults to null', () {
+          const exception = BlossomResumableUploadException('upload failed');
+          expect(exception.failureReason, isNull);
         });
       });
 
@@ -2776,6 +2864,9 @@ void main() {
         service = BlossomUploadService(
           authProvider: mockAuthProvider,
           dio: mockDio,
+          // authUnavailable is transient, so the un-signable case below
+          // retries; skip the backoff so the test stays fast.
+          sleep: (_) async {},
         );
       });
 
@@ -2825,8 +2916,12 @@ void main() {
         );
 
         expect(result.success, isFalse);
-        // Auth-header build failure (unsigned event) classifies as auth.
-        expect(result.failureReason, equals(BlossomUploadFailureReason.auth));
+        // Auth-header build failure (signer unreachable) is transient and
+        // classifies as authUnavailable, NOT a permanent `auth` rejection.
+        expect(
+          result.failureReason,
+          equals(BlossomUploadFailureReason.authUnavailable),
+        );
 
         await tempDir.delete(recursive: true);
       });

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -2650,6 +2650,39 @@ void main() {
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
+        'maps authUnavailable failureReason to AvatarUploadError.network',
+        setUp: () {
+          when(
+            () => mockBlossomUploadService.uploadImageBytes(
+              bytes: any(named: 'bytes'),
+              filename: any(named: 'filename'),
+              nostrPubkey: any(named: 'nostrPubkey'),
+              mimeType: any(named: 'mimeType'),
+            ),
+          ).thenAnswer(
+            (_) async => const BlossomUploadResult(
+              success: false,
+              errorMessage: 'Failed to create Blossom authentication',
+              failureReason: BlossomUploadFailureReason.authUnavailable,
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) => bloc.add(
+          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+        ),
+        skip: 1,
+        expect: () => [
+          isA<ProfileEditorState>().having(
+            (s) => s.avatarUploadError,
+            'avatarUploadError',
+            AvatarUploadError.network,
+          ),
+        ],
+        errors: () => [isA<Exception>()],
+      );
+
+      blocTest<ProfileEditorBloc, ProfileEditorState>(
         'maps fileTooLarge failureReason to AvatarUploadError.fileTooLarge',
         setUp: () {
           when(

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -238,6 +238,52 @@ void main() {
       });
     });
 
+    group('BlossomUploadFailureException with failureReason', () {
+      test(
+        'returns true for authUnavailable (signer briefly unreachable)',
+        () {
+          // The regression this fixes: a momentary signer DNS blip leaves
+          // the auth header un-creatable. statusCode is null, so without the
+          // typed reason the old "Failed to create Blossom authentication"
+          // string matched contains('auth') and killed the retry forever.
+          const error = BlossomUploadFailureException(
+            'Failed to create Blossom authentication',
+            failureReason: BlossomUploadFailureReason.authUnavailable,
+          );
+
+          expect(uploadManager.isRetriableError(error), isTrue);
+        },
+      );
+
+      test('returns true for network reason', () {
+        const error = BlossomUploadFailureException(
+          'Cannot connect to Blossom server',
+          failureReason: BlossomUploadFailureReason.network,
+        );
+
+        expect(uploadManager.isRetriableError(error), isTrue);
+      });
+
+      test('returns false for a permanent auth rejection (no statusCode)', () {
+        // The "not authenticated" path: the user genuinely has no signer.
+        const error = BlossomUploadFailureException(
+          'User not authenticated - please sign in to upload',
+          failureReason: BlossomUploadFailureReason.auth,
+        );
+
+        expect(uploadManager.isRetriableError(error), isFalse);
+      });
+
+      test('returns false for fileTooLarge reason', () {
+        const error = BlossomUploadFailureException(
+          'Server error (413)',
+          failureReason: BlossomUploadFailureReason.fileTooLarge,
+        );
+
+        expect(uploadManager.isRetriableError(error), isFalse);
+      });
+    });
+
     group('generic exceptions (string matching fallback)', () {
       test('returns true for timeout errors', () {
         expect(
@@ -274,12 +320,20 @@ void main() {
         );
       });
 
-      test('returns false for auth errors', () {
-        expect(
-          uploadManager.isRetriableError(Exception('Authentication failed')),
-          isFalse,
-        );
-      });
+      test(
+        'returns true for a bare auth string with no structured classification',
+        () {
+          // The substring "auth" no longer gates retries: a permanent
+          // rejection now arrives as a 401/403 statusCode or a typed
+          // failureReason (see the structured group below). A bare string
+          // is ambiguous, so it falls through to retriable-by-default —
+          // biasing toward retry rather than permanently killing the upload.
+          expect(
+            uploadManager.isRetriableError(Exception('Authentication failed')),
+            isTrue,
+          );
+        },
+      );
 
       test('returns false for permission errors', () {
         expect(

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -228,32 +228,21 @@ void main() {
 
         expect(uploadManager.isRetriableError(error), isTrue);
       });
+    });
 
-      test('retries Blossom auth creation failures without HTTP status', () {
+    group('BlossomUploadFailureException with failureReason', () {
+      test('returns true for authUnavailable (signer briefly unreachable)', () {
+        // The regression this fixes: a momentary signer DNS blip leaves
+        // the auth header un-creatable. statusCode is null, so without the
+        // typed reason the old "Failed to create Blossom authentication"
+        // string matched contains('auth') and killed the retry forever.
         const error = BlossomUploadFailureException(
           'Failed to create Blossom authentication',
+          failureReason: BlossomUploadFailureReason.authUnavailable,
         );
 
         expect(uploadManager.isRetriableError(error), isTrue);
       });
-    });
-
-    group('BlossomUploadFailureException with failureReason', () {
-      test(
-        'returns true for authUnavailable (signer briefly unreachable)',
-        () {
-          // The regression this fixes: a momentary signer DNS blip leaves
-          // the auth header un-creatable. statusCode is null, so without the
-          // typed reason the old "Failed to create Blossom authentication"
-          // string matched contains('auth') and killed the retry forever.
-          const error = BlossomUploadFailureException(
-            'Failed to create Blossom authentication',
-            failureReason: BlossomUploadFailureReason.authUnavailable,
-          );
-
-          expect(uploadManager.isRetriableError(error), isTrue);
-        },
-      );
 
       test('returns true for network reason', () {
         const error = BlossomUploadFailureException(
@@ -508,24 +497,21 @@ void main() {
     });
 
     group('BlossomUploadFailureException with failureReason', () {
-      test(
-        'returns NETWORK_ERROR for authUnavailable (signer briefly '
-        'unreachable, no statusCode)',
-        () async {
-          // Without the typed reason this null-statusCode failure fell through
-          // to the generic UNKNOWN bucket; classify it as a connectivity issue
-          // to match the network-framed copy the user sees.
-          const error = BlossomUploadFailureException(
-            'Failed to create Blossom authentication',
-            failureReason: BlossomUploadFailureReason.authUnavailable,
-          );
+      test('returns NETWORK_ERROR for authUnavailable (signer briefly '
+          'unreachable, no statusCode)', () async {
+        // Without the typed reason this null-statusCode failure fell through
+        // to the generic UNKNOWN bucket; classify it as a connectivity issue
+        // to match the network-framed copy the user sees.
+        const error = BlossomUploadFailureException(
+          'Failed to create Blossom authentication',
+          failureReason: BlossomUploadFailureReason.authUnavailable,
+        );
 
-          expect(
-            await uploadManager.categorizeError(error),
-            equals('NETWORK_ERROR'),
-          );
-        },
-      );
+        expect(
+          await uploadManager.categorizeError(error),
+          equals('NETWORK_ERROR'),
+        );
+      });
 
       test(
         'still classifies a network reason via its message (DNS not shortcut)',

--- a/mobile/test/services/upload_manager_error_handling_test.dart
+++ b/mobile/test/services/upload_manager_error_handling_test.dart
@@ -507,6 +507,45 @@ void main() {
       });
     });
 
+    group('BlossomUploadFailureException with failureReason', () {
+      test(
+        'returns NETWORK_ERROR for authUnavailable (signer briefly '
+        'unreachable, no statusCode)',
+        () async {
+          // Without the typed reason this null-statusCode failure fell through
+          // to the generic UNKNOWN bucket; classify it as a connectivity issue
+          // to match the network-framed copy the user sees.
+          const error = BlossomUploadFailureException(
+            'Failed to create Blossom authentication',
+            failureReason: BlossomUploadFailureReason.authUnavailable,
+          );
+
+          expect(
+            await uploadManager.categorizeError(error),
+            equals('NETWORK_ERROR'),
+          );
+        },
+      );
+
+      test(
+        'still classifies a network reason via its message (DNS not shortcut)',
+        () async {
+          // Only authUnavailable is shortcut on the reason; a network reason
+          // keeps flowing through string matching so DNS_ERROR vs NETWORK_ERROR
+          // stays distinguishable.
+          const error = BlossomUploadFailureException(
+            'Failed host lookup: blossom.divine.video',
+            failureReason: BlossomUploadFailureReason.network,
+          );
+
+          expect(
+            await uploadManager.categorizeError(error),
+            equals('DNS_ERROR'),
+          );
+        },
+      );
+    });
+
     group('no internet', () {
       test('returns NO_INTERNET when connectivity is none', () async {
         mockConnectivity('none');


### PR DESCRIPTION
Closes #5505

## Description

A momentary DNS failure for the remote signer host (e.g.
`Failed host lookup: 'login.divine.video'`) while building the kind-24242
Blossom auth event **permanently** killed a video upload with no retry.
For Divine OAuth accounts every signature is produced remotely via Keycast,
so a blip there means the Blossom auth event can't be created — but the
cause is purely transient and the upload succeeds the moment the network
returns.

The retry path mis-classified this. The auth-header **creation** failure
was conflated with a server auth **rejection**:

- The service tagged it `BlossomUploadFailureReason.auth`.
- `UploadManager.isRetriableError` had no status code, fell to string
  matching, and `"Failed to create Blossom authentication"` hit
  `contains('auth')` → treated as permanent → upload dead.

This PR separates the two failure modes cleanly along the per-layer error
contract:

- **New `BlossomUploadFailureReason.authUnavailable`** — the service could
  not *produce* a signed auth header (signer/network briefly unreachable).
  Transient → retriable. `auth` now means **only** a 401/403 server
  rejection.
- `BlossomResumableUploadException` and `BlossomUploadFailureException`
  now carry the typed `failureReason`, so classification is structured
  rather than string-parsed. All three auth-header-creation sites
  (resumable init, resumable complete, legacy PUT) tag `authUnavailable`.
- `isRetriableError` classifies structurally first: `authUnavailable` /
  `network` → retriable; `auth` / `fileTooLarge` → permanent; the 5xx
  nuance still flows through the status-code branch. The `contains('auth')`
  heuristic no longer gates retries — only a real 401/403 marks auth
  permanent.
- In-service image-upload retry (`_isTransientUploadError` /
  `_isTransientUploadResult`) also treats `authUnavailable` as transient.
- Profile editor maps `authUnavailable` → the network "check your
  connection" error copy.

**Related Issue:** 

## Out of Scope

The larger resilience idea — automatically resuming a publish draft once
connectivity is restored — is a separate feature and intentionally not in
this PR. This PR only fixes the retry **classification** of a transient
signer outage.

## Verification

- `flutter analyze lib test integration_test` → No issues
- `blossom_upload_service` package: 188 tests pass, file coverage 100.00%
  (the package's CI coverage gate)
- `upload_manager_error_handling` + resumable + integration tests: pass
- `profile_editor_bloc` tests: pass
- `dart format` clean on all changed files

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)