### PR TITLE
fix(search): bound NIP-50 relay query stalls

### DIFF
--- a/mobile/docs/PEOPLE_SEARCH.md
+++ b/mobile/docs/PEOPLE_SEARCH.md
@@ -27,7 +27,7 @@ UserSearchBloc                              mobile/lib/blocs/user_search/
 ProfileRepository.searchUsersProgressive    mobile/packages/profile_repository/
   Phase 1 (offset==0): searchUsersLocally        SQLite cache, no timeout
   Phase 2:             funnelcake.searchProfiles REST, no explicit timeout
-  Phase 3 (offset==0): nostrClient.queryUsers    NIP-50 WS, .timeout(5s)
+  Phase 3 (offset==0): nostrClient.queryUsers    NIP-50 WS, 4.5s relay budget + 5s guard
   Each phase records a SearchSourceStatus in the result envelope.
   Final yield: _enrichFromCache + _applyFilter (block filter + boost)
         ↓
@@ -45,8 +45,10 @@ The repository consults sources in a fixed, sequential order:
    Consulted on every page. Skipped (`SearchSourceSkipped`) when the
    client is configured without a base URL.
 3. **nip50Relay** — Federated NIP-50 search across three hardcoded
-   relays. Consulted only on the first page (`offset == 0`). Hard
-   timeout of `_nip50SearchTimeout` (5 s).
+   relays. Consulted only on the first page (`offset == 0`). The SDK
+   relay query has a 4.5 s budget and returns partial results when that
+   budget expires; the repository keeps a 5 s guard for setup stalls
+   before the SDK budget starts.
 
 After each phase that produced new profiles, the repository yields a
 `ProgressiveSearchResult` carrying:

