### PR TITLE
fix(profile): recover own profile refresh

### DIFF
--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -54,6 +54,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
         profile: cachedProfile,
         extractedUsername: cachedProfile?.divineUsername,
         externalNip05: cachedProfile?.externalNip05,
+        verifiedClaims: _claimsFromState(state),
       ),
     );
 
@@ -143,6 +144,7 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
           profile: currentProfile,
           extractedUsername: currentProfile.divineUsername,
           externalNip05: currentProfile.externalNip05,
+          verifiedClaims: _claimsFromState(state),
         );
       },
       onError: (error, stackTrace) {
@@ -168,7 +170,9 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     Emitter<MyProfileState> emit,
   ) async {
     final currentProfile = _profileFromState(state);
-    emit(_loadingStateFor(currentProfile));
+    emit(
+      _loadingStateFor(currentProfile, verifiedClaims: _claimsFromState(state)),
+    );
 
     try {
       final freshProfile = await _profileRepository.fetchFreshProfile(
@@ -176,11 +180,24 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       );
       if (isClosed) return;
 
+      final latestClaims = _claimsFromState(state);
       if (freshProfile != null) {
-        emit(_loadedStateFor(freshProfile, isFresh: true));
+        emit(
+          _loadedStateFor(
+            freshProfile,
+            isFresh: true,
+            verifiedClaims: latestClaims,
+          ),
+        );
         add(const VerifiedClaimsRequested());
-      } else if (currentProfile != null) {
-        emit(_loadedStateFor(currentProfile, isFresh: false));
+      } else if (_profileFromState(state) case final latestProfile?) {
+        emit(
+          _loadedStateFor(
+            latestProfile,
+            isFresh: false,
+            verifiedClaims: latestClaims,
+          ),
+        );
         add(const VerifiedClaimsRequested());
       } else {
         emit(const MyProfileError(errorType: MyProfileErrorType.notFound));
@@ -188,8 +205,15 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     } on Exception catch (e, stackTrace) {
       addError(e, stackTrace);
       if (isClosed) return;
-      if (currentProfile != null) {
-        emit(_loadedStateFor(currentProfile, isFresh: false));
+      final latestClaims = _claimsFromState(state);
+      if (_profileFromState(state) case final latestProfile?) {
+        emit(
+          _loadedStateFor(
+            latestProfile,
+            isFresh: false,
+            verifiedClaims: latestClaims,
+          ),
+        );
         add(const VerifiedClaimsRequested());
       } else {
         emit(const MyProfileError(errorType: MyProfileErrorType.networkError));
@@ -261,19 +285,38 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
     return profile?.pubkey == pubkey ? profile : null;
   }
 
-  MyProfileLoading _loadingStateFor(UserProfile? profile) => MyProfileLoading(
+  List<IdentityClaim> _claimsFromState(MyProfileState state) {
+    final claims = switch (state) {
+      MyProfileLoaded(:final profile, :final verifiedClaims) =>
+        profile.pubkey == pubkey ? verifiedClaims : const <IdentityClaim>[],
+      MyProfileUpdated(:final profile, :final verifiedClaims) =>
+        profile.pubkey == pubkey ? verifiedClaims : const <IdentityClaim>[],
+      MyProfileLoading(:final profile, :final verifiedClaims) =>
+        profile?.pubkey == pubkey ? verifiedClaims : const <IdentityClaim>[],
+      _ => const <IdentityClaim>[],
+    };
+    return claims;
+  }
+
+  MyProfileLoading _loadingStateFor(
+    UserProfile? profile, {
+    List<IdentityClaim> verifiedClaims = const [],
+  }) => MyProfileLoading(
     profile: profile,
     extractedUsername: profile?.divineUsername,
     externalNip05: profile?.externalNip05,
+    verifiedClaims: verifiedClaims,
   );
 
   MyProfileLoaded _loadedStateFor(
     UserProfile profile, {
     required bool isFresh,
+    List<IdentityClaim> verifiedClaims = const [],
   }) => MyProfileLoaded(
     profile: profile,
     isFresh: isFresh,
     extractedUsername: profile.divineUsername,
     externalNip05: profile.externalNip05,
+    verifiedClaims: verifiedClaims,
   );
 }

--- a/mobile/lib/blocs/my_profile/my_profile_bloc.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_bloc.dart
@@ -27,6 +27,10 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       transformer: restartable(),
     );
     on<MyProfileFetchRequested>(_onFetchRequested);
+    on<MyProfileRefreshRequested>(
+      _onRefreshRequested,
+      transformer: sequential(),
+    );
     on<VerifiedClaimsRequested>(_onVerifiedClaimsRequested);
   }
 
@@ -133,7 +137,13 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
             externalNip05: profile.externalNip05,
           );
         }
-        return const MyProfileLoading();
+        final currentProfile = _profileFromState(state);
+        if (currentProfile == null) return const MyProfileLoading();
+        return MyProfileLoading(
+          profile: currentProfile,
+          extractedUsername: currentProfile.divineUsername,
+          externalNip05: currentProfile.externalNip05,
+        );
       },
       onError: (error, stackTrace) {
         addError(error, stackTrace);
@@ -150,6 +160,45 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       await _profileRepository.fetchFreshProfile(pubkey: pubkey);
     } on Exception catch (e, stackTrace) {
       addError(e, stackTrace);
+    }
+  }
+
+  Future<void> _onRefreshRequested(
+    MyProfileRefreshRequested event,
+    Emitter<MyProfileState> emit,
+  ) async {
+    final currentProfile = _profileFromState(state);
+    emit(_loadingStateFor(currentProfile));
+
+    try {
+      final freshProfile = await _profileRepository.fetchFreshProfile(
+        pubkey: pubkey,
+      );
+      if (isClosed) return;
+
+      if (freshProfile != null) {
+        emit(_loadedStateFor(freshProfile, isFresh: true));
+        add(const VerifiedClaimsRequested());
+      } else if (currentProfile != null) {
+        emit(_loadedStateFor(currentProfile, isFresh: false));
+        add(const VerifiedClaimsRequested());
+      } else {
+        emit(const MyProfileError(errorType: MyProfileErrorType.notFound));
+      }
+    } on Exception catch (e, stackTrace) {
+      addError(e, stackTrace);
+      if (isClosed) return;
+      if (currentProfile != null) {
+        emit(_loadedStateFor(currentProfile, isFresh: false));
+        add(const VerifiedClaimsRequested());
+      } else {
+        emit(const MyProfileError(errorType: MyProfileErrorType.networkError));
+      }
+    } finally {
+      final completer = event.completer;
+      if (completer != null && !completer.isCompleted) {
+        completer.complete();
+      }
     }
   }
 
@@ -201,4 +250,30 @@ class MyProfileBloc extends Bloc<MyProfileEvent, MyProfileState> {
       }
     }
   }
+
+  UserProfile? _profileFromState(MyProfileState state) {
+    final profile = switch (state) {
+      MyProfileLoaded(:final profile) => profile,
+      MyProfileUpdated(:final profile) => profile,
+      MyProfileLoading(:final profile) => profile,
+      _ => null,
+    };
+    return profile?.pubkey == pubkey ? profile : null;
+  }
+
+  MyProfileLoading _loadingStateFor(UserProfile? profile) => MyProfileLoading(
+    profile: profile,
+    extractedUsername: profile?.divineUsername,
+    externalNip05: profile?.externalNip05,
+  );
+
+  MyProfileLoaded _loadedStateFor(
+    UserProfile profile, {
+    required bool isFresh,
+  }) => MyProfileLoaded(
+    profile: profile,
+    isFresh: isFresh,
+    extractedUsername: profile.divineUsername,
+    externalNip05: profile.externalNip05,
+  );
 }

--- a/mobile/lib/blocs/my_profile/my_profile_event.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_event.dart
@@ -39,6 +39,19 @@ final class MyProfileFetchRequested extends MyProfileEvent {
   const MyProfileFetchRequested();
 }
 
+/// Event triggered when the current user explicitly refreshes their profile.
+///
+/// Unlike [MyProfileFetchRequested], this drives visible loading/error state
+/// and completes [completer] when the refresh attempt finishes so pull-to-
+/// refresh controls can stop their indicator without reaching into the
+/// repository layer.
+final class MyProfileRefreshRequested extends MyProfileEvent {
+  const MyProfileRefreshRequested({this.completer});
+
+  /// Optional completion signal for UI refresh affordances.
+  final Completer<void>? completer;
+}
+
 /// Event triggered to fetch verifier-confirmed NIP-39 identity claims for
 /// the currently loaded profile.
 ///

--- a/mobile/lib/blocs/my_profile/my_profile_state.dart
+++ b/mobile/lib/blocs/my_profile/my_profile_state.dart
@@ -31,6 +31,7 @@ final class MyProfileLoading extends MyProfileState {
     this.profile,
     this.extractedUsername,
     this.externalNip05,
+    this.verifiedClaims = const [],
   });
 
   /// Cached profile to display while loading fresh data.
