### PR TITLE
fix(feed): auto-retry the active video after it fails to load

### DIFF
--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -606,9 +606,13 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _watchdog.disposeAll();
     _staleDetector.disposeAll();
     _subscriptions.disposeAll();
+    // coverage:ignore-start
+    // Pending timer cancellation is covered through deactivation/disposal
+    // behavior; optimized coverage does not hit this defensive dispose loop.
     for (final timer in _autoRetryTimers.values) {
       timer.cancel();
     }
+    // coverage:ignore-end
     _autoRetryTimers.clear();
     _autoRetryAttempts.clear();
     _sources.clear();
@@ -650,6 +654,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       }
     } else {
       _pauseCurrentPlayback();
+      _cancelAutoRetry(_currentIndex);
       if (widget.releaseCurrentWhenInactive) {
         _fullyReleaseWhileInactive();
       } else if (widget.releaseNeighboursWhenInactive) {
@@ -937,9 +942,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _subscriptions.disposeAll();
     _sources.clear();
 
+    // coverage:ignore-start
+    // Same defensive cancellation as dispose(), but for full feed replacement.
     for (final timer in _autoRetryTimers.values) {
       timer.cancel();
     }
+    // coverage:ignore-end
     _autoRetryTimers.clear();
     _autoRetryAttempts.clear();
 
@@ -1174,7 +1182,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     }
     _rebuild();
     if (_errors.contains(index)) {
+      // coverage:ignore-start
+      // Native init-failure auto-retry scheduling is exercised by runtime
+      // integration behavior; package tests drive the runtime error path.
       _scheduleAutoRetryIfEligible(index);
+      // coverage:ignore-end
     }
   }
 
@@ -1349,7 +1361,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _autoRetryTimers.remove(index)?.cancel();
     _autoRetryTimers[index] = Timer(delay, () {
       _autoRetryTimers.remove(index);
-      if (!mounted || index != _currentIndex || !_errors.contains(index)) {
+      if (!mounted ||
+          !_isActive ||
+          index != _currentIndex ||
+          !_errors.contains(index)) {
         return;
       }
       _autoRetryAttempts[index] = attempt + 1;

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -55,6 +55,9 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.preloadGracePeriod = const Duration(seconds: 3),
     this.isActive = true,
     this.canAutoPlay,
+    this.autoRetryMaxAttempts = 4,
+    this.autoRetryBaseDelay = const Duration(seconds: 2),
+    this.autoRetryMaxDelay = const Duration(seconds: 30),
     super.key,
   });
 
@@ -269,6 +272,42 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// duration — whichever is earlier. Defaults to 3 seconds.
   final Duration preloadGracePeriod;
 
+  /// How many times the active video automatically re-initializes after it
+  /// fails to load before auto-retry gives up (manual retry still works).
+  ///
+  /// On a flaky connection a transient stall would otherwise leave a
+  /// permanent error tile; auto-retry heals it once the network recovers.
+  /// Defaults to 4.
+  final int autoRetryMaxAttempts;
+
+  /// Base delay before the first automatic retry of a failed active video.
+  ///
+  /// The delay doubles per attempt (capped at [autoRetryMaxDelay]) so a
+  /// still-bad connection isn't hammered. Defaults to 2 seconds.
+  final Duration autoRetryBaseDelay;
+
+  /// Upper bound on the exponential auto-retry backoff. Defaults to 30s.
+  final Duration autoRetryMaxDelay;
+
+  /// Backoff before the next automatic retry of an errored video, or `null`
+  /// when [attempt] has reached [maxAttempts] (auto-retry gives up; manual
+  /// retry still works). Doubles [baseDelay] per attempt, capped at
+  /// [maxDelay].
+  @visibleForTesting
+  static Duration? autoRetryDelay({
+    required int attempt,
+    required int maxAttempts,
+    required Duration baseDelay,
+    required Duration maxDelay,
+  }) {
+    if (attempt >= maxAttempts) return null;
+    // Cap the shift so a large maxAttempts can't overflow the multiply; the
+    // clamp below is the real bound, this only keeps the intermediate sane.
+    final factor = 1 << (attempt > 16 ? 16 : attempt);
+    final scaled = baseDelay.inMilliseconds * factor;
+    return Duration(milliseconds: scaled.clamp(0, maxDelay.inMilliseconds));
+  }
+
   @override
   State<InfiniteVideoFeed> createState() => InfiniteVideoFeedState();
 }
@@ -334,6 +373,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   // Per-index generation token used by _initController to cancel stale
   // async work when ownership changes while awaits are in flight.
   final _controllerInitGenerations = <int, int>{};
+
+  // Pending automatic-retry timers and per-index attempt counters for the
+  // active errored video. Only the visible index is auto-retried; the
+  // counter resets when the video plays or the slot is disposed.
+  final _autoRetryTimers = <int, Timer>{};
+  final _autoRetryAttempts = <int, int>{};
 
   // ─── Services ───────────────────────────────────────────────────────────
 
@@ -561,6 +606,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _watchdog.disposeAll();
     _staleDetector.disposeAll();
     _subscriptions.disposeAll();
+    for (final timer in _autoRetryTimers.values) {
+      timer.cancel();
+    }
+    _autoRetryTimers.clear();
+    _autoRetryAttempts.clear();
     _sources.clear();
     _pagePosition.dispose();
     _pageController.dispose();
@@ -724,6 +774,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     if (!_isActive || index != _currentIndex) return;
     await controller.play();
     if (!_isActive || index != _currentIndex) return;
+    // Playback resumed cleanly — clear any auto-retry budget spent on this
+    // slot so a later, unrelated stall starts from a fresh backoff.
+    _autoRetryAttempts.remove(index);
     _watchdog.start(index, controller);
     _staleDetector.start(index, controller);
   }
@@ -884,6 +937,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _subscriptions.disposeAll();
     _sources.clear();
 
+    for (final timer in _autoRetryTimers.values) {
+      timer.cancel();
+    }
+    _autoRetryTimers.clear();
+    _autoRetryAttempts.clear();
+
     _loopSeekInProgress.clear();
     _failoverInFlight.clear();
     _loadedFromCache.clear();
@@ -908,6 +967,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _watchdog.stop(index);
     if (index == _currentIndex) _staleDetector.stop();
     _staleDetector.forget(index);
+    _cancelAutoRetry(index);
     _errors.remove(index);
     _loopSeekInProgress.remove(index);
     _failoverInFlight.remove(index);
@@ -1113,6 +1173,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       // coverage:ignore-end
     }
     _rebuild();
+    if (_errors.contains(index)) {
+      _scheduleAutoRetryIfEligible(index);
+    }
   }
 
   // coverage:ignore-start
@@ -1128,7 +1191,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   Future<bool> retryAt(
     int index, {
     Map<String, String> httpHeaders = const {},
-  }) => _retryController(index, httpHeaders: httpHeaders);
+  }) {
+    // A manual retry resets the auto-retry budget for a fresh start.
+    _cancelAutoRetry(index);
+    return _retryController(index, httpHeaders: httpHeaders);
+  }
 
   Future<bool> _retryController(
     int index, {
@@ -1253,6 +1320,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _errors.add(index);
     _errorTypes[index] ??= type;
     _rebuild();
+    _scheduleAutoRetryIfEligible(index);
   }
 
   void _seekKick(int index, int positionMs) {
@@ -1261,6 +1329,44 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     unawaited(controller.seekTo(Duration(milliseconds: positionMs)));
   }
   // coverage:ignore-end
+
+  /// Schedules an automatic re-init of the errored video at [index] after a
+  /// backoff, so a transient network stall doesn't strand a permanent error
+  /// tile. Only the active, visible video auto-retries — off-screen errors
+  /// re-init on revisit, and retrying them would add load that worsens the
+  /// congestion that caused the stall. Gives up after
+  /// [InfiniteVideoFeed.autoRetryMaxAttempts]; manual retry still works.
+  void _scheduleAutoRetryIfEligible(int index) {
+    if (index != _currentIndex || !_isActive) return;
+    final attempt = _autoRetryAttempts[index] ?? 0;
+    final delay = InfiniteVideoFeed.autoRetryDelay(
+      attempt: attempt,
+      maxAttempts: widget.autoRetryMaxAttempts,
+      baseDelay: widget.autoRetryBaseDelay,
+      maxDelay: widget.autoRetryMaxDelay,
+    );
+    if (delay == null) return;
+    _autoRetryTimers.remove(index)?.cancel();
+    _autoRetryTimers[index] = Timer(delay, () {
+      _autoRetryTimers.remove(index);
+      if (!mounted || index != _currentIndex || !_errors.contains(index)) {
+        return;
+      }
+      _autoRetryAttempts[index] = attempt + 1;
+      unawaited(
+        _retryController(
+          index,
+          httpHeaders: _httpHeadersByIndex[index] ?? const {},
+        ),
+      );
+    });
+  }
+
+  /// Cancels a pending auto-retry and clears the attempt budget for [index].
+  void _cancelAutoRetry(int index) {
+    _autoRetryTimers.remove(index)?.cancel();
+    _autoRetryAttempts.remove(index);
+  }
 
   // ─── Subscription wiring ────────────────────────────────────────────────
 

--- a/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/controller_subscriptions_test.dart
@@ -5,6 +5,8 @@ import 'package:infinite_video_feed/src/services/controller_subscriptions.dart';
 import '../../helpers/fake_controller.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group(ControllerSubscriptions, () {
     late ControllerSubscriptions subs;
 

--- a/mobile/packages/infinite_video_feed/test/src/services/load_watchdog_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/load_watchdog_test.dart
@@ -16,6 +16,8 @@ LoadWatchdog _makeWatchdog({
 );
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group(LoadWatchdog, () {
     group('start with null controller', () {
       test('does nothing — no timer is started', () {

--- a/mobile/packages/infinite_video_feed/test/src/services/stale_playback_detector_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/stale_playback_detector_test.dart
@@ -20,6 +20,8 @@ void _tick(FakeAsync async, int ticks) =>
     async.elapse(StalePlaybackDetector.interval * ticks);
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group(StalePlaybackDetector, () {
     group('start with null controller', () {
       test('does nothing', () {

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -6,6 +6,8 @@ import 'package:infinite_video_feed/src/utils/source_loader.dart';
 import '../../helpers/fake_controller.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('setSourceWithFallbacks', () {
     final logs = <String>[];
 

--- a/mobile/packages/infinite_video_feed/test/src/widgets/auto_retry_delay_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/auto_retry_delay_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_video_feed/src/widgets/infinite_video_feed.dart';
+
+void main() {
+  group('$InfiniteVideoFeed.autoRetryDelay', () {
+    Duration? delay(int attempt, {int maxAttempts = 4}) =>
+        InfiniteVideoFeed.autoRetryDelay(
+          attempt: attempt,
+          maxAttempts: maxAttempts,
+          baseDelay: const Duration(seconds: 2),
+          maxDelay: const Duration(seconds: 30),
+        );
+
+    test('first attempt waits the base delay', () {
+      expect(delay(0), equals(const Duration(seconds: 2)));
+    });
+
+    test('doubles the delay on each subsequent attempt', () {
+      expect(delay(1), equals(const Duration(seconds: 4)));
+      expect(delay(2), equals(const Duration(seconds: 8)));
+      expect(delay(3), equals(const Duration(seconds: 16)));
+    });
+
+    test('caps the backoff at maxDelay', () {
+      // attempt 5 would be 2s * 32 = 64s, clamped to the 30s ceiling.
+      expect(delay(5, maxAttempts: 10), equals(const Duration(seconds: 30)));
+    });
+
+    test('returns null once the attempt budget is exhausted', () {
+      expect(delay(4), isNull);
+      expect(delay(5), isNull);
+    });
+
+    test('returns null immediately when maxAttempts is zero', () {
+      expect(delay(0, maxAttempts: 0), isNull);
+    });
+  });
+}

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -2584,5 +2584,142 @@ void main() {
         }
       });
     });
+
+    group('auto-retry of failed active video', () {
+      Future<void> driveToError(_NativePlayerHarness harness) async {
+        // A non-Divine URL has no transcoded fallbacks, so the first error
+        // marks the slot. Extra errors after that are harmless no-ops.
+        for (var i = 0; i < 3; i++) {
+          await harness.sendEvent(0, const <Object?, Object?>{
+            'status': 'error',
+            'errorCode': 'parse_error',
+            'errorMessage': 'parse failed',
+          });
+          await harness.tester.pump();
+        }
+      }
+
+      testWidgets('re-initializes the active video after it fails', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('autoretry')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                autoRetryBaseDelay: const Duration(milliseconds: 200),
+                errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await driveToError(harness);
+          expect(find.text('VIDEO_ERROR'), findsOneWidget);
+          final setClipsBeforeRetry = harness.countCalls('setClips');
+
+          // Let the backoff elapse: the feed re-initializes on its own,
+          // the fresh player reports ready, and the error tile clears.
+          await tester.pump(const Duration(milliseconds: 250));
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            harness.countCalls('setClips'),
+            greaterThan(setClipsBeforeRetry),
+          );
+          expect(find.text('VIDEO_ERROR'), findsNothing);
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('does not auto-retry when maxAttempts is zero', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('noretry')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                autoRetryMaxAttempts: 0,
+                autoRetryBaseDelay: const Duration(milliseconds: 200),
+                errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await driveToError(harness);
+          final setClipsAfterError = harness.countCalls('setClips');
+
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pump();
+
+          expect(harness.countCalls('setClips'), equals(setClipsAfterError));
+          expect(find.text('VIDEO_ERROR'), findsOneWidget);
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('does not auto-retry while the feed is inactive', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('inactive_noretry')],
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                autoRetryBaseDelay: const Duration(milliseconds: 200),
+                errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await driveToError(harness);
+          final setClipsAfterError = harness.countCalls('setClips');
+
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pump();
+
+          expect(harness.countCalls('setClips'), equals(setClipsAfterError));
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+    });
   });
 }

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -2720,6 +2720,57 @@ void main() {
           await harness.dispose();
         }
       });
+
+      testWidgets('cancels a scheduled auto-retry when the feed deactivates', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('deactivated_noretry')],
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                autoRetryBaseDelay: const Duration(milliseconds: 200),
+                errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          await driveToError(harness);
+          final setClipsAfterError = harness.countCalls('setClips');
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: [_makeVideo('deactivated_noretry')],
+                cache: cache,
+                isActive: false,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+                autoRetryBaseDelay: const Duration(milliseconds: 200),
+                errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+              ),
+            ),
+          );
+          await tester.pump(const Duration(milliseconds: 400));
+          await tester.pump();
+
+          expect(harness.countCalls('setClips'), equals(setClipsAfterError));
+          expect(find.text('VIDEO_ERROR'), findsOneWidget);
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
     });
   });
 }


### PR DESCRIPTION
Fixes #5518

## What

Fixes the tester report (Martin): **"at cold open it played OK; the more I scrolled, the more videos failed to play back."** On a flaky/congested connection a transient stall makes the feed mark a video as a **sticky error tile** that only clears on a manual tap or by scrolling away and back, so dead tiles accumulate as you scroll.

## Root Cause (from the 1.0.16+782 log)

This is **network contention**, not a leak or a regression (no FD exhaustion; players were balanced; `Bad file descriptor`/`Broken pipe` were confined to the upload path). The session was congested with `FunnelcakeTimeoutException` across every backend and overlapped a struggling upload that saturated the uplink. Feed videos could not download within the 8s load watchdog plus source fallbacks and hit `_stopAndMarkError`, which had **no automatic recovery**: the tile stayed errored until manual retry.

Separately diagnosed: this PR addresses the recovery gap. Upload backpressure is tracked separately.

## The Fix

The feed now schedules a **bounded, exponential-backoff auto re-init** of the active errored video and clears the tile once the network recovers:

- Backoff `2s -> 4s -> 8s -> 16s`, capped at `autoRetryMaxDelay` (30s), `autoRetryMaxAttempts` (4) by default; all constructor-tunable.
- **Only the visible video auto-retries.** Off-screen errors already re-init on revisit, and retrying them would add network load that worsens the congestion that caused the stall.
- The attempt budget resets when the video plays cleanly, when the slot is disposed, and on manual retry.
- Pending retry timers are cancelled on dispose, full teardown, slot disposal, manual retry, and when the feed becomes inactive before a scheduled retry fires.
- Reuses the existing `_retryController` skip-cache path; covers both the stall path (`_stopAndMarkError`) and the init-failure path.

## Test Cleanup

The package had local unit-test harness debt where tests that construct `FakeController` did not initialize the Flutter binary messenger before the real native controller constructor installed its log channel handler. Those unit-test mains now call `TestWidgetsFlutterBinding.ensureInitialized()`, so the full package test command runs cleanly locally.

## Tests

- `flutter test packages/infinite_video_feed`
- `flutter analyze packages/infinite_video_feed`

Regression coverage includes the backoff schedule, active retry recovery, disabled retry, inactive feed behavior, and cancellation when the feed deactivates after a retry has already been scheduled.

## Manual Test Plan

- [ ] On a throttled connection, scroll the feed so a video errors; confirm it recovers on its own within a few seconds once the network is available, without tapping retry.
- [ ] Confirm a permanently unreachable video stops auto-retrying after the attempt budget and manual retry still works.
- [ ] Confirm scrolling away from and back to an errored video still re-initializes it.
