### PR TITLE
fix(auth): preserve drafts when removing local account

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4093,5 +4093,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "የተመረጡ ቅንጥቦችን አዋህድ",
     "videoEditorDeleteSelectedClipsSemanticLabel": "የተመረጡ ቅንጥቦችን ሰርዝ",
     "videoEditorMergeProgressLabel": "ትንሽ ይቆዩ፣ ቅንጥቦችዎን እያዋሃድን ነው",
-    "videoEditorMergeFailed": "ቅንጥቦችን ማዋሃድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።"
+    "videoEditorMergeFailed": "ቅንጥቦችን ማዋሃድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "دمج المقاطع المحددة",
     "videoEditorDeleteSelectedClipsSemanticLabel": "حذف المقاطع المحددة",
     "videoEditorMergeProgressLabel": "لحظة من فضلك، نقوم بدمج مقاطعك",
-    "videoEditorMergeFailed": "تعذّر دمج المقاطع. يُرجى المحاولة مرة أخرى."
+    "videoEditorMergeFailed": "تعذّر دمج المقاطع. يُرجى المحاولة مرة أخرى.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4099,5 +4099,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Обединяване на избраните клипове",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Изтриване на избраните клипове",
     "videoEditorMergeProgressLabel": "Един момент, обединяваме клиповете ти",
-    "videoEditorMergeFailed": "Клиповете не могат да бъдат обединени. Опитай отново."
+    "videoEditorMergeFailed": "Клиповете не могат да бъдат обединени. Опитай отново.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Ausgewählte Clips zusammenführen",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Ausgewählte Clips löschen",
     "videoEditorMergeProgressLabel": "Einen Moment, wir führen deine Clips zusammen",
-    "videoEditorMergeFailed": "Clips konnten nicht zusammengeführt werden. Bitte versuche es erneut."
+    "videoEditorMergeFailed": "Clips konnten nicht zusammengeführt werden. Bitte versuche es erneut.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1137,7 +1137,7 @@
   "nostrSettingsClientAttribution": "Client Attribution",
   "nostrSettingsClientAttributionSubtitle": "Include a Divine client tag on events you publish so other Nostr apps can attribute them correctly.",
   "nostrSettingsRemoveKeys": "Remove this account from this device",
