### PR TITLE
feat(video-recorder): make the zoom ruler interactive

### DIFF
--- a/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
@@ -128,6 +128,11 @@ class _InteractiveZoomRulerState extends State<_InteractiveZoomRuler> {
   /// the same damped gravity-well curve as the pinch's 1× detent, so the
   /// scrubbed value gently clicks onto whole factors and the 0.5× stop.
   double _snapToMajor(double value) {
+    // The camera's zoom extremes are reachable stops in their own right. When
+    // a bound sits within [_snapRadius] of a major (e.g. maxZoom 2.1 next to
+    // the 2× mark), the detent would otherwise pull it inward and the user
+    // could never reach the actual min/max — so never snap a bound.
+    if (value == widget.minZoom || value == widget.maxZoom) return value;
     final mark = _nearestMajorMark(value);
     final dist = (value - mark).abs();
     if (dist >= _snapRadius) return value;

--- a/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
@@ -116,15 +116,25 @@ class _InteractiveZoomRulerState extends State<_InteractiveZoomRuler> {
 
   void _onDragEnd(DragEndDetails details) => _dragZoom = null;
 
-  /// Whether scrubbing from [from] to [to] passed a major ruler mark — every
+  /// Whether scrubbing from [from] to [to] reached a major ruler mark — every
   /// whole factor, plus the 0.5× ultra-wide stop — matching the ticks the
-  /// painter draws as majors.
+  /// painter draws as majors. Catches both crossing a mark mid-drag and
+  /// arriving on one pinned to a clamp bound, where the value lands on the mark
+  /// from one side and can never cross past it (e.g. the 0.5× stop on an
+  /// ultra-wide min, or a 1× min) — the cross-only checks stay silent there.
   bool _crossedMajorMark(double from, double to) {
     if (from == to) return false;
     final crossedWhole = from.floorToDouble() != to.floorToDouble();
     final crossedHalf = (from < 0.5) != (to < 0.5);
-    return crossedWhole || crossedHalf;
+    final arrivedAtMark = _isMajorMark(to) && !_isMajorMark(from);
+    return crossedWhole || crossedHalf || arrivedAtMark;
   }
+
+  /// Whether [value] sits exactly on a major mark — a whole factor or the 0.5×
+  /// stop. Lets [_crossedMajorMark] detect arrival on a mark that coincides
+  /// with a clamp bound.
+  bool _isMajorMark(double value) =>
+      value == 0.5 || value == value.roundToDouble();
 
   /// Eases [value] toward the nearest major mark within [_snapRadius], using
   /// the same damped gravity-well curve as the pinch's 1× detent, so the
@@ -148,8 +158,10 @@ class _InteractiveZoomRulerState extends State<_InteractiveZoomRuler> {
     return (value - 0.5).abs() < (value - whole).abs() ? 0.5 : whole;
   }
 
-  void _nudge(double delta) =>
-      _setZoom((widget.zoom + delta).clamp(widget.minZoom, widget.maxZoom));
+  double _nudgedZoom(double delta) =>
+      (widget.zoom + delta).clamp(widget.minZoom, widget.maxZoom);
+
+  void _nudge(double delta) => _setZoom(_nudgedZoom(delta));
 
   void _setZoom(double value) {
     if (value == widget.zoom) return;
@@ -163,17 +175,27 @@ class _InteractiveZoomRulerState extends State<_InteractiveZoomRuler> {
       label: context.l10n.videoRecorderZoomLevelLabel(
         _accessibilityValue(widget.zoom),
       ),
+      // Carry the factor on `value` too, so a VoiceOver adjust gesture re-reads
+      // the new zoom (iOS re-announces `value`, not `label`, after a nudge).
+      value: '${_accessibilityValue(widget.zoom)}×',
+      increasedValue: '${_accessibilityValue(_nudgedZoom(_semanticZoomStep))}×',
+      decreasedValue:
+          '${_accessibilityValue(_nudgedZoom(-_semanticZoomStep))}×',
       onIncrease: () => _nudge(_semanticZoomStep),
       onDecrease: () => _nudge(-_semanticZoomStep),
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onHorizontalDragStart: _onDragStart,
-        onHorizontalDragUpdate: _onDragUpdate,
-        onHorizontalDragEnd: _onDragEnd,
-        child: _ZoomRuler(
-          zoom: widget.zoom,
-          minZoom: widget.minZoom,
-          maxZoom: widget.maxZoom,
+      // The visual read-out duplicates the slider's label/value, so keep it out
+      // of the semantics tree rather than letting it merge into the label.
+      child: ExcludeSemantics(
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onHorizontalDragStart: _onDragStart,
+          onHorizontalDragUpdate: _onDragUpdate,
+          onHorizontalDragEnd: _onDragEnd,
+          child: _ZoomRuler(
+            zoom: widget.zoom,
+            minZoom: widget.minZoom,
+            maxZoom: widget.maxZoom,
+          ),
         ),
       ),
     );

--- a/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
@@ -5,10 +5,10 @@ import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/services/haptic_service.dart';
 
 /// Transient zoom indicator modelled on the native Android camera ruler.
 ///
@@ -103,8 +103,10 @@ class _InteractiveZoomRulerState extends State<_InteractiveZoomRuler> {
       widget.maxZoom,
     );
     // Tick as the value passes a major mark, mirroring the pinch detent.
+    // Flutter's HapticFeedback directly, like the other recorder/editor UI
+    // widgets — the UI layer must not import the app's service package.
     if (_crossedMajorMark(current, next)) {
-      unawaited(HapticService.snapFeedback());
+      unawaited(HapticFeedback.lightImpact());
     }
     // [_dragZoom] tracks the raw finger position; the detent is an emit-only
     // transform so the well never traps the accumulator.

--- a/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_zoom_indicator.dart
@@ -1,20 +1,27 @@
-// ABOUTME: Android-style zoom ruler that appears only while pinch-zooming
+// ABOUTME: Android-style zoom ruler shown while pinch-zooming; also draggable
 // ABOUTME: Fine ticks scroll under a fixed centre marker; value floats above
+
+import 'dart:async';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/services/haptic_service.dart';
 
 /// Transient zoom indicator modelled on the native Android camera ruler.
 ///
 /// A horizontal strip of fine tick marks scrolls under a fixed centre
 /// accent while the user pinch-zooms, with the live zoom factor floating
-/// above it. It is purely a read-out — the pinch gesture on the preview
-/// drives the zoom — so it ignores pointer events and only becomes visible
-/// while [VideoRecorderBlocState.showZoomIndicator] is set (during a pinch
-/// and for a short hold afterwards).
+/// above it. While visible it is also interactive: a horizontal drag along
+/// the ruler scrubs the zoom — dragging toward the higher marks (left) zooms
+/// in, mirroring how the ticks scroll under a pinch. The value eases onto the
+/// major marks (whole factors and the 0.5× stop) with a soft detent and a
+/// haptic tick, matching the pinch's 1× snap. It only accepts pointer events
+/// while [VideoRecorderBlocState.showZoomIndicator] is set (during a pinch and
+/// for a short hold afterwards); the rest of the time it ignores them so the
+/// preview keeps its own gestures.
 ///
 /// Renders nothing when the active camera exposes no usable zoom range
 /// (single lens / before initialization).
@@ -42,22 +49,124 @@ class VideoRecorderZoomIndicator extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
+    // Only grab pointer events while the ruler is visible, so the preview
+    // keeps its pinch / tap / long-press gestures the rest of the time.
     return IgnorePointer(
+      ignoring: !showZoomIndicator,
       child: ExcludeSemantics(
         excluding: !showZoomIndicator,
         child: AnimatedOpacity(
           duration: const Duration(milliseconds: 200),
           opacity: showZoomIndicator ? 1 : 0,
-          child: Semantics(
-            label: context.l10n.videoRecorderZoomLevelLabel(
-              _accessibilityValue(zoomLevel),
-            ),
-            child: _ZoomRuler(
-              zoom: zoomLevel,
-              minZoom: minZoomLevel,
-              maxZoom: maxZoomLevel,
-            ),
+          child: _InteractiveZoomRuler(
+            zoom: zoomLevel,
+            minZoom: minZoomLevel,
+            maxZoom: maxZoomLevel,
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Wraps the [_ZoomRuler] read-out with a horizontal drag scrubber and
+/// slider semantics, dispatching [VideoRecorderZoomLevelSet] as the user
+/// adjusts the zoom.
+class _InteractiveZoomRuler extends StatefulWidget {
+  const _InteractiveZoomRuler({
+    required this.zoom,
+    required this.minZoom,
+    required this.maxZoom,
+  });
+
+  final double zoom;
+  final double minZoom;
+  final double maxZoom;
+
+  @override
+  State<_InteractiveZoomRuler> createState() => _InteractiveZoomRulerState();
+}
+
+class _InteractiveZoomRulerState extends State<_InteractiveZoomRuler> {
+  /// Zoom captured at drag start and advanced locally on every update, so a
+  /// burst of drag events doesn't compound against a stale [widget.zoom]
+  /// between rebuilds. Null while no drag is in progress.
+  double? _dragZoom;
+
+  void _onDragStart(DragStartDetails details) => _dragZoom = widget.zoom;
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    final current = _dragZoom ?? widget.zoom;
+    // The ruler scrolls left as the zoom grows, so dragging left zooms in.
+    final next = (current - details.delta.dx / _pxPerZoomUnit).clamp(
+      widget.minZoom,
+      widget.maxZoom,
+    );
+    // Tick as the value passes a major mark, mirroring the pinch detent.
+    if (_crossedMajorMark(current, next)) {
+      unawaited(HapticService.snapFeedback());
+    }
+    // [_dragZoom] tracks the raw finger position; the detent is an emit-only
+    // transform so the well never traps the accumulator.
+    _dragZoom = next;
+    _setZoom(_snapToMajor(next));
+  }
+
+  void _onDragEnd(DragEndDetails details) => _dragZoom = null;
+
+  /// Whether scrubbing from [from] to [to] passed a major ruler mark — every
+  /// whole factor, plus the 0.5× ultra-wide stop — matching the ticks the
+  /// painter draws as majors.
+  bool _crossedMajorMark(double from, double to) {
+    if (from == to) return false;
+    final crossedWhole = from.floorToDouble() != to.floorToDouble();
+    final crossedHalf = (from < 0.5) != (to < 0.5);
+    return crossedWhole || crossedHalf;
+  }
+
+  /// Eases [value] toward the nearest major mark within [_snapRadius], using
+  /// the same damped gravity-well curve as the pinch's 1× detent, so the
+  /// scrubbed value gently clicks onto whole factors and the 0.5× stop.
+  double _snapToMajor(double value) {
+    final mark = _nearestMajorMark(value);
+    final dist = (value - mark).abs();
+    if (dist >= _snapRadius) return value;
+    final t = dist / _snapRadius;
+    final pulled = mark + (value >= mark ? 1.0 : -1.0) * _snapRadius * t * t;
+    return pulled.clamp(widget.minZoom, widget.maxZoom);
+  }
+
+  double _nearestMajorMark(double value) {
+    final whole = value.roundToDouble();
+    return (value - 0.5).abs() < (value - whole).abs() ? 0.5 : whole;
+  }
+
+  void _nudge(double delta) =>
+      _setZoom((widget.zoom + delta).clamp(widget.minZoom, widget.maxZoom));
+
+  void _setZoom(double value) {
+    if (value == widget.zoom) return;
+    context.read<VideoRecorderBloc>().add(VideoRecorderZoomLevelSet(value));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      slider: true,
+      label: context.l10n.videoRecorderZoomLevelLabel(
+        _accessibilityValue(widget.zoom),
+      ),
+      onIncrease: () => _nudge(_semanticZoomStep),
+      onDecrease: () => _nudge(-_semanticZoomStep),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onHorizontalDragStart: _onDragStart,
+        onHorizontalDragUpdate: _onDragUpdate,
+        onHorizontalDragEnd: _onDragEnd,
+        child: _ZoomRuler(
+          zoom: widget.zoom,
+          minZoom: widget.minZoom,
+          maxZoom: widget.maxZoom,
         ),
       ),
     );
@@ -189,6 +298,14 @@ const _pxPerZoomUnit = 110.0;
 
 /// Spacing between minor tick marks, in zoom units.
 const _minorStep = 0.1;
+
+/// Zoom step applied per screen-reader increase / decrease action.
+const _semanticZoomStep = 0.1;
+
+/// Radius (in zoom units) of the soft detent around each major mark while
+/// dragging. Matches the pinch gesture's 1× gravity well; kept well below the
+/// 0.5× tick spacing so neighbouring wells never overlap.
+const _snapRadius = 0.15;
 
 const _minorTickHeight = 9.0;
 const _majorTickHeight = 16.0;

--- a/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
@@ -1,5 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -94,18 +95,30 @@ void main() {
         expect(opacity.opacity, equals(0));
       });
 
+      testWidgets('exposes the zoom level as a semantics label while visible', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.bySemanticsLabel(l10n.videoRecorderZoomLevelLabel('1')),
+          findsOneWidget,
+        );
+      });
+
       testWidgets('excludes the zoom semantics label when hidden', (
         tester,
       ) async {
-        final semantics = tester.ensureSemantics();
-        try {
-          await tester.pumpWidget(buildWidget(showZoomIndicator: false));
-          await tester.pumpAndSettle();
+        await tester.pumpWidget(buildWidget(showZoomIndicator: false));
+        await tester.pumpAndSettle();
 
-          expect(find.bySemanticsLabel('Zoom to 1×'), findsNothing);
-        } finally {
-          semantics.dispose();
-        }
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(
+          find.bySemanticsLabel(l10n.videoRecorderZoomLevelLabel('1')),
+          findsNothing,
+        );
       });
 
       testWidgets('renders nothing when the camera has a single zoom stop', (
@@ -127,6 +140,23 @@ void main() {
           () => bloc.add(captureAny()),
         ).captured.whereType<VideoRecorderZoomLevelSet>().toList();
       }
+
+      List<MethodCall> recordPlatformCalls() {
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+              calls.add(call);
+              return null;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null);
+        });
+        return calls;
+      }
+
+      Iterable<MethodCall> hapticTicks(List<MethodCall> calls) =>
+          calls.where((c) => c.method == 'HapticFeedback.vibrate');
 
       testWidgets('dragging left zooms in', (tester) async {
         await tester.pumpWidget(buildWidget(zoomLevel: 2));
@@ -232,16 +262,7 @@ void main() {
       });
 
       testWidgets('ticks haptics when crossing a major mark', (tester) async {
-        final calls = <MethodCall>[];
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
-              calls.add(call);
-              return null;
-            });
-        addTearDown(() {
-          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-              .setMockMethodCallHandler(SystemChannels.platform, null);
-        });
+        final calls = recordPlatformCalls();
 
         await tester.pumpWidget(buildWidget());
         await tester.pumpAndSettle();
@@ -253,10 +274,109 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(
-          calls.where((c) => c.method == 'HapticFeedback.vibrate'),
-          isNotEmpty,
+        expect(hapticTicks(calls), isNotEmpty);
+      });
+
+      testWidgets('ticks the 0.5× stop even when it sits on the camera min', (
+        tester,
+      ) async {
+        final calls = recordPlatformCalls();
+
+        // Default minZoom 0.5 IS the 0.5× stop: the value can only arrive on it
+        // from above, never cross below it, yet the detent must still tick.
+        await tester.pumpWidget(buildWidget(zoomLevel: 0.7));
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(110, 0),
         );
+        await tester.pumpAndSettle();
+
+        expect(hapticTicks(calls), isNotEmpty);
+      });
+
+      testWidgets('eases onto and ticks the 0.5× stop on an ultra-wide lens', (
+        tester,
+      ) async {
+        final calls = recordPlatformCalls();
+
+        // 0.7× dragged right to a raw 0.45× crosses the 0.5× mark (haptic) and
+        // lands inside its detent radius, so the value is pulled toward 0.5×.
+        await tester.pumpWidget(buildWidget(zoomLevel: 0.7, minZoomLevel: 0.3));
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(27.5, 0),
+        );
+        await tester.pumpAndSettle();
+
+        final events = capturedZoomEvents();
+        expect(events, isNotEmpty);
+        expect(events.last.value, closeTo(0.5, 0.06));
+        expect(hapticTicks(calls), isNotEmpty);
+      });
+
+      testWidgets('does not spam haptics while pinned against a bound', (
+        tester,
+      ) async {
+        final calls = recordPlatformCalls();
+
+        // One long over-drag pins the value at 5×; it must tick at most once
+        // for the 5× mark rather than on every clamped update.
+        await tester.pumpWidget(buildWidget(zoomLevel: 4.8));
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(-1000, 0),
+        );
+        await tester.pumpAndSettle();
+
+        expect(hapticTicks(calls).length, lessThanOrEqualTo(1));
+      });
+
+      testWidgets('semantic increase nudges the zoom up by a step', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(zoomLevel: 2));
+        await tester.pumpAndSettle();
+
+        tester.semantics.increase(
+          find.semantics.byAction(SemanticsAction.increase),
+        );
+        await tester.pump();
+
+        expect(capturedZoomEvents().last.value, closeTo(2.1, 1e-9));
+      });
+
+      testWidgets('semantic decrease nudges the zoom down by a step', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget(zoomLevel: 2));
+        await tester.pumpAndSettle();
+
+        tester.semantics.decrease(
+          find.semantics.byAction(SemanticsAction.decrease),
+        );
+        await tester.pump();
+
+        expect(capturedZoomEvents().last.value, closeTo(1.9, 1e-9));
+      });
+
+      testWidgets('semantic increase clamps at the camera max', (tester) async {
+        // 4.95× + a 0.1× step overshoots the 5× max and must clamp, not emit
+        // 5.05×. Unlike a drag, the nudge clamps without snapping to a detent.
+        await tester.pumpWidget(buildWidget(zoomLevel: 4.95));
+        await tester.pumpAndSettle();
+
+        tester.semantics.increase(
+          find.semantics.byAction(SemanticsAction.increase),
+        );
+        await tester.pump();
+
+        expect(capturedZoomEvents().last.value, closeTo(5, 1e-9));
       });
 
       testWidgets('does not capture drags while hidden', (tester) async {

--- a/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
@@ -194,6 +194,43 @@ void main() {
         expect(events.last.value, closeTo(2, 0.02));
       });
 
+      testWidgets('reaches a non-integer camera max next to a detent', (
+        tester,
+      ) async {
+        // maxZoom 2.1 sits inside the 2× detent radius; the bound must stay
+        // reachable rather than being pulled back toward 2×.
+        await tester.pumpWidget(buildWidget(maxZoomLevel: 2.1));
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(-1000, 0),
+        );
+        await tester.pumpAndSettle();
+
+        final events = capturedZoomEvents();
+        expect(events, isNotEmpty);
+        expect(events.last.value, closeTo(2.1, 1e-9));
+      });
+
+      testWidgets('reaches a non-integer camera min next to a detent', (
+        tester,
+      ) async {
+        // minZoom 0.95 sits inside the 1× detent radius.
+        await tester.pumpWidget(buildWidget(minZoomLevel: 0.95));
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(1000, 0),
+        );
+        await tester.pumpAndSettle();
+
+        final events = capturedZoomEvents();
+        expect(events, isNotEmpty);
+        expect(events.last.value, closeTo(0.95, 1e-9));
+      });
+
       testWidgets('ticks haptics when crossing a major mark', (tester) async {
         final calls = <MethodCall>[];
         TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart
@@ -1,5 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -13,6 +14,10 @@ class _MockVideoRecorderBloc
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(const VideoRecorderZoomLevelSet(1));
+  });
 
   group(VideoRecorderZoomIndicator, () {
     late _MockVideoRecorderBloc bloc;
@@ -113,6 +118,124 @@ void main() {
 
         expect(find.byType(AnimatedOpacity), findsNothing);
         expect(find.text('1×'), findsNothing);
+      });
+    });
+
+    group('interaction', () {
+      List<VideoRecorderZoomLevelSet> capturedZoomEvents() {
+        return verify(
+          () => bloc.add(captureAny()),
+        ).captured.whereType<VideoRecorderZoomLevelSet>().toList();
+      }
+
+      testWidgets('dragging left zooms in', (tester) async {
+        await tester.pumpWidget(buildWidget(zoomLevel: 2));
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(-110, 0),
+        );
+        await tester.pumpAndSettle();
+
+        final events = capturedZoomEvents();
+        expect(events, isNotEmpty);
+        expect(events.last.value, greaterThan(2));
+      });
+
+      testWidgets('dragging right zooms out', (tester) async {
+        await tester.pumpWidget(buildWidget(zoomLevel: 3));
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(110, 0),
+        );
+        await tester.pumpAndSettle();
+
+        final events = capturedZoomEvents();
+        expect(events, isNotEmpty);
+        expect(events.last.value, lessThan(3));
+      });
+
+      testWidgets('never dispatches beyond the camera max', (tester) async {
+        await tester.pumpWidget(
+          buildWidget(zoomLevel: 4.8),
+        );
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(-1000, 0),
+        );
+        await tester.pumpAndSettle();
+
+        for (final event in capturedZoomEvents()) {
+          expect(event.value, lessThanOrEqualTo(5));
+        }
+      });
+
+      testWidgets('eases onto a major mark when released nearby', (
+        tester,
+      ) async {
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        // 1× dragged ~0.95 lands at a raw 1.95×, inside the 2× detent radius,
+        // so the emitted value is pulled snug to 2× rather than left at 1.95×.
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(-104.5, 0),
+        );
+        await tester.pumpAndSettle();
+
+        final events = capturedZoomEvents();
+        expect(events, isNotEmpty);
+        expect(events.last.value, closeTo(2, 0.02));
+      });
+
+      testWidgets('ticks haptics when crossing a major mark', (tester) async {
+        final calls = <MethodCall>[];
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+              calls.add(call);
+              return null;
+            });
+        addTearDown(() {
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(SystemChannels.platform, null);
+        });
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pumpAndSettle();
+
+        // 1× → ~2× crosses the 2× whole-factor mark.
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(-110, 0),
+        );
+        await tester.pumpAndSettle();
+
+        expect(
+          calls.where((c) => c.method == 'HapticFeedback.vibrate'),
+          isNotEmpty,
+        );
+      });
+
+      testWidgets('does not capture drags while hidden', (tester) async {
+        await tester.pumpWidget(buildWidget(showZoomIndicator: false));
+        await tester.pumpAndSettle();
+
+        await tester.drag(
+          find.byType(VideoRecorderZoomIndicator),
+          const Offset(-110, 0),
+          warnIfMissed: false,
+        );
+        await tester.pumpAndSettle();
+
+        verifyNever(
+          () => bloc.add(any(that: isA<VideoRecorderZoomLevelSet>())),
+        );
       });
     });
   });