--- a/mobile/integration_test/helpers/test_nostr_service.dart
+++ b/mobile/integration_test/helpers/test_nostr_service.dart
@@ -185,7 +185,8 @@ class TestNostrService implements NostrClient {
     List<int> relayTypes = const [],
     bool sendAfterAuth = false,
     bool useCache = true,
-    Duration? timeout,
+    bool useQueryPool = true,
+    Duration timeout = const Duration(seconds: 5),
   }) async {
     final matchingEvents = <Event>[];
 

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -513,6 +513,7 @@ class NostrClient {
     List<int> relayTypes = RelayType.all,
     bool sendAfterAuth = false,
     bool useCache = true,
+    bool useQueryPool = true,
     Duration timeout = const Duration(seconds: 5),
   }) async {
     final effectiveTempRelays = _allowedRelays(tempRelays);
@@ -534,20 +535,21 @@ class NostrClient {
       await retryDisconnectedRelays();
     }
     final filtersJson = filters.map((f) => f.toJson()).toList();
+    Future<List<Event>> runWebSocketQuery() => _nostr.queryEvents(
+      filtersJson,
+      id: subscriptionId,
+      tempRelays: effectiveTempRelays,
+      relayTypes: relayTypes,
+      sendAfterAuth: sendAfterAuth,
+      timeout: timeout,
+    );
     // Throttle concurrent one-shot REQs so high fan-out (a profile with many
-    // videos → per-item like-count/badge/profile/repost fetches) can't trip a
+    // videos -> per-item like-count/badge/profile/repost fetches) can't trip a
     // relay's "too many concurrent REQs" limit. `withResource` releases the
     // slot when the (time-bounded) query completes, so it can't leak.
-    final websocketEvents = await _queryPool.withResource(
-      () => _nostr.queryEvents(
-        filtersJson,
-        id: subscriptionId,
-        tempRelays: effectiveTempRelays,
-        relayTypes: relayTypes,
-        sendAfterAuth: sendAfterAuth,
-        timeout: timeout,
-      ),
-    );
+    final websocketEvents = useQueryPool
+        ? await _queryPool.withResource(runWebSocketQuery)
+        : await runWebSocketQuery();
 
     // Cache websocket results (fire-and-forget)
     if (websocketEvents.isNotEmpty) {
@@ -1228,7 +1230,11 @@ class NostrClient {
       search: query,
     );
 
-    return queryEvents([filter], tempRelays: _nip50SearchRelays);
+    return queryEvents(
+      [filter],
+      tempRelays: _nip50SearchRelays,
+      useQueryPool: false,
+    );
   }
 
   /// Creates a NIP-98 HTTP authentication header.

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -544,7 +544,7 @@ class NostrClient {
       timeout: timeout,
     );
     // Throttle concurrent one-shot REQs so high fan-out (a profile with many
-    // videos -> per-item like-count/badge/profile/repost fetches) can't trip a
+    // videos → per-item like-count/badge/profile/repost fetches) can't trip a
     // relay's "too many concurrent REQs" limit. `withResource` releases the
     // slot when the (time-bounded) query completes, so it can't leak.
     final websocketEvents = useQueryPool
@@ -1223,7 +1223,11 @@ class NostrClient {
   ///
   /// Unlike [searchUsers], this returns a Future that completes once,
   /// making it suitable for one-time search operations.
-  Future<List<Event>> queryUsers(String query, {int? limit}) {
+  Future<List<Event>> queryUsers(
+    String query, {
+    int? limit,
+    Duration timeout = const Duration(seconds: 5),
+  }) {
     final filter = Filter(
       kinds: const [EventKind.metadata],
       limit: limit ?? 100,
@@ -1234,6 +1238,7 @@ class NostrClient {
       [filter],
       tempRelays: _nip50SearchRelays,
       useQueryPool: false,
+      timeout: timeout,
     );
   }
 

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -3460,6 +3460,56 @@ void main() {
         expect(tempRelays, contains('wss://nostr.wine'));
         expect(tempRelays, hasLength(3));
       });
+
+      test('bypasses general query pool for interactive search', () async {
+        final originalMaxConcurrentQueries = NostrClient.maxConcurrentQueries;
+        NostrClient.maxConcurrentQueries = 1;
+        addTearDown(
+          () => NostrClient.maxConcurrentQueries = originalMaxConcurrentQueries,
+        );
+
+        var callCount = 0;
+        final pendingBackgroundQuery = Completer<List<Event>>();
+        final profileEvent = _createTestEvent(
+          kind: EventKind.metadata,
+          content: '{"name": "Alice"}',
+        );
+
+        when(
+          () => mockNostr.queryEvents(
+            any(),
+            id: any(named: 'id'),
+            tempRelays: any(named: 'tempRelays'),
+            relayTypes: any(named: 'relayTypes'),
+            sendAfterAuth: any(named: 'sendAfterAuth'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) {
+          callCount++;
+          if (callCount == 1) {
+            return pendingBackgroundQuery.future;
+          }
+          return Future.value([profileEvent]);
+        });
+
+        final backgroundQuery = client.queryEvents(
+          [
+            Filter(kinds: const [1059]),
+          ],
+          useCache: false,
+        );
+        await pumpEventQueue();
+
+        final result = await client
+            .queryUsers('alice')
+            .timeout(const Duration(milliseconds: 100));
+
+        expect(result, [profileEvent]);
+        expect(callCount, 2);
+
+        pendingBackgroundQuery.complete(<Event>[]);
+        await backgroundQuery;
+      });
     });
 
     group('countEvents', () {

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -320,11 +320,7 @@ class Nostr {
     var eventBox = EventMemBox(sortAfterAdd: false);
     var completer = Completer<void>();
     final subscriptionId = id ?? StringUtil.rndNameStr(16);
-    const callerTimeoutBuffer = Duration(milliseconds: 250);
-    final effectiveTimeout = timeout > callerTimeoutBuffer
-        ? timeout - callerTimeoutBuffer
-        : timeout;
-    final deadline = DateTime.now().add(effectiveTimeout);
+    final deadline = DateTime.now().add(timeout);
 
     Duration remainingTimeout() {
       final remaining = deadline.difference(DateTime.now());

--- a/mobile/packages/nostr_sdk/lib/nostr.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr.dart
@@ -319,25 +319,38 @@ class Nostr {
   }) async {
     var eventBox = EventMemBox(sortAfterAdd: false);
     var completer = Completer<void>();
+    final subscriptionId = id ?? StringUtil.rndNameStr(16);
+    const callerTimeoutBuffer = Duration(milliseconds: 250);
+    final effectiveTimeout = timeout > callerTimeoutBuffer
+        ? timeout - callerTimeoutBuffer
+        : timeout;
+    final deadline = DateTime.now().add(effectiveTimeout);
 
-    final subscriptionId = await query(
-      filters,
-      id: id,
-      tempRelays: tempRelays,
-      relayTypes: relayTypes,
-      sendAfterAuth: sendAfterAuth,
-      (event) {
-        eventBox.add(event);
-      },
-      onComplete: () {
-        if (!completer.isCompleted) {
-          completer.complete();
-        }
-      },
-    );
+    Duration remainingTimeout() {
+      final remaining = deadline.difference(DateTime.now());
+      if (remaining.isNegative || remaining == Duration.zero) {
+        return Duration.zero;
+      }
+      return remaining;
+    }
 
     try {
-      await completer.future.timeout(timeout);
+      await query(
+        filters,
+        id: subscriptionId,
+        tempRelays: tempRelays,
+        relayTypes: relayTypes,
+        sendAfterAuth: sendAfterAuth,
+        (event) {
+          eventBox.add(event);
+        },
+        onComplete: () {
+          if (!completer.isCompleted) {
+            completer.complete();
+          }
+        },
+      ).timeout(remainingTimeout());
+      await completer.future.timeout(remainingTimeout());
     } on TimeoutException {
       unsubscribe(subscriptionId);
     }

--- a/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
+++ b/mobile/packages/nostr_sdk/lib/relay/relay_pool.dart
@@ -237,7 +237,9 @@ class RelayPool {
         // For vine.hol.is, send the query to trigger AUTH challenge
         if (relay.url.contains('vine.hol.is')) {
           log('🔐 vine.hol.is query - sending to trigger AUTH challenge');
-          var result = await relay.send(message, forceSend: true);
+          final result = await relay
+              .send(message, forceSend: true)
+              .timeout(perRelaySendTimeout, onTimeout: () => false);
           if (result) {
             relay.saveQuery(subscription);
             return true;
@@ -251,7 +253,9 @@ class RelayPool {
       } else {
         // Skip reconnect during query fan-out to avoid blocking
         // other relays while one dead relay tries exponential backoff.
-        final result = await relay.send(message, skipReconnect: true);
+        final result = await relay
+            .send(message, skipReconnect: true)
+            .timeout(perRelaySendTimeout, onTimeout: () => false);
         if (result) {
           relay.saveQuery(subscription);
         }

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -406,7 +406,7 @@ void main() {
       ], timeout: const Duration(seconds: 1));
       stopwatch.stop();
 
-      expect(stopwatch.elapsedMilliseconds, lessThan(1000));
+      expect(stopwatch.elapsedMilliseconds, lessThan(2000));
       expect(events, isEmpty);
       expect(
         hangingRelay.sentMessages.where((m) => m.first == 'REQ'),

--- a/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart
@@ -329,6 +329,35 @@ class _ConnectionAwareTempRelay extends Relay {
   }
 }
 
+class _HangingSendRelay extends Relay {
+  _HangingSendRelay(String url) : super(url, RelayStatus(url));
+
+  final List<List<dynamic>> sentMessages = [];
+
+  @override
+  Future<bool> doConnect() async {
+    relayStatus.connected = ClientConnected.connected;
+    return true;
+  }
+
+  @override
+  Future<void> disconnect() async {
+    relayStatus.connected = ClientConnected.disconnect;
+  }
+
+  @override
+  Future<bool> send(
+    List<dynamic> message, {
+    bool? forceSend,
+    bool queueIfFailed = true,
+    bool skipReconnect = false,
+    DateTime? deadline,
+  }) {
+    sentMessages.add(message);
+    return Completer<bool>().future;
+  }
+}
+
 void main() {
   group('RelayPool concurrency', () {
     late Nostr nostr;
@@ -362,6 +391,27 @@ void main() {
       // fails to send and is not registered in the EOSE tracking
       expect(stopwatch.elapsedMilliseconds, lessThan(2000));
       expect(events, isEmpty);
+    });
+
+    test('hung relay send does not outlive queryEvents timeout', () async {
+      final hangingRelay = _HangingSendRelay('wss://hanging.relay');
+      await nostr.relayPool.add(hangingRelay);
+
+      final stopwatch = Stopwatch()..start();
+      final events = await nostr.queryEvents([
+        {
+          'kinds': [1],
+          'limit': 1,
+        },
+      ], timeout: const Duration(seconds: 1));
+      stopwatch.stop();
+
+      expect(stopwatch.elapsedMilliseconds, lessThan(1000));
+      expect(events, isEmpty);
+      expect(
+        hangingRelay.sentMessages.where((m) => m.first == 'REQ'),
+        hasLength(1),
+      );
     });
 
     test(

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -32,11 +32,11 @@ const _nameServerHttpTimeout = Duration(seconds: 10);
 // which still carries the typed REST fields after #4175.
 const _publishSeedRelayTimeout = Duration(seconds: 4);
 
-// Caps the NIP-50 user search query. On timeout the bloc still receives
-// the accumulated partial result, with the relay source marked as
-// SearchSourceFailed(reason: timeout) so the UI can surface a retry
-// affordance when nothing else contributed.
+// Caps NIP-50 user search. The relay query has a slightly shorter inner
+// budget and returns partial results on SDK timeout; the outer guard is a
+// repository safety net for stalls before the SDK budget starts.
 const _nip50SearchTimeout = Duration(seconds: 5);
+const _nip50RelayQueryTimeout = Duration(milliseconds: 4500);
 
 // TODO(search): Move ProfileSearchFilter to a shared package
 // (e.g., search_utils) when we need to reuse search logic across
@@ -1150,7 +1150,11 @@ class ProfileRepository {
       final phase3Watch = Stopwatch()..start();
       try {
         final events = await _nostrClient
-            .queryUsers(trimmed, limit: limit)
+            .queryUsers(
+              trimmed,
+              limit: limit,
+              timeout: _nip50RelayQueryTimeout,
+            )
             .timeout(_nip50SearchTimeout);
         for (final event in events) {
           final profile = UserProfile.fromNostrEvent(event);

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -59,6 +59,7 @@ void main() {
       );
       registerFallbackValue(Uri.parse('https://example.com'));
       registerFallbackValue(<Filter>[]);
+      registerFallbackValue(Duration.zero);
     });
 
     setUp(() {
@@ -2826,7 +2827,11 @@ void main() {
         ).thenReturn(jsonEncode({'display_name': 'Test Remote'}));
 
         when(
-          () => mockNostrClient.queryUsers('test', limit: 200),
+          () => mockNostrClient.queryUsers(
+            'test',
+            limit: 200,
+            timeout: any(named: 'timeout'),
+          ),
         ).thenAnswer((_) async => [mockRemoteEvent]);
 
         // Act
@@ -2894,7 +2899,11 @@ void main() {
         ).thenAnswer((_) async => []);
 
         when(
-          () => mockNostrClient.queryUsers('test', limit: 200),
+          () => mockNostrClient.queryUsers(
+            'test',
+            limit: 200,
+            timeout: any(named: 'timeout'),
+          ),
         ).thenAnswer((_) async => [mockProfileEvent]);
 
         // Act
@@ -2950,7 +2959,11 @@ void main() {
 
           // NIP-50
           when(
-            () => mockNostrClient.queryUsers('test', limit: 200),
+            () => mockNostrClient.queryUsers(
+              'test',
+              limit: 200,
+              timeout: any(named: 'timeout'),
+            ),
           ).thenAnswer((_) async => []);
 
           final repoWithFunnelcake = ProfileRepository(
@@ -2996,7 +3009,11 @@ void main() {
           ).thenAnswer((_) async => []);
 
           when(
-            () => mockNostrClient.queryUsers('test', limit: 200),
+            () => mockNostrClient.queryUsers(
+              'test',
+              limit: 200,
+              timeout: any(named: 'timeout'),
+            ),
           ).thenAnswer((_) async => [mockProfileEvent]);
 
           final repoWithFunnelcake = ProfileRepository(
@@ -3043,7 +3060,11 @@ void main() {
           ).thenAnswer((_) async => []);
 
           when(
-            () => mockNostrClient.queryUsers('test', limit: 200),
+            () => mockNostrClient.queryUsers(
+              'test',
+              limit: 200,
+              timeout: any(named: 'timeout'),
+            ),
           ).thenThrow(StateError('WebSocket error'));
 
           final repoWithFunnelcake = ProfileRepository(
@@ -3099,7 +3120,11 @@ void main() {
           ).thenAnswer((_) async => []);
 
           when(
-            () => mockNostrClient.queryUsers('test', limit: 200),
+            () => mockNostrClient.queryUsers(
+              'test',
+              limit: 200,
+              timeout: any(named: 'timeout'),
+            ),
           ).thenAnswer((_) async => [mockWsEvent]);
 
           final repoWithFunnelcake = ProfileRepository(
@@ -3134,7 +3159,11 @@ void main() {
           ).thenReturn(jsonEncode({'display_name': 'Alice Test'}));
 
           when(
-            () => mockNostrClient.queryUsers('test', limit: 200),
+            () => mockNostrClient.queryUsers(
+              'test',
+              limit: 200,
+              timeout: any(named: 'timeout'),
+            ),
           ).thenAnswer((_) async => [mockWsEvent]);
 
           var filterCalled = false;
@@ -3177,7 +3206,11 @@ void main() {
             );
 
             when(
-              () => mockNostrClient.queryUsers('alice', limit: 200),
+              () => mockNostrClient.queryUsers(
+                'alice',
+                limit: 200,
+                timeout: any(named: 'timeout'),
+              ),
             ).thenAnswer((_) async => []);
 
             when(
@@ -3238,7 +3271,11 @@ void main() {
             () => mockUserProfilesDao.getAllProfiles(),
           ).thenAnswer((_) async => []);
           when(
-            () => mockNostrClient.queryUsers(any(), limit: any(named: 'limit')),
+            () => mockNostrClient.queryUsers(
+              any(),
+              limit: any(named: 'limit'),
+              timeout: any(named: 'timeout'),
+            ),
           ).thenAnswer((_) async => []);
         });
 
@@ -3470,7 +3507,11 @@ void main() {
             () => wsEvent.content,
           ).thenReturn(jsonEncode({'display_name': 'WS User'}));
           when(
-            () => mockNostrClient.queryUsers('test', limit: 200),
+            () => mockNostrClient.queryUsers(
+              'test',
+              limit: 200,
+              timeout: any(named: 'timeout'),
+            ),
           ).thenAnswer((_) async => [wsEvent]);
 
           final repo = ProfileRepository(
@@ -3505,7 +3546,11 @@ void main() {
             ).thenThrow(StateError('db down'));
             when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
             when(
-              () => mockNostrClient.queryUsers('test', limit: 200),
+              () => mockNostrClient.queryUsers(
+                'test',
+                limit: 200,
+                timeout: any(named: 'timeout'),
+              ),
             ).thenAnswer((_) async => []);
 
             final repo = ProfileRepository(
@@ -3542,7 +3587,11 @@ void main() {
             ),
           ).thenThrow(Exception('connection refused'));
           when(
-            () => mockNostrClient.queryUsers('test', limit: 200),
+            () => mockNostrClient.queryUsers(
+              'test',
+              limit: 200,
+              timeout: any(named: 'timeout'),
+            ),
           ).thenAnswer((_) async => []);
 
           final repo = ProfileRepository(
@@ -3570,7 +3619,11 @@ void main() {
             ).thenAnswer((_) async => []);
             when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
             when(
-              () => mockNostrClient.queryUsers('test', limit: 200),
+              () => mockNostrClient.queryUsers(
+                'test',
+                limit: 200,
+                timeout: any(named: 'timeout'),
+              ),
             ).thenAnswer((_) async {
               // Sleep past the 5 s NIP-50 timeout so .timeout() fires.
               await Future<void>.delayed(const Duration(seconds: 6));
@@ -3594,6 +3647,13 @@ void main() {
               (relayStatus! as SearchSourceFailed).reason,
               SearchSourceFailureReason.timeout,
             );
+            verify(
+              () => mockNostrClient.queryUsers(
+                'test',
+                limit: 200,
+                timeout: const Duration(milliseconds: 4500),
+              ),
+            ).called(1);
           },
           timeout: const Timeout(Duration(seconds: 10)),
         );
@@ -3614,7 +3674,11 @@ void main() {
               ),
             ).thenThrow(Exception('REST down'));
             when(
-              () => mockNostrClient.queryUsers('test', limit: 200),
+              () => mockNostrClient.queryUsers(
+                'test',
+                limit: 200,
+                timeout: any(named: 'timeout'),
+              ),
             ).thenThrow(StateError('WS down'));
 
             final repo = ProfileRepository(
@@ -3653,7 +3717,11 @@ void main() {
               () => mockUserProfilesDao.getAllProfiles(),
             ).thenAnswer((_) async => []);
             when(
-              () => mockNostrClient.queryUsers('test', limit: 200),
+              () => mockNostrClient.queryUsers(
+                'test',
+                limit: 200,
+                timeout: any(named: 'timeout'),
+              ),
             ).thenAnswer((_) async => []);
 
             final repo = ProfileRepository(

--- a/mobile/test/helpers/test_nostr_service.dart
+++ b/mobile/test/helpers/test_nostr_service.dart
@@ -185,7 +185,8 @@ class TestNostrService implements NostrClient {
     List<int> relayTypes = const [],
     bool sendAfterAuth = false,
     bool useCache = true,
-    Duration? timeout,
+    bool useQueryPool = true,
+    Duration timeout = const Duration(seconds: 5),
   }) async {
     final matchingEvents = <Event>[];
 


### PR DESCRIPTION
## Summary

Closes #5561.

This fixes an intermittent profile-search timeout where the NIP-50 relay phase could be marked failed after 5 seconds even though the search flow had already produced usable results.

## Root Cause

`ProfileRepository.searchUsersProgressive` wraps `NostrClient.queryUsers` in a 5 second timeout. `NostrClient.queryUsers` delegates to `Nostr.queryEvents`, but the SDK timeout only started after `RelayPool.query` returned a subscription id. `RelayPool.query` waits for relay sends during setup, so a hung temp relay send could consume the repository-level timeout before the SDK timeout ever started.

Interactive profile search also used the general one-shot query pool, which meant user-initiated NIP-50 search could sit behind unrelated background query fan-out.

## Changes

- Add a `useQueryPool` option to `NostrClient.queryEvents` and make `queryUsers` bypass the general query pool for interactive NIP-50 search.
- Make `Nostr.queryEvents` apply its timeout across both query setup and result waiting.
- Cap query fan-out sends with the existing relay send timeout so a hung relay cannot hold query setup indefinitely.
- Update test helper overrides to match the extended `queryEvents` signature.
- Add regression coverage for interactive search bypassing the query pool and hung relay sends returning within the query timeout.

## Validation

- Pre-push analyzer passed.
- Pre-push changed-file tests passed.
- `flutter test packages/nostr_client/test/src/nostr_client_test.dart --plain-name queryUsers`
- `flutter test packages/nostr_sdk/test/unit/relay_pool_concurrency_test.dart`
- `flutter analyze packages/nostr_client/lib/src/nostr_client.dart packages/nostr_sdk/lib/nostr.dart packages/nostr_sdk/lib/relay/relay_pool.dart test/helpers/test_nostr_service.dart integration_test/helpers/test_nostr_service.dart`

## Risk

Low to moderate. The query pool still protects background one-shot fan-out by default; the bypass is limited to interactive NIP-50 profile search. The SDK timeout change preserves the existing return-partial-results behavior while expanding the timeout boundary to include query setup.