-  "nostrSettingsRemoveKeysSubtitle": "Remove this account's local login from this device. This won't delete your Divine account or Nostr identity.",
+  "nostrSettingsRemoveKeysSubtitle": "Remove this account's local login from this device. Your local drafts and clips stay saved for this account.",
   "nostrSettingsCouldNotRemoveKeys": "Could not remove this account from this device. Please try again.",
   "nostrSettingsFailedToRemoveKeys": "Failed to remove this account: {error}",
   "@nostrSettingsFailedToRemoveKeys": {
@@ -3634,7 +3634,7 @@
   "deleteAccountPreparingDeletion": "Preparing deletion...",
   "deleteAccountProgressEvents": "{current} / {total} events",
   "@deleteAccountProgressEvents": {"placeholders": {"current": {"type": "int"}, "total": {"type": "int"}}},
-  "deleteAccountRemoveKeysBody": "This removes the local login for this account from this device. It won't delete your Divine account or Nostr identity.\n\nIf this is your last local account, you'll return to the login screen.",
+  "deleteAccountRemoveKeysBody": "This removes the local login for this account from this device. It won't delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you'll return to the login screen.",
   "deleteAccountRemoveKeysConfirm": "Remove from device",
   "deleteAccountRemoveKeysTitle": "Remove this account from this device?",
   "deleteAccountServerDeletionFailed": "Could not delete your account from the server. Please check your connection and try again.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3631,6 +3631,7 @@
   "deleteAccountFinalConfirmationBody": "To confirm permanent deletion of ALL your content from Nostr relays, type:",
   "deleteAccountFinalConfirmationTitle": "\u26a0\ufe0f Final Confirmation",
   "deleteAccountKeyDeletionWarning": "Account deleted, but your keys may not have been fully removed from this device. Go to Settings \u2192 Nostr Keys \u2192 Remove Keys to retry.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
   "deleteAccountPreparingDeletion": "Preparing deletion...",
   "deleteAccountProgressEvents": "{current} / {total} events",
   "@deleteAccountProgressEvents": {"placeholders": {"current": {"type": "int"}, "total": {"type": "int"}}},

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Combinar clips seleccionados",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Eliminar clips seleccionados",
     "videoEditorMergeProgressLabel": "Un momento, estamos combinando tus clips",
-    "videoEditorMergeFailed": "No se pudieron combinar los clips. Inténtalo de nuevo."
+    "videoEditorMergeFailed": "No se pudieron combinar los clips. Inténtalo de nuevo.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2537,5 +2537,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Pagsamahin ang mga napiling clip",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Tanggalin ang mga napiling clip",
     "videoEditorMergeProgressLabel": "Sandali lang, pinagsasama namin ang iyong mga clip",
-    "videoEditorMergeFailed": "Hindi mapagsama ang mga clip. Pakisubukang muli."
+    "videoEditorMergeFailed": "Hindi mapagsama ang mga clip. Pakisubukang muli.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Fusionner les clips sélectionnés",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Supprimer les clips sélectionnés",
     "videoEditorMergeProgressLabel": "Un instant, nous fusionnons vos clips",
-    "videoEditorMergeFailed": "Impossible de fusionner les clips. Veuillez réessayer."
+    "videoEditorMergeFailed": "Impossible de fusionner les clips. Veuillez réessayer.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Gabungkan klip yang dipilih",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Hapus klip yang dipilih",
     "videoEditorMergeProgressLabel": "Sebentar, kami sedang menggabungkan klipmu",
-    "videoEditorMergeFailed": "Tidak dapat menggabungkan klip. Silakan coba lagi."
+    "videoEditorMergeFailed": "Tidak dapat menggabungkan klip. Silakan coba lagi.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Unisci le clip selezionate",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Elimina le clip selezionate",
     "videoEditorMergeProgressLabel": "Un momento, stiamo unendo le tue clip",
-    "videoEditorMergeFailed": "Impossibile unire le clip. Riprova."
+    "videoEditorMergeFailed": "Impossibile unire le clip. Riprova.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "選択したクリップを結合",
     "videoEditorDeleteSelectedClipsSemanticLabel": "選択したクリップを削除",
     "videoEditorMergeProgressLabel": "少々お待ちください。クリップを結合しています",
-    "videoEditorMergeFailed": "クリップを結合できませんでした。もう一度お試しください。"
+    "videoEditorMergeFailed": "クリップを結合できませんでした。もう一度お試しください。",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3285,5 +3285,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "선택한 클립 병합",
     "videoEditorDeleteSelectedClipsSemanticLabel": "선택한 클립 삭제",
     "videoEditorMergeProgressLabel": "잠시만요, 클립을 병합하고 있어요",
-    "videoEditorMergeFailed": "클립을 병합할 수 없습니다. 다시 시도해 주세요."
+    "videoEditorMergeFailed": "클립을 병합할 수 없습니다. 다시 시도해 주세요.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Geselecteerde clips samenvoegen",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Geselecteerde clips verwijderen",
     "videoEditorMergeProgressLabel": "Een moment, we voegen je clips samen",
-    "videoEditorMergeFailed": "Kan clips niet samenvoegen. Probeer het opnieuw."
+    "videoEditorMergeFailed": "Kan clips niet samenvoegen. Probeer het opnieuw.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Scal zaznaczone klipy",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Usuń zaznaczone klipy",
     "videoEditorMergeProgressLabel": "Chwila, scalamy Twoje klipy",
-    "videoEditorMergeFailed": "Nie udało się scalić klipów. Spróbuj ponownie."
+    "videoEditorMergeFailed": "Nie udało się scalić klipów. Spróbuj ponownie.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Mesclar clipes selecionados",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Excluir clipes selecionados",
     "videoEditorMergeProgressLabel": "Um momento, estamos mesclando seus clipes",
-    "videoEditorMergeFailed": "Não foi possível mesclar os clipes. Tente novamente."
+    "videoEditorMergeFailed": "Não foi possível mesclar os clipes. Tente novamente.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Îmbină clipurile selectate",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Șterge clipurile selectate",
     "videoEditorMergeProgressLabel": "Un moment, îți îmbinăm clipurile",
-    "videoEditorMergeFailed": "Clipurile nu au putut fi îmbinate. Încearcă din nou."
+    "videoEditorMergeFailed": "Clipurile nu au putut fi îmbinate. Încearcă din nou.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Slå samman markerade klipp",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Ta bort markerade klipp",
     "videoEditorMergeProgressLabel": "Ett ögonblick, vi slår samman dina klipp",
-    "videoEditorMergeFailed": "Det gick inte att slå samman klippen. Försök igen."
+    "videoEditorMergeFailed": "Det gick inte att slå samman klippen. Försök igen.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -3968,5 +3968,6 @@
     "videoEditorMergeSelectedClipsSemanticLabel": "Seçili klipleri birleştir",
     "videoEditorDeleteSelectedClipsSemanticLabel": "Seçili klipleri sil",
     "videoEditorMergeProgressLabel": "Bir saniye, kliplerini birleştiriyoruz",
-    "videoEditorMergeFailed": "Klipler birleştirilemedi. Lütfen tekrar dene."
+    "videoEditorMergeFailed": "Klipler birleştirilemedi. Lütfen tekrar dene.",
+  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -3637,7 +3637,7 @@ abstract class AppLocalizations {
   /// No description provided for @nostrSettingsRemoveKeysSubtitle.
   ///
   /// In en, this message translates to:
-  /// **'Remove this account\'s local login from this device. This won\'t delete your Divine account or Nostr identity.'**
+  /// **'Remove this account\'s local login from this device. Your local drafts and clips stay saved for this account.'**
   String get nostrSettingsRemoveKeysSubtitle;
 
   /// No description provided for @nostrSettingsCouldNotRemoveKeys.
@@ -11378,7 +11378,7 @@ abstract class AppLocalizations {
   /// No description provided for @deleteAccountRemoveKeysBody.
   ///
   /// In en, this message translates to:
-  /// **'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.'**
+  /// **'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.'**
   String get deleteAccountRemoveKeysBody;
 
   /// No description provided for @deleteAccountRemoveKeysConfirm.

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -11363,6 +11363,12 @@ abstract class AppLocalizations {
   /// **'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.'**
   String get deleteAccountKeyDeletionWarning;
 
+  /// No description provided for @deleteAccountLocalDataDeletionFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Account deleted and signed out, but some local data could not be removed from this device.'**
+  String get deleteAccountLocalDataDeletionFailed;
+
   /// No description provided for @deleteAccountPreparingDeletion.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6389,7 +6389,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6380,6 +6380,10 @@ class AppLocalizationsAm extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6439,6 +6439,10 @@ class AppLocalizationsAr extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6448,7 +6448,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6565,7 +6565,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6556,6 +6556,10 @@ class AppLocalizationsBg extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6574,7 +6574,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6565,6 +6565,10 @@ class AppLocalizationsDe extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2062,7 +2062,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get nostrSettingsRemoveKeysSubtitle =>
-      'Remove this account\'s local login from this device. This won\'t delete your Divine account or Nostr identity.';
+      'Remove this account\'s local login from this device. Your local drafts and clips stay saved for this account.';
 
   @override
   String get nostrSettingsCouldNotRemoveKeys =>
@@ -6501,7 +6501,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6492,6 +6492,10 @@ class AppLocalizationsEn extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6553,7 +6553,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6544,6 +6544,10 @@ class AppLocalizationsEs extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6574,7 +6574,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6565,6 +6565,10 @@ class AppLocalizationsFil extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6580,7 +6580,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6571,6 +6571,10 @@ class AppLocalizationsFr extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6477,7 +6477,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6468,6 +6468,10 @@ class AppLocalizationsId extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6543,6 +6543,10 @@ class AppLocalizationsIt extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6552,7 +6552,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6265,7 +6265,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -6256,6 +6256,10 @@ class AppLocalizationsJa extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6279,6 +6279,10 @@ class AppLocalizationsKo extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -6288,7 +6288,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6530,7 +6530,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6521,6 +6521,10 @@ class AppLocalizationsNl extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6636,6 +6636,10 @@ class AppLocalizationsPl extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6645,7 +6645,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6529,6 +6529,10 @@ class AppLocalizationsPt extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6538,7 +6538,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6653,7 +6653,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6644,6 +6644,10 @@ class AppLocalizationsRo extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6503,7 +6503,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6494,6 +6494,10 @@ class AppLocalizationsSv extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6469,6 +6469,10 @@ class AppLocalizationsTr extends AppLocalizations {
       'Account deleted, but your keys may not have been fully removed from this device. Go to Settings → Nostr Keys → Remove Keys to retry.';
 
   @override
+  String get deleteAccountLocalDataDeletionFailed =>
+      'Account deleted and signed out, but some local data could not be removed from this device.';
+
+  @override
   String get deleteAccountPreparingDeletion => 'Preparing deletion...';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6478,7 +6478,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get deleteAccountRemoveKeysBody =>
-      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nIf this is your last local account, you\'ll return to the login screen.';
+      'This removes the local login for this account from this device. It won\'t delete your Divine account or Nostr identity.\n\nYour drafts and clips stay saved on this device for this account. If this is your last local account, you\'ll return to the login screen.';
 
   @override
   String get deleteAccountRemoveKeysConfirm => 'Remove from device';

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -3705,6 +3705,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// When [deleteKeys] is true, the current account's local login material is
   /// removed from the device.
   ///
+  /// When [deleteLocalUserData] is true, owner-scoped local rows for the
+  /// current account are also deleted. Keep this false for "Remove this account
+  /// from this device" so device-local drafts/clips survive re-login. Use true
+  /// only for flows that explicitly delete the account and its local data.
+  ///
   /// When [abortOnKeyDeletionFailure] is true (only meaningful with
   /// [deleteKeys]), platform key deletion is attempted **before** any
   /// session cleanup. If deletion fails the method throws immediately and
@@ -3719,6 +3724,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Future<void> signOut({
     bool deleteKeys = false,
     bool abortOnKeyDeletionFailure = false,
+    bool deleteLocalUserData = false,
   }) async {
     final pubkeyAtSignOutStart = _currentKeyContainer?.publicKeyHex;
     final npubAtSignOutStart = _currentKeyContainer?.npub;
@@ -3727,6 +3733,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       'authSource=${_authSource.name}, '
       'deleteKeys=$deleteKeys, '
       'abortOnKeyDeletionFailure=$abortOnKeyDeletionFailure, '
+      'deleteLocalUserData=$deleteLocalUserData, '
       'currentPubkey=${_currentKeyContainer?.publicKeyHex ?? "null"}',
       name: 'AuthService',
       category: LogCategory.auth,
@@ -3792,13 +3799,13 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       await prefs.remove('terms_accepted_at');
 
       // Clear user-specific cached data on explicit logout.
-      // Per-user DAO rows (drafts, clips, uploads, etc.) are only deleted
-      // on destructive sign-out (deleteKeys=true). Non-destructive sign-out
-      // (account switch) preserves them since they're scoped by ownerPubkey.
+      // Owner-scoped local rows (drafts, clips, uploads, etc.) are only
+      // deleted when the caller explicitly opts in. Removing local login
+      // material from the device is not enough reason to destroy local work.
       await _userDataCleanupService.clearUserSpecificData(
         reason: 'explicit_logout',
         userPubkey: _currentKeyContainer?.publicKeyHex,
-        deleteUserData: deleteKeys,
+        deleteUserData: deleteLocalUserData,
       );
 
       // Clear configured relays so next login re-discovers from NIP-65
@@ -4950,8 +4957,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         // clips, pending uploads) are already invisible to the incoming account
         // because every query filters by ownerPubkey. Deleting them here would
         // cause permanent data loss on account switch and mismatched re-login.
-        // Destructive per-user DAO deletion is reserved for explicit account
-        // removal (signOut(deleteKeys: true)).
+        // Destructive per-user DAO deletion is reserved for account deletion
+        // (signOut(deleteKeys: true, deleteLocalUserData: true)).
         await _userDataCleanupService.clearUserSpecificData(
           reason: 'identity_change',
           isIdentityChange: true,

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -3747,6 +3747,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     }
 
     Object? keyDeletionError;
+    Object? userDataCleanupError;
 
     await _runBeforeSessionTeardownCallbacks();
 
@@ -3754,6 +3755,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Clear TOS acceptance on any logout - user must re-accept when logging
       // back in
       final prefs = await SharedPreferences.getInstance();
+      final currentPubkey = _currentKeyContainer?.publicKeyHex;
 
       // Capture the leaving account as the session recovery anchor BEFORE any
       // teardown — but only for non-destructive sign-out (account switch).
@@ -3802,11 +3804,25 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       // Owner-scoped local rows (drafts, clips, uploads, etc.) are only
       // deleted when the caller explicitly opts in. Removing local login
       // material from the device is not enough reason to destroy local work.
-      await _userDataCleanupService.clearUserSpecificData(
-        reason: 'explicit_logout',
-        userPubkey: _currentKeyContainer?.publicKeyHex,
-        deleteUserData: deleteLocalUserData,
-      );
+      if (deleteKeys && !deleteLocalUserData && currentPubkey != null) {
+        await _userDataCleanupService.markOwnerScopedLegacyDataForUser(
+          currentPubkey,
+        );
+      }
+      try {
+        await _userDataCleanupService.clearUserSpecificData(
+          reason: 'explicit_logout',
+          userPubkey: currentPubkey,
+          deleteUserData: deleteLocalUserData,
+        );
+      } catch (e) {
+        userDataCleanupError = e;
+        Log.error(
+          'User data cleanup failed during signOut: $e',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+      }
 
       // Clear configured relays so next login re-discovers from NIP-65
       await prefs.remove('configured_relays');
@@ -3819,8 +3835,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       await prefs.remove('current_user_pubkey_hex');
 
       // Multi-account: archive or remove this account's signer info
-      final currentPubkey = _currentKeyContainer?.publicKeyHex;
-
       // Account-scoped CacheSync invalidation. Cache keys follow
       // `${pubkey}:${operation}` (RFC #4244), so this clears the
       // leaving account only and leaves other accounts intact.
@@ -4017,6 +4031,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     if (keyDeletionError != null) {
       throw SecureKeyStorageException(
         'Signed out but key deletion failed: $keyDeletionError',
+      );
+    }
+    if (userDataCleanupError != null && deleteLocalUserData) {
+      throw UserDataCleanupException(
+        'Signed out but local user data cleanup failed',
+        userDataCleanupError,
       );
     }
   }

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -55,8 +55,6 @@ class UserDataCleanupService {
     // Viewing history
     'seen_video_ids',
     'seen_video_metrics',
-    // Drafts
-    'vine_drafts',
     // Labeler subscriptions
     'subscribed_labelers',
     'label_cache',
@@ -66,6 +64,12 @@ class UserDataCleanupService {
     // TOS acceptance (user must re-accept on new account)
     'age_verified_16_plus',
     'terms_accepted_at',
+  ];
+
+  /// Legacy owner-scoped preference keys that contain user data but may still
+  /// need to survive a same-user non-destructive logout.
+  static const List<String> ownerScopedLegacyKeys = [
+    'vine_drafts',
   ];
 
   /// Key prefixes for dynamic user-specific data (keys that embed pubkey/npub).
@@ -102,7 +106,7 @@ class UserDataCleanupService {
     }
 
     // No stored pubkey - check if orphaned user data exists
-    for (final key in userSpecificKeys) {
+    for (final key in [...userSpecificKeys, ...ownerScopedLegacyKeys]) {
       if (_prefs.containsKey(key)) {
         return true;
       }
@@ -155,6 +159,16 @@ class UserDataCleanupService {
       }
     }
 
+    if (deleteUserData || isIdentityChange) {
+      for (final key in ownerScopedLegacyKeys) {
+        if (_prefs.containsKey(key)) {
+          await _prefs.remove(key);
+          clearedCount++;
+          clearedKeys.add(key);
+        }
+      }
+    }
+
     // Clear user-specific database tables (DMs, conversations, notifications,
     // and optionally per-user DAO rows when deleteUserData is true)
     if (onDatabaseCleanup != null) {
@@ -168,12 +182,15 @@ class UserDataCleanupService {
           name: 'UserDataCleanupService',
           category: LogCategory.auth,
         );
-      } catch (e) {
+      } catch (e, stackTrace) {
         Log.error(
-          'Database cleanup failed: $e',
+          'Database cleanup failed: $e\n$stackTrace',
           name: 'UserDataCleanupService',
           category: LogCategory.auth,
         );
+        if (deleteUserData) {
+          rethrow;
+        }
       }
     }
 

--- a/mobile/lib/services/user_data_cleanup_service.dart
+++ b/mobile/lib/services/user_data_cleanup_service.dart
@@ -72,6 +72,8 @@ class UserDataCleanupService {
     'vine_drafts',
   ];
 
+  static const String legacyDraftOwnerKey = 'vine_drafts_owner_pubkey_hex';
+
   /// Key prefixes for dynamic user-specific data (keys that embed pubkey/npub).
   /// Only cleared on identity change (different user), NOT on same-user logout.
   /// These caches are keyed by pubkey so they can't leak between users, and the
@@ -105,15 +107,36 @@ class UserDataCleanupService {
       return true;
     }
 
-    // No stored pubkey - check if orphaned user data exists
-    for (final key in [...userSpecificKeys, ...ownerScopedLegacyKeys]) {
+    // No stored pubkey - check if orphaned user data exists. Owner-scoped
+    // legacy data may belong to the same account after Remove from Device; keep
+    // it only when the preserved owner marker matches the logging-in pubkey.
+    for (final key in userSpecificKeys) {
       if (_prefs.containsKey(key)) {
         return true;
       }
     }
+    for (final key in ownerScopedLegacyKeys) {
+      if (!_prefs.containsKey(key)) continue;
+      if (key == 'vine_drafts' &&
+          _prefs.getString(legacyDraftOwnerKey) == currentPubkeyHex) {
+        continue;
+      }
+      return true;
+    }
 
     // Fresh install, no cleanup needed
     return false;
+  }
+
+  /// Marks preserved legacy owner-scoped data as belonging to [userPubkey].
+  ///
+  /// Remove-from-device clears the current-session pubkey while intentionally
+  /// preserving local drafts. This marker lets the next same-user login migrate
+  /// those drafts without treating them as foreign orphaned data.
+  Future<void> markOwnerScopedLegacyDataForUser(String userPubkey) async {
+    if (_prefs.containsKey('vine_drafts')) {
+      await _prefs.setString(legacyDraftOwnerKey, userPubkey);
+    }
   }
 
   /// Clears all user-specific data from SharedPreferences.
@@ -166,6 +189,11 @@ class UserDataCleanupService {
           clearedCount++;
           clearedKeys.add(key);
         }
+      }
+      if (_prefs.containsKey(legacyDraftOwnerKey)) {
+        await _prefs.remove(legacyDraftOwnerKey);
+        clearedCount++;
+        clearedKeys.add(legacyDraftOwnerKey);
       }
     }
 
@@ -255,4 +283,14 @@ class UserDataCleanupService {
       );
     }
   }
+}
+
+class UserDataCleanupException implements Exception {
+  const UserDataCleanupException(this.message, [this.cause]);
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => cause == null ? message : '$message: $cause';
 }

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -13,6 +13,7 @@ import 'package:nostr_key_manager/nostr_key_manager.dart'
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/services/account_deletion_service.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Show warning dialog for removing keys from device only
@@ -292,6 +293,8 @@ Future<void> executeAccountDeletion({
   // Captured before the first await so the post-sign-out catch can localize
   // without reading BuildContext across an async gap.
   final keyDeletionWarningText = context.l10n.deleteAccountKeyDeletionWarning;
+  final localDataDeletionFailedText =
+      context.l10n.deleteAccountLocalDataDeletionFailed;
 
   // Step 1: Execute NIP-62 deletion request (requires working signer)
   try {
@@ -339,6 +342,7 @@ Future<void> executeAccountDeletion({
       // signOut may throw SecureKeyStorageException if platform key
       // deletion failed — the user IS signed out but keys may remain.
       String? keyDeletionWarning;
+      String? localDataDeletionFailure;
       try {
         await authService.signOut(deleteKeys: true, deleteLocalUserData: true);
       } on SecureKeyStorageException catch (e) {
@@ -348,16 +352,28 @@ Future<void> executeAccountDeletion({
           category: LogCategory.auth,
         );
         keyDeletionWarning = keyDeletionWarningText;
+      } on UserDataCleanupException catch (e) {
+        Log.warning(
+          'Local user data cleanup failed during account deletion: $e',
+          name: screenName,
+          category: LogCategory.auth,
+        );
+        localDataDeletionFailure = localDataDeletionFailedText;
       }
 
       // Close loading indicator and show result snackbar
       // Router will automatically redirect to /welcome after sign out
       dismissDialog();
       if (context.mounted) {
+        final snackbarText =
+            keyDeletionWarning ??
+            localDataDeletionFailure ??
+            context.l10n.deleteAccountSuccess;
         ScaffoldMessenger.of(context).showSnackBar(
           DivineSnackbarContainer.snackBar(
-            keyDeletionWarning ?? context.l10n.deleteAccountSuccess,
-            error: keyDeletionWarning != null,
+            snackbarText,
+            error:
+                keyDeletionWarning != null || localDataDeletionFailure != null,
           ),
         );
       }

--- a/mobile/lib/widgets/delete_account_dialog.dart
+++ b/mobile/lib/widgets/delete_account_dialog.dart
@@ -333,14 +333,14 @@ Future<void> executeAccountDeletion({
         );
       }
 
-      // Step 3: Sign out and delete local keys
+      // Step 3: Sign out, delete local keys, and clear local account data
       // Router will automatically redirect to /welcome when auth state
       // becomes unauthenticated.
       // signOut may throw SecureKeyStorageException if platform key
       // deletion failed — the user IS signed out but keys may remain.
       String? keyDeletionWarning;
       try {
-        await authService.signOut(deleteKeys: true);
+        await authService.signOut(deleteKeys: true, deleteLocalUserData: true);
       } on SecureKeyStorageException catch (e) {
         Log.warning(
           'Key deletion failed during account deletion: $e',

--- a/mobile/test/services/account_deletion_flow_test.dart
+++ b/mobile/test/services/account_deletion_flow_test.dart
@@ -79,7 +79,10 @@ void main() {
       ).thenAnswer((_) async => PublishSuccess(event: mockEvent));
 
       when(
-        () => mockAuthService.signOut(deleteKeys: true),
+        () => mockAuthService.signOut(
+          deleteKeys: true,
+          deleteLocalUserData: true,
+        ),
       ).thenAnswer((_) async => Future.value());
 
       final deletionService = AccountDeletionService(
@@ -120,8 +123,13 @@ void main() {
       // Verify NIP-62 event was published
       verify(() => mockNostrService.publishEvent(any())).called(1);
 
-      // Verify user was signed out with keys deleted
-      verify(() => mockAuthService.signOut(deleteKeys: true)).called(1);
+      // Verify user was signed out with keys and local user data deleted
+      verify(
+        () => mockAuthService.signOut(
+          deleteKeys: true,
+          deleteLocalUserData: true,
+        ),
+      ).called(1);
 
       // Verify completion dialog appears
       expect(find.text('✓ Account Deleted'), findsOneWidget);

--- a/mobile/test/services/auth_service_delete_keycast_account_test.dart
+++ b/mobile/test/services/auth_service_delete_keycast_account_test.dart
@@ -45,6 +45,9 @@ void main() {
       when(
         () => mockCleanupService.claimLegacyRows(any()),
       ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
     });
 
     test('returns success when no OAuth client is configured', () async {

--- a/mobile/test/services/auth_service_expired_session_downgrade_test.dart
+++ b/mobile/test/services/auth_service_expired_session_downgrade_test.dart
@@ -44,6 +44,9 @@ void main() {
       when(
         () => mockCleanupService.claimLegacyRows(any()),
       ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
 
       // In-memory secure storage backing
       secureStorage = {};

--- a/mobile/test/services/auth_service_identity_change_preservation_test.dart
+++ b/mobile/test/services/auth_service_identity_change_preservation_test.dart
@@ -138,6 +138,9 @@ void main() {
       when(
         () => mockCleanupService.claimLegacyRows(any()),
       ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
 
       authService = AuthService(
         userDataCleanupService: mockCleanupService,

--- a/mobile/test/services/auth_service_identity_change_preservation_test.dart
+++ b/mobile/test/services/auth_service_identity_change_preservation_test.dart
@@ -207,7 +207,7 @@ void main() {
     );
 
     test(
-      'explicit account removal (deleteKeys: true) still deletes user data',
+      'remove-device signOut (deleteKeys: true) preserves user data by default',
       () async {
         // First sign in so there is a current identity to sign out from.
         when(
@@ -215,7 +215,8 @@ void main() {
         ).thenReturn(false);
         await _ignoringDiscoveryErrors(authService.createNewIdentity);
 
-        // Now perform a destructive sign-out (account deletion / remove keys).
+        // Now remove local login material. This must not delete device-local
+        // drafts/clips because they are scoped by ownerPubkey.
         when(
           () => mockCleanupService.clearUserSpecificData(
             reason: any(named: 'reason'),
@@ -226,16 +227,42 @@ void main() {
 
         await authService.signOut(deleteKeys: true);
 
-        // The explicit-logout path must still pass deleteUserData: true.
+        // The explicit-logout path preserves owner-scoped local data by default.
         verify(
           () => mockCleanupService.clearUserSpecificData(
             reason: 'explicit_logout',
             userPubkey: any(named: 'userPubkey'),
-            deleteUserData: true,
+            // ignore: avoid_redundant_argument_values
+            deleteUserData: false,
           ),
         ).called(1);
       },
     );
+
+    test('account deletion opts in to deleting local user data', () async {
+      when(
+        () => mockCleanupService.shouldClearDataForUser(any()),
+      ).thenReturn(false);
+      await _ignoringDiscoveryErrors(authService.createNewIdentity);
+
+      when(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: any(named: 'reason'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
+        ),
+      ).thenAnswer((_) async => 0);
+
+      await authService.signOut(deleteKeys: true, deleteLocalUserData: true);
+
+      verify(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: 'explicit_logout',
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: true,
+        ),
+      ).called(1);
+    });
 
     test(
       'non-destructive signOut (account switch) passes deleteUserData: false',

--- a/mobile/test/services/auth_service_invite_session_cleanup_test.dart
+++ b/mobile/test/services/auth_service_invite_session_cleanup_test.dart
@@ -122,6 +122,9 @@ void main() {
       when(
         () => mockCleanupService.claimLegacyRows(any()),
       ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
 
       when(
         () => mockOAuthClient.refreshSession(

--- a/mobile/test/services/auth_service_local_first_startup_test.dart
+++ b/mobile/test/services/auth_service_local_first_startup_test.dart
@@ -46,6 +46,9 @@ void main() {
       when(
         () => mockCleanupService.claimLegacyRows(any()),
       ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
 
       secureStorage = {};
 

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -2101,7 +2101,7 @@ void main() {
     });
 
     test(
-      'destructive sign-out passes the signed-in pubkey to cleanup',
+      'remove-device sign-out preserves owner-scoped data for signed-in pubkey',
       () async {
         SharedPreferences.setMockInitialValues({
           'authentication_source': 'automatic',
@@ -2117,7 +2117,8 @@ void main() {
           () => mockCleanupService.clearUserSpecificData(
             reason: 'explicit_logout',
             userPubkey: expectedPubkey,
-            deleteUserData: true,
+            // ignore: avoid_redundant_argument_values
+            deleteUserData: false,
           ),
         ).called(1);
       },

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -133,6 +133,9 @@ void main() {
     when(
       () => mockCleanupService.claimLegacyRows(any()),
     ).thenAnswer((_) async {});
+    when(
+      () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+    ).thenAnswer((_) async {});
 
     // Default flutter secure storage stubs
     when(

--- a/mobile/test/services/auth_service_nip07_test.dart
+++ b/mobile/test/services/auth_service_nip07_test.dart
@@ -100,6 +100,9 @@ void main() {
     when(
       () => mockCleanupService.claimLegacyRows(any()),
     ).thenAnswer((_) async {});
+    when(
+      () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+    ).thenAnswer((_) async {});
 
     when(
       () => mockSecureStorage.read(key: any(named: 'key')),

--- a/mobile/test/services/auth_service_oauth_local_signing_test.dart
+++ b/mobile/test/services/auth_service_oauth_local_signing_test.dart
@@ -163,6 +163,9 @@ void main() {
     when(
       () => mockCleanupService.claimLegacyRows(any()),
     ).thenAnswer((_) async {});
+    when(
+      () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+    ).thenAnswer((_) async {});
 
     when(() => mockOAuthClient.close()).thenReturn(null);
 

--- a/mobile/test/services/auth_service_oauth_recovery_test.dart
+++ b/mobile/test/services/auth_service_oauth_recovery_test.dart
@@ -186,6 +186,9 @@ void main() {
     when(
       () => mockCleanupService.claimLegacyRows(any()),
     ).thenAnswer((_) async {});
+    when(
+      () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+    ).thenAnswer((_) async {});
 
     // Mock OAuth client: logout clears the same keys that the real
     // KeycastOAuth.logout() would clear via SecureKeycastStorage.

--- a/mobile/test/services/auth_service_signing_mismatch_test.dart
+++ b/mobile/test/services/auth_service_signing_mismatch_test.dart
@@ -115,6 +115,9 @@ void main() {
     when(
       () => mockCleanupService.claimLegacyRows(any()),
     ).thenAnswer((_) async {});
+    when(
+      () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+    ).thenAnswer((_) async {});
 
     when(
       () => mockSecureStorage.read(key: any(named: 'key')),

--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -174,7 +174,7 @@ void main() {
       ).called(1);
     });
 
-    test('destructive signOut passes deleteUserData: true', () async {
+    test('remove-device signOut preserves owner-scoped user data', () async {
       // Arrange
       when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
       when(
@@ -194,13 +194,49 @@ void main() {
         ),
       ).thenAnswer((_) async => newKeyContainer);
 
-      // Act: Sign out with key deletion
+      // Act: remove local login material without deleting local work.
       await authService.signOut(deleteKeys: true);
 
       // Assert: Keys should be deleted
       verify(() => mockKeyStorage.deleteKeys()).called(1);
 
-      // Assert: Cleanup called with deleteUserData=true (destructive)
+      // Assert: owner-scoped rows are preserved. Removing local login material
+      // should not destroy device-local drafts/clips.
+      verify(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: 'explicit_logout',
+          userPubkey: any(named: 'userPubkey'),
+          // ignore: avoid_redundant_argument_values
+          deleteUserData: false,
+        ),
+      ).called(1);
+
+      // Note: After deleteKeys=true, a new identity is auto-created,
+      // which sets a new pubkey. So we verify cleanup was called,
+      // not that pubkey is null (since new identity sets it).
+    });
+
+    test('account deletion signOut deletes owner-scoped user data', () async {
+      // Arrange
+      when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async => {});
+      when(
+        () => mockKeyStorage.deleteIdentityKeyContainer(
+          any(),
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async {});
+      when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+      when(() => mockKeyStorage.initialize()).thenAnswer((_) async => {});
+
+      final newKeyContainer = SecureKeyContainer.fromNsec(testNsec);
+      when(
+        () => mockKeyStorage.generateAndStoreKeys(
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).thenAnswer((_) async => newKeyContainer);
+
+      await authService.signOut(deleteKeys: true, deleteLocalUserData: true);
+
       verify(
         () => mockCleanupService.clearUserSpecificData(
           reason: 'explicit_logout',
@@ -208,10 +244,6 @@ void main() {
           deleteUserData: true,
         ),
       ).called(1);
-
-      // Note: After deleteKeys=true, a new identity is auto-created,
-      // which sets a new pubkey. So we verify cleanup was called,
-      // not that pubkey is null (since new identity sets it).
     });
 
     test(

--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -115,6 +115,9 @@ void main() {
         () => mockCleanupService.claimLegacyRows(any()),
       ).thenAnswer((_) async {});
       when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
+      when(
         () => mockKeyStorage.deleteIdentityKeyContainer(
           any(),
           biometricPrompt: any(named: 'biometricPrompt'),
@@ -544,6 +547,41 @@ void main() {
         expect(authService.authState, equals(AuthState.unauthenticated));
         verify(() => mockKeyStorage.deleteKeys()).called(1);
       });
+
+      test(
+        'account deletion cleanup failure surfaces after teardown',
+        () async {
+          final keyContainer = SecureKeyContainer.fromNsec(testNsec);
+          authService.debugSetCurrentKeyContainer(keyContainer);
+          when(
+            () => mockCleanupService.clearUserSpecificData(
+              reason: 'explicit_logout',
+              userPubkey: keyContainer.publicKeyHex,
+              deleteUserData: true,
+            ),
+          ).thenThrow(StateError('database cleanup failed'));
+          when(() => mockKeyStorage.deleteKeys()).thenAnswer((_) async {});
+          when(
+            () => mockKeyStorage.deleteIdentityKeyContainer(
+              any(),
+              biometricPrompt: any(named: 'biometricPrompt'),
+            ),
+          ).thenAnswer((_) async {});
+          when(() => mockKeyStorage.hasKeys()).thenAnswer((_) async => false);
+          when(
+            () => mockKeyStorage.getKeyContainer(),
+          ).thenAnswer((_) async => null);
+
+          await expectLater(
+            authService.signOut(deleteKeys: true, deleteLocalUserData: true),
+            throwsA(isA<UserDataCleanupException>()),
+          );
+
+          verify(() => mockKeyStorage.deleteKeys()).called(1);
+          expect(authService.currentIdentity, isNull);
+          expect(authService.authState, equals(AuthState.unauthenticated));
+        },
+      );
 
       test('signOut with abortOnKeyDeletionFailure throws before cleanup '
           'when key deletion fails', () async {

--- a/mobile/test/services/user_data_cleanup_service_test.dart
+++ b/mobile/test/services/user_data_cleanup_service_test.dart
@@ -112,10 +112,29 @@ void main() {
         expect(prefs.containsKey('content_moderation_local_mutes'), isFalse);
       });
 
-      test('clears draft-related keys', () async {
+      test(
+        'preserves legacy drafts on same-user non-destructive cleanup',
+        () async {
+          await prefs.setString('vine_drafts', '{"drafts": []}');
+
+          await service.clearUserSpecificData();
+
+          expect(prefs.containsKey('vine_drafts'), isTrue);
+        },
+      );
+
+      test('clears legacy drafts on destructive cleanup', () async {
         await prefs.setString('vine_drafts', '{"drafts": []}');
 
-        await service.clearUserSpecificData();
+        await service.clearUserSpecificData(deleteUserData: true);
+
+        expect(prefs.containsKey('vine_drafts'), isFalse);
+      });
+
+      test('clears legacy drafts on identity change', () async {
+        await prefs.setString('vine_drafts', '{"drafts": []}');
+
+        await service.clearUserSpecificData(isIdentityChange: true);
 
         expect(prefs.containsKey('vine_drafts'), isFalse);
       });
@@ -209,6 +228,7 @@ void main() {
         'returns correct count including prefix keys on identity change',
         () async {
           await prefs.setStringList('curated_lists', ['list1']);
+          await prefs.setString('vine_drafts', '{"drafts": []}');
           await prefs.setString('following_list_abc123', '["pubkey1"]');
           await prefs.setString('relay_discovery_npub1abc', 'data');
 
@@ -217,8 +237,8 @@ void main() {
             isIdentityChange: true,
           );
 
-          // 1 static + 2 prefix keys
-          expect(count, equals(3));
+          // 1 static + 1 owner-scoped legacy key + 2 prefix keys
+          expect(count, equals(4));
         },
       );
 
@@ -275,6 +295,30 @@ void main() {
         },
       );
 
+      test(
+        'does not throw database cleanup failure on non-destructive cleanup',
+        () async {
+          service.onDatabaseCleanup =
+              ({String? userPubkey, bool deleteUserData = false}) async {
+                throw StateError('cleanup failed');
+              };
+
+          await expectLater(service.clearUserSpecificData(), completes);
+        },
+      );
+
+      test('throws database cleanup failure on destructive cleanup', () async {
+        service.onDatabaseCleanup =
+            ({String? userPubkey, bool deleteUserData = false}) async {
+              throw StateError('cleanup failed');
+            };
+
+        await expectLater(
+          service.clearUserSpecificData(deleteUserData: true),
+          throwsA(isA<StateError>()),
+        );
+      });
+
       test('claimLegacyRows calls onClaimLegacyRows callback', () async {
         String? receivedPubkey;
         service.onClaimLegacyRows = (String pubkey) async {
@@ -312,9 +356,6 @@ void main() {
         expect(keys, contains('seen_video_ids'));
         expect(keys, contains('content_reports_history'));
 
-        // Drafts
-        expect(keys, contains('vine_drafts'));
-
         // TOS
         expect(keys, contains('age_verified_16_plus'));
         expect(keys, contains('terms_accepted_at'));
@@ -327,6 +368,14 @@ void main() {
         expect(keys, isNot(contains('relay_url')));
         expect(keys, isNot(contains('analytics_enabled')));
         expect(keys, isNot(contains('current_user_pubkey_hex')));
+      });
+    });
+
+    group('ownerScopedLegacyKeys', () {
+      test('contains legacy draft storage', () {
+        const keys = UserDataCleanupService.ownerScopedLegacyKeys;
+
+        expect(keys, contains('vine_drafts'));
       });
     });
 

--- a/mobile/test/services/user_data_cleanup_service_test.dart
+++ b/mobile/test/services/user_data_cleanup_service_test.dart
@@ -57,6 +57,36 @@ void main() {
           expect(service.shouldClearDataForUser('any_pubkey'), isTrue);
         },
       );
+
+      test(
+        'keeps preserved legacy drafts for same-user re-login',
+        () async {
+          const pubkey = 'same_user_pubkey';
+          await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
+          await service.markOwnerScopedLegacyDataForUser(pubkey);
+
+          expect(service.shouldClearDataForUser(pubkey), isFalse);
+        },
+      );
+
+      test(
+        'clears preserved legacy drafts for a different user',
+        () async {
+          await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
+          await service.markOwnerScopedLegacyDataForUser('old_user_pubkey');
+
+          expect(service.shouldClearDataForUser('new_user_pubkey'), isTrue);
+        },
+      );
+
+      test(
+        'clears unmarked legacy drafts as orphaned data',
+        () async {
+          await prefs.setString('vine_drafts', '[{"id":"draft1"}]');
+
+          expect(service.shouldClearDataForUser('any_pubkey'), isTrue);
+        },
+      );
     });
 
     group('clearUserSpecificData', () {
@@ -125,18 +155,44 @@ void main() {
 
       test('clears legacy drafts on destructive cleanup', () async {
         await prefs.setString('vine_drafts', '{"drafts": []}');
+        await service.markOwnerScopedLegacyDataForUser('abc123');
 
         await service.clearUserSpecificData(deleteUserData: true);
 
         expect(prefs.containsKey('vine_drafts'), isFalse);
+        expect(
+          prefs.containsKey(UserDataCleanupService.legacyDraftOwnerKey),
+          isFalse,
+        );
       });
 
       test('clears legacy drafts on identity change', () async {
         await prefs.setString('vine_drafts', '{"drafts": []}');
+        await service.markOwnerScopedLegacyDataForUser('abc123');
 
         await service.clearUserSpecificData(isIdentityChange: true);
 
         expect(prefs.containsKey('vine_drafts'), isFalse);
+        expect(
+          prefs.containsKey(UserDataCleanupService.legacyDraftOwnerKey),
+          isFalse,
+        );
+      });
+
+      test('marks legacy draft owner only when legacy drafts exist', () async {
+        await service.markOwnerScopedLegacyDataForUser('abc123');
+        expect(
+          prefs.containsKey(UserDataCleanupService.legacyDraftOwnerKey),
+          isFalse,
+        );
+
+        await prefs.setString('vine_drafts', '{"drafts": []}');
+        await service.markOwnerScopedLegacyDataForUser('abc123');
+
+        expect(
+          prefs.getString(UserDataCleanupService.legacyDraftOwnerKey),
+          equals('abc123'),
+        );
       });
 
       test('returns count of cleared keys', () async {

--- a/mobile/test/widgets/delete_account_dialog_test.dart
+++ b/mobile/test/widgets/delete_account_dialog_test.dart
@@ -4,8 +4,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/services/account_deletion_service.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:openvine/widgets/delete_account_dialog.dart';
+
+class _MockAccountDeletionService extends Mock
+    implements AccountDeletionService {}
+
+class _MockAuthService extends Mock implements AuthService {}
 
 /// Minimal router wrapper so [context.pop()] works inside the dialog.
 Widget _wrapWithRouter(Widget child) {
@@ -141,6 +150,57 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(called, isTrue);
+    });
+  });
+
+  group('executeAccountDeletion', () {
+    testWidgets('shows failure when local data cleanup fails after sign-out', (
+      tester,
+    ) async {
+      final deletionService = _MockAccountDeletionService();
+      final authService = _MockAuthService();
+      when(
+        () =>
+            deletionService.deleteAccount(onProgress: any(named: 'onProgress')),
+      ).thenAnswer((_) async => DeleteAccountResult.createSuccess('event-id'));
+      when(
+        authService.deleteKeycastAccount,
+      ).thenAnswer((_) async => (true, null));
+      when(
+        () => authService.signOut(deleteKeys: true, deleteLocalUserData: true),
+      ).thenThrow(
+        const UserDataCleanupException(
+          'Signed out but local user data cleanup failed',
+        ),
+      );
+
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        _wrapWithRouter(
+          Builder(
+            builder: (context) {
+              capturedContext = context;
+              return const Scaffold(body: SizedBox.shrink());
+            },
+          ),
+        ),
+      );
+
+      await executeAccountDeletion(
+        context: capturedContext,
+        deletionService: deletionService,
+        authService: authService,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'Account deleted and signed out, but some local data could not be '
+          'removed from this device.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('Your account has been deleted'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fixes #5496.

This PR separates removing local login material from deleting owner-scoped local user data. The issue report was caused by the remove-from-device flow calling `signOut(deleteKeys: true)`, which also made cleanup delete local-only drafts and clips.

## What changed

- Adds an explicit `deleteLocalUserData` opt-in to `AuthService.signOut`, defaulting to `false`.
- Keeps Settings -> Nostr Settings -> Remove this account from this device on key removal only, preserving device-local drafts/clips for that account.
- Makes the true Delete Account flow opt into local user data deletion with `deleteLocalUserData: true`.
- Updates remove-device copy to explain that drafts and clips stay saved on this device for the account.
- Regenerates l10n output and updates regression coverage for both preserve and delete paths.

## Root cause

`deleteKeys: true` was doing two jobs: deleting local login credentials and deleting owner-scoped local data. Drafts and clips are local-only and owner-scoped, so using the remove-device action as a troubleshooting logout permanently destroyed local work.

## Validation

- `flutter gen-l10n`
- `mise exec -- dart format lib test integration_test`
- `flutter analyze`
- `flutter test test/l10n/arb_consistency_test.dart`
- `flutter test test/widgets/nostr_settings_screen_test.dart test/services/account_deletion_flow_test.dart`
- `flutter test test/services/auth_service_signout_cleanup_test.dart test/services/auth_service_identity_change_preservation_test.dart test/services/auth_service_multi_account_test.dart`
- Pre-push hook: analyzer plus changed-file tests, including `test/widgets/delete_account_dialog_test.dart`
