### PR TITLE
fix(video-editor): release preview decoder before export render

### DIFF
--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -55,6 +55,13 @@ class VideoEditorConstants {
   /// the rest of the session.
   static const draftSaveTimeout = Duration(seconds: 15);
 
+  /// Maximum time to wait for the screen pushed over the editor (the metadata /
+  /// export screen) to finish its entrance transition before releasing the
+  /// preview decoder anyway. Bounds the wait so a missing transition signal can
+  /// never stall the export — the decoder is released (and the render proceeds)
+  /// at the latest after this.
+  static const coverTransitionTimeout = Duration(milliseconds: 1500);
+
   /// Primary accent color used in the video editor UI.
   static const primaryColor = Color(0xFFFFF140);
 

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -84,6 +84,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   bool get isAutosavedDraft => state.isAutosavedDraft;
 
   int _renderGeneration = 0;
+  Future<void>? _activeRenderFuture;
 
   /// When true, [triggerAutosave] is a no-op.
   ///
@@ -939,10 +940,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   ///
   /// Combines all clips, applies audio settings, and creates the final
   /// rendered clip for publishing.
-  Future<void> startRenderVideo() async {
+  Future<void> startRenderVideo() {
     if (state.finalRenderedClip != null) {
       setProcessing(false);
-      return;
+      return Future<void>.value();
     }
 
     Log.info(
@@ -952,8 +953,19 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     );
     setProcessing(true);
 
-    final renderParameters = _buildRenderParameters();
     final generation = ++_renderGeneration;
+    late final Future<void> renderFuture;
+    renderFuture = _runRenderVideo(generation).whenComplete(() {
+      if (identical(_activeRenderFuture, renderFuture)) {
+        _activeRenderFuture = null;
+      }
+    });
+    _activeRenderFuture = renderFuture;
+    return renderFuture;
+  }
+
+  Future<void> _runRenderVideo(int generation) async {
+    final renderParameters = _buildRenderParameters();
 
     final result = await VideoEditorRenderService.renderVideoToClip(
       clips: _clips,
@@ -994,8 +1006,40 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
   /// Cancel an ongoing video render operation.
   Future<void> cancelRenderVideo() async {
+    final generation = ++_renderGeneration;
+    final activeRender = _activeRenderFuture;
     await VideoEditorRenderService.cancelTask(draftId);
-    state = state.copyWith(isProcessing: false);
+    if (activeRender != null) {
+      try {
+        await activeRender;
+      } catch (e) {
+        Log.debug(
+          'Render future completed after cancellation: $e',
+          name: 'VideoEditorNotifier',
+          category: LogCategory.video,
+        );
+      }
+    }
+    if (generation == _renderGeneration) {
+      state = state.copyWith(isProcessing: false);
+    }
+  }
+
+  /// Waits until the current render has completed or cancellation teardown has
+  /// unwound. Used by codec-heavy UI surfaces before rebuilding preview
+  /// decoders.
+  Future<void> waitForRenderIdle() async {
+    final activeRender = _activeRenderFuture;
+    if (activeRender == null) return;
+    try {
+      await activeRender;
+    } catch (e) {
+      Log.debug(
+        'Render future completed while waiting for idle: $e',
+        name: 'VideoEditorNotifier',
+        category: LogCategory.video,
+      );
+    }
   }
 
   /// Publish the video to the Nostr network.

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -28,6 +28,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/video_editor/video_text_editor_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
+import 'package:openvine/utils/await_push_transition.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
@@ -606,6 +607,18 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     }
   }
 
+  /// Awaits the entrance transition of a screen pushed over the editor.
+  ///
+  /// Uses the screen's own context, which sits **above** the canvas's nested
+  /// `Navigator`, so `ModalRoute.of` resolves to the go_router editor route
+  /// whose `secondaryAnimation` the push actually drives. The canvas's own
+  /// context resolves to that inner route instead, which the outer push never
+  /// animates — so the canvas delegates here.
+  Future<void> _awaitMetadataCoverTransition() => awaitPushTransition(
+    context,
+    timeout: VideoEditorConstants.coverTransitionTimeout,
+  );
+
   @override
   Widget build(BuildContext context) {
     return MultiBlocProvider(
@@ -677,6 +690,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
                 );
               },
               onOpenMusicLibrary: _openMusicLibrary,
+              awaitPushCoverTransition: _awaitMetadataCoverTransition,
               child: ValueListenableBuilder<bool>(
                 valueListenable: _isLoadingDraft,
                 builder: (_, isLoading, _) =>

--- a/mobile/lib/utils/await_push_transition.dart
+++ b/mobile/lib/utils/await_push_transition.dart
@@ -1,0 +1,51 @@
+// ABOUTME: Awaits the current route's push transition so heavy resources (the
+// ABOUTME: camera, a video decoder) are released only after the cover animation.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// Waits for the current route's push transition to finish before returning.
+///
+/// Releasing a heavy resource (camera, video decoder) while the pushed route is
+/// still animating in would reveal the placeholder behind it; this defers until
+/// the route's [ModalRoute.secondaryAnimation] reaches
+/// [AnimationStatus.completed]. Returns immediately when nothing is animating
+/// over the current route.
+///
+/// Pass [timeout] to bound the wait so a missing transition signal can never
+/// stall the caller; on timeout the listener is detached and the future
+/// resolves. With no [timeout] the wait resolves only once the transition
+/// genuinely completes.
+Future<void> awaitPushTransition(
+  BuildContext context, {
+  Duration? timeout,
+}) async {
+  await WidgetsBinding.instance.endOfFrame;
+
+  if (!context.mounted) return;
+
+  final route = ModalRoute.of(context);
+  if (route == null) return;
+
+  final secondary = route.secondaryAnimation;
+  if (secondary == null || secondary.status == AnimationStatus.completed) {
+    return;
+  }
+
+  final completer = Completer<void>();
+  void onStatus(AnimationStatus status) {
+    if (status == AnimationStatus.completed && !completer.isCompleted) {
+      secondary.removeStatusListener(onStatus);
+      completer.complete();
+    }
+  }
+
+  secondary.addStatusListener(onStatus);
+  await (timeout == null
+      ? completer.future
+      : completer.future.timeout(
+          timeout,
+          onTimeout: () => secondary.removeStatusListener(onStatus),
+        ));
+}

--- a/mobile/lib/utils/await_push_transition.dart
+++ b/mobile/lib/utils/await_push_transition.dart
@@ -10,13 +10,16 @@ import 'package:flutter/material.dart';
 /// Releasing a heavy resource (camera, video decoder) while the pushed route is
 /// still animating in would reveal the placeholder behind it; this defers until
 /// the route's [ModalRoute.secondaryAnimation] reaches
-/// [AnimationStatus.completed]. Returns immediately when nothing is animating
-/// over the current route.
+/// [AnimationStatus.completed]. Returns immediately only when a screen already
+/// fully covers the current route (its secondary animation is already
+/// `completed`).
 ///
-/// Pass [timeout] to bound the wait so a missing transition signal can never
-/// stall the caller; on timeout the listener is detached and the future
-/// resolves. With no [timeout] the wait resolves only once the transition
-/// genuinely completes.
+/// Intended to be called right after a `push`, where the secondary animation is
+/// mid-transition. A route that never becomes covered — no push, or the push is
+/// dismissed again — leaves the animation `dismissed`, so the wait resolves only
+/// via [timeout]. Pass [timeout] to bound the wait; on timeout the listener is
+/// detached and the future resolves. With no [timeout] the wait resolves only
+/// once the transition genuinely completes.
 Future<void> awaitPushTransition(
   BuildContext context, {
   Duration? timeout,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -187,6 +187,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// #5522). pro_image_editor invokes `onDone` before `onCompleteWithParameters`,
   /// so this is always created (in [_handleDone]) before it is awaited.
   Completer<void>? _decoderReleaseGate;
+  bool _isMetadataRouteActive = false;
 
   bool _isInitialized = false;
   bool _isImportingHistory = false;
@@ -1159,6 +1160,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // contend for the device's scarce hardware codecs (see #5522). The gate is
     // created by [_handleDone], which always runs first.
     await (_decoderReleaseGate?.future ?? Future<void>.value());
+    if (!_isMetadataRouteActive) {
+      notifier.setProcessing(false);
+      return;
+    }
     notifier.startRenderVideo();
   }
 
@@ -1191,6 +1196,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // context — timeout-bounded — when the scope didn't provide it.
     final awaitCover = VideoEditorScope.of(context).awaitPushCoverTransition;
     final gate = _decoderReleaseGate = Completer<void>();
+    _isMetadataRouteActive = true;
     final navigation = context.push(VideoMetadataScreen.path);
     try {
       await (awaitCover?.call() ??
@@ -1205,7 +1211,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       if (!gate.isCompleted) gate.complete();
     }
 
-    await navigation;
+    try {
+      await navigation;
+    } finally {
+      _isMetadataRouteActive = false;
+    }
+    if (!mounted || _clipPaths.isEmpty) return;
+    await ref.read(videoEditorProvider.notifier).waitForRenderIdle();
     if (!mounted || _clipPaths.isEmpty) return;
     await _initializePlayer(_clipPaths, startPosition: resumePosition);
     if (mounted && wasPlaying) {

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -334,6 +334,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     _playheadTicker?.dispose();
     _videoPlayerSubscription?.cancel();
     _videoPlayer?.dispose();
+    // Null it so a release/init still awaiting bails instead of double-disposing
+    // or writing to the disposed notifier below.
+    _videoPlayer = null;
     _isPlayerReadyNotifier.dispose();
     _seamService.clear();
     _pendingSeamRenders.dispose();
@@ -830,7 +833,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // Dispose old player if it exists.
     await _videoPlayerSubscription?.cancel();
     await _videoPlayer?.dispose();
-    _isPlayerReadyNotifier.value = false;
+    if (mounted) _isPlayerReadyNotifier.value = false;
 
     final clips = ref.read(clipManagerProvider).clips;
 
@@ -840,11 +843,16 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       category: LogCategory.video,
     );
 
-    _videoPlayer = DivineVideoPlayerController(useTexture: true);
+    // Hold the controller locally and re-check identity after every await: a
+    // fast Done-tap (release) or a newer init can replace/null `_videoPlayer`
+    // mid-flight. Whoever supersedes us owns disposing this controller, so we
+    // just abandon it rather than resurrecting a released player.
+    final player = DivineVideoPlayerController(useTexture: true);
+    _videoPlayer = player;
 
-    await _videoPlayer!.initialize();
-    if (!mounted) return;
-    await _videoPlayer!.setClips(
+    await player.initialize();
+    if (!mounted || !identical(_videoPlayer, player)) return;
+    await player.setClips(
       [
         ...buildSeamAwarePlayerClips(clips, _seamService),
       ],
@@ -852,24 +860,20 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
           ? _timelineToPlayer(startPosition)
           : null,
     );
-    if (!mounted) return;
+    if (!mounted || !identical(_videoPlayer, player)) return;
 
     if (clips.isEmpty) return;
     _ensureSeamsRendered(clips);
-    await _videoPlayer!.setLooping(looping: true);
-    if (!mounted) return;
+    await player.setLooping(looping: true);
+    if (!mounted || !identical(_videoPlayer, player)) return;
 
     _isPlayerReadyNotifier.value = true;
 
     // Notify BLoC that player is ready
-    if (mounted) {
-      context.read<VideoEditorMainBloc>().add(const VideoEditorPlayerReady());
-    }
+    context.read<VideoEditorMainBloc>().add(const VideoEditorPlayerReady());
 
     // Setup state stream listener
-    _videoPlayerSubscription = _videoPlayer!.stateStream.listen(
-      _onPlayerStateChanged,
-    );
+    _videoPlayerSubscription = player.stateStream.listen(_onPlayerStateChanged);
 
     // Initialize audio if selected
     await _syncAudioTracks();
@@ -892,11 +896,17 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   Future<void> _releasePlayer() async {
     final player = _videoPlayer;
     if (player == null) return;
-    _setPlayheadTickerActive(false);
+    // Claim ownership immediately so a concurrent init / dispose sees null and
+    // bails instead of racing us on the same controller.
+    _videoPlayer = null;
     await _videoPlayerSubscription?.cancel();
     _videoPlayerSubscription = null;
-    _videoPlayer = null;
-    _isPlayerReadyNotifier.value = false;
+    // The wait before this can outlive the widget (dispose() disposes the
+    // notifier/ticker); only touch them while still mounted.
+    if (mounted) {
+      _setPlayheadTickerActive(false);
+      _isPlayerReadyNotifier.value = false;
+    }
     await player.dispose();
   }
 

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -30,6 +30,7 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/video_editor/transition_seam_render_service.dart';
+import 'package:openvine/utils/await_push_transition.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_feed_preview_overlay.dart';
@@ -179,6 +180,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   final _isPlayerReadyNotifier = ValueNotifier<bool>(false);
   DivineVideoPlayerController? _videoPlayer;
   StreamSubscription<DivineVideoPlayerState>? _videoPlayerSubscription;
+
+  /// Completed by [_handleDone] once the preview decoder has been released, so
+  /// [_handleEditorComplete] can hold the export encoder back until then — the
+  /// two must never contend for the device's scarce hardware codecs (see
+  /// #5522). pro_image_editor invokes `onDone` before `onCompleteWithParameters`,
+  /// so this is always created (in [_handleDone]) before it is awaited.
+  Completer<void>? _decoderReleaseGate;
 
   bool _isInitialized = false;
   bool _isImportingHistory = false;
@@ -872,6 +880,26 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     );
   }
 
+  /// Tears down the native preview player so a codec-heavy export can claim the
+  /// device's scarce hardware codecs.
+  ///
+  /// The exporter encodes via `ProVideoEditor` (MediaCodec / AVFoundation); on
+  /// codec-limited devices a still-alive — even paused — preview decoder
+  /// contends with it (the encoder `RENDER_ERROR` class #5522 released the
+  /// background feed for, one layer up). `_videoPlayer` is nulled before the
+  /// dispose so the canvas drops to its thumbnail placeholder, and the player
+  /// is rebuilt via [_initializePlayer] when the editor regains focus.
+  Future<void> _releasePlayer() async {
+    final player = _videoPlayer;
+    if (player == null) return;
+    _setPlayheadTickerActive(false);
+    await _videoPlayerSubscription?.cancel();
+    _videoPlayerSubscription = null;
+    _videoPlayer = null;
+    _isPlayerReadyNotifier.value = false;
+    await player.dispose();
+  }
+
   /// Syncs native audio overlay tracks from the [TimelineOverlayBloc]
   /// sound items.
   ///
@@ -1116,14 +1144,23 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       }
     }
     notifier.updateEditorEditingParameters(parameters);
+    // Hold the export encoder back until [_handleDone] has released the preview
+    // decoder (after the metadata screen covers the editor), so the two never
+    // contend for the device's scarce hardware codecs (see #5522). The gate is
+    // created by [_handleDone], which always runs first.
+    await (_decoderReleaseGate?.future ?? Future<void>.value());
     notifier.startRenderVideo();
   }
 
   /// Handles the done action from the main editor.
   ///
-  /// Pauses video, marks processing state, navigates to metadata screen,
-  /// and resumes video when returning only if it was playing before.
-  /// Audio sync handled by listener.
+  /// Navigates to the metadata screen and, once it has finished covering the
+  /// editor ([awaitPushTransition]), releases the preview decoder off-screen and
+  /// opens [_decoderReleaseGate] so [_handleEditorComplete] only then starts the
+  /// export encoder — the two must never contend (see #5522). Rebuilds the
+  /// player at the same position on return, resuming playback only if it was
+  /// playing before. Mirrors `openVideoEditorFromRecorder`; audio sync handled
+  /// by listener.
   Future<void> _handleDone() async {
     Log.info(
       '🎬 Done pressed - navigating to metadata screen',
@@ -1131,13 +1168,36 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       category: LogCategory.video,
     );
     final wasPlaying = _videoPlayer?.state.isPlaying ?? false;
-    _videoPlayer?.pause();
-    // IMPORTANT: Don't start video rendering here. We must await
-    // `_handleEditorComplete` which generate the layer image before we start
-    // rendering! However, we can navigate to the metadata screen immediately
-    // since it shows a progress spinner anyway (~200ms task).
+    final resumePosition = context
+        .read<VideoEditorMainBloc>()
+        .state
+        .currentPosition;
     ref.read(videoEditorProvider.notifier).setProcessing(true);
-    await context.push(VideoMetadataScreen.path);
+
+    // Delegate the cover-transition wait to the screen: its context sits above
+    // this canvas's nested `Navigator`, so the editor route's secondaryAnimation
+    // is actually driven by the push (the canvas context resolves to the inner
+    // route, which the outer push never animates). Falls back to the canvas
+    // context — timeout-bounded — when the scope didn't provide it.
+    final awaitCover = VideoEditorScope.of(context).awaitPushCoverTransition;
+    final gate = _decoderReleaseGate = Completer<void>();
+    final navigation = context.push(VideoMetadataScreen.path);
+    try {
+      await (awaitCover?.call() ??
+          awaitPushTransition(
+            context,
+            timeout: VideoEditorConstants.coverTransitionTimeout,
+          ));
+      await _releasePlayer();
+    } finally {
+      // Always open the gate so the render can never wedge, even if the release
+      // throws.
+      if (!gate.isCompleted) gate.complete();
+    }
+
+    await navigation;
+    if (!mounted || _clipPaths.isEmpty) return;
+    await _initializePlayer(_clipPaths, startPosition: resumePosition);
     if (mounted && wasPlaying) {
       _videoPlayer?.play();
     }

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_scope.dart
@@ -30,6 +30,7 @@ class VideoEditorScope extends InheritedWidget {
     required this.zoomMatrixNotifier,
     required this.fromLibrary,
     this.editorOverride,
+    this.awaitPushCoverTransition,
     super.child = const SizedBox.shrink(),
     super.key,
   });
@@ -75,6 +76,13 @@ class VideoEditorScope extends InheritedWidget {
 
   /// Callback to open the text editor.
   final Future<TextLayer?> Function([TextLayer? layer]) onAddEditTextLayer;
+
+  /// Awaits the entrance transition of a screen pushed over the editor, using a
+  /// context **above** the canvas's nested `Navigator` so the editor route's
+  /// `secondaryAnimation` is actually driven by the push. Provided by the
+  /// screen; the canvas falls back to its own (nested) context when absent
+  /// (e.g. in isolated widget tests that never navigate).
+  final Future<void> Function()? awaitPushCoverTransition;
 
   /// FittedBox scale factor between bodySize and renderSize.
   double get fittedBoxScale =>

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -20,6 +20,7 @@ import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/screens/video_editor/video_editor_screen.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
+import 'package:openvine/utils/await_push_transition.dart';
 
 /// Closes the video recorder.
 ///
@@ -65,7 +66,7 @@ Future<void> openVideoEditorFromRecorder(
       ? context.push(VideoEditorScreen.path)
       : context.push(VideoMetadataScreen.path);
 
-  await _awaitPushTransition(context);
+  await awaitPushTransition(context);
   bloc.add(const VideoRecorderCameraPausedForNavigation());
 
   await navigation;
@@ -83,7 +84,7 @@ Future<void> openRecorderLibrary(BuildContext context, WidgetRef ref) async {
 
   final navigation = context.pushNamed(LibraryScreen.clipsOnlyRouteName);
 
-  await _awaitPushTransition(context);
+  await awaitPushTransition(context);
   bloc.add(const VideoRecorderCameraPausedForNavigation());
 
   await navigation;
@@ -134,34 +135,4 @@ Future<bool> _ensureAuthenticatedForRecorderExit(
     context.go(WelcomeScreen.path);
   }
   return false;
-}
-
-/// Waits for the current route's push transition to finish before returning.
-///
-/// Disposing the camera while the new route is still animating in would reveal
-/// the camera-init screen behind it; this defers until the secondary animation
-/// completes.
-Future<void> _awaitPushTransition(BuildContext context) async {
-  await WidgetsBinding.instance.endOfFrame;
-
-  if (!context.mounted) return;
-
-  final route = ModalRoute.of(context);
-  if (route == null) return;
-
-  final secondary = route.secondaryAnimation;
-  if (secondary == null || secondary.status == AnimationStatus.completed) {
-    return;
-  }
-
-  final completer = Completer<void>();
-  void onStatus(AnimationStatus status) {
-    if (status == AnimationStatus.completed && !completer.isCompleted) {
-      secondary.removeStatusListener(onStatus);
-      completer.complete();
-    }
-  }
-
-  secondary.addStatusListener(onStatus);
-  await completer.future;
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -898,6 +898,10 @@ void main() {
     });
 
     group('cancelRenderVideo', () {
+      tearDown(() {
+        VideoEditorRenderService.renderVideoToClipOverride = null;
+      });
+
       test(
         'resets isProcessing to false when clips are already empty',
         () async {
@@ -966,6 +970,55 @@ void main() {
 
         expect(container.read(videoEditorProvider).isProcessing, isFalse);
       });
+
+      test(
+        'waits for active render future to unwind before completing cancel',
+        () async {
+          final notifier = container.read(videoEditorProvider.notifier);
+
+          container
+              .read(clipManagerProvider.notifier)
+              .addClip(
+                video: EditorVideo.file('/docs/original.mp4'),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+                duration: const Duration(seconds: 2),
+                limitClipDuration: false,
+              );
+
+          final renderCompleter = Completer<(DivineVideoClip, String?)?>();
+          VideoEditorRenderService.renderVideoToClipOverride =
+              ({
+                required clips,
+                required editorStateHistory,
+                parameters,
+                taskId,
+              }) => renderCompleter.future;
+
+          final render = notifier.startRenderVideo();
+
+          var cancelCompleted = false;
+          final cancel = notifier.cancelRenderVideo().then(
+            (_) => cancelCompleted = true,
+          );
+
+          await Future<void>.delayed(Duration.zero);
+          expect(
+            cancelCompleted,
+            isFalse,
+            reason:
+                'cancel must not let the editor rebuild its preview decoder '
+                'until the active render future has released native resources',
+          );
+
+          renderCompleter.complete(null);
+          await cancel;
+          await render;
+
+          expect(cancelCompleted, isTrue);
+          expect(container.read(videoEditorProvider).isProcessing, isFalse);
+        },
+      );
     });
   });
 

--- a/mobile/test/utils/await_push_transition_test.dart
+++ b/mobile/test/utils/await_push_transition_test.dart
@@ -1,0 +1,78 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/await_push_transition.dart';
+
+void main() {
+  group('awaitPushTransition', () {
+    testWidgets('completes once the pushed route finishes its transition', (
+      tester,
+    ) async {
+      late BuildContext homeContext;
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigatorKey,
+          home: Builder(
+            builder: (context) {
+              homeContext = context;
+              return const Scaffold(body: Text('home'));
+            },
+          ),
+        ),
+      );
+
+      navigatorKey.currentState!.push(
+        MaterialPageRoute<void>(
+          builder: (_) => const Scaffold(body: Text('next')),
+        ),
+      );
+
+      var completed = false;
+      unawaited(
+        awaitPushTransition(homeContext).then((_) => completed = true),
+      );
+
+      // Mid-transition: the cover animation has not reached completed yet.
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      expect(completed, isFalse);
+
+      await tester.pumpAndSettle();
+      expect(completed, isTrue);
+    });
+
+    testWidgets('returns immediately when nothing covers the route', (
+      tester,
+    ) async {
+      late BuildContext homeContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              homeContext = context;
+              return const Scaffold(body: Text('home'));
+            },
+          ),
+        ),
+      );
+
+      var completed = false;
+      unawaited(
+        awaitPushTransition(
+          homeContext,
+          timeout: const Duration(milliseconds: 200),
+        ).then((_) => completed = true),
+      );
+
+      // endOfFrame resolves, the secondary animation never completes, so only
+      // the timeout can release the wait.
+      await tester.pump();
+      expect(completed, isFalse);
+
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(completed, isTrue);
+    });
+  });
+}

