### PR TITLE
fix(video-recorder): smooth and extend hold-to-record drag zoom

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:io';
+import 'dart:math' as math;
 
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:divine_camera/divine_camera.dart'
@@ -981,16 +982,28 @@ class VideoRecorderBloc
     Emitter<VideoRecorderBlocState> emit,
   ) async {
     const maxDragDistance = 240.0;
-    final dragDistance = (-event.offsetFromOrigin.dy).clamp(
-      0.0,
+    // Up is negative dy, so a positive [verticalDrag] is a drag up (zoom in)
+    // and a negative one is a drag down (zoom out).
+    final verticalDrag = (-event.offsetFromOrigin.dy).clamp(
+      -maxDragDistance,
       maxDragDistance,
     );
 
-    final availableZoomRange =
-        _cameraService.maxZoomLevel - state.baseZoomLevel;
-    final zoomLevel =
-        state.baseZoomLevel +
-        (dragDistance / maxDragDistance) * availableZoomRange;
+    // Exponential drag→zoom mapping so perceived sensitivity is uniform in
+    // both directions: an equal drag step always multiplies zoom by the same
+    // factor, so 1×→2× travels the same distance as 2×→4×. Dragging up
+    // approaches the camera max; dragging down approaches the camera min
+    // (e.g. an ultra-wide 0.6×). The previous linear, upward-only mapping
+    // packed the whole absolute range into a short upward drag — jumpy at the
+    // most-used low end — and could never reach sub-1× zoom. Mirrors the
+    // multiplicative pinch mapping in _onScaleUpdated.
+    final baseZoom = state.baseZoomLevel <= 0 ? 1.0 : state.baseZoomLevel;
+    final targetBound = verticalDrag >= 0
+        ? _cameraService.maxZoomLevel
+        : _cameraService.minZoomLevel;
+    final progress = verticalDrag.abs() / maxDragDistance;
+    final zoomLevel = (baseZoom * math.pow(targetBound / baseZoom, progress))
+        .clamp(_cameraService.minZoomLevel, _cameraService.maxZoomLevel);
 
     // Re-uses the same camera+state path as ZoomLevelSet.
     add(VideoRecorderZoomLevelSet(zoomLevel));

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -203,6 +203,7 @@ class VideoRecorderBloc
       _onRecordingStopRequested,
       transformer: sequential(),
     );
+    on<VideoRecorderLongPressZoomStarted>(_onLongPressZoomStarted);
     on<VideoRecorderZoomedByLongPress>(_onZoomedByLongPress);
     on<VideoRecorderScaleStarted>(_onScaleStarted);
     on<VideoRecorderScaleUpdated>(_onScaleUpdated);
@@ -975,6 +976,17 @@ class VideoRecorderBloc
     try {
       await File(workCopyPath).delete();
     } catch (_) {}
+  }
+
+  void _onLongPressZoomStarted(
+    VideoRecorderLongPressZoomStarted event,
+    Emitter<VideoRecorderBlocState> emit,
+  ) {
+    // Anchor the drag-zoom to the zoom level in effect when the gesture
+    // begins. Without this, a long-press on a recording started elsewhere
+    // (tap, volume key, BLE remote) — or one resumed after a pinch changed the
+    // zoom — would measure from a stale base and snap on the first move.
+    emit(state.copyWith(baseZoomLevel: state.zoomLevel));
   }
 
   Future<void> _onZoomedByLongPress(

--- a/mobile/lib/blocs/video_recorder/video_recorder_event.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_event.dart
@@ -163,6 +163,16 @@ final class VideoRecorderRecordingStopRequested extends VideoRecorderEvent {
   List<Object?> get props => [result];
 }
 
+/// A long-press gesture began — captures the current zoom as the base that
+/// subsequent [VideoRecorderZoomedByLongPress] drags are measured from.
+///
+/// Recording-start already anchors the base for hold-to-record, but a
+/// long-press that lands on a recording started elsewhere (tap, volume key,
+/// BLE remote) never re-runs that path, so it needs its own capture.
+final class VideoRecorderLongPressZoomStarted extends VideoRecorderEvent {
+  const VideoRecorderLongPressZoomStarted();
+}
+
 /// Adjusts zoom by vertical drag offset during a long-press gesture.
 final class VideoRecorderZoomedByLongPress extends VideoRecorderEvent {
   const VideoRecorderZoomedByLongPress(this.offsetFromOrigin);

--- a/mobile/lib/widgets/video_recorder/shutter_gesture_detector.dart
+++ b/mobile/lib/widgets/video_recorder/shutter_gesture_detector.dart
@@ -25,6 +25,7 @@ class ShutterGestureDetector extends StatefulWidget {
     super.key,
     this.isLongPressSupported = true,
     this.startsRecordingOnPressDown = false,
+    this.onLongPressZoomStart,
     this.onLongPressMoveUpdate,
     this.behavior,
   });
@@ -37,6 +38,11 @@ class ShutterGestureDetector extends StatefulWidget {
   final VoidCallback onTapToggle;
   final VoidCallback onLongPressStartRecording;
   final VoidCallback onLongPressStopRecording;
+
+  /// Fires at the start of every long-press gesture, before any move updates
+  /// and even when the press lands on an already-active recording. Lets the
+  /// host capture the zoom level that [onLongPressMoveUpdate] drags anchor to.
+  final VoidCallback? onLongPressZoomStart;
   final GestureLongPressMoveUpdateCallback? onLongPressMoveUpdate;
   final HitTestBehavior? behavior;
 
@@ -76,6 +82,10 @@ class _ShutterGestureDetectorState extends State<ShutterGestureDetector> {
   }
 
   void _handleLongPressStart(LongPressStartDetails _) {
+    // Anchor the zoom base for this gesture before the recording-state gate,
+    // so a long-press that only zooms (recording already active) still
+    // captures it.
+    widget.onLongPressZoomStart?.call();
     if (widget.isRecording) return;
     _startedByLongPress = true;
     widget.onLongPressStartRecording();

--- a/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_record_button.dart
@@ -75,6 +75,11 @@ class RecordButton extends ConsumerWidget {
         onLongPressStopRecording: () => context.read<VideoRecorderBloc>().add(
           const VideoRecorderRecordingStopRequested(),
         ),
+        onLongPressZoomStart: isLongPressSupported
+            ? () => context.read<VideoRecorderBloc>().add(
+                const VideoRecorderLongPressZoomStarted(),
+              )
+            : null,
         onLongPressMoveUpdate: state.isRecording && isLongPressSupported
             ? (details) => context.read<VideoRecorderBloc>().add(
                 VideoRecorderZoomedByLongPress(details.localOffsetFromOrigin),

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -240,6 +240,86 @@ void main() {
       });
     });
 
+    group('VideoRecorderZoomedByLongPress', () {
+      // minZoomLevel = 0.5, maxZoomLevel = 5, base = 1.0 (default),
+      // maxDragDistance = 240. Up is negative dy.
+      setUp(() {
+        when(
+          () => cameraService.setZoomLevel(any()),
+        ).thenAnswer((_) async => true);
+      });
+
+      test('a full upward drag reaches the camera max zoom', () async {
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        bloc.add(const VideoRecorderZoomedByLongPress(Offset(0, -240)));
+        await pumpEventQueue();
+
+        expect(bloc.state.zoomLevel, closeTo(5.0, 0.01));
+      });
+
+      test('maps the upward drag exponentially, not linearly', () async {
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        // Half the drag lands on the geometric midpoint sqrt(1 × 5) ≈ 2.236,
+        // not the linear midpoint of 3.0. This keeps the most-used low end
+        // (1×→2×) gentle instead of jumpy.
+        bloc.add(const VideoRecorderZoomedByLongPress(Offset(0, -120)));
+        await pumpEventQueue();
+
+        expect(bloc.state.zoomLevel, closeTo(2.2360, 0.01));
+        expect(bloc.state.zoomLevel, lessThan(3.0));
+      });
+
+      test(
+        'a downward drag zooms out below 1× toward the camera min',
+        () async {
+          final bloc = buildBloc();
+          addTearDown(bloc.close);
+
+          // A full downward drag (positive dy) reaches the ultra-wide min 0.5×.
+          bloc.add(const VideoRecorderZoomedByLongPress(Offset(0, 240)));
+          await pumpEventQueue();
+
+          expect(bloc.state.zoomLevel, closeTo(0.5, 0.01));
+          verify(() => cameraService.setZoomLevel(0.5)).called(1);
+        },
+      );
+
+      test('the downward drag is also mapped exponentially', () async {
+        final bloc = buildBloc();
+        addTearDown(bloc.close);
+
+        // Half the downward drag lands on sqrt(1 × 0.5) ≈ 0.707.
+        bloc.add(const VideoRecorderZoomedByLongPress(Offset(0, 120)));
+        await pumpEventQueue();
+
+        expect(bloc.state.zoomLevel, closeTo(0.7071, 0.01));
+      });
+
+      test(
+        'equal upward drag steps multiply zoom by a constant factor',
+        () async {
+          final bloc = buildBloc();
+          addTearDown(bloc.close);
+
+          // Uniform perceived sensitivity: the zoom at the midpoint squared
+          // equals base × the zoom at the endpoint (2.236² ≈ 1 × 5).
+          bloc.add(const VideoRecorderZoomedByLongPress(Offset(0, -120)));
+          await pumpEventQueue();
+          final midZoom = bloc.state.zoomLevel;
+
+          bloc.add(const VideoRecorderZoomedByLongPress(Offset(0, -240)));
+          await pumpEventQueue();
+          final endZoom = bloc.state.zoomLevel;
+
+          expect(midZoom * midZoom, closeTo(1.0 * endZoom, 0.05));
+        },
+      );
+    });
+
     group('VideoRecorderFlashToggled', () {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'cycles off → torch → auto → off and persists each new mode',

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -320,6 +320,49 @@ void main() {
       );
     });
 
+    group('VideoRecorderLongPressZoomStarted', () {
+      setUp(() {
+        when(
+          () => cameraService.setZoomLevel(any()),
+        ).thenAnswer((_) async => true);
+      });
+
+      test('captures the current zoom as the drag base', () async {
+        // baseZoomLevel defaults to 1×; the gesture must re-anchor it to the
+        // live 3× zoom.
+        final bloc = buildBloc()
+          ..emit(const VideoRecorderBlocState(zoomLevel: 3));
+        addTearDown(bloc.close);
+
+        bloc.add(const VideoRecorderLongPressZoomStarted());
+        await pumpEventQueue();
+
+        expect(bloc.state.baseZoomLevel, 3.0);
+      });
+
+      test(
+        'anchors a following drag so it does not snap back to a stale base',
+        () async {
+          // Path-B regression: recording started elsewhere and a pinch moved
+          // zoom to 3× while baseZoomLevel is still the pinch-start 1×. Without
+          // the start capture the first drag would jump toward 1×.
+          final bloc = buildBloc()
+            ..emit(const VideoRecorderBlocState(zoomLevel: 3));
+          addTearDown(bloc.close);
+
+          bloc.add(const VideoRecorderLongPressZoomStarted());
+          await pumpEventQueue();
+          // A small upward drag (10% of the range) nudges zoom up from 3×,
+          // not down toward the stale 1× base (which would land near 1.17×).
+          bloc.add(const VideoRecorderZoomedByLongPress(Offset(0, -24)));
+          await pumpEventQueue();
+
+          expect(bloc.state.zoomLevel, greaterThan(3.0));
+          expect(bloc.state.zoomLevel, closeTo(3.155, 0.05));
+        },
+      );
+    });
+
     group('VideoRecorderFlashToggled', () {
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'cycles off → torch → auto → off and persists each new mode',

--- a/mobile/test/widgets/video_recorder/shutter_long_press_mixin_test.dart
+++ b/mobile/test/widgets/video_recorder/shutter_long_press_mixin_test.dart
@@ -9,6 +9,7 @@ void main() {
       required VoidCallback onTapToggle,
       required VoidCallback onLongPressStartRecording,
       required VoidCallback onLongPressStopRecording,
+      VoidCallback? onLongPressZoomStart,
       bool isRecording = false,
       bool isEnabled = true,
       bool isLongPressSupported = true,
@@ -27,6 +28,7 @@ void main() {
               onTapToggle: onTapToggle,
               onLongPressStartRecording: onLongPressStartRecording,
               onLongPressStopRecording: onLongPressStopRecording,
+              onLongPressZoomStart: onLongPressZoomStart,
               child: const SizedBox(width: 80, height: 80),
             ),
           ),
@@ -77,6 +79,58 @@ void main() {
 
         expect(started, equals(0));
         expect(stopped, equals(0));
+      },
+    );
+
+    testWidgets('long-press from idle captures the zoom base then records', (
+      tester,
+    ) async {
+      var zoomStart = 0;
+      var started = 0;
+      await pumpHost(
+        tester,
+        onTapToggle: () {},
+        onLongPressStartRecording: () => started++,
+        onLongPressStopRecording: () {},
+        onLongPressZoomStart: () => zoomStart++,
+      );
+
+      final gesture = await tester.startGesture(
+        tester.getCenter(find.byType(ShutterGestureDetector)),
+      );
+      await tester.pump(const Duration(seconds: 1));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(zoomStart, equals(1));
+      expect(started, equals(1));
+    });
+
+    testWidgets(
+      'long-press on an active recording still captures the zoom base',
+      (tester) async {
+        var zoomStart = 0;
+        var started = 0;
+        await pumpHost(
+          tester,
+          isRecording: true,
+          onTapToggle: () {},
+          onLongPressStartRecording: () => started++,
+          onLongPressStopRecording: () {},
+          onLongPressZoomStart: () => zoomStart++,
+        );
+
+        final gesture = await tester.startGesture(
+          tester.getCenter(find.byType(ShutterGestureDetector)),
+        );
+        await tester.pump(const Duration(seconds: 1));
+        await gesture.up();
+        await tester.pumpAndSettle();
+
+        // Path B: the press did not start the recording (it was already
+        // active) but must still anchor the drag-zoom base.
+        expect(zoomStart, equals(1));
+        expect(started, equals(0));
       },
     );
 


### PR DESCRIPTION
Closes #5534

## Description

The hold-to-record vertical-drag zoom (hold the record button, slide the finger up/down) had two problems reported by users:

1. **Too sensitive.** It used a **linear** mapping of drag distance onto the absolute zoom range (`base + drag/240 * (maxZoom - base)`). Because zoom is perceived **multiplicatively**, that packed the most-used low end (1×→2×) into the first few pixels of drag — small finger movements felt far too jumpy. With a typical `maxZoom` of 8×, 1×→2× took ~34px while 4×→8× took ~137px.
2. **Could not zoom below 1×.** Downward drags were clamped to zero, so the gesture could only zoom *in* from the base. On devices with an ultra-wide lens (e.g. min zoom 0.6×) you could never reach sub-1× zoom via this gesture.

This PR switches the handler to an **exponential, bidirectional** mapping:

- An equal drag step always multiplies zoom by the same factor → **uniform perceived sensitivity** in both directions. This matches the multiplicative pinch-to-zoom mapping already used in `_onScaleUpdated` (the long-press path had been left on the old linear logic).
- Dragging **up** approaches the camera **max**; dragging **down** approaches the camera **min** (ultra-wide). The result is clamped to the camera's zoom bounds.

**Related Issue:** Relates to #

## Out of Scope

- No 1× snap detent on the long-press drag (pinch keeps its detent). With base = 1× the origin already sits exactly at 1×, so it is trivially returnable.
- `maxDragDistance` (240) is unchanged; the exponential curve is the fix. It remains the one knob to spread the full range over more thumb travel if needed.

## Verification

- `flutter analyze lib/blocs/video_recorder/video_recorder_bloc.dart test/blocs/video_recorder/video_recorder_bloc_test.dart` → no issues
- `flutter test test/blocs/video_recorder/video_recorder_bloc_test.dart` → all 54 pass (5 new `VideoRecorderZoomedByLongPress` cases covering max reach, exponential vs linear midpoint, sub-1× zoom-out, and uniform step factor)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)