### PR TITLE
fix(camera): smooth iOS preview with previewOptimized stabilization

### DIFF
--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -1749,9 +1749,9 @@ class CameraController: NSObject {
         let applied = applyVideoStabilization()
         if !applied {
             requestedStabilizationMode = previous
-            // applyVideoStabilization already nudged the preview output to the
-            // rejected mode; resync it to the restored mode.
-            applyPreviewStabilization()
+            // Re-apply the restored mode to both connections so the preview
+            // handoff matches the recording connection's actual state.
+            applyVideoStabilization()
         }
         return applied
     }
@@ -1829,17 +1829,28 @@ class CameraController: NSObject {
     @discardableResult
     private func applyVideoStabilization() -> Bool {
         let applied = applyRecordingStabilization()
-        applyPreviewStabilization()
+        // Only hand the preview to the preview-optimized output when the
+        // recording connection actually carries a non-off mode. A requested
+        // mode that could not be applied (e.g. unsupported after a lens/format
+        // switch) leaves the recording unstabilized, so the preview must stay
+        // on the full-resolution output to keep preview and file in sync.
+        applyPreviewStabilization(
+            recordingStabilized: applied && requestedStabilizationMode != .off
+        )
         return applied
     }
 
-    /// Keeps `previewOutput`'s connection in sync with whether stabilization is
-    /// on: `.previewOptimized` while the user has a mode selected (a smooth live
-    /// preview that doesn't zoom/jerk at record start), `.off` otherwise so the
-    /// preview matches the unstabilized recording. Flips `previewDrivesTexture`
-    /// so `captureOutput` routes the texture from the right output, and disables
-    /// the connection while unused so no frames are spent on it.
-    private func applyPreviewStabilization() {
+    /// Keeps `previewOutput`'s connection in sync with the recording
+    /// connection: `.previewOptimized` while the recording is actually
+    /// stabilized (a smooth live preview that doesn't zoom/jerk at record
+    /// start), `.off` otherwise so the preview matches the unstabilized
+    /// recording. `recordingStabilized` is true only when the requested mode
+    /// was successfully applied to the recording connection — a rejected mode
+    /// (e.g. unsupported after a lens/format switch) keeps the preview on the
+    /// full-resolution output. Flips `previewDrivesTexture` so `captureOutput`
+    /// routes the texture from the right output, and disables the connection
+    /// while unused so no frames are spent on it.
+    private func applyPreviewStabilization(recordingStabilized: Bool) {
         let previewConnection = previewOutput?.connection(with: .video)
         guard previewOptimizedActive,
             let connection = previewConnection,
@@ -1853,13 +1864,12 @@ class CameraController: NSObject {
             previewDrivesTexture = false
             return
         }
-        let wantPreviewOptimized = requestedStabilizationMode != .off
-        connection.isEnabled = wantPreviewOptimized
+        connection.isEnabled = recordingStabilized
         if #available(iOS 17.0, *) {
             connection.preferredVideoStabilizationMode =
-                wantPreviewOptimized ? .previewOptimized : .off
+                recordingStabilized ? .previewOptimized : .off
         }
-        previewDrivesTexture = wantPreviewOptimized
+        previewDrivesTexture = recordingStabilized
     }
 
     /// Applies `requestedStabilizationMode` to `videoOutput`'s connection — the

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -155,6 +155,12 @@ class CameraController: NSObject {
     private var maxDurationTimer: Timer?
     private var maxDurationMs: Int?
     private var isWriterSessionStarted: Bool = false
+
+    /// PTS of the last video frame appended to the asset writer. Used at
+    /// finalize to bound the writer session to the video's actual end, so a
+    /// look-ahead stabilization mode (which delays video ~0.5–1s behind audio)
+    /// can't leave the clip ending on a frozen frame while audio keeps playing.
+    private var lastVideoFramePTS: CMTime?
     
     /// Completion handler for camera switch - called when first frame from new camera arrives
     private var switchCameraCompletion: (([String: Any]?, String?) -> Void)?
@@ -2136,6 +2142,7 @@ class CameraController: NSObject {
 
             self.isRecording = true
             self.isWriterSessionStarted = false  // Will be set to true when first frame is received
+            self.lastVideoFramePTS = nil
             self.recordingStartTime = Date()
 
             // Check and enable auto-flash if needed
@@ -2210,36 +2217,55 @@ class CameraController: NSObject {
         videoOutputQueue.async { [weak self] in
             guard let self = self else { return }
 
+            // Bound the session to the last video frame. With a look-ahead
+            // stabilization mode the trailing ~0.5–1s of video never reaches
+            // the writer, so audio would otherwise outlast video and the clip
+            // would end on a held (frozen) frame. Ending here trims that
+            // surplus audio so both tracks stop together.
+            if writer.status == .writing,
+                self.isWriterSessionStarted,
+                let endPTS = self.lastVideoFramePTS {
+                writer.endSession(atSourceTime: endPTS)
+            }
+
             self.videoWriterInput?.markAsFinished()
             self.audioWriterInput?.markAsFinished()
-            
+
             writer.finishWriting { [weak self] in
                 guard let self = self else { return }
                 
                 DispatchQueue.main.async {
                     if writer.status == .completed {
-                        // Calculate duration
-                        let duration: Int
-                        if let startTime = self.recordingStartTime {
-                            duration = Int(Date().timeIntervalSince(startTime) * 1000)
-                        } else {
-                            duration = 0
-                        }
-                        
                         // Get video dimensions
                         guard let outputURL = self.currentRecordingURL else {
                             completion(nil, "Output URL not available")
                             return
                         }
-                        
+
                         var width: Int = 1920
                         var height: Int = 1080
-                        
+
                         let asset = AVAsset(url: outputURL)
                         if let track = asset.tracks(withMediaType: .video).first {
                             let size = track.naturalSize.applying(track.preferredTransform)
                             width = Int(abs(size.width))
                             height = Int(abs(size.height))
+                        }
+
+                        // Report the finished file's real duration. The
+                        // wall-clock span over-reports for look-ahead
+                        // stabilization (the trailing video never reaches the
+                        // writer), which would make a player hold the last
+                        // frame. Fall back to wall clock only if the asset
+                        // duration is unavailable.
+                        let assetSeconds = CMTimeGetSeconds(asset.duration)
+                        let duration: Int
+                        if assetSeconds.isFinite, assetSeconds > 0 {
+                            duration = Int(assetSeconds * 1000)
+                        } else if let startTime = self.recordingStartTime {
+                            duration = Int(Date().timeIntervalSince(startTime) * 1000)
+                        } else {
+                            duration = 0
                         }
 
                         // Definitive signal for the "clip saved without sound"
@@ -2283,11 +2309,12 @@ class CameraController: NSObject {
                     self.currentRecordingURL = nil
                     self.recordingStartTime = nil
                     self.isWriterSessionStarted = false
+                    self.lastVideoFramePTS = nil
                 }
             }
         }
     }
-    
+
     /// Pauses the camera preview.
     func pausePreview() {
         disableScreenFlash()
@@ -2414,7 +2441,8 @@ class CameraController: NSObject {
             self.videoWriterInput = nil
             self.audioWriterInput = nil
             self.pixelBufferAdaptor = nil
-            
+            self.lastVideoFramePTS = nil
+
             if self.textureId >= 0 {
                 self.textureRegistry.unregisterTexture(self.textureId)
                 self.textureId = -1
@@ -2521,6 +2549,7 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
 
                 if writer.status == .writing && videoInput.isReadyForMoreMediaData {
                     adaptor.append(pixelBuffer, withPresentationTime: timestamp)
+                    lastVideoFramePTS = timestamp
                 }
             }
         }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -1766,6 +1766,10 @@ class CameraController: NSObject {
         ]
         // Preview can drop late frames — they never reach the asset writer.
         output.alwaysDiscardsLateVideoFrames = true
+        // Shares videoOutputQueue on purpose: one serial queue serializes both
+        // outputs so the texture handoff (previewDrivesTexture) and the
+        // switch-completion / pixel-buffer state stay race-free. A separate
+        // queue would reintroduce those races for marginal throughput.
         output.setSampleBufferDelegate(self, queue: videoOutputQueue)
 
         guard session.canAddOutput(output) else {
@@ -1830,10 +1834,16 @@ class CameraController: NSObject {
     /// so `captureOutput` routes the texture from the right output, and disables
     /// the connection while unused so no frames are spent on it.
     private func applyPreviewStabilization() {
+        let previewConnection = previewOutput?.connection(with: .video)
         guard previewOptimizedActive,
-            let connection = previewOutput?.connection(with: .video),
+            let connection = previewConnection,
             connection.isVideoStabilizationSupported
         else {
+            // A camera that lost stabilization support (e.g. after a lens
+            // switch) would otherwise keep this output delivering frames the
+            // texture path immediately discards — disable it so no frames are
+            // spent on it.
+            previewConnection?.isEnabled = false
             previewDrivesTexture = false
             return
         }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -22,6 +22,15 @@ class CameraController: NSObject {
     private var videoOutput: AVCaptureVideoDataOutput?
     private var audioOutput: AVCaptureAudioDataOutput?
 
+    /// Optional second, preview-sized video data output dedicated to the live
+    /// preview texture. Runs `.previewOptimized` stabilization (iOS 17+) so the
+    /// preview stays smooth and does not jump/jerk when recording starts, while
+    /// `videoOutput` keeps the user-selected overscan mode for the recorded
+    /// file. Nil when the dual-output path is unavailable (older iOS,
+    /// unsupported device, or the session rejects a second video data output);
+    /// the controller then drives the texture from `videoOutput` as before.
+    private var previewOutput: AVCaptureVideoDataOutput?
+
     /// Still-photo output for single-frame capture (stop-motion). Added at
     /// session setup alongside the video data output; AVCapturePhotoOutput
     /// coexists with AVCaptureVideoDataOutput (unlike AVCaptureMovieFileOutput).
@@ -83,6 +92,18 @@ class CameraController: NSObject {
     // so it affects both the live preview texture and the recorded file.
     // Defaults to .off to preserve existing behaviour until the user opts in.
     private var requestedStabilizationMode: AVCaptureVideoStabilizationMode = .off
+
+    /// True once `previewOutput` is wired and able to carry `.previewOptimized`.
+    private var previewOptimizedActive = false
+
+    /// True while the preview texture should be fed from `previewOutput` rather
+    /// than `videoOutput` — i.e. the dual-output path is active AND the user has
+    /// a non-off stabilization mode selected. Read on `videoOutputQueue` in
+    /// `captureOutput`; written when the stabilization mode changes. The
+    /// cross-queue access is a benign single-`Bool` race (mirrors the existing
+    /// cross-queue reads of `requestedStabilizationMode`): a stale read costs at
+    /// most one frame routed from the other output, never a dropped frame.
+    private var previewDrivesTexture = false
 
     // Auto lens switching via zoom
     // When true, uses a virtual multi-camera device (builtInTripleCamera,
@@ -747,6 +768,15 @@ class CameraController: NSObject {
             DivineCameraLog.shared.error("DivineCamera: Cannot add photo output to session", name: "DivineCamera.Setup")
         }
 
+        // Optional preview-optimized output (iOS 17+). A second, preview-sized
+        // data output carries `.previewOptimized`, so the live preview stays
+        // smooth and does not jump when recording starts. `videoOutput` keeps
+        // the user-selected overscan mode for the recorded file. Added AFTER the
+        // photo output so that, on any device with an output-count limit, the
+        // existing photo capture wins and this optional output falls back to the
+        // single-output preview path.
+        setupPreviewOptimizedOutputIfPossible(session: session)
+
         // NOTE: AVCaptureAudioDataOutput is also added lazily in startRecording().
         
         // NOTE: MovieOutput is intentionally NOT added here during initialization.
@@ -1203,6 +1233,16 @@ class CameraController: NSObject {
                     let isFront = newDevice.position == .front
                     if photoConnection.isVideoMirroringSupported {
                         photoConnection.isVideoMirrored = isFront && self.mirrorFrontCameraOutput
+                    }
+                }
+                if self.previewOptimizedActive,
+                    let previewConnection = self.previewOutput?.connection(with: .video) {
+                    if previewConnection.isVideoOrientationSupported {
+                        previewConnection.videoOrientation = .portrait
+                    }
+                    let isFront = newDevice.position == .front
+                    if previewConnection.isVideoMirroringSupported {
+                        previewConnection.isVideoMirrored = isFront && self.mirrorFrontCameraOutput
                     }
                 }
             } catch {
@@ -1703,16 +1743,114 @@ class CameraController: NSObject {
         let applied = applyVideoStabilization()
         if !applied {
             requestedStabilizationMode = previous
+            // applyVideoStabilization already nudged the preview output to the
+            // rejected mode; resync it to the restored mode.
+            applyPreviewStabilization()
         }
         return applied
     }
 
-    /// Applies `requestedStabilizationMode` to the video connection. The
-    /// stabilized frames feed both the preview texture and the asset writer,
-    /// so the recording matches what the user sees. Returns true when the
-    /// requested mode could be applied (off is always considered applied).
+    /// Builds the optional preview-optimized output and adds it to `session`.
+    /// On success `previewOutput` is set and `previewOptimizedActive` becomes
+    /// true; on any failure the controller silently keeps the single-output
+    /// preview path (texture from `videoOutput`). Must run inside the session's
+    /// begin/commit configuration block.
+    private func setupPreviewOptimizedOutputIfPossible(
+        session: AVCaptureSession
+    ) {
+        guard #available(iOS 17.0, *) else { return }
+
+        let output = AVCaptureVideoDataOutput()
+        output.videoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+        ]
+        // Preview can drop late frames — they never reach the asset writer.
+        output.alwaysDiscardsLateVideoFrames = true
+        output.setSampleBufferDelegate(self, queue: videoOutputQueue)
+
+        guard session.canAddOutput(output) else {
+            DivineCameraLog.shared.debug(
+                "DivineCamera: Session rejected a second video data output; "
+                    + "using single-output preview",
+                name: "DivineCamera.Stabilization"
+            )
+            return
+        }
+        session.addOutput(output)
+
+        // Preview-sized buffers are the eligibility requirement for
+        // `.previewOptimized` on a data output, and are lighter for the
+        // texture. These can only be set once the output joins the session.
+        output.automaticallyConfiguresOutputBufferDimensions = false
+        output.deliversPreviewSizedOutputBuffers = true
+
+        guard let connection = output.connection(with: .video),
+            connection.isVideoStabilizationSupported
+        else {
+            session.removeOutput(output)
+            DivineCameraLog.shared.debug(
+                "DivineCamera: Preview output has no stabilizable connection; "
+                    + "using single-output preview",
+                name: "DivineCamera.Stabilization"
+            )
+            return
+        }
+        if connection.isVideoOrientationSupported {
+            connection.videoOrientation = .portrait
+        }
+        if connection.isVideoMirroringSupported {
+            connection.isVideoMirrored =
+                (currentLens == .front) && mirrorFrontCameraOutput
+        }
+        // Idle until the user turns stabilization on (see applyPreviewStabilization).
+        connection.isEnabled = false
+
+        self.previewOutput = output
+        self.previewOptimizedActive = true
+        DivineCameraLog.shared.debug(
+            "DivineCamera: Preview-optimized output added",
+            name: "DivineCamera.Stabilization"
+        )
+    }
+
+    /// Applies the requested mode to the recording connection and keeps the
+    /// preview-optimized output in sync. Returns true when the requested
+    /// (recording) mode could be applied.
     @discardableResult
     private func applyVideoStabilization() -> Bool {
+        let applied = applyRecordingStabilization()
+        applyPreviewStabilization()
+        return applied
+    }
+
+    /// Keeps `previewOutput`'s connection in sync with whether stabilization is
+    /// on: `.previewOptimized` while the user has a mode selected (a smooth live
+    /// preview that doesn't zoom/jerk at record start), `.off` otherwise so the
+    /// preview matches the unstabilized recording. Flips `previewDrivesTexture`
+    /// so `captureOutput` routes the texture from the right output, and disables
+    /// the connection while unused so no frames are spent on it.
+    private func applyPreviewStabilization() {
+        guard previewOptimizedActive,
+            let connection = previewOutput?.connection(with: .video),
+            connection.isVideoStabilizationSupported
+        else {
+            previewDrivesTexture = false
+            return
+        }
+        let wantPreviewOptimized = requestedStabilizationMode != .off
+        connection.isEnabled = wantPreviewOptimized
+        if #available(iOS 17.0, *) {
+            connection.preferredVideoStabilizationMode =
+                wantPreviewOptimized ? .previewOptimized : .off
+        }
+        previewDrivesTexture = wantPreviewOptimized
+    }
+
+    /// Applies `requestedStabilizationMode` to `videoOutput`'s connection — the
+    /// frames written to the asset writer. Returns true when the requested mode
+    /// could be applied (off is always considered applied).
+    @discardableResult
+    private func applyRecordingStabilization() -> Bool {
         guard let connection = videoOutput?.connection(with: .video) else {
             return requestedStabilizationMode == .off
         }
@@ -1777,10 +1915,12 @@ class CameraController: NSObject {
         if #available(iOS 13.0, *) {
             candidates.append((.cinematicExtended, "cinematicExtended"))
         }
-        // previewOptimized is intentionally omitted for this recorder. Apple
-        // only supports it on connections with a preview layer or preview-sized
-        // AVCaptureVideoDataOutput, while this controller records from the
-        // full-resolution data output that backs the Flutter texture.
+        // previewOptimized is intentionally omitted for this recorder's
+        // selectable modes: it stabilizes the live preview, not the recorded
+        // file. It is applied internally to a dedicated preview-sized output
+        // (see setupPreviewOptimizedOutputIfPossible) so the preview stays
+        // smooth, while the recorded file uses the user-selected overscan mode
+        // on the full-resolution output.
         if #available(iOS 26.0, *) {
             candidates.append((.lowLatency, "lowLatency"))
         }
@@ -2255,7 +2395,10 @@ class CameraController: NSObject {
             self.audioInput = nil
             self.videoOutput = nil
             self.audioOutput = nil
-            
+            self.previewOutput = nil
+            self.previewOptimizedActive = false
+            self.previewDrivesTexture = false
+
             // Cleanup asset writer if recording
             self.assetWriter = nil
             self.videoWriterInput = nil
@@ -2339,7 +2482,7 @@ extension CameraController: FlutterTexture {
 extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
     func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
         guard !isPaused else { return }
-        
+
         // Handle video output
         if output == videoOutput {
             // Get pixel buffer from sample buffer
@@ -2348,53 +2491,35 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                 print("DivineCamera: Could not get pixel buffer from sample buffer")
                 return
             }
-            
-            // Thread-safe update of the pixel buffer for preview
-            pixelBufferLock.lock()
-            let isFirstFrame = latestSampleBuffer == nil
-            latestSampleBuffer = sampleBuffer
-            pixelBufferRef = pixelBuffer
-            pixelBufferLock.unlock()
-            
-            if isFirstFrame {
-                DivineCameraLog.shared.debug("DivineCamera: First frame received! Pixel buffer dimensions: \(CVPixelBufferGetWidth(pixelBuffer))x\(CVPixelBufferGetHeight(pixelBuffer))")
-                
-                // Complete initialization now that we know frames are flowing
-                DispatchQueue.main.async { [weak self] in
-                    self?.completeInitializationIfNeeded(timedOut: false)
-                }
+
+            // The preview texture is driven by previewOutput while the
+            // preview-optimized path is engaged; otherwise videoOutput drives it.
+            if !previewDrivesTexture {
+                updatePreviewTexture(pixelBuffer: pixelBuffer, sampleBuffer: sampleBuffer)
             }
-            
-            // Notify Flutter on main thread that a new frame is available
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self, self.textureId >= 0 else { return }
-                self.textureRegistry.textureFrameAvailable(self.textureId)
-            }
-            
-            // Complete camera switch if waiting for first frame from new camera.
-            // This is done AFTER textureFrameAvailable so Flutter shows the new frame
-            // before receiving the state update with the new lens.
-            if let switchCompletion = switchCameraCompletion {
-                switchCameraCompletion = nil
-                let state = getCameraState()
-                switchCompletion(state, nil)
-            }
-            
+
             // Write video frame to asset writer if recording
             if isRecording, let writer = assetWriter, let videoInput = videoWriterInput, let adaptor = pixelBufferAdaptor {
                 let timestamp = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-                
+
                 // Start session on first frame
                 if !isWriterSessionStarted && writer.status == .writing {
                     writer.startSession(atSourceTime: timestamp)
                     isWriterSessionStarted = true
                     DivineCameraLog.shared.debug("DivineCamera: Writer session started at \(timestamp.seconds)")
                 }
-                
+
                 if writer.status == .writing && videoInput.isReadyForMoreMediaData {
                     adaptor.append(pixelBuffer, withPresentationTime: timestamp)
                 }
             }
+        }
+        // Preview-optimized output drives the texture only while engaged.
+        else if output == previewOutput {
+            guard previewDrivesTexture,
+                let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
+            else { return }
+            updatePreviewTexture(pixelBuffer: pixelBuffer, sampleBuffer: sampleBuffer)
         }
         // Handle audio output
         else if output == audioOutput {
@@ -2407,6 +2532,46 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                     audioInput.append(sampleBuffer)
                 }
             }
+        }
+    }
+
+    /// Publishes a freshly captured frame to the Flutter texture and handles
+    /// first-frame initialization and pending camera-switch completion. Called
+    /// from whichever output currently drives the preview — `previewOutput`
+    /// while the preview-optimized path is engaged, otherwise `videoOutput`.
+    private func updatePreviewTexture(
+        pixelBuffer: CVPixelBuffer,
+        sampleBuffer: CMSampleBuffer
+    ) {
+        // Thread-safe update of the pixel buffer for preview
+        pixelBufferLock.lock()
+        let isFirstFrame = latestSampleBuffer == nil
+        latestSampleBuffer = sampleBuffer
+        pixelBufferRef = pixelBuffer
+        pixelBufferLock.unlock()
+
+        if isFirstFrame {
+            DivineCameraLog.shared.debug("DivineCamera: First frame received! Pixel buffer dimensions: \(CVPixelBufferGetWidth(pixelBuffer))x\(CVPixelBufferGetHeight(pixelBuffer))")
+
+            // Complete initialization now that we know frames are flowing
+            DispatchQueue.main.async { [weak self] in
+                self?.completeInitializationIfNeeded(timedOut: false)
+            }
+        }
+
+        // Notify Flutter on main thread that a new frame is available
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self, self.textureId >= 0 else { return }
+            self.textureRegistry.textureFrameAvailable(self.textureId)
+        }
+
+        // Complete camera switch if waiting for first frame from new camera.
+        // This is done AFTER textureFrameAvailable so Flutter shows the new frame
+        // before receiving the state update with the new lens.
+        if let switchCompletion = switchCameraCompletion {
+            switchCameraCompletion = nil
+            let state = getCameraState()
+            switchCompletion(state, nil)
         }
     }
 }

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -98,12 +98,25 @@ class CameraController: NSObject {
 
     /// True while the preview texture should be fed from `previewOutput` rather
     /// than `videoOutput` — i.e. the dual-output path is active AND the user has
-    /// a non-off stabilization mode selected. Read on `videoOutputQueue` in
-    /// `captureOutput`; written when the stabilization mode changes. The
-    /// cross-queue access is a benign single-`Bool` race (mirrors the existing
-    /// cross-queue reads of `requestedStabilizationMode`): a stale read costs at
-    /// most one frame routed from the other output, never a dropped frame.
-    private var previewDrivesTexture = false
+    /// a non-off stabilization mode selected.
+    ///
+    /// Synchronized because writes happen while applying stabilization on
+    /// `sessionQueue`, while reads happen on `videoOutputQueue` in
+    /// `captureOutput`.
+    private let previewDrivesTextureLock = NSLock()
+    private var _previewDrivesTexture = false
+    private var previewDrivesTexture: Bool {
+        get {
+            previewDrivesTextureLock.lock()
+            defer { previewDrivesTextureLock.unlock() }
+            return _previewDrivesTexture
+        }
+        set {
+            previewDrivesTextureLock.lock()
+            _previewDrivesTexture = newValue
+            previewDrivesTextureLock.unlock()
+        }
+    }
 
     // Auto lens switching via zoom
     // When true, uses a virtual multi-camera device (builtInTripleCamera,

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -156,11 +156,14 @@ class CameraController: NSObject {
     private var maxDurationMs: Int?
     private var isWriterSessionStarted: Bool = false
 
-    /// PTS of the last video frame appended to the asset writer. Used at
-    /// finalize to bound the writer session to the video's actual end, so a
-    /// look-ahead stabilization mode (which delays video ~0.5–1s behind audio)
-    /// can't leave the clip ending on a frozen frame while audio keeps playing.
-    private var lastVideoFramePTS: CMTime?
+    /// End PTS (`presentationTime + frameDuration`) of the last video frame
+    /// appended to the asset writer. Used at finalize to bound the writer
+    /// session to the video's actual end, so a look-ahead stabilization mode
+    /// (which delays video ~0.5–1s behind audio) can't leave the clip ending on
+    /// a frozen frame while audio keeps playing. The frame's *end* — not its
+    /// start — so the last frame keeps its full display duration and short
+    /// recordings don't collapse toward zero.
+    private var lastVideoFrameEndPTS: CMTime?
     
     /// Completion handler for camera switch - called when first frame from new camera arrives
     private var switchCameraCompletion: (([String: Any]?, String?) -> Void)?
@@ -2152,7 +2155,7 @@ class CameraController: NSObject {
 
             self.isRecording = true
             self.isWriterSessionStarted = false  // Will be set to true when first frame is received
-            self.lastVideoFramePTS = nil
+            self.lastVideoFrameEndPTS = nil
             self.recordingStartTime = Date()
 
             // Check and enable auto-flash if needed
@@ -2234,7 +2237,7 @@ class CameraController: NSObject {
             // surplus audio so both tracks stop together.
             if writer.status == .writing,
                 self.isWriterSessionStarted,
-                let endPTS = self.lastVideoFramePTS {
+                let endPTS = self.lastVideoFrameEndPTS {
                 writer.endSession(atSourceTime: endPTS)
             }
 
@@ -2319,7 +2322,7 @@ class CameraController: NSObject {
                     self.currentRecordingURL = nil
                     self.recordingStartTime = nil
                     self.isWriterSessionStarted = false
-                    self.lastVideoFramePTS = nil
+                    self.lastVideoFrameEndPTS = nil
                 }
             }
         }
@@ -2451,7 +2454,7 @@ class CameraController: NSObject {
             self.videoWriterInput = nil
             self.audioWriterInput = nil
             self.pixelBufferAdaptor = nil
-            self.lastVideoFramePTS = nil
+            self.lastVideoFrameEndPTS = nil
 
             if self.textureId >= 0 {
                 self.textureRegistry.unregisterTexture(self.textureId)
@@ -2559,7 +2562,15 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
 
                 if writer.status == .writing && videoInput.isReadyForMoreMediaData {
                     adaptor.append(pixelBuffer, withPresentationTime: timestamp)
-                    lastVideoFramePTS = timestamp
+                    // Track the frame's END, not its start, so endSession keeps
+                    // the last frame's full duration. Capture buffers usually
+                    // carry a valid duration; fall back to ~30fps if not.
+                    let frameDuration = CMSampleBufferGetDuration(sampleBuffer)
+                    let endDuration =
+                        frameDuration.isNumeric && frameDuration.seconds > 0
+                            ? frameDuration
+                            : CMTime(value: 1, timescale: 30)
+                    lastVideoFrameEndPTS = timestamp + endDuration
                 }
             }
         }

--- a/mobile/packages/divine_camera/lib/divine_camera.dart
+++ b/mobile/packages/divine_camera/lib/divine_camera.dart
@@ -224,9 +224,11 @@ class DivineCamera {
 
   /// Sets the video stabilization mode.
   ///
-  /// The stabilized frames feed both the preview and the recording. On
-  /// platforms without stabilization support (macOS, Linux) this is a no-op
-  /// that returns false.
+  /// The selected mode stabilizes the recorded file. On iOS 17+ the live
+  /// preview is stabilized independently through a preview-optimized output so
+  /// it stays smooth at record start, so the preview and the recording may use
+  /// different stabilization internally. On platforms without stabilization
+  /// support (macOS, Linux) this is a no-op that returns false.
   ///
   /// [mode] the stabilization mode to apply.
   /// Returns true if the requested mode was applied.

--- a/mobile/packages/divine_camera/test/ios_stabilization_contract_test.dart
+++ b/mobile/packages/divine_camera/test/ios_stabilization_contract_test.dart
@@ -42,5 +42,35 @@ void main() {
         contains('Self.isPreviewOptimized(requestedStabilizationMode)'),
       );
     });
+
+    test('drives the preview from a dedicated preview-sized output', () {
+      // The preview-optimized path needs a second, preview-sized data output —
+      // that is the eligibility requirement for .previewOptimized on a data
+      // output (the recorder still records from the full-resolution output).
+      expect(
+        controllerSource,
+        contains('func setupPreviewOptimizedOutputIfPossible'),
+      );
+      expect(
+        controllerSource,
+        contains('deliversPreviewSizedOutputBuffers = true'),
+      );
+    });
+
+    test('gates the second output behind a runtime feasibility check', () {
+      // A single AVCaptureSession may reject a second video data output, so the
+      // preview-optimized path must be guarded and fall back to the existing
+      // single-output preview rather than regress on unsupported devices.
+      expect(controllerSource, contains('session.canAddOutput(output)'));
+      expect(controllerSource, contains('using single-output preview'));
+    });
+
+    test('applies previewOptimized to the preview connection only', () {
+      // previewOptimized is applied to the preview output (and only while the
+      // user has stabilization on); the recorded file keeps the user-selected
+      // overscan mode on the full-resolution output.
+      expect(controllerSource, contains('.previewOptimized : .off'));
+      expect(controllerSource, contains('previewOptimizedActive = true'));
+    });
   });
 }


### PR DESCRIPTION
Closes #5521
Closes #5501

## Description

On iOS, selecting **standard**/**cinematic** stabilization made the camera
suddenly zoom in and feel jerky the moment recording started.

Root cause: the live preview texture and the `AVAssetWriter` both consumed the
same full-resolution `AVCaptureVideoDataOutput`. iOS engages the overscan crop
of `standard`/`cinematic` at capture time (with a multi-frame look-ahead that
takes ~0.5–1 s to settle), so the crop + warm-up were visible **in the live
preview** exactly at record start. It's device-dependent — e.g. iPhone 12 is
unaffected because it engages stabilization continuously during preview.

Fix: drive the preview from a **second, preview-sized** `AVCaptureVideoDataOutput`
running **`.previewOptimized`** (iOS 17+), while the full-resolution output keeps
the user-selected overscan mode for the recorded file. `previewOptimized` engages
continuously and has no look-ahead, so the preview stays smooth and never jumps
at record start — and the recording is still stabilized.

Safety:
- The **`off` path is unchanged for everyone** — the preview connection is idle
  and the texture comes from the full-res output as before, unless the user turns
  stabilization on.
- The dual-output path is gated on `iOS 17 + canAddOutput + a stabilizable
  connection`; if a device rejects a second video-data-output it **falls back to
  the existing single-output preview** (no regression).
- `previewOptimized` stays **internal** — it is not added to the user-selectable
  recording modes, preserving the #5476 decision and its contract test.
- **No WYSIWYG regression**: on the tested device `previewOptimized` and
  `standard`/`cinematic` crop identically, so the preview and the recorded file
  share the same framing (see "How to read the on-device signals" below).

**Related Issue:** 

## Second fix: frozen last frame at the end of cinematic clips

Same look-ahead, different surface. `standard`/`cinematic` delay the recording
output by a multi-frame look-ahead, so the last ~0.5–1 s of **video** lands
behind the last **audio** sample. The `AVAssetWriter` then produced a clip whose
video track ends earlier than its audio track: the in-app player held the last
video frame (looked "frozen") while audio kept playing. The render pass re-muxed
it away, which masked the issue until you played the raw clip.

Fix: track the last appended video frame's PTS and bound the writer session to
it via `endSession(atSourceTime:)` before finishing, so surplus audio is trimmed
to the video's real end and both tracks stop together. `durationMs` now comes
from the finished asset's duration instead of the wall clock (which over-reported
by the look-ahead window). No guessed constant — the cut is the real last video
PTS, so it also works for the audio-less case via the corrected duration.

## Out of Scope

- If a device falls back (logs `using single-output preview`), the seamless fix
  won't engage there; a heavier preview-layer route would be a separate change.

## Verification

- `flutter analyze` (divine_camera) and full `flutter analyze lib test integration_test` — no issues
- `flutter test` divine_camera — 66 pass, incl. the extended `ios_stabilization_contract_test.dart` (+3 new contract tests)
- `flutter test` video_recorder bloc — pass

### Verified on a physical iPhone (a device that reproduces the jump)

- `DivineCamera.Stabilization` log shows **`Preview-optimized output added`** → the
  dual-output path engaged, not the single-output fallback.
- In **cinematic**, the live preview was previously badly delayed (the multi-frame
  look-ahead lagged the preview ~0.5–1 s behind real motion). With the fix the
  preview is real-time again and no longer jumps/zooms at record start.
- Preview framing matches the recorded output — no WYSIWYG regression.

### How to read the on-device signals (so this isn't misjudged)

- **The fix's signature is the disappearance of the preview *latency/jump*, not a
  change in framing.** `previewOptimized` and `standard`/`cinematic` crop the same
  on the tested device, so **the preview looking identical to the recording is
  expected and correct** — it does *not* mean the preview optimization is a no-op.
- Confirm the dual path engaged: log line `Preview-optimized output added`
  (vs `using single-output preview` = fell back, e.g. older iOS or an
  output-count-limited device).
- Confirm the recording still carries the chosen mode: after selecting a mode the
  log shows `Applied video stabilization mode: <mode>`, and the saved clip
  (recorded while walking) is visibly stabilized.
- Stabilization is a **no-op on the Simulator** and is device-dependent (e.g.
  iPhone 12 never showed the jump because it stabilizes continuously during
  preview) — it must be checked on a physical device that reproduces the issue.

### Second fix — verified on a physical iPhone

- cinematic clip → raw in-app player: **no frozen last frame**, last frame
  intact, reported length matches the actual end.
- after the end-PTS refinement (bound the session to the frame's *end*, not its
  start) the final frame keeps its full duration and short clips don't collapse
  toward zero.

Worth a final pass on merge: `off`/`standard` clips end cleanly with audio
intact (nothing over-trimmed), and a very short tap-record yields a sane
duration.

## Review fixes (follow-up commits)

- **Preview handoff gated on the recording actually being stabilized.**
  `previewDrivesTexture` now engages only when `applyRecordingStabilization`
  applied a non-off mode — not merely when one was requested. A lens/format
  switch that makes the requested mode unsupported leaves the recording
  unstabilized, so the preview stays on the full-resolution output instead of
  switching to `previewOptimized`, keeping preview and file in sync.
- `applyPreviewStabilization` disables the preview output's connection on the
  guard-fail path (a lens switch that loses stabilization support) so it stops
  delivering frames the texture path would only discard.
- Documented that `previewOutput` deliberately shares `videoOutputQueue` with
  `videoOutput`: one serial queue keeps the texture handoff and switch-completion
  state race-free; a separate queue would reintroduce those races.
- Updated the `setVideoStabilizationMode` Dart doc — preview and recording now
  use separate outputs/modes, so the old "stabilized frames feed both" wording
  was stale.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