@@ -44,8 +45,18 @@ final class MyProfileLoading extends MyProfileState {
   /// Null if the NIP-05 is a divine.video/openvine.co domain or not set.
   final String? externalNip05;
 
+  /// Verifier-confirmed NIP-39 identity claims from the previously visible
+  /// profile. Preserved during refresh so the row does not disappear while the
+  /// verifier revalidates.
+  final List<IdentityClaim> verifiedClaims;
+
   @override
-  List<Object?> get props => [profile, extractedUsername, externalNip05];
+  List<Object?> get props => [
+    profile,
+    extractedUsername,
+    externalNip05,
+    verifiedClaims,
+  ];
 }
 
 /// Successfully loaded profile state.

--- a/mobile/lib/widgets/profile/profile_banner_layer.dart
+++ b/mobile/lib/widgets/profile/profile_banner_layer.dart
@@ -88,6 +88,8 @@ class _ProfileBannerLayerState extends ConsumerState<ProfileBannerLayer> {
       final state = context.watch<MyProfileBloc>().state;
       return switch (state) {
         MyProfileUpdated(:final profile) => profile,
+        MyProfileLoaded(:final profile) => profile,
+        MyProfileLoading(:final profile) => profile,
         _ => null,
       };
     } on ProviderNotFoundException {

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -287,24 +287,81 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
   }
 
   void _onRefreshRequested() {
+    unawaited(_refreshSyncedTabs());
+  }
+
+  Future<void> _refreshSyncedTabs() async {
     // Re-dispatch sync only for tabs that have been viewed (lazy load still
     // applies).
+    final refreshes = <Future<void>>[];
     for (final kind in _syncedKinds) {
       switch (kind) {
         case ProfileTabKind.videos:
           break;
         case ProfileTabKind.collabs:
-          _collabVideosBloc?.add(const ProfileCollabVideosFetchRequested());
+          final bloc = _collabVideosBloc;
+          if (bloc == null) break;
+          bloc.add(const ProfileCollabVideosFetchRequested());
+          refreshes.add(
+            bloc.stream.firstWhere(
+              (state) =>
+                  !state.isRefreshing &&
+                  state.status != ProfileCollabVideosStatus.loading,
+              orElse: () => bloc.state,
+            ),
+          );
         case ProfileTabKind.liked:
-          _likedVideosBloc?.add(const ProfileLikedVideosSyncRequested());
+          final bloc = _likedVideosBloc;
+          if (bloc == null) break;
+          bloc.add(const ProfileLikedVideosSyncRequested());
+          refreshes.add(
+            bloc.stream.firstWhere(
+              (state) =>
+                  !state.isRefreshing &&
+                  state.status != ProfileLikedVideosStatus.syncing &&
+                  state.status != ProfileLikedVideosStatus.loading,
+              orElse: () => bloc.state,
+            ),
+          );
         case ProfileTabKind.reposts:
-          _repostedVideosBloc?.add(const ProfileRepostedVideosSyncRequested());
+          final bloc = _repostedVideosBloc;
+          if (bloc == null) break;
+          bloc.add(const ProfileRepostedVideosSyncRequested());
+          refreshes.add(
+            bloc.stream.firstWhere(
+              (state) =>
+                  !state.isRefreshing &&
+                  state.status != ProfileRepostedVideosStatus.syncing &&
+                  state.status != ProfileRepostedVideosStatus.loading,
+              orElse: () => bloc.state,
+            ),
+          );
         case ProfileTabKind.saved:
-          _savedVideosBloc?.add(const ProfileSavedVideosSyncRequested());
+          final bloc = _savedVideosBloc;
+          if (bloc == null) break;
+          bloc.add(const ProfileSavedVideosSyncRequested());
+          refreshes.add(
+            bloc.stream.firstWhere(
+              (state) =>
+                  !state.isRefreshing &&
+                  state.status != ProfileSavedVideosStatus.syncing &&
+                  state.status != ProfileSavedVideosStatus.loading,
+              orElse: () => bloc.state,
+            ),
+          );
         case ProfileTabKind.comments:
-          _commentsBloc?.add(const ProfileCommentsSyncRequested());
+          final bloc = _commentsBloc;
+          if (bloc == null) break;
+          bloc.add(const ProfileCommentsSyncRequested());
+          refreshes.add(
+            bloc.stream.firstWhere(
+              (state) => state.status != ProfileCommentsStatus.loading,
+              orElse: () => bloc.state,
+            ),
+          );
       }
     }
+    await Future.wait(refreshes);
   }
 
   Future<void> _refreshProfileContent() async {
@@ -322,10 +379,15 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       profileRefresh.complete();
     }
 
