### PR TITLE
fix(feed): prevent idle warmup contention

### DIFF
--- a/mobile/lib/providers/foreground_idle_warmup_provider.dart
+++ b/mobile/lib/providers/foreground_idle_warmup_provider.dart
@@ -1,12 +1,15 @@
 // ABOUTME: App-shell providers for foreground-idle data warmups.
 // ABOUTME: Warms existing feed and notification caches without prefetching media bytes.
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/for_you_provider.dart';
 import 'package:openvine/providers/new_videos_feed_provider.dart';
 import 'package:openvine/providers/popular_videos_feed_provider.dart';
@@ -14,19 +17,67 @@ import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/foreground_idle_warmup_coordinator.dart';
 
+/// Tracks whether foreground feeds have recently been under user control.
+class ForegroundFeedActivityGate {
+  /// Creates a feed activity gate.
+  ForegroundFeedActivityGate({Duration idleDelay = const Duration(seconds: 10)})
+    : _idleDelay = idleDelay;
+
+  final Duration _idleDelay;
+  final _changes = StreamController<void>.broadcast();
+
+  Timer? _idleTimer;
+  bool _isIdle = true;
+
+  /// Emits whenever foreground feed activity changes warmup eligibility.
+  Stream<void> get changes => _changes.stream;
+
+  /// Whether foreground warmup work may run.
+  bool get isIdle => _isIdle;
+
+  /// Marks the foreground feed active until [idleDelay] elapses with no update.
+  void markActive() {
+    _idleTimer?.cancel();
+    if (_isIdle) {
+      _isIdle = false;
+      _changes.add(null);
+    }
+    _idleTimer = Timer(_idleDelay, () {
+      _isIdle = true;
+      _changes.add(null);
+    });
+  }
+
+  /// Releases resources owned by the gate.
+  void dispose() {
+    _idleTimer?.cancel();
+    _changes.close();
+  }
+}
+
+/// Foreground feed activity gate used to keep warmups behind active swipes.
+final foregroundFeedActivityGateProvider = Provider<ForegroundFeedActivityGate>(
+  (ref) {
+    final gate = ForegroundFeedActivityGate();
+    ref.onDispose(gate.dispose);
+    return gate;
+  },
+);
+
 /// Coordinates low-priority data warmups for adjacent app surfaces.
 final foregroundIdleWarmupCoordinatorProvider =
     Provider<ForegroundIdleWarmupCoordinator>((ref) {
+      final activityGate = ref.watch(foregroundFeedActivityGateProvider);
       return ForegroundIdleWarmupCoordinator(
         isForeground: () => ref.read(appForegroundProvider),
-        // The scheduler only fires after startup settles and then very
-        // occasionally. Keep this gate explicit so richer idle signals can be
-        // added without changing task semantics.
-        isIdle: () => ref.read(appForegroundProvider),
+        isIdle: () => activityGate.isIdle,
+        gateChanges: activityGate.changes,
         tasks: [
           ForegroundIdleWarmupTask(
             id: ForegroundIdleWarmupTaskId.forYou,
             cooldown: const Duration(minutes: 10),
+            shouldRun: () =>
+                ref.read(funnelcakeAvailableProvider).asData?.value == true,
             run: () async {
               await ref.read(forYouFeedProvider.future);
             },

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -22,6 +22,7 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/comments/comments_screen.dart';
 import 'package:openvine/screens/feed/dm_reply_context.dart';
@@ -791,6 +792,11 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                                         trafficSource: widget.trafficSource,
                                         sourceDetail: widget.sourceDetail,
                                         onActiveVideoChanged: (video, index) {
+                                          ref
+                                              .read(
+                                                foregroundFeedActivityGateProvider,
+                                              )
+                                              .markActive();
                                           _resumeAutoAdvanceAfterSwipe();
                                           FeedPerformanceTracker()
                                               .startVideoSwipeTracking(
@@ -834,9 +840,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                           ReelReplyBridge(
                             setComposerFocused: (focused) {
                               if (mounted && focused != _replyComposerFocused) {
-                                setState(
-                                  () => _replyComposerFocused = focused,
-                                );
+                                setState(() => _replyComposerFocused = focused);
                               }
                             },
                             playReaction: (emoji) {

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_feed/video_feed_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
@@ -366,6 +367,9 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                       isLoadingMore: state.isLoadingMore,
                       trafficSource: ViewTrafficSource.home,
                       onActiveVideoChanged: (video, index) {
+                        ref
+                            .read(foregroundFeedActivityGateProvider)
+                            .markActive();
                         _currentIndex = index;
                         context.read<VideoFeedBloc>().add(
                           VideoFeedActiveIndexChanged(index),

--- a/mobile/lib/services/foreground_idle_warmup_coordinator.dart
+++ b/mobile/lib/services/foreground_idle_warmup_coordinator.dart
@@ -116,6 +116,7 @@ class ForegroundIdleWarmupTask {
     required this.id,
     required this.run,
     required this.cooldown,
+    this.shouldRun,
     this.timeout = const Duration(seconds: 12),
   });
 
@@ -128,6 +129,9 @@ class ForegroundIdleWarmupTask {
   /// Maximum time this low-priority task may occupy the serial queue.
   final Duration timeout;
 
+  /// Whether this task has applicable warmup work right now.
+  final bool Function()? shouldRun;
+
   /// Performs the data-only warmup.
   final Future<void> Function() run;
 }
@@ -139,15 +143,18 @@ class ForegroundIdleWarmupCoordinator {
     required List<ForegroundIdleWarmupTask> tasks,
     required bool Function() isForeground,
     required bool Function() isIdle,
+    Stream<void>? gateChanges,
     DateTime Function()? now,
   }) : _tasks = List.unmodifiable(tasks),
        _isForeground = isForeground,
        _isIdle = isIdle,
+       _gateChanges = gateChanges,
        _now = now ?? DateTime.now;
 
   final List<ForegroundIdleWarmupTask> _tasks;
   final bool Function() _isForeground;
   final bool Function() _isIdle;
+  final Stream<void>? _gateChanges;
   final DateTime Function() _now;
 
   final Map<ForegroundIdleWarmupTaskId, DateTime> _lastSuccessAt = {};
@@ -158,9 +165,7 @@ class ForegroundIdleWarmupCoordinator {
   /// If another pass is running, returns the same future. Each pass checks the
   /// foreground/idle gates before every task so user interaction can stop the
   /// queue quickly.
-  Future<void> requestWarmup({
-    required ForegroundIdleWarmupTrigger trigger,
-  }) {
+  Future<void> requestWarmup({required ForegroundIdleWarmupTrigger trigger}) {
     final inFlight = _inFlight;
     if (inFlight != null) {
       Log.debug(
@@ -215,6 +220,14 @@ class ForegroundIdleWarmupCoordinator {
         );
         continue;
       }
+      if (task.shouldRun?.call() == false) {
+        Log.debug(
+          'Foreground idle warmup skipped ${task.id.name}: not applicable',
+          name: 'ForegroundIdleWarmupCoordinator',
+          category: LogCategory.system,
+        );
+        continue;
+      }
 
       try {
         Log.debug(
@@ -222,20 +235,33 @@ class ForegroundIdleWarmupCoordinator {
           name: 'ForegroundIdleWarmupCoordinator',
           category: LogCategory.system,
         );
-        await task.run().timeout(task.timeout);
-        _lastSuccessAt[task.id] = _now();
-        Log.info(
-          'Foreground idle warmup completed ${task.id.name}',
-          name: 'ForegroundIdleWarmupCoordinator',
-          category: LogCategory.system,
-        );
-      } on TimeoutException {
-        Log.warning(
-          'Foreground idle warmup timed out '
-          '(${task.id.name}, ${trigger.name}, ${task.timeout.inSeconds}s)',
-          name: 'ForegroundIdleWarmupCoordinator',
-          category: LogCategory.system,
-        );
+        final outcome = await _runTask(task);
+        switch (outcome) {
+          case _ForegroundIdleWarmupTaskOutcome.completed:
+            _lastSuccessAt[task.id] = _now();
+            Log.info(
+              'Foreground idle warmup completed ${task.id.name}',
+              name: 'ForegroundIdleWarmupCoordinator',
+              category: LogCategory.system,
+            );
+            continue;
+          case _ForegroundIdleWarmupTaskOutcome.gateClosed:
+            Log.info(
+              'Foreground idle warmup stopped during ${task.id.name}: '
+              'foreground=${_isForeground()}, idle=${_isIdle()}',
+              name: 'ForegroundIdleWarmupCoordinator',
+              category: LogCategory.system,
+            );
+            return;
+          case _ForegroundIdleWarmupTaskOutcome.timedOut:
+            Log.warning(
+              'Foreground idle warmup timed out '
+              '(${task.id.name}, ${trigger.name}, ${task.timeout.inSeconds}s)',
+              name: 'ForegroundIdleWarmupCoordinator',
+              category: LogCategory.system,
+            );
+            continue;
+        }
       } catch (error) {
         Log.warning(
           'Foreground idle warmup failed '
@@ -247,9 +273,42 @@ class ForegroundIdleWarmupCoordinator {
     }
   }
 
+  Future<_ForegroundIdleWarmupTaskOutcome> _runTask(
+    ForegroundIdleWarmupTask task,
+  ) async {
+    final gateChanges = _gateChanges;
+    StreamSubscription<void>? gateSubscription;
+    final gateClosed = Completer<_ForegroundIdleWarmupTaskOutcome>();
+
+    void completeIfGateClosed() {
+      if (_canRun || gateClosed.isCompleted) return;
+      gateClosed.complete(_ForegroundIdleWarmupTaskOutcome.gateClosed);
+    }
+
+    if (gateChanges != null) {
+      gateSubscription = gateChanges.listen((_) => completeIfGateClosed());
+      completeIfGateClosed();
+    }
+
+    try {
+      return await Future.any([
+        task.run().then((_) => _ForegroundIdleWarmupTaskOutcome.completed),
+        Future<_ForegroundIdleWarmupTaskOutcome>.delayed(
+          task.timeout,
+          () => _ForegroundIdleWarmupTaskOutcome.timedOut,
+        ),
+        if (gateChanges != null) gateClosed.future,
+      ]);
+    } finally {
+      await gateSubscription?.cancel();
+    }
+  }
+
   bool _isCoolingDown(ForegroundIdleWarmupTask task) {
     final lastSuccessAt = _lastSuccessAt[task.id];
     if (lastSuccessAt == null) return false;
     return _now().difference(lastSuccessAt) < task.cooldown;
   }
 }
+
+enum _ForegroundIdleWarmupTaskOutcome { completed, gateClosed, timedOut }

--- a/mobile/lib/services/foreground_idle_warmup_coordinator.dart
+++ b/mobile/lib/services/foreground_idle_warmup_coordinator.dart
@@ -159,12 +159,19 @@ class ForegroundIdleWarmupCoordinator {
 
   final Map<ForegroundIdleWarmupTaskId, DateTime> _lastSuccessAt = {};
   Future<void>? _inFlight;
+  Future<void>? _abandonedTaskRun;
 
   /// Requests a best-effort warmup pass.
   ///
   /// If another pass is running, returns the same future. Each pass checks the
   /// foreground/idle gates before every task so user interaction can stop the
   /// queue quickly.
+  ///
+  /// When a pass abandons a still-running task (a gate closed or the task
+  /// timed out), the coordinator keeps accounting for that task until it
+  /// settles. A new request made in that window waits for the abandoned task
+  /// instead of starting an overlapping pass, so warmups can never contend
+  /// with each other.
   Future<void> requestWarmup({required ForegroundIdleWarmupTrigger trigger}) {
     final inFlight = _inFlight;
     if (inFlight != null) {
@@ -174,6 +181,17 @@ class ForegroundIdleWarmupCoordinator {
         category: LogCategory.system,
       );
       return inFlight;
+    }
+
+    final abandonedTaskRun = _abandonedTaskRun;
+    if (abandonedTaskRun != null) {
+      Log.debug(
+        'Foreground idle warmup held (${trigger.name}): '
+        'awaiting an abandoned task to settle',
+        name: 'ForegroundIdleWarmupCoordinator',
+        category: LogCategory.system,
+      );
+      return abandonedTaskRun;
     }
 
     if (!_canRun) {
@@ -235,7 +253,7 @@ class ForegroundIdleWarmupCoordinator {
           name: 'ForegroundIdleWarmupCoordinator',
           category: LogCategory.system,
         );
-        final outcome = await _runTask(task);
+        final (outcome, run) = await _runTask(task);
         switch (outcome) {
           case _ForegroundIdleWarmupTaskOutcome.completed:
             _lastSuccessAt[task.id] = _now();
@@ -252,6 +270,7 @@ class ForegroundIdleWarmupCoordinator {
               name: 'ForegroundIdleWarmupCoordinator',
               category: LogCategory.system,
             );
+            _trackAbandonedRun(run);
             return;
           case _ForegroundIdleWarmupTaskOutcome.timedOut:
             Log.warning(
@@ -260,7 +279,8 @@ class ForegroundIdleWarmupCoordinator {
               name: 'ForegroundIdleWarmupCoordinator',
               category: LogCategory.system,
             );
-            continue;
+            _trackAbandonedRun(run);
+            return;
         }
       } catch (error) {
         Log.warning(
@@ -273,7 +293,7 @@ class ForegroundIdleWarmupCoordinator {
     }
   }
 
-  Future<_ForegroundIdleWarmupTaskOutcome> _runTask(
+  Future<(_ForegroundIdleWarmupTaskOutcome, Future<void>)> _runTask(
     ForegroundIdleWarmupTask task,
   ) async {
     final gateChanges = _gateChanges;
@@ -285,23 +305,43 @@ class ForegroundIdleWarmupCoordinator {
       gateClosed.complete(_ForegroundIdleWarmupTaskOutcome.gateClosed);
     }
 
+    final run = task.run();
+
     if (gateChanges != null) {
       gateSubscription = gateChanges.listen((_) => completeIfGateClosed());
       completeIfGateClosed();
     }
 
     try {
-      return await Future.any([
-        task.run().then((_) => _ForegroundIdleWarmupTaskOutcome.completed),
+      final outcome = await Future.any([
+        run.then((_) => _ForegroundIdleWarmupTaskOutcome.completed),
         Future<_ForegroundIdleWarmupTaskOutcome>.delayed(
           task.timeout,
           () => _ForegroundIdleWarmupTaskOutcome.timedOut,
         ),
         if (gateChanges != null) gateClosed.future,
       ]);
+      return (outcome, run);
     } finally {
       await gateSubscription?.cancel();
     }
+  }
+
+  /// Keeps a still-running task accounted for after its pass stopped waiting
+  /// on it, so a later request waits instead of starting an overlapping pass.
+  void _trackAbandonedRun(Future<void> run) {
+    final abandoned = run.then<void>(
+      (_) {},
+      onError: (Object _, StackTrace _) {},
+    );
+    _abandonedTaskRun = abandoned;
+    unawaited(
+      abandoned.whenComplete(() {
+        if (identical(_abandonedTaskRun, abandoned)) {
+          _abandonedTaskRun = null;
+        }
+      }),
+    );
   }
 
   bool _isCoolingDown(ForegroundIdleWarmupTask task) {

--- a/mobile/test/providers/foreground_idle_warmup_provider_test.dart
+++ b/mobile/test/providers/foreground_idle_warmup_provider_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Provider wiring tests for foreground-idle warmup tasks.
 // ABOUTME: Verifies app-shell gates and dependency arguments without real IO.
 
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
@@ -10,6 +12,7 @@ import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/curation_providers.dart';
 import 'package:openvine/providers/for_you_provider.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/new_videos_feed_provider.dart';
@@ -29,6 +32,18 @@ class _MockAuthService extends Mock implements AuthService {}
 
 class _MockNotificationRefreshCoordinator extends Mock
     implements NotificationRefreshCoordinator {}
+
+class _AvailableFunnelcake extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() async => true;
+}
+
+Completer<bool>? _funnelcakeAvailabilityCompleter;
+
+class _LoadingFunnelcake extends FunnelcakeAvailable {
+  @override
+  Future<bool> build() => _funnelcakeAvailabilityCompleter!.future;
+}
 
 final _feedBuilds = <String>[];
 const _expectedEmptyFollowingWarmupBuilds = [
@@ -75,7 +90,10 @@ void main() {
     late _MockAuthService authService;
     late _MockNotificationRefreshCoordinator notificationCoordinator;
 
-    ProviderContainer createContainer({required List<String> following}) {
+    ProviderContainer createContainer({
+      required List<String> following,
+      bool funnelcakeAvailabilityLoading = false,
+    }) {
       when(() => followRepository.followingPubkeys).thenReturn(following);
       when(() => authService.currentPublicKeyHex).thenReturn('viewer-pubkey');
       when(
@@ -102,6 +120,11 @@ void main() {
           notificationRefreshCoordinatorProvider.overrideWithValue(
             notificationCoordinator,
           ),
+          funnelcakeAvailableProvider.overrideWith(
+            funnelcakeAvailabilityLoading
+                ? _LoadingFunnelcake.new
+                : _AvailableFunnelcake.new,
+          ),
           forYouFeedProvider.overrideWith(_TestForYouFeed.new),
           newVideosFeedProvider.overrideWith(_TestNewVideosFeed.new),
           popularVideosFeedProvider.overrideWith(_TestPopularVideosFeed.new),
@@ -117,6 +140,7 @@ void main() {
       authService = _MockAuthService();
       notificationCoordinator = _MockNotificationRefreshCoordinator();
       _feedBuilds.clear();
+      _funnelcakeAvailabilityCompleter = null;
     });
 
     test('foreground=false gates all warmup work', () async {
@@ -148,8 +172,76 @@ void main() {
       );
     });
 
+    test('recent foreground feed activity gates all warmup work', () async {
+      final container = createContainer(following: const ['author-pubkey']);
+      container.read(foregroundFeedActivityGateProvider).markActive();
+
+      await container
+          .read(foregroundIdleWarmupCoordinatorProvider)
+          .requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+          );
+
+      expect(_feedBuilds, isEmpty);
+      verifyNever(() => followRepository.followingPubkeys);
+      verifyNever(
+        () => videosRepository.getHomeFeedVideos(
+          authors: any(named: 'authors'),
+          videoRefs: any(named: 'videoRefs'),
+          userPubkey: any(named: 'userPubkey'),
+          limit: any(named: 'limit'),
+          until: any(named: 'until'),
+          skipCache: any(named: 'skipCache'),
+        ),
+      );
+      verifyNever(
+        () => notificationCoordinator.refresh(
+          reason: NotificationRefreshReason.foregroundIdleWarmup,
+        ),
+      );
+    });
+
+    test('unresolved Funnelcake availability skips For You warmup', () async {
+      _funnelcakeAvailabilityCompleter = Completer<bool>();
+      final container = createContainer(
+        following: const [],
+        funnelcakeAvailabilityLoading: true,
+      );
+
+      await container
+          .read(foregroundIdleWarmupCoordinatorProvider)
+          .requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
+          );
+
+      expect(_feedBuilds, [
+        'newVideos',
+        'popular',
+        'popular:native',
+        'popular:classic',
+      ]);
+
+      _funnelcakeAvailabilityCompleter!.complete(true);
+      await container.read(funnelcakeAvailableProvider.future);
+
+      await container
+          .read(foregroundIdleWarmupCoordinatorProvider)
+          .requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+          );
+
+      expect(_feedBuilds, [
+        'newVideos',
+        'popular',
+        'popular:native',
+        'popular:classic',
+        'forYou',
+      ]);
+    });
+
     test('empty following list skips home feed repository fetch', () async {
       final container = createContainer(following: const []);
+      await container.read(funnelcakeAvailableProvider.future);
 
       await container
           .read(foregroundIdleWarmupCoordinatorProvider)
@@ -173,6 +265,7 @@ void main() {
 
     test('popular warmup preloads native and classic variants', () async {
       final container = createContainer(following: const []);
+      await container.read(funnelcakeAvailableProvider.future);
 
       await container
           .read(foregroundIdleWarmupCoordinatorProvider)
@@ -185,6 +278,7 @@ void main() {
 
     test('notification warmup uses foreground idle warmup reason', () async {
       final container = createContainer(following: const []);
+      await container.read(funnelcakeAvailableProvider.future);
 
       await container
           .read(foregroundIdleWarmupCoordinatorProvider)
@@ -203,6 +297,7 @@ void main() {
       'non-empty following fetches home feed with current user and batch size',
       () async {
         final container = createContainer(following: const ['author-pubkey']);
+        await container.read(funnelcakeAvailableProvider.future);
 
         await container
             .read(foregroundIdleWarmupCoordinatorProvider)

--- a/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
+++ b/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
@@ -311,7 +311,7 @@ void main() {
       expect(calls, ['forYou', 'popular', 'forYou']);
     });
 
-    test('timed out tasks do not block later tasks or consume cooldown', () {
+    test('a timed-out task blocks later passes until it settles', () {
       fakeAsync((async) {
         final slowTask = Completer<void>();
         final coordinator = coordinatorWith([
@@ -336,8 +336,12 @@ void main() {
         async.elapse(const Duration(seconds: 1));
         async.flushMicrotasks();
 
-        expect(calls, ['forYou', 'newVideos', 'popular']);
+        // The timed-out task stops the pass; later tasks are blocked rather
+        // than run alongside the still-active task.
+        expect(calls, ['forYou']);
 
+        // A new request cannot start an overlapping pass while the abandoned
+        // task is still active.
         unawaited(
           coordinator.requestWarmup(
             trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
@@ -346,8 +350,77 @@ void main() {
         async.elapse(const Duration(seconds: 1));
         async.flushMicrotasks();
 
-        expect(calls, ['forYou', 'newVideos', 'popular', 'forYou']);
+        expect(calls, ['forYou']);
+
+        // Once it settles, the next request runs the remaining tasks. The
+        // timed-out task did not consume cooldown, so it runs again.
+        slowTask.complete();
+        async.flushMicrotasks();
+        unawaited(
+          coordinator.requestWarmup(
+            trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+          ),
+        );
+        async.elapse(const Duration(seconds: 1));
+        async.flushMicrotasks();
+
+        expect(calls, ['forYou', 'forYou', 'newVideos', 'popular']);
       });
+    });
+
+    test('blocks a new pass until an abandoned task settles after gate '
+        'close', () async {
+      final gateChanges = StreamController<void>.broadcast();
+      addTearDown(gateChanges.close);
+      final taskCompleter = Completer<void>();
+      final coordinator = ForegroundIdleWarmupCoordinator(
+        tasks: [
+          task(
+            ForegroundIdleWarmupTaskId.forYou,
+            run: () async {
+              calls.add('forYou');
+              await taskCompleter.future;
+            },
+          ),
+          task(ForegroundIdleWarmupTaskId.popular),
+        ],
+        isForeground: () => isForeground,
+        isIdle: () => isIdle,
+        gateChanges: gateChanges.stream,
+        now: () => now,
+      );
+
+      final first = coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.startupSettled,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(calls, ['forYou']);
+
+      // Gate closes mid-task: the pass returns but the task is still running.
+      isIdle = false;
+      gateChanges.add(null);
+      await first;
+      expect(calls, ['forYou']);
+
+      // Idle resumes, but a new request must not start an overlapping pass
+      // while the abandoned task is still active.
+      isIdle = true;
+      final held = coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(calls, ['forYou']);
+
+      // Once the abandoned task settles, the held request resolves and
+      // later requests run normally.
+      taskCompleter.complete();
+      await held;
+      expect(calls, ['forYou']);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+      expect(calls, ['forYou', 'forYou', 'popular']);
     });
 
     test('stops before the next task if the app stops being idle', () async {

--- a/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
+++ b/mobile/test/services/foreground_idle_warmup_coordinator_test.dart
@@ -53,12 +53,7 @@ void main() {
         trigger: ForegroundIdleWarmupTrigger.videoPlaybackSettled,
       );
 
-      expect(calls, [
-        'forYou',
-        'newVideos',
-        'popular',
-        'notifications',
-      ]);
+      expect(calls, ['forYou', 'newVideos', 'popular', 'notifications']);
     });
 
     test('does not run while the app is backgrounded', () async {
@@ -168,6 +163,45 @@ void main() {
       expect(calls, ['forYou-start', 'forYou-end']);
     });
 
+    test('stops waiting for an in-flight task when a gate closes', () async {
+      final gateChanges = StreamController<void>.broadcast();
+      addTearDown(gateChanges.close);
+      final taskCompleter = Completer<void>();
+      final coordinator = ForegroundIdleWarmupCoordinator(
+        tasks: [
+          task(
+            ForegroundIdleWarmupTaskId.forYou,
+            run: () async {
+              calls.add('forYou-start');
+              await taskCompleter.future;
+              calls.add('forYou-end');
+            },
+          ),
+          task(ForegroundIdleWarmupTaskId.popular),
+        ],
+        isForeground: () => isForeground,
+        isIdle: () => isIdle,
+        gateChanges: gateChanges.stream,
+        now: () => now,
+      );
+
+      final warmup = coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.startupSettled,
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(calls, ['forYou-start']);
+
+      isIdle = false;
+      gateChanges.add(null);
+      await warmup;
+
+      expect(calls, ['forYou-start']);
+      expect(taskCompleter.isCompleted, isFalse);
+
+      taskCompleter.complete();
+    });
+
     test('skips tasks inside their cooldown window', () async {
       final coordinator = coordinatorWith([
         task(ForegroundIdleWarmupTaskId.forYou),
@@ -190,6 +224,31 @@ void main() {
       expect(calls, ['forYou', 'forYou']);
     });
 
+    test('not-applicable tasks do not consume cooldown', () async {
+      var shouldRun = false;
+      final coordinator = coordinatorWith([
+        ForegroundIdleWarmupTask(
+          id: ForegroundIdleWarmupTaskId.forYou,
+          cooldown: const Duration(minutes: 5),
+          shouldRun: () => shouldRun,
+          run: () async => calls.add('forYou'),
+        ),
+      ]);
+
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.startupSettled,
+      );
+
+      expect(calls, isEmpty);
+
+      shouldRun = true;
+      await coordinator.requestWarmup(
+        trigger: ForegroundIdleWarmupTrigger.periodicIdleCheck,
+      );
+
+      expect(calls, ['forYou']);
+    });
+
     test('runs tasks again at the cooldown boundary', () async {
       final coordinator = coordinatorWith([
         task(ForegroundIdleWarmupTaskId.forYou),
@@ -210,10 +269,7 @@ void main() {
     test('applies cooldowns independently per task', () async {
       final coordinator = coordinatorWith([
         task(ForegroundIdleWarmupTaskId.forYou),
-        task(
-          ForegroundIdleWarmupTaskId.popular,
-          cooldown: Duration.zero,
-        ),
+        task(ForegroundIdleWarmupTaskId.popular, cooldown: Duration.zero),
       ]);
 
       await coordinator.requestWarmup(
@@ -290,12 +346,7 @@ void main() {
         async.elapse(const Duration(seconds: 1));
         async.flushMicrotasks();
 
-        expect(calls, [
-          'forYou',
-          'newVideos',
-          'popular',
-          'forYou',
-        ]);
+        expect(calls, ['forYou', 'newVideos', 'popular', 'forYou']);
       });
     });
 


### PR DESCRIPTION
## Description

Fixes foreground idle warmup so it stays genuinely low priority while the user is actively using feed surfaces.

Root cause: the warmup coordinator had an explicit idle gate, but the app-shell wiring treated foreground as idle. The startup warmup could therefore begin while the feed was actively swiping, initializing players, and prefetching media. For You also awaited its feed future even when Funnelcake availability was still unresolved, which matched the issue logs where an apparent no-op held the serial warmup queue until the 12s timeout.

Changes:

- Add a foreground feed activity gate that marks feeds non-idle for a short window after active video changes.
- Wire home and pooled fullscreen feeds to mark foreground feed activity without coupling UI details into the coordinator service.
- Let the coordinator stop waiting for an in-flight warmup task when foreground/idle gates close, instead of holding the queue until timeout.
- Keep abandoned or timed-out warmup tasks accounted for until they settle, so a later request cannot start overlapping warmup work.
- Add task-level applicability checks so For You skips while Funnelcake availability is unresolved or unavailable, without consuming cooldown.
- Add regression coverage for interaction gating, in-flight gate closure, not-applicable cooldown behavior, abandoned-task serialization, and unresolved Funnelcake availability.

**Related Issue:** Closes #5547

## Out of Scope

None.

## Verification

- `flutter analyze`
- `flutter test test/services/foreground_idle_warmup_coordinator_test.dart test/providers/foreground_idle_warmup_provider_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart test/screens/feed/video_feed_page_test.dart`
- Pre-push hook: merge-conflict guard, changed-file analyzer, and changed-file tests passed

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes a bug)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore