### PR TITLE
fix(video-editor): stop preview playhead jumping back when a transition finishes rendering

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -480,9 +480,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // time from the stale anchor before the next native report re-anchors it;
     // the report with isPlaying == true restarts it.
     _setPlayheadTickerActive(false);
-    // Playback owns the play time now; release any scrub / swap pin so reports
-    // can drive the timeline forward again.
-    _pendingSeekTarget = null;
+    // Restart jumps to the start, so re-pin the play time to zero: a stale
+    // pre-restart report is rejected while the player seeks, and a position-0
+    // report (the restart target) is accepted. _onPlayerStateChanged releases
+    // the pin once playback is actually reported.
+    _pendingSeekTarget = Duration.zero;
     _videoPlayer?.seekTo(Duration.zero);
     _videoPlayer?.play();
   }
@@ -498,8 +500,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       _setPlayheadTickerActive(false);
       _videoPlayer?.pause();
     } else {
-      // Playback owns the play time now; release any scrub / swap pin.
-      _pendingSeekTarget = null;
+      // Keep any scrub / swap pin until the player actually reports isPlaying
+      // (released in _onPlayerStateChanged). Clearing it here, before the first
+      // isPlaying report, would reopen the window where a delayed reset report
+      // (seekTarget == null) is accepted and snaps the playhead to the start.
       _videoPlayer?.play();
     }
   }
@@ -514,8 +518,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       _setPlayheadTickerActive(false);
       _videoPlayer?.pause();
     } else {
-      // Playback owns the play time now; release any scrub / swap pin.
-      _pendingSeekTarget = null;
+      // Keep any scrub / swap pin until the player reports isPlaying; see
+      // _onPlaybackToggleRequested for why clearing it here would reopen the
+      // delayed-reset-report window.
       _videoPlayer?.play();
     }
   }
@@ -743,6 +748,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         .read<VideoEditorMainBloc>()
         .state
         .currentPosition;
+    // Pin so a reset report from loading the (seam-aware) composition doesn't
+    // snap the playhead back while paused.
+    _pendingSeekTarget = currentPosition;
     _videoPlayer?.setClips([
       ...buildSeamAwarePlayerClips(clips, _seamService),
     ], startPosition: _timelineToPlayer(currentPosition));
@@ -1197,6 +1205,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             .state
             .currentPosition;
 
+        // Pin so a reset report from loading the seam-aware composition
+        // doesn't snap the playhead back while paused.
+        _pendingSeekTarget = currentPosition;
         _videoPlayer?.setClips([
           ...buildSeamAwarePlayerClips(clips, _seamService),
         ], startPosition: _timelineToPlayer(currentPosition));
@@ -1219,6 +1230,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             .state
             .currentPosition;
 
+        // Pin so a reset report from loading the seam-aware composition
+        // doesn't snap the playhead back while paused.
+        _pendingSeekTarget = currentPosition;
         _videoPlayer?.setClips([
           ...buildSeamAwarePlayerClips(clips, _seamService),
         ], startPosition: _timelineToPlayer(currentPosition));
@@ -1476,6 +1490,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
               if (!mounted) return;
               _lastReportedPosition = currentPosition;
+              _pendingSeekTarget = currentPosition;
               _proVideoController.setPlayTime(currentPosition);
             } catch (e, s) {
               Log.error(
@@ -1552,6 +1567,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
               );
             } finally {
               _lastReportedPosition = startPosition;
+              _pendingSeekTarget = startPosition;
               if (_seekEpoch == ownerEpoch) {
                 _isSeeking = false;
               }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -92,6 +92,38 @@ class VideoEditorCanvas extends StatelessWidget {
     required bool seedSelectedSoundAsAudioTrack,
   }) => hasSelectedSound && seedSelectedSoundAsAudioTrack;
 
