### PR TITLE
fix(video-editor): release feed codecs when opening camera/editor

### DIFF
--- a/mobile/lib/blocs/codec_heavy_surface/codec_heavy_surface_cubit.dart
+++ b/mobile/lib/blocs/codec_heavy_surface/codec_heavy_surface_cubit.dart
@@ -1,0 +1,38 @@
+// ABOUTME: Tracks whether a codec-heavy surface (camera/editor/exporter) is open
+// ABOUTME: so background video feeds release every hardware decoder they hold.
+
+import 'package:equatable/equatable.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+part 'codec_heavy_surface_state.dart';
+
+/// Tracks whether a codec-heavy surface — the camera, the video editor, or the
+/// exporter — is currently on screen.
+///
+/// These surfaces need exclusive access to the device's scarce hardware video
+/// codecs (decoder + encoder). Video feeds that stay mounted in the background
+/// (e.g. the home feed inside a `StatefulShellRoute`) keep their *current*
+/// player warm across tab switches for instant resume, but must hand back every
+/// native decoder while one of these surfaces is open — otherwise the editor's
+/// decode/encode init fails on codec-limited devices (observed as
+/// `DECODER_INIT_FAILED` on the preview and an encoder `RENDER_ERROR` on
+/// export).
+///
+/// Reference-counted via [CodecHeavySurfaceState.activeCount] so nested
+/// codec-heavy routes (e.g. an export/metadata screen pushed over the editor)
+/// keep the signal asserted until the last one leaves. Call [enter] from
+/// `initState` and [exit] from `dispose` of each such screen.
+class CodecHeavySurfaceCubit extends Cubit<CodecHeavySurfaceState> {
+  CodecHeavySurfaceCubit() : super(const CodecHeavySurfaceState());
+
+  /// Registers a codec-heavy surface as visible. Safe to call from `initState`.
+  void enter() =>
+      emit(CodecHeavySurfaceState(activeCount: state.activeCount + 1));
+
+  /// Registers a codec-heavy surface as gone. Safe to call from `dispose`.
+  void exit() => emit(
+    CodecHeavySurfaceState(
+      activeCount: state.activeCount > 0 ? state.activeCount - 1 : 0,
+    ),
+  );
+}

--- a/mobile/lib/blocs/codec_heavy_surface/codec_heavy_surface_state.dart
+++ b/mobile/lib/blocs/codec_heavy_surface/codec_heavy_surface_state.dart
@@ -1,0 +1,18 @@
+part of 'codec_heavy_surface_cubit.dart';
+
+/// State for [CodecHeavySurfaceCubit].
+class CodecHeavySurfaceState extends Equatable {
+  const CodecHeavySurfaceState({this.activeCount = 0});
+
+  /// Number of codec-heavy surfaces currently on screen.
+  ///
+  /// Reference-counted so nested surfaces (e.g. an export screen pushed over
+  /// the editor) keep [isActive] asserted until the last one leaves.
+  final int activeCount;
+
+  /// Whether at least one codec-heavy surface is open.
+  bool get isActive => activeCount > 0;
+
+  @override
+  List<Object?> get props => [activeCount];
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:invite_api_client/invite_api_client.dart';
 import 'package:openvine/app_update/app_update.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
 import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
+import 'package:openvine/blocs/codec_heavy_surface/codec_heavy_surface_cubit.dart';
 import 'package:openvine/blocs/dm/unread_count/dm_unread_count_cubit.dart';
 import 'package:openvine/blocs/email_verification/email_verification_cubit.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
@@ -2425,6 +2426,9 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                 sharedPreferences: ref.read(sharedPreferencesProvider),
               ),
             ),
+            // App-global signal: a codec-heavy surface (camera/editor/exporter)
+            // is open, so background feeds must release their hardware decoders.
+            BlocProvider(create: (_) => CodecHeavySurfaceCubit()),
             BlocProvider(
               create: (_) => LocaleCubit(
                 localePreferenceService: LocalePreferenceService(

--- a/mobile/lib/mixins/codec_heavy_surface_guard.dart
+++ b/mobile/lib/mixins/codec_heavy_surface_guard.dart
@@ -26,10 +26,29 @@ mixin CodecHeavySurfaceGuard<T extends StatefulWidget> on State<T> {
   Animation<double>? _entranceAnimation;
   bool _entered = false;
 
+  /// Whether to wait for the entrance transition before asserting the signal.
+  ///
+  /// `true` (default) keeps the previous screen's video frame visible during
+  /// the push animation. Correct for the **camera**, which does not allocate a
+  /// video decoder on open — the preview uses the camera pipeline and the
+  /// encoder is created only when recording starts — so there is no codec
+  /// contention to race.
+  ///
+  /// Override to `false` for a surface that allocates a hardware **decoder**
+  /// immediately on mount: the **video editor** builds its preview player in
+  /// `initState`/the first post-frame, so the background feed must hand back its
+  /// decoder before that new one is created — even at the cost of a brief frame
+  /// drop behind the incoming screen.
+  bool get assertCodecSignalAfterEntranceTransition => true;
+
   @override
   void initState() {
     super.initState();
     _codecHeavySurfaceCubit = context.read<CodecHeavySurfaceCubit?>();
+    if (!assertCodecSignalAfterEntranceTransition) {
+      _enterCodecHeavySurface();
+      return;
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _armAfterEntrance();
     });

--- a/mobile/lib/mixins/codec_heavy_surface_guard.dart
+++ b/mobile/lib/mixins/codec_heavy_surface_guard.dart
@@ -1,0 +1,70 @@
+// ABOUTME: State mixin asserting the codec-heavy-surface signal after the
+// ABOUTME: entrance transition, so background feeds aren't disposed mid-animation.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/codec_heavy_surface/codec_heavy_surface_cubit.dart';
+
+/// Mixin for codec-heavy screens (camera, video editor, exporter) that asserts
+/// [CodecHeavySurfaceCubit] while they are on screen so background feeds release
+/// the device's scarce hardware decoders.
+///
+/// The signal is asserted only **after** the screen's entrance transition
+/// completes. Asserting it in `initState` drains background feeds while the push
+/// animation is still running, so the previous screen's video visibly
+/// disappears behind the incoming one. Waiting for the transition keeps that
+/// frame on screen until the new screen fully covers it.
+///
+/// The matching release fires in `dispose`, but only if the signal was actually
+/// asserted — a screen popped mid-transition never entered, so it must not exit
+/// (that would leave the reference count unbalanced).
+///
+/// The cubit is looked up nullably: it is an app-level optimization, so a screen
+/// mounted in an isolated/test tree without it simply becomes a no-op.
+mixin CodecHeavySurfaceGuard<T extends StatefulWidget> on State<T> {
+  CodecHeavySurfaceCubit? _codecHeavySurfaceCubit;
+  Animation<double>? _entranceAnimation;
+  bool _entered = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _codecHeavySurfaceCubit = context.read<CodecHeavySurfaceCubit?>();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _armAfterEntrance();
+    });
+  }
+
+  void _armAfterEntrance() {
+    final animation = ModalRoute.of(context)?.animation;
+    if (animation == null || animation.isCompleted) {
+      _enterCodecHeavySurface();
+      return;
+    }
+    _entranceAnimation = animation..addStatusListener(_onEntranceStatus);
+  }
+
+  void _onEntranceStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed) return;
+    _detachEntranceListener();
+    if (mounted) _enterCodecHeavySurface();
+  }
+
+  void _enterCodecHeavySurface() {
+    if (_entered) return;
+    _entered = true;
+    _codecHeavySurfaceCubit?.enter();
+  }
+
+  void _detachEntranceListener() {
+    _entranceAnimation?.removeStatusListener(_onEntranceStatus);
+    _entranceAnimation = null;
+  }
+
+  @override
+  void dispose() {
+    _detachEntranceListener();
+    if (_entered) _codecHeavySurfaceCubit?.exit();
+    super.dispose();
+  }
+}

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -21,6 +21,7 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/extensions/video_editor_extensions.dart';
 import 'package:openvine/extensions/video_editor_history_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/mixins/codec_heavy_surface_guard.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
@@ -63,7 +64,8 @@ class VideoEditorScreen extends ConsumerStatefulWidget {
   ConsumerState<VideoEditorScreen> createState() => _VideoEditorScreenState();
 }
 
-class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen> {
+class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
+    with CodecHeavySurfaceGuard {
   final _editorKey = GlobalKey<ProImageEditorState>();
   final GlobalKey<State<StatefulWidget>> _removeAreaKey = GlobalKey();
 

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -66,6 +66,11 @@ class VideoEditorScreen extends ConsumerStatefulWidget {
 
 class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     with CodecHeavySurfaceGuard {
+  // The editor builds its preview decoder immediately, so release the feed's
+  // decoder now rather than waiting for the entrance transition.
+  @override
+  bool get assertCodecSignalAfterEntranceTransition => false;
+
   final _editorKey = GlobalKey<ProImageEditorState>();
   final GlobalKey<State<StatefulWidget>> _removeAreaKey = GlobalKey();
 

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -14,6 +14,7 @@ import 'package:openvine/blocs/sound_waveform/sound_waveform_bloc.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/mixins/codec_heavy_surface_guard.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
@@ -118,7 +119,7 @@ class VideoRecorderView extends ConsumerStatefulWidget {
 }
 
 class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
-    with WidgetsBindingObserver {
+    with WidgetsBindingObserver, CodecHeavySurfaceGuard {
   ProviderSubscription<AudioEvent?>? _soundSubscription;
   OverlayVisibility? _overlayVisibilityNotifier;
   VideoRecorderMode? _lastRecorderMode;

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/codec_heavy_surface/codec_heavy_surface_cubit.dart';
 import 'package:openvine/blocs/feed_loading_moderation/feed_loading_moderation_cubit.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
@@ -246,6 +247,16 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
   @override
   Widget build(BuildContext context) {
     final isFeedActive = widget.isActive && _routeAllowsPlayback;
+    // While a codec-heavy surface (camera, video editor, exporter) is open, a
+    // backgrounded feed must release even its warm current player so the editor
+    // can claim the device's scarce hardware decoders/encoder. Selected so the
+    // feed re-evaluates the moment the surface opens or closes. Nullable lookup:
+    // the signal is an optimization, so a feed mounted without the cubit (tests,
+    // isolated previews) simply never force-drains rather than crashing.
+    final codecHeavySurfaceActive = context
+        .select<CodecHeavySurfaceCubit?, bool>(
+          (cubit) => cubit?.state.isActive ?? false,
+        );
     return MultiBlocListener(
       listeners: [
         BlocListener<VideoVolumeCubit, VideoVolumeState>(
@@ -271,6 +282,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
         videos: widget.videos,
         isActive: isFeedActive,
         releaseNeighboursWhenInactive: widget.releaseNeighboursWhenInactive,
+        releaseCurrentWhenInactive: codecHeavySurfaceActive,
         // mediaCacheProvider is a keepAlive singleton; identity is stable for
         // the app lifetime, so ref.read is safe here. See
         // .claude/rules/state_management.md → "Bridging Riverpod-provided

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -42,6 +42,7 @@ class InfiniteVideoFeed extends StatefulWidget {
     this.keepPreviousAlive = true,
     this.keepNextAlive = true,
     this.releaseNeighboursWhenInactive = false,
+    this.releaseCurrentWhenInactive = false,
     this.prefetchCount = 8,
     this.shouldPortraitExpand = true,
     this.maxLoopDuration,
@@ -188,6 +189,22 @@ class InfiniteVideoFeed extends StatefulWidget {
   /// staying on screen (e.g. behind a focused text composer).
   final bool releaseNeighboursWhenInactive;
 
+  /// Whether the *current* player is released too — a full drain of the live
+  /// window — while the feed is inactive (see [isActive]).
+  ///
+  /// A backgrounded feed normally keeps its current player warm even when
+  /// neighbours are released ([releaseNeighboursWhenInactive]), so playback
+  /// resumes instantly at the same frame on reactivation. Set this `true` only
+  /// while a surface that needs the device's scarce hardware video codecs for
+  /// itself is open — the camera, the video editor, or the exporter. When it is
+  /// `true` and the feed is (or becomes) inactive, every native player is
+  /// disposed, handing the decoders back. The current video re-initializes —
+  /// restarting from its first frame — when the feed becomes active again.
+  ///
+  /// Takes precedence over [releaseNeighboursWhenInactive]: a full drain
+  /// releases the neighbours regardless of that flag.
+  final bool releaseCurrentWhenInactive;
+
   /// Number of videos ahead of the current index to prefetch to disk.
   ///
   /// These videos are downloaded via [MediaCacheManager] and played
@@ -304,6 +321,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   // controllers that become active. Seeded from widget.initialVolume.
   late double _volume;
   late bool _isActive;
+
+  // Set when a full drain (releaseCurrentWhenInactive) tore down the current
+  // controller while inactive. The next activation re-initializes the window
+  // instead of trying to resume a player that no longer exists.
+  bool _needsReinitOnActivate = false;
 
   // Generation counter for the player window so async neighbour-init can
   // detect that the user scrolled away mid-load.
@@ -442,14 +464,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     super.didUpdateWidget(oldWidget);
     if (widget.isActive != oldWidget.isActive) {
       _setPlaybackActive(widget.isActive);
-    } else if (!widget.isActive &&
-        widget.releaseNeighboursWhenInactive !=
-            oldWidget.releaseNeighboursWhenInactive) {
-      if (widget.releaseNeighboursWhenInactive) {
-        _releaseNeighboursAndPrefetch();
-      } else {
-        unawaited(_onIndexChanged(_currentIndex));
-      }
+    } else if (!widget.isActive) {
+      _reconcileInactiveReleasePolicy(oldWidget);
     }
     _syncCurrentAutoPlayGate(oldWidget);
     if (widget.videos == oldWidget.videos) return;
@@ -569,6 +585,13 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     if (_isActive == isActive) return;
     _isActive = isActive;
     if (_isActive) {
+      if (_needsReinitOnActivate) {
+        // A full drain dropped the current player while inactive. Re-build the
+        // live window from scratch instead of resuming a disposed controller.
+        _needsReinitOnActivate = false;
+        unawaited(_onIndexChanged(_currentIndex));
+        return;
+      }
       _resumeCurrentPlaybackIfReady();
       if (widget.releaseNeighboursWhenInactive) {
         // Re-expand the live window and resume disk prefetch now that the
@@ -577,10 +600,54 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       }
     } else {
       _pauseCurrentPlayback();
-      if (widget.releaseNeighboursWhenInactive) {
+      if (widget.releaseCurrentWhenInactive) {
+        _fullyReleaseWhileInactive();
+      } else if (widget.releaseNeighboursWhenInactive) {
         _releaseNeighboursAndPrefetch();
       }
     }
+  }
+
+  /// Applies the release policy when a flag changes while the feed stays
+  /// inactive (its [InfiniteVideoFeed.isActive] did not flip this update).
+  void _reconcileInactiveReleasePolicy(InfiniteVideoFeed oldWidget) {
+    // A codec-heavy surface just opened over a backgrounded feed: drop the
+    // current player too. Takes precedence over the neighbour policy.
+    if (widget.releaseCurrentWhenInactive) {
+      if (!oldWidget.releaseCurrentWhenInactive) {
+        _fullyReleaseWhileInactive();
+      }
+      return;
+    }
+    // The surface closed again while the feed is still inactive. The pool was
+    // already drained; there is nothing to re-acquire until reactivation, which
+    // re-inits via [_needsReinitOnActivate].
+    if (oldWidget.releaseCurrentWhenInactive) return;
+
+    if (widget.releaseNeighboursWhenInactive ==
+        oldWidget.releaseNeighboursWhenInactive) {
+      return;
+    }
+    if (widget.releaseNeighboursWhenInactive) {
+      _releaseNeighboursAndPrefetch();
+    } else {
+      unawaited(_onIndexChanged(_currentIndex));
+    }
+  }
+
+  /// Tears down every live controller (current + neighbours) and cancels disk
+  /// prefetch while the feed is inactive, flagging a re-init so the current
+  /// video reloads when the feed becomes active again.
+  ///
+  /// Driven by [InfiniteVideoFeed.releaseCurrentWhenInactive] when a
+  /// codec-heavy surface (camera, video editor, exporter) needs the hardware
+  /// decoders this backgrounded feed is holding.
+  void _fullyReleaseWhileInactive() {
+    if (_controllers.isEmpty && _needsReinitOnActivate) return;
+    _log('Releasing all players while inactive (codec-heavy surface open)');
+    _teardownAllControllers();
+    _needsReinitOnActivate = true;
+    _rebuild();
   }
 
   /// Disposes the neighbour controllers and cancels the in-flight disk

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -645,6 +645,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   void _fullyReleaseWhileInactive() {
     if (_controllers.isEmpty && _needsReinitOnActivate) return;
     _log('Releasing all players while inactive (codec-heavy surface open)');
+    // Stop the whole prefetch cycle, not just the active download
+    // (_teardownAllControllers only cancels the active op), so a backgrounded
+    // feed downloads nothing while the codec-heavy surface is open.
+    _prefetcher.cancelCycle();
     _teardownAllControllers();
     _needsReinitOnActivate = true;
     _rebuild();
@@ -742,6 +746,17 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   Future<void> _updatePlayerWindow(int index) async {
     final generation = ++_playerWindowGeneration;
 
+    // Full drain: a codec-heavy surface is open over this inactive feed, so it
+    // must hold no native players at all. An index change, a first mount, or a
+    // video-list update while drained must not re-allocate a decoder the
+    // camera/editor needs. Flag a re-init so the window rebuilds from the
+    // current list once the feed becomes active again.
+    if (widget.releaseCurrentWhenInactive && !_isActive) {
+      _controllers.keys.toList().forEach(_disposeAt);
+      _needsReinitOnActivate = true;
+      return;
+    }
+
     final lastIndex = widget.videos.length - 1;
     // Neighbour players are kept alive while the feed is active. When the feed
     // is hidden and configured to release them
@@ -816,10 +831,15 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   }
 
   Future<void> _runPrefetch(int index) async {
-    // Pause disk prefetch while a release-on-inactive feed is hidden so a
-    // background feed stops downloading upcoming videos. It resumes from the
-    // current index on reactivation.
-    if (widget.releaseNeighboursWhenInactive && !_isActive) return;
+    // Pause disk prefetch while a hidden feed is releasing players (neighbours
+    // only, or a full drain under a codec-heavy surface) so it stops
+    // downloading upcoming videos. It resumes from the current index on
+    // reactivation.
+    if (!_isActive &&
+        (widget.releaseNeighboursWhenInactive ||
+            widget.releaseCurrentWhenInactive)) {
+      return;
+    }
     if (widget.prefetchCount <= 0) return;
 
     // coverage:ignore-start

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -2279,5 +2279,202 @@ void main() {
         }
       });
     });
+
+    group('releaseCurrentWhenInactive', () {
+      testWidgets('drops the current player too when going inactive', (
+        tester,
+      ) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = [_makeVideo('cur'), _makeVideo('next')];
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseCurrentWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+
+          // Full drain: not even the current player is retained.
+          expect(key.currentState!.debugLiveControllerIndices, isEmpty);
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets(
+        'fully drains when the flag turns on while already inactive',
+        (
+          tester,
+        ) async {
+          // Mirrors the production path: the home feed is backgrounded on
+          // another tab (neighbours released, current kept warm) and *then* a
+          // codec-heavy surface (camera/editor) opens over it.
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+          final key = GlobalKey<InfiniteVideoFeedState>();
+          final videos = [_makeVideo('cur'), _makeVideo('next')];
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos,
+                  cache: cache,
+                  releaseNeighboursWhenInactive: true,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            // Backgrounded: neighbour released, current kept warm.
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos,
+                  cache: cache,
+                  isActive: false,
+                  releaseNeighboursWhenInactive: true,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                ),
+              ),
+            );
+            await tester.pump();
+            expect(
+              key.currentState!.debugLiveControllerIndices,
+              equals(<int>{0}),
+            );
+
+            // Codec-heavy surface opens over the still-inactive feed.
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos,
+                  cache: cache,
+                  isActive: false,
+                  releaseNeighboursWhenInactive: true,
+                  releaseCurrentWhenInactive: true,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                ),
+              ),
+            );
+            await tester.pump();
+
+            expect(key.currentState!.debugLiveControllerIndices, isEmpty);
+          } finally {
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
+
+      testWidgets('re-initialises the current video when reactivated after a '
+          'full release', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        final videos = [_makeVideo('cur'), _makeVideo('next')];
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          // Full drain while a codec-heavy surface is open.
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseCurrentWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          expect(key.currentState!.debugLiveControllerIndices, isEmpty);
+
+          // Surface closed, feed visible again — the window rebuilds.
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+    });
   });
 }

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -2475,6 +2475,114 @@ void main() {
           await harness.dispose();
         }
       });
+
+      testWidgets('stays fully drained across a video-list update while '
+          'inactive', (tester) async {
+        // A backgrounded feed whose videos refresh from relay data while the
+        // camera/editor is open must not re-allocate a decoder.
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+        final key = GlobalKey<InfiniteVideoFeedState>();
+        var videos = [_makeVideo('cur'), _makeVideo('next')];
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+          expect(
+            key.currentState!.debugLiveControllerIndices,
+            equals(<int>{0, 1}),
+          );
+
+          // Inactive + full drain → empty.
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseCurrentWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          expect(key.currentState!.debugLiveControllerIndices, isEmpty);
+
+          // Video list grows while still inactive + drained — must NOT rebuild
+          // a controller.
+          videos = [...videos, _makeVideo('appended')];
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                key: key,
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseCurrentWhenInactive: true,
+                prefetchCount: 0,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+          expect(key.currentState!.debugLiveControllerIndices, isEmpty);
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
+
+      testWidgets('skips disk prefetch while fully drained', (tester) async {
+        DivineVideoPlayerController.resetIdCounterForTesting();
+        final harness = _NativePlayerHarness(tester);
+        await harness.install(playerIds: const <int>[0, 1, 2, 3, 4]);
+        final videos = List.generate(
+          4,
+          (i) => _makeVideo('d$i', videoUrl: 'https://example.com/d$i.mp4'),
+        );
+
+        try {
+          await tester.pumpWidget(
+            _wrapFeed(
+              InfiniteVideoFeed(
+                videos: videos,
+                cache: cache,
+                isActive: false,
+                releaseCurrentWhenInactive: true,
+                prefetchCount: 5,
+                preloadGracePeriod: Duration.zero,
+              ),
+            ),
+          );
+          await tester.pump();
+          await tester.pump();
+
+          // A fully drained feed downloads nothing.
+          verifyNever(
+            () => cache.cacheFileCancellable(any(), key: any(named: 'key')),
+          );
+        } finally {
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await harness.dispose();
+        }
+      });
     });
   });
 }

