### PR TITLE
fix(video-editor): recover from Qualcomm encoder failures on export

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "2488009fafaccd178e3c96f8ec1fc4bcb852e6ced6a09e6e49da89084f85ed51"
+      sha256: "22fa69a8f4e3c100e6bb25691694f3127e34d3019cdd0d575d8d2cda0f9d7819"
       url: "https://pub.dev"
     source: hosted
-    version: "1.21.4"
+    version: "1.21.5"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -302,7 +302,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.21.4
+  pro_video_editor: ^1.21.5
   pro_image_editor: ^12.8.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #5525

## Description

Bumps `pro_video_editor` `1.21.4` → `1.21.5`.

This is a **fix**, delivered through a package update rather than an app-side code change — the bug was fixed in `pro_video_editor` itself (in `1.21.5`), so the app only needs to pull in that release.

`1.21.5` fixes:

- **(android)** Video export failing with a codec exception on Qualcomm `c2.qti.*` encoders. The encoder is now retried through a fallback chain (operating-rate cap → unset → Main/Baseline profile → software) before surfacing a typed `RenderEncoderException`. Devices that already worked keep their original export speed.
- **(android, iOS, macOS)** A render/cancel race where cancelling right after starting an export failed with `TASK_NOT_FOUND`. An early cancel is now handled in the Dart layer before the native task starts, so the render resolves as canceled.

**Related Issue:** 

## Out of Scope

None. There is no Dart code to change in this repo — the fixes live in the package; this PR is purely the dependency bump (`pubspec.yaml` + `pubspec.lock`).

## Verification

- `flutter pub get` resolves cleanly with no lockfile churn beyond `pro_video_editor`.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)