+  /// Tolerance within which a player position report is treated as having
+  /// converged on a pending scrub / swap target. Comfortably wider than a
+  /// single frame and the native report interval (~200ms) so an exact seek's
+  /// settled report is accepted, yet far narrower than the multi-second gap
+  /// back to position 0 whose reset report must be rejected.
+  @visibleForTesting
+  static const seekSettleTolerance = Duration(milliseconds: 120);
+
+  /// Whether a player position [report] (in editor-timeline space) may drive
+  /// the play time, given a possibly-pending [seekTarget] that a scrub or a
+  /// composition swap pinned the play time to.
+  ///
+  /// When a transition seam finishes rendering the composition is swapped to
+  /// splice in the freshly rendered seam file; while the native player loads
+  /// that file it briefly reports position 0, which — if accepted — snaps the
+  /// timeline playhead back to the start. Rapid back-and-forth scrubbing emits
+  /// the same kind of stale, superseded report. While a target is pending and
+  /// playback is paused, only a report that has converged to within
+  /// [seekSettleTolerance] of the target is accepted; anything else is a stale
+  /// / reset report and is dropped. Playback always accepts reports — once
+  /// playing, the play time follows playback, not the pinned target.
+  @visibleForTesting
+  static bool shouldAcceptPlayerReport({
+    required Duration report,
+    required Duration? seekTarget,
+    required bool isPlaying,
+  }) {
+    if (isPlaying || seekTarget == null) return true;
+    final delta = report - seekTarget;
+    return (delta.isNegative ? -delta : delta) <= seekSettleTolerance;
+  }
+
   @override
   Widget build(BuildContext context) {
     final isSubEditorOpen = context.select(
@@ -200,6 +232,22 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// Monotonically increasing seek generation. Bumped on every composition
   /// swap so in-flight seeks from the previous composition are discarded.
   int _seekEpoch = 0;
+
+  /// Editor-timeline position the play time is currently pinned to by a scrub
+  /// seek or a composition swap. While set (and playback is paused) any player
+  /// position report that deviates from it is dropped — the short-lived
+  /// position 0 the native player emits while loading a freshly rendered
+  /// transition seam file in [_swapComposition] (which can arrive hundreds of
+  /// ms after the swap completes), and out-of-order reports from a superseded
+  /// scrub seek. Without it such a report drives the play time and snaps the
+  /// timeline playhead back to position 0 (or a previously scrubbed spot).
+  ///
+  /// The pin is intentionally *not* released on the first converged report —
+  /// that report arrives well before the delayed reset report, so clearing
+  /// early would let the reset report through. It is released only when
+  /// playback resumes (it then owns the play time) or when a new scrub / swap
+  /// re-pins it (see [VideoEditorCanvas.shouldAcceptPlayerReport]).
+  Duration? _pendingSeekTarget;
 
   /// Cached documents directory path — resolved once in [initState].
   late final Future<String> _documentsPath;
@@ -341,6 +389,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// across the reload so [_onPlayerStateChanged] skips emission, then pins
   /// [_lastReportedPosition] to the restored position before releasing
   /// ownership (only if no newer swap took over).
+  ///
+  /// [_isSeeking] only covers reports emitted *during* the reload. Loading the
+  /// freshly rendered seam file makes the native player emit a reset report
+  /// (position 0) hundreds of ms *after* the reload completes; pinning
+  /// [_pendingSeekTarget] keeps that delayed report from snapping the playhead
+  /// back to the start while playback stays paused.
   Future<void> _swapComposition(
     List<DivineVideoClip> clips, {
     required Duration timelineStartPosition,
@@ -359,6 +413,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       // newer swap (e.g. a trim-start) already set.
       if (mounted && _seekEpoch == ownerEpoch) {
         _lastReportedPosition = timelineStartPosition;
+        _pendingSeekTarget = timelineStartPosition;
         _proVideoController.setPlayTime(timelineStartPosition);
       }
     } catch (e, s) {
@@ -425,6 +480,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // time from the stale anchor before the next native report re-anchors it;
     // the report with isPlaying == true restarts it.
     _setPlayheadTickerActive(false);
+    // Playback owns the play time now; release any scrub / swap pin so reports
+    // can drive the timeline forward again.
+    _pendingSeekTarget = null;
     _videoPlayer?.seekTo(Duration.zero);
     _videoPlayer?.play();
   }
@@ -440,6 +498,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       _setPlayheadTickerActive(false);
       _videoPlayer?.pause();
     } else {
+      // Playback owns the play time now; release any scrub / swap pin.
+      _pendingSeekTarget = null;
       _videoPlayer?.play();
     }
   }
@@ -454,6 +514,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       _setPlayheadTickerActive(false);
       _videoPlayer?.pause();
     } else {
+      // Playback owns the play time now; release any scrub / swap pin.
+      _pendingSeekTarget = null;
       _videoPlayer?.play();
     }
   }
@@ -521,7 +583,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // A scrub owns the play time now; stop the playback interpolator so it
     // can't overwrite the seek target before the next player report stops it.
     _setPlayheadTickerActive(false);
-    _proVideoController.setPlayTime(playTimePosition ?? position);
+    final playTime = playTimePosition ?? position;
+    _proVideoController.setPlayTime(playTime);
+    // Pin the play time to this scrub so late reports from a superseded seek
+    // are dropped until the player converges here (see [_onPlayerStateChanged]
+    // / [VideoEditorCanvas.shouldAcceptPlayerReport]).
+    _pendingSeekTarget = playTime;
 
     if (_isSeeking) {
       _pendingSeekPosition = position;
@@ -569,7 +636,25 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       bloc.add(VideoEditorPlaybackChanged(isPlaying: isPlaying));
     }
 
+    // Once playback resumes it owns the play time, so release any scrub / swap
+    // pin. While paused the pin is kept (not cleared on the first converged
+    // report) so a reset report arriving hundreds of ms after a seam swap
+    // finishes loading is still rejected instead of snapping the playhead back
+    // to the start.
+    if (isPlaying) _pendingSeekTarget = null;
+
     _lastPlayerDuration = playerState.duration;
+
+    final timelinePosition = _playerToTimeline(playerState.position);
+
+    // Drop the delayed reset report a composition swap emits while loading the
+    // new seam file (and late reports from a superseded scrub seek) so the
+    // playhead doesn't snap back to the start.
+    final reportAccepted = VideoEditorCanvas.shouldAcceptPlayerReport(
+      report: timelinePosition,
+      seekTarget: _pendingSeekTarget,
+      isPlaying: isPlaying,
+    );
 
     // The play time may only be driven by playback while no seek / trim / drag
     // gesture owns it (those paths call setPlayTime directly).
@@ -578,9 +663,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         !_isTrimmingClip &&
         !_isDraggingLayer &&
         !_isSeeking &&
-        _pendingSeekPosition == null;
+        _pendingSeekPosition == null &&
+        reportAccepted;
 
-    final timelinePosition = _playerToTimeline(playerState.position);
     if (canDrivePlayTime && timelinePosition != _lastReportedPosition) {
       _lastReportedPosition = timelinePosition;
       bloc.add(VideoEditorPositionChanged(timelinePosition));

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -94,9 +94,9 @@ class VideoEditorCanvas extends StatelessWidget {
 
   /// Tolerance within which a player position report is treated as having
   /// converged on a pending scrub / swap target. Comfortably wider than a
-  /// single frame and the native report interval (~200ms) so an exact seek's
-  /// settled report is accepted, yet far narrower than the multi-second gap
-  /// back to position 0 whose reset report must be rejected.
+  /// single frame so frame-snapped reports from an exact seek are accepted, yet
+  /// far narrower than the multi-second gap back to position 0 whose reset
+  /// report must be rejected.
   @visibleForTesting
   static const seekSettleTolerance = Duration(milliseconds: 120);
 

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -202,6 +202,108 @@ void main() {
     });
   });
 
+  group('VideoEditorCanvas.shouldAcceptPlayerReport', () {
+    const target = Duration(seconds: 3, milliseconds: 500);
+
+    test(
+      'accepts any report while playing, regardless of a pending target',
+      () {
+        // Playback owns the play time, so the settle guard never applies.
+        expect(
+          VideoEditorCanvas.shouldAcceptPlayerReport(
+            report: Duration.zero,
+            seekTarget: target,
+            isPlaying: true,
+          ),
+          isTrue,
+        );
+      },
+    );
+
+    test('accepts any report when no scrub / swap target is pending', () {
+      expect(
+        VideoEditorCanvas.shouldAcceptPlayerReport(
+          report: const Duration(seconds: 2),
+          seekTarget: null,
+          isPlaying: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('accepts a paused report that has converged on the target', () {
+      // Within tolerance on either side (frame snapping after an exact seek).
+      expect(
+        VideoEditorCanvas.shouldAcceptPlayerReport(
+          report: target + const Duration(milliseconds: 40),
+          seekTarget: target,
+          isPlaying: false,
+        ),
+        isTrue,
+      );
+      expect(
+        VideoEditorCanvas.shouldAcceptPlayerReport(
+          report: target - const Duration(milliseconds: 40),
+          seekTarget: target,
+          isPlaying: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'rejects the position-0 reset report a seam swap emits while paused',
+      () {
+        // The reported regression: a transition finishes rendering, the player
+        // loads the seam file and reports position 0. Accepting it would snap the
+        // playhead back to the start.
+        expect(
+          VideoEditorCanvas.shouldAcceptPlayerReport(
+            report: Duration.zero,
+            seekTarget: target,
+            isPlaying: false,
+          ),
+          isFalse,
+        );
+      },
+    );
+
+    test('rejects a stale paused report from a superseded scrub seek', () {
+      // Scrubbed 2s -> 4s -> 3.5s; a late report for the 2s leading seek must
+      // not drive the play time back to 2s.
+      expect(
+        VideoEditorCanvas.shouldAcceptPlayerReport(
+          report: const Duration(seconds: 2),
+          seekTarget: target,
+          isPlaying: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('accepts a paused report exactly at the tolerance boundary', () {
+      expect(
+        VideoEditorCanvas.shouldAcceptPlayerReport(
+          report: target + VideoEditorCanvas.seekSettleTolerance,
+          seekTarget: target,
+          isPlaying: false,
+        ),
+        isTrue,
+      );
+      expect(
+        VideoEditorCanvas.shouldAcceptPlayerReport(
+          report:
+              target +
+              VideoEditorCanvas.seekSettleTolerance +
+              const Duration(milliseconds: 1),
+          seekTarget: target,
+          isPlaying: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('interpolatePlayheadPosition', () {
     const maxDuration = Duration(seconds: 10);
 


### PR DESCRIPTION
Closes #5540

## Description

The preview playhead jumped back to the start roughly 500 ms after an overlapping clip transition, such as dissolve, finished rendering while the timeline was paused.

**Root cause:** when a transition seam finishes rendering, `_swapComposition` reloads the player with the freshly rendered seam file. The native player emits a reset position report at position 0 a few hundred ms after the reload completes. `_isSeeking` only suppresses reports emitted during the reload, so this delayed report leaked through, drove `currentPosition`, and snapped the timeline playhead back to the start.

**Fix:** pin the play time to the restored position with `_pendingSeekTarget` across both scrub seeks and composition swaps, then drop paused player reports that deviate from the pin through `shouldAcceptPlayerReport` with a 120 ms tolerance. The pin is intentionally not cleared on the first converged report, because that report can arrive before the delayed reset report. It is released when playback resumes or when a new scrub or swap re-pins it. During playback the guard is bypassed so it cannot freeze the playhead.

## Linked Issue

Closes #5540.

## Out of Scope

- Transitions that finish rendering while the preview is actively playing. The guard is intentionally bypassed during playback to avoid freezing the playhead, so a brief blip is still theoretically possible there. Scrubbing pauses the preview and transitions are applied paused, so this path is not hit in the reported flow. It can be handled separately with backward-jump detection during playback if it ever surfaces.

## Verification

- `flutter analyze` on the changed files: no issues.
- `flutter test test/widgets/video_editor/main_editor/video_editor_canvas_test.dart`: 17/17 pass, including `shouldAcceptPlayerReport` cases for the paused position-0 reset report, stale superseded scrub reports, and the tolerance boundary.
- Local pre-push hook: analyze and targeted tests passed before pushing commit `ba4fc86ee`.
- Manual on-device, reporter-confirmed: apply an overlapping transition, wait for it to finish rendering, and the paused playhead no longer jumps back.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Code refactor
- [ ] Build configuration change
- [ ] Documentation
- [ ] Chore