### PR TITLE
feat(feed): swipe left/right to directly tune your recommendations

### DIFF
--- a/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-design.md
+++ b/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-design.md
@@ -1,7 +1,7 @@
 # Swipe-to-Tune Feed Recommendations — Design
 
-**Date:** 2026-06-25  
-**Status:** Design proposal — ready for implementation planning after kind reservation  
+**Date:** 2026-06-25
+**Status:** Design proposal — mobile implementation tracked by #5517
 **Scope:** `divine-mobile` client only
 
 ---
@@ -91,7 +91,7 @@ Use a new **regular append-only Nostr kind** owned by Divine.
 
 ```jsonc
 {
-  "kind": <feedTuningKind>, // final regular-range kind TBD: 1000-9999
+  "kind": 4242, // EventKind.feedTuning, regular range 1000-9999
   "content": "",
   "tags": [
     ["direction", "more"],                              // "more" | "less"
@@ -130,16 +130,14 @@ Use a new **regular append-only Nostr kind** owned by Divine.
   filtering and mirrors NIP-09 deletion examples already used in repository
   tests.
 - **Undo:** publish a NIP-09 kind-5 deletion request referencing the
-  feed-tuning event id with an `e` tag and `["k", "<feedTuningKind>"]`.
+  feed-tuning event id with an `e` tag and `["k", "4242"]`.
   Re-swiping remains latest-wins; deletion is for accidental immediate undo.
 
-### Open Protocol Dependency
+### Open Rollout Dependency
 
-Implementation must not hardcode a placeholder. Before merge, pick an unused
-regular-range kind (`1000-9999`), add it to
-`mobile/packages/nostr_sdk/lib/event_kind.dart` or the repo's active kind
-constants, reserve/register it in the Nostr kinds registry if that is the
-chosen workflow, and coordinate relay allow-listing.
+Mobile pins `EventKind.feedTuning = 4242` as the Divine client/backend contract.
+Before enabling the feature flag in production, funnelcake ingestion and the
+relay allow-list must use that same kind.
 
 ---
 
@@ -149,7 +147,8 @@ Follow the repo's layered flow: **UI -> BLoC -> Repository -> Client**.
 
 ### Repository Layer: `feed_tuning_repository`
 
-Create `mobile/packages/feed_tuning_repository` as a pure Dart package.
+Create `mobile/packages/feed_tuning_repository` as a Flutter workspace package
+with no UI dependencies.
 
 Responsibilities:
 
@@ -183,7 +182,7 @@ Implementation notes:
   read better.
 - Constructor-inject the Nostr client/signing abstraction used by existing
   publish repositories.
-- Follow the `dm_repository` reporter-port pattern for pure Dart packages:
+- Follow the `dm_repository` reporter-port pattern:
   network/relay publish failures are not Crashlytics-worthy; programming
   invariants and unexpected malformed target derivation are.
 - Tests should use the existing mocktail style in package tests.
@@ -270,8 +269,8 @@ Undo:
 
 ## Implementation Sequence
 
-1. **Protocol prep:** choose/reserve final kind, add constants, and confirm the
-   relay allow-list path. Do not leave a placeholder kind in committed code.
+1. **Protocol prep:** pin the mobile/backend kind constant and confirm the relay
+   allow-list path before enabling the feature flag.
 2. **Repository package:** build event construction, publish, undo, reporter
    sites, package tests.
 3. **BLoC wiring:** add the tuning event + `lastTuningAction` outbox and bloc
@@ -374,9 +373,8 @@ backend must honor:
 Two cross-repo blockers are owned jointly and must be settled before the loop is
 live end-to-end:
 
-1. **The kind number** (`<feedTuningKind>`) is unallocated. The backend reserves
-   an unused regular-range kind and reports it back; both repos pin the same
-   constant (`packages/nostr_sdk/lib/event_kind.dart` on the mobile side).
+1. **The kind number** is pinned to `4242` on mobile; backend ingestion must use
+   the same constant.
 2. **Relay allow-listing** of that kind.
 
 A ready-to-use briefing prompt for the funnelcake/Gorse agent is maintained
@@ -395,5 +393,5 @@ Safe cuts if implementation pressure is real:
 Not recommended to cut:
 
 - Accessibility actions. Gesture-only tuning is not acceptable.
-- Final kind reservation. Shipping placeholder protocol constants will create
-  relay/backend churn.
+- Kind coordination. Mobile, relay, and backend must agree on `4242` before the
+  feature flag is enabled.

--- a/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-design.md
+++ b/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-design.md
@@ -1,0 +1,323 @@
+# Swipe-to-Tune Feed Recommendations — Design
+
+**Date:** 2026-06-25
+**Status:** Approved (brainstorm) — ready for implementation plan
+**Scope of this spec:** divine-mobile client only
+
+---
+
+## Summary
+
+Let users directly shape their own recommendation algorithm by swiping on
+the video feed:
+
+- **Swipe right** = "more like this" (love it, want more).
+- **Swipe left** = "less like this" (not for me, want less).
+
+Each swipe registers a signal and advances the feed (fast, Tinder-like
+rhythm). The signal is published to the relay as a public, append-only
+Nostr event. A later, separately-specced backend change has funnelcake
+read these events off the relay and feed them into Gorse to reshape the
+user's personalized recommendations.
+
+This is **feed-shaping, not a social reaction.** A NIP-25 reaction (the
+Like / heart) is a *public expression about content*. A swipe is a
+*personal instruction to your own algorithm*. They are deliberately
+distinct: you can like a video without wanting more of it, or want more
+without publicly liking it.
+
+### What this spec covers vs. defers
+
+| In scope (this spec) | Deferred (separate spec) |
+|---|---|
+| The horizontal swipe gesture + in-gesture indicators | Funnelcake ingestion of the events off the relay |
+| Publishing the feed-tuning Nostr event | Gorse feedback-model mapping / reranking |
+| The new `feed_tuning_repository` package | Relay kind allow-listing (ops task, see Risks) |
+| `FullscreenFeedBloc` wiring + feed advance | Reserving the kind number in the registry-of-kinds |
+| Undo + accessibility + tests | Any "interests list" / cross-device sync surface |
+
+The event contract below is defined precisely so the backend work can
+consume it without further negotiation.
+
+---
+
+## Decisions (and the reasoning behind them)
+
+These were settled during brainstorming; recording them so the rationale
+isn't re-litigated during implementation.
+
+1. **Mobile client end-to-end first.** Ship the gesture + the published
+   event now; backend ingestion is a follow-up. The event contract is the
+   interface between the two.
+
+2. **A swipe is private feed-shaping, not a public reaction.** It is
+   conceptually separate from the Like. We do **not** reuse kind 7.
+
+3. **Stored publicly (plaintext).** "Personal" means *shapes my feed*,
+   not *secret*. The event is plaintext so funnelcake/Gorse can read it
+   straight off the relay. (We considered NIP-44 encryption-to-self and
+   encryption-to-the-service; both were rejected because the chosen model
+   is "public personal-preference event" — simplest to ingest, and the
+   user is comfortable with the signals being public.)
+
+4. **Append-only feedback events, latest-wins.** Each swipe is one small
+   immutable event. This maps 1:1 onto Gorse's feedback model
+   (user, item, feedback-type, timestamp) and avoids the
+   write-amplification / lost-update races of a single rewritten
+   preference list. "Changed your mind" = a newer event supersedes by
+   `created_at`.
+
+5. **Dedicated Divine feed-tuning kind — NOT NIP-32 kind 1985.**
+   NIP-32 Labeling (kind 1985) was evaluated and initially recommended
+   because it is purpose-built to attach labels to events/people/topics.
+   It was **rejected** because kind 1985 is the channel distributed-
+   moderation tooling scans: even namespaced, a high-volume stream of
+   `less` labels targeting creators can be read by a naive or hostile
+   aggregator as crowd-sourced downranking / soft-moderation of those
+   creators (a reputation/harassment vector), and it pollutes the
+   labeling space that moderation tools query. Instead we use a
+   **use-case-specific microstandard** — our own dedicated kind that no
+   moderation tooling reads — which is exactly what the NIPs registry
+   steers toward (it marks NIP-90 DVMs "unrecommended… prefer
+   use-case-specific microstandards"). We still **borrow NIP-32's
+   targeting conventions** (`e`/`a`/`p`/`t` tags) on our own kind.
+
+6. **Fast dismiss + advance for both directions.** Any horizontal swipe
+   registers the signal and advances to the next video — a quick rhythm
+   for rapidly training the feed. (We accept the minor contradiction of
+   leaving a video you "love"; velocity of training was preferred over
+   lingering.)
+
+7. **Keep the `p` (creator) tag on both `more` and `less`.** A variant
+   that dropped `p` on `less` events (to avoid any public anti-creator
+   statement) was offered and **not** chosen — generalization to the
+   creator is wanted on both directions.
+
+8. **Not a block/mute.** Feed-tuning feeds recommendations only. It never
+   writes to the NIP-51 mute list / blocklist. Distinct concern, distinct
+   system.
+
+---
+
+## The relay contract (the interface to the backend)
+
+A new **regular (append-only) Nostr event kind**, owned by Divine.
+
+```jsonc
+{
+  "kind": 3XXXX,           // dedicated Divine "feed-tuning" kind.
+                           // Regular range (1000–9999 per NIP-01) so relays
+                           // store it. FINAL NUMBER TBD — see Open Items.
+  "content": "",           // empty; everything indexable lives in tags
+  "tags": [
+    ["direction", "more"],                              // or "less"
+    ["a", "34236:<authorPubkey>:<dTag>", "<relayHint>"],// the video (addressable)
+    ["e", "<videoEventId>", "<relayHint>"],             // the video (event id)
+    ["p", "<authorPubkey>"],                            // creator (generalize)
+    ["t", "<hashtag>"]                                  // 0..n topic tags (generalize)
+  ]
+}
+```
+
+### Contract rules
+
+- **Direction** is carried in a single `["direction", "more"|"less"]`
+  tag. One kind, two directions (not two kinds).
+- **Video reference uses BOTH `a` and `e`.** Divine videos are
+  addressable kind 34236 (NIP-71). Per the repo's dual-tag rule, clients
+  reference addressable events by either coordinate (`a`) or id (`e`);
+  include both so the backend can match on whichever it indexes.
+- **`p` (creator)** and **`t` (topics)** are included on **both**
+  directions so Gorse can generalize beyond the single item ("less of
+  this creator", "less of #fitness"). Topics come from the video event's
+  own hashtag (`t`) tags. If a video has no hashtags, no `t` tags are
+  emitted.
+- **Append-only, latest-wins by `created_at`.** No `d` tag; this is not
+  addressable/replaceable.
+- **Undo = NIP-09 deletion.** An Undo publishes a kind-5 deletion
+  request referencing the just-published feed-tuning event id. (Latest-
+  wins already self-heals a corrected opinion; the explicit deletion is
+  for accidental swipes.)
+- **Reader:** only funnelcake/Gorse is expected to read these (filtered
+  by our kind). Other clients MAY, but nothing depends on it.
+
+---
+
+## Mobile architecture
+
+Follows the repo's layered flow: **UI → BLoC → Repository → Client.**
+
+### Data/Client layer — no changes
+
+`nostr_client` (`mobile/packages/nostr_client`) already publishes
+arbitrary kinds via `publishEvent(Event)`. No changes needed.
+
+### Repository layer — new package `feed_tuning_repository`
+
+`mobile/packages/feed_tuning_repository` (pure Dart, ships with tests).
+
+- **Responsibility:** own the construction and publishing of feed-tuning
+  events. This is the only place that knows the kind number and tag
+  layout.
+- **Public API (shape, not final):**
+  ```dart
+  /// Publishes a "more like this" feed-tuning signal for [video].
+  /// Fire-and-forget; returns the published event id for Undo, or null
+  /// if no signer / publish could not be attempted.
+  Future<String?> tuneMore(VideoEvent video);
+
+  /// Publishes a "less like this" feed-tuning signal for [video].
+  Future<String?> tuneLess(VideoEvent video);
+
+  /// Retracts a previously-published signal via a NIP-09 deletion.
+  Future<void> undo(String feedTuningEventId);
+  ```
+- **Dependencies:** constructor-injected `nostr_client` (or the signer +
+  client abstraction the other repos use) and a nullable
+  **reporter-port** typedef for Crashlytics (per the error-handling
+  rule for pure-Dart packages — see `dm_repository` precedent). Owns its
+  own `FeedTuningRepositoryReportableSites` constants.
+- **Constants:** the kind number and namespace strings live in a
+  constants class in this package (no hardcoded literals in call sites),
+  cross-referenced with `lib/constants/nostr_event_kinds.dart`.
+- **Failure contract:** fire-and-forget; network/relay failures are
+  expected and NOT reported to Crashlytics (per the decision matrix).
+  Programming-invariant violations are wrapped via the reporter port.
+
+### Business-logic layer — `FullscreenFeedBloc`
+
+Extend the existing `mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart`.
+
+- **New events:** `FullscreenFeedTunedMore` / `FullscreenFeedTunedLess`
+  (carry the target `VideoEvent` / index).
+- **Handler:** calls `feedTuningRepository.tuneMore/tuneLess`, then
+  advances by **reusing the existing video-removal path**
+  (`removedIdsStream` / current removal mechanism) — no new
+  feed-navigation machinery.
+- **Undo:** the handler exposes enough state (the published event id) for
+  the UI's Undo affordance to call `undo(...)` and re-insert the video.
+- **No error strings in state.** Status enum + `addError` only.
+- The repository is injected; if the bloc is constructed in a
+  `ConsumerWidget`/`BlocProvider.create` that reads a Riverpod-provided
+  `feedTuningRepository` whose identity can flip on auth change, apply
+  the existing record-`ValueKey` bridging rule (see
+  `state_management.md`). Confirm the provider's identity stability
+  during implementation; gate on readiness (Pattern A) if available.
+
+### Presentation layer — the gesture + indicators
+
+Horizontal-drag detection on the feed item, dispatching tune events to
+the bloc. Extracted into small private widget classes (no
+`Widget`-returning methods).
+
+---
+
+## UX & feedback
+
+### Gesture
+
+- **Horizontal drag** on the active feed item. Both directions dismiss +
+  advance once the commit threshold is crossed.
+- **Angle/threshold disambiguation:** near-vertical drags must still go
+  to the vertical pager (advance/rewind video). Only drags past a
+  horizontal angle + distance threshold count as tuning. This is the top
+  implementation risk (see Risks).
+
+### In-gesture indicators ("subtle")
+
+- An **edge-anchored indicator** (a `DivineIcon` + a short `context.l10n`
+  label) **fades in, brightens, and scales with drag progress** — a small
+  nudge barely shows it; a committing drag makes it solid.
+- **Direction is color- and glyph-coded:** `more` = warmer/brighter with
+  an upward/positive glyph; `less` = cooler/dimmer with a downward glyph.
+  Exact `VineTheme` tokens chosen at implementation, contrast-checked per
+  `accessibility.md`.
+- The **video translates/tilts** with the finger so it physically feels
+  like pushing it away (right) or toward (left).
+- **Haptic tick** fires when the drag crosses the commit threshold; the
+  indicator locks solid. Release past threshold commits; release before
+  threshold snaps back and publishes nothing.
+
+### Discoverability
+
+- A **one-time coach-mark** (faint left/right chevron hint) on the first
+  feed session, dismissed on first use. No permanent on-screen chrome.
+
+### Accessibility
+
+- The gesture surface is wrapped in `Semantics` with directional labels.
+- On commit, announce "More like this" / "Less like this" via
+  `SemanticsService.sendAnnouncement(View.of(context), …,
+  Directionality.of(context))`.
+- All copy via `context.l10n` (new ARB keys added + `flutter gen-l10n`).
+
+### Undo
+
+- After a swipe, a brief snackbar with **Undo**. Tapping it calls
+  `feedTuningRepository.undo(eventId)` (NIP-09 deletion) and re-inserts
+  the dismissed video into the current feed position.
+
+---
+
+## Risks & mitigations
+
+1. **Gesture conflict (highest risk).** The native pooled player /
+   `infinite_video_feed` may already claim horizontal drags, and vertical
+   paging must keep winning on near-vertical drags. Mitigation: implement
+   explicit angle + distance disambiguation; verify vertical paging,
+   double-tap-like, and any existing overlays are unaffected. Spike this
+   first.
+2. **Relay kind allow-listing (ops, deferred).** The divine relay rejects
+   some unknown kinds by policy. The new kind must be allow-listed before
+   the loop works end-to-end. We control the relay; this is config, not a
+   code blocker, but the mobile feature is inert until it's done. Track
+   as a dependency of the backend spec.
+3. **Kind number collision.** No central allocator forces a number;
+   reserve it in the registry-of-kinds and pick an unused regular-range
+   value to avoid ambiguity for any client reading multiple kinds.
+4. **Volume.** Swiping is high-frequency. Publishing is fire-and-forget
+   and debounced per video (one in-flight per video; re-swiping replaces
+   intent). Confirm no UI jank from publish on the gesture thread.
+
+---
+
+## Testing
+
+- **`feed_tuning_repository` (new package — tests required in same PR):**
+  - event construction: correct kind, `direction` tag, `a`/`e`/`p`/`t`
+    tags derived from a `VideoEvent` (incl. the no-hashtags case);
+  - `more` vs `less` differ only by the `direction` value;
+  - `undo` builds a correct kind-5 deletion referencing the event id;
+  - reporter-port: expected network failures are NOT reported;
+    invariant violations ARE wrapped/reported.
+- **`FullscreenFeedBloc` (`blocTest`):** `FullscreenFeedTunedMore/Less`
+  call the repository and advance the feed; Undo re-inserts.
+- **Widget tests:** drag past threshold publishes + advances; drag below
+  threshold snaps back + publishes nothing; indicator + `Semantics`
+  present; Undo path; `MaterialApp` carries
+  `AppLocalizations.localizationsDelegates` / `supportedLocales`.
+
+---
+
+## Open items to finalize during implementation
+
+- **Final kind number** (reserve via registry-of-kinds; add to
+  `nostr_event_kinds.dart` + the new package's constants).
+- **Exact `VineTheme` color tokens + `DivineIcon` glyphs** for the two
+  directions (contrast-checked).
+- **Commit threshold values** (angle, distance, velocity) for the gesture
+  disambiguation — tuned on-device.
+- **Whether a `k` tag** (stringified target kind `34236`) is worth adding
+  for the backend's convenience — cheap; decide with the funnelcake spec.
+
+---
+
+## Possible v1 scope cuts (if needed)
+
+These can be deferred without changing the contract:
+
+- **Undo** (latest-wins + a future re-swipe already corrects intent).
+- **One-time coach-mark** (gesture still works without it).
+
+Neither is recommended to cut unless implementation pressure requires it;
+both are small.

--- a/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-design.md
+++ b/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-design.md
@@ -1,323 +1,399 @@
 # Swipe-to-Tune Feed Recommendations — Design
 
-**Date:** 2026-06-25
-**Status:** Approved (brainstorm) — ready for implementation plan
-**Scope of this spec:** divine-mobile client only
+**Date:** 2026-06-25  
+**Status:** Design proposal — ready for implementation planning after kind reservation  
+**Scope:** `divine-mobile` client only
 
 ---
 
 ## Summary
 
-Let users directly shape their own recommendation algorithm by swiping on
-the video feed:
+Users can directly tune their own recommendation feed from the fullscreen
+video player:
 
-- **Swipe right** = "more like this" (love it, want more).
-- **Swipe left** = "less like this" (not for me, want less).
+- **Swipe right** = more like this.
+- **Swipe left** = less like this.
 
-Each swipe registers a signal and advances the feed (fast, Tinder-like
-rhythm). The signal is published to the relay as a public, append-only
-Nostr event. A later, separately-specced backend change has funnelcake
-read these events off the relay and feed them into Gorse to reshape the
-user's personalized recommendations.
+A committed horizontal swipe publishes a small Nostr feedback event and
+advances the feed immediately. The event is public, append-only, and shaped so
+a later funnelcake/Gorse change can consume it as recommendation feedback:
+`user`, `item`, `direction`, `timestamp`, plus optional creator/topic
+generalization tags.
 
-This is **feed-shaping, not a social reaction.** A NIP-25 reaction (the
-Like / heart) is a *public expression about content*. A swipe is a
-*personal instruction to your own algorithm*. They are deliberately
-distinct: you can like a video without wanting more of it, or want more
-without publicly liking it.
+This is **feed-shaping, not a social reaction**. A NIP-25 reaction is a public
+statement about content. A tuning swipe is a personal instruction to the user's
+own algorithm. The two stay separate: a user can like a video without wanting
+more of it, or want more like it without publicly liking it.
 
-### What this spec covers vs. defers
+### In Scope vs Deferred
 
-| In scope (this spec) | Deferred (separate spec) |
+| In scope in this mobile spec | Deferred to later work |
 |---|---|
-| The horizontal swipe gesture + in-gesture indicators | Funnelcake ingestion of the events off the relay |
-| Publishing the feed-tuning Nostr event | Gorse feedback-model mapping / reranking |
-| The new `feed_tuning_repository` package | Relay kind allow-listing (ops task, see Risks) |
-| `FullscreenFeedBloc` wiring + feed advance | Reserving the kind number in the registry-of-kinds |
-| Undo + accessibility + tests | Any "interests list" / cross-device sync surface |
+| Horizontal gesture, thresholding, indicator animation, haptics | Funnelcake ingestion from relay |
+| Publishing the feed-tuning event | Gorse feedback mapping/reranking |
+| New `feed_tuning_repository` package | Relay kind allow-listing/deploy |
+| `FullscreenFeedBloc` tuning event + page-advance wiring | Reserving/registering the final kind number |
+| Undo affordance for accidental swipes | Interests/profile sync or user-facing preference list |
+| L10n, accessibility, tests | Cross-device display of past tuning actions |
 
-The event contract below is defined precisely so the backend work can
-consume it without further negotiation.
-
----
-
-## Decisions (and the reasoning behind them)
-
-These were settled during brainstorming; recording them so the rationale
-isn't re-litigated during implementation.
-
-1. **Mobile client end-to-end first.** Ship the gesture + the published
-   event now; backend ingestion is a follow-up. The event contract is the
-   interface between the two.
-
-2. **A swipe is private feed-shaping, not a public reaction.** It is
-   conceptually separate from the Like. We do **not** reuse kind 7.
-
-3. **Stored publicly (plaintext).** "Personal" means *shapes my feed*,
-   not *secret*. The event is plaintext so funnelcake/Gorse can read it
-   straight off the relay. (We considered NIP-44 encryption-to-self and
-   encryption-to-the-service; both were rejected because the chosen model
-   is "public personal-preference event" — simplest to ingest, and the
-   user is comfortable with the signals being public.)
-
-4. **Append-only feedback events, latest-wins.** Each swipe is one small
-   immutable event. This maps 1:1 onto Gorse's feedback model
-   (user, item, feedback-type, timestamp) and avoids the
-   write-amplification / lost-update races of a single rewritten
-   preference list. "Changed your mind" = a newer event supersedes by
-   `created_at`.
-
-5. **Dedicated Divine feed-tuning kind — NOT NIP-32 kind 1985.**
-   NIP-32 Labeling (kind 1985) was evaluated and initially recommended
-   because it is purpose-built to attach labels to events/people/topics.
-   It was **rejected** because kind 1985 is the channel distributed-
-   moderation tooling scans: even namespaced, a high-volume stream of
-   `less` labels targeting creators can be read by a naive or hostile
-   aggregator as crowd-sourced downranking / soft-moderation of those
-   creators (a reputation/harassment vector), and it pollutes the
-   labeling space that moderation tools query. Instead we use a
-   **use-case-specific microstandard** — our own dedicated kind that no
-   moderation tooling reads — which is exactly what the NIPs registry
-   steers toward (it marks NIP-90 DVMs "unrecommended… prefer
-   use-case-specific microstandards"). We still **borrow NIP-32's
-   targeting conventions** (`e`/`a`/`p`/`t` tags) on our own kind.
-
-6. **Fast dismiss + advance for both directions.** Any horizontal swipe
-   registers the signal and advances to the next video — a quick rhythm
-   for rapidly training the feed. (We accept the minor contradiction of
-   leaving a video you "love"; velocity of training was preferred over
-   lingering.)
-
-7. **Keep the `p` (creator) tag on both `more` and `less`.** A variant
-   that dropped `p` on `less` events (to avoid any public anti-creator
-   statement) was offered and **not** chosen — generalization to the
-   creator is wanted on both directions.
-
-8. **Not a block/mute.** Feed-tuning feeds recommendations only. It never
-   writes to the NIP-51 mute list / blocklist. Distinct concern, distinct
-   system.
+The mobile work should be useful before backend ingestion lands: swipes feel
+real, publish successfully once the relay accepts the kind, and leave a clear
+event stream for backend implementation.
 
 ---
 
-## The relay contract (the interface to the backend)
+## Decisions
 
-A new **regular (append-only) Nostr event kind**, owned by Divine.
+1. **Mobile end-to-end first.** Ship gesture and event publishing now. Backend
+   ingestion is a separate spec. The event contract below is the interface.
+
+2. **A swipe is not a Like.** Do not reuse NIP-25 kind 7. Likes remain social;
+   swipes are recommendation feedback.
+
+3. **Public plaintext event.** "Personal" means "shapes my feed", not
+   "secret". We considered NIP-44 encryption-to-self and encryption to a
+   service pubkey, but plaintext is the chosen v1 because funnelcake can ingest
+   it directly from relay storage. Users should assume tuning signals are
+   public.
+
+4. **Append-only, latest-wins.** Each swipe creates one immutable feedback
+   event. Gorse can interpret the newest event for `(user, target)` as the
+   current intent. Correcting your mind means swiping again; accidental swipes
+   can additionally be retracted with NIP-09.
+
+5. **Dedicated Divine feed-tuning kind, not NIP-32 kind 1985.** NIP-32 labels
+   were rejected because moderation tooling scans kind 1985. A high-volume
+   stream of "less" labels on creators could be misread by naive or hostile
+   tooling as distributed downranking/moderation. We use a use-case-specific
+   kind and only borrow normal targeting tags (`a`, `e`, `p`, `t`).
+
+6. **Both directions dismiss and advance.** Training rhythm matters. Even
+   "more like this" advances to the next video instead of lingering.
+
+7. **Keep creator/topic generalization on both directions.** `p` and `t` tags
+   appear on both `more` and `less` events so the backend can learn at item,
+   creator, and topic levels. This is deliberately not a block/mute signal.
+
+8. **Advance by paging, never by removing.** A committed swipe pages the feed
+   forward on the existing scroll/page controller (the same one
+   `FullscreenFeedIndexChanged` already tracks). The swiped video stays in the
+   list — it is not added to `removedVideoIds` and does not touch the
+   deletion/block/mute removal path (`_onRemoveVideo` /
+   `FullscreenFeedStatus.emptyAfterRemoval`, see `fullscreen_feed_bloc.dart:481`).
+   Undo is just "page back". This avoids a whole second dismissal/restore
+   subsystem.
+
+---
+
+## Event Contract
+
+Use a new **regular append-only Nostr kind** owned by Divine.
 
 ```jsonc
 {
-  "kind": 3XXXX,           // dedicated Divine "feed-tuning" kind.
-                           // Regular range (1000–9999 per NIP-01) so relays
-                           // store it. FINAL NUMBER TBD — see Open Items.
-  "content": "",           // empty; everything indexable lives in tags
+  "kind": <feedTuningKind>, // final regular-range kind TBD: 1000-9999
+  "content": "",
   "tags": [
-    ["direction", "more"],                              // or "less"
-    ["a", "34236:<authorPubkey>:<dTag>", "<relayHint>"],// the video (addressable)
-    ["e", "<videoEventId>", "<relayHint>"],             // the video (event id)
-    ["p", "<authorPubkey>"],                            // creator (generalize)
-    ["t", "<hashtag>"]                                  // 0..n topic tags (generalize)
+    ["direction", "more"],                              // "more" | "less"
+    ["a", "34236:<authorPubkey>:<dTag>", "<relayHint>"],// stable video coordinate
+    ["e", "<videoEventId>", "<relayHint>"],             // concrete event version
+    ["p", "<authorPubkey>"],                            // creator generalization
+    ["t", "<hashtag>"],                                 // 0..n topic tags
+    ["k", "34236"]                                      // target event kind
   ]
 }
 ```
 
-### Contract rules
+### Contract Rules
 
-- **Direction** is carried in a single `["direction", "more"|"less"]`
-  tag. One kind, two directions (not two kinds).
-- **Video reference uses BOTH `a` and `e`.** Divine videos are
-  addressable kind 34236 (NIP-71). Per the repo's dual-tag rule, clients
-  reference addressable events by either coordinate (`a`) or id (`e`);
-  include both so the backend can match on whichever it indexes.
-- **`p` (creator)** and **`t` (topics)** are included on **both**
-  directions so Gorse can generalize beyond the single item ("less of
-  this creator", "less of #fitness"). Topics come from the video event's
-  own hashtag (`t`) tags. If a video has no hashtags, no `t` tags are
-  emitted.
-- **Append-only, latest-wins by `created_at`.** No `d` tag; this is not
-  addressable/replaceable.
-- **Undo = NIP-09 deletion.** An Undo publishes a kind-5 deletion
-  request referencing the just-published feed-tuning event id. (Latest-
-  wins already self-heals a corrected opinion; the explicit deletion is
-  for accidental swipes.)
-- **Reader:** only funnelcake/Gorse is expected to read these (filtered
-  by our kind). Other clients MAY, but nothing depends on it.
+- **Kind range:** the kind must be in the regular range (`1000-9999`), not the
+  parameterized-replaceable range (`30000-39999`), because every swipe is an
+  append-only event and must not require a `d` tag.
+- **Direction:** exactly one `["direction", "more"|"less"]` tag. One kind,
+  two directions.
+- **`e` is the authoritative item key, always present.** It identifies the
+  concrete video event and is always reliable. Backend ingestion keys the Gorse
+  item on `e`.
+- **`a` is best-effort enrichment.** Include it only when the video has a *real*
+  `d` tag. The model is not safe to read blindly here: `VideoEvent.vineId` /
+  `stableId` fall back to the event id when there is no `d` tag
+  (`video_event.dart:558`), so `34236:<pubkey>:<vineId>` can be a fabricated
+  coordinate. Emitting `a` requires a real-d-tag accessor on the model (add a
+  `dTag` / `hasDTag` getter); if it's absent, omit `a` and ship `e`-only. No
+  invariant reporting — an `e`-only event is valid, not an error.
+- **Relay hint:** prefer `video.sourceRelay`; otherwise use the canonical
+  Divine relay hint. Do not emit an empty third tag value.
+- **Creator/topic tags:** include `p` for `video.pubkey` and one `t` per
+  `video.hashtags` entry, normalized the same way video publishing/parsing
+  already does. If there are no hashtags, emit no `t` tags.
+- **Target kind:** include `["k", "34236"]` in v1. It is cheap for backend
+  filtering and mirrors NIP-09 deletion examples already used in repository
+  tests.
+- **Undo:** publish a NIP-09 kind-5 deletion request referencing the
+  feed-tuning event id with an `e` tag and `["k", "<feedTuningKind>"]`.
+  Re-swiping remains latest-wins; deletion is for accidental immediate undo.
+
+### Open Protocol Dependency
+
+Implementation must not hardcode a placeholder. Before merge, pick an unused
+regular-range kind (`1000-9999`), add it to
+`mobile/packages/nostr_sdk/lib/event_kind.dart` or the repo's active kind
+constants, reserve/register it in the Nostr kinds registry if that is the
+chosen workflow, and coordinate relay allow-listing.
 
 ---
 
-## Mobile architecture
+## Mobile Architecture
 
-Follows the repo's layered flow: **UI → BLoC → Repository → Client.**
+Follow the repo's layered flow: **UI -> BLoC -> Repository -> Client**.
 
-### Data/Client layer — no changes
+### Repository Layer: `feed_tuning_repository`
 
-`nostr_client` (`mobile/packages/nostr_client`) already publishes
-arbitrary kinds via `publishEvent(Event)`. No changes needed.
+Create `mobile/packages/feed_tuning_repository` as a pure Dart package.
 
-### Repository layer — new package `feed_tuning_repository`
+Responsibilities:
 
-`mobile/packages/feed_tuning_repository` (pure Dart, ships with tests).
+- Construct and publish feed-tuning events.
+- Own the kind number, tag names, direction enum, and target derivation.
+- Publish NIP-09 deletion events for Undo.
+- Hide signer/client details from UI and BLoC code.
 
-- **Responsibility:** own the construction and publishing of feed-tuning
-  events. This is the only place that knows the kind number and tag
-  layout.
-- **Public API (shape, not final):**
-  ```dart
-  /// Publishes a "more like this" feed-tuning signal for [video].
-  /// Fire-and-forget; returns the published event id for Undo, or null
-  /// if no signer / publish could not be attempted.
-  Future<String?> tuneMore(VideoEvent video);
+Public API shape:
 