--- a/mobile/test/blocs/codec_heavy_surface/codec_heavy_surface_cubit_test.dart
+++ b/mobile/test/blocs/codec_heavy_surface/codec_heavy_surface_cubit_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/codec_heavy_surface/codec_heavy_surface_cubit.dart';
+
+void main() {
+  group(CodecHeavySurfaceCubit, () {
+    late CodecHeavySurfaceCubit cubit;
+
+    setUp(() => cubit = CodecHeavySurfaceCubit());
+    tearDown(() => cubit.close());
+
+    test('starts inactive', () {
+      expect(cubit.state.activeCount, equals(0));
+      expect(cubit.state.isActive, isFalse);
+    });
+
+    test('becomes active on enter and inactive again on exit', () {
+      cubit.enter();
+      expect(cubit.state.isActive, isTrue);
+
+      cubit.exit();
+      expect(cubit.state.isActive, isFalse);
+    });
+
+    test('stays active until the last nested surface leaves', () {
+      cubit
+        ..enter()
+        ..enter();
+      expect(cubit.state.activeCount, equals(2));
+      expect(cubit.state.isActive, isTrue);
+
+      cubit.exit();
+      // One surface still open — stays asserted.
+      expect(cubit.state.isActive, isTrue);
+
+      cubit.exit();
+      expect(cubit.state.isActive, isFalse);
+    });
+
+    test('exit below zero is clamped and a later enter still activates', () {
+      cubit.exit();
+      expect(cubit.state.activeCount, equals(0));
+      expect(cubit.state.isActive, isFalse);
+
+      cubit.enter();
+      expect(cubit.state.isActive, isTrue);
+    });
+  });
+}