-    context.read<ProfileFeedCubit>().add(const ProfileFeedRefreshRequested());
-    _onRefreshRequested();
+    final profileFeedCubit = context.read<ProfileFeedCubit>();
+    profileFeedCubit.add(const ProfileFeedRefreshRequested());
+    final feedRefresh = profileFeedCubit.stream.firstWhere(
+      (state) => !state.isRefreshing && !state.isFetchingTotalCount,
+      orElse: () => profileFeedCubit.state,
+    );
+    final tabRefresh = _refreshSyncedTabs();
 
-    await profileRefresh.future;
+    await Future.wait([profileRefresh.future, feedRefresh, tabRefresh]);
   }
 
   @override
@@ -570,6 +632,7 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     final content = RefreshIndicator(
       color: VineTheme.primary,
       backgroundColor: VineTheme.surfaceContainer,
+      notificationPredicate: (_) => true,
       onRefresh: _refreshProfileContent,
       child: ClipRRect(
         borderRadius: const .vertical(bottom: .circular(30)),

--- a/mobile/lib/widgets/profile/profile_grid.dart
+++ b/mobile/lib/widgets/profile/profile_grid.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/others_followers/others_followers_bloc.dart';
 import 'package:openvine/blocs/profile_collab_videos/profile_collab_videos_bloc.dart';
 import 'package:openvine/blocs/profile_comments/profile_comments_bloc.dart';
@@ -306,6 +307,27 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
     }
   }
 
+  Future<void> _refreshProfileContent() async {
+    final profileRefresh = Completer<void>();
+
+    if (widget.isOwnProfile) {
+      try {
+        context.read<MyProfileBloc>().add(
+          MyProfileRefreshRequested(completer: profileRefresh),
+        );
+      } on ProviderNotFoundException {
+        profileRefresh.complete();
+      }
+    } else {
+      profileRefresh.complete();
+    }
+
+    context.read<ProfileFeedCubit>().add(const ProfileFeedRefreshRequested());
+    _onRefreshRequested();
+
+    await profileRefresh.future;
+  }
+
   @override
   void dispose() {
     widget.refreshNotifier?.removeListener(_onRefreshRequested);
@@ -545,58 +567,67 @@ class _ProfileGridViewState extends ConsumerState<ProfileGridView>
       ),
     );
 
