### PR TITLE
fix(feed): ignore stale Nostr enrichment

### DIFF
--- a/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
+++ b/mobile/lib/blocs/profile_feed/profile_feed_enrichment_merge.dart
@@ -29,12 +29,15 @@ List<VideoEvent> mergeProfileFeedEnrichment({
   final keepFromCurrent = current
       .where((v) => !sourceKeys.contains(canonicalProfileFeedVideoKey(v)))
       .toList();
-  final mergedSource = incoming.map((video) {
-    final currentVideo = currentByKey[canonicalProfileFeedVideoKey(video)];
-    return currentVideo == null
-        ? video
-        : _mergeEnrichmentIntoCurrent(currentVideo, video);
-  }).toList();
+  final mergedSource = incoming
+      .map((video) {
+        final currentVideo = currentByKey[canonicalProfileFeedVideoKey(video)];
+        return currentVideo == null
+            ? null
+            : _mergeEnrichmentIntoCurrent(currentVideo, video);
+      })
+      .nonNulls
+      .toList();
   return removeTombstones(
     mergeProfileFeedVideoLists(keepFromCurrent, mergedSource),
   );

--- a/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_cubit_test.dart
@@ -973,5 +973,40 @@ void main() {
 
       expect(cubit.state.videos.single.title, 'enriched');
     });
+
+    test(
+      'stale background enrichment cannot reintroduce refreshed videos',
+      () async {
+        final enrichment = Completer<List<VideoEvent>>();
+        var enrichCallCount = 0;
+        h.enrichOverride = (videos) {
+          enrichCallCount += 1;
+          if (enrichCallCount == 1) return enrichment.future;
+          return Future.value(videos);
+        };
+        h.stubAuthorFeedSequence([
+          _result([_video('old-rest', vineId: 'old-vine')]),
+          _result([_video('new-rest', vineId: 'new-vine')]),
+        ]);
+
+        final cubit = h.build();
+        addTearDown(cubit.close);
+        await pumpEventQueue();
+        expect(cubit.state.videos.map((video) => video.id), ['old-rest']);
+
+        cubit.add(const ProfileFeedRefreshRequested());
+        await pumpEventQueue();
+        expect(cubit.state.videos.map((video) => video.id), ['new-rest']);
+
+        enrichment.complete([
+          _video('old-nostr', vineId: 'old-vine', originalLikes: 10),
+        ]);
+        await pumpEventQueue();
+        await pumpEventQueue();
+
+        expect(cubit.state.videos.map((video) => video.id), ['new-rest']);
+        expect(cubit.state.videos.single.originalLikes, isNull);
+      },
+    );
   });
 }

--- a/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
+++ b/mobile/test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart
@@ -56,5 +56,24 @@ void main() {
         '39307:pubkey:subtitles:video-subtitles',
       ]);
     });
+
+    test('does not reintroduce source videos missing from current state', () {
+      final staleSource = _video(id: 'old-rest', vineId: 'old-vine');
+      final current = _video(id: 'new-rest', vineId: 'new-vine');
+      final enriched = _video(
+        id: 'old-nostr',
+        vineId: 'old-vine',
+        textTrackRef: 'https://media.divine.video/stale.vtt',
+      );
+
+      final merged = mergeProfileFeedEnrichment(
+        current: [current],
+        sourceKeys: {canonicalProfileFeedVideoKey(staleSource)},
+        incoming: [enriched],
+        removeTombstones: (videos) => videos,
+      );
+
+      expect(merged, [current]);
+    });
   });
 }

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -347,6 +347,91 @@ void main() {
         ],
       );
 
+      test(
+        'ignores stale background enrichment after switching sources',
+        () async {
+          final authors = ['author1'];
+          final compactVideo = createTestVideo('video-1').copyWith(
+            rawTags: const {
+              'd': 'video-1',
+              'url': 'https://example.com/video-1.mp4',
+              'title': 'REST row',
+              'thumb': 'https://example.com/video-1.jpg',
+            },
+          );
+          final newVideos = createTestVideos(2, idPrefix: 'new');
+          final enrichment = Completer<List<VideoEvent>>();
+          var enrichCallCount = 0;
+
+          when(() => mockFollowRepository.followingPubkeys).thenReturn(authors);
+          when(
+            () => mockVideosRepository.getHomeFeedVideos(
+              authors: authors,
+              videoRefs: any(named: 'videoRefs'),
+              userPubkey: any(named: 'userPubkey'),
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: [compactVideo]));
+          when(
+            () => mockVideosRepository.getNewVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => newVideos);
+
+          final bloc = VideoFeedBloc(
+            videosRepository: mockVideosRepository,
+            followRepository: mockFollowRepository,
+            curatedListRepository: mockCuratedListRepository,
+            enrichVideos: (videos) {
+              enrichCallCount += 1;
+              if (enrichCallCount == 1) return enrichment.future;
+              return Future.value(videos);
+            },
+          );
+          addTearDown(bloc.close);
+
+          bloc.add(const VideoFeedStarted(mode: FeedMode.following));
+          await pumpEventQueue();
+          expect(bloc.state.videos.map((video) => video.id), ['video-1']);
+
+          bloc.add(const VideoFeedSourceChanged(VideoFeedSource.newVideos()));
+          await pumpEventQueue();
+          expect(bloc.state.source, const VideoFeedSource.newVideos());
+          expect(bloc.state.videos.map((video) => video.id), [
+            'new-0',
+            'new-1',
+          ]);
+
+          enrichment.complete([
+            compactVideo.copyWith(
+              rawTags: {
+                ...compactVideo.rawTags,
+                'verification': 'verified_mobile',
+                'proofmode': '{}',
+              },
+            ),
+          ]);
+          await pumpEventQueue();
+          await pumpEventQueue();
+
+          expect(bloc.state.source, const VideoFeedSource.newVideos());
+          expect(bloc.state.videos.map((video) => video.id), [
+            'new-0',
+            'new-1',
+          ]);
+          expect(
+            bloc.state.videos.any(
+              (video) => video.rawTags.containsKey('proofmode'),
+            ),
+            isFalse,
+          );
+        },
+      );
+
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'reports unexpected background enrichment failures as Reportable',
         setUp: () {


### PR DESCRIPTION
## Summary

Closes #5545.

This PR keeps feed Nostr enrichment non-blocking and hardens stale-result handling where the issue still had a real gap. The home feed already ignored stale enrichment by source, but profile-feed enrichment could reintroduce a REST row if its background Nostr query completed after a refresh removed that row from the current window.

## Changes

- Drops stale profile enrichment rows whose source key is no longer present in the current profile feed state.
- Adds a merge-level regression test for stale profile enrichment.
- Adds a ProfileFeedCubit regression test proving stale enrichment cannot reintroduce refreshed videos.
- Adds a VideoFeedBloc regression test proving stale enrichment is ignored after switching feed sources.

## Verification

- flutter test test/blocs/profile_feed/profile_feed_enrichment_merge_test.dart test/blocs/profile_feed/profile_feed_cubit_test.dart test/blocs/video_feed/video_feed_bloc_test.dart test/utils/video_nostr_enrichment_streaming_test.dart
- flutter analyze
- pre-push hook: analyzer and changed-file tests passed

## Risk

Low. The production change only narrows profile enrichment merging so background data can update rows that still exist, without adding old rows back into a refreshed feed. Existing proof/C2PA enrichment behavior remains intact for current rows.