--- a/mobile/test/utils/await_push_transition_test.dart
+++ b/mobile/test/utils/await_push_transition_test.dart
@@ -43,7 +43,7 @@ void main() {
       expect(completed, isTrue);
     });
 
-    testWidgets('returns immediately when nothing covers the route', (
+    testWidgets('resolves via the timeout when no transition completes', (
       tester,
     ) async {
       late BuildContext homeContext;


### PR DESCRIPTION
Closes #5542

## Description

On codec-limited devices the video editor preview decoder stayed alive through export, contending with the render encoder for scarce hardware codecs. This is the same RENDER_ERROR / DECODER_INIT_FAILED class that #5522 fixed for the background feed, one layer up.

This releases the editor preview decoder when navigating to the metadata/export screen, with these guarantees:

- Released off-screen: the release waits until the metadata screen has finished covering the editor before tearing the preview down to its thumbnail placeholder.
- Released before render start: editor completion waits on a decoder-release gate before starting final export.
- Not recreated during render teardown: if the user backs out of metadata during export, the editor waits for the active render future to complete or cancellation teardown to unwind before rebuilding the preview decoder.
- No late export after dismissed metadata: if metadata is popped before editor completion parameters arrive, the late completion clears processing state instead of starting an export for a dismissed route.

The cover-transition wait reuses the recorder pattern via the shared awaitPushTransition util. The editor delegates the wait to the screen context because the canvas lives below a nested Navigator, while the screen context sees the route whose secondary animation is driven by the go_router push.

## Key changes

- Added shared awaitPushTransition helper and moved recorder navigation to it without changing recorder behavior.
- Released the editor preview decoder after the metadata cover transition and gated export start on that release.
- Added VideoEditorNotifier render lifecycle tracking so cancel/return paths can wait for active render idle before restoring preview playback.
- Added a metadata-route-active guard so late editor completion cannot start export after the metadata route has already been dismissed.
- Added regression coverage for cancellation waiting on the active render future.

## Out of Scope

- Releasing the editor preview decoder while the in-editor camera is open. That is a separate follow-up; this PR covers the export path only.

## Verification

- flutter analyze from mobile/ passed after rebase.
- flutter test test/providers/video_editor_provider_test.dart passed.
- flutter test test/widgets/video_editor/main_editor/video_editor_canvas_test.dart test/widgets/video_editor/main_editor/video_editor_scope_test.dart test/widgets/video_editor/video_editor_scaffold_test.dart test/widgets/video_recorder/video_recorder_navigation_test.dart test/utils/await_push_transition_test.dart passed.
- Pre-push hook passed changed-file analyze and tests before pushing ccbfa4873.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor