### PR TITLE
fix(camera): stop Android preview crash on torn-down texture and encoder executor

### DIFF
--- a/.github/workflows/divine_camera.yaml
+++ b/.github/workflows/divine_camera.yaml
@@ -24,3 +24,32 @@ jobs:
     uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/flutter_package.yml@v1
     with:
       working_directory: "mobile/packages/divine_camera"
+
+  android-unit-tests:
+    name: Android Unit Tests
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: mobile/
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.44.0"
+          channel: "stable"
+          cache: true
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.14.3"
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Run divine_camera Android unit tests
+        working-directory: mobile/android
+        run: gradle :divine_camera:testDebugUnitTest

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/CameraController.kt
@@ -40,6 +40,9 @@ import java.util.concurrent.Executors
 private const val TAG = "DivineCameraController"
 private const val LENS_SWITCH_HYSTERESIS = 0.03f
 
+/** How a preview [Surface] should be supplied to a CameraX surface request. */
+internal enum class SurfaceProvision { REUSE, CREATE, DECLINE }
+
 /**
  * Controller for CameraX-based camera operations.
  * Handles camera initialization, preview, video recording, and camera controls.
@@ -64,7 +67,8 @@ class CameraController(
     private var flutterSurfaceTexture: SurfaceTexture? = null
     private var previewSurface: Surface? = null
 
-    private var cameraExecutor: ExecutorService = Executors.newSingleThreadExecutor()
+    private var cameraExecutor: ExecutorService =
+        RejectionTolerantExecutorService(Executors.newSingleThreadExecutor())
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private var currentLens: Int = CameraSelector.LENS_FACING_BACK
@@ -218,6 +222,25 @@ class CameraController(
             STABILIZATION_LOW_LATENCY,
             STABILIZATION_AUTO,
         )
+
+        /**
+         * Decides how a preview surface request should be fulfilled.
+         *
+         * The Flutter [SurfaceTexture] can be torn down (released and the
+         * field nulled by `release()`) between registering a surface provider
+         * and CameraX actually dispatching the request. Reading it then
+         * passing it straight to `Surface(...)` crashes with
+         * `surfaceTexture must not be null`, so callers must [DECLINE] when no
+         * texture is available rather than build a surface from null.
+         */
+        internal fun decideSurfaceProvision(
+            hasTexture: Boolean,
+            existingSurfaceValid: Boolean,
+        ): SurfaceProvision = when {
+            existingSurfaceValid -> SurfaceProvision.REUSE
+            hasTexture -> SurfaceProvision.CREATE
+            else -> SurfaceProvision.DECLINE
+        }
 
         /** Returns the next lower quality, or null if already at minimum. */
         fun lowerQuality(current: Quality): Quality? = when (current) {
@@ -774,6 +797,28 @@ class CameraController(
     }
 
     /**
+     * Returns a preview [Surface] to hand to a CameraX surface request,
+     * reusing the existing one when still valid and otherwise creating a new
+     * one from [surfaceTexture]. Returns null when no surface can be supplied
+     * (the Flutter texture was released), so the caller declines the request
+     * via `willNotProvideSurface()` instead of constructing `Surface(null)`.
+     */
+    private fun resolvePreviewSurface(surfaceTexture: SurfaceTexture?): Surface? {
+        val existing = previewSurface
+        return when (
+            decideSurfaceProvision(
+                hasTexture = surfaceTexture != null,
+                existingSurfaceValid = existing != null && existing.isValid,
+            )
+        ) {
+            SurfaceProvision.REUSE -> existing
+            SurfaceProvision.CREATE ->
+                surfaceTexture?.let { Surface(it).also { s -> previewSurface = s } }
+            SurfaceProvision.DECLINE -> null
+        }
+    }
+
+    /**
      * Starts the camera with preview and video capture use cases.
      */
     private fun startCamera(callback: (Map<String, Any?>?, String?) -> Unit) {
@@ -849,16 +894,17 @@ class CameraController(
                 aspectRatio = videoHeight.toFloat() / videoWidth.toFloat()
                 DivineCameraLog.d(TAG, "Aspect ratio set to: $aspectRatio (portrait), video dimensions: ${videoWidth}x${videoHeight}")
 
-                // Set the buffer size to match camera resolution
-                flutterSurfaceTexture?.setDefaultBufferSize(videoWidth, videoHeight)
+                // Capture the texture locally: the request fires asynchronously
+                // and release() may have nulled the field in the meantime.
+                val surfaceTexture = flutterSurfaceTexture
+                surfaceTexture?.setDefaultBufferSize(videoWidth, videoHeight)
 
-                // Create surface from Flutter's SurfaceTexture
-                previewSurface = Surface(flutterSurfaceTexture)
+                val surface = resolvePreviewSurface(surfaceTexture)
 
                 // Provide the surface
-                if (previewSurface != null && previewSurface!!.isValid) {
+                if (surface != null && surface.isValid) {
                     request.provideSurface(
-                        previewSurface!!,
+                        surface,
                         ContextCompat.getMainExecutor(context)
                     ) { result ->
                         DivineCameraLog.d(TAG, "Surface result code: ${result.resultCode}")
@@ -873,7 +919,8 @@ class CameraController(
                         callback(state, null)
                     }
                 } else {
-                    DivineCameraLog.e(TAG, "Preview surface is null or invalid!")
+                    DivineCameraLog.w(TAG, "Preview texture unavailable; declining surface request")
+                    request.willNotProvideSurface()
                     if (!callbackCalled) {
                         callbackCalled = true
                         callback(null, "Failed to create preview surface")
@@ -1006,28 +1053,22 @@ class CameraController(
                 // Update aspect ratio for portrait mode (height/width gives 9:16 ratio)
                 aspectRatio = videoHeight.toFloat() / videoWidth.toFloat()
 
-                // Update buffer size for new camera resolution
-                flutterSurfaceTexture?.setDefaultBufferSize(videoWidth, videoHeight)
+                // Capture the texture locally: release() may have nulled the
+                // field between registering the provider and this request.
+                val surfaceTexture = flutterSurfaceTexture
+                surfaceTexture?.setDefaultBufferSize(videoWidth, videoHeight)
 
-                // Provide the existing surface
-                if (previewSurface != null && previewSurface!!.isValid) {
+                val surface = resolvePreviewSurface(surfaceTexture)
+                if (surface != null && surface.isValid) {
                     request.provideSurface(
-                        previewSurface!!,
+                        surface,
                         ContextCompat.getMainExecutor(context)
                     ) { result ->
                         DivineCameraLog.d(TAG, "Switch: Surface result code: ${result.resultCode}")
                     }
                 } else {
-                    // Surface was released, create new one
-                    previewSurface = Surface(flutterSurfaceTexture)
-                    if (previewSurface != null && previewSurface!!.isValid) {
-                        request.provideSurface(
-                            previewSurface!!,
-                            ContextCompat.getMainExecutor(context)
-                        ) { result ->
-                            DivineCameraLog.d(TAG, "Switch: New surface result code: ${result.resultCode}")
-                        }
-                    }
+                    DivineCameraLog.w(TAG, "Switch: preview texture unavailable; declining surface request")
+                    request.willNotProvideSurface()
                 }
             }
 
@@ -1572,18 +1613,11 @@ class CameraController(
                 // Post surface provision to let setZoomRatio settle
                 // in the camera pipeline before any frames flow.
                 mainHandler.postDelayed({
-                    val surface = if (
-                        previewSurface != null &&
-                        previewSurface!!.isValid
-                    ) {
-                        previewSurface!!
-                    } else {
-                        previewSurface =
-                            Surface(flutterSurfaceTexture)
-                        previewSurface!!
-                    }
-
-                    if (surface.isValid) {
+                    // Re-read the texture: release() can null it during the
+                    // delay, which would crash Surface(null).
+                    val surface =
+                        resolvePreviewSurface(flutterSurfaceTexture)
+                    if (surface != null && surface.isValid) {
                         request.provideSurface(
                             surface,
                             ContextCompat.getMainExecutor(
@@ -1596,13 +1630,20 @@ class CameraController(
                                     "${result.resultCode}"
                             )
                         }
+                        DivineCameraLog.d(
+                            TAG,
+                            "AutoSwitch surface provided " +
+                                "(delayed)"
+                        )
+                    } else {
+                        DivineCameraLog.w(
+                            TAG,
+                            "AutoSwitch: preview texture " +
+                                "unavailable; declining request"
+                        )
+                        request.willNotProvideSurface()
                     }
                     isAutoSwitching = false
-                    DivineCameraLog.d(
-                        TAG,
-                        "AutoSwitch surface provided " +
-                            "(delayed)"
-                    )
                 }, 100)
             }
 
@@ -2348,8 +2389,9 @@ class CameraController(
             textureEntry = null
             flutterSurfaceTexture = null
 
-            // Shutdown executor after a delay to let CameraX finish pending tasks
-            // This prevents RejectedExecutionException during cleanup
+            // Delay shutdown so CameraX can drain in-flight encoder/muxer
+            // tasks. cameraExecutor is rejection-tolerant, so any callback
+            // that still arrives after shutdown is dropped, not crashed.
             if (!cameraExecutor.isShutdown) {
                 mainHandler.postDelayed({
                     try {

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/RejectionTolerantExecutorService.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/RejectionTolerantExecutorService.kt
@@ -1,0 +1,34 @@
+package co.openvine.divine_camera
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.RejectedExecutionException
+
+/**
+ * Wraps an [ExecutorService] so tasks submitted after shutdown are dropped
+ * instead of throwing [RejectedExecutionException].
+ *
+ * CameraX's `EncoderImpl` posts MediaCodec teardown callbacks (including a
+ * late `onError`) to the recorder executor. When the camera is released the
+ * executor is shut down, and a callback that arrives afterwards would
+ * otherwise crash the app with an uncaught `RejectedExecutionException` on
+ * the MediaCodec thread. Swallowing the rejection makes teardown
+ * timing-independent.
+ */
+internal class RejectionTolerantExecutorService(
+    private val delegate: ExecutorService,
+) : ExecutorService by delegate {
+    override fun execute(command: Runnable) {
+        try {
+            delegate.execute(command)
+        } catch (e: RejectedExecutionException) {
+            DivineCameraLog.w(
+                TAG,
+                "Dropped task on terminated camera executor: ${e.message}",
+            )
+        }
+    }
+
+    private companion object {
+        private const val TAG = "RejectionTolerantExecutor"
+    }
+}

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/RejectionTolerantExecutorService.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/RejectionTolerantExecutorService.kt
@@ -13,6 +13,13 @@ import java.util.concurrent.RejectedExecutionException
  * otherwise crash the app with an uncaught `RejectedExecutionException` on
  * the MediaCodec thread. Swallowing the rejection makes teardown
  * timing-independent.
+ *
+ * Only [execute] is guarded. Kotlin's `by` delegation forwards `submit`,
+ * `invokeAll`, and `invokeAny` straight to [delegate], whose own `execute`
+ * (not this override) runs the task, so a rejection raised on those paths
+ * would still propagate. That is sufficient here because `EncoderImpl` posts
+ * its teardown callbacks via `execute(...)`; extend this wrapper if a future
+ * caller routes work through `submit(...)`.
  */
 internal class RejectionTolerantExecutorService(
     private val delegate: ExecutorService,

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
@@ -262,7 +262,8 @@ internal class VideoStabilizationTest {
     }
 }
 
-@RunWith(RobolectricTestRunner::class)
+// Pure decision logic with no Android framework dependency, so it runs on
+// the plain JUnit runner rather than Robolectric.
 internal class SurfaceProvisionTest {
     @Test
     fun existingSurfaceValid_reusesRegardlessOfTexture() {

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
@@ -7,6 +7,10 @@ import io.flutter.plugin.common.MethodChannel
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -255,5 +259,95 @@ internal class VideoStabilizationTest {
                 intArrayOf(off, on, preview),
             ),
         )
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+internal class SurfaceProvisionTest {
+    @Test
+    fun existingSurfaceValid_reusesRegardlessOfTexture() {
+        assertEquals(
+            SurfaceProvision.REUSE,
+            CameraController.decideSurfaceProvision(
+                hasTexture = true,
+                existingSurfaceValid = true,
+            ),
+        )
+        assertEquals(
+            SurfaceProvision.REUSE,
+            CameraController.decideSurfaceProvision(
+                hasTexture = false,
+                existingSurfaceValid = true,
+            ),
+        )
+    }
+
+    @Test
+    fun noExistingSurfaceButTexturePresent_createsNew() {
+        assertEquals(
+            SurfaceProvision.CREATE,
+            CameraController.decideSurfaceProvision(
+                hasTexture = true,
+                existingSurfaceValid = false,
+            ),
+        )
+    }
+
+    @Test
+    fun noTexture_declinesInsteadOfBuildingFromNull() {
+        // Regression for the "surfaceTexture must not be null" crash: when the
+        // Flutter texture was released before the surface request lands, the
+        // request must be declined, never turned into Surface(null).
+        assertEquals(
+            SurfaceProvision.DECLINE,
+            CameraController.decideSurfaceProvision(
+                hasTexture = false,
+                existingSurfaceValid = false,
+            ),
+        )
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
+internal class RejectionTolerantExecutorServiceTest {
+    @Test
+    fun execute_beforeShutdown_runsTaskOnDelegate() {
+        val executor =
+            RejectionTolerantExecutorService(Executors.newSingleThreadExecutor())
+        val latch = CountDownLatch(1)
+
+        executor.execute { latch.countDown() }
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        executor.shutdown()
+    }
+
+    @Test
+    fun execute_afterShutdown_dropsTaskWithoutThrowing() {
+        // Regression for the encoder-teardown RejectedExecutionException: a
+        // MediaCodec callback that posts after release()'s shutdown must be
+        // dropped, not crash on the codec thread.
+        val executor =
+            RejectionTolerantExecutorService(Executors.newSingleThreadExecutor())
+        executor.shutdown()
+        assertTrue(executor.isShutdown)
+
+        val ran = AtomicBoolean(false)
+        executor.execute { ran.set(true) }
+
+        assertFalse(ran.get())
+    }
+
+    @Test
+    fun lifecycleMethods_delegateToWrappedExecutor() {
+        val executor =
+            RejectionTolerantExecutorService(Executors.newSingleThreadExecutor())
+        assertFalse(executor.isShutdown)
+
+        executor.shutdown()
+
+        assertTrue(executor.isShutdown)
+        assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS))
+        assertTrue(executor.isTerminated)
     }
 }


### PR DESCRIPTION
Closes #5536

## Description

Fixes two long-standing **Android-only** `divine_camera` crashes, both teardown races triggered by opening the video recorder and leaving it quickly (common on low-end devices like the Samsung SM-A055F). iOS is unaffected.

**1. `IllegalArgumentException: surfaceTexture must not be null`** (live in 1.0.15, ~20 crashes / 13 users, first seen 1.0.4)

CameraX dispatches the preview surface request asynchronously on the main executor. The three surface-provider callbacks (`startCamera`, `switchCamera`, `autoSwitchToLens`) read the mutable `flutterSurfaceTexture` field *at callback time* and passed it straight into `Surface(...)`. If `release()` ran first it had already nulled the field, so the late request built `Surface(null)` and crashed (Kotlin couldn't smart-cast the `var`, so the original safe-called `setDefaultBufferSize` but left the constructor unguarded).

Each callback now captures the texture into a local and routes through `resolvePreviewSurface()`, which reuses a still-valid surface, creates one only when the texture is present, and otherwise **declines the request via `SurfaceRequest.willNotProvideSurface()`** instead of constructing a surface from null.

**2. `RejectedExecutionException` in `EncoderImpl.MediaCodecCallback.onError`** (~13 crashes / 11 users, regressed Apr 5, during recording teardown)

`Recorder.setExecutor(cameraExecutor)` makes CameraX's encoder post MediaCodec teardown callbacks (incl. a late `onError`) to `cameraExecutor`, which `release()` shuts down. A callback arriving after shutdown threw an uncaught rejection on the codec thread. `cameraExecutor` is now wrapped in a `RejectionTolerantExecutorService` that drops post-shutdown tasks, making teardown timing-independent — the prior 500 ms delayed shutdown only papered over the race.

**Related Issue:** Relates to Crashlytics `e76533d9…` (surface null) and `3697e311…` (executor rejection).

## CI hardening

The package workflow now also runs `:divine_camera:testDebugUnitTest` in GitHub Actions so the new Kotlin regression tests gate future changes.

## Out of Scope

- The three preview surface-provider blocks remain three separate call sites (now sharing the `resolvePreviewSurface()` / `decideSurfaceProvision()` helpers); a fuller unification of `startCamera`/`switchCamera`/`autoSwitchToLens` is a larger refactor left for another PR.

## Verification

- `flutter analyze` (divine_camera) — No issues found.
- `flutter test` (divine_camera) — 344 tests passed.
- `gradle :divine_camera:testDebugUnitTest` — wired into `Divine Camera CI` as `Android Unit Tests`.
- Local Android Gradle execution is blocked on this machine by a missing Java runtime; the GitHub runner installs Temurin 17 and Gradle 8.14.3 before running the Gradle task.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ CI/test coverage