-  /// Publishes a "less like this" feed-tuning signal for [video].
-  Future<String?> tuneLess(VideoEvent video);
+```dart
+enum FeedTuningDirection { more, less }
 
-  /// Retracts a previously-published signal via a NIP-09 deletion.
+abstract interface class FeedTuningRepository {
+  /// Publishes a feed-tuning signal for [video]. Fire-and-forget.
+  /// Returns the published event id (known synchronously at signing time),
+  /// or null when there is no signer and nothing was attempted.
+  Future<String?> tune({
+    required VideoEvent video,
+    required FeedTuningDirection direction,
+  });
+
+  /// Retracts a prior signal via a NIP-09 (kind-5) deletion.
   Future<void> undo(String feedTuningEventId);
-  ```
-- **Dependencies:** constructor-injected `nostr_client` (or the signer +
-  client abstraction the other repos use) and a nullable
-  **reporter-port** typedef for Crashlytics (per the error-handling
-  rule for pure-Dart packages — see `dm_repository` precedent). Owns its
-  own `FeedTuningRepositoryReportableSites` constants.
-- **Constants:** the kind number and namespace strings live in a
-  constants class in this package (no hardcoded literals in call sites),
-  cross-referenced with `lib/constants/nostr_event_kinds.dart`.
-- **Failure contract:** fire-and-forget; network/relay failures are
-  expected and NOT reported to Crashlytics (per the decision matrix).
-  Programming-invariant violations are wrapped via the reporter port.
+}
+```
 
-### Business-logic layer — `FullscreenFeedBloc`
+Implementation notes:
 
-Extend the existing `mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart`.
+- Prefer one `tune(...)` method plus convenience wrappers only if call sites
+  read better.
+- Constructor-inject the Nostr client/signing abstraction used by existing
+  publish repositories.
+- Follow the `dm_repository` reporter-port pattern for pure Dart packages:
+  network/relay publish failures are not Crashlytics-worthy; programming
+  invariants and unexpected malformed target derivation are.
+- Tests should use the existing mocktail style in package tests.
+- Expose constants from the package and cross-reference the shared EventKind
+  constant. Do not scatter numeric kinds or tag strings across app code.
 
-- **New events:** `FullscreenFeedTunedMore` / `FullscreenFeedTunedLess`
-  (carry the target `VideoEvent` / index).
-- **Handler:** calls `feedTuningRepository.tuneMore/tuneLess`, then
-  advances by **reusing the existing video-removal path**
-  (`removedIdsStream` / current removal mechanism) — no new
-  feed-navigation machinery.
-- **Undo:** the handler exposes enough state (the published event id) for
-  the UI's Undo affordance to call `undo(...)` and re-insert the video.
-- **No error strings in state.** Status enum + `addError` only.
-- The repository is injected; if the bloc is constructed in a
-  `ConsumerWidget`/`BlocProvider.create` that reads a Riverpod-provided
-  `feedTuningRepository` whose identity can flip on auth change, apply
-  the existing record-`ValueKey` bridging rule (see
-  `state_management.md`). Confirm the provider's identity stability
-  during implementation; gate on readiness (Pattern A) if available.
+### BLoC Layer: `FullscreenFeedBloc`
 
-### Presentation layer — the gesture + indicators
+The BLoC publishes the signal; it does **not** mutate the video list (advancing
+is paging — see Decision 8).
 
-Horizontal-drag detection on the feed item, dispatching tune events to
-the bloc. Extracted into small private widget classes (no
-`Widget`-returning methods).
+- Add `FullscreenFeedTuningSwipeCommitted(videoId, direction)`.
+- Inject `FeedTuningRepository`.
+- Resolve the active `VideoEvent` from state by `videoId` at commit time, so a
+  stale UI-captured object isn't published after pagination/reorder.
+- Call `feedTuningRepository.tune(...)` and keep the returned event id in a
+  short-lived `lastTuningAction` outbox value in state for the UI's snackbar.
+  Clear it once consumed so a rebuild doesn't re-show the snackbar.
+- The video list is untouched: no `removedVideoIds`, no `_onRemoveVideo`, no
+  `emptyAfterRemoval`. The UI pages forward on commit and pages back on Undo.
+- On Undo, call `undo(eventId)` (the id is always available when a publish was
+  attempted; a null id means nothing to retract).
+- No error strings in state — status enum + `addError` only.
+
+### Dependency Wiring
+
+Wire the repository at the fullscreen feed route boundary:
+
+- Add a Riverpod provider for `FeedTuningRepository`.
+- If the provider can change identity on auth/signing changes, wrap
+  `BlocProvider` with a `ValueKey((feedRepository, feedTuningRepository, ...))`
+  per `docs/STATE_MANAGEMENT.md`.
+- Gate bloc creation if signer/client dependencies are not ready. Do not create
+  a bloc that captures a null signer and silently stays unable to publish after
+  auth flips.
+
+### Presentation Layer
+
+Add a small gesture wrapper around the active fullscreen feed item/feed stack.
+Keep it as widget classes, not `Widget _buildX()` helpers.
+
+Gesture behavior:
+
+- Track horizontal drag only after angle and distance thresholds clearly beat
+  vertical paging.
+- Below threshold: snap back and publish nothing.
+- At threshold crossing: fire one haptic tick and lock the indicator.
+- Release past threshold: dispatch tuning commit to the BLoC.
+- Release before threshold or cancel: reset visual state.
+
+Visual feedback:
+
+- Right swipe: warmer/brighter "more" indicator.
+- Left swipe: cooler/dimmer "less" indicator.
+- Edge-anchored icon + localized label fades/scales with drag progress.
+- The video translates with the finger and tilts subtly; keep movement bounded
+  so text/action overlays remain readable during partial drags.
+- Use `VineTheme`/`divine_ui` tokens only. Choose exact colors/icons during
+  implementation and contrast-check them.
+
+Discoverability:
+
+- One-time coach mark on the first eligible feed session: faint left/right
+  chevrons with short localized copy.
+- Dismiss on first committed tuning swipe or explicit close.
+- Persist the dismissal locally. Do not add permanent chrome.
+
+Accessibility:
+
+- Provide explicit semantic actions or buttons for "More like this" and "Less
+  like this" so non-drag users can tune the feed.
+- Announce committed actions with `SemanticsService.sendAnnouncement(...)`.
+- All copy goes through `context.l10n`; update ARB files and generated l10n.
+
+Undo:
+
+- Show a floating snackbar after commit with localized text and an Undo action.
+- The snackbar reads the BLoC outbox; it does not await the repository from UI.
+- Undo pages back to the swiped video and dispatches the undo event. The event id
+  is known synchronously at publish time, so there is no "id arrives later" race
+  to handle.
 
 ---
 
-## UX & feedback
+## Implementation Sequence
 
-### Gesture
-
-- **Horizontal drag** on the active feed item. Both directions dismiss +
-  advance once the commit threshold is crossed.
-- **Angle/threshold disambiguation:** near-vertical drags must still go
-  to the vertical pager (advance/rewind video). Only drags past a
-  horizontal angle + distance threshold count as tuning. This is the top
-  implementation risk (see Risks).
-
-### In-gesture indicators ("subtle")
-
-- An **edge-anchored indicator** (a `DivineIcon` + a short `context.l10n`
-  label) **fades in, brightens, and scales with drag progress** — a small
-  nudge barely shows it; a committing drag makes it solid.
-- **Direction is color- and glyph-coded:** `more` = warmer/brighter with
-  an upward/positive glyph; `less` = cooler/dimmer with a downward glyph.
-  Exact `VineTheme` tokens chosen at implementation, contrast-checked per
-  `accessibility.md`.
-- The **video translates/tilts** with the finger so it physically feels
-  like pushing it away (right) or toward (left).
-- **Haptic tick** fires when the drag crosses the commit threshold; the
-  indicator locks solid. Release past threshold commits; release before
-  threshold snaps back and publishes nothing.
-
-### Discoverability
-
-- A **one-time coach-mark** (faint left/right chevron hint) on the first
-  feed session, dismissed on first use. No permanent on-screen chrome.
-
-### Accessibility
-
-- The gesture surface is wrapped in `Semantics` with directional labels.
-- On commit, announce "More like this" / "Less like this" via
-  `SemanticsService.sendAnnouncement(View.of(context), …,
-  Directionality.of(context))`.
-- All copy via `context.l10n` (new ARB keys added + `flutter gen-l10n`).
-
-### Undo
-
-- After a swipe, a brief snackbar with **Undo**. Tapping it calls
-  `feedTuningRepository.undo(eventId)` (NIP-09 deletion) and re-inserts
-  the dismissed video into the current feed position.
+1. **Protocol prep:** choose/reserve final kind, add constants, and confirm the
+   relay allow-list path. Do not leave a placeholder kind in committed code.
+2. **Repository package:** build event construction, publish, undo, reporter
+   sites, package tests.
+3. **BLoC wiring:** add the tuning event + `lastTuningAction` outbox and bloc
+   tests (publish + no list mutation), without touching gesture UI yet.
+4. **Gesture spike:** add the wrapper behind a local feature flag or test-only
+   switch, tune thresholds on device, and verify vertical paging still wins.
+5. **Full UI:** indicators, haptics, coach mark, snackbar, l10n, accessibility.
+6. **Verification pass:** affected package tests, fullscreen feed bloc/widget
+   tests, l10n consistency, `flutter analyze`, and goldens only if visual
+   baselines change.
 
 ---
 
-## Risks & mitigations
+## Risks and Mitigations
 
-1. **Gesture conflict (highest risk).** The native pooled player /
-   `infinite_video_feed` may already claim horizontal drags, and vertical
-   paging must keep winning on near-vertical drags. Mitigation: implement
-   explicit angle + distance disambiguation; verify vertical paging,
-   double-tap-like, and any existing overlays are unaffected. Spike this
-   first.
-2. **Relay kind allow-listing (ops, deferred).** The divine relay rejects
-   some unknown kinds by policy. The new kind must be allow-listed before
-   the loop works end-to-end. We control the relay; this is config, not a
-   code blocker, but the mobile feature is inert until it's done. Track
-   as a dependency of the backend spec.
-3. **Kind number collision.** No central allocator forces a number;
-   reserve it in the registry-of-kinds and pick an unused regular-range
-   value to avoid ambiguity for any client reading multiple kinds.
-4. **Volume.** Swiping is high-frequency. Publishing is fire-and-forget
-   and debounced per video (one in-flight per video; re-swiping replaces
-   intent). Confirm no UI jank from publish on the gesture thread.
+1. **Gesture conflict with vertical paging.** Highest risk. The fullscreen
+   feed uses `FeedVideos`/`InfiniteVideoFeed`; horizontal recognition must not
+   steal near-vertical drags, taps, double-tap-like actions, DM reply focus, or
+   right-rail interactions. Spike thresholds before polishing UI.
+
+2. **Relay kind rejection.** Mobile publishing is inert until the relay accepts
+   the new kind. Treat allow-listing as a dependency before declaring the loop
+   end-to-end.
+
+3. **Kind collision or wrong range.** Use a regular-range kind. Avoid 30k
+   addressable kinds because swipe events are append-only feedback, not
+   replaceable records.
+
+4. **Don't wire tuning into removal.** Tuning advances by paging, not by
+   removing (Decision 8). A reviewer should confirm a tuning swipe never adds to
+   `removedVideoIds` or calls `_onRemoveVideo` — otherwise it behaves like
+   deletion/block/mute and the video vanishes instead of just scrolling past.
+
+5. **High-volume publishing.** Swipes can be rapid. The repository should
+   tolerate concurrent calls, and the BLoC should debounce duplicate commits for
+   the same visible video while a dismissal is in flight.
+
+6. **Public signal semantics.** "Less" events are public. The UI should not
+   describe them as private. Backend ingestion must also treat them as
+   recommendation input only, never moderation/blocking.
 
 ---
 
 ## Testing
 
-- **`feed_tuning_repository` (new package — tests required in same PR):**
-  - event construction: correct kind, `direction` tag, `a`/`e`/`p`/`t`
-    tags derived from a `VideoEvent` (incl. the no-hashtags case);
-  - `more` vs `less` differ only by the `direction` value;
-  - `undo` builds a correct kind-5 deletion referencing the event id;
-  - reporter-port: expected network failures are NOT reported;
-    invariant violations ARE wrapped/reported.
-- **`FullscreenFeedBloc` (`blocTest`):** `FullscreenFeedTunedMore/Less`
-  call the repository and advance the feed; Undo re-inserts.
-- **Widget tests:** drag past threshold publishes + advances; drag below
-  threshold snaps back + publishes nothing; indicator + `Semantics`
-  present; Undo path; `MaterialApp` carries
-  `AppLocalizations.localizationsDelegates` / `supportedLocales`.
+Repository package tests:
+
+- Builds `more` and `less` events with the final kind, empty content,
+  `direction`, `e`, `p`, `k`, and `t` tags.
+- Includes `a` only when the addressable coordinate is trustworthy.
+- Uses relay hints correctly without empty placeholder fields.
+- `more` and `less` differ only by direction.
+- `undo` publishes a kind-5 deletion with `e` and `k` tags for the tuning
+  event.
+- Expected publish/network failures are not reported; invariant failures are
+  reported through the reporter port.
+
+BLoC tests:
+
+- Committed `more`/`less` resolves the current video and calls the repository
+  with the right direction.
+- Commit with no resolvable active video is a no-op.
+- The handler does not add to `removedVideoIds` or call `_onRemoveVideo`.
+- Undo with an event id calls repository `undo`; a null id is a no-op.
+- `lastTuningAction` outbox is set on commit and cleared once consumed.
+
+Widget/accessibility tests:
+
+- Horizontal drag past threshold dispatches a tuning event; below threshold
+  dispatches none.
+- Vertical drag still pages the feed and does not tune.
+- Indicator appears with localized labels and semantic actions.
+- Snackbar Undo dispatches the undo event.
+- L10n test covers new ARB keys and generated files.
+
+Manual/device checks:
+
+- Threshold feel on iOS and Android.
+- Haptic fires once at threshold crossing.
+- Right rail buttons, tap-to-pause, comments, DM reply bar, keyboard behavior,
+  and feed settings remain usable.
+- No jank from publish work on gesture commit.
 
 ---
 
-## Open items to finalize during implementation
+## Backend Handoff (Deferred — Canonical Contract)
 
-- **Final kind number** (reserve via registry-of-kinds; add to
-  `nostr_event_kinds.dart` + the new package's constants).
-- **Exact `VineTheme` color tokens + `DivineIcon` glyphs** for the two
-  directions (contrast-checked).
-- **Commit threshold values** (angle, distance, velocity) for the gesture
-  disambiguation — tuned on-device.
-- **Whether a `k` tag** (stringified target kind `34236`) is worth adding
-  for the backend's convenience — cheap; decide with the funnelcake spec.
+The Event Contract above is the **canonical interface** to the deferred
+funnelcake/Gorse work. That side reads these events off the relay and maps them
+into Gorse feedback to reshape `GET /api/users/{pubkey}/recommendations`. The
+backend must honor:
 
----
+- **Key the Gorse item on the `e` tag** (always present). Treat `a` / `k` / `p` /
+  `t` as enrichment, and tolerate `e`-only events.
+- `direction` = positive/negative feedback; `pubkey` = the user; the latest event
+  by `created_at` wins for a `(user, target)` pair; a NIP-09 kind-5 deletion
+  retracts a prior signal.
+- **Recommendation input only** — never moderation, blocking, or reporting.
 
-## Possible v1 scope cuts (if needed)
+Two cross-repo blockers are owned jointly and must be settled before the loop is
+live end-to-end:
 
-These can be deferred without changing the contract:
+1. **The kind number** (`<feedTuningKind>`) is unallocated. The backend reserves
+   an unused regular-range kind and reports it back; both repos pin the same
+   constant (`packages/nostr_sdk/lib/event_kind.dart` on the mobile side).
+2. **Relay allow-listing** of that kind.
 
-- **Undo** (latest-wins + a future re-swipe already corrects intent).
-- **One-time coach-mark** (gesture still works without it).
+A ready-to-use briefing prompt for the funnelcake/Gorse agent is maintained
+alongside this work; it embeds this same contract so the backend agent needs no
+access to this repo.
 
-Neither is recommended to cut unless implementation pressure requires it;
-both are small.
+## Possible v1 Cuts
+
+Safe cuts if implementation pressure is real:
+
+- Undo. Latest-wins plus swiping the other way already corrects intent; ship the
+  snackbar without retract, or defer Undo to a fast-follow.
+- Coach mark. Gesture and accessibility actions still work without it.
+- Animated tilt polish. Keep the indicator and translation.
+
+Not recommended to cut:
+
+- Accessibility actions. Gesture-only tuning is not acceptable.
+- Final kind reservation. Shipping placeholder protocol constants will create
+  relay/backend churn.

--- a/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-funnelcake-agent-prompt.md
+++ b/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-funnelcake-agent-prompt.md
@@ -29,7 +29,7 @@ tooling. It is recommendation feedback, never a moderation/block signal.)
 
 ```jsonc
 {
-  "kind": <FEED_TUNING_KIND>,   // TBD — see "Coordination". Regular range 1000-9999.
+  "kind": 4242,                 // EventKind.feedTuning. Regular range 1000-9999.
   "content": "",
   "tags": [
     ["direction", "more"],                              // "more" | "less"
@@ -76,9 +76,8 @@ Produce a short spec, then a plan, then implement. Decide and document:
 
 ## Coordination with the mobile side (cross-repo, do not skip)
 
-- **The kind number is unallocated.** Pick an unused regular-range kind
-  (1000-9999), reserve it (registry-of-kinds if that's the workflow), and report
-  it back so divine-mobile pins the same constant. Both repos MUST agree.
+- **The kind number is pinned on mobile.** Use kind `4242` for funnelcake
+  ingestion so both repos agree on the same regular-range constant.
 - **Relay allow-listing.** The relay rejects unknown kinds by policy in some
   paths. Get the new kind accepted or the whole loop is inert.
 - These are the critical-path blockers; surface them early.

--- a/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-funnelcake-agent-prompt.md
+++ b/docs/superpowers/specs/2026-06-25-swipe-feed-tuning-funnelcake-agent-prompt.md
@@ -1,0 +1,97 @@
+# Briefing prompt — funnelcake/Gorse agent
+
+Companion to `2026-06-25-swipe-feed-tuning-design.md` (the divine-mobile client
+spec). Hand the fenced block below to an agent working in the funnelcake / Gorse
+backend. It is self-contained — the agent does not need access to the mobile
+repo.
+
+---
+
+````markdown
+# Task: ingest Divine "feed-tuning" Nostr events into Gorse to personalize recommendations
+
+You're working in the funnelcake / Gorse backend. The divine-mobile client is
+shipping a "swipe to tune your feed" feature: swipe right = "more like this",
+swipe left = "less like this" on a video. Each swipe publishes a small public
+Nostr event to the relay. **Your job is the backend half: read those events off
+the relay and feed them into Gorse so they reshape that user's recommendations**
+(the `GET /api/users/{pubkey}/recommendations` endpoint the app already calls).
+
+Start by using the `using-divine-brain` skill to ground yourself in how
+funnelcake, the relay, and Gorse fit together, and read the relay LLM guide
+(`https://relay.divine.video/docs/llm-guide`).
+
+## The event contract (what the client publishes)
+
+A **dedicated regular (append-only) Nostr kind owned by Divine** — NOT a standard
+kind. (Deliberately not NIP-32 kind 1985, to avoid colliding with moderation
+tooling. It is recommendation feedback, never a moderation/block signal.)
+
+```jsonc
+{
+  "kind": <FEED_TUNING_KIND>,   // TBD — see "Coordination". Regular range 1000-9999.
+  "content": "",
+  "tags": [
+    ["direction", "more"],                              // "more" | "less"
+    ["e", "<videoEventId>", "<relayHint>"],             // the video — ALWAYS present, authoritative item key
+    ["a", "34236:<authorPubkey>:<dTag>", "<relayHint>"],// addressable coord — present ONLY when a real d-tag exists
+    ["p", "<authorPubkey>"],                            // creator — for creator-level generalization
+    ["t", "<hashtag>"],                                 // 0..n topic tags — for topic-level generalization
+    ["k", "34236"]                                      // target event kind
+  ]
+}
+```
+
+Semantics you must honor:
+- **`e` is the authoritative item id, always present.** Key your Gorse item on
+  `e`; treat `a` / `k` / `p` / `t` as enrichment. Expect and tolerate `e`-only
+  events (`a` is omitted when the source video has no trustworthy d-tag).
+- **Append-only, latest-wins.** A user may swipe a video multiple times; the
+  newest event by `created_at` for a given (pubkey, target) is current intent.
+- **Undo / retract = NIP-09.** A kind-5 deletion event referencing a feed-tuning
+  event id means "forget that signal." Handle deletions.
+- `pubkey` = the user, video = the item, `direction` = positive/negative feedback.
+
+## What to figure out (design before you build)
+
+Produce a short spec, then a plan, then implement. Decide and document:
+
+1. **Ingestion path.** How does funnelcake consume relay events today
+   (subscription, crawler, batch)? Add the new kind to that path. The relay must
+   allow-list the kind before events flow (see Coordination).
+2. **Gorse mapping.** Map to Gorse's feedback model (user, item, feedback type,
+   timestamp):
+   - How do "more"/"less" become Gorse feedback? Check the deployed Gorse
+     version's negative-feedback support (see the `gorse-*` skills and the live
+     config) before deciding the feedback-type taxonomy.
+   - How do `p` (creator) and `t` (topic) generalize? **KISS: start item-level
+     only** unless creator/topic clearly adds value — the tags are there when you
+     want them; let Gorse's own collaborative filtering generalize first.
+   - Reflect latest-wins + deletions in Gorse (overwrite / delete feedback row /
+     tombstone).
+3. **Idempotency & volume.** Swiping is high-frequency. Ingestion must be
+   idempotent on event id and tolerate bursts.
+4. **Verification.** Prove a "less" swipe actually demotes that item in
+   `/api/users/{pubkey}/recommendations`. Define a test or manual check.
+
+## Coordination with the mobile side (cross-repo, do not skip)
+
+- **The kind number is unallocated.** Pick an unused regular-range kind
+  (1000-9999), reserve it (registry-of-kinds if that's the workflow), and report
+  it back so divine-mobile pins the same constant. Both repos MUST agree.
+- **Relay allow-listing.** The relay rejects unknown kinds by policy in some
+  paths. Get the new kind accepted or the whole loop is inert.
+- These are the critical-path blockers; surface them early.
+
+## Constraints
+
+- Recommendation input only. Never wire into moderation, blocking, reporting, or
+  trust/reputation surfaces.
+- Don't truncate Nostr ids anywhere (ids, logs, analytics).
+- Follow funnelcake's existing deploy workflow (`funnelcake-deployment-workflow`
+  skill); don't hand-edit production config without it.
+
+Deliver: a short design doc + implementation plan, the agreed kind number, and
+the relay allow-list status. Flag open questions back rather than guessing on
+Gorse taxonomy.
+````

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -158,6 +158,7 @@ class FullscreenFeedBloc
   final FeedTuningRepository? _feedTuningRepository;
   StreamSubscription<bool>? _hasMoreSubscription;
   StreamSubscription<String>? _removedIdsSubscription;
+  int _tuningActionSequence = 0;
 
   /// Queue of video IDs waiting to be cached in the background.
   final Queue<_CacheRequest> _cacheQueue = Queue<_CacheRequest>();
@@ -193,6 +194,7 @@ class FullscreenFeedBloc
         lastTuningAction: FullscreenFeedTuningAction(
           videoId: event.videoId,
           direction: event.direction,
+          sequence: ++_tuningActionSequence,
           publishedEventId: publishedEventId,
         ),
       ),

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -9,6 +9,7 @@ import 'dart:ui' show VoidCallback;
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:equatable/equatable.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart' hide LogCategory;
@@ -98,6 +99,7 @@ class FullscreenFeedBloc
     MediaAvailabilityChecker? availabilityChecker,
     BlockAuthorFilter? blockFilter,
     UnavailableVideoFilter? unavailableFilter,
+    FeedTuningRepository? feedTuningRepository,
   }) : _videosStream = videosStream,
        _initialVideoId = initialVideoId,
        _initialStableId = initialStableId,
@@ -112,6 +114,7 @@ class FullscreenFeedBloc
            availabilityChecker ?? const MediaAvailabilityChecker(),
        _blockFilter = blockFilter,
        _unavailableFilter = unavailableFilter,
+       _feedTuningRepository = feedTuningRepository,
        super(FullscreenFeedState(currentIndex: initialIndex)) {
     on<FullscreenFeedStarted>(_onStarted);
     on<FullscreenFeedHasMoreChanged>(_onHasMoreChanged);
@@ -135,6 +138,8 @@ class FullscreenFeedBloc
       _onBlocklistChanged,
       transformer: sequential(),
     );
+    on<FullscreenFeedTuningSwipeCommitted>(_onTuningSwipeCommitted);
+    on<FullscreenFeedTuningUndoRequested>(_onTuningUndoRequested);
   }
 
   final Stream<List<VideoEvent>> _videosStream;
@@ -150,6 +155,7 @@ class FullscreenFeedBloc
   final MediaAvailabilityChecker _availabilityChecker;
   final BlockAuthorFilter? _blockFilter;
   final UnavailableVideoFilter? _unavailableFilter;
+  final FeedTuningRepository? _feedTuningRepository;
   StreamSubscription<bool>? _hasMoreSubscription;
   StreamSubscription<String>? _removedIdsSubscription;
 
@@ -158,6 +164,48 @@ class FullscreenFeedBloc
 
   /// Number of downloads currently in progress.
   int _activeCacheDownloads = 0;
+
+  /// Publish a feed-tuning signal for the swiped video and record it for the
+  /// UI's Undo snackbar. Does not mutate the video list — the UI pages forward.
+  Future<void> _onTuningSwipeCommitted(
+    FullscreenFeedTuningSwipeCommitted event,
+    Emitter<FullscreenFeedState> emit,
+  ) async {
+    final repository = _feedTuningRepository;
+    if (repository == null) return;
+
+    VideoEvent? target;
+    for (final video in state.videos) {
+      if (video.id == event.videoId) {
+        target = video;
+        break;
+      }
+    }
+    if (target == null) return;
+
+    final publishedEventId = await repository.tune(
+      video: target,
+      direction: event.direction,
+    );
+
+    emit(
+      state.copyWith(
+        lastTuningAction: FullscreenFeedTuningAction(
+          videoId: event.videoId,
+          direction: event.direction,
+          publishedEventId: publishedEventId,
+        ),
+      ),
+    );
+  }
+
+  /// Retract a previously-published feed-tuning signal.
+  Future<void> _onTuningUndoRequested(
+    FullscreenFeedTuningUndoRequested event,
+    Emitter<FullscreenFeedState> emit,
+  ) async {
+    await _feedTuningRepository?.undo(event.feedTuningEventId);
+  }
 
   /// Handle feed started - subscribe to the videos stream using emit.forEach.
   ///

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_event.dart
@@ -132,3 +132,37 @@ final class FullscreenFeedBlocklistChanged extends FullscreenFeedEvent {
   @override
   List<Object?> get props => [];
 }
+
+/// Dispatched when the user commits a feed-tuning swipe on [videoId]
+/// ("more"/"less like this").
+///
+/// The BLoC publishes the signal via the injected `FeedTuningRepository` and
+/// records the result in [FullscreenFeedState.lastTuningAction]. It does NOT
+/// mutate the video list — advancing the feed is the UI's job (page forward).
+final class FullscreenFeedTuningSwipeCommitted extends FullscreenFeedEvent {
+  const FullscreenFeedTuningSwipeCommitted({
+    required this.videoId,
+    required this.direction,
+  });
+
+  /// Event ID of the swiped video.
+  final String videoId;
+
+  /// Swipe direction — more or less like this.
+  final FeedTuningDirection direction;
+
+  @override
+  List<Object?> get props => [videoId, direction];
+}
+
+/// Dispatched when the user taps Undo on a just-published tuning signal. The
+/// BLoC retracts it via a NIP-09 deletion.
+final class FullscreenFeedTuningUndoRequested extends FullscreenFeedEvent {
+  const FullscreenFeedTuningUndoRequested(this.feedTuningEventId);
+
+  /// Event ID of the feed-tuning event to retract.
+  final String feedTuningEventId;
+
+  @override
+  List<Object?> get props => [feedTuningEventId];
+}

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -24,6 +24,7 @@ final class FullscreenFeedTuningAction extends Equatable {
   const FullscreenFeedTuningAction({
     required this.videoId,
     required this.direction,
+    required this.sequence,
     this.publishedEventId,
   });
 
@@ -33,12 +34,15 @@ final class FullscreenFeedTuningAction extends Equatable {
   /// The direction that was published.
   final FeedTuningDirection direction;
 
+  /// Monotonic action id so identical consecutive swipes still notify listeners.
+  final int sequence;
+
   /// Published feed-tuning event id, or `null` when nothing was published
   /// (no signer). Undo is only possible when this is non-null.
   final String? publishedEventId;
 
   @override
-  List<Object?> get props => [videoId, direction, publishedEventId];
+  List<Object?> get props => [videoId, direction, sequence, publishedEventId];
 }
 
 /// State for the FullscreenFeedBloc.
@@ -93,7 +97,8 @@ final class FullscreenFeedState extends Equatable {
 
   /// The most recently committed feed-tuning swipe, for the UI's Undo
   /// snackbar. `null` until the user tunes a video. A `BlocListener` reacts to
-  /// changes here; it is never cleared (latest-wins, change-only semantics).
+  /// changes here. [FullscreenFeedTuningAction.sequence] makes each committed
+  /// swipe distinct even when the same video/direction/event id repeats.
   final FullscreenFeedTuningAction? lastTuningAction;
 
   /// The current video, if available.

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -19,6 +19,28 @@ enum FullscreenFeedStatus {
   failure,
 }
 
+/// A just-committed feed-tuning swipe, surfaced for the UI's Undo snackbar.
+final class FullscreenFeedTuningAction extends Equatable {
+  const FullscreenFeedTuningAction({
+    required this.videoId,
+    required this.direction,
+    this.publishedEventId,
+  });
+
+  /// Event ID of the swiped video.
+  final String videoId;
+
+  /// The direction that was published.
+  final FeedTuningDirection direction;
+
+  /// Published feed-tuning event id, or `null` when nothing was published
+  /// (no signer). Undo is only possible when this is non-null.
+  final String? publishedEventId;
+
+  @override
+  List<Object?> get props => [videoId, direction, publishedEventId];
+}
+
 /// State for the FullscreenFeedBloc.
 final class FullscreenFeedState extends Equatable {
   const FullscreenFeedState({
@@ -31,6 +53,7 @@ final class FullscreenFeedState extends Equatable {
     this.pendingSkipTarget,
     this.initialTargetResolved = false,
     this.userChangedIndex = false,
+    this.lastTuningAction,
   });
 
   /// The current status.
@@ -67,6 +90,11 @@ final class FullscreenFeedState extends Equatable {
 
   /// Whether the user has manually moved the feed cursor since launch.
   final bool userChangedIndex;
+
+  /// The most recently committed feed-tuning swipe, for the UI's Undo
+  /// snackbar. `null` until the user tunes a video. A `BlocListener` reacts to
+  /// changes here; it is never cleared (latest-wins, change-only semantics).
+  final FullscreenFeedTuningAction? lastTuningAction;
 
   /// The current video, if available.
   VideoEvent? get currentVideo =>
@@ -105,6 +133,7 @@ final class FullscreenFeedState extends Equatable {
     int? pendingSkipTarget,
     bool? initialTargetResolved,
     bool? userChangedIndex,
+    FullscreenFeedTuningAction? lastTuningAction,
     bool clearPendingSkipTarget = false,
   }) {
     return FullscreenFeedState(
@@ -120,6 +149,7 @@ final class FullscreenFeedState extends Equatable {
       initialTargetResolved:
           initialTargetResolved ?? this.initialTargetResolved,
       userChangedIndex: userChangedIndex ?? this.userChangedIndex,
+      lastTuningAction: lastTuningAction ?? this.lastTuningAction,
     );
   }
 
@@ -135,5 +165,6 @@ final class FullscreenFeedState extends Equatable {
     pendingSkipTarget,
     initialTargetResolved,
     userChangedIndex,
+    lastTuningAction,
   ];
 }

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -54,6 +54,12 @@ enum FeatureFlag {
         'compliant senders deliver where divine reads. Keep off until the '
         'backend relay accepts kind-10050.',
   ),
+  feedTuning(
+    'Feed Tuning Swipes',
+    'Swipe left/right on the fullscreen feed to send "less/more like this" '
+        'signals that personalize recommendations. Off by default until the '
+        'relay and recommendation backend are ready.',
+  ),
   ;
 
   const FeatureFlag(

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -51,6 +51,8 @@ class BuildConfiguration {
       case FeatureFlag.publishDmRelayList:
         // Default OFF until the backend relay accepts kind-10050 (#4974 RC3).
         return const bool.fromEnvironment('FF_PUBLISH_DM_RELAY_LIST');
+      case FeatureFlag.feedTuning:
+        return const bool.fromEnvironment('FF_FEED_TUNING');
     }
   }
 
@@ -93,6 +95,8 @@ class BuildConfiguration {
         return 'FF_ADVANCED_RELAY_SETTINGS';
       case FeatureFlag.publishDmRelayList:
         return 'FF_PUBLISH_DM_RELAY_LIST';
+      case FeatureFlag.feedTuning:
+        return 'FF_FEED_TUNING';
     }
   }
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1,5 +1,17 @@
 {
   "@@locale": "en",
+  "feedTuningMoreLabel": "More like this",
+  "@feedTuningMoreLabel": {
+    "description": "Indicator and snackbar text when the user swipes right to get more videos like the current one."
+  },
+  "feedTuningLessLabel": "Less like this",
+  "@feedTuningLessLabel": {
+    "description": "Indicator and snackbar text when the user swipes left to get fewer videos like the current one."
+  },
+  "feedTuningUndo": "Undo",
+  "@feedTuningUndo": {
+    "description": "Snackbar action that retracts a just-published feed-tuning swipe."
+  },
   "dmMessageBubbleVideoReplyHint": "Open the referenced video",
   "@dmMessageBubbleVideoReplyHint": {
     "description": "Accessibility label for the compact quoted-video preview shown above a DM reply that references a shared video; activating it opens that video."

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -130,6 +130,24 @@ abstract class AppLocalizations {
     Locale('tr'),
   ];
 
+  /// Indicator and snackbar text when the user swipes right to get more videos like the current one.
+  ///
+  /// In en, this message translates to:
+  /// **'More like this'**
+  String get feedTuningMoreLabel;
+
+  /// Indicator and snackbar text when the user swipes left to get fewer videos like the current one.
+  ///
+  /// In en, this message translates to:
+  /// **'Less like this'**
+  String get feedTuningLessLabel;
+
+  /// Snackbar action that retracts a just-published feed-tuning swipe.
+  ///
+  /// In en, this message translates to:
+  /// **'Undo'**
+  String get feedTuningUndo;
+
   /// Accessibility label for the compact quoted-video preview shown above a DM reply that references a shared video; activating it opens that video.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9,6 +9,15 @@ class AppLocalizationsAm extends AppLocalizations {
   AppLocalizationsAm([String locale = 'am']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'የተጠቀሰውን ቪዲዮ ክፈት';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9,6 +9,15 @@ class AppLocalizationsAr extends AppLocalizations {
   AppLocalizationsAr([String locale = 'ar']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'افتح الفيديو المُشار إليه';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9,6 +9,15 @@ class AppLocalizationsBg extends AppLocalizations {
   AppLocalizationsBg([String locale = 'bg']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Отваряне на посочения видеоклип';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9,6 +9,15 @@ class AppLocalizationsDe extends AppLocalizations {
   AppLocalizationsDe([String locale = 'de']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Referenziertes Video öffnen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9,6 +9,15 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Open the referenced video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9,6 +9,15 @@ class AppLocalizationsEs extends AppLocalizations {
   AppLocalizationsEs([String locale = 'es']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Abrir el vídeo referenciado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9,6 +9,15 @@ class AppLocalizationsFil extends AppLocalizations {
   AppLocalizationsFil([String locale = 'fil']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Buksan ang tinukoy na video';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9,6 +9,15 @@ class AppLocalizationsFr extends AppLocalizations {
   AppLocalizationsFr([String locale = 'fr']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Ouvrir la vidéo référencée';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9,6 +9,15 @@ class AppLocalizationsId extends AppLocalizations {
   AppLocalizationsId([String locale = 'id']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Buka video yang dirujuk';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9,6 +9,15 @@ class AppLocalizationsIt extends AppLocalizations {
   AppLocalizationsIt([String locale = 'it']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Apri il video di riferimento';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9,6 +9,15 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => '参照先の動画を開く';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9,6 +9,15 @@ class AppLocalizationsKo extends AppLocalizations {
   AppLocalizationsKo([String locale = 'ko']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => '참조된 동영상 열기';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9,6 +9,15 @@ class AppLocalizationsNl extends AppLocalizations {
   AppLocalizationsNl([String locale = 'nl']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Verwezen video openen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9,6 +9,15 @@ class AppLocalizationsPl extends AppLocalizations {
   AppLocalizationsPl([String locale = 'pl']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Otwórz przywołane wideo';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9,6 +9,15 @@ class AppLocalizationsPt extends AppLocalizations {
   AppLocalizationsPt([String locale = 'pt']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Abrir o vídeo referenciado';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9,6 +9,15 @@ class AppLocalizationsRo extends AppLocalizations {
   AppLocalizationsRo([String locale = 'ro']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint =>
       'Deschide videoclipul referențiat';
 

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9,6 +9,15 @@ class AppLocalizationsSv extends AppLocalizations {
   AppLocalizationsSv([String locale = 'sv']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Öppna den refererade videon';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9,6 +9,15 @@ class AppLocalizationsTr extends AppLocalizations {
   AppLocalizationsTr([String locale = 'tr']) : super(locale);
 
   @override
+  String get feedTuningMoreLabel => 'More like this';
+
+  @override
+  String get feedTuningLessLabel => 'Less like this';
+
+  @override
+  String get feedTuningUndo => 'Undo';
+
+  @override
   String get dmMessageBubbleVideoReplyHint => 'Atıfta bulunulan videoyu aç';
 
   @override

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -11,6 +11,7 @@ import 'package:content_policy/content_policy.dart';
 import 'package:curated_list_repository/curated_list_repository.dart';
 import 'package:curation_repository/curation_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
@@ -492,6 +493,30 @@ DmReactionsRepository dmReactionsRepository(Ref ref) {
     ),
   );
   return repository;
+}
+
+/// Provider for [FeedTuningRepository] — publishes swipe "more/less like this"
+/// feed-tuning signals.
+///
+/// Watches only [nostrServiceProvider] (a stable, keepAlive client). The
+/// repository reads `publicKey` live at publish time, so it stays correct
+/// across auth/signer changes without rebuilding — no `ValueKey` guard is
+/// needed at the consumer (rule exception: genuinely stable + reads live
+/// state).
+@Riverpod(keepAlive: true)
+FeedTuningRepository feedTuningRepository(Ref ref) {
+  return FeedTuningRepository(
+    nostrClient: ref.watch(nostrServiceProvider),
+    errorReporter: (error, stackTrace, {required site}) {
+      unawaited(
+        CrashReportingService.instance.recordError(
+          error,
+          stackTrace,
+          reason: 'FeedTuningRepository.$site',
+        ),
+      );
+    },
+  );
 }
 
 @Riverpod(keepAlive: true)

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -735,6 +735,80 @@ final class DmReactionsRepositoryProvider
 String _$dmReactionsRepositoryHash() =>
     r'6cb1c9a4cfd154236685a01aae4f87473cffdb7d';
 
+/// Provider for [FeedTuningRepository] — publishes swipe "more/less like this"
+/// feed-tuning signals.
+///
+/// Watches only [nostrServiceProvider] (a stable, keepAlive client). The
+/// repository reads `publicKey` live at publish time, so it stays correct
+/// across auth/signer changes without rebuilding — no `ValueKey` guard is
+/// needed at the consumer (rule exception: genuinely stable + reads live
+/// state).
+
+@ProviderFor(feedTuningRepository)
+final feedTuningRepositoryProvider = FeedTuningRepositoryProvider._();
+
+/// Provider for [FeedTuningRepository] — publishes swipe "more/less like this"
+/// feed-tuning signals.
+///
+/// Watches only [nostrServiceProvider] (a stable, keepAlive client). The
+/// repository reads `publicKey` live at publish time, so it stays correct
+/// across auth/signer changes without rebuilding — no `ValueKey` guard is
+/// needed at the consumer (rule exception: genuinely stable + reads live
+/// state).
+
+final class FeedTuningRepositoryProvider
+    extends
+        $FunctionalProvider<
+          FeedTuningRepository,
+          FeedTuningRepository,
+          FeedTuningRepository
+        >
+    with $Provider<FeedTuningRepository> {
+  /// Provider for [FeedTuningRepository] — publishes swipe "more/less like this"
+  /// feed-tuning signals.
+  ///
+  /// Watches only [nostrServiceProvider] (a stable, keepAlive client). The
+  /// repository reads `publicKey` live at publish time, so it stays correct
+  /// across auth/signer changes without rebuilding — no `ValueKey` guard is
+  /// needed at the consumer (rule exception: genuinely stable + reads live
+  /// state).
+  FeedTuningRepositoryProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'feedTuningRepositoryProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$feedTuningRepositoryHash();
+
+  @$internal
+  @override
+  $ProviderElement<FeedTuningRepository> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  FeedTuningRepository create(Ref ref) {
+    return feedTuningRepository(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(FeedTuningRepository value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<FeedTuningRepository>(value),
+    );
+  }
+}
+
+String _$feedTuningRepositoryHash() =>
+    r'01bfa8cd85f2ee092123e2826e4d6b356d64470f';
+
 @ProviderFor(dmRepository)
 final dmRepositoryProvider = DmRepositoryProvider._();
 

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:analytics/analytics.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:feed_repository/feed_repository.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -28,6 +29,7 @@ import 'package:openvine/screens/feed/feed_settings_menu.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:openvine/widgets/feed_tuning/feed_tuning_swipe_overlay.dart';
 import 'package:openvine/widgets/nav_rounded_shell.dart';
 import 'package:openvine/widgets/video_feed_item/feed_videos.dart';
 import 'package:openvine/widgets/video_feed_item/inline_comment_composer_bar.dart';
@@ -249,6 +251,11 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
           orElse: () => false,
         );
 
+    // Stable, keepAlive repository; reads `publicKey` live at publish time, so
+    // capturing it once in `create:` stays correct across auth changes (no
+    // ValueKey guard needed — see feedTuningRepositoryProvider).
+    final feedTuningRepository = ref.watch(feedTuningRepositoryProvider);
+
     return MultiBlocProvider(
       providers: [
         BlocProvider(
@@ -265,6 +272,7 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             blossomAuthService: blossomAuthService,
             blockFilter: blockFilter,
             unavailableFilter: unavailableFilter,
+            feedTuningRepository: feedTuningRepository,
           )..add(const FullscreenFeedStarted()),
         ),
         BlocProvider(create: (_) => VideoPlaybackStatusCubit()),
@@ -448,6 +456,57 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
     );
   }
 
+  /// Publish a feed-tuning signal for the active video and page forward.
+  void _onTuned(FeedTuningDirection direction) {
+    final bloc = context.read<FullscreenFeedBloc>();
+    final video = bloc.state.currentVideo;
+    if (video == null) return;
+    bloc.add(
+      FullscreenFeedTuningSwipeCommitted(
+        videoId: video.id,
+        direction: direction,
+      ),
+    );
+    final nextIndex = bloc.state.currentIndex + 1;
+    if (nextIndex < bloc.state.videos.length) {
+      _animateToPage(nextIndex);
+    }
+  }
+
+  void _showTuningSnackbar(FullscreenFeedTuningAction action) {
+    final l10n = context.l10n;
+    final label = action.direction == FeedTuningDirection.more
+        ? l10n.feedTuningMoreLabel
+        : l10n.feedTuningLessLabel;
+    final eventId = action.publishedEventId;
+    ScaffoldMessenger.of(context)
+      ..clearSnackBars()
+      ..showSnackBar(
+        SnackBar(
+          behavior: SnackBarBehavior.floating,
+          content: Text(label),
+          action: eventId == null
+              ? null
+              : SnackBarAction(
+                  label: l10n.feedTuningUndo,
+                  onPressed: () => _undoTuning(eventId, action.videoId),
+                ),
+        ),
+      );
+  }
+
+  void _undoTuning(String feedTuningEventId, String videoId) {
+    final bloc = context.read<FullscreenFeedBloc>()
+      ..add(FullscreenFeedTuningUndoRequested(feedTuningEventId));
+    final videos = bloc.state.videos;
+    for (var i = 0; i < videos.length; i++) {
+      if (videos[i].id == videoId) {
+        _animateToPage(i);
+        return;
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     // Refilter the open feed when the blocklist changes broadly (block / mute
@@ -530,6 +589,16 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                   curr.status == FullscreenFeedStatus.emptyAfterRemoval,
               listener: (context, _) {
                 unawaited(Navigator.of(context).maybePop());
+              },
+            ),
+            // Show an Undo snackbar after a feed-tuning swipe commits.
+            BlocListener<FullscreenFeedBloc, FullscreenFeedState>(
+              listenWhen: (prev, curr) =>
+                  prev.lastTuningAction != curr.lastTuningAction &&
+                  curr.lastTuningAction != null,
+              listener: (context, state) {
+                final action = state.lastTuningAction;
+                if (action != null) _showTuningSnackbar(action);
               },
             ),
           ],
@@ -691,39 +760,48 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                           // rounded cutouts seam continuously into the bar.
                           child: Stack(
                             children: [
-                              VideoTapShield(
-                                child: _MaybeRoundFeedBottom(
-                                  roundCorners: showCommentBar,
-                                  child: MediaQuery.removePadding(
-                                    context: context,
-                                    removeBottom: true,
-                                    child: FeedVideos(
-                                      key: _feedVideosKey,
-                                      // Pause the reel while the DM reply composer
-                                      // is focused so it doesn't play under the
-                                      // keyboard.
-                                      isActive: !_replyComposerFocused,
-                                      videos: state.videos,
-                                      contextTitle: widget.contextTitle,
-                                      currentIndex: state.currentIndex,
-                                      hasMore: state.canLoadMore,
-                                      isLoadingMore: state.isLoadingMore,
-                                      trafficSource: widget.trafficSource,
-                                      sourceDetail: widget.sourceDetail,
-                                      onActiveVideoChanged: (video, index) {
-                                        _resumeAutoAdvanceAfterSwipe();
-                                        FeedPerformanceTracker()
-                                            .startVideoSwipeTracking(video.id);
-                                        context.read<FullscreenFeedBloc>().add(
-                                          FullscreenFeedIndexChanged(index),
-                                        );
-                                        widget.onPageChanged?.call(index);
-                                      },
-                                      onNearEnd: () {
-                                        if (state.canLoadMore) {
-                                          _triggerLoadMore();
-                                        }
-                                      },
+                              FeedTuningSwipeOverlay(
+                                onTuned: _onTuned,
+                                child: VideoTapShield(
+                                  child: _MaybeRoundFeedBottom(
+                                    roundCorners: showCommentBar,
+                                    child: MediaQuery.removePadding(
+                                      context: context,
+                                      removeBottom: true,
+                                      child: FeedVideos(
+                                        key: _feedVideosKey,
+                                        // Pause the reel while the DM reply composer
+                                        // is focused so it doesn't play under the
+                                        // keyboard.
+                                        isActive: !_replyComposerFocused,
+                                        videos: state.videos,
+                                        contextTitle: widget.contextTitle,
+                                        currentIndex: state.currentIndex,
+                                        hasMore: state.canLoadMore,
+                                        isLoadingMore: state.isLoadingMore,
+                                        trafficSource: widget.trafficSource,
+                                        sourceDetail: widget.sourceDetail,
+                                        onActiveVideoChanged: (video, index) {
+                                          _resumeAutoAdvanceAfterSwipe();
+                                          FeedPerformanceTracker()
+                                              .startVideoSwipeTracking(
+                                                video.id,
+                                              );
+                                          context
+                                              .read<FullscreenFeedBloc>()
+                                              .add(
+                                                FullscreenFeedIndexChanged(
+                                                  index,
+                                                ),
+                                              );
+                                          widget.onPageChanged?.call(index);
+                                        },
+                                        onNearEnd: () {
+                                          if (state.canLoadMore) {
+                                            _triggerLoadMore();
+                                          }
+                                        },
+                                      ),
                                     ),
                                   ),
                                 ),

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -18,6 +18,8 @@ import 'package:openvine/blocs/fullscreen_feed/fullscreen_feed_bloc.dart';
 import 'package:openvine/blocs/inline_comment_composer/inline_comment_composer_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -533,6 +535,12 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
     // identity (see `rules/state_management.md`).
     final commentsRepository = ref.watch(commentsRepositoryProvider);
 
+    // Swipe-to-tune is off by default; flip the flag on once the relay
+    // allow-lists the kind and the recommendation backend ships.
+    final feedTuningEnabled = ref.watch(
+      isFeatureEnabledProvider(FeatureFlag.feedTuning),
+    );
+
     return BlocProvider<InlineCommentComposerCubit>(
       key: ValueKey(commentsRepository),
       create: (_) =>
@@ -760,7 +768,8 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                           // rounded cutouts seam continuously into the bar.
                           child: Stack(
                             children: [
-                              FeedTuningSwipeOverlay(
+                              FeedTuningSwipeGate(
+                                enabled: feedTuningEnabled,
                                 onTuned: _onTuned,
                                 child: VideoTapShield(
                                   child: _MaybeRoundFeedBottom(

--- a/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
+++ b/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
@@ -113,6 +113,37 @@ class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
   }
 }
 
+/// Gates [FeedTuningSwipeOverlay] behind a feature flag.
+///
+/// When [enabled] is false the [child] is returned untouched — no gesture, no
+/// indicator, no overlay — so the feed behaves exactly as before. The screen
+/// drives [enabled] from `isFeatureEnabledProvider(FeatureFlag.feedTuning)`,
+/// which is off by default until the relay and recommendation backend ship.
+class FeedTuningSwipeGate extends StatelessWidget {
+  /// Creates a feature-gated swipe-to-tune wrapper around [child].
+  const FeedTuningSwipeGate({
+    required this.enabled,
+    required this.onTuned,
+    required this.child,
+    super.key,
+  });
+
+  /// Whether the swipe-to-tune gesture is active.
+  final bool enabled;
+
+  /// Called when a swipe commits past the threshold.
+  final ValueChanged<FeedTuningDirection> onTuned;
+
+  /// The feed content the gesture wraps when [enabled].
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return child;
+    return FeedTuningSwipeOverlay(onTuned: onTuned, child: child);
+  }
+}
+
 class _TuningIndicator extends StatelessWidget {
   const _TuningIndicator({required this.direction, required this.progress});
 

--- a/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
+++ b/mobile/lib/widgets/feed_tuning/feed_tuning_swipe_overlay.dart
@@ -1,0 +1,164 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Horizontal-swipe detector over the fullscreen feed that lets the user tune
+/// recommendations: swipe right = "more like this", swipe left = "less like
+/// this".
+///
+/// A committing swipe fires [onTuned]; the parent publishes the signal and
+/// pages the feed forward. The child follows the finger and a directional
+/// indicator brightens with drag progress; crossing [commitThreshold] fires a
+/// haptic tick. Releasing before the threshold snaps back and does nothing.
+/// Screen-reader users get the same two actions via custom semantic actions.
+class FeedTuningSwipeOverlay extends StatefulWidget {
+  /// Creates a swipe-to-tune overlay around [child].
+  const FeedTuningSwipeOverlay({
+    required this.onTuned,
+    required this.child,
+    this.commitThreshold = 96,
+    super.key,
+  });
+
+  /// Called when a swipe commits past [commitThreshold].
+  final ValueChanged<FeedTuningDirection> onTuned;
+
+  /// The feed content the gesture wraps.
+  final Widget child;
+
+  /// Horizontal drag distance (logical pixels) needed to commit a tune.
+  final double commitThreshold;
+
+  @override
+  State<FeedTuningSwipeOverlay> createState() => _FeedTuningSwipeOverlayState();
+}
+
+class _FeedTuningSwipeOverlayState extends State<FeedTuningSwipeOverlay> {
+  double _dragExtent = 0;
+  bool _passedThreshold = false;
+
+  double get _progress =>
+      (_dragExtent.abs() / widget.commitThreshold).clamp(0.0, 1.0);
+
+  FeedTuningDirection? get _direction {
+    if (_dragExtent == 0) return null;
+    return _dragExtent > 0
+        ? FeedTuningDirection.more
+        : FeedTuningDirection.less;
+  }
+
+  void _onUpdate(DragUpdateDetails details) {
+    setState(() => _dragExtent += details.delta.dx);
+    final passed = _dragExtent.abs() >= widget.commitThreshold;
+    if (passed && !_passedThreshold) {
+      HapticFeedback.selectionClick();
+    }
+    _passedThreshold = passed;
+  }
+
+  void _onEnd(DragEndDetails details) {
+    final direction = _direction;
+    final committed = _passedThreshold && direction != null;
+    _reset();
+    if (committed) widget.onTuned(direction);
+  }
+
+  void _reset() {
+    setState(() {
+      _dragExtent = 0;
+      _passedThreshold = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final direction = _direction;
+    return Semantics(
+      container: true,
+      customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
+        CustomSemanticsAction(label: l10n.feedTuningMoreLabel): () =>
+            widget.onTuned(FeedTuningDirection.more),
+        CustomSemanticsAction(label: l10n.feedTuningLessLabel): () =>
+            widget.onTuned(FeedTuningDirection.less),
+      },
+      child: GestureDetector(
+        behavior: HitTestBehavior.translucent,
+        onHorizontalDragUpdate: _onUpdate,
+        onHorizontalDragEnd: _onEnd,
+        onHorizontalDragCancel: _reset,
+        child: Stack(
+          fit: StackFit.passthrough,
+          children: [
+            Transform.translate(
+              offset: Offset(_dragExtent * 0.4, 0),
+              child: widget.child,
+            ),
+            if (direction != null)
+              Positioned.fill(
+                child: IgnorePointer(
+                  child: _TuningIndicator(
+                    direction: direction,
+                    progress: _progress,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TuningIndicator extends StatelessWidget {
+  const _TuningIndicator({required this.direction, required this.progress});
+
+  final FeedTuningDirection direction;
+  final double progress;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final isMore = direction == FeedTuningDirection.more;
+    final color = isMore ? VineTheme.vineGreen : VineTheme.onSurfaceMuted;
+    final label = isMore ? l10n.feedTuningMoreLabel : l10n.feedTuningLessLabel;
+    final icon = isMore ? DivineIconName.arrowUp : DivineIconName.arrowDown;
+
+    return Align(
+      alignment: isMore ? Alignment.centerRight : Alignment.centerLeft,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Opacity(
+          opacity: progress,
+          child: Transform.scale(
+            scale: 0.8 + 0.2 * progress,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: VineTheme.surfaceContainerHigh.withValues(alpha: 0.9),
+                borderRadius: BorderRadius.circular(999),
+                border: Border.all(color: color, width: 2),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 10,
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    DivineIcon(icon: icon, color: color, size: 28),
+                    const SizedBox(height: 4),
+                    Text(label, style: VineTheme.labelLargeFont(color: color)),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/packages/feed_tuning_repository/analysis_options.yaml
+++ b/mobile/packages/feed_tuning_repository/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/feed_tuning_repository/lib/feed_tuning_repository.dart
+++ b/mobile/packages/feed_tuning_repository/lib/feed_tuning_repository.dart
@@ -1,0 +1,3 @@
+export 'src/feed_tuning_direction.dart';
+export 'src/feed_tuning_reportable_sites.dart';
+export 'src/feed_tuning_repository.dart';

--- a/mobile/packages/feed_tuning_repository/lib/src/feed_tuning_direction.dart
+++ b/mobile/packages/feed_tuning_repository/lib/src/feed_tuning_direction.dart
@@ -1,0 +1,18 @@
+/// Direction of a feed-tuning swipe.
+///
+/// [more] = "more like this" (swipe right); [less] = "less like this"
+/// (swipe left). The [tagValue] is what travels in the event's `direction`
+/// tag, so the backend reads a stable string rather than an enum index.
+enum FeedTuningDirection {
+  /// "More like this" — swipe right.
+  more,
+
+  /// "Less like this" — swipe left.
+  less;
+
+  /// The value written into the event's `["direction", ...]` tag.
+  String get tagValue => switch (this) {
+    FeedTuningDirection.more => 'more',
+    FeedTuningDirection.less => 'less',
+  };
+}

--- a/mobile/packages/feed_tuning_repository/lib/src/feed_tuning_reportable_sites.dart
+++ b/mobile/packages/feed_tuning_repository/lib/src/feed_tuning_reportable_sites.dart
@@ -1,0 +1,11 @@
+/// Crashlytics `site` identifiers for `FeedTuningRepository` error reports.
+///
+/// Network/relay publish failures are expected and NOT reported (see the
+/// repository). These sites mark the only programming-invariant paths.
+abstract class FeedTuningReportableSites {
+  /// Site for failures while publishing a tuning signal.
+  static const String tune = 'tune';
+
+  /// Site for failures while publishing a tuning retraction.
+  static const String undo = 'undo';
+}

--- a/mobile/packages/feed_tuning_repository/lib/src/feed_tuning_repository.dart
+++ b/mobile/packages/feed_tuning_repository/lib/src/feed_tuning_repository.dart
@@ -19,6 +19,10 @@ abstract class FeedTuningTags {
   static const String direction = 'direction';
 }
 
+/// Canonical Divine relay hint used when the source video does not carry one.
+@visibleForTesting
+const feedTuningDefaultRelayHint = 'wss://relay.divine.video';
+
 /// Publishes Divine feed-tuning signals — "more like this" / "less like this"
 /// swipes — as append-only [EventKind.feedTuning] events, and retracts them
 /// via NIP-09 deletions.
@@ -128,10 +132,7 @@ class FeedTuningRepository {
   }
 
   List<String> _eTag(VideoEvent video) {
-    final relay = video.sourceRelay;
-    return (relay == null || relay.isEmpty)
-        ? ['e', video.id]
-        : ['e', video.id, relay];
+    return ['e', video.id, _relayHint(video)];
   }
 
   /// The addressable coordinate, only when the source video carried a real `d`
@@ -143,9 +144,11 @@ class FeedTuningRepository {
     if (dTag == null || dTag.isEmpty) return null;
 
     final coordinate = '$kind:${video.pubkey}:$dTag';
+    return ['a', coordinate, _relayHint(video)];
+  }
+
+  String _relayHint(VideoEvent video) {
     final relay = video.sourceRelay;
-    return (relay == null || relay.isEmpty)
-        ? ['a', coordinate]
-        : ['a', coordinate, relay];
+    return relay == null || relay.isEmpty ? feedTuningDefaultRelayHint : relay;
   }
 }

--- a/mobile/packages/feed_tuning_repository/lib/src/feed_tuning_repository.dart
+++ b/mobile/packages/feed_tuning_repository/lib/src/feed_tuning_repository.dart
@@ -1,0 +1,151 @@
+import 'package:feed_tuning_repository/src/feed_tuning_direction.dart';
+import 'package:feed_tuning_repository/src/feed_tuning_reportable_sites.dart';
+import 'package:meta/meta.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+/// Reports an unexpected (invariant-violating) error to Crashlytics.
+///
+/// Wired in the app layer to `CrashReportingService.instance.recordError`.
+/// Expected failures (no signer, relay/network errors) are NOT reported.
+typedef FeedTuningErrorReporter =
+    void Function(Object error, StackTrace stackTrace, {required String site});
+
+/// Tag names used by the feed-tuning event contract.
+@visibleForTesting
+abstract class FeedTuningTags {
+  /// The `direction` tag name carrying `"more"` or `"less"`.
+  static const String direction = 'direction';
+}
+
+/// Publishes Divine feed-tuning signals — "more like this" / "less like this"
+/// swipes — as append-only [EventKind.feedTuning] events, and retracts them
+/// via NIP-09 deletions.
+///
+/// The signal is public, latest-wins, and read only by funnelcake/Gorse. It is
+/// deliberately separate from the social Like (NIP-25 reaction) and is never a
+/// moderation/block signal.
+class FeedTuningRepository {
+  /// Creates a repository that publishes via [nostrClient]. [errorReporter],
+  /// when provided, receives only invariant-violating failures.
+  FeedTuningRepository({
+    required NostrClient nostrClient,
+    FeedTuningErrorReporter? errorReporter,
+  }) : _nostrClient = nostrClient,
+       _report = errorReporter;
+
+  final NostrClient _nostrClient;
+  final FeedTuningErrorReporter? _report;
+
+  /// Publishes a feed-tuning signal for [video] in the given [direction].
+  ///
+  /// Fire-and-forget: relay failures are swallowed (expected on flaky
+  /// networks). Returns the published event id — known synchronously at
+  /// construction — or `null` when there is no signer and nothing was
+  /// attempted.
+  Future<String?> tune({
+    required VideoEvent video,
+    required FeedTuningDirection direction,
+  }) async {
+    final event = _build(
+      kind: EventKind.feedTuning,
+      tags: _tuneTags(video, direction),
+      site: FeedTuningReportableSites.tune,
+    );
+    if (event == null) return null;
+    await _publish(event);
+    return event.id;
+  }
+
+  /// Retracts a previously-published feed-tuning event via a NIP-09 (kind-5)
+  /// deletion referencing [feedTuningEventId]. No-op without a signer.
+  Future<void> undo(String feedTuningEventId) async {
+    final event = _build(
+      kind: EventKind.eventDeletion,
+      tags: [
+        ['e', feedTuningEventId],
+        ['k', '${EventKind.feedTuning}'],
+      ],
+      site: FeedTuningReportableSites.undo,
+    );
+    if (event == null) return;
+    await _publish(event);
+  }
+
+  Event? _build({
+    required int kind,
+    required List<List<String>> tags,
+    required String site,
+  }) {
+    final String pubkey;
+    try {
+      pubkey = _nostrClient.publicKey;
+    } on Object {
+      // No signer / no public key yet — expected during cold start or signed
+      // out. Nothing to publish, nothing to report.
+      return null;
+    }
+    if (pubkey.isEmpty) return null;
+
+    try {
+      return Event(pubkey, kind, tags, '');
+    } on Object catch (error, stackTrace) {
+      _report?.call(error, stackTrace, site: site);
+      return null;
+    }
+  }
+
+  Future<void> _publish(Event event) async {
+    try {
+      await _nostrClient.publishEvent(event);
+    } on Object {
+      // Relay/network publish failures are expected; surfaced via UX, not
+      // Crashlytics. The append-only event is latest-wins, so a dropped
+      // publish self-heals on the next swipe.
+    }
+  }
+
+  List<List<String>> _tuneTags(
+    VideoEvent video,
+    FeedTuningDirection direction,
+  ) {
+    final kind = video.eventKind ?? EventKind.videoVertical;
+    final tags = <List<String>>[
+      [FeedTuningTags.direction, direction.tagValue],
+      _eTag(video),
+    ];
+
+    final aTag = _aTag(video, kind);
+    if (aTag != null) tags.add(aTag);
+
+    tags.add(['p', video.pubkey]);
+    for (final hashtag in video.hashtags) {
+      tags.add(['t', hashtag]);
+    }
+    tags.add(['k', '$kind']);
+    return tags;
+  }
+
+  List<String> _eTag(VideoEvent video) {
+    final relay = video.sourceRelay;
+    return (relay == null || relay.isEmpty)
+        ? ['e', video.id]
+        : ['e', video.id, relay];
+  }
+
+  /// The addressable coordinate, only when the source video carried a real `d`
+  /// tag. [VideoEvent.vineId] falls back to the event id when there is no `d`
+  /// tag, which would fabricate a coordinate — so gate on the raw tag instead.
+  List<String>? _aTag(VideoEvent video, int kind) {
+    if (!video.rawTags.containsKey('d')) return null;
+    final dTag = video.vineId;
+    if (dTag == null || dTag.isEmpty) return null;
+
+    final coordinate = '$kind:${video.pubkey}:$dTag';
+    final relay = video.sourceRelay;
+    return (relay == null || relay.isEmpty)
+        ? ['a', coordinate]
+        : ['a', coordinate, relay];
+  }
+}

--- a/mobile/packages/feed_tuning_repository/pubspec.yaml
+++ b/mobile/packages/feed_tuning_repository/pubspec.yaml
@@ -1,0 +1,27 @@
+name: feed_tuning_repository
+description: >-
+  Publishes Divine "feed-tuning" signals (swipe more/less like this) as
+  append-only Nostr events for funnelcake/Gorse to personalize recommendations.
+version: 0.1.0+1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+  meta: ^1.17.0
+  models:
+    path: ../models
+  nostr_client:
+    path: ../nostr_client
+  nostr_sdk:
+    path: ../nostr_sdk
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.4
+  very_good_analysis: ^10.2.0

--- a/mobile/packages/feed_tuning_repository/test/feed_tuning_repository_test.dart
+++ b/mobile/packages/feed_tuning_repository/test/feed_tuning_repository_test.dart
@@ -1,0 +1,285 @@
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+final String _userPubkey = 'a' * 64;
+
+VideoEvent _video({
+  String id = 'video-event-id-0001',
+  String pubkey = 'creator-pubkey-hex',
+  Map<String, String> rawTags = const {},
+  String? vineId,
+  List<String> hashtags = const [],
+  String? sourceRelay,
+  int? eventKind,
+}) {
+  return VideoEvent(
+    id: id,
+    pubkey: pubkey,
+    createdAt: 0,
+    content: '',
+    timestamp: DateTime(2020),
+    rawTags: rawTags,
+    vineId: vineId,
+    hashtags: hashtags,
+    sourceRelay: sourceRelay,
+    eventKind: eventKind,
+  );
+}
+
+List<String>? _tag(Event event, String name) {
+  for (final tag in event.tags) {
+    if (tag.isNotEmpty && tag.first == name) return tag;
+  }
+  return null;
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Event(_userPubkey, EventKind.textNote, const [], ''));
+  });
+
+  group(FeedTuningRepository, () {
+    late _MockNostrClient nostrClient;
+    late List<({Object error, String site})> reported;
+    late FeedTuningRepository repository;
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      reported = [];
+      when(() => nostrClient.publicKey).thenReturn(_userPubkey);
+      when(() => nostrClient.publishEvent(any())).thenAnswer(
+        (invocation) async => PublishSuccess(
+          event: invocation.positionalArguments.first as Event,
+        ),
+      );
+      repository = FeedTuningRepository(
+        nostrClient: nostrClient,
+        errorReporter: (error, stackTrace, {required site}) =>
+            reported.add((error: error, site: site)),
+      );
+    });
+
+    Event capturedEvent() =>
+        verify(() => nostrClient.publishEvent(captureAny())).captured.single
+            as Event;
+
+    group('tune', () {
+      test('publishes a feedTuning event signed by the current user', () async {
+        await repository.tune(
+          video: _video(),
+          direction: FeedTuningDirection.more,
+        );
+
+        final event = capturedEvent();
+        expect(event.kind, equals(EventKind.feedTuning));
+        expect(event.pubkey, equals(_userPubkey));
+        expect(event.content, isEmpty);
+      });
+
+      test('encodes "more" in the direction tag', () async {
+        await repository.tune(
+          video: _video(),
+          direction: FeedTuningDirection.more,
+        );
+        expect(
+          _tag(capturedEvent(), 'direction'),
+          equals(['direction', 'more']),
+        );
+      });
+
+      test('encodes "less" in the direction tag', () async {
+        await repository.tune(
+          video: _video(),
+          direction: FeedTuningDirection.less,
+        );
+        expect(
+          _tag(capturedEvent(), 'direction'),
+          equals(['direction', 'less']),
+        );
+      });
+
+      test('tags the video event id, creator, and target kind', () async {
+        await repository.tune(
+          video: _video(id: 'vid-123', pubkey: 'creator-99', eventKind: 34236),
+          direction: FeedTuningDirection.more,
+        );
+
+        final event = capturedEvent();
+        expect(_tag(event, 'e'), equals(['e', 'vid-123']));
+        expect(_tag(event, 'p'), equals(['p', 'creator-99']));
+        expect(_tag(event, 'k'), equals(['k', '34236']));
+      });
+
+      test('omits the a tag when the video has no real d tag', () async {
+        await repository.tune(
+          video: _video(vineId: 'falls-back-to-event-id'),
+          direction: FeedTuningDirection.more,
+        );
+        expect(_tag(capturedEvent(), 'a'), isNull);
+      });
+
+      test('includes the a coordinate when a real d tag is present', () async {
+        await repository.tune(
+          video: _video(
+            pubkey: 'creator-99',
+            rawTags: const {'d': 'real-d-tag'},
+            vineId: 'real-d-tag',
+            eventKind: 34236,
+          ),
+          direction: FeedTuningDirection.more,
+        );
+        expect(
+          _tag(capturedEvent(), 'a'),
+          equals(['a', '34236:creator-99:real-d-tag']),
+        );
+      });
+
+      test('builds the a coordinate from the actual video kind', () async {
+        await repository.tune(
+          video: _video(
+            pubkey: 'creator-99',
+            rawTags: const {'d': 'real-d-tag'},
+            vineId: 'real-d-tag',
+            eventKind: 34235,
+          ),
+          direction: FeedTuningDirection.more,
+        );
+        expect(
+          _tag(capturedEvent(), 'a'),
+          equals(['a', '34235:creator-99:real-d-tag']),
+        );
+      });
+
+      test('emits one t tag per hashtag', () async {
+        await repository.tune(
+          video: _video(hashtags: const ['fitness', 'cats']),
+          direction: FeedTuningDirection.more,
+        );
+
+        final tTags = capturedEvent().tags.where(
+          (t) => t.isNotEmpty && t.first == 't',
+        );
+        expect(
+          tTags,
+          equals([
+            ['t', 'fitness'],
+            ['t', 'cats'],
+          ]),
+        );
+      });
+
+      test(
+        'adds a relay hint to e and a tags when sourceRelay is set',
+        () async {
+          await repository.tune(
+            video: _video(
+              pubkey: 'creator-99',
+              rawTags: const {'d': 'real-d-tag'},
+              vineId: 'real-d-tag',
+              sourceRelay: 'wss://relay.divine.video',
+            ),
+            direction: FeedTuningDirection.more,
+          );
+
+          final event = capturedEvent();
+          expect(_tag(event, 'e')!.last, equals('wss://relay.divine.video'));
+          expect(_tag(event, 'a')!.last, equals('wss://relay.divine.video'));
+        },
+      );
+
+      test('returns the published event id', () async {
+        final id = await repository.tune(
+          video: _video(),
+          direction: FeedTuningDirection.more,
+        );
+        expect(id, equals(capturedEvent().id));
+      });
+
+      test(
+        'returns null and does not publish when there is no public key',
+        () async {
+          when(() => nostrClient.publicKey).thenReturn('');
+
+          final id = await repository.tune(
+            video: _video(),
+            direction: FeedTuningDirection.more,
+          );
+
+          expect(id, isNull);
+          verifyNever(() => nostrClient.publishEvent(any()));
+        },
+      );
+
+      test('returns null when the signer is unavailable (throws)', () async {
+        when(() => nostrClient.publicKey).thenThrow(StateError('no key'));
+
+        final id = await repository.tune(
+          video: _video(),
+          direction: FeedTuningDirection.more,
+        );
+
+        expect(id, isNull);
+        verifyNever(() => nostrClient.publishEvent(any()));
+        expect(reported, isEmpty);
+      });
+
+      test(
+        'still returns the id and does not report on relay failure',
+        () async {
+          when(
+            () => nostrClient.publishEvent(any()),
+          ).thenThrow(Exception('relay down'));
+
+          final id = await repository.tune(
+            video: _video(),
+            direction: FeedTuningDirection.more,
+          );
+
+          expect(id, isNotNull);
+          expect(reported, isEmpty);
+        },
+      );
+
+      test(
+        'reports an invariant violation when the user key is invalid',
+        () async {
+          when(() => nostrClient.publicKey).thenReturn('not-a-valid-hex-key');
+
+          final id = await repository.tune(
+            video: _video(),
+            direction: FeedTuningDirection.more,
+          );
+
+          expect(id, isNull);
+          expect(reported.single.site, equals(FeedTuningReportableSites.tune));
+        },
+      );
+    });
+
+    group('undo', () {
+      test(
+        'publishes a kind-5 deletion referencing the tuning event',
+        () async {
+          await repository.undo('tuning-event-id-77');
+
+          final event = capturedEvent();
+          expect(event.kind, equals(EventKind.eventDeletion));
+          expect(_tag(event, 'e'), equals(['e', 'tuning-event-id-77']));
+          expect(_tag(event, 'k'), equals(['k', '${EventKind.feedTuning}']));
+        },
+      );
+
+      test('is a no-op without a signer', () async {
+        when(() => nostrClient.publicKey).thenReturn('');
+        await repository.undo('tuning-event-id-77');
+        verifyNever(() => nostrClient.publishEvent(any()));
+      });
+    });
+  });
+}

--- a/mobile/packages/feed_tuning_repository/test/feed_tuning_repository_test.dart
+++ b/mobile/packages/feed_tuning_repository/test/feed_tuning_repository_test.dart
@@ -111,7 +111,10 @@ void main() {
         );
 
         final event = capturedEvent();
-        expect(_tag(event, 'e'), equals(['e', 'vid-123']));
+        expect(
+          _tag(event, 'e'),
+          equals(['e', 'vid-123', feedTuningDefaultRelayHint]),
+        );
         expect(_tag(event, 'p'), equals(['p', 'creator-99']));
         expect(_tag(event, 'k'), equals(['k', '34236']));
       });
@@ -136,7 +139,11 @@ void main() {
         );
         expect(
           _tag(capturedEvent(), 'a'),
-          equals(['a', '34236:creator-99:real-d-tag']),
+          equals([
+            'a',
+            '34236:creator-99:real-d-tag',
+            feedTuningDefaultRelayHint,
+          ]),
         );
       });
 
@@ -152,7 +159,11 @@ void main() {
         );
         expect(
           _tag(capturedEvent(), 'a'),
-          equals(['a', '34235:creator-99:real-d-tag']),
+          equals([
+            'a',
+            '34235:creator-99:real-d-tag',
+            feedTuningDefaultRelayHint,
+          ]),
         );
       });
 

--- a/mobile/packages/nostr_sdk/lib/event_kind.dart
+++ b/mobile/packages/nostr_sdk/lib/event_kind.dart
@@ -142,6 +142,15 @@ class EventKind {
 
   static const int groupMembers = 39002;
 
+  /// Divine "feed-tuning" signal — a private feed-shaping swipe ("more"/"less"
+  /// like this), published as an append-only regular event and consumed by
+  /// funnelcake/Gorse to personalize recommendations. Not a NIP-25 reaction and
+  /// not a moderation signal.
+  ///
+  /// The number is owned jointly with the backend: it must match the kind the
+  /// funnelcake ingestion reserves and that the divine relay allow-lists.
+  static const int feedTuning = 4242;
+
   // ---------------------------------------------------------------------------
   // NIP-01 Replaceable Event Helpers
   // ---------------------------------------------------------------------------

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -44,6 +44,7 @@ workspace:
   - packages/dm_repository
   - packages/divine_video_player
   - packages/feed_repository
+  - packages/feed_tuning_repository
   - packages/infinite_video_feed
   - packages/follow_repository
   - packages/funnelcake_api_client

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -195,6 +195,9 @@ dependencies:
   # Feed Repository - ViewSource-resolved, lifecycle-stable video feeds (#3383)
   feed_repository:
 
+  # Feed Tuning Repository - publishes swipe "more/less like this" signals
+  feed_tuning_repository:
+
   # Curated List Repository - NIP-51 kind 30005 curated video lists
   curated_list_repository:
 

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -25,7 +26,22 @@ class MockBlossomAuthService extends Mock implements BlossomAuthService {}
 
 class MockFile extends Mock implements File {}
 
+class MockFeedTuningRepository extends Mock implements FeedTuningRepository {}
+
 void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      VideoEvent(
+        id: 'fallback',
+        pubkey: '0' * 64,
+        createdAt: 0,
+        content: '',
+        timestamp: DateTime(2020),
+      ),
+    );
+    registerFallbackValue(FeedTuningDirection.more);
+  });
+
   group('FullscreenFeedBloc', () {
     late StreamController<List<VideoEvent>> videosController;
     late StreamController<bool> hasMoreController;
@@ -82,6 +98,7 @@ void main() {
       MediaAvailabilityChecker? availabilityChecker,
       BlockAuthorFilter? blockFilter,
       UnavailableVideoFilter? unavailableFilter,
+      FeedTuningRepository? feedTuningRepository,
     }) => FullscreenFeedBloc(
       videosStream: videosController.stream,
       initialIndex: initialIndex,
@@ -96,6 +113,7 @@ void main() {
       availabilityChecker: availabilityChecker,
       blockFilter: blockFilter,
       unavailableFilter: unavailableFilter,
+      feedTuningRepository: feedTuningRepository,
     );
 
     test('initial state has correct values', () {
@@ -224,7 +242,105 @@ void main() {
           null,
           false,
           false,
+          null,
         ]);
+      });
+
+      group('feed tuning', () {
+        late MockFeedTuningRepository tuningRepository;
+
+        setUp(() {
+          tuningRepository = MockFeedTuningRepository();
+          when(
+            () => tuningRepository.tune(
+              video: any(named: 'video'),
+              direction: any(named: 'direction'),
+            ),
+          ).thenAnswer((_) async => 'published-id');
+          when(() => tuningRepository.undo(any())).thenAnswer((_) async {});
+        });
+
+        blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+          'publishes the swiped video and records the action without removal',
+          build: () => createBloc(feedTuningRepository: tuningRepository),
+          act: (bloc) async {
+            bloc.add(const FullscreenFeedStarted());
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            videosController.add([
+              createTestVideo('video1'),
+              createTestVideo('video2'),
+            ]);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            bloc.add(
+              const FullscreenFeedTuningSwipeCommitted(
+                videoId: 'video1',
+                direction: FeedTuningDirection.less,
+              ),
+            );
+          },
+          wait: const Duration(milliseconds: 100),
+          verify: (bloc) {
+            final captured = verify(
+              () => tuningRepository.tune(
+                video: captureAny(named: 'video'),
+                direction: FeedTuningDirection.less,
+              ),
+            ).captured;
+            expect((captured.single as VideoEvent).id, 'video1');
+            expect(bloc.state.lastTuningAction?.videoId, 'video1');
+            expect(
+              bloc.state.lastTuningAction?.direction,
+              FeedTuningDirection.less,
+            );
+            expect(
+              bloc.state.lastTuningAction?.publishedEventId,
+              'published-id',
+            );
+            expect(bloc.state.removedVideoIds, isEmpty);
+          },
+        );
+
+        blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+          'is a no-op when the swiped video is not in the feed',
+          build: () => createBloc(feedTuningRepository: tuningRepository),
+          act: (bloc) async {
+            bloc.add(const FullscreenFeedStarted());
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            videosController.add([createTestVideo('video1')]);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            bloc.add(
+              const FullscreenFeedTuningSwipeCommitted(
+                videoId: 'missing',
+                direction: FeedTuningDirection.more,
+              ),
+            );
+          },
+          wait: const Duration(milliseconds: 100),
+          verify: (bloc) {
+            verifyNever(
+              () => tuningRepository.tune(
+                video: any(named: 'video'),
+                direction: any(named: 'direction'),
+              ),
+            );
+            expect(bloc.state.lastTuningAction, isNull);
+          },
+        );
+
+        blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+          'retracts the signal via the repository on undo',
+          build: () => createBloc(feedTuningRepository: tuningRepository),
+          act: (bloc) async {
+            bloc.add(
+              const FullscreenFeedTuningUndoRequested('tuning-event-id'),
+            );
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+          },
+          wait: const Duration(milliseconds: 100),
+          verify: (_) {
+            verify(() => tuningRepository.undo('tuning-event-id')).called(1);
+          },
+        );
       });
 
       test('videoUpdateSignature changes when loop metadata changes', () {

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -296,7 +296,42 @@ void main() {
               bloc.state.lastTuningAction?.publishedEventId,
               'published-id',
             );
+            expect(bloc.state.lastTuningAction?.sequence, 1);
             expect(bloc.state.removedVideoIds, isEmpty);
+          },
+        );
+
+        blocTest<FullscreenFeedBloc, FullscreenFeedState>(
+          'records identical repeated swipes as distinct actions',
+          build: () => createBloc(feedTuningRepository: tuningRepository),
+          act: (bloc) async {
+            bloc.add(const FullscreenFeedStarted());
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            videosController.add([createTestVideo('video1')]);
+            await Future<void>.delayed(const Duration(milliseconds: 50));
+            bloc
+              ..add(
+                const FullscreenFeedTuningSwipeCommitted(
+                  videoId: 'video1',
+                  direction: FeedTuningDirection.more,
+                ),
+              )
+              ..add(
+                const FullscreenFeedTuningSwipeCommitted(
+                  videoId: 'video1',
+                  direction: FeedTuningDirection.more,
+                ),
+              );
+          },
+          wait: const Duration(milliseconds: 150),
+          verify: (bloc) {
+            verify(
+              () => tuningRepository.tune(
+                video: any(named: 'video'),
+                direction: FeedTuningDirection.more,
+              ),
+            ).called(2);
+            expect(bloc.state.lastTuningAction?.sequence, 2);
           },
         );
 

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -814,6 +814,11 @@ const _knownUntranslatedDebt = {
   'subtitleEditorSaveError',
   'subtitleEditorRetry',
   'subtitleEditorCueHint',
+  // Added by the swipe-to-tune feed feature. Existing locales fall back to
+  // English until the next translation pass.
+  'feedTuningMoreLabel',
+  'feedTuningLessLabel',
+  'feedTuningUndo',
 };
 
 Map<String, Object?> _readArb(File file) {

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -1,0 +1,108 @@
+import 'package:feed_tuning_repository/feed_tuning_repository.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/widgets/feed_tuning/feed_tuning_swipe_overlay.dart';
+
+void main() {
+  final l10n = lookupAppLocalizations(const Locale('en'));
+
+  Future<List<FeedTuningDirection>> pumpOverlay(WidgetTester tester) async {
+    final tuned = <FeedTuningDirection>[];
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: Center(
+            child: FeedTuningSwipeOverlay(
+              onTuned: tuned.add,
+              child: const SizedBox(width: 300, height: 500),
+            ),
+          ),
+        ),
+      ),
+    );
+    return tuned;
+  }
+
+  group(FeedTuningSwipeOverlay, () {
+    testWidgets('swiping right past the threshold tunes "more"', (
+      tester,
+    ) async {
+      final tuned = await pumpOverlay(tester);
+
+      await tester.drag(
+        find.byType(FeedTuningSwipeOverlay),
+        const Offset(200, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.more]);
+    });
+
+    testWidgets('swiping left past the threshold tunes "less"', (tester) async {
+      final tuned = await pumpOverlay(tester);
+
+      await tester.drag(
+        find.byType(FeedTuningSwipeOverlay),
+        const Offset(-200, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.less]);
+    });
+
+    testWidgets('a short swipe below the threshold does not tune', (
+      tester,
+    ) async {
+      final tuned = await pumpOverlay(tester);
+
+      await tester.drag(
+        find.byType(FeedTuningSwipeOverlay),
+        const Offset(30, 0),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tuned, isEmpty);
+    });
+
+    testWidgets('shows the directional indicator during a drag', (
+      tester,
+    ) async {
+      await pumpOverlay(tester);
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(FeedTuningSwipeOverlay)),
+      );
+      await gesture.moveBy(const Offset(60, 0));
+      await tester.pump();
+
+      expect(find.text(l10n.feedTuningMoreLabel), findsOneWidget);
+      expect(find.text(l10n.feedTuningLessLabel), findsNothing);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('exposes more/less as custom semantic actions', (tester) async {
+      final handle = tester.ensureSemantics();
+      await pumpOverlay(tester);
+
+      final moreId = CustomSemanticsAction.getIdentifier(
+        CustomSemanticsAction(label: l10n.feedTuningMoreLabel),
+      );
+      final lessId = CustomSemanticsAction.getIdentifier(
+        CustomSemanticsAction(label: l10n.feedTuningLessLabel),
+      );
+      final node = tester.getSemantics(find.byType(FeedTuningSwipeOverlay));
+
+      expect(
+        node.getSemanticsData().customSemanticsActionIds,
+        containsAll(<int>[moreId, lessId]),
+      );
+      handle.dispose();
+    });
+  });
+}

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -106,6 +106,84 @@ void main() {
     });
   });
 
+  group('gesture arena vs. vertical paging', () {
+    testWidgets('horizontal swipe tunes WITHOUT changing the page', (
+      tester,
+    ) async {
+      final tuned = <FeedTuningDirection>[];
+      final controller = PageController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: FeedTuningSwipeOverlay(
+              onTuned: tuned.add,
+              child: PageView(
+                controller: controller,
+                scrollDirection: Axis.vertical,
+                children: const [
+                  SizedBox.expand(child: Center(child: Text('page-0'))),
+                  SizedBox.expand(child: Center(child: Text('page-1'))),
+                  SizedBox.expand(child: Center(child: Text('page-2'))),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.fling(
+        find.byType(FeedTuningSwipeOverlay),
+        const Offset(-300, 0),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tuned, [FeedTuningDirection.less]);
+      expect(controller.page, 0); // vertical pager untouched
+    });
+
+    testWidgets('vertical swipe pages WITHOUT tuning', (tester) async {
+      final tuned = <FeedTuningDirection>[];
+      final controller = PageController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: FeedTuningSwipeOverlay(
+              onTuned: tuned.add,
+              child: PageView(
+                controller: controller,
+                scrollDirection: Axis.vertical,
+                children: const [
+                  SizedBox.expand(child: Center(child: Text('page-0'))),
+                  SizedBox.expand(child: Center(child: Text('page-1'))),
+                  SizedBox.expand(child: Center(child: Text('page-2'))),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.fling(
+        find.byType(FeedTuningSwipeOverlay),
+        const Offset(0, -600),
+        1500,
+      );
+      await tester.pumpAndSettle();
+
+      expect(tuned, isEmpty);
+      expect(controller.page, 1); // advanced one page
+    });
+  });
+
   group(FeedTuningSwipeGate, () {
     testWidgets('wraps the child with the overlay when enabled', (
       tester,

--- a/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
+++ b/mobile/test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart
@@ -105,4 +105,46 @@ void main() {
       handle.dispose();
     });
   });
+
+  group(FeedTuningSwipeGate, () {
+    testWidgets('wraps the child with the overlay when enabled', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: FeedTuningSwipeGate(
+              enabled: true,
+              onTuned: (_) {},
+              child: const SizedBox(width: 100, height: 100),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(FeedTuningSwipeOverlay), findsOneWidget);
+    });
+
+    testWidgets('renders only the child when disabled', (tester) async {
+      const childKey = Key('feed-child');
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: FeedTuningSwipeGate(
+              enabled: false,
+              onTuned: _noop,
+              child: SizedBox(key: childKey, width: 100, height: 100),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(FeedTuningSwipeOverlay), findsNothing);
+      expect(find.byKey(childKey), findsOneWidget);
+    });
+  });
 }
+
+void _noop(FeedTuningDirection _) {}


### PR DESCRIPTION
## What

Closes #5517.

Lets users directly shape their own algorithm from the fullscreen feed:

- **Swipe right** = "more like this"
- **Swipe left** = "less like this"

Each committed swipe publishes a small public Nostr event and pages forward.
The later funnelcake/Gorse change can read these events from the relay and feed
them into recommendations for `GET /api/users/{pubkey}/recommendations`.

This PR is the divine-mobile client half only: gesture, indicators,
accessibility actions, BLoC/repository publishing, and Undo. The relay and
backend rollout remains separate, and the feature flag is off by default until
that work is ready.

Design + the funnelcake agent brief live in
`docs/superpowers/specs/2026-06-25-swipe-feed-tuning-*.md`.

## The signal

A dedicated append-only kind, `EventKind.feedTuning = 4242`, deliberately not a
NIP-25 reaction and not NIP-32 kind 1985:

```text
kind: 4242
tags:
  ["direction", "more"|"less"]
  ["e", <videoEventId>, <relayHint>]   // authoritative item key, always present
  ["a", "34236:<pubkey>:<dTag>", ...]  // only when the video has a real d tag
  ["p", <authorPubkey>]
  ["t", <hashtag>] ...
  ["k", "<videoKind>"]
```

`e` is the authoritative item key. `a` is best-effort because
`VideoEvent.vineId` falls back to the event id when there is no real `d` tag;
the repository gates it on `rawTags.containsKey('d')` so it never fabricates a
coordinate. `video.sourceRelay` is used as the relay hint when available,
otherwise the canonical Divine relay hint is used.

## How it is built

- **`feed_tuning_repository`**: Flutter workspace package with no UI
  dependencies; builds and publishes the feed-tuning event plus the NIP-09
  deletion for Undo. Relay failures are swallowed as expected network outcomes;
  invariant failures go through the reporter port.
- **`FullscreenFeedBloc`**: handles `FullscreenFeedTuningSwipeCommitted` and
  `FullscreenFeedTuningUndoRequested`, publishes the signal, and records a
  `lastTuningAction` outbox with a sequence id so repeated identical swipes
  still notify listeners. It does not mutate the video list or touch
  `removedVideoIds`.
- **`FeedTuningSwipeOverlay`**: horizontal drag detector with progress
  indicators, threshold haptics, snap-back below threshold, and custom semantic
  actions for screen-reader users.
- **Screen wiring**: on commit, dispatch + page forward; a listener shows an
  Undo snackbar when `lastTuningAction` changes. The repository provider is
  stable and reads `publicKey` live.

## Coordination before enabling

- Funnelcake ingestion must use kind `4242`.
- The Divine relay must allow-list kind `4242`.
- Keep `FeatureFlag.feedTuning` off by default until the backend/relay path is
  ready and verified.

## Testing

- `flutter test` in `mobile/packages/feed_tuning_repository`
- `flutter test test/widgets/feed_tuning/feed_tuning_swipe_overlay_test.dart test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart test/l10n/arb_consistency_test.dart`
- Pre-push changed-file tests, including `test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart`
- `flutter analyze lib test`
- `git diff --check origin/main...HEAD`

## Deferred

- Funnelcake/Gorse ingestion and recommendation verification.
- Relay allow-list rollout.
- One-time coach mark for gesture discoverability.