### PR DESCRIPTION
Closes #5560

## Description

The zoom ruler (`VideoRecorderZoomIndicator`) was a read-out only — the pinch gesture on the preview drove the zoom and the ruler explicitly ignored all pointer events. This makes it interactive while it's visible, so users can fine-tune zoom by scrubbing the ruler directly instead of only pinching.

- **Drag to zoom:** a horizontal drag along the ruler sets the zoom. Dragging left zooms in, matching the direction the ticks scroll under a pinch (iOS-camera convention). It dispatches the existing `VideoRecorderZoomLevelSet` event, clamped to the camera's `[min, max]` range so the bloc never rejects an out-of-bounds value (`_onZoomLevelSet` rejects rather than clamps).
- **Snap detents:** the scrubbed value eases onto the major marks (whole factors + the 0.5× ultra-wide stop) using the same damped gravity-well curve as the pinch's 1× detent. The detent is an emit-only transform, so the raw finger position never gets trapped in the well.
- **Haptics:** a light `HapticService.snapFeedback()` tick fires each time the value crosses a major mark, mirroring the pinch's 1× snap feedback.
- **Gesture isolation:** pointer events are only captured while the ruler is visible (`showZoomIndicator`), so the preview keeps its pinch / tap / long-press gestures the rest of the time.
- **Accessibility:** the ruler now exposes slider semantics with increase/decrease actions (0.1× steps) for screen-reader users.

**Related Issue:** 

## Out of Scope

- The pinch's 350ms snap *hold* (which guards against accidental slip-through from pinch momentum) is intentionally not ported — a finger drag has no momentum, so the gravity well alone is enough.

## Verification

- `dart format` (no changes)
- `flutter analyze lib/widgets/video_recorder/video_recorder_zoom_indicator.dart test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart` — no issues
- `flutter test test/widgets/video_recorder/video_recorder_zoom_indicator_test.dart` — 12 passing (drag direction, max clamp, snap-to-major, haptic on crossing, no-capture-while-hidden)

> Not yet verified on a physical device — the single-finger-drag vs two-finger-pinch gesture arena should be smoke-tested on hardware.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)