### PR TITLE
fix(explore): warm popular classic feed before switching

### DIFF
--- a/mobile/lib/providers/foreground_idle_warmup_provider.dart
+++ b/mobile/lib/providers/foreground_idle_warmup_provider.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Warms existing feed and notification caches without prefetching media bytes.
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
@@ -62,6 +63,9 @@ final foregroundIdleWarmupCoordinatorProvider =
             cooldown: const Duration(minutes: 10),
             run: () async {
               await ref.read(popularVideosFeedProvider.future);
+              final popular = ref.read(popularVideosFeedProvider.notifier);
+              await popular.preloadVariant(PopularVideosVariant.native);
+              await popular.preloadVariant(PopularVideosVariant.classic);
             },
           ),
           ForegroundIdleWarmupTask(

--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -47,10 +47,19 @@ final popularVideosLoadedVariantProvider = StateProvider<PopularVideosVariant?>(
 @Riverpod(keepAlive: true)
 class PopularVideosFeed extends _$PopularVideosFeed {
   String? _nextCursor;
+  PopularVideosVariant? _pendingLoadedVariant;
+  void Function()? _removeLoadedVariantListener;
   final _enrichmentAttemptTracker = NostrTagEnrichmentAttemptTracker();
 
   @override
   Future<VideoFeedState> build() async {
+    _listenForLoadedVariantState();
+    ref.listen(popularVideosVariantProvider, (previous, next) {
+      if (previous == next) return;
+      _pendingLoadedVariant = null;
+      ref.read(popularVideosLoadedVariantProvider.notifier).state = null;
+    });
+
     // Watch content filter version — rebuilds when preferences change.
     ref.watch(contentFilterVersionProvider);
     ref.watch(divineHostFilterVersionProvider);
@@ -115,7 +124,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
           hasMoreContent: _pageHasMoreContent(page),
           lastUpdated: DateTime.now(),
         );
-        _markLoadedIfActive(variant);
+        _markLoadedWhenPublished(variant);
         return feedState;
       }
 
@@ -125,7 +134,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
         category: LogCategory.video,
       );
 
-      _markLoadedIfActive(variant);
+      _markLoadedWhenPublished(variant);
       return const VideoFeedState(videos: [], hasMoreContent: false);
     } catch (e) {
       Log.error(
@@ -134,7 +143,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
         category: LogCategory.video,
       );
       if (preserveExistingOnError) rethrow;
-      _markLoadedIfActive(variant);
+      _markLoadedWhenPublished(variant);
       return VideoFeedState(
         videos: const [],
         hasMoreContent: false,
@@ -303,6 +312,25 @@ class PopularVideosFeed extends _$PopularVideosFeed {
 
   bool _pageHasMoreContent(PopularVideosPage page) {
     return page.hasMore;
+  }
+
+  void _listenForLoadedVariantState() {
+    if (_removeLoadedVariantListener != null) return;
+    _removeLoadedVariantListener = listenSelf((_, next) {
+      if (!next.hasValue) return;
+      final variant = _pendingLoadedVariant;
+      if (variant == null) return;
+      _pendingLoadedVariant = null;
+      _markLoadedIfActive(variant);
+    });
+    ref.onDispose(() {
+      _removeLoadedVariantListener?.call();
+      _removeLoadedVariantListener = null;
+    });
+  }
+
+  void _markLoadedWhenPublished(PopularVideosVariant variant) {
+    _pendingLoadedVariant = variant;
   }
 
   void _markLoadedIfActive(PopularVideosVariant variant) {

--- a/mobile/lib/providers/popular_videos_feed_provider.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.dart
@@ -26,6 +26,15 @@ final popularVideosVariantProvider = StateProvider<PopularVideosVariant>(
   (ref) => PopularVideosVariant.native,
 );
 
+/// The Popular variant represented by the currently rendered feed data.
+///
+/// Riverpod can retain the previous AsyncValue while a dependency-triggered
+/// rebuild is loading. The Popular tab uses this marker to avoid presenting a
+/// stale Native page as Classic (or vice versa) during variant switches.
+final popularVideosLoadedVariantProvider = StateProvider<PopularVideosVariant?>(
+  (ref) => null,
+);
+
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///
 /// Delegates video fetching to [VideosRepository.getPopularVideos] with the
@@ -101,11 +110,13 @@ class PopularVideosFeed extends _$PopularVideosFeed {
           category: LogCategory.video,
         );
 
-        return VideoFeedState(
+        final feedState = VideoFeedState(
           videos: filteredVideos,
           hasMoreContent: _pageHasMoreContent(page),
           lastUpdated: DateTime.now(),
         );
+        _markLoadedIfActive(variant);
+        return feedState;
       }
 
       Log.warning(
@@ -114,6 +125,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
         category: LogCategory.video,
       );
 
+      _markLoadedIfActive(variant);
       return const VideoFeedState(videos: [], hasMoreContent: false);
     } catch (e) {
       Log.error(
@@ -122,6 +134,7 @@ class PopularVideosFeed extends _$PopularVideosFeed {
         category: LogCategory.video,
       );
       if (preserveExistingOnError) rethrow;
+      _markLoadedIfActive(variant);
       return VideoFeedState(
         videos: const [],
         hasMoreContent: false,
@@ -143,6 +156,20 @@ class PopularVideosFeed extends _$PopularVideosFeed {
       preferredLanguages: hints.preferredLanguages,
       viewerCountry: hints.viewerCountry,
     );
+  }
+
+  /// Warms the repository-backed first page for [variant] without changing the
+  /// visible feed when another variant is selected.
+  Future<void> preloadVariant(PopularVideosVariant variant) async {
+    try {
+      await _fetchFirstPage(variant, skipCache: false);
+    } catch (e) {
+      Log.warning(
+        'PopularVideosFeed: Failed to preload ${variant.name} variant: $e',
+        name: 'PopularVideosFeedProvider',
+        category: LogCategory.video,
+      );
+    }
   }
 
   /// Load more videos for pagination.
@@ -276,6 +303,12 @@ class PopularVideosFeed extends _$PopularVideosFeed {
 
   bool _pageHasMoreContent(PopularVideosPage page) {
     return page.hasMore;
+  }
+
+  void _markLoadedIfActive(PopularVideosVariant variant) {
+    if (!ref.mounted) return;
+    if (ref.read(popularVideosVariantProvider) != variant) return;
+    ref.read(popularVideosLoadedVariantProvider.notifier).state = variant;
   }
 
   void _scheduleEnrichment(List<VideoEvent> videos) {

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -60,7 +60,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'65699a1837af9591bea6bb5b62962c77740851a5';
+String _$popularVideosFeedHash() => r'c057c58282d3be8f0d5869b38b94b33cb05bff63';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/lib/providers/popular_videos_feed_provider.g.dart
+++ b/mobile/lib/providers/popular_videos_feed_provider.g.dart
@@ -60,7 +60,7 @@ final class PopularVideosFeedProvider
   PopularVideosFeed create() => PopularVideosFeed();
 }
 
-String _$popularVideosFeedHash() => r'21c0da7f654380965c6ecfd0ed0ff378bc54ad84';
+String _$popularVideosFeedHash() => r'65699a1837af9591bea6bb5b62962c77740851a5';
 
 /// Popular Videos feed provider - shows trending videos by recent engagement.
 ///

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -68,6 +68,8 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
     // Use popularVideosFeedProvider which tries REST API (sort=watching) first,
     // then falls back to Nostr (NIP-50 sort:hot) if unavailable.
     final feedAsync = ref.watch(popularVideosFeedProvider);
+    final selectedVariant = ref.watch(popularVideosVariantProvider);
+    final loadedVariant = ref.watch(popularVideosLoadedVariantProvider);
 
     Log.debug(
       '🔍 PopularVideosTab: AsyncValue state - isLoading: ${feedAsync.isLoading}, '
@@ -83,7 +85,9 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
     }
 
     // CRITICAL: Check hasValue FIRST before isLoading
-    if (feedAsync.hasValue && feedAsync.value != null) {
+    if (feedAsync.hasValue &&
+        feedAsync.value != null &&
+        loadedVariant == selectedVariant) {
       return _buildDataState(feedAsync.value!.videos);
     }
 

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -418,6 +418,95 @@ void main() {
     });
 
     test(
+      'popular videos exposes selected variant as loading until its page resolves',
+      () async {
+        final classicCompleter = Completer<PopularVideosPage>();
+        final requestedVariants = <PopularVideosVariant>[];
+
+        when(
+          () => mockVideosRepository.getPopularVideosPage(
+            limit: any(named: 'limit'),
+            until: any(named: 'until'),
+            cursor: any(named: 'cursor'),
+            variant: any(named: 'variant'),
+            skipCache: any(named: 'skipCache'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((invocation) {
+          final variant =
+              invocation.namedArguments[#variant] as PopularVideosVariant;
+          requestedVariants.add(variant);
+          if (variant == PopularVideosVariant.native) {
+            return Future.value(_popularPage([_video('popular-native')]));
+          }
+          return classicCompleter.future;
+        });
+
+        final container = ProviderContainer(
+          overrides: [
+            sharedPreferencesProvider.overrideWithValue(sharedPreferences),
+            appReadyProvider.overrideWithValue(true),
+            videoEventServiceProvider.overrideWithValue(mockVideoEventService),
+            contentBlocklistRepositoryProvider.overrideWithValue(
+              mockBlocklistRepository,
+            ),
+            videosRepositoryProvider.overrideWithValue(mockVideosRepository),
+            nostrServiceProvider.overrideWithValue(mockNostrClient),
+          ],
+        );
+        addTearDown(container.dispose);
+
+        final subscription = container.listen(
+          popularVideosFeedProvider,
+          (_, _) {},
+        );
+        addTearDown(subscription.close);
+
+        final nativeState = await container.read(
+          popularVideosFeedProvider.future,
+        );
+        expect(nativeState.videos.map((video) => video.id), [
+          'popular-native',
+        ]);
+        expect(
+          container.read(popularVideosLoadedVariantProvider),
+          PopularVideosVariant.native,
+        );
+
+        container.read(popularVideosVariantProvider.notifier).state =
+            PopularVideosVariant.classic;
+        await pumpEventQueue();
+
+        expect(requestedVariants, [
+          PopularVideosVariant.native,
+          PopularVideosVariant.classic,
+        ]);
+        expect(
+          container.read(popularVideosLoadedVariantProvider),
+          PopularVideosVariant.native,
+          reason:
+              'The UI must not treat the old Native page as the selected Classic page.',
+        );
+
+        classicCompleter.complete(
+          _popularPage([_vineArchiveVideo('popular-classic')]),
+        );
+        final classicState = await container.read(
+          popularVideosFeedProvider.future,
+        );
+
+        expect(classicState.videos.map((video) => video.id), [
+          'popular-classic',
+        ]);
+        expect(
+          container.read(popularVideosLoadedVariantProvider),
+          PopularVideosVariant.classic,
+        );
+      },
+    );
+
+    test(
       'popular videos preserves existing videos when refresh fails',
       () async {
         final initialVideos = [_video('popular-initial')];

--- a/mobile/test/providers/explore_feed_refresh_retention_test.dart
+++ b/mobile/test/providers/explore_feed_refresh_retention_test.dart
@@ -462,6 +462,20 @@ void main() {
           (_, _) {},
         );
         addTearDown(subscription.close);
+        final loadedVariantSubscription = container.listen(
+          popularVideosLoadedVariantProvider,
+          (_, next) {
+            if (next != PopularVideosVariant.classic) return;
+            final currentFeed = container.read(popularVideosFeedProvider).value;
+            expect(
+              currentFeed?.videos.map((video) => video.id),
+              ['popular-classic'],
+              reason:
+                  'Loaded variant must not update before matching feed data is published.',
+            );
+          },
+        );
+        addTearDown(loadedVariantSubscription.close);
 
         final nativeState = await container.read(
           popularVideosFeedProvider.future,
@@ -484,7 +498,7 @@ void main() {
         ]);
         expect(
           container.read(popularVideosLoadedVariantProvider),
-          PopularVideosVariant.native,
+          isNull,
           reason:
               'The UI must not treat the old Native page as the selected Classic page.',
         );

--- a/mobile/test/providers/foreground_idle_warmup_provider_test.dart
+++ b/mobile/test/providers/foreground_idle_warmup_provider_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
@@ -52,6 +53,11 @@ class _TestPopularVideosFeed extends PopularVideosFeed {
   Future<VideoFeedState> build() async {
     _feedBuilds.add('popular');
     return const VideoFeedState(videos: [], hasMoreContent: false);
+  }
+
+  @override
+  Future<void> preloadVariant(PopularVideosVariant variant) async {
+    _feedBuilds.add('popular:${variant.name}');
   }
 }
 
@@ -144,7 +150,13 @@ void main() {
             trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
           );
 
-      expect(_feedBuilds, ['forYou', 'newVideos', 'popular']);
+      expect(_feedBuilds, [
+        'forYou',
+        'newVideos',
+        'popular',
+        'popular:native',
+        'popular:classic',
+      ]);
       verify(() => followRepository.followingPubkeys).called(1);
       verifyNever(
         () => videosRepository.getHomeFeedVideos(
@@ -156,6 +168,24 @@ void main() {
           skipCache: any(named: 'skipCache'),
         ),
       );
+    });
+
+    test('popular warmup preloads native and classic variants', () async {
+      final container = createContainer(following: const []);
+
+      await container
+          .read(foregroundIdleWarmupCoordinatorProvider)
+          .requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+          );
+
+      expect(_feedBuilds, [
+        'forYou',
+        'newVideos',
+        'popular',
+        'popular:native',
+        'popular:classic',
+      ]);
     });
 
     test('notification warmup uses foreground idle warmup reason', () async {

--- a/mobile/test/providers/foreground_idle_warmup_provider_test.dart
+++ b/mobile/test/providers/foreground_idle_warmup_provider_test.dart
@@ -31,6 +31,13 @@ class _MockNotificationRefreshCoordinator extends Mock
     implements NotificationRefreshCoordinator {}
 
 final _feedBuilds = <String>[];
+const _expectedEmptyFollowingWarmupBuilds = [
+  'forYou',
+  'newVideos',
+  'popular',
+  'popular:native',
+  'popular:classic',
+];
 
 class _TestForYouFeed extends ForYouFeed {
   @override
@@ -150,13 +157,7 @@ void main() {
             trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
           );
 
-      expect(_feedBuilds, [
-        'forYou',
-        'newVideos',
-        'popular',
-        'popular:native',
-        'popular:classic',
-      ]);
+      expect(_feedBuilds, _expectedEmptyFollowingWarmupBuilds);
       verify(() => followRepository.followingPubkeys).called(1);
       verifyNever(
         () => videosRepository.getHomeFeedVideos(
@@ -179,13 +180,7 @@ void main() {
             trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
           );
 
-      expect(_feedBuilds, [
-        'forYou',
-        'newVideos',
-        'popular',
-        'popular:native',
-        'popular:classic',
-      ]);
+      expect(_feedBuilds, _expectedEmptyFollowingWarmupBuilds);
     });
 
     test('notification warmup uses foreground idle warmup reason', () async {


### PR DESCRIPTION
Closes #5516

## Summary
- warm both Popular Native and Classic during foreground-idle warmup
- track which Popular variant the current data belongs to, so variant switches show the existing loading indicator until the selected variant resolves
- publish the loaded-variant marker from the Popular provider state transition so it cannot advance before matching feed data is available
- add provider regression coverage for stale variant data, loaded-marker ordering, and warmup coverage for both variants

## Root cause
Riverpod can retain the previous `AsyncValue` while a dependency-triggered Popular rebuild is loading. The initial fix added a loaded-variant marker, but it updated that marker inside the fetch helper before the provider published the matching `AsyncData`, leaving a possible transient stale-render window.

## Verification
- `flutter analyze`
- `flutter test test/providers/foreground_idle_warmup_provider_test.dart test/providers/explore_feed_refresh_retention_test.dart`