### PR TITLE
feat(dm): cross-device DM read-state sync via self-encrypted markers (#4977)

### DIFF
--- a/mobile/packages/db_client/lib/src/database/app_database.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.dart
@@ -411,6 +411,22 @@ class AppDatabase extends _$AppDatabase {
     // Add dm_protocol column for NIP-04/NIP-17 protocol tracking
     await _addColumnIfMissing('conversations', 'dm_protocol', 'TEXT');
 
+    // Add last_read_timestamp read cursor for cross-device read-state sync
+    // (#4977). Backfill already-read rows once so the upgrade doesn't surface
+    // a one-time unread bump. The WHERE clause makes it self-idempotent: once
+    // a row has a non-null cursor (set here or by markAsRead) it is skipped on
+    // subsequent launches.
+    await _addColumnIfMissing(
+      'conversations',
+      'last_read_timestamp',
+      'INTEGER',
+    );
+    await customStatement(
+      'UPDATE conversations SET last_read_timestamp = last_message_timestamp '
+      'WHERE last_read_timestamp IS NULL AND is_read = 1 '
+      'AND last_message_timestamp IS NOT NULL',
+    );
+
     // Add is_deleted column for NIP-09 kind 5 soft-delete support
     await _addColumnIfMissing(
       'direct_messages',

--- a/mobile/packages/db_client/lib/src/database/app_database.g.dart
+++ b/mobile/packages/db_client/lib/src/database/app_database.g.dart
@@ -10402,6 +10402,17 @@ class $ConversationsTable extends Conversations
     ),
     defaultValue: const Constant(true),
   );
+  static const VerificationMeta _lastReadTimestampMeta = const VerificationMeta(
+    'lastReadTimestamp',
+  );
+  @override
+  late final GeneratedColumn<int> lastReadTimestamp = GeneratedColumn<int>(
+    'last_read_timestamp',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
   static const VerificationMeta _currentUserHasSentMeta =
       const VerificationMeta('currentUserHasSent');
   @override
@@ -10459,6 +10470,7 @@ class $ConversationsTable extends Conversations
     lastMessageSenderPubkey,
     subject,
     isRead,
+    lastReadTimestamp,
     currentUserHasSent,
     createdAt,
     ownerPubkey,
@@ -10537,6 +10549,15 @@ class $ConversationsTable extends Conversations
         isRead.isAcceptableOrUnknown(data['is_read']!, _isReadMeta),
       );
     }
+    if (data.containsKey('last_read_timestamp')) {
+      context.handle(
+        _lastReadTimestampMeta,
+        lastReadTimestamp.isAcceptableOrUnknown(
+          data['last_read_timestamp']!,
+          _lastReadTimestampMeta,
+        ),
+      );
+    }
     if (data.containsKey('current_user_has_sent')) {
       context.handle(
         _currentUserHasSentMeta,
@@ -10610,6 +10631,10 @@ class $ConversationsTable extends Conversations
         DriftSqlType.bool,
         data['${effectivePrefix}is_read'],
       )!,
+      lastReadTimestamp: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}last_read_timestamp'],
+      ),
       currentUserHasSent: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}current_user_has_sent'],
@@ -10661,6 +10686,14 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
   /// Whether the conversation has unread messages.
   final bool isRead;
 
+  /// Per-conversation read cursor (unix seconds) for cross-device read-state
+  /// sync (#4977). Monotonic high-water mark of the newest message the user
+  /// has read; published encrypted-to-self over Nostr and restored on
+  /// reinstall. NULL until the conversation is first read. Ingest never writes
+  /// it — only `ConversationsDao.markAsRead` / `applyReadCursor` advance it,
+  /// and only ever forward (`max`).
+  final int? lastReadTimestamp;
+
   /// Whether the current user has sent a message in this conversation.
   final bool currentUserHasSent;
 
@@ -10684,6 +10717,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     this.lastMessageSenderPubkey,
     this.subject,
     required this.isRead,
+    this.lastReadTimestamp,
     required this.currentUserHasSent,
     required this.createdAt,
     this.ownerPubkey,
@@ -10710,6 +10744,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       map['subject'] = Variable<String>(subject);
     }
     map['is_read'] = Variable<bool>(isRead);
+    if (!nullToAbsent || lastReadTimestamp != null) {
+      map['last_read_timestamp'] = Variable<int>(lastReadTimestamp);
+    }
     map['current_user_has_sent'] = Variable<bool>(currentUserHasSent);
     map['created_at'] = Variable<int>(createdAt);
     if (!nullToAbsent || ownerPubkey != null) {
@@ -10739,6 +10776,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           ? const Value.absent()
           : Value(subject),
       isRead: Value(isRead),
+      lastReadTimestamp: lastReadTimestamp == null && nullToAbsent
+          ? const Value.absent()
+          : Value(lastReadTimestamp),
       currentUserHasSent: Value(currentUserHasSent),
       createdAt: Value(createdAt),
       ownerPubkey: ownerPubkey == null && nullToAbsent
@@ -10772,6 +10812,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       ),
       subject: serializer.fromJson<String?>(json['subject']),
       isRead: serializer.fromJson<bool>(json['isRead']),
+      lastReadTimestamp: serializer.fromJson<int?>(json['lastReadTimestamp']),
       currentUserHasSent: serializer.fromJson<bool>(json['currentUserHasSent']),
       createdAt: serializer.fromJson<int>(json['createdAt']),
       ownerPubkey: serializer.fromJson<String?>(json['ownerPubkey']),
@@ -10792,6 +10833,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
       ),
       'subject': serializer.toJson<String?>(subject),
       'isRead': serializer.toJson<bool>(isRead),
+      'lastReadTimestamp': serializer.toJson<int?>(lastReadTimestamp),
       'currentUserHasSent': serializer.toJson<bool>(currentUserHasSent),
       'createdAt': serializer.toJson<int>(createdAt),
       'ownerPubkey': serializer.toJson<String?>(ownerPubkey),
@@ -10808,6 +10850,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     Value<String?> lastMessageSenderPubkey = const Value.absent(),
     Value<String?> subject = const Value.absent(),
     bool? isRead,
+    Value<int?> lastReadTimestamp = const Value.absent(),
     bool? currentUserHasSent,
     int? createdAt,
     Value<String?> ownerPubkey = const Value.absent(),
@@ -10827,6 +10870,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
         : this.lastMessageSenderPubkey,
     subject: subject.present ? subject.value : this.subject,
     isRead: isRead ?? this.isRead,
+    lastReadTimestamp: lastReadTimestamp.present
+        ? lastReadTimestamp.value
+        : this.lastReadTimestamp,
     currentUserHasSent: currentUserHasSent ?? this.currentUserHasSent,
     createdAt: createdAt ?? this.createdAt,
     ownerPubkey: ownerPubkey.present ? ownerPubkey.value : this.ownerPubkey,
@@ -10850,6 +10896,9 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           : this.lastMessageSenderPubkey,
       subject: data.subject.present ? data.subject.value : this.subject,
       isRead: data.isRead.present ? data.isRead.value : this.isRead,
+      lastReadTimestamp: data.lastReadTimestamp.present
+          ? data.lastReadTimestamp.value
+          : this.lastReadTimestamp,
       currentUserHasSent: data.currentUserHasSent.present
           ? data.currentUserHasSent.value
           : this.currentUserHasSent,
@@ -10874,6 +10923,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           ..write('lastMessageSenderPubkey: $lastMessageSenderPubkey, ')
           ..write('subject: $subject, ')
           ..write('isRead: $isRead, ')
+          ..write('lastReadTimestamp: $lastReadTimestamp, ')
           ..write('currentUserHasSent: $currentUserHasSent, ')
           ..write('createdAt: $createdAt, ')
           ..write('ownerPubkey: $ownerPubkey, ')
@@ -10892,6 +10942,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
     lastMessageSenderPubkey,
     subject,
     isRead,
+    lastReadTimestamp,
     currentUserHasSent,
     createdAt,
     ownerPubkey,
@@ -10909,6 +10960,7 @@ class ConversationRow extends DataClass implements Insertable<ConversationRow> {
           other.lastMessageSenderPubkey == this.lastMessageSenderPubkey &&
           other.subject == this.subject &&
           other.isRead == this.isRead &&
+          other.lastReadTimestamp == this.lastReadTimestamp &&
           other.currentUserHasSent == this.currentUserHasSent &&
           other.createdAt == this.createdAt &&
           other.ownerPubkey == this.ownerPubkey &&
@@ -10924,6 +10976,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
   final Value<String?> lastMessageSenderPubkey;
   final Value<String?> subject;
   final Value<bool> isRead;
+  final Value<int?> lastReadTimestamp;
   final Value<bool> currentUserHasSent;
   final Value<int> createdAt;
   final Value<String?> ownerPubkey;
@@ -10938,6 +10991,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     this.lastMessageSenderPubkey = const Value.absent(),
     this.subject = const Value.absent(),
     this.isRead = const Value.absent(),
+    this.lastReadTimestamp = const Value.absent(),
     this.currentUserHasSent = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.ownerPubkey = const Value.absent(),
@@ -10953,6 +11007,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     this.lastMessageSenderPubkey = const Value.absent(),
     this.subject = const Value.absent(),
     this.isRead = const Value.absent(),
+    this.lastReadTimestamp = const Value.absent(),
     this.currentUserHasSent = const Value.absent(),
     required int createdAt,
     this.ownerPubkey = const Value.absent(),
@@ -10970,6 +11025,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     Expression<String>? lastMessageSenderPubkey,
     Expression<String>? subject,
     Expression<bool>? isRead,
+    Expression<int>? lastReadTimestamp,
     Expression<bool>? currentUserHasSent,
     Expression<int>? createdAt,
     Expression<String>? ownerPubkey,
@@ -10988,6 +11044,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
         'last_message_sender_pubkey': lastMessageSenderPubkey,
       if (subject != null) 'subject': subject,
       if (isRead != null) 'is_read': isRead,
+      if (lastReadTimestamp != null) 'last_read_timestamp': lastReadTimestamp,
       if (currentUserHasSent != null)
         'current_user_has_sent': currentUserHasSent,
       if (createdAt != null) 'created_at': createdAt,
@@ -11006,6 +11063,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     Value<String?>? lastMessageSenderPubkey,
     Value<String?>? subject,
     Value<bool>? isRead,
+    Value<int?>? lastReadTimestamp,
     Value<bool>? currentUserHasSent,
     Value<int>? createdAt,
     Value<String?>? ownerPubkey,
@@ -11022,6 +11080,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
           lastMessageSenderPubkey ?? this.lastMessageSenderPubkey,
       subject: subject ?? this.subject,
       isRead: isRead ?? this.isRead,
+      lastReadTimestamp: lastReadTimestamp ?? this.lastReadTimestamp,
       currentUserHasSent: currentUserHasSent ?? this.currentUserHasSent,
       createdAt: createdAt ?? this.createdAt,
       ownerPubkey: ownerPubkey ?? this.ownerPubkey,
@@ -11059,6 +11118,9 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
     if (isRead.present) {
       map['is_read'] = Variable<bool>(isRead.value);
     }
+    if (lastReadTimestamp.present) {
+      map['last_read_timestamp'] = Variable<int>(lastReadTimestamp.value);
+    }
     if (currentUserHasSent.present) {
       map['current_user_has_sent'] = Variable<bool>(currentUserHasSent.value);
     }
@@ -11088,6 +11150,7 @@ class ConversationsCompanion extends UpdateCompanion<ConversationRow> {
           ..write('lastMessageSenderPubkey: $lastMessageSenderPubkey, ')
           ..write('subject: $subject, ')
           ..write('isRead: $isRead, ')
+          ..write('lastReadTimestamp: $lastReadTimestamp, ')
           ..write('currentUserHasSent: $currentUserHasSent, ')
           ..write('createdAt: $createdAt, ')
           ..write('ownerPubkey: $ownerPubkey, ')
@@ -18874,6 +18937,7 @@ typedef $$ConversationsTableCreateCompanionBuilder =
       Value<String?> lastMessageSenderPubkey,
       Value<String?> subject,
       Value<bool> isRead,
+      Value<int?> lastReadTimestamp,
       Value<bool> currentUserHasSent,
       required int createdAt,
       Value<String?> ownerPubkey,
@@ -18890,6 +18954,7 @@ typedef $$ConversationsTableUpdateCompanionBuilder =
       Value<String?> lastMessageSenderPubkey,
       Value<String?> subject,
       Value<bool> isRead,
+      Value<int?> lastReadTimestamp,
       Value<bool> currentUserHasSent,
       Value<int> createdAt,
       Value<String?> ownerPubkey,
@@ -18943,6 +19008,11 @@ class $$ConversationsTableFilterComposer
 
   ColumnFilters<bool> get isRead => $composableBuilder(
     column: $table.isRead,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get lastReadTimestamp => $composableBuilder(
+    column: $table.lastReadTimestamp,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -19016,6 +19086,11 @@ class $$ConversationsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get lastReadTimestamp => $composableBuilder(
+    column: $table.lastReadTimestamp,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<bool> get currentUserHasSent => $composableBuilder(
     column: $table.currentUserHasSent,
     builder: (column) => ColumnOrderings(column),
@@ -19078,6 +19153,11 @@ class $$ConversationsTableAnnotationComposer
   GeneratedColumn<bool> get isRead =>
       $composableBuilder(column: $table.isRead, builder: (column) => column);
 
+  GeneratedColumn<int> get lastReadTimestamp => $composableBuilder(
+    column: $table.lastReadTimestamp,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<bool> get currentUserHasSent => $composableBuilder(
     column: $table.currentUserHasSent,
     builder: (column) => column,
@@ -19136,6 +19216,7 @@ class $$ConversationsTableTableManager
                 Value<String?> lastMessageSenderPubkey = const Value.absent(),
                 Value<String?> subject = const Value.absent(),
                 Value<bool> isRead = const Value.absent(),
+                Value<int?> lastReadTimestamp = const Value.absent(),
                 Value<bool> currentUserHasSent = const Value.absent(),
                 Value<int> createdAt = const Value.absent(),
                 Value<String?> ownerPubkey = const Value.absent(),
@@ -19150,6 +19231,7 @@ class $$ConversationsTableTableManager
                 lastMessageSenderPubkey: lastMessageSenderPubkey,
                 subject: subject,
                 isRead: isRead,
+                lastReadTimestamp: lastReadTimestamp,
                 currentUserHasSent: currentUserHasSent,
                 createdAt: createdAt,
                 ownerPubkey: ownerPubkey,
@@ -19166,6 +19248,7 @@ class $$ConversationsTableTableManager
                 Value<String?> lastMessageSenderPubkey = const Value.absent(),
                 Value<String?> subject = const Value.absent(),
                 Value<bool> isRead = const Value.absent(),
+                Value<int?> lastReadTimestamp = const Value.absent(),
                 Value<bool> currentUserHasSent = const Value.absent(),
                 required int createdAt,
                 Value<String?> ownerPubkey = const Value.absent(),
@@ -19180,6 +19263,7 @@ class $$ConversationsTableTableManager
                 lastMessageSenderPubkey: lastMessageSenderPubkey,
                 subject: subject,
                 isRead: isRead,
+                lastReadTimestamp: lastReadTimestamp,
                 currentUserHasSent: currentUserHasSent,
                 createdAt: createdAt,
                 ownerPubkey: ownerPubkey,

--- a/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/conversations_dao.dart
@@ -258,19 +258,87 @@ END
 
   /// Mark a conversation as read.
   ///
+  /// Sets `isRead = true` and advances the read cursor
+  /// [Conversations.lastReadTimestamp] forward to the conversation's latest
+  /// message timestamp (monotonic: `max(existing, lastMessageTimestamp)`,
+  /// never lowered). The cursor is the cross-device / reinstall-restorable
+  /// read pointer (#4977).
+  ///
   /// Returns `true` if the row was updated, `false` if [id] was not found.
-  ///
-  /// Throws:
-  ///
-  /// * [InvalidDataException] if a column constraint is violated.
   Future<bool> markAsRead(String id, {String? ownerPubkey}) async {
-    final rows =
-        await (update(conversations)..where(
-              (t) =>
-                  t.id.equals(id) & _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
-            ))
-            .write(const ConversationsCompanion(isRead: Value(true)));
+    final rows = await customUpdate(
+      'UPDATE conversations SET is_read = 1, '
+      'last_read_timestamp = MAX( '
+      'COALESCE(last_read_timestamp, 0), '
+      'COALESCE(last_message_timestamp, 0)) '
+      'WHERE id = ?${_ownerSqlClause(ownerPubkey)}',
+      variables: [Variable(id), ..._ownerSqlVariables(ownerPubkey)],
+      updates: {attachedDatabase.conversations},
+      updateKind: UpdateKind.update,
+    );
     return rows > 0;
+  }
+
+  /// Advances the read cursor for [id] to `max(existing, timestamp)` and, when
+  /// the cursor then covers the latest message, marks the conversation read.
+  ///
+  /// Used by cross-device reconcile (a restored remote read-marker) and the
+  /// reinstall last-sent floor. Monotonic — never lowers the cursor, never
+  /// flips a genuinely-unread conversation read (only marks read when the
+  /// cursor reaches the latest message). Returns `true` if a row matched.
+  Future<bool> applyReadCursor(
+    String id,
+    int timestamp, {
+    String? ownerPubkey,
+  }) async {
+    final rows = await customUpdate(
+      'UPDATE conversations SET '
+      'last_read_timestamp = MAX(COALESCE(last_read_timestamp, 0), ?), '
+      'is_read = CASE WHEN COALESCE(last_message_timestamp, 0) <= '
+      'MAX(COALESCE(last_read_timestamp, 0), ?) THEN 1 ELSE is_read END '
+      'WHERE id = ?${_ownerSqlClause(ownerPubkey)}',
+      variables: [
+        Variable(timestamp),
+        Variable(timestamp),
+        Variable(id),
+        ..._ownerSqlVariables(ownerPubkey),
+      ],
+      updates: {attachedDatabase.conversations},
+      updateKind: UpdateKind.update,
+    );
+    return rows > 0;
+  }
+
+  /// Owner filter as a raw-SQL fragment matching [_ownedOrLegacy]: empty when
+  /// [ownerPubkey] is null (all rows), else owner-or-legacy-NULL.
+  String _ownerSqlClause(String? ownerPubkey) => ownerPubkey == null
+      ? ''
+      : ' AND (owner_pubkey = ? OR owner_pubkey IS NULL)';
+
+  List<Variable<Object>> _ownerSqlVariables(String? ownerPubkey) =>
+      ownerPubkey == null ? const [] : [Variable(ownerPubkey)];
+
+  /// Returns the timestamp of [userPubkey]'s own most-recent (non-deleted)
+  /// sent message per conversation, keyed by conversation id.
+  ///
+  /// The source for the reinstall "last-sent floor" (#4977): a conversation
+  /// the user last replied in can have its read cursor restored from the
+  /// self-1059 wraps the history drain recovered, without any read-marker.
+  Future<Map<String, int>> lastSentTimestampsByConversation(
+    String userPubkey, {
+    String? ownerPubkey,
+  }) async {
+    final rows = await customSelect(
+      'SELECT conversation_id AS cid, MAX(created_at) AS ts '
+      'FROM direct_messages '
+      'WHERE sender_pubkey = ? AND is_deleted = 0'
+      '${_ownerSqlClause(ownerPubkey)} '
+      'GROUP BY conversation_id',
+      variables: [Variable(userPubkey), ..._ownerSqlVariables(ownerPubkey)],
+    ).get();
+    return {
+      for (final row in rows) row.read<String>('cid'): row.read<int>('ts'),
+    };
   }
 
   /// Get unread conversation count.
@@ -317,15 +385,29 @@ END
   }
 
   /// Mark multiple conversations as read in a single batch.
+  ///
+  /// Advances each conversation's read cursor
+  /// [Conversations.lastReadTimestamp] to its latest message timestamp, with
+  /// the same monotonic semantics as [markAsRead].
   Future<void> markMultipleAsRead(
     List<String> ids, {
     String? ownerPubkey,
   }) async {
     if (ids.isEmpty) return;
-    await (update(conversations)..where(
-          (t) => t.id.isIn(ids) & _ownedOrLegacy(t.ownerPubkey, ownerPubkey),
-        ))
-        .write(const ConversationsCompanion(isRead: Value(true)));
+    final placeholders = List.filled(ids.length, '?').join(', ');
+    await customUpdate(
+      'UPDATE conversations SET is_read = 1, '
+      'last_read_timestamp = MAX( '
+      'COALESCE(last_read_timestamp, 0), '
+      'COALESCE(last_message_timestamp, 0)) '
+      'WHERE id IN ($placeholders)${_ownerSqlClause(ownerPubkey)}',
+      variables: [
+        ...ids.map(Variable.new),
+        ..._ownerSqlVariables(ownerPubkey),
+      ],
+      updates: {attachedDatabase.conversations},
+      updateKind: UpdateKind.update,
+    );
   }
 
   /// Delete a conversation by ID.

--- a/mobile/packages/db_client/lib/src/database/tables.dart
+++ b/mobile/packages/db_client/lib/src/database/tables.dart
@@ -934,6 +934,15 @@ class Conversations extends Table {
   BoolColumn get isRead =>
       boolean().withDefault(const Constant(true)).named('is_read')();
 
+  /// Per-conversation read cursor (unix seconds) for cross-device read-state
+  /// sync (#4977). Monotonic high-water mark of the newest message the user
+  /// has read; published encrypted-to-self over Nostr and restored on
+  /// reinstall. NULL until the conversation is first read. Ingest never writes
+  /// it — only `ConversationsDao.markAsRead` / `applyReadCursor` advance it,
+  /// and only ever forward (`max`).
+  IntColumn get lastReadTimestamp =>
+      integer().nullable().named('last_read_timestamp')();
+
   /// Whether the current user has sent a message in this conversation.
   BoolColumn get currentUserHasSent => boolean()
       .withDefault(const Constant(false))

--- a/mobile/packages/db_client/test/src/database/app_database_test.dart
+++ b/mobile/packages/db_client/test/src/database/app_database_test.dart
@@ -738,6 +738,67 @@ void main() {
       );
 
       test(
+        'adds last_read_timestamp and backfills already-read rows on upgrade '
+        '(#4977)',
+        () async {
+          // Simulate a pre-#4977 conversations table with no cursor column.
+          await database.customStatement('DROP TABLE conversations');
+          await database.customStatement('''
+            CREATE TABLE conversations (
+              id TEXT NOT NULL PRIMARY KEY,
+              participant_pubkeys TEXT NOT NULL,
+              is_group INTEGER NOT NULL DEFAULT 0,
+              last_message_content TEXT,
+              last_message_timestamp INTEGER,
+              last_message_sender_pubkey TEXT,
+              subject TEXT,
+              is_read INTEGER NOT NULL DEFAULT 1,
+              current_user_has_sent INTEGER NOT NULL DEFAULT 0,
+              created_at INTEGER NOT NULL,
+              owner_pubkey TEXT,
+              dm_protocol TEXT
+            )
+          ''');
+          await database.customStatement(
+            'INSERT INTO conversations '
+            '(id, participant_pubkeys, created_at, last_message_timestamp, '
+            'is_read) VALUES '
+            "('read_conv', '[\"a\",\"b\"]', 1, 200, 1), "
+            "('unread_conv', '[\"a\",\"c\"]', 1, 300, 0)",
+          );
+
+          // Reopen → beforeOpen adds the column and runs the one-time backfill.
+          await database.close();
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+
+          final rows = await database
+              .customSelect(
+                'SELECT id, last_read_timestamp FROM conversations '
+                'ORDER BY id',
+              )
+              .get();
+          final byId = {
+            for (final r in rows)
+              r.read<String>('id'): r.readNullable<int>('last_read_timestamp'),
+          };
+          // Already-read row backfilled to its latest message; unread NULL.
+          expect(byId['read_conv'], 200);
+          expect(byId['unread_conv'], isNull);
+
+          // Idempotent: a second open does not change the backfilled values.
+          await database.close();
+          database = AppDatabase.test(NativeDatabase(File(tempDbPath)));
+          final again = await database
+              .customSelect(
+                'SELECT last_read_timestamp FROM conversations '
+                "WHERE id = 'read_conv'",
+              )
+              .getSingle();
+          expect(again.read<int>('last_read_timestamp'), 200);
+        },
+      );
+
+      test(
         'schema parity — dm_message_reactions fresh-install matches runtime '
         'CREATE-IF-NOT-EXISTS path',
         () async {

--- a/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/conversations_dao_test.dart
@@ -313,6 +313,11 @@ void main() {
               .map((column) => column.$name)
               .toSet();
           const immutableColumns = {'id', 'created_at'};
+          // last_read_timestamp is intentionally NEVER written by the upsert
+          // conflict path: the read cursor is owned exclusively by
+          // markAsRead / applyReadCursor so re-ingesting messages (incl. the
+          // reinstall drain) cannot move read state. (#4977)
+          const cursorOwnedColumns = {'last_read_timestamp'};
           const handledColumns = {
             'participant_pubkeys',
             'is_group',
@@ -328,7 +333,11 @@ void main() {
 
           expect(
             handledColumns,
-            unorderedEquals(schemaColumns.difference(immutableColumns)),
+            unorderedEquals(
+              schemaColumns
+                  .difference(immutableColumns)
+                  .difference(cursorOwnedColumns),
+            ),
           );
         },
       );
@@ -541,6 +550,166 @@ void main() {
 
         final conv2 = await dao.getConversation('conv_2');
         expect(conv2!.isRead, isFalse);
+      });
+    });
+
+    group('read cursor (#4977)', () {
+      test('markAsRead advances the cursor to the latest message', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["a","b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000200,
+          isRead: false,
+        );
+
+        await dao.markAsRead('conv_1');
+
+        final result = await dao.getConversation('conv_1');
+        expect(result!.isRead, isTrue);
+        expect(result.lastReadTimestamp, 1700000200);
+      });
+
+      test('markAsRead never lowers the cursor (monotonic)', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["a","b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000500,
+          isRead: false,
+        );
+        await dao.markAsRead('conv_1');
+        // A later upsert leaves the cursor untouched; a re-read whose latest
+        // message is OLDER must not lower it.
+        await dao.applyReadCursor('conv_1', 1700000100);
+
+        final result = await dao.getConversation('conv_1');
+        expect(result!.lastReadTimestamp, 1700000500);
+      });
+
+      test(
+        'applyReadCursor advances the cursor and marks read when it covers '
+        'the latest message',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["a","b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageTimestamp: 1700000300,
+            lastMessageSenderPubkey: 'b',
+            isRead: false,
+          );
+
+          // A restored remote marker / last-sent floor at-or-after the latest
+          // message marks the conversation read.
+          final updated = await dao.applyReadCursor('conv_1', 1700000300);
+          expect(updated, isTrue);
+
+          final result = await dao.getConversation('conv_1');
+          expect(result!.isRead, isTrue);
+          expect(result.lastReadTimestamp, 1700000300);
+        },
+      );
+
+      test(
+        'applyReadCursor below the latest message advances the cursor but '
+        'leaves a genuinely-unread conversation unread',
+        () async {
+          await dao.upsertConversation(
+            id: 'conv_1',
+            participantPubkeys: '["a","b"]',
+            isGroup: false,
+            createdAt: 1700000000,
+            lastMessageTimestamp: 1700000300,
+            lastMessageSenderPubkey: 'b',
+            isRead: false,
+          );
+
+          final updated = await dao.applyReadCursor('conv_1', 1700000100);
+          expect(updated, isTrue);
+
+          final result = await dao.getConversation('conv_1');
+          expect(result!.isRead, isFalse);
+          expect(result.lastReadTimestamp, 1700000100);
+        },
+      );
+
+      test('applyReadCursor never lowers the cursor', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["a","b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000300,
+          isRead: false,
+        );
+        await dao.applyReadCursor('conv_1', 1700000250);
+        await dao.applyReadCursor('conv_1', 1700000150);
+
+        final result = await dao.getConversation('conv_1');
+        expect(result!.lastReadTimestamp, 1700000250);
+      });
+
+      test('applyReadCursor returns false for a non-existent row', () async {
+        final updated = await dao.applyReadCursor('nope', 1700000000);
+        expect(updated, isFalse);
+      });
+
+      test('markMultipleAsRead advances each cursor', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["a","b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000200,
+          isRead: false,
+        );
+        await dao.upsertConversation(
+          id: 'conv_2',
+          participantPubkeys: '["a","c"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000400,
+          isRead: false,
+        );
+
+        await dao.markMultipleAsRead(['conv_1', 'conv_2']);
+
+        final c1 = await dao.getConversation('conv_1');
+        final c2 = await dao.getConversation('conv_2');
+        expect(c1!.isRead, isTrue);
+        expect(c1.lastReadTimestamp, 1700000200);
+        expect(c2!.isRead, isTrue);
+        expect(c2.lastReadTimestamp, 1700000400);
+      });
+
+      test('ingest upsert never writes the cursor', () async {
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["a","b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageTimestamp: 1700000200,
+          lastMessageSenderPubkey: 'b',
+          isRead: false,
+        );
+        // Re-ingest a newer received message (the normal ingest path).
+        await dao.upsertConversation(
+          id: 'conv_1',
+          participantPubkeys: '["a","b"]',
+          isGroup: false,
+          createdAt: 1700000000,
+          lastMessageContent: 'newer',
+          lastMessageTimestamp: 1700000600,
+          lastMessageSenderPubkey: 'b',
+          isRead: false,
+        );
+
+        final result = await dao.getConversation('conv_1');
+        expect(result!.lastReadTimestamp, isNull);
       });
     });
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1505,14 +1505,17 @@ class DmRepository {
         return;
       }
 
-      // Cross-device DM read-state marker (#4977). Route to the reconciler
-      // before the DM-only kinds gate so it is never rendered as a message,
-      // then record it terminally so it is not re-decrypted every launch. The
-      // reconcile is idempotent (a forward-only max cursor) and the post-drain
-      // restore re-applies any cursor whose conversation had not synced yet.
+      // Cross-device DM read-state marker (#4977). Route only Divine's read
+      // marker d-tag to the reconciler before the DM-only kinds gate so it is
+      // never rendered as a message, then record it terminally so it is not
+      // re-decrypted every launch. Other app-specific self-wraps must remain
+      // unrecorded so future/foreign kind-30078 handlers can still process
+      // them instead of losing them to the processed-wrap ledger.
       if (rumor.kind == EventKind.appSpecificData) {
-        await _reconcileReadMarker(rumor);
-        await _recordProcessedWrap(giftWrapEvent.id);
+        if (_hasReadMarkerDTag(rumor)) {
+          await _reconcileReadMarker(rumor);
+          await _recordProcessedWrap(giftWrapEvent.id);
+        }
         return;
       }
 

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -216,7 +216,9 @@ class DmRepository {
     DmReactionsRepository? reactionsRepository,
     bool publishDmRelayListEnabled = false,
     String? dmInboxRelayUrl,
+    Duration readMarkerDebounceDelay = _defaultReadMarkerDebounceDelay,
   }) : _nostrClient = nostrClient,
+       _readMarkerDebounceDelay = readMarkerDebounceDelay,
        _directMessagesDao = directMessagesDao,
        _conversationsDao = conversationsDao,
        _outgoingDmsDao = outgoingDmsDao,
@@ -320,6 +322,24 @@ class DmRepository {
   /// NOT cached — the memo is cleared once it resolves so the next caller
   /// re-queries, and RC3 never overwrites a real list on a transient failure.
   Future<({_OwnDmInboxState state, List<String>? relays})>? _ownInboxFuture;
+
+  /// Debounced cross-device DM read-state marker publish (#4977). Reading a
+  /// conversation advances its read cursor and schedules this; a burst of
+  /// reads (e.g. paging through many threads) coalesces into ONE self-encrypted
+  /// kind-30078 marker publish — bounding 1059 accumulation, metadata cadence,
+  /// and the relay's 60-events/min/pubkey rate limit. Cancelled on reset/stop.
+  Timer? _readMarkerDebounce;
+  final Duration _readMarkerDebounceDelay;
+  static const _defaultReadMarkerDebounceDelay = Duration(seconds: 3);
+  static const _readMarkerDTag = 'divine/dm-read/v1';
+  static const _readMarkerPayloadVersion = 1;
+
+  /// Read cursors parsed from a restored marker whose conversation row did not
+  /// exist yet — a marker processed before its messages during the reinstall
+  /// drain. Flushed once the drain completes (all conversations present), keyed
+  /// by conversation id → max read timestamp. Cleared on reset. Loss on a
+  /// kill mid-drain self-heals on the next read + marker publish.
+  final Map<String, int> _pendingReadCursors = {};
 
   /// A single long-lived decrypt isolate, alive only for the duration of a
   /// history drain. Spawned in [_runHistoryDrain] for local-key signers and
@@ -484,6 +504,11 @@ class DmRepository {
     }
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
+    // Drop a pending read-marker publish and any un-flushed read cursors so
+    // they never leak across an account switch. #4977.
+    _readMarkerDebounce?.cancel();
+    _readMarkerDebounce = null;
+    _pendingReadCursors.clear();
     unawaited(_giftWrapSubscription?.cancel());
     _giftWrapSubscription = null;
     // Drop the outgoing user's resolved own-inbox relays so the next user
@@ -1178,6 +1203,9 @@ class DmRepository {
         final nip04Recovered = await _recoverOutgoingNip04(pubkey);
         if (nip04Recovered) {
           await syncState.markHistoryDrainComplete(pubkey);
+          // Restore read state now that the full conversation set is present:
+          // last-sent floor + any read markers stashed during the drain. #4977.
+          await _restoreReadStateAfterDrain(pubkey);
           Log.info(
             'DM history drain complete for $pubkey: '
             'pages=$pagesRun, eventsFetched=$totalEvents',
@@ -1252,6 +1280,11 @@ class DmRepository {
     _resetGeneration++;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
+    // Cancel a pending read-marker publish; the cursor is persisted, so it
+    // republishes on the next read or session. Keep _pendingReadCursors — the
+    // same user may resume listening. #4977.
+    _readMarkerDebounce?.cancel();
+    _readMarkerDebounce = null;
     _eventLock = null;
     await _giftWrapSubscription?.cancel();
     _giftWrapSubscription = null;
@@ -1469,6 +1502,17 @@ class DmRepository {
         if (outcome == DmReactionWrapOutcome.processed) {
           await _recordProcessedWrap(giftWrapEvent.id);
         }
+        return;
+      }
+
+      // Cross-device DM read-state marker (#4977). Route to the reconciler
+      // before the DM-only kinds gate so it is never rendered as a message,
+      // then record it terminally so it is not re-decrypted every launch. The
+      // reconcile is idempotent (a forward-only max cursor) and the post-drain
+      // restore re-applies any cursor whose conversation had not synced yet.
+      if (rumor.kind == EventKind.appSpecificData) {
+        await _reconcileReadMarker(rumor);
+        await _recordProcessedWrap(giftWrapEvent.id);
         return;
       }
 
@@ -3722,21 +3766,194 @@ class DmRepository {
   }
 
   /// Mark a conversation as read.
-  Future<void> markConversationAsRead(String conversationId) {
-    return _conversationsDao.markAsRead(
+  ///
+  /// Advances the conversation's read cursor (see
+  /// [ConversationsDao.markAsRead]) and schedules a debounced cross-device
+  /// read-state marker publish (#4977).
+  Future<void> markConversationAsRead(String conversationId) async {
+    await _conversationsDao.markAsRead(
       conversationId,
       ownerPubkey: _ownerPubkey,
     );
+    _scheduleReadMarkerPublish();
   }
 
   /// Mark multiple conversations as read in a single batch.
   ///
-  /// No-op when [conversationIds] is empty.
-  Future<void> markConversationsAsRead(List<String> conversationIds) {
-    return _conversationsDao.markMultipleAsRead(
+  /// No-op when [conversationIds] is empty. Advances each cursor and schedules
+  /// a single debounced read-state marker publish (#4977).
+  Future<void> markConversationsAsRead(List<String> conversationIds) async {
+    if (conversationIds.isEmpty) return;
+    await _conversationsDao.markMultipleAsRead(
       conversationIds,
       ownerPubkey: _ownerPubkey,
     );
+    _scheduleReadMarkerPublish();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cross-device read-state sync (#4977)
+  // ---------------------------------------------------------------------------
+
+  /// Schedule a debounced publish of the read-state marker so a burst of reads
+  /// coalesces into one self-encrypted kind-30078 marker.
+  void _scheduleReadMarkerPublish() {
+    if (!isInitialized) return;
+    _readMarkerDebounce?.cancel();
+    _readMarkerDebounce = Timer(
+      _readMarkerDebounceDelay,
+      () => unawaited(_publishReadMarker()),
+    );
+  }
+
+  /// Build the current per-conversation read-cursor map and publish it as a
+  /// self-addressed, NIP-44-sealed kind-30078 marker (#4977 v1).
+  ///
+  /// Best-effort: a failed publish just means read state syncs on the next
+  /// read. Published to the user's own DM inbox relays (or the default pool) —
+  /// the same set the history drain reads — so other devices and a reinstall
+  /// recover it.
+  Future<void> _publishReadMarker() async {
+    final service = _messageService;
+    if (service == null || !isInitialized) return;
+    final gen = _resetGeneration;
+    try {
+      final conversations = await _conversationsDao.getAllConversations(
+        ownerPubkey: _ownerPubkey,
+      );
+      if (_disposed || _resetGeneration != gen) return;
+      final readMap = <String, int>{};
+      for (final convo in conversations) {
+        final cursor = convo.lastReadTimestamp;
+        if (cursor == null || cursor <= 0) continue;
+        final tupleKey = _participantTupleKey(convo.participantPubkeys);
+        if (tupleKey == null) continue;
+        final existing = readMap[tupleKey];
+        if (existing == null || cursor > existing) readMap[tupleKey] = cursor;
+      }
+      if (readMap.isEmpty) return;
+      final content = jsonEncode(<String, dynamic>{
+        'v': _readMarkerPayloadVersion,
+        'read': readMap,
+      });
+      final ownInbox = await _ownInboxTargetRelays();
+      if (_disposed || _resetGeneration != gen) return;
+      await service.publishSelfApplicationMarker(
+        content: content,
+        tags: const [
+          ['d', _readMarkerDTag],
+        ],
+        targetRelays: ownInbox,
+      );
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'DM read-marker publish failed (non-fatal): $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  /// The canonical cross-client wire key for a conversation: its participant
+  /// pubkeys, sorted, comma-joined (matching divine-web's form). Each client
+  /// maps this tuple to its own internal conversation id. Returns null when
+  /// [participantPubkeysJson] can't be parsed.
+  String? _participantTupleKey(String participantPubkeysJson) {
+    try {
+      final list = (jsonDecode(participantPubkeysJson) as List<dynamic>)
+          .cast<String>();
+      if (list.isEmpty) return null;
+      final sorted = List<String>.from(list)..sort();
+      return sorted.join(',');
+    } on Object {
+      return null;
+    }
+  }
+
+  /// Reconcile a restored kind-30078 read-state marker rumor (#4977): advance
+  /// each conversation's read cursor to the marker's timestamp (forward-only
+  /// max). A conversation not yet ingested (marker processed before its
+  /// messages during the drain) is stashed in [_pendingReadCursors] and
+  /// applied when the drain completes.
+  Future<void> _reconcileReadMarker(Event rumor) async {
+    if (!_hasReadMarkerDTag(rumor)) return;
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(rumor.content);
+    } on Object {
+      return;
+    }
+    if (decoded is! Map) return;
+    final read = decoded['read'];
+    if (read is! Map) return;
+    for (final entry in read.entries) {
+      final tupleKey = entry.key;
+      final ts = entry.value;
+      if (tupleKey is! String || ts is! int) continue;
+      final pubkeys = tupleKey.split(',');
+      if (pubkeys.length < 2) continue;
+      final conversationId = computeConversationId(pubkeys);
+      final applied = await _conversationsDao.applyReadCursor(
+        conversationId,
+        ts,
+        ownerPubkey: _ownerPubkey,
+      );
+      if (!applied) {
+        final existing = _pendingReadCursors[conversationId];
+        if (existing == null || ts > existing) {
+          _pendingReadCursors[conversationId] = ts;
+        }
+      }
+    }
+  }
+
+  bool _hasReadMarkerDTag(Event rumor) {
+    for (final tag in rumor.tags) {
+      if (tag.length >= 2 && tag[0] == 'd') return tag[1] == _readMarkerDTag;
+    }
+    return false;
+  }
+
+  /// After the history drain completes, restore read state (#4977):
+  /// (1) the last-sent floor — for each conversation the user replied in,
+  /// advance the cursor to their own most-recent sent message; and
+  /// (2) flush [_pendingReadCursors] — markers whose conversations had not yet
+  /// been ingested when the marker was first processed.
+  Future<void> _restoreReadStateAfterDrain(String pubkey) async {
+    try {
+      final floors = await _conversationsDao.lastSentTimestampsByConversation(
+        pubkey,
+        ownerPubkey: pubkey,
+      );
+      for (final entry in floors.entries) {
+        if (_disposed || _userPubkey != pubkey) return;
+        await _conversationsDao.applyReadCursor(
+          entry.key,
+          entry.value,
+          ownerPubkey: pubkey,
+        );
+      }
+      if (_pendingReadCursors.isNotEmpty) {
+        final pending = Map<String, int>.from(_pendingReadCursors);
+        _pendingReadCursors.clear();
+        for (final entry in pending.entries) {
+          if (_disposed || _userPubkey != pubkey) return;
+          await _conversationsDao.applyReadCursor(
+            entry.key,
+            entry.value,
+            ownerPubkey: pubkey,
+          );
+        }
+      }
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'DM read-state restore after drain failed: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+    }
   }
 
   /// Remove a conversation and all its messages atomically.

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -291,6 +291,51 @@ class NIP17MessageService {
     }
   }
 
+  /// Build a kind-[eventKind] rumor with [content] + [tags] and publish it as
+  /// a **self-addressed** NIP-59 gift wrap (never to a counterparty) to
+  /// [targetRelays] — the user's own DM inbox relays, or the default pool when
+  /// `null`/empty. Returns `true` when the wrap reached at least one relay.
+  ///
+  /// Used for the DM read-state cursor marker (#4977): a kind-30078
+  /// application-data rumor whose `content` is the read map. The gift-wrap seal
+  /// (kind 13) NIP-44-encrypts it to the user's own key, so the read map is
+  /// never world-readable on the (unauthenticated) relay. Self-wrap failure is
+  /// non-fatal — a missed marker just means read state is restored on the next
+  /// publish.
+  Future<bool> publishSelfApplicationMarker({
+    required String content,
+    required List<List<String>> tags,
+    int eventKind = EventKind.appSpecificData,
+    List<String>? targetRelays,
+  }) async {
+    try {
+      final nostr = Nostr(_signer, [], _dummyRelayGenerator);
+      await nostr.refreshPublicKey();
+      final rumor = Event(_senderPublicKey, eventKind, tags, content);
+      final selfWrapEvent = await _giftWrapBuilder(
+        nostr,
+        rumor,
+        _senderPublicKey,
+      );
+      if (selfWrapEvent == null) return false;
+      final published = (targetRelays != null && targetRelays.isNotEmpty)
+          ? await _nostrService.publishEvent(
+              selfWrapEvent,
+              targetRelays: targetRelays,
+            )
+          : await _nostrService.publishEvent(selfWrapEvent);
+      return published is PublishSuccess;
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'DM read-marker self-wrap failed (non-fatal): $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return false;
+    }
+  }
+
   /// Convenience wrapper that builds a rumor and sends it in one call.
   ///
   /// Existing callers (group sends, file sends, NIP-04 fallback wiring)

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -445,6 +445,31 @@ void main() {
         ),
       ).thenAnswer((_) async => true);
 
+      // Global stubs for the #4977 read-state cursor surface so any path that
+      // touches the marker reconcile / debounced publish / drain floor has a
+      // default. Tests that assert on these restub or verify as needed.
+      when(
+        () => mockConversationsDao.applyReadCursor(
+          any(),
+          any(),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async => true);
+      when(
+        () => mockConversationsDao.lastSentTimestampsByConversation(
+          any(),
+          ownerPubkey: any(named: 'ownerPubkey'),
+        ),
+      ).thenAnswer((_) async => <String, int>{});
+      when(
+        () => mockMessageService.publishSelfApplicationMarker(
+          content: any(named: 'content'),
+          tags: any(named: 'tags'),
+          eventKind: any(named: 'eventKind'),
+          targetRelays: any(named: 'targetRelays'),
+        ),
+      ).thenAnswer((_) async => true);
+
       // Default stub for buildRumor — production sendMessage now calls
       // buildRumor first to enqueue a queue row keyed by the rumor's id
       // before publishing. Returning a real Event so .id is computed
@@ -494,6 +519,7 @@ void main() {
       // existing RC3 tests exercise the publish path; gating tests override.
       bool publishDmRelayListEnabled = true,
       String? dmInboxRelayUrl = 'wss://relay.divine.video',
+      Duration readMarkerDebounceDelay = const Duration(seconds: 3),
     }) {
       return DmRepository(
         nostrClient: mockNostrClient,
@@ -518,6 +544,7 @@ void main() {
         reactionsRepository: reactionsRepository,
         publishDmRelayListEnabled: publishDmRelayListEnabled,
         dmInboxRelayUrl: dmInboxRelayUrl,
+        readMarkerDebounceDelay: readMarkerDebounceDelay,
         errorReporter: (error, stackTrace, {required site}) {
           reporterCalls.add(_ReporterCall(error, stackTrace, site));
         },
@@ -5127,6 +5154,210 @@ void main() {
           ),
         ).called(1);
       });
+    });
+
+    group('read-state marker (#4977)', () {
+      final tupleKey = (<String>[
+        _validPubkeyA,
+        _validPubkeyB,
+      ]..sort()).join(',');
+      final conversationId = DmRepository.computeConversationId([
+        _validPubkeyA,
+        _validPubkeyB,
+      ]);
+
+      ConversationRow readConversation({int? cursor}) => ConversationRow(
+        id: conversationId,
+        participantPubkeys: jsonEncode([_validPubkeyA, _validPubkeyB]),
+        isGroup: false,
+        createdAt: 1700000000,
+        lastMessageContent: 'Hi',
+        lastMessageTimestamp: 1700000200,
+        lastMessageSenderPubkey: _validPubkeyB,
+        isRead: cursor != null,
+        currentUserHasSent: true,
+        ownerPubkey: _validPubkeyA,
+        dmProtocol: 'nip17',
+        lastReadTimestamp: cursor,
+      );
+
+      test(
+        'reading a conversation publishes a debounced self-only read marker '
+        'keyed by the participant tuple',
+        () async {
+          when(
+            () => mockConversationsDao.getAllConversations(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => [readConversation(cursor: 1700000200)]);
+
+          final repository = createRepository(
+            readMarkerDebounceDelay: Duration.zero,
+          );
+          await repository.markConversationAsRead(conversationId);
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          final captured = verify(
+            () => mockMessageService.publishSelfApplicationMarker(
+              content: captureAny(named: 'content'),
+              tags: captureAny(named: 'tags'),
+              eventKind: any(named: 'eventKind'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).captured;
+          expect(captured, isNotEmpty);
+          final payload = jsonDecode(captured[0] as String) as Map;
+          final tags = captured[1] as List<List<String>>;
+          expect(payload['v'], 1);
+          expect((payload['read'] as Map)[tupleKey], 1700000200);
+          expect(tags, contains(equals(['d', 'divine/dm-read/v1'])));
+
+          // Self-only: a read marker never goes out as a counterparty message.
+          verifyNever(
+            () => mockMessageService.sendRumor(
+              rumorEvent: any(named: 'rumorEvent'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'does not publish a marker when no conversation has been read',
+        () async {
+          when(
+            () => mockConversationsDao.getAllConversations(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => [readConversation()]);
+
+          final repository = createRepository(
+            readMarkerDebounceDelay: Duration.zero,
+          );
+          await repository.markConversationAsRead(conversationId);
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          verifyNever(
+            () => mockMessageService.publishSelfApplicationMarker(
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+              eventKind: any(named: 'eventKind'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+        },
+      );
+
+      test('coalesces a burst of reads into a single marker publish', () async {
+        when(
+          () => mockConversationsDao.getAllConversations(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenAnswer((_) async => [readConversation(cursor: 1700000200)]);
+
+        final repository = createRepository(
+          readMarkerDebounceDelay: const Duration(milliseconds: 60),
+        );
+        await repository.markConversationAsRead(conversationId);
+        await repository.markConversationAsRead(conversationId);
+        await repository.markConversationAsRead(conversationId);
+        await Future<void>.delayed(const Duration(milliseconds: 160));
+
+        verify(
+          () => mockMessageService.publishSelfApplicationMarker(
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+            eventKind: any(named: 'eventKind'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).called(1);
+      });
+
+      test(
+        'an incoming kind-30078 read marker advances cursors and is not '
+        'rendered as a message',
+        () async {
+          Event giftWrap() => Event.fromJson({
+            'id': _giftWrapEventId,
+            'pubkey':
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'created_at': 1700000000,
+            'kind': EventKind.giftWrap,
+            'tags': [
+              ['p', _validPubkeyA],
+            ],
+            'content': 'encrypted',
+            'sig': '',
+          });
+          final markerRumor = Event.fromJson({
+            'id': _rumorEventId,
+            'pubkey': _validPubkeyA,
+            'created_at': 1700000300,
+            'kind': EventKind.appSpecificData,
+            'tags': [
+              ['d', 'divine/dm-read/v1'],
+            ],
+            'content': jsonEncode({
+              'v': 1,
+              'read': {tupleKey: 1700000300},
+            }),
+            'sig': '',
+          });
+
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => markerRumor,
+          );
+          await repository.startListening();
+          controller.add(giftWrap());
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          verify(
+            () => mockConversationsDao.applyReadCursor(
+              conversationId,
+              1700000300,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          );
+        },
+      );
     });
 
     // -----------------------------------------------------------------

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -3603,6 +3603,44 @@ void main() {
       );
 
       test(
+        'restores read state after the drain via the last-sent floor (#4977)',
+        () async {
+          when(() => mockNostrClient.connectedRelayCount).thenReturn(2);
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((_) async => const <Event>[]);
+          // The drain recovered the user's own last-sent message in this convo.
+          when(
+            () => mockConversationsDao.lastSentTimestampsByConversation(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => {'conv_floor': 1700000900});
+
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 100
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          final repository = createRepository(syncState: syncState);
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The floor advances that conversation's read cursor to the
+          // user's own last-sent timestamp.
+          verify(
+            () => mockConversationsDao.applyReadCursor(
+              'conv_floor',
+              1700000900,
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test(
         'isHistoryRecoveryComplete reflects the persisted drain-complete flag '
         '(#5304)',
         () {
@@ -5354,6 +5392,193 @@ void main() {
               thumbnailUrl: any(named: 'thumbnailUrl'),
               ownerPubkey: any(named: 'ownerPubkey'),
               tagsJson: any(named: 'tagsJson'),
+            ),
+          );
+        },
+      );
+
+      test(
+        'markConversationsAsRead marks the batch and schedules one publish',
+        () async {
+          when(
+            () => mockConversationsDao.markMultipleAsRead(
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockConversationsDao.getAllConversations(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer((_) async => [readConversation(cursor: 1700000200)]);
+
+          final repository = createRepository(
+            readMarkerDebounceDelay: Duration.zero,
+          );
+          await repository.markConversationsAsRead([conversationId, 'other']);
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          verify(
+            () => mockConversationsDao.markMultipleAsRead(
+              [conversationId, 'other'],
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).called(1);
+          verify(
+            () => mockMessageService.publishSelfApplicationMarker(
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+              eventKind: any(named: 'eventKind'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test('markConversationsAsRead is a no-op for an empty list', () async {
+        final repository = createRepository(
+          readMarkerDebounceDelay: Duration.zero,
+        );
+        await repository.markConversationsAsRead([]);
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        verifyNever(
+          () => mockConversationsDao.markMultipleAsRead(
+            any(),
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        );
+        verifyNever(
+          () => mockMessageService.publishSelfApplicationMarker(
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+            eventKind: any(named: 'eventKind'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+
+      test(
+        'a conversation with an unparseable participant list is skipped',
+        () async {
+          when(
+            () => mockConversationsDao.getAllConversations(
+              ownerPubkey: any(named: 'ownerPubkey'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              ConversationRow(
+                id: conversationId,
+                participantPubkeys: 'not-json',
+                isGroup: false,
+                createdAt: 1,
+                lastMessageTimestamp: 200,
+                lastMessageSenderPubkey: _validPubkeyB,
+                isRead: true,
+                currentUserHasSent: true,
+                ownerPubkey: _validPubkeyA,
+                dmProtocol: 'nip17',
+                lastReadTimestamp: 200,
+              ),
+            ],
+          );
+
+          final repository = createRepository(
+            readMarkerDebounceDelay: Duration.zero,
+          );
+          await repository.markConversationAsRead(conversationId);
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          // The only conversation yields no tuple key → empty map → no publish.
+          verifyNever(
+            () => mockMessageService.publishSelfApplicationMarker(
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+              eventKind: any(named: 'eventKind'),
+              targetRelays: any(named: 'targetRelays'),
+            ),
+          );
+        },
+      );
+
+      test('a read-marker publish failure is non-fatal', () async {
+        when(
+          () => mockConversationsDao.getAllConversations(
+            ownerPubkey: any(named: 'ownerPubkey'),
+          ),
+        ).thenThrow(StateError('db down'));
+
+        final repository = createRepository(
+          readMarkerDebounceDelay: Duration.zero,
+        );
+        // Must not throw out of the debounced timer.
+        await repository.markConversationAsRead(conversationId);
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        verifyNever(
+          () => mockMessageService.publishSelfApplicationMarker(
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+            eventKind: any(named: 'eventKind'),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        );
+      });
+
+      test(
+        'a marker with a foreign d-tag does not advance any cursor',
+        () async {
+          final foreignMarker = Event.fromJson({
+            'id': _rumorEventId,
+            'pubkey': _validPubkeyA,
+            'created_at': 1700000300,
+            'kind': EventKind.appSpecificData,
+            'tags': [
+              ['d', 'some/other/app'],
+            ],
+            'content': jsonEncode({
+              'v': 1,
+              'read': {tupleKey: 1700000300},
+            }),
+            'sig': '',
+          });
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(_giftWrapEventId),
+          ).thenAnswer((_) async => false);
+          final controller = StreamController<Event>();
+          when(
+            () => mockNostrClient.subscribe(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+            ),
+          ).thenAnswer((_) => controller.stream);
+
+          final repository = createRepository(
+            rumorDecryptor: (_, _) async => foreignMarker,
+          );
+          await repository.startListening();
+          controller.add(
+            Event.fromJson({
+              'id': _giftWrapEventId,
+              'pubkey':
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              'created_at': 1700000000,
+              'kind': EventKind.giftWrap,
+              'tags': [
+                ['p', _validPubkeyA],
+              ],
+              'content': 'encrypted',
+              'sig': '',
+            }),
+          );
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          verifyNever(
+            () => mockConversationsDao.applyReadCursor(
+              any(),
+              any(),
+              ownerPubkey: any(named: 'ownerPubkey'),
             ),
           );
         },

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -5526,8 +5526,9 @@ void main() {
       });
 
       test(
-        'a marker with a foreign d-tag does not advance any cursor',
+        'a marker with a foreign d-tag is ignored without ledgering',
         () async {
+          final ledger = _InMemoryProcessedGiftWrapsDao();
           final foreignMarker = Event.fromJson({
             'id': _rumorEventId,
             'pubkey': _validPubkeyA,
@@ -5554,6 +5555,7 @@ void main() {
           ).thenAnswer((_) => controller.stream);
 
           final repository = createRepository(
+            processedGiftWrapsDao: ledger,
             rumorDecryptor: (_, _) async => foreignMarker,
           );
           await repository.startListening();
@@ -5581,6 +5583,7 @@ void main() {
               ownerPubkey: any(named: 'ownerPubkey'),
             ),
           );
+          expect(ledger.recorded, isNot(contains(_giftWrapEventId)));
         },
       );
     });

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -89,6 +89,116 @@ void main() {
       );
     });
 
+    group('publishSelfApplicationMarker (#4977)', () {
+      setUp(() {
+        // The self marker is NIP-44-sealed to the sender's own key, so the
+        // sender pubkey must be a real curve point derived from the signing
+        // key (the module-level _testPublicKey is a non-curve placeholder).
+        service = NIP17MessageService(
+          signer: LocalNostrSigner(_testPrivateKey),
+          senderPublicKey: getPublicKey(_testPrivateKey),
+          nostrService: mockNostrClient,
+        );
+      });
+
+      test('routes the self marker to the provided targetRelays', () async {
+        List<String>? routedTo;
+        when(
+          () => mockNostrClient.publishEvent(
+            any(),
+            targetRelays: any(named: 'targetRelays'),
+          ),
+        ).thenAnswer((inv) async {
+          routedTo = inv.namedArguments[#targetRelays] as List<String>?;
+          return PublishSuccess(event: inv.positionalArguments[0] as Event);
+        });
+
+        final ok = await service.publishSelfApplicationMarker(
+          content: '{"v":1,"read":{}}',
+          tags: const [
+            ['d', 'divine/dm-read/v1'],
+          ],
+          targetRelays: const ['wss://inbox.example.com'],
+        );
+
+        expect(ok, isTrue);
+        expect(routedTo, const ['wss://inbox.example.com']);
+      });
+
+      test('falls back to the default pool when no targetRelays', () async {
+        var bareCalls = 0;
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer((inv) async {
+          bareCalls++;
+          return PublishSuccess(event: inv.positionalArguments[0] as Event);
+        });
+
+        final ok = await service.publishSelfApplicationMarker(
+          content: '{"v":1,"read":{}}',
+          tags: const [
+            ['d', 'divine/dm-read/v1'],
+          ],
+        );
+
+        expect(ok, isTrue);
+        expect(bareCalls, 1);
+      });
+
+      test('returns false when the publish does not succeed', () async {
+        when(
+          () => mockNostrClient.publishEvent(any()),
+        ).thenAnswer((_) async => const PublishNoRelays());
+
+        final ok = await service.publishSelfApplicationMarker(
+          content: '{"v":1,"read":{}}',
+          tags: const [
+            ['d', 'divine/dm-read/v1'],
+          ],
+        );
+
+        expect(ok, isFalse);
+      });
+
+      test('returns false when the gift wrap builder yields null', () async {
+        final nullBuilderService = NIP17MessageService(
+          signer: LocalNostrSigner(_testPrivateKey),
+          senderPublicKey: _testPublicKey,
+          nostrService: mockNostrClient,
+          giftWrapBuilder: (_, _, _) async => null,
+        );
+
+        final ok = await nullBuilderService.publishSelfApplicationMarker(
+          content: '{"v":1,"read":{}}',
+          tags: const [
+            ['d', 'divine/dm-read/v1'],
+          ],
+        );
+
+        expect(ok, isFalse);
+        verifyNever(() => mockNostrClient.publishEvent(any()));
+      });
+
+      test(
+        'returns false (non-fatal) when the gift wrap builder throws',
+        () async {
+          final throwingService = NIP17MessageService(
+            signer: LocalNostrSigner(_testPrivateKey),
+            senderPublicKey: _testPublicKey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (_, _, _) async => throw StateError('boom'),
+          );
+
+          final ok = await throwingService.publishSelfApplicationMarker(
+            content: '{"v":1,"read":{}}',
+            tags: const [
+              ['d', 'divine/dm-read/v1'],
+            ],
+          );
+
+          expect(ok, isFalse);
+        },
+      );
+    });
+
     group('sendPrivateMessage', () {
       test('returns success with gift wrap event details', () async {
         when(() => mockNostrClient.publishEvent(any())).thenAnswer(

--- a/mobile/packages/nostr_sdk/lib/event_kind.dart
+++ b/mobile/packages/nostr_sdk/lib/event_kind.dart
@@ -128,6 +128,10 @@ class EventKind {
 
   static const int longFormLinked = 30024;
 
+  /// NIP-78 application-specific data (addressable). Used by diVine as the
+  /// self-encrypted DM read-state cursor marker (#4977).
+  static const int appSpecificData = 30078;
+
   static const int liveEvent = 30311;
 
   static const int communityDefinition = 34550;


### PR DESCRIPTION
## Description

DM read state was a local-only Drift boolean wiped on reinstall, so the #4953/#4973 recovery drain re-derived every received-last conversation as unread. The local-clobbering precursor shipped as #5515 (PR #5506). This PR adds cross-device DM read-state sync: a per-conversation read cursor published, encrypted-to-self, over Nostr and restored on reinstall, without exposing a read receipt to the other party.

Closes #4977.

## What Changed

- Added a nullable `last_read_timestamp` cursor on conversations, with an idempotent runtime migration and one-time backfill for already-read rows.
- Advanced read cursors only from explicit read actions or read-marker reconciliation; ingest never writes the cursor.
- Published a debounced self-addressed NIP-59 gift wrap carrying a kind-30078 read-marker rumor keyed by sorted participant-pubkey tuple.
- Restored read state during DM history recovery by reconciling read markers and applying a last-sent floor after the drain completes.
- Kept privacy intact by publishing markers only to the user's own inbox relays/default pool via encrypted self-wraps.
- Hardened kind-30078 routing so only Divine's `divine/dm-read/v1` marker is terminally ledgered; foreign/future app-specific self-wraps are ignored without being recorded as processed.
- Added regression coverage for migration/backfill, cursor monotonicity, marker publish/reconcile behavior, privacy routing, debounce behavior, restore floors, and foreign d-tag ledger safety.

## Design Notes

**Transport / kind.** v1 uses a self-addressed NIP-59 gift wrap (kind 1059) carrying a kind-30078 read-marker rumor. 1059 is already relay-allowed and signed on every DM, so this needs no backend change. It publishes to the user's own kind-10050 inbox relays, or the default pool, which matches the gift-wrap drain source after #4974.

**Encrypted payload shape.** The payload is `{"v":1,"read":{"<participantTuple>":<unixSeconds>}}`. The tuple is sorted participant pubkeys so mobile and divine-web can share the wire format even if internal conversation ids differ.

**Read semantics.** The cursor is monotonic and only advances with `max`. Remote reconciliation never lowers read state, and it only marks a conversation read when the restored cursor covers the latest local message.

**Restore path.** Read markers are handled before the DM-only kinds gate so they never render as messages. Markers that arrive before their conversation rows are held pending and flushed after the drain. The last-sent floor restores conversations where the user replied even if no read marker exists yet.

**Known limitations.** Read-without-reply restore depends on a marker having been published before uninstall. Reading offline and immediately uninstalling cannot restore that read state. Older read state from before this feature shipped is not retroactively recoverable, but read state self-heals going forward.

## How To Reproduce The Original Bug

1. Sign in to Divine and open Messages.
2. Have another account send messages in a few threads so the latest message in those conversations is received, not sent by you.
3. Open those threads so they become read.
4. Uninstall the app or clear app data.
5. Reinstall, sign in with the same account, open Messages, and wait for the history drain.
6. On `main`, those received-last conversations come back unread because read state only lived in the wiped local database.

## Testing The Fix On A Device

**Reinstall restore**

1. Sign in and make several threads read where the latest message was received.
2. Wait about 5 seconds online so the debounced marker can publish.
3. Uninstall or clear data, reinstall, sign in again, and open Messages.
4. After the drain finishes, previously read threads should stay read, and replied-in threads should stay read via the last-sent floor.

**Cross-device sync**

1. Sign in to the same account on two devices.
2. Read an unread thread on Device 1 and wait about 5 seconds online.
3. Re-open Messages on Device 2 so it drains/reconciles.
4. The same thread should show read on Device 2.

**Privacy**

- The counterparty should never receive or see a read indicator. Relay traffic for read state is encrypted kind-1059 self-wrap traffic addressed to the reader's own pubkey.

## Verification

- `dart format lib/src/dm_repository.dart test/src/dm_repository_test.dart`
- `mise exec -- dart format lib test integration_test`
- From `mobile/packages/dm_repository`: `flutter analyze lib test`
- From `mobile/packages/dm_repository`: `flutter test --coverage` — 411 tests passed.
- Pre-push hook from `mobile/`: merge-conflict check, analyzer, generated-file verification, and changed-file tests for db_client + dm_repository passed.

## Type Of Change

- [x] New feature
- [x] Bug fix / data restoration hardening