-    final content = ClipRRect(
-      borderRadius: const .vertical(bottom: .circular(30)),
-      child: ColoredBox(
-        color: VineTheme.surfaceBackground,
-        child: DefaultTabController(
-          length: _tabKinds.length,
-          child: NestedScrollView(
-            controller: widget.scrollController,
-            physics: const ClampingScrollPhysics(),
-            headerSliverBuilder: (context, innerBoxIsScrolled) => [
-              // Profile Header (GlobalKey for measuring height)
-              SliverToBoxAdapter(
-                child: Stack(
-                  children: [
-                    ProfileBannerLayer(
-                      userIdHex: widget.userIdHex,
-                      isOwnProfile: widget.isOwnProfile,
-                      profile: widget.profile,
-                    ),
-                    ProfileHeaderWidget(
-                      key: _headerKey,
-                      userIdHex: widget.userIdHex,
-                      isOwnProfile: widget.isOwnProfile,
-                      videoCount: widget.videos.length,
-                      profile: widget.profile,
-                      profileStats: widget.profileStats,
-                      onEditProfile: widget.onEditProfile,
-                      onBack: widget.onBack,
-                      onMore: widget.onMore,
-                      displayNameHint: widget.displayNameHint,
-                      avatarUrlHint: widget.avatarUrlHint,
-                      displayName: widget.displayName,
-                      onOpenClips: widget.onOpenClips,
-                      onMessageUser: widget.onMessageUser,
-                      onShareProfile: widget.onShareProfile,
-                      onBlockedTap: widget.onBlockedTap,
-                    ),
-                  ],
+    final content = RefreshIndicator(
+      color: VineTheme.primary,
+      backgroundColor: VineTheme.surfaceContainer,
+      onRefresh: _refreshProfileContent,
+      child: ClipRRect(
+        borderRadius: const .vertical(bottom: .circular(30)),
+        child: ColoredBox(
+          color: VineTheme.surfaceBackground,
+          child: DefaultTabController(
+            length: _tabKinds.length,
+            child: NestedScrollView(
+              controller: widget.scrollController,
+              physics: const AlwaysScrollableScrollPhysics(
+                parent: ClampingScrollPhysics(),
+              ),
+              headerSliverBuilder: (context, innerBoxIsScrolled) => [
+                // Profile Header (GlobalKey for measuring height)
+                SliverToBoxAdapter(
+                  child: Stack(
+                    children: [
+                      ProfileBannerLayer(
+                        userIdHex: widget.userIdHex,
+                        isOwnProfile: widget.isOwnProfile,
+                        profile: widget.profile,
+                      ),
+                      ProfileHeaderWidget(
+                        key: _headerKey,
+                        userIdHex: widget.userIdHex,
+                        isOwnProfile: widget.isOwnProfile,
+                        videoCount: widget.videos.length,
+                        profile: widget.profile,
+                        profileStats: widget.profileStats,
+                        onEditProfile: widget.onEditProfile,
+                        onBack: widget.onBack,
+                        onMore: widget.onMore,
+                        displayNameHint: widget.displayNameHint,
+                        avatarUrlHint: widget.avatarUrlHint,
+                        displayName: widget.displayName,
+                        onOpenClips: widget.onOpenClips,
+                        onMessageUser: widget.onMessageUser,
+                        onShareProfile: widget.onShareProfile,
+                        onBlockedTap: widget.onBlockedTap,
+                      ),
+                    ],
+                  ),
                 ),
-              ),
 
-              // Sticky Tab Bar
-              ProfileTabBar(
-                controller: _tabController,
-                scrollController: widget.scrollController,
-                tabs: [for (final kind in _tabKinds) _tabPresentationFor(kind)],
-                headerKey: _headerKey,
-                // Sticky cache-revalidation bar for the active cached tab.
-                isRefreshing: _activeTabRefreshing(videosRefreshing),
-              ),
-            ],
-            body: tabContent,
+                // Sticky Tab Bar
+                ProfileTabBar(
+                  controller: _tabController,
+                  scrollController: widget.scrollController,
+                  tabs: [
+                    for (final kind in _tabKinds) _tabPresentationFor(kind),
+                  ],
+                  headerKey: _headerKey,
+                  // Sticky cache-revalidation bar for the active cached tab.
+                  isRefreshing: _activeTabRefreshing(videosRefreshing),
+                ),
+              ],
+              body: tabContent,
+            ),
           ),
         ),
       ),

--- a/mobile/lib/widgets/profile/profile_header_identity.dart
+++ b/mobile/lib/widgets/profile/profile_header_identity.dart
@@ -345,6 +345,7 @@ class _VerifiedAccountsBlock extends StatelessWidget {
         final state = bloc.state;
         if (state is MyProfileLoaded) return state.verifiedClaims;
         if (state is MyProfileUpdated) return state.verifiedClaims;
+        if (state is MyProfileLoading) return state.verifiedClaims;
         return const [];
       });
     } on ProviderNotFoundException {

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -28,6 +28,7 @@ class _ErrorCapturingObserver extends BlocObserver {
 void main() {
   group(MyProfileBloc, () {
     late _MockProfileRepository mockProfileRepository;
+    late StreamController<UserProfile?> profileStreamController;
 
     // Test data constants - using full 64-character hex pubkey as required
     const testPubkey =
@@ -238,6 +239,12 @@ void main() {
       test('$MyProfileFetchRequested instances are equal', () {
         const event1 = MyProfileFetchRequested();
         const event2 = MyProfileFetchRequested();
+        expect(event1, equals(event2));
+      });
+
+      test('$MyProfileRefreshRequested instances are equal', () {
+        const event1 = MyProfileRefreshRequested();
+        const event2 = MyProfileRefreshRequested();
         expect(event1, equals(event2));
       });
     });
@@ -837,6 +844,49 @@ void main() {
       );
 
       blocTest<MyProfileBloc, MyProfileState>(
+        'keeps the last displayed profile when the watched row is deleted',
+        setUp: () {
+          final controller = StreamController<UserProfile?>();
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+          when(
+            () => mockProfileRepository.watchProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => controller.stream);
+          addTearDown(() {
+            if (!controller.isClosed) {
+              controller.close();
+            }
+          });
+          profileStreamController = controller;
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const MyProfileSubscriptionRequested());
+          await pumpEventQueue();
+          profileStreamController.add(
+            createTestProfile(displayName: 'Visible Profile'),
+          );
+          await pumpEventQueue();
+          profileStreamController.add(null);
+          await pumpEventQueue();
+        },
+        expect: () => [
+          isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
+          isA<MyProfileUpdated>().having(
+            (s) => s.profile.displayName,
+            'profile.displayName',
+            'Visible Profile',
+          ),
+          isA<MyProfileLoading>().having(
+            (s) => s.profile?.displayName,
+            'profile.displayName',
+            'Visible Profile',
+          ),
+        ],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
         'extracts username from stream profile NIP-05',
         setUp: () {
           final profile = createTestProfile(nip05: '_@alice.divine.video');
@@ -950,6 +1000,99 @@ void main() {
             () => mockProfileRepository.watchProfile(pubkey: testPubkey),
           ).called(2);
         },
+      );
+    });
+
+    group('$MyProfileRefreshRequested', () {
+      blocTest<MyProfileBloc, MyProfileState>(
+        'emits notFound and completes when no profile exists',
+        setUp: () {
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          final completer = Completer<void>();
+          bloc.add(MyProfileRefreshRequested(completer: completer));
+          await completer.future;
+        },
+        expect: () => [
+          isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
+          isA<MyProfileError>().having(
+            (s) => s.errorType,
+            'errorType',
+            MyProfileErrorType.notFound,
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).called(1);
+        },
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'keeps the current profile visible when refresh fails',
+        seed: () => MyProfileUpdated(
+          profile: createTestProfile(displayName: 'Visible Profile'),
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenThrow(Exception('Network error'));
+        },
+        build: createBloc,
+        act: (bloc) async {
+          final completer = Completer<void>();
+          bloc.add(MyProfileRefreshRequested(completer: completer));
+          await completer.future;
+        },
+        expect: () => [
+          isA<MyProfileLoading>().having(
+            (s) => s.profile?.displayName,
+            'profile.displayName',
+            'Visible Profile',
+          ),
+          isA<MyProfileLoaded>()
+              .having(
+                (s) => s.profile.displayName,
+                'profile.displayName',
+                'Visible Profile',
+              )
+              .having((s) => s.isFresh, 'isFresh', false),
+        ],
+        errors: () => [isA<Exception>()],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'does not preserve a stale profile for a different pubkey',
+        seed: () => MyProfileUpdated(
+          profile: createTestProfile(
+            pubkey:
+                'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+            displayName: 'Wrong User',
+          ),
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          final completer = Completer<void>();
+          bloc.add(MyProfileRefreshRequested(completer: completer));
+          await completer.future;
+        },
+        expect: () => [
+          isA<MyProfileLoading>().having((s) => s.profile, 'profile', isNull),
+          isA<MyProfileError>().having(
+            (s) => s.errorType,
+            'errorType',
+            MyProfileErrorType.notFound,
+          ),
+        ],
       );
     });
 

--- a/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
+++ b/mobile/test/blocs/my_profile/my_profile_bloc_test.dart
@@ -1004,6 +1004,14 @@ void main() {
     });
 
     group('$MyProfileRefreshRequested', () {
+      const verifiedClaim = IdentityClaim(
+        pubkey: testPubkey,
+        platform: 'github',
+        identity: 'octocat',
+        proof: 'https://github.com/octocat',
+      );
+      late Completer<UserProfile?> refreshFetchCompleter;
+
       blocTest<MyProfileBloc, MyProfileState>(
         'emits notFound and completes when no profile exists',
         setUp: () {
@@ -1063,6 +1071,113 @@ void main() {
               .having((s) => s.isFresh, 'isFresh', false),
         ],
         errors: () => [isA<Exception>()],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'preserves verified claims while refresh revalidates',
+        seed: () => MyProfileUpdated(
+          profile: createTestProfile(displayName: 'Visible Profile'),
+          verifiedClaims: const [verifiedClaim],
+        ),
+        setUp: () {
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) async => null);
+        },
+        build: createBloc,
+        act: (bloc) async {
+          final completer = Completer<void>();
+          bloc.add(MyProfileRefreshRequested(completer: completer));
+          await completer.future;
+        },
+        expect: () => [
+          isA<MyProfileLoading>()
+              .having(
+                (s) => s.profile?.displayName,
+                'profile.displayName',
+                'Visible Profile',
+              )
+              .having((s) => s.verifiedClaims, 'verifiedClaims', [
+                verifiedClaim,
+              ]),
+          isA<MyProfileLoaded>()
+              .having(
+                (s) => s.profile.displayName,
+                'profile.displayName',
+                'Visible Profile',
+              )
+              .having((s) => s.verifiedClaims, 'verifiedClaims', [
+                verifiedClaim,
+              ]),
+        ],
+      );
+
+      blocTest<MyProfileBloc, MyProfileState>(
+        'uses the latest watched profile when refresh returns no profile',
+        setUp: () {
+          final controller = StreamController<UserProfile?>();
+          refreshFetchCompleter = Completer<UserProfile?>();
+          when(
+            () => mockProfileRepository.getCachedProfile(pubkey: testPubkey),
+          ).thenAnswer(
+            (_) async => createTestProfile(displayName: 'Old Profile'),
+          );
+          when(
+            () => mockProfileRepository.watchProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => controller.stream);
+          when(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).thenAnswer((_) => refreshFetchCompleter.future);
+          addTearDown(() {
+            if (!controller.isClosed) {
+              controller.close();
+            }
+          });
+          profileStreamController = controller;
+          addTearDown(() {
+            if (!refreshFetchCompleter.isCompleted) {
+              refreshFetchCompleter.complete(null);
+            }
+          });
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const MyProfileSubscriptionRequested());
+          await pumpEventQueue();
+          final completer = Completer<void>();
+          bloc.add(MyProfileRefreshRequested(completer: completer));
+          await pumpEventQueue();
+          profileStreamController.add(
+            createTestProfile(displayName: 'New Profile'),
+          );
+          await pumpEventQueue();
+          refreshFetchCompleter.complete(null);
+          await completer.future;
+        },
+        expect: () => [
+          isA<MyProfileLoading>().having(
+            (s) => s.profile?.displayName,
+            'profile.displayName',
+            'Old Profile',
+          ),
+          isA<MyProfileUpdated>().having(
+            (s) => s.profile.displayName,
+            'profile.displayName',
+            'New Profile',
+          ),
+          isA<MyProfileLoaded>()
+              .having(
+                (s) => s.profile.displayName,
+                'profile.displayName',
+                'New Profile',
+              )
+              .having((s) => s.isFresh, 'isFresh', false),
+        ],
+        verify: (_) {
+          verify(
+            () => mockProfileRepository.fetchFreshProfile(pubkey: testPubkey),
+          ).called(1);
+        },
       );
 
       blocTest<MyProfileBloc, MyProfileState>(

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:likes_repository/likes_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/my_profile/my_profile_bloc.dart';
 import 'package:openvine/blocs/profile_feed/profile_feed_cubit.dart';
 import 'package:openvine/features/feature_flags/models/feature_flag.dart';
@@ -37,6 +38,9 @@ class _MockBookmarkService extends Mock implements BookmarkService {}
 class _MockProfileFeedCubit extends MockBloc<ProfileFeedEvent, ProfileFeedState>
     implements ProfileFeedCubit {}
 
+class _MockMyProfileBloc extends MockBloc<MyProfileEvent, MyProfileState>
+    implements MyProfileBloc {}
+
 void main() {
   const userIdHex =
       'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
@@ -49,7 +53,13 @@ void main() {
     late _MockContentBlocklistRepository blocklistRepository;
     late _MockBookmarkService bookmarkService;
     late _MockProfileFeedCubit profileFeedCubit;
+    late _MockMyProfileBloc myProfileBloc;
     late MockNostrClient nostrClient;
+
+    setUpAll(() {
+      registerFallbackValue(const MyProfileLoadRequested());
+      registerFallbackValue(const ProfileFeedStarted());
+    });
 
     setUp(() {
       likesRepository = _MockLikesRepository();
@@ -59,6 +69,7 @@ void main() {
       blocklistRepository = _MockContentBlocklistRepository();
       bookmarkService = _MockBookmarkService();
       profileFeedCubit = _MockProfileFeedCubit();
+      myProfileBloc = _MockMyProfileBloc();
       nostrClient = createMockNostrService();
 
       when(() => nostrClient.publicKey).thenReturn(userIdHex);
@@ -83,6 +94,29 @@ void main() {
         const Stream<ProfileFeedState>.empty(),
         initialState: const ProfileFeedState(status: ProfileFeedStatus.ready),
       );
+      final profile = UserProfile(
+        pubkey: userIdHex,
+        displayName: 'Visible Profile',
+        rawData: const {},
+        createdAt: DateTime(2024),
+        eventId:
+            'profile1234567890123456789012345678901234567890123456789012345',
+      );
+      whenListen(
+        myProfileBloc,
+        const Stream<MyProfileState>.empty(),
+        initialState: MyProfileUpdated(profile: profile),
+      );
+      when(() => myProfileBloc.state).thenReturn(
+        MyProfileUpdated(profile: profile),
+      );
+      when(() => myProfileBloc.pubkey).thenReturn(userIdHex);
+      when(() => myProfileBloc.add(any())).thenAnswer((invocation) {
+        final event = invocation.positionalArguments.first;
+        if (event is MyProfileRefreshRequested) {
+          event.completer?.complete();
+        }
+      });
     });
 
     Widget buildSubject({
@@ -94,12 +128,7 @@ void main() {
         home: Scaffold(
           body: MultiBlocProvider(
             providers: [
-              BlocProvider<MyProfileBloc>(
-                create: (_) => MyProfileBloc(
-                  profileRepository: createMockProfileRepository(),
-                  pubkey: userIdHex,
-                ),
-              ),
+              BlocProvider<MyProfileBloc>.value(value: myProfileBloc),
               BlocProvider<ProfileFeedCubit>.value(value: profileFeedCubit),
             ],
             child: ProfileGridView(
@@ -167,5 +196,24 @@ void main() {
         expect(find.byType(ProfileVideosGridSkeleton), findsOneWidget);
       },
     );
+
+    testWidgets('pull-to-refresh refreshes profile metadata and feed', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(isOwnProfile: true));
+      await tester.pump();
+
+      final refreshIndicator = tester.widget<RefreshIndicator>(
+        find.byType(RefreshIndicator),
+      );
+      await refreshIndicator.onRefresh();
+
+      verify(
+        () => myProfileBloc.add(any(that: isA<MyProfileRefreshRequested>())),
+      ).called(1);
+      verify(
+        () => profileFeedCubit.add(const ProfileFeedRefreshRequested()),
+      ).called(1);
+    });
   });
 }

--- a/mobile/test/widgets/profile/profile_grid_test.dart
+++ b/mobile/test/widgets/profile/profile_grid_test.dart
@@ -107,9 +107,9 @@ void main() {
         const Stream<MyProfileState>.empty(),
         initialState: MyProfileUpdated(profile: profile),
       );
-      when(() => myProfileBloc.state).thenReturn(
-        MyProfileUpdated(profile: profile),
-      );
+      when(
+        () => myProfileBloc.state,
+      ).thenReturn(MyProfileUpdated(profile: profile));
       when(() => myProfileBloc.pubkey).thenReturn(userIdHex);
       when(() => myProfileBloc.add(any())).thenAnswer((invocation) {
         final event = invocation.positionalArguments.first;
@@ -207,6 +207,28 @@ void main() {
         find.byType(RefreshIndicator),
       );
       await refreshIndicator.onRefresh();
+
+      verify(
+        () => myProfileBloc.add(any(that: isA<MyProfileRefreshRequested>())),
+      ).called(1);
+      verify(
+        () => profileFeedCubit.add(const ProfileFeedRefreshRequested()),
+      ).called(1);
+    });
+
+    testWidgets('pull gesture triggers profile metadata and feed refresh', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildSubject(isOwnProfile: true));
+      await tester.pump();
+
+      await tester.fling(
+        find.byType(NestedScrollView),
+        const Offset(0, 500),
+        1000,
+      );
+      await tester.pump();
+      await tester.pump(const Duration(seconds: 1));
 
       verify(
         () => myProfileBloc.add(any(that: isA<MyProfileRefreshRequested>())),


### PR DESCRIPTION
## Summary
- keep the last visible own profile for the same pubkey in MyProfileBloc when the watched Drift row emits null, instead of blanking the profile UI
- add explicit MyProfileRefreshRequested state handling so pull-to-refresh can re-run the profile repository fetch/write path and preserve stale profile data only when it belongs to that user
- keep banner and verified-account UI populated from preserved/loading profile states while refresh revalidates
- wrap the profile grid in a RefreshIndicator that works through NestedScrollView pull gestures and waits for profile/feed/tab refresh work to settle

## Why profiles appeared lost
The local user profile row is cache-backed. The DB encryption bootstrap can back up and recreate the Drift DB after missing/stale cipher keys or DB corruption, which leaves the profile table empty until Funnelcake/relays rehydrate it. Before this change, a null watch emission could replace an already-visible profile with loading/empty UI, and there was no user-triggered profile metadata refresh from the profile screen.

This also addresses the #5066 symptom where profile editing could leave the profile image/save flow stuck in a loading-looking state: the own-profile surface now preserves the visible profile and gives the user a working refresh path to rehydrate profile metadata after local cache loss.

## Tests
- flutter test test/blocs/my_profile/my_profile_bloc_test.dart test/widgets/profile/profile_grid_test.dart
- flutter analyze lib test
- pre-push hook: analyzer + changed-file tests

Closes #5066