### PR TITLE
fix(inbox): stabilize DM message ordering and drop dead DAO method (#4407)

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -110,63 +110,6 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     return query.get();
   }
 
-  /// Returns the latest non-deleted message for each conversation in one query.
-  ///
-  /// Results are keyed by `conversationId`. Conversations with no messages are
-  /// omitted from the returned map.
-  Future<Map<String, DirectMessageRow>> getLatestMessagesForConversations(
-    Iterable<String> conversationIds, {
-    String? ownerPubkey,
-  }) async {
-    final ids = conversationIds.toSet().toList();
-    if (ids.isEmpty) return const {};
-
-    final variables = <Variable<Object>>[...ids.map(Variable.withString)];
-    if (ownerPubkey != null) {
-      variables
-        ..add(Variable.withString(ownerPubkey))
-        ..add(Variable.withString(ownerPubkey));
-    }
-
-    final ownerFilter = ownerPubkey == null
-        ? '1 = 1'
-        : '(dm.owner_pubkey = ? OR dm.owner_pubkey IS NULL)';
-    final newerOwnerFilter = ownerPubkey == null
-        ? '1 = 1'
-        : '(newer.owner_pubkey = ? OR newer.owner_pubkey IS NULL)';
-    final placeholders = List.filled(ids.length, '?').join(', ');
-
-    final rows = await customSelect(
-      '''
-      SELECT dm.*
-      FROM direct_messages dm
-      WHERE dm.is_deleted = 0
-        AND dm.conversation_id IN ($placeholders)
-        AND $ownerFilter
-        AND NOT EXISTS (
-          SELECT 1
-          FROM direct_messages newer
-          WHERE newer.conversation_id = dm.conversation_id
-            AND newer.is_deleted = 0
-            AND $newerOwnerFilter
-            AND (
-              newer.created_at > dm.created_at OR
-              (newer.created_at = dm.created_at AND newer.id > dm.id)
-            )
-        )
-      ''',
-      variables: variables,
-      readsFrom: {directMessages},
-    ).get();
-
-    final latestByConversation = <String, DirectMessageRow>{};
-    for (final row in rows) {
-      final message = directMessages.map(row.data);
-      latestByConversation[message.conversationId] = message;
-    }
-    return latestByConversation;
-  }
-
   /// Watch messages for a conversation (reactive stream), newest first.
   ///
   /// Excludes soft-deleted messages (NIP-09 kind 5).

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -105,6 +105,10 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
       )
       ..orderBy([
         (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+        // `id` is the rumor event hash: this secondary sort is a stable but
+        // arbitrary tie-break for messages sharing a `createdAt` second. Keep
+        // it `id DESC` to match ConversationsDao.backfillLatestMessagePreviews
+        // so the inbox preview agrees with the open conversation's newest row.
         (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
       ]);
     if (limit != null) query.limit(limit, offset: offset);
@@ -128,6 +132,10 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
       )
       ..orderBy([
         (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+        // `id` is the rumor event hash: this secondary sort is a stable but
+        // arbitrary tie-break for messages sharing a `createdAt` second. Keep
+        // it `id DESC` to match ConversationsDao.backfillLatestMessagePreviews
+        // so the inbox preview agrees with the open conversation's newest row.
         (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
       ]);
     if (limit != null) query.limit(limit);

--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -105,6 +105,7 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
       )
       ..orderBy([
         (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+        (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
       ]);
     if (limit != null) query.limit(limit, offset: offset);
     return query.get();
@@ -127,6 +128,7 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
       )
       ..orderBy([
         (t) => OrderingTerm(expression: t.createdAt, mode: OrderingMode.desc),
+        (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
       ]);
     if (limit != null) query.limit(limit);
     return query.watch();

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -238,6 +238,44 @@ void main() {
         },
       );
 
+      test(
+        'uses id desc as a stable tie-breaker for equal timestamps',
+        () async {
+          await dao.insertMessage(
+            id: 'msg_same_a',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_alice',
+            content: 'First same-time message',
+            createdAt: 1700000200,
+            giftWrapId: 'gw_same_a',
+          );
+          await dao.insertMessage(
+            id: 'msg_same_c',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_bob',
+            content: 'Latest same-time message',
+            createdAt: 1700000200,
+            giftWrapId: 'gw_same_c',
+          );
+          await dao.insertMessage(
+            id: 'msg_same_b',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_alice',
+            content: 'Middle same-time message',
+            createdAt: 1700000200,
+            giftWrapId: 'gw_same_b',
+          );
+
+          final results = await dao.getMessagesForConversation(conversationId1);
+
+          expect(results.map((message) => message.id), [
+            'msg_same_c',
+            'msg_same_b',
+            'msg_same_a',
+          ]);
+        },
+      );
+
       test('respects limit and offset parameters', () async {
         for (var i = 0; i < 5; i++) {
           await dao.insertMessage(
@@ -316,6 +354,45 @@ void main() {
         expect(results[0].id, equals('msg_new'));
         expect(results[1].id, equals('msg_old'));
       });
+
+      test(
+        'uses id desc as a stable tie-breaker for equal timestamps',
+        () async {
+          await dao.insertMessage(
+            id: 'msg_same_a',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_alice',
+            content: 'First same-time message',
+            createdAt: 1700000200,
+            giftWrapId: 'gw_watch_same_a',
+          );
+          await dao.insertMessage(
+            id: 'msg_same_c',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_bob',
+            content: 'Latest same-time message',
+            createdAt: 1700000200,
+            giftWrapId: 'gw_watch_same_c',
+          );
+          await dao.insertMessage(
+            id: 'msg_same_b',
+            conversationId: conversationId1,
+            senderPubkey: 'pubkey_alice',
+            content: 'Middle same-time message',
+            createdAt: 1700000200,
+            giftWrapId: 'gw_watch_same_b',
+          );
+
+          final stream = dao.watchMessagesForConversation(conversationId1);
+          final results = await stream.first;
+
+          expect(results.map((message) => message.id), [
+            'msg_same_c',
+            'msg_same_b',
+            'msg_same_a',
+          ]);
+        },
+      );
 
       test('respects limit parameter', () async {
         for (var i = 0; i < 3; i++) {

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -290,66 +290,6 @@ void main() {
       });
     });
 
-    group('getLatestMessagesForConversations', () {
-      test(
-        'returns the latest non-deleted message for each conversation',
-        () async {
-          await dao.insertMessage(
-            id: 'conv1_old',
-            conversationId: conversationId1,
-            senderPubkey: 'pubkey_alice',
-            content: 'Old 1',
-            createdAt: 1700000000,
-            giftWrapId: 'gw_conv1_old',
-          );
-          await dao.insertMessage(
-            id: 'conv1_new',
-            conversationId: conversationId1,
-            senderPubkey: 'pubkey_bob',
-            content: 'New 1',
-            createdAt: 1700000200,
-            giftWrapId: 'gw_conv1_new',
-          );
-          await dao.insertMessage(
-            id: 'conv2_old',
-            conversationId: conversationId2,
-            senderPubkey: 'pubkey_alice',
-            content: 'Old 2',
-            createdAt: 1700000100,
-            giftWrapId: 'gw_conv2_old',
-          );
-          await dao.insertMessage(
-            id: 'conv2_new',
-            conversationId: conversationId2,
-            senderPubkey: 'pubkey_bob',
-            content: 'New 2',
-            createdAt: 1700000300,
-            giftWrapId: 'gw_conv2_new',
-          );
-
-          await dao.markMessageDeleted('conv2_new');
-
-          final latest = await dao.getLatestMessagesForConversations([
-            conversationId1,
-            conversationId2,
-            'missing',
-          ]);
-
-          expect(latest.keys, containsAll([conversationId1, conversationId2]));
-          expect(latest, isNot(contains('missing')));
-          expect(latest[conversationId1]?.id, equals('conv1_new'));
-          expect(latest[conversationId1]?.content, equals('New 1'));
-          expect(latest[conversationId2]?.id, equals('conv2_old'));
-          expect(
-            latest[conversationId2]?.content,
-            equals('Old 2'),
-            reason:
-                'soft-deleted newer rows must not win latest-message lookup',
-          );
-        },
-      );
-    });
-
     group('watchMessagesForConversation', () {
       test('emits initial list sorted by createdAt desc', () async {
         await dao.insertMessage(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -7931,9 +7931,14 @@ void main() {
             conversations.first.lastMessageSenderPubkey,
             equals(_validPubkeyA),
           );
+          // The watch path maps conversation rows straight to previews; it
+          // must never re-read messages per conversation (the removed
+          // _overlayLatestMessages overlay used to). See #4407.
           verifyNever(
-            () => mockDirectMessagesDao.getLatestMessagesForConversations(
+            () => mockDirectMessagesDao.getMessagesForConversation(
               any(),
+              limit: any(named: 'limit'),
+              offset: any(named: 'offset'),
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
           );


### PR DESCRIPTION
## Description

Final cleanup for #4407. PR #4415 already removed the transitional `_overlayLatestMessages` inbox overlay and its `asyncMap` calls, making conversation rows (plus the one-shot post-auth `backfillLatestMessagePreviews`) the sole source of truth for inbox previews. That left `DirectMessagesDao.getLatestMessagesForConversations` — the batched query the overlay used — with zero production callers.

This removes that dead method and its only remaining test coverage:

- Delete `getLatestMessagesForConversations` from `direct_messages_dao.dart`.
- Delete its DAO unit-test group in `direct_messages_dao_test.dart`.
- In `dm_repository_test.dart`'s "uses the conversation row preview as the source of truth" test, replace the now-uncompilable `verifyNever(getLatestMessagesForConversations)` with `verifyNever(getMessagesForConversation)` — a stronger guard that the inbox watch path performs no per-conversation message read at all.
- Align `getMessagesForConversation` and `watchMessagesForConversation` with preview backfill ordering by using `createdAt DESC, id DESC`, with regression coverage for equal-timestamp messages.

Pure dead-code removal plus deterministic ordering cleanup; no production behavior change to the inbox watch path. The `upsertConversation` strictly-newer write-path guard and the deletion-rollback `forceUpdateLastMessage` path keep in-session previews correct without the overlay, and the same-timestamp fallback now matches the one-shot backfill. There is no backend/protocol contract on the local preview columns; they are a client-side denormalization of NIP-17 gift wraps.

**Related Issue:** Closes #4407

## Verification

- `flutter analyze lib test` — `mobile/packages/db_client` — No issues found.
- `flutter test` — `mobile/packages/db_client` full suite — all pass.
- `flutter analyze lib test` — `mobile/packages/dm_repository` — No issues found.
- `flutter test test/src/dm_repository_test.dart` — `mobile/packages/dm_repository` — all pass.
- Pre-commit hook — format + generated-files verification — pass.
- Pre-push hook — merge-conflict check, analyzer, generated-files verification, changed-file tests — pass.

## Type of Change

- [x] Code refactor