--- a/mobile/test/mixins/codec_heavy_surface_guard_test.dart
+++ b/mobile/test/mixins/codec_heavy_surface_guard_test.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/blocs/codec_heavy_surface/codec_heavy_surface_cubit.dart';
+import 'package:openvine/mixins/codec_heavy_surface_guard.dart';
+
+class _GuardedScreen extends StatefulWidget {
+  const _GuardedScreen();
+
+  @override
+  State<_GuardedScreen> createState() => _GuardedScreenState();
+}
+
+class _GuardedScreenState extends State<_GuardedScreen>
+    with CodecHeavySurfaceGuard {
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  group(CodecHeavySurfaceGuard, () {
+    late CodecHeavySurfaceCubit cubit;
+    late GlobalKey<NavigatorState> navKey;
+
+    setUp(() {
+      cubit = CodecHeavySurfaceCubit();
+      navKey = GlobalKey<NavigatorState>();
+    });
+
+    tearDown(() => cubit.close());
+
+    Future<void> pumpHost(WidgetTester tester) => tester.pumpWidget(
+      BlocProvider<CodecHeavySurfaceCubit>.value(
+        value: cubit,
+        child: MaterialApp(
+          navigatorKey: navKey,
+          home: const Scaffold(body: SizedBox.shrink()),
+        ),
+      ),
+    );
+
+    testWidgets('asserts the signal only after the entrance transition '
+        'completes', (tester) async {
+      await pumpHost(tester);
+
+      unawaited(
+        navKey.currentState!.push(
+          MaterialPageRoute<void>(builder: (_) => const _GuardedScreen()),
+        ),
+      );
+
+      // Mid-transition: the screen is animating in, the signal must stay off so
+      // the background feed keeps rendering behind it.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(cubit.state.isActive, isFalse);
+
+      // Transition finished — now the signal asserts.
+      await tester.pumpAndSettle();
+      expect(cubit.state.isActive, isTrue);
+    });
+
+    testWidgets('releases the signal on pop', (tester) async {
+      await pumpHost(tester);
+
+      unawaited(
+        navKey.currentState!.push(
+          MaterialPageRoute<void>(builder: (_) => const _GuardedScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(cubit.state.isActive, isTrue);
+
+      navKey.currentState!.pop();
+      await tester.pumpAndSettle();
+      expect(cubit.state.isActive, isFalse);
+    });
+
+    testWidgets('does not assert when popped before the transition completes', (
+      tester,
+    ) async {
+      await pumpHost(tester);
+
+      unawaited(
+        navKey.currentState!.push(
+          MaterialPageRoute<void>(builder: (_) => const _GuardedScreen()),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(cubit.state.isActive, isFalse);
+
+      // Pop before the entrance transition finishes: enter never fired, so the
+      // count must stay balanced at zero (no stray exit driving it negative).
+      navKey.currentState!.pop();
+      await tester.pumpAndSettle();
+      expect(cubit.state.isActive, isFalse);
+      expect(cubit.state.activeCount, equals(0));
+    });
+  });
+}

--- a/mobile/test/mixins/codec_heavy_surface_guard_test.dart
+++ b/mobile/test/mixins/codec_heavy_surface_guard_test.dart
@@ -19,6 +19,23 @@ class _GuardedScreenState extends State<_GuardedScreen>
   Widget build(BuildContext context) => const SizedBox.shrink();
 }
 
+class _ImmediateGuardedScreen extends StatefulWidget {
+  const _ImmediateGuardedScreen();
+
+  @override
+  State<_ImmediateGuardedScreen> createState() =>
+      _ImmediateGuardedScreenState();
+}
+
+class _ImmediateGuardedScreenState extends State<_ImmediateGuardedScreen>
+    with CodecHeavySurfaceGuard {
+  @override
+  bool get assertCodecSignalAfterEntranceTransition => false;
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
 void main() {
   group(CodecHeavySurfaceGuard, () {
     late CodecHeavySurfaceCubit cubit;
@@ -60,6 +77,30 @@ void main() {
       // Transition finished — now the signal asserts.
       await tester.pumpAndSettle();
       expect(cubit.state.isActive, isTrue);
+    });
+
+    testWidgets('asserts the signal immediately when the transition wait is '
+        'disabled', (tester) async {
+      await pumpHost(tester);
+
+      unawaited(
+        navKey.currentState!.push(
+          MaterialPageRoute<void>(
+            builder: (_) => const _ImmediateGuardedScreen(),
+          ),
+        ),
+      );
+
+      // First frame, still mid-transition: the override drains right away so a
+      // screen that allocates a decoder on mount (the editor) does not race the
+      // feed's decoder.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      expect(cubit.state.isActive, isTrue);
+
+      navKey.currentState!.pop();
+      await tester.pumpAndSettle();
+      expect(cubit.state.isActive, isFalse);
     });
 
     testWidgets('releases the signal on pop', (tester) async {


### PR DESCRIPTION
Closes #5523

## Description

On codec-limited (Qualcomm) devices the home feed's **current** native video player was never released when navigating into the camera or video editor. The feed stays mounted in the background (`StatefulShellRoute`), so its decoder kept holding a hardware codec instance across `profile → drafts → editor`. The device then ran out of codec instances, producing the failures seen in user logs:

- editor **preview** → `ERROR_CODE_DECODER_INIT_FAILED` (even with `format_supported=YES`)
- exporter → encoder `RENDER_ERROR`
- the leaked feed player → `ERROR_CODE_DECODING_RESOURCES_RECLAIMED` exactly when the export encoder spun up

Background feeds already release their *neighbour* players when inactive, but intentionally keep the *current* player warm for instant resume on tab switches (the correct behaviour, matching TikTok). The gap was the codec-heavy surfaces (camera/editor/exporter), where even the current player must be released.

 

### What changed

- **`CodecHeavySurfaceCubit`** (app-global, ref-counted): asserts a `bool` while a camera/editor/exporter screen is on screen. Count lives in the state, not as a mutable field.
- **`InfiniteVideoFeed.releaseCurrentWhenInactive`** (new flag): when set and the feed is inactive, the *whole* pool is drained (current player included) and re-initialised when the feed becomes visible again. Plain tab switches are unaffected — the current player stays warm.
- **`FeedVideos`** watches the cubit (nullable lookup → graceful no-op when not provided) and forwards the flag.
- **`CodecHeavySurfaceGuard`** mixin: camera + editor screens assert the signal **only after their entrance transition completes**, so the feed frame stays visible during the push animation instead of disappearing mid-transition. The matching release fires on dispose, and only if the signal was actually asserted (a screen popped mid-transition stays balanced).

**Related Issue:** Relates to the performance/codec crash reports on Qualcomm devices (againstri).

## Out of Scope

- **Encoder-config robustness** in the native render path (`operating-rate=Integer.MAX_VALUE`, High-profile 1080p fallback to software encoder) — a separate, independent fix for the same export failure. Tracked as follow-up, not in this PR.
- 4 pre-existing timing-sensitive test failures in `infinite_video_feed` services (`controller_subscriptions`, `load_watchdog`, `stale_playback_detector`, `source_loader`) — verified present on the base branch **without** this diff, so unrelated.

- **Direct-publish inline render from the Drafts/Library tab.** Posting a never-rendered multi-clip draft (`finalRenderedClip == null && clips.length > 1`) runs the encoder inline via `publishVideo` while no camera/editor screen is mounted. This is background-render-vs-foreground-feed contention: once the user returns to the home feed it goes active and reclaims its decoder, so draining the foreground feed cannot help and would be the wrong UX. Belongs to the encoder-robustness follow-up above, not the foreground-surface drain model.

## Verification

- `flutter analyze` (changed files + `infinite_video_feed`): clean
- `dart format`: clean
- `infinite_video_feed` widget tests incl. new `releaseCurrentWhenInactive` group
- `codec_heavy_surface_cubit_test`, `codec_heavy_surface_guard_test` (transition timing + balanced ref-count)
- `feed_videos_test`, `video_recorder_screen_test`, editor sticker-roundtrip / recorder-navigation tests
- Rebased onto fresh `origin/main`; all of the above re-run green after rebase

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
