### PR TITLE
fix(video-player): recover frozen texture mid-clip without waiting for the loop

### DIFF
--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/VideoTextureOutput.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/VideoTextureOutput.swift
@@ -66,6 +66,28 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     private var mediaDataRearmCount = 0
     private static let maxMediaDataRearmCount = 10
 
+    /// Item time of the most recently delivered frame, or `.invalid` until
+    /// the first frame and after every attach / flush. Used to detect a
+    /// "playing but frozen" texture: when the player clock advances past this
+    /// while `copyPixelBuffer` keeps returning `nil`, the output pull is
+    /// wedged and needs an explicit re-prime (see `pullAndDeliverFrame`).
+    private var lastDeliveredItemTime: CMTime = .invalid
+
+    /// Throttle (monotonic `CACurrentMediaTime()`) gating how often the
+    /// stalled-texture recovery may re-arm the output, so a persistently
+    /// wedged frame can't spam `requestNotificationOfMediaDataChange` on
+    /// every display-link tick.
+    private var nextStallRecoveryTime: CFTimeInterval = 0
+
+    /// How far the player clock must advance past `lastDeliveredItemTime`
+    /// with no new frame before the texture counts as stalled. Comfortably
+    /// above a normal between-tick frame gap so brief decode hiccups and the
+    /// loop-boundary time reset don't trip it.
+    private static let stalledTextureAdvanceSeconds = 0.25
+
+    /// Minimum spacing between stalled-texture recovery re-arms.
+    private static let stallRecoveryIntervalSeconds: CFTimeInterval = 0.3
+
     /// Serialises access to `latestPixelBuffer`, which is written on the
     /// display-link callback (main thread) and read on Flutter's render
     /// thread via `copyPixelBuffer()`.
@@ -140,6 +162,8 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         hasDeliveredFirstFrame = false
         pendingSeekTime = .invalid
         mediaDataRearmCount = 0
+        lastDeliveredItemTime = .invalid
+        nextStallRecoveryTime = 0
 
         // The first `copyPixelBuffer` attempt right after attach often
         // races decoder init (especially on HEVC 10-bit / HDR), and
@@ -208,7 +232,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         forceRefreshDeadline = 0
         forceWindowFailCount = 0
         mediaDataRearmCount = 0
-        deliverFrame(pixelBuffer)
+        deliverFrame(pixelBuffer, at: time)
         return true
     }
 
@@ -217,6 +241,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     /// Called after a seek flushes the output queue.
     func outputSequenceWasFlushed(_ output: AVPlayerItemOutput) {
         mediaDataRearmCount = 0
+        lastDeliveredItemTime = .invalid
         (output as? AVPlayerItemVideoOutput)?
             .requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
     }
@@ -252,7 +277,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         pendingSeekTime = .invalid
         forceRefreshDeadline = 0
         forceWindowFailCount = 0
-        deliverFrame(pixelBuffer)
+        deliverFrame(pixelBuffer, at: targetTime)
     }
 
     // MARK: - App lifecycle
@@ -345,7 +370,9 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
     }
     #endif
 
-    private func deliverFrame(_ pixelBuffer: CVPixelBuffer) {
+    private func deliverFrame(_ pixelBuffer: CVPixelBuffer, at itemTime: CMTime) {
+        lastDeliveredItemTime = itemTime
+        nextStallRecoveryTime = 0
         os_unfair_lock_lock(&pixelBufferLock)
         latestPixelBuffer = pixelBuffer
         os_unfair_lock_unlock(&pixelBufferLock)
@@ -374,7 +401,7 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
                 pendingSeekTime = .invalid
                 forceRefreshDeadline = 0
                 forceWindowFailCount = 0
-                deliverFrame(pixelBuffer)
+                deliverFrame(pixelBuffer, at: itemTime)
             } else {
                 forceWindowFailCount += 1
             }
@@ -394,19 +421,53 @@ final class VideoTextureOutput: NSObject, FlutterTexture, AVPlayerItemOutputPull
         }
 
         // Skip `hasNewPixelBuffer(forItemTime:)` and just attempt the
-        // copy. With an `AVMutableComposition` + `AVVideoComposition`,
-        // the predicate returns `false` indefinitely on some HEVC
-        // sources even while the player is actively decoding — audio
-        // continues, time advances, but the texture stays on the first
-        // frame until a flush (loop restart) clears the deadlock.
-        // `copyPixelBuffer(forItemTime:)` is cheap when no new frame
-        // is ready (returns `nil`), so polling it on every display-link
-        // tick costs only the call itself.
+        // copy. The predicate returns `false` indefinitely on some
+        // sources (HEVC over `AVMutableComposition`, and progressive
+        // MP4 under decode pressure) even while the player is actively
+        // decoding — audio continues and time advances, but the texture
+        // wedges on the last frame. `copyPixelBuffer(forItemTime:)` is
+        // cheap when no new frame is ready (returns `nil`), so polling
+        // it on every display-link tick costs only the call itself; a
+        // sustained `nil` streak while playing triggers an explicit
+        // re-prime via `recoverStalledTextureIfNeeded`.
         if let pixelBuffer = output.copyPixelBuffer(
             forItemTime: itemTime,
             itemTimeForDisplay: nil
         ) {
-            deliverFrame(pixelBuffer)
+            deliverFrame(pixelBuffer, at: itemTime)
+        } else {
+            recoverStalledTextureIfNeeded(output, itemTime: itemTime)
         }
+    }
+
+    /// Breaks the "playing but frozen" deadlock where `AVPlayerItemVideoOutput`
+    /// keeps returning `nil` from `copyPixelBuffer` while the player clock
+    /// keeps advancing — audio plays on, but the texture stays on the last
+    /// delivered frame until the next flush (loop restart) clears it. Re-arms
+    /// the output's media-data notification — the same unstick the loop flush
+    /// performs in `outputSequenceWasFlushed` — as soon as the clock has
+    /// demonstrably moved past `lastDeliveredItemTime`, so playback recovers
+    /// mid-clip instead of only on the next loop.
+    ///
+    /// Gated so it can't fire spuriously: a paused player legitimately holds
+    /// its last frame (`rate <= 0`), and a genuine buffer underrun freezes the
+    /// player clock too (`itemTime` stops advancing), so neither trips it.
+    /// Throttled to one re-arm per `stallRecoveryIntervalSeconds`.
+    private func recoverStalledTextureIfNeeded(
+        _ output: AVPlayerItemVideoOutput,
+        itemTime: CMTime
+    ) {
+        guard let player, player.rate > 0, lastDeliveredItemTime.isValid
+        else { return }
+        let advanced = CMTimeGetSeconds(itemTime)
+            - CMTimeGetSeconds(lastDeliveredItemTime)
+        guard advanced > VideoTextureOutput.stalledTextureAdvanceSeconds
+        else { return }
+        let now = CACurrentMediaTime()
+        guard now >= nextStallRecoveryTime else { return }
+        nextStallRecoveryTime =
+            now + VideoTextureOutput.stallRecoveryIntervalSeconds
+        mediaDataRearmCount = 0
+        output.requestNotificationOfMediaDataChange(withAdvanceInterval: 0)
     }
 }

--- a/mobile/packages/divine_video_player/test/src/texture_stall_recovery_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/texture_stall_recovery_contract_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('VideoTextureOutput stalled-texture recovery contract', () {
+    test('re-primes the output when the clock advances but frames stall', () {
+      final source = _textureOutputSourceFile().readAsStringSync();
+
+      // The display-link poll must actively recover from the
+      // "playing but frozen" deadlock instead of waiting for the next
+      // loop flush — the symptom users hit on slow connections / cold
+      // playback (audio continues, picture frozen for a full loop).
+      expect(
+        source,
+        contains('recoverStalledTextureIfNeeded'),
+        reason:
+            'A stalled, actively-playing texture must self-recover '
+            'mid-clip, not only on the loop-restart flush.',
+      );
+      expect(
+        source,
+        contains(
+          'requestNotificationOfMediaDataChange(withAdvanceInterval: 0)',
+        ),
+        reason:
+            'Recovery re-arms the output with the same media-data '
+            'notification the loop flush uses to unstick the pull.',
+      );
+    });
+
+    test('guards recovery against paused players and genuine underruns', () {
+      final source = _textureOutputSourceFile().readAsStringSync();
+
+      // rate > 0 keeps a paused player (legitimately holding its last
+      // frame) from firing; the advance check keeps a buffer underrun
+      // (player clock frozen) from firing.
+      expect(source, contains('player.rate > 0'));
+      expect(source, contains('lastDeliveredItemTime'));
+      expect(source, contains('stalledTextureAdvanceSeconds'));
+    });
+
+    test('throttles recovery re-arms', () {
+      final source = _textureOutputSourceFile().readAsStringSync();
+
+      expect(source, contains('stallRecoveryIntervalSeconds'));
+      expect(source, contains('nextStallRecoveryTime'));
+    });
+
+    test('resets the last-delivered marker on attach and flush', () {
+      final source = _textureOutputSourceFile().readAsStringSync();
+
+      // Both attach (new item) and outputSequenceWasFlushed (loop
+      // restart) must clear the marker so a post-reset tick can't
+      // compare against a stale time and false-trigger recovery.
+      final invalidations = RegExp(
+        'lastDeliveredItemTime = .invalid',
+      ).allMatches(source).length;
+      expect(
+        invalidations,
+        greaterThanOrEqualTo(2),
+        reason: 'lastDeliveredItemTime must reset on both attach and flush.',
+      );
+    });
+  });
+}
+
+/// The iOS and macOS players share a single Darwin source tree
+/// (`darwin/divine_video_player/Sources/`), so the contract is asserted
+/// once against the shared file.
+File _textureOutputSourceFile() {
+  final packageRelative = File(
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'VideoTextureOutput.swift',
+  );
+  if (packageRelative.existsSync()) {
+    return packageRelative;
+  }
+
+  return File(
+    'packages/divine_video_player/'
+    'darwin/divine_video_player/Sources/divine_video_player/'
+    'VideoTextureOutput.swift',
+  );
+}


