### PR TITLE
fix(playback): handle media 202 as processing

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -726,7 +726,11 @@ internal class DivineVideoPlayerInstance(
             map["errorCode"] = when (error.errorCode) {
                 PlaybackException.ERROR_CODE_IO_BAD_HTTP_STATUS -> {
                     val status = (error.cause as? androidx.media3.datasource.HttpDataSource.InvalidResponseCodeException)?.responseCode ?: 0
-                    if (status in 400..499) "http_client_error" else "http_server_error"
+                    when {
+                        status == 202 -> "media_processing"
+                        status in 400..499 -> "http_client_error"
+                        else -> "http_server_error"
+                    }
                 }
                 PlaybackException.ERROR_CODE_IO_FILE_NOT_FOUND,
                 PlaybackException.ERROR_CODE_IO_INVALID_HTTP_CONTENT_TYPE,

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -1026,7 +1026,14 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
 
         // HTTP errors carried inside AVFoundation errors.
         if let httpResponse = err.userInfo["NSURLErrorFailingURLResponseErrorKey"] as? HTTPURLResponse {
+            if httpResponse.statusCode == 202 {
+                return "media_processing"
+            }
             return httpResponse.statusCode >= 500 ? "http_server_error" : "http_client_error"
+        }
+
+        if err.localizedDescription.contains("HTTP 202") {
+            return "media_processing"
         }
 
         switch (err.domain, err.code) {

--- a/mobile/packages/divine_video_player/lib/src/player_error_code.dart
+++ b/mobile/packages/divine_video_player/lib/src/player_error_code.dart
@@ -7,6 +7,12 @@
 /// This lets Dart make reliable, platform-independent retry/failover
 /// decisions without string-parsing the raw error message.
 enum NativePlayerErrorCode {
+  /// HTTP 202 from Divine media while renditions are still processing.
+  ///
+  /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` with response code 202.
+  /// iOS: CoreMedia / AVFoundation errors whose message includes HTTP 202.
+  mediaProcessing,
+
   /// HTTP 4xx response from the media server.
   ///
   /// Android: `ERROR_CODE_IO_BAD_HTTP_STATUS` when 400–499.
@@ -57,6 +63,7 @@ enum NativePlayerErrorCode {
   /// source. HTTP 4xx/5xx and parse errors indicate the current source is not
   /// usable right now, so the feed should skip to the next available source.
   bool get shouldFailover => switch (this) {
+    mediaProcessing => false,
     httpClientError => true,
     httpServerError => true,
     parseError => true,
@@ -73,6 +80,7 @@ enum NativePlayerErrorCode {
   ///
   /// Transient conditions like network loss or timeout may resolve on retry.
   bool get isTransient => switch (this) {
+    mediaProcessing => true,
     networkError => true,
     timeout => true,
     httpServerError => false,
@@ -84,6 +92,7 @@ enum NativePlayerErrorCode {
 
   /// Parses the string value sent over the platform channel.
   static NativePlayerErrorCode fromString(String value) => switch (value) {
+    'media_processing' => mediaProcessing,
     'http_client_error' => httpClientError,
     'http_server_error' => httpServerError,
     'network_error' => networkError,

--- a/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
+++ b/mobile/packages/divine_video_player/test/src/video_player_state_test.dart
@@ -4,6 +4,10 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group(NativePlayerErrorCode, () {
     group('shouldFailover', () {
+      test('returns false for mediaProcessing', () {
+        expect(NativePlayerErrorCode.mediaProcessing.shouldFailover, isFalse);
+      });
+
       test('returns true for httpClientError', () {
         expect(NativePlayerErrorCode.httpClientError.shouldFailover, isTrue);
       });
@@ -34,6 +38,10 @@ void main() {
     });
 
     group('isTransient', () {
+      test('returns true for mediaProcessing', () {
+        expect(NativePlayerErrorCode.mediaProcessing.isTransient, isTrue);
+      });
+
       test('returns true for networkError', () {
         expect(NativePlayerErrorCode.networkError.isTransient, isTrue);
       });
@@ -64,6 +72,13 @@ void main() {
     });
 
     group('fromString', () {
+      test('parses media_processing', () {
+        expect(
+          NativePlayerErrorCode.fromString('media_processing'),
+          equals(NativePlayerErrorCode.mediaProcessing),
+        );
+      });
+
       test('parses http_client_error', () {
         expect(
           NativePlayerErrorCode.fromString('http_client_error'),
@@ -388,10 +403,7 @@ void main() {
         final copy = original.copyWith(status: PlaybackStatus.idle);
 
         expect(copy.errorMessage, equals('boom'));
-        expect(
-          copy.errorCode,
-          equals(NativePlayerErrorCode.networkError),
-        );
+        expect(copy.errorCode, equals(NativePlayerErrorCode.networkError));
       });
     });
 
@@ -486,9 +498,9 @@ void main() {
       });
 
       test('defaults unknown status to idle', () {
-        final state = DivineVideoPlayerState.fromMap(
-          {'status': 'unknown_status'},
-        );
+        final state = DivineVideoPlayerState.fromMap({
+          'status': 'unknown_status',
+        });
         expect(state.status, equals(PlaybackStatus.idle));
       });
 
@@ -514,9 +526,7 @@ void main() {
       });
 
       test('includes error message when present', () {
-        const state = DivineVideoPlayerState(
-          status: PlaybackStatus.error,
-        );
+        const state = DivineVideoPlayerState(status: PlaybackStatus.error);
         expect(state.toString(), contains('error'));
       });
 

--- a/mobile/packages/infinite_video_feed/lib/src/services/disk_prefetcher.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/disk_prefetcher.dart
@@ -4,6 +4,8 @@ import 'dart:io';
 import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart';
 
+const _defaultProcessingRetryAfter = Duration(seconds: 15);
+
 /// Resolves the URL to download for [video], or `null` to skip.
 typedef PrefetchUrlResolver = String? Function(VideoEvent video);
 
@@ -30,13 +32,17 @@ class DiskPrefetcher {
     required MediaCacheManager cache,
     required void Function(String message) log,
     Duration stallTimeout = const Duration(seconds: 8),
+    DateTime Function() now = DateTime.now,
   }) : _cache = cache,
        _log = log,
-       _stallTimeout = stallTimeout;
+       _stallTimeout = stallTimeout,
+       _now = now;
 
   final MediaCacheManager _cache;
   final void Function(String) _log;
   final Duration _stallTimeout;
+  final DateTime Function() _now;
+  final _processingRetryAfterByVideoId = <String, DateTime>{};
 
   CancellableCacheOperation? _active;
   int _generation = 0;
@@ -125,9 +131,7 @@ class DiskPrefetcher {
     _cycleVideos = videos;
     _cycleResolveUrls = resolveUrls;
 
-    _log(
-      'Prefetch cycle #$generation: range=[$startIndex..$endIndex]',
-    );
+    _log('Prefetch cycle #$generation: range=[$startIndex..$endIndex]');
 
     for (var i = startIndex; i <= _cycleEndIndex; i++) {
       if (isDisposed) return;
@@ -142,6 +146,18 @@ class DiskPrefetcher {
       if (_cache.getCachedFileSync(video.id) != null) {
         _log('Prefetch skip index $i — already cached (${video.id})');
         continue;
+      }
+
+      final retryAfter = _processingRetryAfterByVideoId[video.id];
+      if (retryAfter != null) {
+        if (_now().isBefore(retryAfter)) {
+          _log(
+            'Prefetch skip index $i — media processing (${video.id}) '
+            'retryAfter=${retryAfter.toIso8601String()}',
+          );
+          continue;
+        }
+        _processingRetryAfterByVideoId.remove(video.id);
       }
 
       final urls = _cycleResolveUrls(video);
@@ -192,10 +208,10 @@ class DiskPrefetcher {
       _active = op;
       _activeIndex = index;
 
-      File? file;
+      CancellableDownloadResult? result;
       var didStall = false;
       try {
-        file = await op.file.timeout(_stallTimeout);
+        result = await op.result.timeout(_stallTimeout);
       } on TimeoutException {
         didStall = true;
         op.cancel();
@@ -211,8 +227,19 @@ class DiskPrefetcher {
         return;
       }
 
-      if (file != null) {
+      if (result?.file != null) {
         _log('Prefetch completed index $index ($videoId)');
+        return;
+      }
+
+      if (result?.statusCode == 202) {
+        final retryAfter = _retryAfterFromHeaders(result!.headers);
+        final nextAttemptAt = _now().add(retryAfter);
+        _processingRetryAfterByVideoId[videoId] = nextAttemptAt;
+        _log(
+          'Prefetch deferred index $index ($videoId) url=$url '
+          '— media processing, retryAfterMs=${retryAfter.inMilliseconds}',
+        );
         return;
       }
 
@@ -228,5 +255,25 @@ class DiskPrefetcher {
   void dispose() {
     isDisposed = true;
     cancelActive();
+  }
+
+  Duration _retryAfterFromHeaders(Map<String, String> headers) {
+    final value = headers['retry-after'];
+    if (value == null || value.trim().isEmpty) {
+      return _defaultProcessingRetryAfter;
+    }
+
+    final seconds = int.tryParse(value.trim());
+    if (seconds != null && seconds >= 0) {
+      return Duration(seconds: seconds);
+    }
+
+    try {
+      final date = HttpDate.parse(value);
+      final delay = date.difference(_now());
+      return delay.isNegative ? Duration.zero : delay;
+    } on HttpException {
+      return _defaultProcessingRetryAfter;
+    }
   }
 }

--- a/mobile/packages/infinite_video_feed/lib/src/services/playback_source_registry.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/services/playback_source_registry.dart
@@ -32,7 +32,6 @@ class PlaybackSourceRegistry {
   ///
   /// Returns `null` for prestart entries (active index `-1`) — no network
   /// source is in use yet, the first frame is coming from a local cache.
-  @visibleForTesting
   String? activeSourceFor(int index) {
     final list = _sources[index];
     if (list == null) return null;

--- a/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/playback_sources.dart
@@ -41,12 +41,7 @@ List<String> resolvePlaybackSources(
     // a progressive stream.
     return isRawBlob
         ? orderedUniqueSources([resolvedSource, hlsUrl, originalUrl])
-        : orderedUniqueSources([
-            resolvedSource,
-            hlsUrl,
-            rawUrl,
-            originalUrl,
-          ]);
+        : orderedUniqueSources([resolvedSource, hlsUrl, rawUrl, originalUrl]);
   }
 
   return orderedUniqueSources([resolvedSource, originalUrl]);
@@ -54,10 +49,7 @@ List<String> resolvePlaybackSources(
 
 /// Classifies a playback failure into a [VideoErrorType] using the error
 /// message and (optionally) the source that produced it.
-VideoErrorType classifyVideoError({
-  String? errorMessage,
-  String? source,
-}) {
+VideoErrorType classifyVideoError({String? errorMessage, String? source}) {
   final lower = (errorMessage ?? '').toLowerCase();
   // Divine derivative URLs can legitimately return HTTP 202 while MP4/HLS
   // processing catches up after upload. Treat that as transient playback
@@ -83,6 +75,16 @@ VideoErrorType classifyVideoError({
   }
 
   return VideoErrorType.generic;
+}
+
+/// Whether an error represents Divine media still preparing renditions.
+///
+/// Freshly-published Divine derivative URLs can return HTTP 202 while the
+/// server finishes MP4/HLS processing. Playback should retry the same source
+/// for these responses instead of treating the rendition as failed.
+bool isMediaProcessingError(Object? error, {String? errorMessage}) {
+  final lower = '${errorMessage ?? ''} ${error ?? ''}'.toLowerCase();
+  return _mentionsHttpStatus(lower, 202);
 }
 
 bool _mentionsHttpStatus(String lower, int status) {

--- a/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/utils/source_loader.dart
@@ -1,13 +1,22 @@
 import 'package:divine_video_player/divine_video_player.dart';
+import 'package:infinite_video_feed/src/utils/playback_sources.dart';
+
+const _mediaProcessingRetryDelays = <Duration>[
+  Duration(seconds: 1),
+  Duration(seconds: 2),
+  Duration(seconds: 3),
+  Duration(seconds: 5),
+  Duration(seconds: 8),
+];
+
+/// Waits before a same-source retry after media returns HTTP 202.
+typedef SourceLoadDelay = Future<void> Function(Duration duration);
 
 /// Signals that source loading was cancelled because the owning controller
 /// window moved on while fallbacks were still in flight.
 class SourceLoadAborted implements Exception {
   /// Creates an abort signal for the stale source load at [index].
-  const SourceLoadAborted({
-    required this.index,
-    required this.source,
-  });
+  const SourceLoadAborted({required this.index, required this.source});
 
   /// Feed index whose source load was aborted.
   final int index;
@@ -32,6 +41,7 @@ Future<(String, int)> setSourceWithFallbacks({
   required void Function(String) log,
   Map<String, String>? Function(String source)? httpHeadersForSource,
   bool Function()? isLoadCurrent,
+  SourceLoadDelay delay = Future<void>.delayed,
 }) async {
   Object? lastError;
   StackTrace? lastStackTrace;
@@ -60,6 +70,39 @@ Future<(String, int)> setSourceWithFallbacks({
       abortIfStale(source);
       lastError = error;
       lastStackTrace = stackTrace;
+      if (isMediaProcessingError(error)) {
+        for (final retryDelay in _mediaProcessingRetryDelays) {
+          log(
+            'Source processing index $index: '
+            'source=$source '
+            'attempt=$attemptIndex '
+            'retryInMs=${retryDelay.inMilliseconds} '
+            'error=$error',
+          );
+          await delay(retryDelay);
+          abortIfStale(source);
+          try {
+            await controller.setSource(
+              VideoClip.network(
+                source,
+                httpHeaders: httpHeadersForSource?.call(source) ?? const {},
+              ),
+            );
+            abortIfStale(source);
+            return (source, attemptIndex);
+          } on SourceLoadAborted {
+            rethrow;
+          } on Object catch (retryError, retryStackTrace) {
+            abortIfStale(source);
+            lastError = retryError;
+            lastStackTrace = retryStackTrace;
+            if (isMediaProcessingError(retryError)) {
+              continue;
+            }
+            break;
+          }
+        }
+      }
       final nextAttempt = attemptIndex + 1;
       if (nextAttempt < sources.length) {
         log(
@@ -67,7 +110,7 @@ Future<(String, int)> setSourceWithFallbacks({
           'failedSource=$source '
           'retrySource=${sources[nextAttempt]} '
           'attempt=$attemptIndex '
-          'error=$error',
+          'error=$lastError',
         );
         continue;
       }
@@ -76,7 +119,7 @@ Future<(String, int)> setSourceWithFallbacks({
         'All sources failed index $index: '
         'failedSource=$source '
         'attempt=$attemptIndex '
-        'error=$error',
+        'error=$lastError',
       );
     }
   }

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -19,6 +19,14 @@ import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+const _runtimeProcessingRetryDelays = <Duration>[
+  Duration(seconds: 1),
+  Duration(seconds: 2),
+  Duration(seconds: 3),
+  Duration(seconds: 5),
+  Duration(seconds: 8),
+];
+
 /// Infinite scrolling video feed using native platform video players.
 ///
 /// Manages [DivineVideoPlayerController] instances for the current and
@@ -71,7 +79,7 @@ class InfiniteVideoFeed extends StatefulWidget {
           Platform.isAndroid ||
           Platform.isIOS ||
           Platform.isMacOS ||
-          Platform.isLinux);
+          Platform.isLinux); // coverage:ignore-line
 
   static bool? _isSupportedOverrideForTesting;
 
@@ -349,6 +357,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   // — this guard prevents them from re-triggering failover or showing
   // the error UI on top of a successfully recovered controller.
   final _failoverInFlight = <int>{};
+  final _processingRetryInFlight = <int>{};
+  final _processingRetryAttempts = <int, int>{};
 
   // Indices whose initial source was the on-disk cache file. If a runtime
   // error fires for one of these we evict the cached file so future loads
@@ -953,6 +963,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
     _loopSeekInProgress.clear();
     _failoverInFlight.clear();
+    _processingRetryInFlight.clear();
+    _processingRetryAttempts.clear();
     _loadedFromCache.clear();
     _errors.clear();
     _errorTypes.clear();
@@ -979,6 +991,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _errors.remove(index);
     _loopSeekInProgress.remove(index);
     _failoverInFlight.remove(index);
+    _processingRetryInFlight.remove(index);
+    _processingRetryAttempts.remove(index);
     _loadedFromCache.remove(index);
     _errorTypes.remove(index);
     _httpHeadersByIndex.remove(index);
@@ -1215,6 +1229,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   }) async {
     _errors.remove(index);
     _errorTypes.remove(index);
+    _processingRetryInFlight.remove(index);
+    _processingRetryAttempts.remove(index);
     if (httpHeaders.isEmpty) {
       _httpHeadersByIndex.remove(index);
     } else {
@@ -1296,6 +1312,86 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       _onVideoStalled(index);
     } finally {
       _failoverInFlight.remove(index);
+    }
+  }
+
+  Future<void> _retryCurrentProcessingSource(
+    int index,
+    Object? errorMessage,
+  ) async {
+    if (_processingRetryInFlight.contains(index)) return;
+
+    final source = _sources.activeSourceFor(index);
+    if (source == null) {
+      _log('No active source to retry for processing index $index');
+      _stopAndMarkError(index, VideoErrorType.generic);
+      return;
+    }
+
+    final attempt = _processingRetryAttempts[index] ?? 0;
+    if (attempt >= _runtimeProcessingRetryDelays.length) {
+      _log(
+        'Processing retry exhausted index $index: '
+        'source=$source error=$errorMessage',
+      );
+      _stopAndMarkError(index, VideoErrorType.generic);
+      return;
+    }
+
+    final controller = _controllers[index];
+    if (controller == null) return;
+
+    final delay = _runtimeProcessingRetryDelays[attempt];
+    _processingRetryAttempts[index] = attempt + 1;
+    _processingRetryInFlight.add(index);
+    var retryProcessingAgain = false;
+    _log(
+      'Processing retry index $index: '
+      'source=$source retryInMs=${delay.inMilliseconds} '
+      'attempt=${attempt + 1}/${_runtimeProcessingRetryDelays.length}',
+    );
+
+    try {
+      await Future<void>.delayed(delay);
+      if (!mounted || !_controllers.containsKey(index)) return;
+      await controller.stop();
+      await controller.setSource(
+        VideoClip.network(
+          source,
+          httpHeaders: _httpHeadersByIndex[index] ?? const {},
+        ),
+      );
+      if (index == _currentIndex && _isActive && _canAutoPlayAt(index)) {
+        await controller.setVolume(_volume);
+        await controller.play();
+        if (index == _currentIndex && _isActive) {
+          _watchdog.start(index, controller);
+          _staleDetector.resetGrace();
+        }
+      }
+      _processingRetryAttempts.remove(index);
+    } on Object catch (e, stackTrace) {
+      _log('Processing retry failed index $index source=$source: $e');
+      Log.error(
+        'Processing retry failed',
+        name: _logName,
+        category: LogCategory.video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      if (isMediaProcessingError(e)) {
+        retryProcessingAgain = true;
+      } else {
+        _stopAndMarkError(
+          index,
+          classifyVideoError(errorMessage: e.toString(), source: source),
+        );
+      }
+    } finally {
+      _processingRetryInFlight.remove(index);
+    }
+    if (retryProcessingAgain) {
+      unawaited(_retryCurrentProcessingSource(index, errorMessage));
     }
   }
   // coverage:ignore-end
@@ -1397,7 +1493,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         index,
         controller,
         isAlreadyError: () =>
-            _errors.contains(index) || _failoverInFlight.contains(index),
+            _errors.contains(index) ||
+            _failoverInFlight.contains(index) ||
+            _processingRetryInFlight.contains(index),
         onError: (errorCode, errorMessage) {
           _log(
             'Runtime playback error at index '
@@ -1406,6 +1504,12 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
           );
           _watchdog.stop(index);
           if (index == _currentIndex) _staleDetector.stop();
+
+          if (errorCode == NativePlayerErrorCode.mediaProcessing ||
+              isMediaProcessingError(errorMessage)) {
+            unawaited(_retryCurrentProcessingSource(index, errorMessage));
+            return;
+          }
 
           // Use the typed error code for a reliable failover decision.
           // Fall back to attempting failover for unknown errors so we

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1321,10 +1321,28 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   ) async {
     if (_processingRetryInFlight.contains(index)) return;
 
+    final controller = _controllers[index];
+    if (controller == null) return;
+    final retryGeneration = _controllerInitGenerations[index];
+
+    bool ownsRetry() {
+      return mounted &&
+          _controllerInitGenerations[index] == retryGeneration &&
+          identical(_controllers[index], controller);
+    }
+
+    bool guardRetryOwnership(String step) {
+      if (ownsRetry()) return true;
+      _log('Abort stale processing retry at index $index during $step');
+      return false;
+    }
+
     final source = _sources.activeSourceFor(index);
     if (source == null) {
       _log('No active source to retry for processing index $index');
-      _stopAndMarkError(index, VideoErrorType.generic);
+      if (ownsRetry()) {
+        _stopAndMarkError(index, VideoErrorType.generic);
+      }
       return;
     }
 
@@ -1334,12 +1352,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         'Processing retry exhausted index $index: '
         'source=$source error=$errorMessage',
       );
-      _stopAndMarkError(index, VideoErrorType.generic);
+      if (ownsRetry()) {
+        _stopAndMarkError(index, VideoErrorType.generic);
+      }
       return;
     }
-
-    final controller = _controllers[index];
-    if (controller == null) return;
 
     final delay = _runtimeProcessingRetryDelays[attempt];
     _processingRetryAttempts[index] = attempt + 1;
@@ -1353,17 +1370,21 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
     try {
       await Future<void>.delayed(delay);
-      if (!mounted || !_controllers.containsKey(index)) return;
+      if (!guardRetryOwnership('delay')) return;
       await controller.stop();
+      if (!guardRetryOwnership('stop')) return;
       await controller.setSource(
         VideoClip.network(
           source,
           httpHeaders: _httpHeadersByIndex[index] ?? const {},
         ),
       );
+      if (!guardRetryOwnership('setSource')) return;
       if (index == _currentIndex && _isActive && _canAutoPlayAt(index)) {
         await controller.setVolume(_volume);
+        if (!guardRetryOwnership('setVolume')) return;
         await controller.play();
+        if (!guardRetryOwnership('play')) return;
         if (index == _currentIndex && _isActive) {
           _watchdog.start(index, controller);
           _staleDetector.resetGrace();
@@ -1371,6 +1392,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       }
       _processingRetryAttempts.remove(index);
     } on Object catch (e, stackTrace) {
+      if (!ownsRetry()) {
+        guardRetryOwnership('error handling');
+        return;
+      }
       _log('Processing retry failed index $index source=$source: $e');
       Log.error(
         'Processing retry failed',
@@ -1388,9 +1413,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         );
       }
     } finally {
-      _processingRetryInFlight.remove(index);
+      if (ownsRetry()) {
+        _processingRetryInFlight.remove(index);
+      }
     }
-    if (retryProcessingAgain) {
+    if (retryProcessingAgain && ownsRetry()) {
       unawaited(_retryCurrentProcessingSource(index, errorMessage));
     }
   }

--- a/mobile/packages/infinite_video_feed/test/src/services/disk_prefetcher_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/services/disk_prefetcher_test.dart
@@ -78,13 +78,8 @@ void main() {
 
         when(() => cache.getCachedFileSync('id3')).thenReturn(null);
         when(
-          () => cache.cacheFileCancellable(
-            url,
-            key: 'id3',
-          ),
-        ).thenReturn(
-          CancellableCacheOperation.completed(mockFile),
-        );
+          () => cache.cacheFileCancellable(url, key: 'id3'),
+        ).thenReturn(CancellableCacheOperation.completed(mockFile));
 
         final videos = [_makeVideo('id3', url: url)];
 
@@ -95,12 +90,7 @@ void main() {
           resolveUrls: (v) => [if (v.videoUrl != null) v.videoUrl!],
         );
 
-        verify(
-          () => cache.cacheFileCancellable(
-            url,
-            key: 'id3',
-          ),
-        ).called(1);
+        verify(() => cache.cacheFileCancellable(url, key: 'id3')).called(1);
         expect(logs.any((l) => l.contains('completed')), isTrue);
       });
 
@@ -110,10 +100,7 @@ void main() {
         // endIndex 5 is out of bounds; should not throw.
         when(() => cache.getCachedFileSync(any())).thenReturn(null);
         when(
-          () => cache.cacheFileCancellable(
-            any(),
-            key: any(named: 'key'),
-          ),
+          () => cache.cacheFileCancellable(any(), key: any(named: 'key')),
         ).thenReturn(CancellableCacheOperation.completed(_MockFile()));
 
         await prefetcher.run(
@@ -125,10 +112,7 @@ void main() {
 
         // Only id4 at index 0 is valid; no exception thrown.
         verify(
-          () => cache.cacheFileCancellable(
-            any(),
-            key: any(named: 'key'),
-          ),
+          () => cache.cacheFileCancellable(any(), key: any(named: 'key')),
         ).called(1);
       });
 
@@ -148,10 +132,7 @@ void main() {
           final downloadCompleter = _ManualCompleter<File?>();
           when(() => slowCache.getCachedFileSync(any())).thenReturn(null);
           when(
-            () => slowCache.cacheFileCancellable(
-              any(),
-              key: any(named: 'key'),
-            ),
+            () => slowCache.cacheFileCancellable(any(), key: any(named: 'key')),
           ).thenAnswer((_) {
             secondRunStarted = true;
             return _PendingOperation(downloadCompleter.future);
@@ -210,13 +191,8 @@ void main() {
           final downloadCompleter = _ManualCompleter<File?>();
           when(() => slowCache.getCachedFileSync(any())).thenReturn(null);
           when(
-            () => slowCache.cacheFileCancellable(
-              any(),
-              key: any(named: 'key'),
-            ),
-          ).thenAnswer(
-            (_) => _PendingOperation(downloadCompleter.future),
-          );
+            () => slowCache.cacheFileCancellable(any(), key: any(named: 'key')),
+          ).thenAnswer((_) => _PendingOperation(downloadCompleter.future));
 
           final videos = List.generate(
             10,
@@ -247,17 +223,11 @@ void main() {
             ),
           );
 
-          expect(
-            logs2.any((l) => l.contains('still active')),
-            isTrue,
-          );
+          expect(logs2.any((l) => l.contains('still active')), isTrue);
 
           // Only one cacheFileCancellable call — the second run skipped.
           verify(
-            () => slowCache.cacheFileCancellable(
-              any(),
-              key: any(named: 'key'),
-            ),
+            () => slowCache.cacheFileCancellable(any(), key: any(named: 'key')),
           ).called(1);
 
           downloadCompleter.complete(null);
@@ -271,10 +241,7 @@ void main() {
 
         when(() => cache.getCachedFileSync('id_fail')).thenReturn(null);
         when(
-          () => cache.cacheFileCancellable(
-            url,
-            key: 'id_fail',
-          ),
+          () => cache.cacheFileCancellable(url, key: 'id_fail'),
         ).thenAnswer((_) => _PendingOperation(failCompleter.future));
 
         final videos = [_makeVideo('id_fail', url: url)];
@@ -290,6 +257,219 @@ void main() {
         await runFuture;
 
         expect(logs.any((l) => l.contains('failed')), isTrue);
+      });
+
+      test('defers HTTP 202 prefetch without trying fallback URL', () async {
+        var now = DateTime.utc(2026, 6, 25);
+        final processingPrefetcher = DiskPrefetcher(
+          cache: cache,
+          log: logs.add,
+          now: () => now,
+        );
+        addTearDown(processingPrefetcher.dispose);
+
+        when(() => cache.getCachedFileSync('id_processing')).thenReturn(null);
+        when(
+          () => cache.cacheFileCancellable(
+            'http://example.com/processing.mp4',
+            key: 'id_processing',
+          ),
+        ).thenReturn(
+          _PendingResultOperation.completed(
+            const CancellableDownloadResult(
+              file: null,
+              statusCode: 202,
+              headers: {'retry-after': '20'},
+            ),
+          ),
+        );
+
+        final videos = [_makeVideo('id_processing')];
+
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const [
+            'http://example.com/processing.mp4',
+            'http://example.com/fallback.mp4',
+          ],
+        );
+
+        verifyNever(
+          () => cache.cacheFileCancellable(
+            'http://example.com/fallback.mp4',
+            key: any(named: 'key'),
+            aliasKey: any(named: 'aliasKey'),
+          ),
+        );
+        expect(logs.any((l) => l.contains('media processing')), isTrue);
+
+        logs.clear();
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const [
+            'http://example.com/processing.mp4',
+            'http://example.com/fallback.mp4',
+          ],
+        );
+
+        expect(logs.any((l) => l.contains('Prefetch skip')), isTrue);
+
+        now = now.add(const Duration(seconds: 21));
+        logs.clear();
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const [
+            'http://example.com/processing.mp4',
+            'http://example.com/fallback.mp4',
+          ],
+        );
+
+        verify(
+          () => cache.cacheFileCancellable(
+            'http://example.com/processing.mp4',
+            key: 'id_processing',
+          ),
+        ).called(2);
+      });
+
+      test('defers HTTP 202 prefetch until Retry-After HTTP date', () async {
+        var now = DateTime.utc(2026, 6, 25, 12);
+        final processingPrefetcher = DiskPrefetcher(
+          cache: cache,
+          log: logs.add,
+          now: () => now,
+        );
+        addTearDown(processingPrefetcher.dispose);
+
+        when(
+          () => cache.getCachedFileSync('id_processing_date'),
+        ).thenReturn(null);
+        when(
+          () => cache.cacheFileCancellable(
+            'http://example.com/processing.mp4',
+            key: 'id_processing_date',
+          ),
+        ).thenReturn(
+          _PendingResultOperation.completed(
+            CancellableDownloadResult(
+              file: null,
+              statusCode: 202,
+              headers: {
+                'retry-after': HttpDate.format(
+                  now.add(const Duration(seconds: 30)),
+                ),
+              },
+            ),
+          ),
+        );
+
+        final videos = [_makeVideo('id_processing_date')];
+
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const ['http://example.com/processing.mp4'],
+        );
+
+        logs.clear();
+        now = now.add(const Duration(seconds: 29));
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const ['http://example.com/processing.mp4'],
+        );
+
+        expect(logs.any((l) => l.contains('Prefetch skip')), isTrue);
+
+        logs.clear();
+        now = now.add(const Duration(seconds: 1));
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const ['http://example.com/processing.mp4'],
+        );
+
+        expect(logs.any((l) => l.contains('media processing')), isTrue);
+        verify(
+          () => cache.cacheFileCancellable(
+            'http://example.com/processing.mp4',
+            key: 'id_processing_date',
+          ),
+        ).called(2);
+      });
+
+      test('uses default retry delay for invalid Retry-After header', () async {
+        var now = DateTime.utc(2026, 6, 25, 12);
+        final processingPrefetcher = DiskPrefetcher(
+          cache: cache,
+          log: logs.add,
+          now: () => now,
+        );
+        addTearDown(processingPrefetcher.dispose);
+
+        when(
+          () => cache.getCachedFileSync('id_processing_invalid'),
+        ).thenReturn(null);
+        when(
+          () => cache.cacheFileCancellable(
+            'http://example.com/processing.mp4',
+            key: 'id_processing_invalid',
+          ),
+        ).thenReturn(
+          _PendingResultOperation.completed(
+            const CancellableDownloadResult(
+              file: null,
+              statusCode: 202,
+              headers: {'retry-after': 'not a date'},
+            ),
+          ),
+        );
+
+        final videos = [_makeVideo('id_processing_invalid')];
+
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const ['http://example.com/processing.mp4'],
+        );
+
+        logs.clear();
+        now = now.add(const Duration(seconds: 14));
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const ['http://example.com/processing.mp4'],
+        );
+
+        expect(logs.any((l) => l.contains('Prefetch skip')), isTrue);
+
+        logs.clear();
+        now = now.add(const Duration(seconds: 1));
+        await processingPrefetcher.run(
+          startIndex: 0,
+          endIndex: 0,
+          videos: videos,
+          resolveUrls: (_) => const ['http://example.com/processing.mp4'],
+        );
+
+        expect(logs.any((l) => l.contains('media processing')), isTrue);
+        verify(
+          () => cache.cacheFileCancellable(
+            'http://example.com/processing.mp4',
+            key: 'id_processing_invalid',
+          ),
+        ).called(2);
       });
 
       test(
@@ -428,6 +608,30 @@ class _PendingOperation implements CancellableCacheOperation {
 
   @override
   Future<File?> get file => _fileFuture;
+
+  @override
+  Future<CancellableDownloadResult> get result async =>
+      CancellableDownloadResult(file: await _fileFuture);
+
+  @override
+  bool get isCancelled => _cancelled;
+  bool _cancelled = false;
+
+  @override
+  void cancel() => _cancelled = true;
+}
+
+class _PendingResultOperation implements CancellableCacheOperation {
+  _PendingResultOperation.completed(CancellableDownloadResult result)
+    : _resultFuture = Future<CancellableDownloadResult>.value(result);
+
+  final Future<CancellableDownloadResult> _resultFuture;
+
+  @override
+  Future<File?> get file async => (await _resultFuture).file;
+
+  @override
+  Future<CancellableDownloadResult> get result => _resultFuture;
 
   @override
   bool get isCancelled => _cancelled;

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -64,10 +64,7 @@ void main() {
         'returns [hlsUrl, rawUrl] deduplicated when originalUrl equals hlsUrl',
         () {
           final video = _makeVideo(videoUrl: _hlsUrl);
-          expect(
-            resolvePlaybackSources(video),
-            equals([_hlsUrl, _rawUrl]),
-          );
+          expect(resolvePlaybackSources(video), equals([_hlsUrl, _rawUrl]));
         },
       );
     });
@@ -76,10 +73,7 @@ void main() {
       test('returns [rawUrl, hlsUrl, originalUrl] deduplicated', () {
         final video = _makeVideo(videoUrl: _rawUrl);
         // raw == original → [rawUrl, hlsUrl]
-        expect(
-          resolvePlaybackSources(video),
-          equals([_rawUrl, _hlsUrl]),
-        );
+        expect(resolvePlaybackSources(video), equals([_rawUrl, _hlsUrl]));
       });
 
       test('includes originalUrl when it differs from rawUrl', () {
@@ -111,10 +105,7 @@ void main() {
     group('with resolver returning null', () {
       test('falls back to videoUrl', () {
         final video = _makeVideo(videoUrl: 'https://example.com/video.mp4');
-        final result = resolvePlaybackSources(
-          video,
-          urlResolver: (_) => null,
-        );
+        final result = resolvePlaybackSources(video, urlResolver: (_) => null);
         expect(result, equals(['https://example.com/video.mp4']));
       });
     });
@@ -122,10 +113,7 @@ void main() {
     group('with resolver returning empty string', () {
       test('falls back to videoUrl', () {
         final video = _makeVideo(videoUrl: 'https://example.com/video.mp4');
-        final result = resolvePlaybackSources(
-          video,
-          urlResolver: (_) => '',
-        );
+        final result = resolvePlaybackSources(video, urlResolver: (_) => '');
         expect(result, equals(['https://example.com/video.mp4']));
       });
     });
@@ -226,6 +214,31 @@ void main() {
       expect(
         classifyVideoError(source: 'https://example.com/video.mp4'),
         equals(VideoErrorType.generic),
+      );
+    });
+  });
+
+  group('isMediaProcessingError', () {
+    test('matches iOS CoreMedia HTTP 202 messages', () {
+      expect(
+        isMediaProcessingError(
+          Exception('CoreMediaErrorDomain error -12667 - HTTP 202'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches Android response-code 202 messages', () {
+      expect(
+        isMediaProcessingError(Exception('Source error. Response code: 202')),
+        isTrue,
+      );
+    });
+
+    test('does not match unrelated 202 numbers', () {
+      expect(
+        isMediaProcessingError(Exception('Response completed in 2025 ms')),
+        isFalse,
       );
     });
   });

--- a/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/source_loader_test.dart
@@ -65,6 +65,105 @@ void main() {
       expect(logs.first, contains('badUrl'));
     });
 
+    test('retries same source for HTTP 202 before falling back', () async {
+      final clips = <VideoClip>[];
+      final controller = _RecordingControllerWithFailures(
+        clips.add,
+        failures: [
+          Exception('CoreMediaErrorDomain error -12667 - HTTP 202'),
+          Exception('Response code: 202'),
+        ],
+      );
+      addTearDown(controller.dispose);
+
+      final delays = <Duration>[];
+      final result = await setSourceWithFallbacks(
+        index: 2,
+        controller: controller,
+        sources: ['processingUrl', 'hlsUrl'],
+        log: logs.add,
+        delay: (duration) async => delays.add(duration),
+      );
+
+      expect(result, equals(('processingUrl', 0)));
+      expect(
+        clips.map((clip) => clip.uri),
+        equals(['processingUrl', 'processingUrl', 'processingUrl']),
+      );
+      expect(delays, hasLength(2));
+      expect(
+        logs.where((line) => line.contains('Source processing')),
+        hasLength(2),
+      );
+      expect(logs.any((line) => line.contains('retrySource=hlsUrl')), isFalse);
+    });
+
+    test('uses source headers when retrying after HTTP 202', () async {
+      final clips = <VideoClip>[];
+      final controller = _RecordingControllerWithFailures(
+        clips.add,
+        failures: [Exception('CoreMediaErrorDomain error -12667 - HTTP 202')],
+      );
+      addTearDown(controller.dispose);
+
+      const headers = {'Authorization': 'Nostr token'};
+      final result = await setSourceWithFallbacks(
+        index: 2,
+        controller: controller,
+        sources: ['processingUrl'],
+        log: logs.add,
+        httpHeadersForSource: (_) => headers,
+        delay: (_) async {},
+      );
+
+      expect(result, equals(('processingUrl', 0)));
+      expect(clips, hasLength(2));
+      expect(clips[0].httpHeaders, equals(headers));
+      expect(clips[1].httpHeaders, equals(headers));
+    });
+
+    test(
+      'falls back after bounded HTTP 202 retry budget is exhausted',
+      () async {
+        final clips = <VideoClip>[];
+        final controller = _RecordingControllerWithFailures(
+          clips.add,
+          failures: List<Exception>.filled(
+            6,
+            Exception('CoreMediaErrorDomain error -12667 - HTTP 202'),
+          ),
+        );
+        addTearDown(controller.dispose);
+
+        final result = await setSourceWithFallbacks(
+          index: 2,
+          controller: controller,
+          sources: ['processingUrl', 'hlsUrl'],
+          log: logs.add,
+          delay: (_) async {},
+        );
+
+        expect(result, equals(('hlsUrl', 1)));
+        expect(
+          clips.map((clip) => clip.uri),
+          equals([
+            'processingUrl',
+            'processingUrl',
+            'processingUrl',
+            'processingUrl',
+            'processingUrl',
+            'processingUrl',
+            'hlsUrl',
+          ]),
+        );
+        expect(
+          logs.where((line) => line.contains('Source processing')),
+          hasLength(5),
+        );
+        expect(logs.any((line) => line.contains('retrySource=hlsUrl')), isTrue);
+      },
+    );
+
     test(
       'applies the same headers to every source in the fallover chain',
       () async {
@@ -115,36 +214,30 @@ void main() {
       expect(clips[1].httpHeaders, equals(headers));
     });
 
-    test(
-      'aborts stale fallback without logging all sources failed',
-      () async {
-        var isCurrent = true;
-        final controller = _DisposedDuringFallbackController(
-          onDisposedFallback: () => isCurrent = false,
-        );
-        addTearDown(controller.dispose);
+    test('aborts stale fallback without logging all sources failed', () async {
+      var isCurrent = true;
+      final controller = _DisposedDuringFallbackController(
+        onDisposedFallback: () => isCurrent = false,
+      );
+      addTearDown(controller.dispose);
 
-        await expectLater(
-          () => setSourceWithFallbacks(
-            index: 0,
-            controller: controller,
-            sources: ['derivedMp4', 'hls', 'raw'],
-            log: logs.add,
-            isLoadCurrent: () => isCurrent,
-          ),
-          throwsA(isA<SourceLoadAborted>()),
-        );
+      await expectLater(
+        () => setSourceWithFallbacks(
+          index: 0,
+          controller: controller,
+          sources: ['derivedMp4', 'hls', 'raw'],
+          log: logs.add,
+          isLoadCurrent: () => isCurrent,
+        ),
+        throwsA(isA<SourceLoadAborted>()),
+      );
 
-        expect(controller.attempts, equals(2));
-        expect(logs, hasLength(1));
-        expect(logs.single, contains('failedSource=derivedMp4'));
-        expect(logs.single, contains('retrySource=hls'));
-        expect(
-          logs.any((line) => line.contains('All sources failed')),
-          isFalse,
-        );
-      },
-    );
+      expect(controller.attempts, equals(2));
+      expect(logs, hasLength(1));
+      expect(logs.single, contains('failedSource=derivedMp4'));
+      expect(logs.single, contains('retrySource=hls'));
+      expect(logs.any((line) => line.contains('All sources failed')), isFalse);
+    });
 
     test(
       'aborts when the controller goes stale after a source opens',
@@ -266,6 +359,23 @@ class _RecordingControllerWithOneFailure extends FakeController {
   }
 }
 
+class _RecordingControllerWithFailures extends FakeController {
+  _RecordingControllerWithFailures(this._record, {required this.failures});
+
+  final void Function(VideoClip) _record;
+  final List<Exception> failures;
+  int attempts = 0;
+
+  @override
+  Future<void> setSource(VideoClip clip) async {
+    _record(clip);
+    if (attempts < failures.length) {
+      throw failures[attempts++];
+    }
+    attempts++;
+  }
+}
+
 class _DisposedDuringFallbackController extends FakeController {
   _DisposedDuringFallbackController({required this.onDisposedFallback});
 
@@ -276,7 +386,7 @@ class _DisposedDuringFallbackController extends FakeController {
   Future<void> setSource(VideoClip clip) async {
     attempts++;
     if (attempts == 1) {
-      throw Exception('HTTP 202 Accepted');
+      throw Exception('first source error');
     }
 
     onDisposedFallback();

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -20,6 +20,7 @@ class _NativePlayerHarness {
   final WidgetTester tester;
   final List<String> methodCalls = <String>[];
   final Map<int, Completer<void>> setClipsDelays = <int, Completer<void>>{};
+  final Map<int, int> failSetClipsAfter = <int, int>{};
   final Set<int> _installedPlayerIds = <int>{};
   static const _globalChannel = MethodChannel('divine_video_player');
   static const _codec = StandardMethodCodec();
@@ -52,6 +53,14 @@ class _NativePlayerHarness {
             if (delay != null && !delay.isCompleted) {
               await delay.future;
             }
+            final failAfter = failSetClipsAfter[playerId];
+            if (failAfter != null &&
+                countCallsForPlayer(playerId, 'setClips') > failAfter) {
+              throw PlatformException(
+                code: 'stale_set_clips',
+                message: 'stale player_$playerId setClips',
+              );
+            }
           }
           return null;
         },
@@ -79,6 +88,9 @@ class _NativePlayerHarness {
 
   int countCalls(String method) =>
       methodCalls.where((call) => call.endsWith(':$method')).length;
+
+  int countCallsForPlayer(int playerId, String method) =>
+      methodCalls.where((call) => call == 'player_$playerId:$method').length;
 
   Future<void> sendEvent(int playerId, Map<Object?, Object?> event) async {
     final eventChannelName = 'divine_video_player/player_$playerId/events';
@@ -2770,6 +2782,97 @@ void main() {
           await harness.dispose();
         }
       });
+    });
+
+    group('runtime processing retry', () {
+      testWidgets(
+        'does not drive a stale controller after the slot is reinitialized',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install();
+          final key = GlobalKey<InfiniteVideoFeedState>();
+          final videos = [_makeVideo('processing_retry')];
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos,
+                  cache: cache,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            expect(key.currentState!.debugLiveControllerIndices, equals({0}));
+            expect(harness.countCallsForPlayer(0, 'setClips'), equals(1));
+
+            harness.failSetClipsAfter[0] = harness.countCallsForPlayer(
+              0,
+              'setClips',
+            );
+            await harness.sendEvent(0, const <Object?, Object?>{
+              'status': 'error',
+              'errorCode': 'media_processing',
+              'errorMessage': 'HTTP 202: media still processing',
+            });
+            await tester.pump();
+            expect(find.text('VIDEO_ERROR'), findsNothing);
+
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos,
+                  cache: cache,
+                  isActive: false,
+                  releaseCurrentWhenInactive: true,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+                ),
+              ),
+            );
+            await tester.pump();
+            expect(key.currentState!.debugLiveControllerIndices, isEmpty);
+
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos,
+                  cache: cache,
+                  releaseCurrentWhenInactive: true,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            expect(key.currentState!.debugLiveControllerIndices, equals({0}));
+            expect(harness.countCallsForPlayer(1, 'setClips'), equals(1));
+
+            await tester.pump(const Duration(milliseconds: 1100));
+            await tester.pump();
+
+            expect(harness.countCallsForPlayer(0, 'setClips'), equals(1));
+            expect(find.text('VIDEO_ERROR'), findsNothing);
+          } finally {
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
     });
   });
 }

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -134,6 +134,9 @@ void main() {
     // Stub cacheFileCancellable so DiskPrefetcher does not throw.
     final mockCancellable = _MockCancellable();
     when(() => mockCancellable.file).thenAnswer((_) async => null);
+    when(
+      () => mockCancellable.result,
+    ).thenAnswer((_) async => const CancellableDownloadResult(file: null));
     when(() => mockCancellable.isCancelled).thenReturn(false);
     when(mockCancellable.cancel).thenReturn(null);
     when(
@@ -1746,9 +1749,7 @@ void main() {
     });
 
     group('prefetch', () {
-      testWidgets('default disk prefetch window stays bounded', (
-        tester,
-      ) async {
+      testWidgets('default disk prefetch window stays bounded', (tester) async {
         DivineVideoPlayerController.resetIdCounterForTesting();
         final harness = _NativePlayerHarness(tester);
         await harness.install();
@@ -2336,9 +2337,7 @@ void main() {
 
       testWidgets(
         'fully drains when the flag turns on while already inactive',
-        (
-          tester,
-        ) async {
+        (tester) async {
           // Mirrors the production path: the home feed is backgrounded on
           // another tab (neighbours released, current kept warm) and *then* a
           // codec-heavy surface (camera/editor) opens over it.

--- a/mobile/packages/media_cache/lib/media_cache.dart
+++ b/mobile/packages/media_cache/lib/media_cache.dart
@@ -54,7 +54,11 @@ library;
 
 export 'src/cancellable_cache_operation.dart' show CancellableCacheOperation;
 export 'src/cancellable_downloader.dart'
-    show CancellableDownload, CancellableDownloader, HttpCancellableDownloader;
+    show
+        CancellableDownload,
+        CancellableDownloadResult,
+        CancellableDownloader,
+        HttpCancellableDownloader;
 export 'src/media_cache_image_provider.dart' show MediaCacheImageProvider;
 export 'src/media_cache_manager.dart'
     show CacheMetrics, MediaCacheConfig, MediaCacheManager;

--- a/mobile/packages/media_cache/lib/src/cancellable_cache_operation.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_cache_operation.dart
@@ -23,7 +23,7 @@ import 'package:unified_logger/unified_logger.dart';
 class CancellableCacheOperation {
   /// Creates an already-completed operation holding [file].
   CancellableCacheOperation.completed(File file) {
-    _completer.complete(file);
+    _completer.complete(CancellableDownloadResult(file: file));
   }
 
   /// Creates a pending operation backed by [stream].
@@ -47,7 +47,7 @@ class CancellableCacheOperation {
           );
           if (response is FileInfo && !_completer.isCompleted) {
             onCached?.call(cacheKey ?? '', response.file.path);
-            _completer.complete(response.file);
+            _completer.complete(CancellableDownloadResult(file: response.file));
           }
         },
         onError: (Object error) {
@@ -56,7 +56,9 @@ class CancellableCacheOperation {
             name: 'MediaCache',
             category: LogCategory.video,
           );
-          if (!_completer.isCompleted) _completer.complete();
+          if (!_completer.isCompleted) {
+            _completer.complete(const CancellableDownloadResult(file: null));
+          }
         },
         onDone: () {
           Log.debug(
@@ -65,12 +67,16 @@ class CancellableCacheOperation {
             name: 'MediaCache',
             category: LogCategory.video,
           );
-          if (!_completer.isCompleted) _completer.complete();
+          if (!_completer.isCompleted) {
+            _completer.complete(const CancellableDownloadResult(file: null));
+          }
         },
         cancelOnError: true,
       );
     } on Object {
-      if (!_completer.isCompleted) _completer.complete();
+      if (!_completer.isCompleted) {
+        _completer.complete(const CancellableDownloadResult(file: null));
+      }
     }
   }
 
@@ -88,8 +94,9 @@ class CancellableCacheOperation {
   }) {
     _download = download;
     unawaited(
-      download.file
-          .then((file) {
+      download.result
+          .then((result) {
+            final file = result.file;
             Log.debug(
               'CancellableCacheOp[$cacheKey]: download done '
               '(file=${file?.path}, cancelled=$_isCancelled)',
@@ -98,15 +105,21 @@ class CancellableCacheOperation {
             );
             if (_completer.isCompleted) return;
             if (file != null && !_isCancelled) onCached?.call(file);
-            _completer.complete(_isCancelled ? null : file);
+            _completer.complete(
+              _isCancelled
+                  ? const CancellableDownloadResult(file: null)
+                  : result,
+            );
           })
           .catchError((Object _) {
-            if (!_completer.isCompleted) _completer.complete();
+            if (!_completer.isCompleted) {
+              _completer.complete(const CancellableDownloadResult(file: null));
+            }
           }),
     );
   }
 
-  final _completer = Completer<File?>();
+  final _completer = Completer<CancellableDownloadResult>();
   StreamSubscription<FileResponse>? _subscription;
   CancellableDownload? _download;
   bool _isCancelled = false;
@@ -114,7 +127,10 @@ class CancellableCacheOperation {
   /// The cached file when the download completes.
   ///
   /// Returns `null` if the operation was cancelled or failed.
-  Future<File?> get file => _completer.future;
+  Future<File?> get file async => (await result).file;
+
+  /// The completed download result.
+  Future<CancellableDownloadResult> get result => _completer.future;
 
   /// Whether this operation has been cancelled.
   bool get isCancelled => _isCancelled;
@@ -129,6 +145,8 @@ class CancellableCacheOperation {
     _isCancelled = true;
     _download?.cancel();
     unawaited(_subscription?.cancel());
-    if (!_completer.isCompleted) _completer.complete();
+    if (!_completer.isCompleted) {
+      _completer.complete(const CancellableDownloadResult(file: null));
+    }
   }
 }

--- a/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
@@ -4,6 +4,25 @@ import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:unified_logger/unified_logger.dart';
 
+/// Result of a cancellable HTTP download.
+class CancellableDownloadResult {
+  /// Creates a download result.
+  const CancellableDownloadResult({
+    required this.file,
+    this.statusCode,
+    this.headers = const {},
+  });
+
+  /// The completed file, or `null` when the download failed or was cancelled.
+  final File? file;
+
+  /// HTTP response status when headers were received.
+  final int? statusCode;
+
+  /// HTTP response headers, lower-cased by `package:http`.
+  final Map<String, String> headers;
+}
+
 /// Handle to an in-progress HTTP download writing to a single target file.
 ///
 /// Cancelling tears down the underlying HTTP socket immediately and removes
@@ -11,7 +30,10 @@ import 'package:unified_logger/unified_logger.dart';
 abstract class CancellableDownload {
   /// Resolves to the downloaded file when complete, or `null` on failure
   /// or cancellation.
-  Future<File?> get file;
+  Future<File?> get file async => (await result).file;
+
+  /// Resolves to the completed download result.
+  Future<CancellableDownloadResult> get result;
 
   /// Whether this download has been cancelled.
   bool get isCancelled;
@@ -85,9 +107,7 @@ class HttpCancellableDownloader implements CancellableDownloader {
     for (final download in activeDownloads) {
       download.cancel();
     }
-    await Future.wait<File?>(
-      activeDownloads.map((download) => download.file),
-    );
+    await Future.wait<File?>(activeDownloads.map((download) => download.file));
     _client.close();
   }
 }
@@ -107,7 +127,7 @@ class _HttpDownload implements CancellableDownload {
   final Map<String, String>? _headers;
   final void Function(_HttpDownload download) onComplete;
 
-  final _completer = Completer<File?>();
+  final _completer = Completer<CancellableDownloadResult>();
   final _abortCompleter = Completer<void>();
   // ignore: cancel_subscriptions, owned across cancel/stream lifecycle methods.
   StreamSubscription<List<int>>? _subscription;
@@ -116,7 +136,10 @@ class _HttpDownload implements CancellableDownload {
   bool _isDone = false;
 
   @override
-  Future<File?> get file => _completer.future;
+  Future<CancellableDownloadResult> get result => _completer.future;
+
+  @override
+  Future<File?> get file async => (await result).file;
 
   @override
   bool get isCancelled => _isCancelled;
@@ -130,7 +153,7 @@ class _HttpDownload implements CancellableDownload {
           name: 'MediaCache',
           category: LogCategory.video,
         );
-        _safeComplete(null);
+        _safeComplete(const CancellableDownloadResult(file: null));
         return;
       }
 
@@ -145,7 +168,13 @@ class _HttpDownload implements CancellableDownload {
       final response = await _client.send(req);
       if (_isCancelled) {
         unawaited(response.stream.drain<void>());
-        _safeComplete(null);
+        _safeComplete(
+          CancellableDownloadResult(
+            file: null,
+            statusCode: response.statusCode,
+            headers: response.headers,
+          ),
+        );
         return;
       }
       if (response.statusCode != HttpStatus.ok) {
@@ -155,7 +184,13 @@ class _HttpDownload implements CancellableDownload {
           category: LogCategory.video,
         );
         unawaited(response.stream.drain<void>());
-        _safeComplete(null);
+        _safeComplete(
+          CancellableDownloadResult(
+            file: null,
+            statusCode: response.statusCode,
+            headers: response.headers,
+          ),
+        );
         return;
       }
 
@@ -184,7 +219,7 @@ class _HttpDownload implements CancellableDownload {
             );
           }
           await _cleanupPartial();
-          _safeComplete(null);
+          _safeComplete(const CancellableDownloadResult(file: null));
         },
         onDone: () async {
           // Mark as done before async finalization so cancel() cannot race
@@ -200,11 +235,23 @@ class _HttpDownload implements CancellableDownload {
           // coverage:ignore-start
           if (_isCancelled) {
             await _safeDelete();
-            _safeComplete(null);
+            _safeComplete(
+              CancellableDownloadResult(
+                file: null,
+                statusCode: response.statusCode,
+                headers: response.headers,
+              ),
+            );
             return;
           }
           // coverage:ignore-end
-          _safeComplete(_file);
+          _safeComplete(
+            CancellableDownloadResult(
+              file: _file,
+              statusCode: response.statusCode,
+              headers: response.headers,
+            ),
+          );
         },
         cancelOnError: true,
       );
@@ -220,7 +267,7 @@ class _HttpDownload implements CancellableDownload {
         );
       }
       await _cleanupPartial();
-      _safeComplete(null);
+      _safeComplete(const CancellableDownloadResult(file: null));
     }
   }
 
@@ -242,9 +289,9 @@ class _HttpDownload implements CancellableDownload {
     }
   }
 
-  void _safeComplete(File? f) {
+  void _safeComplete(CancellableDownloadResult result) {
     if (_completer.isCompleted) return;
-    _completer.complete(f);
+    _completer.complete(result);
     onComplete(this);
   }
 
@@ -263,17 +310,23 @@ class _HttpDownload implements CancellableDownload {
     unawaited(
       subscription.cancel().whenComplete(() async {
         await _cleanupPartial();
-        _safeComplete(null);
+        _safeComplete(const CancellableDownloadResult(file: null));
       }),
     );
   }
 }
 
 class _CompletedDownload implements CancellableDownload {
-  _CompletedDownload(File? file) : file = Future<File?>.value(file);
+  _CompletedDownload(File? file)
+    : result = Future<CancellableDownloadResult>.value(
+        CancellableDownloadResult(file: file),
+      );
 
   @override
-  final Future<File?> file;
+  final Future<CancellableDownloadResult> result;
+
+  @override
+  Future<File?> get file async => (await result).file;
 
   @override
   bool get isCancelled => false;

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -549,44 +549,42 @@ class MediaCacheManager extends CacheManager {
     final completer = Completer<File?>();
     _pendingCacheOperations[key] = completer;
 
-    unawaited(
-      () async {
-        try {
-          final fileInfo = await downloadFile(
-            url,
-            key: key,
-            authHeaders: authHeaders ?? {},
-          );
+    unawaited(() async {
+      try {
+        final fileInfo = await downloadFile(
+          url,
+          key: key,
+          authHeaders: authHeaders ?? {},
+        );
 
-          if (_isProcessingResponse(fileInfo)) {
-            await removeCachedFile(key);
-            try {
-              if (fileInfo.file.existsSync()) {
-                await fileInfo.file.delete();
-              }
-            } on Object {
-              // Best-effort cleanup; the cache metadata has already been
-              // removed so the processing response cannot be replayed.
+        if (_isProcessingResponse(fileInfo)) {
+          await removeCachedFile(key);
+          try {
+            if (fileInfo.file.existsSync()) {
+              await fileInfo.file.delete();
             }
-            if (!completer.isCompleted) completer.complete(null);
-            return;
+          } on Object {
+            // Best-effort cleanup; the cache metadata has already been
+            // removed so the processing response cannot be replayed.
           }
-
-          // Update manifest
-          if (_config.enableSyncManifest && !_isClosed) {
-            _cacheManifest[key] = fileInfo.file.path;
-          }
-
-          if (!completer.isCompleted) {
-            completer.complete(_isClosed ? null : fileInfo.file);
-          }
-        } on Exception {
           if (!completer.isCompleted) completer.complete(null);
-        } finally {
-          _pendingCacheOperations.remove(key);
+          return;
         }
-      }(),
-    );
+
+        // Update manifest
+        if (_config.enableSyncManifest && !_isClosed) {
+          _cacheManifest[key] = fileInfo.file.path;
+        }
+
+        if (!completer.isCompleted) {
+          completer.complete(_isClosed ? null : fileInfo.file);
+        }
+      } on Exception {
+        if (!completer.isCompleted) completer.complete(null);
+      } finally {
+        _pendingCacheOperations.remove(key);
+      }
+    }());
 
     return completer.future;
   }
@@ -705,7 +703,8 @@ class MediaCacheManager extends CacheManager {
           headers: authHeaders,
         );
         activeDownload = download;
-        final file = await download.file;
+        final downloadResult = await download.result;
+        final file = downloadResult.file;
         if (file != null && !download.isCancelled) {
           // Register in flutter_cache_manager's store so the file survives
           // app restart and shows up in [getAllObjects] on next launch.
@@ -878,11 +877,9 @@ class MediaCacheManager extends CacheManager {
               key: item.key,
               authHeaders: authHeadersProvider?.call(item.key),
               trackPrefetchMetrics: false,
-            ).file.whenComplete(
-              () {
-                inFlightByKey.removeWhere((key, _) => key == item.key);
-              },
-            );
+            ).file.whenComplete(() {
+              inFlightByKey.removeWhere((key, _) => key == item.key);
+            });
         inFlightByKey[item.key] = downloadFuture;
         batch.add(downloadFuture);
       }
@@ -990,7 +987,7 @@ class MediaCacheManager extends CacheManager {
 /// Bridges a deferred [Future] (which performs async setup before the real
 /// [CancellableDownload] starts) into the [CancellableDownload] interface
 /// expected by [CancellableCacheOperation.fromDownload].
-class _DeferredDownload implements CancellableDownload {
+class _DeferredDownload extends CancellableDownload {
   _DeferredDownload({
     required Future<File?> future,
     required void Function() cancel,
@@ -1004,7 +1001,8 @@ class _DeferredDownload implements CancellableDownload {
   final bool Function() _isCancelledGetter;
 
   @override
-  Future<File?> get file => _future;
+  Future<CancellableDownloadResult> get result async =>
+      CancellableDownloadResult(file: await _future);
 
   // coverage:ignore-start
   @override
@@ -1015,9 +1013,10 @@ class _DeferredDownload implements CancellableDownload {
   void cancel() => _cancel();
 }
 
-class _CompletedNullDownload implements CancellableDownload {
+class _CompletedNullDownload extends CancellableDownload {
   @override
-  Future<File?> get file async => null;
+  Future<CancellableDownloadResult> get result async =>
+      const CancellableDownloadResult(file: null);
 
   // coverage:ignore-start
   @override

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -308,7 +308,8 @@ class MediaCacheManager extends CacheManager {
   Future<void> _aliasWriteQueue = Future<void>.value();
 
   /// Tracks keys currently being cached to prevent duplicate requests.
-  final Map<String, Completer<File?>> _pendingCacheOperations = {};
+  final Map<String, Completer<CancellableDownloadResult>>
+  _pendingCacheOperations = {};
 
   /// Tracks cancellable operations currently in-flight.
   final Set<CancellableCacheOperation> _activeCancellableOperations = {};
@@ -542,11 +543,13 @@ class MediaCacheManager extends CacheManager {
 
     // Check if already being cached
     if (_pendingCacheOperations.containsKey(key)) {
-      return _pendingCacheOperations[key]!.future;
+      return _pendingCacheOperations[key]!.future.then(
+        (result) => result.file,
+      );
     }
 
     // Start caching
-    final completer = Completer<File?>();
+    final completer = Completer<CancellableDownloadResult>();
     _pendingCacheOperations[key] = completer;
 
     unawaited(() async {
@@ -567,7 +570,9 @@ class MediaCacheManager extends CacheManager {
             // Best-effort cleanup; the cache metadata has already been
             // removed so the processing response cannot be replayed.
           }
-          if (!completer.isCompleted) completer.complete(null);
+          if (!completer.isCompleted) {
+            completer.complete(const CancellableDownloadResult(file: null));
+          }
           return;
         }
 
@@ -577,16 +582,20 @@ class MediaCacheManager extends CacheManager {
         }
 
         if (!completer.isCompleted) {
-          completer.complete(_isClosed ? null : fileInfo.file);
+          completer.complete(
+            CancellableDownloadResult(file: _isClosed ? null : fileInfo.file),
+          );
         }
       } on Exception {
-        if (!completer.isCompleted) completer.complete(null);
+        if (!completer.isCompleted) {
+          completer.complete(const CancellableDownloadResult(file: null));
+        }
       } finally {
         _pendingCacheOperations.remove(key);
       }
     }());
 
-    return completer.future;
+    return completer.future.then((result) => result.file);
   }
 
   /// Downloads and caches a file with the ability to cancel mid-download.
@@ -644,11 +653,15 @@ class MediaCacheManager extends CacheManager {
     if (_pendingCacheOperations.containsKey(key)) {
       final sharedFuture = _pendingCacheOperations[key]!.future;
       var localCancelled = false;
-      final localCompleter = Completer<File?>();
+      final localCompleter = Completer<CancellableDownloadResult>();
       unawaited(
-        sharedFuture.then((file) {
+        sharedFuture.then((result) {
           if (!localCompleter.isCompleted) {
-            localCompleter.complete(localCancelled ? null : file);
+            localCompleter.complete(
+              localCancelled
+                  ? const CancellableDownloadResult(file: null)
+                  : result,
+            );
           }
         }),
       );
@@ -658,7 +671,11 @@ class MediaCacheManager extends CacheManager {
           cancel: () {
             if (localCancelled) return;
             localCancelled = true;
-            if (!localCompleter.isCompleted) localCompleter.complete();
+            if (!localCompleter.isCompleted) {
+              localCompleter.complete(
+                const CancellableDownloadResult(file: null),
+              );
+            }
           },
           // coverage:ignore-start
           isCancelledGetter: () => localCancelled,
@@ -681,7 +698,7 @@ class MediaCacheManager extends CacheManager {
     }
 
     final relativePath = _relativePathFor(key, url);
-    final completer = Completer<File?>();
+    final completer = Completer<CancellableDownloadResult>();
     // Register before the async download starts so any concurrent caller
     // (cacheFile or another cacheFileCancellable) for the same key joins
     // this operation instead of issuing a second download.
@@ -693,7 +710,9 @@ class MediaCacheManager extends CacheManager {
       try {
         final baseDir = await _resolveBaseCacheDir();
         if (cancelledBeforeStart) {
-          if (!completer.isCompleted) completer.complete();
+          if (!completer.isCompleted) {
+            completer.complete(const CancellableDownloadResult(file: null));
+          }
           return;
         }
         final targetFile = File(path.join(baseDir, relativePath));
@@ -731,14 +750,16 @@ class MediaCacheManager extends CacheManager {
             }
           }
         }
-        if (!completer.isCompleted) completer.complete(file);
+        if (!completer.isCompleted) completer.complete(downloadResult);
       } on Object catch (error) {
         Log.warning(
           'MediaCacheManager: download setup failed for $url: $error',
           name: 'MediaCache',
           category: LogCategory.video,
         );
-        if (!completer.isCompleted) completer.complete();
+        if (!completer.isCompleted) {
+          completer.complete(const CancellableDownloadResult(file: null));
+        }
       } finally {
         _pendingCacheOperations.remove(key);
       }
@@ -974,7 +995,9 @@ class MediaCacheManager extends CacheManager {
 
     final pending = _pendingCacheOperations.values.toList(growable: false);
     for (final completer in pending) {
-      if (!completer.isCompleted) completer.complete();
+      if (!completer.isCompleted) {
+        completer.complete(const CancellableDownloadResult(file: null));
+      }
     }
     _pendingCacheOperations.clear();
 
@@ -989,20 +1012,19 @@ class MediaCacheManager extends CacheManager {
 /// expected by [CancellableCacheOperation.fromDownload].
 class _DeferredDownload extends CancellableDownload {
   _DeferredDownload({
-    required Future<File?> future,
+    required Future<CancellableDownloadResult> future,
     required void Function() cancel,
     required bool Function() isCancelledGetter,
   }) : _future = future,
        _cancel = cancel,
        _isCancelledGetter = isCancelledGetter;
 
-  final Future<File?> _future;
+  final Future<CancellableDownloadResult> _future;
   final void Function() _cancel;
   final bool Function() _isCancelledGetter;
 
   @override
-  Future<CancellableDownloadResult> get result async =>
-      CancellableDownloadResult(file: await _future);
+  Future<CancellableDownloadResult> get result => _future;
 
   // coverage:ignore-start
   @override

--- a/mobile/packages/media_cache/test/src/cancellable_cache_operation_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_cache_operation_test.dart
@@ -25,6 +25,10 @@ class _ThrowingDownload implements CancellableDownload {
   Future<File?> get file => Future<File?>.error(Exception('download failed'));
 
   @override
+  Future<CancellableDownloadResult> get result =>
+      Future<CancellableDownloadResult>.error(Exception('download failed'));
+
+  @override
   bool get isCancelled => false;
 
   @override
@@ -124,17 +128,14 @@ void main() {
         await controller.close();
       });
 
-      test(
-        'file future completes with null when stream.listen throws '
-        'synchronously',
-        () async {
-          final op = CancellableCacheOperation.fromStream(
-            _SynchronouslyThrowingStream(),
-          );
+      test('file future completes with null when stream.listen throws '
+          'synchronously', () async {
+        final op = CancellableCacheOperation.fromStream(
+          _SynchronouslyThrowingStream(),
+        );
 
-          expect(await op.file, isNull);
-        },
-      );
+        expect(await op.file, isNull);
+      });
     });
 
     group('cancel', () {

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -27,7 +27,33 @@ class _CallbackClient extends http.BaseClient {
   }
 }
 
+class _ResultOnlyDownload extends CancellableDownload {
+  _ResultOnlyDownload(this._result);
+
+  final CancellableDownloadResult _result;
+
+  @override
+  Future<CancellableDownloadResult> get result async => _result;
+
+  @override
+  bool get isCancelled => false;
+
+  @override
+  void cancel() {}
+}
+
 void main() {
+  group(CancellableDownload, () {
+    test('file returns the file from result', () async {
+      final file = File('video.mp4');
+      final download = _ResultOnlyDownload(
+        CancellableDownloadResult(file: file),
+      );
+
+      expect(await download.file, same(file));
+    });
+  });
+
   group(HttpCancellableDownloader, () {
     late Directory tempDir;
 
@@ -189,10 +215,7 @@ void main() {
       final target = File('${tempDir.path}/non_success_warns.mp4');
 
       final file = await downloader
-          .download(
-            url: 'https://example.com/missing.mp4',
-            targetFile: target,
-          )
+          .download(url: 'https://example.com/missing.mp4', targetFile: target)
           .file;
 
       expect(file, isNull);
@@ -238,24 +261,24 @@ void main() {
       expect(target.existsSync(), isFalse);
     });
 
-    test('returns null for non-OK responses', () async {
+    test('returns null for non-OK responses and exposes status', () async {
       final client = _CallbackClient(
         (_) async => http.StreamedResponse(
           Stream<List<int>>.value(utf8.encode('not found')),
           404,
+          headers: {'retry-after': '10'},
         ),
       );
       final downloader = HttpCancellableDownloader(client);
       final target = File('${tempDir.path}/non_success.mp4');
 
-      final file = await downloader
-          .download(
-            url: 'https://example.com/missing.mp4',
-            targetFile: target,
-          )
-          .file;
+      final result = await downloader
+          .download(url: 'https://example.com/missing.mp4', targetFile: target)
+          .result;
 
-      expect(file, isNull);
+      expect(result.file, isNull);
+      expect(result.statusCode, equals(404));
+      expect(result.headers['retry-after'], equals('10'));
       expect(target.existsSync(), isFalse);
     });
 
@@ -318,10 +341,7 @@ void main() {
         final target = File('${tempDir.path}/error_stream.mp4');
 
         final future = downloader
-            .download(
-              url: 'https://example.com/error.mp4',
-              targetFile: target,
-            )
+            .download(url: 'https://example.com/error.mp4', targetFile: target)
             .file;
 
         controller
@@ -343,10 +363,7 @@ void main() {
       final target = File('${tempDir.path}/send_throw.mp4');
 
       final file = await downloader
-          .download(
-            url: 'https://example.com/fail.mp4',
-            targetFile: target,
-          )
+          .download(url: 'https://example.com/fail.mp4', targetFile: target)
           .file;
 
       expect(file, isNull);
@@ -366,10 +383,7 @@ void main() {
       final target = File('${tempDir.path}/http_not_allowed.mp4');
 
       final file = await downloader
-          .download(
-            url: 'http://example.com/insecure.mp4',
-            targetFile: target,
-          )
+          .download(url: 'http://example.com/insecure.mp4', targetFile: target)
           .file;
 
       expect(file, isNull);
@@ -425,35 +439,32 @@ void main() {
       expect(target.existsSync(), isTrue);
     });
 
-    test(
-      'cancel during stream completion keeps successful file',
-      () async {
-        final controller = StreamController<List<int>>();
-        final client = _CallbackClient(
-          (_) async => http.StreamedResponse(controller.stream, 200),
-        );
-        final downloader = HttpCancellableDownloader(client);
-        final target = File('${tempDir.path}/cancel_during_done.mp4');
+    test('cancel during stream completion keeps successful file', () async {
+      final controller = StreamController<List<int>>();
+      final client = _CallbackClient(
+        (_) async => http.StreamedResponse(controller.stream, 200),
+      );
+      final downloader = HttpCancellableDownloader(client);
+      final target = File('${tempDir.path}/cancel_during_done.mp4');
 
-        final dl = downloader.download(
-          url: 'https://example.com/cancel_during_done.mp4',
-          targetFile: target,
-        );
+      final dl = downloader.download(
+        url: 'https://example.com/cancel_during_done.mp4',
+        targetFile: target,
+      );
 
-        // Ensure listener is attached before we trigger completion.
-        await Future<void>.delayed(const Duration(milliseconds: 1));
-        controller.add(utf8.encode('partial'));
-        await controller.close();
+      // Ensure listener is attached before we trigger completion.
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+      controller.add(utf8.encode('partial'));
+      await controller.close();
 
-        // Trigger cancellation while stream completion is in-flight.
-        dl.cancel();
+      // Trigger cancellation while stream completion is in-flight.
+      dl.cancel();
 
-        final file = await dl.file;
-        expect(file, isNotNull);
-        expect(dl.isCancelled, isFalse);
-        expect(target.existsSync(), isTrue);
-      },
-    );
+      final file = await dl.file;
+      expect(file, isNotNull);
+      expect(dl.isCancelled, isFalse);
+      expect(target.existsSync(), isTrue);
+    });
 
     test('cancel queued before stream done deletes the target file', () async {
       final controller = StreamController<List<int>>();

--- a/mobile/packages/media_cache/test/src/helpers/mocks.dart
+++ b/mobile/packages/media_cache/test/src/helpers/mocks.dart
@@ -155,6 +155,10 @@ class FakeCancellableDownload implements CancellableDownload {
   Future<io.File?> get file => _completer.future;
 
   @override
+  Future<CancellableDownloadResult> get result async =>
+      CancellableDownloadResult(file: await file);
+
+  @override
   bool get isCancelled => _isCancelled;
 
   @override

--- a/mobile/packages/media_cache/test/src/helpers/mocks.dart
+++ b/mobile/packages/media_cache/test/src/helpers/mocks.dart
@@ -148,15 +148,14 @@ class FakeCancellableDownload implements CancellableDownload {
   final io.File targetFile;
   final Map<String, String>? headers;
 
-  final _completer = Completer<io.File?>();
+  final _completer = Completer<CancellableDownloadResult>();
   bool _isCancelled = false;
 
   @override
-  Future<io.File?> get file => _completer.future;
+  Future<io.File?> get file async => (await _completer.future).file;
 
   @override
-  Future<CancellableDownloadResult> get result async =>
-      CancellableDownloadResult(file: await file);
+  Future<CancellableDownloadResult> get result => _completer.future;
 
   @override
   bool get isCancelled => _isCancelled;
@@ -165,19 +164,25 @@ class FakeCancellableDownload implements CancellableDownload {
   void cancel() {
     if (_isCancelled || _completer.isCompleted) return;
     _isCancelled = true;
-    _completer.complete();
+    _completer.complete(const CancellableDownloadResult(file: null));
   }
 
   /// Completes the download with [file] (typically a pre-created test file).
   void completeWith(io.File file) {
     if (_completer.isCompleted) return;
-    _completer.complete(file);
+    _completer.complete(CancellableDownloadResult(file: file));
+  }
+
+  /// Completes the download with an explicit [result].
+  void completeResult(CancellableDownloadResult result) {
+    if (_completer.isCompleted) return;
+    _completer.complete(result);
   }
 
   /// Completes the download with `null` (failure / no body).
   void completeNull() {
     if (_completer.isCompleted) return;
-    _completer.complete();
+    _completer.complete(const CancellableDownloadResult(file: null));
   }
 }
 

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -696,6 +696,41 @@ void main() {
       });
 
       test(
+        'preserves downloader status and headers for non-file results',
+        () async {
+          final timestamp = DateTime.now().millisecondsSinceEpoch;
+          final downloader = FakeCancellableDownloader();
+          cacheManager = TestableMediaCacheManager(
+            config: MediaCacheConfig(
+              cacheKey: 'cancellable_status_$timestamp',
+              enableSyncManifest: true,
+            ),
+            downloaderOverride: downloader,
+          );
+
+          final op = cacheManager.cacheFileCancellable(
+            'https://example.com/processing.mp4',
+            key: 'processing_key',
+          );
+
+          await pumpDownloads(downloader);
+          downloader.downloads.single.completeResult(
+            const CancellableDownloadResult(
+              file: null,
+              statusCode: 202,
+              headers: {'retry-after': '30'},
+            ),
+          );
+
+          final result = await op.result;
+
+          expect(result.file, isNull);
+          expect(result.statusCode, equals(202));
+          expect(result.headers['retry-after'], equals('30'));
+        },
+      );
+
+      test(
         'manifest is NOT updated when enableSyncManifest is false',
         () async {
           final timestamp = DateTime.now().millisecondsSinceEpoch;


### PR DESCRIPTION
## Summary
- Treat HTTP 202 media responses as a processing state instead of a playback failure.
- Retry the active rendition with bounded backoff on initial load and runtime playback, without burning through fallback sources.
- Surface HTTP status and headers from media cache downloads so prefetch can defer 202s quickly and honor Retry-After.
- Add regression coverage across source loading, playback error classification, runtime feed retry, prefetch, media cache, and native player error mapping.

## Root Cause
Freshly published rendition URLs can return HTTP 202 while transcoding is still in progress. The active player path previously treated any source load error as a reason to try the next fallback URL, while prefetch collapsed non-2xx responses into null files and waited for the stall timeout. That caused the player and prefetcher to burn through renditions before they were ready.

## Verification
- flutter test test/src/utils/source_loader_test.dart test/src/utils/playback_sources_test.dart test/src/services/disk_prefetcher_test.dart (mobile/packages/infinite_video_feed)
- flutter test (mobile/packages/infinite_video_feed)
- flutter test test/src/cancellable_downloader_test.dart (mobile/packages/media_cache)
- flutter test (mobile/packages/media_cache)
- flutter test test/src/video_player_state_test.dart (mobile/packages/divine_video_player)
- flutter test (mobile/packages/divine_video_player)
- flutter analyze (mobile)
- git diff --check

Closes #5546