### PR DESCRIPTION
Closes #5512

## What

Fixes the beta video glitch where a feed video **plays the first part, then the picture freezes while audio keeps going, and only the second loop plays smoothly**.

## Root cause

The native iOS/macOS player (`DivineVideoPlayer`, the `AVPlayerItemVideoOutput` texture pull introduced when the pooled player was replaced by the native player in #4682) can wedge: `copyPixelBuffer(forItemTime:)` keeps returning `nil` while the `AVPlayer` clock keeps advancing — audio plays on, but the Flutter texture stays on the last delivered frame. The codebase already documented this exact deadlock in `VideoTextureOutput.pullAndDeliverFrame` ("audio continues, time advances, but the texture stays on the … frame until a flush (loop restart) clears the deadlock"). The only recovery was the loop-restart flush, so a **cold / under-buffered first play** showed a frozen picture for a whole loop, then played fine on the second pass.

### Evidence
- Diagnosed from a user log (1.0.15+778). App stayed **foreground** through every freeze, so the background frame-delivery pause (#5369) was not the trigger.
- The buffering watchdog (`DivineVideoPlayer.Freeze`) — which only fires on an empty *playback* buffer — **never logged**, despite the visible freeze. The buffer was healthy and the clock advanced; the picture froze anyway ⇒ texture-pull deadlock, not a network underrun.
- Every disk prefetch (small ~459 KB `/720p.mp4` files) timed out at 8 s that session ⇒ a slow link, so nearly every video played cold → the latent deadlock fired on basically every clip. The CDN itself is healthy (459 KB, 0.5 s from a good connection).
- Recent feed-throttling PRs that landed just before this build (#5408 `prefetchCount` 25→8; #8d0e8ab1d thermal-load reduction; e1f9f343f neighbour release) cut read-ahead, keeping more videos cold and making the deadlock fire far more often.

## The fix

The display-link poll now detects the stall — player actively playing (`rate > 0`) **and** the clock advanced past the last delivered frame while `copyPixelBuffer` returns `nil` — and re-arms the output's media-data notification (`requestNotificationOfMediaDataChange`), the same unstick the loop flush performs. Playback recovers within a fraction of a second instead of a full loop.

Gated so it can't fire spuriously:
- **Paused player** (legitimately holds its last frame): `rate > 0` guard.
- **Genuine buffer underrun** (player clock frozen too): the "clock advanced past last frame" guard.
- **Throttled** to one re-arm per 0.3 s; resets its marker on attach and on flush so post-reset ticks can't false-trigger.

## Tests

Added `texture_stall_recovery_contract_test.dart`, mirroring this package's existing Dart-asserts-Swift-source contract idiom (the package has no Swift XCTest target). It pins the recovery path, its guards, the throttle, and the attach/flush resets. Verified it fails on `origin/main` (symbol absent) and passes here; full `divine_video_player` suite (229 tests) green; `flutter analyze` clean.

## Manual test plan (on-device — native change, can't be exercised in CI)

- [ ] On a throttled/slow connection, scroll the feed cold and confirm videos no longer freeze on the first loop with audio continuing.
- [ ] Confirm paused videos still hold their frame (no flicker/re-pull while paused).
- [ ] Confirm seek/scrub and loop transitions still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)