### PR TITLE
feat(feed): add Classics mode to the home feed picker

### DIFF
--- a/mobile/lib/blocs/video_feed/feed_mode_preference_store.dart
+++ b/mobile/lib/blocs/video_feed/feed_mode_preference_store.dart
@@ -105,6 +105,9 @@ class FeedModePreferenceStore {
     if (saved == FeedMode.forYou.name) {
       return const VideoFeedSource.forYou();
     }
+    if (saved == FeedMode.classic.name) {
+      return const VideoFeedSource.classic();
+    }
     return null;
   }
 

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -130,7 +130,18 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
   bool _usesHomeFeedCache(VideoFeedSource source) =>
       source.type == VideoFeedSourceType.forYou ||
       source.type == VideoFeedSourceType.following ||
-      source.type == VideoFeedSourceType.newVideos;
+      source.type == VideoFeedSourceType.newVideos ||
+      source.type == VideoFeedSourceType.classic;
+
+  /// Whether [source] paginates via an opaque server cursor (recommendation
+  /// and popular feeds) rather than a `createdAt` "until" timestamp.
+  ///
+  /// Cursor-backed feeds arrive in server-ranked order, so pages must be
+  /// appended as-is (no `createdAt` re-sort) and exhaustion is signalled by a
+  /// null [HomeFeedResult.paginationCursor] rather than an empty page.
+  bool _usesCursorPagination(VideoFeedSource source) =>
+      source.type == VideoFeedSourceType.forYou ||
+      source.type == VideoFeedSourceType.classic;
 
   bool _canEmitForSource(
     VideoFeedSource source,
@@ -332,8 +343,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       return;
     }
 
-    if (state.source.type == VideoFeedSourceType.forYou &&
-        state.paginationCursor == null) {
+    if (_usesCursorPagination(state.source) && state.paginationCursor == null) {
       emit(state.copyWith(hasMore: false));
       return;
     }
@@ -351,12 +361,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
           .reduce((a, b) => a < b ? a : b);
       final until = oldestCreatedAt;
 
+      final usesCursor = _usesCursorPagination(source);
       final result = await _fetchVideosForSource(
         source,
-        until: source.type == VideoFeedSourceType.forYou ? null : until,
-        paginationCursor: source.type == VideoFeedSourceType.forYou
-            ? state.paginationCursor
-            : null,
+        until: usesCursor ? null : until,
+        paginationCursor: usesCursor ? state.paginationCursor : null,
       );
       if (!_canEmitForSource(source, emit)) return;
 
@@ -376,10 +385,10 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         }
       }
 
-      // For You pages arrive in server-ranked recommendation order;
-      // re-sorting by createdAt would shuffle new videos around the
+      // Cursor-backed feeds (For You, Classics) arrive in server-ranked
+      // order; re-sorting by createdAt would shuffle new videos around the
       // current play index and resurface already-seen ones.
-      if (source.type != VideoFeedSourceType.forYou) {
+      if (!usesCursor) {
         updatedVideos.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       }
       final addedUniqueVideos = updatedVideos.length > state.videos.length;
@@ -814,7 +823,7 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     required bool fallbackHasMore,
   }) {
     final upstreamHasMore = result.hasMore ?? fallbackHasMore;
-    if (source.type != VideoFeedSourceType.forYou) {
+    if (!_usesCursorPagination(source)) {
       return upstreamHasMore;
     }
 
@@ -865,6 +874,16 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       _videosRepository
           .getNewVideos(until: until, skipCache: skipCache)
           .then((videos) => HomeFeedResult(videos: videos)),
+    VideoFeedSourceType.classic =>
+      paginationCursor == null
+          ? _videosRepository.getClassicVideos(
+              until: until,
+              skipCache: skipCache,
+            )
+          : _videosRepository.getClassicVideos(
+              cursor: paginationCursor,
+              skipCache: skipCache,
+            ),
   };
 
   void _scheduleNostrEnrichment({

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -119,8 +119,8 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
 
   /// Whether [source] participates in the cross-restart [HomeFeedCache].
   ///
-  /// All three home modes (For You, Following, New) are served from and
-  /// written to the cache so cold start shows the last feed instantly. The
+  /// All four home modes (For You, Following, New, Classics) are served from
+  /// and written to the cache so cold start shows the last feed instantly. The
   /// `forYou` staleness concern from #3861 is handled differently now: the
   /// cached feed is positioned at the user's last index and everything past
   /// the active video is replaced with fresh server data on every load

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -13,6 +13,9 @@ enum FeedMode {
 
   /// Legacy persisted restore value. Home no longer exposes this mode.
   latest,
+
+  /// Popular classic Vine archive videos.
+  classic,
 }
 
 /// Typed source for the home video feed.
@@ -28,6 +31,9 @@ enum VideoFeedSourceType {
 
   /// Most recently published videos (chronological).
   newVideos,
+
+  /// Popular classic Vine archive videos.
+  classic,
 }
 
 /// Source selection for [VideoFeedBloc].
@@ -56,11 +62,18 @@ final class VideoFeedSource extends Equatable {
       listId = null,
       listName = null;
 
+  /// Popular classic Vine archive videos.
+  const VideoFeedSource.classic()
+    : type = VideoFeedSourceType.classic,
+      listId = null,
+      listName = null;
+
   /// Compatibility conversion for legacy mode-based callers.
   factory VideoFeedSource.fromMode(FeedMode mode) => switch (mode) {
     FeedMode.following => const VideoFeedSource.following(),
     FeedMode.forYou => const VideoFeedSource.forYou(),
     FeedMode.latest => const VideoFeedSource.newVideos(),
+    FeedMode.classic => const VideoFeedSource.classic(),
   };
 
   /// The source type.
@@ -76,6 +89,7 @@ final class VideoFeedSource extends Equatable {
   FeedMode get mode => switch (type) {
     VideoFeedSourceType.forYou => FeedMode.forYou,
     VideoFeedSourceType.newVideos => FeedMode.latest,
+    VideoFeedSourceType.classic => FeedMode.classic,
     VideoFeedSourceType.following ||
     VideoFeedSourceType.subscribedList => FeedMode.following,
   };
@@ -85,6 +99,7 @@ final class VideoFeedSource extends Equatable {
     VideoFeedSourceType.forYou => FeedMode.forYou.name,
     VideoFeedSourceType.newVideos => FeedMode.latest.name,
     VideoFeedSourceType.following => FeedMode.following.name,
+    VideoFeedSourceType.classic => FeedMode.classic.name,
     VideoFeedSourceType.subscribedList => listName ?? '',
   };
 
@@ -93,6 +108,7 @@ final class VideoFeedSource extends Equatable {
     VideoFeedSourceType.forYou => FeedMode.forYou.name,
     VideoFeedSourceType.newVideos => FeedMode.latest.name,
     VideoFeedSourceType.following => FeedMode.following.name,
+    VideoFeedSourceType.classic => FeedMode.classic.name,
     VideoFeedSourceType.subscribedList => 'list:$listId',
   };
 
@@ -152,6 +168,8 @@ final class VideoFeedBlocState extends Equatable {
                ? const VideoFeedSource.following()
                : mode == FeedMode.latest
                ? const VideoFeedSource.newVideos()
+               : mode == FeedMode.classic
+               ? const VideoFeedSource.classic()
                : const VideoFeedSource.forYou());
 
   /// The current loading status.

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2019,6 +2019,7 @@
     "feedModeForYou": "ለእርስዎ",
     "feedModeNew": "አዲስ",
     "feedModeFollowing": "እየተከተሉ",
+    "feedModeClassics": "ክላሲኮች",
     "feedModeSemanticLabel": "የፊድ ሁነታ: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -2039,6 +2040,7 @@
     "feedForYouEmpty": "የእርስዎ ለአንተ ምግብ ባዶ ነው።\nቪዲዮዎችን ያስሱ እና ለመቅረጽ ፈጣሪዎችን ይከተሉ።",
     "feedFollowingEmpty": "እስካሁን ከምትከተላቸው ሰዎች ምንም ቪዲዮዎች የሉም።\nየሚወዷቸውን ፈጣሪዎች ያግኙ እና ይከተሉዋቸው።",
     "feedLatestEmpty": "እስካሁን ምንም አዲስ ቪዲዮዎች የሉም።\nበቅርቡ ተመልሰው ይመልከቱ።",
+    "feedClassicEmpty": "እስካሁን ምንም ክላሲኮች የሉም።\nበቅርቡ ተመልሰው ይመልከቱ።",
     "feedExploreVideos": "ቪዲዮዎችን ያስሱ",
     "feedExternalVideoSlow": "ውጫዊ ቪዲዮ ቀስ በቀስ በመጫን ላይ",
     "feedSkip": "ዝለል",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1699,6 +1699,7 @@
     "feedModeForYou": "لك",
     "feedModeNew": "جديد",
     "feedModeFollowing": "المتابَعون",
+    "feedModeClassics": "الكلاسيكيات",
     "feedModeSemanticLabel": "وضع الموجز: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1719,6 +1720,7 @@
     "feedForYouEmpty": "خلاصة لك فارغة.\nاستكشف المقاطع واتبع صناع المحتوى لتخصيصها.",
     "feedFollowingEmpty": "لا توجد مقاطع بعد من الأشخاص الذين تتابعهم.\nاعثر على صناع محتوى يعجبونك وتابعهم.",
     "feedLatestEmpty": "لا توجد مقاطع جديدة بعد.\nعد لاحقًا.",
+    "feedClassicEmpty": "لا توجد كلاسيكيات بعد.\nعد لاحقًا.",
     "feedExploreVideos": "استكشاف مقاطع الفيديو",
     "feedExternalVideoSlow": "الفيديو الخارجي يُحمَّل ببطء",
     "feedSkip": "تخطي",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1906,6 +1906,7 @@
     "feedModeForYou": "За теб",
     "feedModeNew": "Ново",
     "feedModeFollowing": "Следвани",
+    "feedModeClassics": "Класики",
     "feedModeSemanticLabel": "Режим на емисията: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1926,6 +1927,7 @@
     "feedForYouEmpty": "Твоят фийд „За теб“ е празен.\nРазгледай видеа и последвай творци, за да го оформиш.",
     "feedFollowingEmpty": "Още няма видеа от хората, които следваш.\nНамери творци, които ти допадат, и ги последвай.",
     "feedLatestEmpty": "Още няма нови видеа.\nПровери пак скоро.",
+    "feedClassicEmpty": "Още няма класики.\nПровери пак скоро.",
     "feedExploreVideos": "Разгледай видеа",
     "feedExternalVideoSlow": "Външното видео се зарежда бавно",
     "feedSkip": "Пропускане",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1709,6 +1709,7 @@
     "feedModeForYou": "Für dich",
     "feedModeNew": "Neu",
     "feedModeFollowing": "Abonniert",
+    "feedModeClassics": "Klassiker",
     "feedModeSemanticLabel": "Feed-Modus: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1729,6 +1730,7 @@
     "feedForYouEmpty": "Dein Für-dich-Feed ist leer.\nEntdecke Videos und folge Creator:innen, um ihn zu personalisieren.",
     "feedFollowingEmpty": "Noch keine Videos von Personen, denen du folgst.\nFinde Creator:innen, die dir gefallen, und folge ihnen.",
     "feedLatestEmpty": "Noch keine neuen Videos.\nSchau bald wieder vorbei.",
+    "feedClassicEmpty": "Noch keine Klassiker.\nSchau bald wieder vorbei.",
     "feedExploreVideos": "Videos entdecken",
     "feedExternalVideoSlow": "Externes Video lädt langsam",
     "feedSkip": "Überspringen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2297,6 +2297,7 @@
   "feedModeForYou": "For You",
   "feedModeNew": "New",
   "feedModeFollowing": "Following",
+  "feedModeClassics": "Classics",
   "feedModeSemanticLabel": "Feed mode: {label}",
   "@feedModeSemanticLabel": {
     "description": "Semantic label for the feed mode row (current mode plus affordance hint). Screen reader only.",
@@ -2324,6 +2325,7 @@
   "feedForYouEmpty": "Your For You feed is empty.\nExplore videos and follow creators to shape it.",
   "feedFollowingEmpty": "No videos from people you follow yet.\nFind creators you like and follow them.",
   "feedLatestEmpty": "No new videos yet.\nCheck back soon.",
+  "feedClassicEmpty": "No classic Vines yet.\nCheck back soon.",
   "feedExploreVideos": "Explore Videos",
   "feedExternalVideoSlow": "External video loading slowly",
   "feedSkip": "Skip",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1713,6 +1713,7 @@
     "feedModeForYou": "Para ti",
     "feedModeNew": "Nuevo",
     "feedModeFollowing": "Siguiendo",
+    "feedModeClassics": "Clásicos",
     "feedModeSemanticLabel": "Modo del feed: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1733,6 +1734,7 @@
     "feedForYouEmpty": "Tu feed Para ti está vacío.\nExplora videos y sigue a creadores para personalizarlo.",
     "feedFollowingEmpty": "Aún no hay videos de personas que sigues.\nEncuentra creadores que te gusten y síguelos.",
     "feedLatestEmpty": "Aún no hay videos nuevos.\nVuelve pronto.",
+    "feedClassicEmpty": "Aún no hay clásicos.\nVuelve pronto.",
     "feedExploreVideos": "Explorar videos",
     "feedExternalVideoSlow": "Un video externo se carga lento",
     "feedSkip": "Saltar",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1050,6 +1050,7 @@
     "feedModeForYou": "Para Sa Iyo",
     "feedModeNew": "Bago",
     "feedModeFollowing": "Fino-follow",
+    "feedModeClassics": "Klasiko",
     "feedModeSemanticLabel": "Mode ng feed: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1070,6 +1071,7 @@
     "feedForYouEmpty": "Walang laman ang For You feed mo.\nMag-explore ng video at mag-follow ng creators para mahubog ito.",
     "feedFollowingEmpty": "Wala pang video mula sa mga taong fino-follow mo.\nHumanap ng creators na gusto mo at i-follow sila.",
     "feedLatestEmpty": "Wala pang bagong video.\nBumalik mamaya.",
+    "feedClassicEmpty": "Wala pang klasiko.\nBumalik mamaya.",
     "feedExploreVideos": "Mag-explore ng Video",
     "feedExternalVideoSlow": "Mabagal nag-lo-load ang external video",
     "feedSkip": "Laktawan",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1709,6 +1709,7 @@
     "feedModeForYou": "Pour toi",
     "feedModeNew": "Nouveau",
     "feedModeFollowing": "Abonnements",
+    "feedModeClassics": "Classiques",
     "feedModeSemanticLabel": "Fil d'actualité : {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1729,6 +1730,7 @@
     "feedForYouEmpty": "Ton fil Pour toi est vide.\nExplore des vidéos et abonne-toi à des créateurs pour le personnaliser.",
     "feedFollowingEmpty": "Aucune vidéo des personnes que tu suis pour le moment.\nTrouve des créateurs que tu aimes et abonne-toi à eux.",
     "feedLatestEmpty": "Aucune nouvelle vidéo pour le moment.\nReviens bientôt.",
+    "feedClassicEmpty": "Aucun classique pour le moment.\nReviens bientôt.",
     "feedExploreVideos": "Explorer les vidéos",
     "feedExternalVideoSlow": "Vidéo externe lente à charger",
     "feedSkip": "Passer",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1706,6 +1706,7 @@
     "feedModeForYou": "Untukmu",
     "feedModeNew": "Baru",
     "feedModeFollowing": "Mengikuti",
+    "feedModeClassics": "Klasik",
     "feedModeSemanticLabel": "Mode feed: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1726,6 +1727,7 @@
     "feedForYouEmpty": "Feed Untuk Anda kamu kosong.\nJelajahi video dan ikuti kreator untuk membentuknya.",
     "feedFollowingEmpty": "Belum ada video dari orang yang kamu ikuti.\nTemukan kreator yang kamu suka dan ikuti mereka.",
     "feedLatestEmpty": "Belum ada video baru.\nCek lagi sebentar lagi.",
+    "feedClassicEmpty": "Belum ada klasik.\nCek lagi sebentar lagi.",
     "feedExploreVideos": "Jelajahi Video",
     "feedExternalVideoSlow": "Video eksternal memuat lambat",
     "feedSkip": "Lewati",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1709,6 +1709,7 @@
     "feedModeForYou": "Per te",
     "feedModeNew": "Nuovo",
     "feedModeFollowing": "Seguiti",
+    "feedModeClassics": "Classici",
     "feedModeSemanticLabel": "Modalità feed: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1729,6 +1730,7 @@
     "feedForYouEmpty": "Il tuo feed Per te è vuoto.\nEsplora i video e segui i creator per personalizzarlo.",
     "feedFollowingEmpty": "Ancora nessun video dalle persone che segui.\nTrova creator che ti piacciono e seguili.",
     "feedLatestEmpty": "Ancora nessun nuovo video.\nTorna a controllare a breve.",
+    "feedClassicEmpty": "Ancora nessun classico.\nTorna a controllare a breve.",
     "feedExploreVideos": "Esplora video",
     "feedExternalVideoSlow": "Video esterno in caricamento lento",
     "feedSkip": "Salta",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1699,6 +1699,7 @@
     "feedModeForYou": "おすすめ",
     "feedModeNew": "新着",
     "feedModeFollowing": "フォロー中",
+    "feedModeClassics": "クラシック",
     "feedModeSemanticLabel": "フィードモード: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1719,6 +1720,7 @@
     "feedForYouEmpty": "おすすめフィードはまだ空です。\n動画を見つけてクリエイターをフォローし、あなた向けに育てましょう。",
     "feedFollowingEmpty": "フォロー中の人の動画はまだありません。\n気に入ったクリエイターを見つけてフォローしましょう。",
     "feedLatestEmpty": "新しい動画はまだありません。\nしばらくしてからもう一度確認してください。",
+    "feedClassicEmpty": "クラシック動画はまだありません。\nしばらくしてからもう一度確認してください。",
     "feedExploreVideos": "動画を探しに行こう",
     "feedExternalVideoSlow": "外部動画の読み込みに時間がかかってる",
     "feedSkip": "スキップ",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1023,6 +1023,7 @@
     "feedModeForYou": "추천",
     "feedModeNew": "최신",
     "feedModeFollowing": "팔로잉",
+    "feedModeClassics": "클래식",
     "feedModeSemanticLabel": "피드 모드: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1043,6 +1044,7 @@
     "feedForYouEmpty": "추천 피드가 비어 있어요.\n동영상을 탐색하고 크리에이터를 팔로우해 피드를 만들어보세요.",
     "feedFollowingEmpty": "아직 팔로우한 사람들의 동영상이 없어요.\n마음에 드는 크리에이터를 찾아 팔로우해 보세요.",
     "feedLatestEmpty": "아직 새로운 동영상이 없어요.\n잠시 후 다시 확인해 주세요.",
+    "feedClassicEmpty": "아직 클래식 동영상이 없어요.\n잠시 후 다시 확인해 주세요.",
     "feedExploreVideos": "영상 둘러보기",
     "feedExternalVideoSlow": "외부 영상 로딩이 느려요",
     "feedSkip": "건너뛰기",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1709,6 +1709,7 @@
     "feedModeForYou": "Voor jou",
     "feedModeNew": "Nieuw",
     "feedModeFollowing": "Volgend",
+    "feedModeClassics": "Klassiekers",
     "feedModeSemanticLabel": "Feedmodus: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1729,6 +1730,7 @@
     "feedForYouEmpty": "Je Voor jou-feed is leeg.\nVerken video's en volg makers om hem vorm te geven.",
     "feedFollowingEmpty": "Nog geen video's van mensen die je volgt.\nVind makers die je leuk vindt en volg ze.",
     "feedLatestEmpty": "Nog geen nieuwe video's.\nKom binnenkort terug.",
+    "feedClassicEmpty": "Nog geen klassiekers.\nKom binnenkort terug.",
     "feedExploreVideos": "Video's verkennen",
     "feedExternalVideoSlow": "Externe video laadt traag",
     "feedSkip": "Overslaan",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1709,6 +1709,7 @@
     "feedModeForYou": "Dla ciebie",
     "feedModeNew": "Nowe",
     "feedModeFollowing": "Obserwowane",
+    "feedModeClassics": "Klasyki",
     "feedModeSemanticLabel": "Tryb kanału: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1729,6 +1730,7 @@
     "feedForYouEmpty": "Twój kanał Dla Ciebie jest pusty.\nOdkrywaj filmy i obserwuj twórców, aby go ukształtować.",
     "feedFollowingEmpty": "Brak filmów od osób, które obserwujesz.\nZnajdź twórców, których lubisz i zacznij ich obserwować.",
     "feedLatestEmpty": "Brak nowych filmów.\nWróć tu wkrótce.",
+    "feedClassicEmpty": "Brak klasyków.\nWróć tu wkrótce.",
     "feedExploreVideos": "Odkrywaj filmy",
     "feedExternalVideoSlow": "Zewnętrzny film wczytuje się powoli",
     "feedSkip": "Pomiń",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1709,6 +1709,7 @@
     "feedModeForYou": "Para você",
     "feedModeNew": "Novo",
     "feedModeFollowing": "Seguindo",
+    "feedModeClassics": "Clássicos",
     "feedModeSemanticLabel": "Modo do feed: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1729,6 +1730,7 @@
     "feedForYouEmpty": "Seu feed Para você está vazio.\nExplore vídeos e siga criadores para personalizá-lo.",
     "feedFollowingEmpty": "Ainda não há vídeos das pessoas que você segue.\nEncontre criadores de que goste e siga-os.",
     "feedLatestEmpty": "Ainda não há vídeos novos.\nVolte em breve.",
+    "feedClassicEmpty": "Ainda não há clássicos.\nVolte em breve.",
     "feedExploreVideos": "Explorar vídeos",
     "feedExternalVideoSlow": "Vídeo externo carregando devagar",
     "feedSkip": "Pular",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1709,6 +1709,7 @@
     "feedModeForYou": "Pentru tine",
     "feedModeNew": "Nou",
     "feedModeFollowing": "Urmăresc",
+    "feedModeClassics": "Clasice",
     "feedModeSemanticLabel": "Mod flux: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1729,6 +1730,7 @@
     "feedForYouEmpty": "Feedul tău Pentru tine este gol.\nExplorează videoclipuri și urmărește creatori pentru a-l modela.",
     "feedFollowingEmpty": "Încă nu există videoclipuri de la persoanele pe care le urmărești.\nGăsește creatori care îți plac și urmărește-i.",
     "feedLatestEmpty": "Încă nu există videoclipuri noi.\nRevino curând.",
+    "feedClassicEmpty": "Încă nu există clasice.\nRevino curând.",
     "feedExploreVideos": "Explorează videoclipuri",
     "feedExternalVideoSlow": "Videoclipul extern se încarcă încet",
     "feedSkip": "Sari peste",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1709,6 +1709,7 @@
     "feedModeForYou": "För dig",
     "feedModeNew": "Nytt",
     "feedModeFollowing": "Följer",
+    "feedModeClassics": "Klassiker",
     "feedModeSemanticLabel": "Flödesläge: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1729,6 +1730,7 @@
     "feedForYouEmpty": "Ditt För dig-flöde är tomt.\nUtforska videor och följ kreatörer för att forma det.",
     "feedFollowingEmpty": "Inga videor från personer du följer än.\nHitta kreatörer du gillar och följ dem.",
     "feedLatestEmpty": "Inga nya videor än.\nTitta in igen snart.",
+    "feedClassicEmpty": "Inga klassiker än.\nTitta in igen snart.",
     "feedExploreVideos": "Upptäck videor",
     "feedExternalVideoSlow": "Extern video laddar långsamt",
     "feedSkip": "Hoppa över",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1706,6 +1706,7 @@
     "feedModeForYou": "Senin için",
     "feedModeNew": "Yeni",
     "feedModeFollowing": "Takip",
+    "feedModeClassics": "Klasikler",
     "feedModeSemanticLabel": "Akış modu: {label}",
     "@feedModeSemanticLabel": {
         "placeholders": {
@@ -1726,6 +1727,7 @@
     "feedForYouEmpty": "Sana Özel akışın boş.\nVideolar keşfet ve içerik üreticileri takip ederek akışını şekillendir.",
     "feedFollowingEmpty": "Takip ettiğin kişilerden henüz video yok.\nBeğendiğin içerik üreticilerini bulup takip et.",
     "feedLatestEmpty": "Henüz yeni video yok.\nYakında tekrar kontrol et.",
+    "feedClassicEmpty": "Henüz klasik yok.\nYakında tekrar kontrol et.",
     "feedExploreVideos": "Videoları Keşfet",
     "feedExternalVideoSlow": "Harici video yavaş yükleniyor",
     "feedSkip": "Atla",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -7178,6 +7178,12 @@ abstract class AppLocalizations {
   /// **'Following'**
   String get feedModeFollowing;
 
+  /// No description provided for @feedModeClassics.
+  ///
+  /// In en, this message translates to:
+  /// **'Classics'**
+  String get feedModeClassics;
+
   /// Semantic label for the feed mode row (current mode plus affordance hint). Screen reader only.
   ///
   /// In en, this message translates to:
@@ -7213,6 +7219,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'No new videos yet.\nCheck back soon.'**
   String get feedLatestEmpty;
+
+  /// No description provided for @feedClassicEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'No classic Vines yet.\nCheck back soon.'**
+  String get feedClassicEmpty;
 
   /// No description provided for @feedExploreVideos.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4029,6 +4029,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get feedModeFollowing => 'እየተከተሉ';
 
   @override
+  String get feedModeClassics => 'ክላሲኮች';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'የፊድ ሁነታ: $label';
   }
@@ -4051,6 +4054,9 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'እስካሁን ምንም አዲስ ቪዲዮዎች የሉም።\nበቅርቡ ተመልሰው ይመልከቱ።';
+
+  @override
+  String get feedClassicEmpty => 'እስካሁን ምንም ክላሲኮች የሉም።\nበቅርቡ ተመልሰው ይመልከቱ።';
 
   @override
   String get feedExploreVideos => 'ቪዲዮዎችን ያስሱ';

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4068,6 +4068,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get feedModeFollowing => 'المتابَعون';
 
   @override
+  String get feedModeClassics => 'الكلاسيكيات';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'وضع الموجز: $label';
   }
@@ -4090,6 +4093,9 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'لا توجد مقاطع جديدة بعد.\nعد لاحقًا.';
+
+  @override
+  String get feedClassicEmpty => 'لا توجد كلاسيكيات بعد.\nعد لاحقًا.';
 
   @override
   String get feedExploreVideos => 'استكشاف مقاطع الفيديو';

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4157,6 +4157,9 @@ class AppLocalizationsBg extends AppLocalizations {
   String get feedModeFollowing => 'Следвани';
 
   @override
+  String get feedModeClassics => 'Класики';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Режим на емисията: $label';
   }
@@ -4179,6 +4182,9 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'Още няма нови видеа.\nПровери пак скоро.';
+
+  @override
+  String get feedClassicEmpty => 'Още няма класики.\nПровери пак скоро.';
 
   @override
   String get feedExploreVideos => 'Разгледай видеа';

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4160,6 +4160,9 @@ class AppLocalizationsDe extends AppLocalizations {
   String get feedModeFollowing => 'Abonniert';
 
   @override
+  String get feedModeClassics => 'Klassiker';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Feed-Modus: $label';
   }
@@ -4183,6 +4186,10 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get feedLatestEmpty =>
       'Noch keine neuen Videos.\nSchau bald wieder vorbei.';
+
+  @override
+  String get feedClassicEmpty =>
+      'Noch keine Klassiker.\nSchau bald wieder vorbei.';
 
   @override
   String get feedExploreVideos => 'Videos entdecken';

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4112,6 +4112,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get feedModeFollowing => 'Following';
 
   @override
+  String get feedModeClassics => 'Classics';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Feed mode: $label';
   }
@@ -4134,6 +4137,9 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'No new videos yet.\nCheck back soon.';
+
+  @override
+  String get feedClassicEmpty => 'No classic Vines yet.\nCheck back soon.';
 
   @override
   String get feedExploreVideos => 'Explore Videos';

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4153,6 +4153,9 @@ class AppLocalizationsEs extends AppLocalizations {
   String get feedModeFollowing => 'Siguiendo';
 
   @override
+  String get feedModeClassics => 'Clásicos';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Modo del feed: $label';
   }
@@ -4175,6 +4178,9 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'Aún no hay videos nuevos.\nVuelve pronto.';
+
+  @override
+  String get feedClassicEmpty => 'Aún no hay clásicos.\nVuelve pronto.';
 
   @override
   String get feedExploreVideos => 'Explorar videos';

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4169,6 +4169,9 @@ class AppLocalizationsFil extends AppLocalizations {
   String get feedModeFollowing => 'Fino-follow';
 
   @override
+  String get feedModeClassics => 'Klasiko';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Mode ng feed: $label';
   }
@@ -4191,6 +4194,9 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'Wala pang bagong video.\nBumalik mamaya.';
+
+  @override
+  String get feedClassicEmpty => 'Wala pang klasiko.\nBumalik mamaya.';
 
   @override
   String get feedExploreVideos => 'Mag-explore ng Video';

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4172,6 +4172,9 @@ class AppLocalizationsFr extends AppLocalizations {
   String get feedModeFollowing => 'Abonnements';
 
   @override
+  String get feedModeClassics => 'Classiques';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Fil d\'actualité : $label';
   }
@@ -4195,6 +4198,10 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get feedLatestEmpty =>
       'Aucune nouvelle vidéo pour le moment.\nReviens bientôt.';
+
+  @override
+  String get feedClassicEmpty =>
+      'Aucun classique pour le moment.\nReviens bientôt.';
 
   @override
   String get feedExploreVideos => 'Explorer les vidéos';

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4083,6 +4083,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get feedModeFollowing => 'Mengikuti';
 
   @override
+  String get feedModeClassics => 'Klasik';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Mode feed: $label';
   }
@@ -4106,6 +4109,9 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get feedLatestEmpty =>
       'Belum ada video baru.\nCek lagi sebentar lagi.';
+
+  @override
+  String get feedClassicEmpty => 'Belum ada klasik.\nCek lagi sebentar lagi.';
 
   @override
   String get feedExploreVideos => 'Jelajahi Video';

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4155,6 +4155,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get feedModeFollowing => 'Seguiti';
 
   @override
+  String get feedModeClassics => 'Classici';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Modalità feed: $label';
   }
@@ -4178,6 +4181,10 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get feedLatestEmpty =>
       'Ancora nessun nuovo video.\nTorna a controllare a breve.';
+
+  @override
+  String get feedClassicEmpty =>
+      'Ancora nessun classico.\nTorna a controllare a breve.';
 
   @override
   String get feedExploreVideos => 'Esplora video';

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -3922,6 +3922,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get feedModeFollowing => 'フォロー中';
 
   @override
+  String get feedModeClassics => 'クラシック';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'フィードモード: $label';
   }
@@ -3944,6 +3947,9 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => '新しい動画はまだありません。\nしばらくしてからもう一度確認してください。';
+
+  @override
+  String get feedClassicEmpty => 'クラシック動画はまだありません。\nしばらくしてからもう一度確認してください。';
 
   @override
   String get feedExploreVideos => '動画を探しに行こう';

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -3936,6 +3936,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get feedModeFollowing => '팔로잉';
 
   @override
+  String get feedModeClassics => '클래식';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return '피드 모드: $label';
   }
@@ -3958,6 +3961,9 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => '아직 새로운 동영상이 없어요.\n잠시 후 다시 확인해 주세요.';
+
+  @override
+  String get feedClassicEmpty => '아직 클래식 동영상이 없어요.\n잠시 후 다시 확인해 주세요.';
 
   @override
   String get feedExploreVideos => '영상 둘러보기';

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4127,6 +4127,9 @@ class AppLocalizationsNl extends AppLocalizations {
   String get feedModeFollowing => 'Volgend';
 
   @override
+  String get feedModeClassics => 'Klassiekers';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Feedmodus: $label';
   }
@@ -4150,6 +4153,9 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get feedLatestEmpty =>
       'Nog geen nieuwe video\'s.\nKom binnenkort terug.';
+
+  @override
+  String get feedClassicEmpty => 'Nog geen klassiekers.\nKom binnenkort terug.';
 
   @override
   String get feedExploreVideos => 'Video\'s verkennen';

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4218,6 +4218,9 @@ class AppLocalizationsPl extends AppLocalizations {
   String get feedModeFollowing => 'Obserwowane';
 
   @override
+  String get feedModeClassics => 'Klasyki';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Tryb kanału: $label';
   }
@@ -4240,6 +4243,9 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'Brak nowych filmów.\nWróć tu wkrótce.';
+
+  @override
+  String get feedClassicEmpty => 'Brak klasyków.\nWróć tu wkrótce.';
 
   @override
   String get feedExploreVideos => 'Odkrywaj filmy';

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4138,6 +4138,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get feedModeFollowing => 'Seguindo';
 
   @override
+  String get feedModeClassics => 'Clássicos';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Modo do feed: $label';
   }
@@ -4160,6 +4163,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'Ainda não há vídeos novos.\nVolte em breve.';
+
+  @override
+  String get feedClassicEmpty => 'Ainda não há clássicos.\nVolte em breve.';
 
   @override
   String get feedExploreVideos => 'Explorar vídeos';

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4234,6 +4234,9 @@ class AppLocalizationsRo extends AppLocalizations {
   String get feedModeFollowing => 'Urmăresc';
 
   @override
+  String get feedModeClassics => 'Clasice';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Mod flux: $label';
   }
@@ -4257,6 +4260,9 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get feedLatestEmpty =>
       'Încă nu există videoclipuri noi.\nRevino curând.';
+
+  @override
+  String get feedClassicEmpty => 'Încă nu există clasice.\nRevino curând.';
 
   @override
   String get feedExploreVideos => 'Explorează videoclipuri';

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4110,6 +4110,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get feedModeFollowing => 'Följer';
 
   @override
+  String get feedModeClassics => 'Klassiker';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Flödesläge: $label';
   }
@@ -4132,6 +4135,9 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get feedLatestEmpty => 'Inga nya videor än.\nTitta in igen snart.';
+
+  @override
+  String get feedClassicEmpty => 'Inga klassiker än.\nTitta in igen snart.';
 
   @override
   String get feedExploreVideos => 'Upptäck videor';

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4091,6 +4091,9 @@ class AppLocalizationsTr extends AppLocalizations {
   String get feedModeFollowing => 'Takip';
 
   @override
+  String get feedModeClassics => 'Klasikler';
+
+  @override
   String feedModeSemanticLabel(String label) {
     return 'Akış modu: $label';
   }
@@ -4114,6 +4117,10 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get feedLatestEmpty =>
       'Henüz yeni video yok.\nYakında tekrar kontrol et.';
+
+  @override
+  String get feedClassicEmpty =>
+      'Henüz klasik yok.\nYakında tekrar kontrol et.';
 
   @override
   String get feedExploreVideos => 'Videoları Keşfet';

--- a/mobile/lib/screens/feed/feed_mode_switch.dart
+++ b/mobile/lib/screens/feed/feed_mode_switch.dart
@@ -90,6 +90,10 @@ class FeedModeSwitch extends StatelessWidget {
           label: l10n.feedModeNew,
           value: 'latest',
         ),
+        VineBottomSheetSelectionOptionData(
+          label: l10n.feedModeClassics,
+          value: 'classic',
+        ),
         ...state.subscribedLists.map(
           (list) => VineBottomSheetSelectionOptionData(
             label: list.name,
@@ -117,6 +121,9 @@ VideoFeedSource _sourceForSelection(String selected, VideoFeedBlocState state) {
   if (selected == 'latest') {
     return const VideoFeedSource.newVideos();
   }
+  if (selected == 'classic') {
+    return const VideoFeedSource.classic();
+  }
   if (selected.startsWith('list:')) {
     final listId = selected.substring('list:'.length);
     final list = state.subscribedLists.firstWhere((list) => list.id == listId);
@@ -132,6 +139,7 @@ String _labelForSource(VideoFeedBlocState state, AppLocalizations l10n) {
     VideoFeedSourceType.forYou => l10n.feedModeForYou,
     VideoFeedSourceType.following => l10n.feedModeFollowing,
     VideoFeedSourceType.newVideos => l10n.feedModeNew,
+    VideoFeedSourceType.classic => l10n.feedModeClassics,
     VideoFeedSourceType.subscribedList =>
       _listNameForSource(state) ?? source.listName ?? source.labelFallback,
   };
@@ -150,6 +158,7 @@ String _labelForMode(FeedMode mode, AppLocalizations l10n) => switch (mode) {
   FeedMode.forYou => l10n.feedModeForYou,
   FeedMode.latest => l10n.feedModeNew,
   FeedMode.following => l10n.feedModeFollowing,
+  FeedMode.classic => l10n.feedModeClassics,
 };
 
 /// Shared row rendering — label + caret + optional trailing widget — used

--- a/mobile/lib/screens/feed/video_feed_page/feed_empty_widget.dart
+++ b/mobile/lib/screens/feed/video_feed_page/feed_empty_widget.dart
@@ -73,6 +73,7 @@ class FeedEmptyWidget extends StatelessWidget {
       FeedMode.forYou => context.l10n.feedForYouEmpty,
       FeedMode.following => context.l10n.feedFollowingEmpty,
       FeedMode.latest => context.l10n.feedLatestEmpty,
+      FeedMode.classic => context.l10n.feedClassicEmpty,
     };
   }
 }

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -738,10 +738,14 @@ class VideosRepository {
   /// Fetches popular classic Vine archive videos for the home feed's
   /// Classics mode.
   ///
-  /// Backed by the v2 popular feed filtered to `platform=vine` (the same
-  /// source as Explore → Classics), mapped into a [HomeFeedResult] so the
-  /// home feed paginates it via [HomeFeedResult.paginationCursor] like the
-  /// For You feed. Funnelcake-only: returns an empty result when no
+  /// Delegates to [getPopularVideosPage] with [PopularVideosVariant.classic],
+  /// so the source is identical to Explore → Popular's "Classic" toggle
+  /// (v2 popular feed, `sort=popular&period=month&platform=vine`,
+  /// cursor-paged, server-ordered) — not the standalone Explore → Classics
+  /// tab, which is offset-based and client-side shuffled. Mapped into a
+  /// [HomeFeedResult] so the home feed paginates it via
+  /// [HomeFeedResult.paginationCursor] like the For You feed. Funnelcake-only:
+  /// returns an empty result when no
   /// Funnelcake relay is connected (relays do not expose the server-side
   /// `platform` filter).
   Future<HomeFeedResult> getClassicVideos({

--- a/mobile/packages/videos_repository/lib/src/videos_repository.dart
+++ b/mobile/packages/videos_repository/lib/src/videos_repository.dart
@@ -735,6 +735,35 @@ class VideosRepository {
     return visible.take(limit).toList();
   }
 
+  /// Fetches popular classic Vine archive videos for the home feed's
+  /// Classics mode.
+  ///
+  /// Backed by the v2 popular feed filtered to `platform=vine` (the same
+  /// source as Explore → Classics), mapped into a [HomeFeedResult] so the
+  /// home feed paginates it via [HomeFeedResult.paginationCursor] like the
+  /// For You feed. Funnelcake-only: returns an empty result when no
+  /// Funnelcake relay is connected (relays do not expose the server-side
+  /// `platform` filter).
+  Future<HomeFeedResult> getClassicVideos({
+    int limit = _defaultLimit,
+    int? until,
+    String? cursor,
+    bool skipCache = false,
+  }) async {
+    final page = await getPopularVideosPage(
+      variant: PopularVideosVariant.classic,
+      limit: limit,
+      until: until,
+      cursor: cursor,
+      skipCache: skipCache,
+    );
+    return HomeFeedResult(
+      videos: page.videos,
+      paginationCursor: page.nextCursor,
+      hasMore: page.hasMore,
+    );
+  }
+
   /// Fetches new divine videos from the popular leaderboard.
   ///
   /// This powers Explore → Popular. It uses Funnelcake's leaderboard endpoint

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -3981,6 +3981,92 @@ void main() {
       });
     });
 
+    group('getClassicVideos', () {
+      late MockFunnelcakeApiClient mockFunnelcakeClient;
+
+      setUp(() {
+        mockFunnelcakeClient = MockFunnelcakeApiClient();
+        when(
+          () => mockFunnelcakeClient.getBulkVideoStats(any()),
+        ).thenAnswer((_) async => const BulkVideoStatsResponse(stats: {}));
+        when(
+          () => mockFunnelcakeClient.getV2PopularVideosPage(
+            variant: any(named: 'variant'),
+            limit: any(named: 'limit'),
+            cursor: any(named: 'cursor'),
+            before: any(named: 'before'),
+            preferredLanguages: any(named: 'preferredLanguages'),
+            viewerCountry: any(named: 'viewerCountry'),
+          ),
+        ).thenAnswer((invocation) async {
+          final stats = await mockFunnelcakeClient.getV2PopularVideos(
+            variant:
+                invocation.namedArguments[#variant] as PopularVideosVariant,
+            limit: invocation.namedArguments[#limit] as int? ?? 25,
+            before: invocation.namedArguments[#before] as int?,
+          );
+          return V2PopularVideosResponse(videos: stats);
+        });
+      });
+
+      test(
+        'delegates to the classic popular feed and maps it to a HomeFeedResult',
+        () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getV2PopularVideos(
+              variant: any(named: 'variant'),
+              limit: any(named: 'limit'),
+              before: any(named: 'before'),
+            ),
+          ).thenAnswer(
+            (_) async => [
+              _createVideoStats(
+                id: 'vine-1',
+                pubkey: 'pubkey-1',
+                dTag: 'vine-1',
+                videoUrl: 'https://example.com/vine-1.mp4',
+                rawTags: const {'platform': 'vine'},
+              ),
+            ],
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getClassicVideos();
+
+          expect(result.videos.map((v) => v.id), ['vine-1']);
+          verify(
+            () => mockFunnelcakeClient.getV2PopularVideosPage(
+              variant: PopularVideosVariant.classic,
+              limit: any(named: 'limit'),
+              cursor: any(named: 'cursor'),
+              before: any(named: 'before'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).called(1);
+        },
+      );
+
+      test('returns an empty result when Funnelcake is unavailable', () async {
+        when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
+
+        final repositoryWithApi = VideosRepository(
+          nostrClient: mockNostrClient,
+          funnelcakeApiClient: mockFunnelcakeClient,
+        );
+
+        final result = await repositoryWithApi.getClassicVideos();
+
+        expect(result.videos, isEmpty);
+        expect(result.hasMore, isFalse);
+      });
+    });
+
     group('getPopularVideos', () {
       group('Funnelcake API first', () {
         late MockFunnelcakeApiClient mockFunnelcakeClient;

--- a/mobile/packages/videos_repository/test/src/videos_repository_test.dart
+++ b/mobile/packages/videos_repository/test/src/videos_repository_test.dart
@@ -4052,6 +4052,48 @@ void main() {
         },
       );
 
+      test(
+        'maps a non-null page cursor to paginationCursor with hasMore',
+        () async {
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getV2PopularVideosPage(
+              variant: any(named: 'variant'),
+              limit: any(named: 'limit'),
+              cursor: any(named: 'cursor'),
+              before: any(named: 'before'),
+              preferredLanguages: any(named: 'preferredLanguages'),
+              viewerCountry: any(named: 'viewerCountry'),
+            ),
+          ).thenAnswer(
+            (_) async => V2PopularVideosResponse(
+              videos: [
+                _createVideoStats(
+                  id: 'vine-1',
+                  pubkey: 'pubkey-1',
+                  dTag: 'vine-1',
+                  videoUrl: 'https://example.com/vine-1.mp4',
+                  rawTags: const {'platform': 'vine'},
+                ),
+              ],
+              nextCursor: 'page-2',
+              hasMore: true,
+            ),
+          );
+
+          final repositoryWithApi = VideosRepository(
+            nostrClient: mockNostrClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+          );
+
+          final result = await repositoryWithApi.getClassicVideos(limit: 1);
+
+          expect(result.videos.map((v) => v.id), ['vine-1']);
+          expect(result.paginationCursor, 'page-2');
+          expect(result.hasMore, isTrue);
+        },
+      );
+
       test('returns an empty result when Funnelcake is unavailable', () async {
         when(() => mockFunnelcakeClient.isAvailable).thenReturn(false);
 

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -1549,13 +1549,24 @@ void main() {
             final cursor =
                 invocation.namedArguments[const Symbol('cursor')] as String?;
             if (cursor == 'cursor-2') {
+              // Page 2 is stamped *newer* than page 1 so a (wrong) timestamp
+              // re-sort would surface it first — pinning the server-ranked
+              // append order the cursor path must preserve.
               return HomeFeedResult(
-                videos: createTestVideos(2, idPrefix: 'page2'),
+                videos: createTestVideos(
+                  2,
+                  idPrefix: 'page2',
+                  startTimestamp: 2000,
+                ),
                 hasMore: false,
               );
             }
             return HomeFeedResult(
-              videos: createTestVideos(2, idPrefix: 'page1'),
+              videos: createTestVideos(
+                2,
+                idPrefix: 'page1',
+                startTimestamp: 1000,
+              ),
               paginationCursor: 'cursor-2',
               hasMore: true,
             );
@@ -1578,6 +1589,12 @@ void main() {
           ).called(1);
           expect(bloc.state.videos.length, 4);
           expect(bloc.state.hasMore, isFalse);
+          // Server-ranked order is appended as-is, never re-sorted: page 1
+          // (older) stays ahead of the newer page 2.
+          expect(
+            bloc.state.videos.map((v) => v.id).toList(),
+            ['page1-0', 'page1-1', 'page2-0', 'page2-1'],
+          );
         },
       );
 
@@ -2677,6 +2694,28 @@ void main() {
         ),
         act: (bloc) => bloc.add(const VideoFeedAutoRefreshRequested()),
         expect: () => <VideoFeedBlocState>[],
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'does nothing when mode is classic',
+        build: createBloc,
+        seed: () => VideoFeedBlocState(
+          status: VideoFeedStatus.success,
+          mode: FeedMode.classic,
+          videos: createTestVideos(5),
+        ),
+        act: (bloc) => bloc.add(const VideoFeedAutoRefreshRequested()),
+        expect: () => <VideoFeedBlocState>[],
+        verify: (_) {
+          verifyNever(
+            () => mockVideosRepository.getClassicVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          );
+        },
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(

--- a/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
+++ b/mobile/test/blocs/video_feed/video_feed_bloc_test.dart
@@ -862,6 +862,68 @@ void main() {
       );
 
       blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'restores persisted classic to Classics',
+        setUp: () async {
+          final videos = createTestVideos(2);
+          SharedPreferences.setMockInitialValues({
+            'selected_feed_mode': 'classic',
+          });
+          final sharedPreferences = await SharedPreferences.getInstance();
+
+          when(
+            () => mockVideosRepository.getClassicVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((_) async => HomeFeedResult(videos: videos));
+
+          savedModeBloc = VideoFeedBloc(
+            videosRepository: mockVideosRepository,
+            followRepository: mockFollowRepository,
+            curatedListRepository: mockCuratedListRepository,
+            sharedPreferences: sharedPreferences,
+          );
+        },
+        build: () => savedModeBloc,
+        act: (bloc) => bloc.add(const VideoFeedStarted()),
+        expect: () => [
+          isA<VideoFeedBlocState>()
+              .having(
+                (s) => s.source.type,
+                'source',
+                VideoFeedSourceType.classic,
+              )
+              .having((s) => s.mode, 'mode', FeedMode.classic),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having(
+                (s) => s.source.type,
+                'source',
+                VideoFeedSourceType.classic,
+              )
+              .having((s) => s.mode, 'mode', FeedMode.classic),
+        ],
+        verify: (_) async {
+          verify(
+            () => mockVideosRepository.getClassicVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).called(1);
+
+          final sharedPreferences = await SharedPreferences.getInstance();
+          expect(
+            sharedPreferences.getString('selected_feed_mode'),
+            const VideoFeedSource.classic().persistenceValue,
+          );
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
         'restores saved subscribed list source when list exists',
         setUp: () async {
           final list = createTestList();
@@ -1414,6 +1476,108 @@ void main() {
               skipCache: any(named: 'skipCache'),
             ),
           );
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'classic source fetches popular classic videos via cursor',
+        setUp: () {
+          final videos = createTestVideos(2);
+          when(
+            () => mockVideosRepository.getClassicVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer(
+            (_) async => HomeFeedResult(
+              videos: videos,
+              paginationCursor: 'next-page',
+              hasMore: true,
+            ),
+          );
+        },
+        build: createBloc,
+        act: (bloc) =>
+            bloc.add(const VideoFeedSourceChanged(VideoFeedSource.classic())),
+        expect: () => [
+          isA<VideoFeedBlocState>()
+              .having(
+                (s) => s.source.type,
+                'source',
+                VideoFeedSourceType.classic,
+              )
+              .having((s) => s.hasMore, 'loading hasMore', true),
+          isA<VideoFeedBlocState>()
+              .having((s) => s.status, 'status', VideoFeedStatus.success)
+              .having((s) => s.mode, 'mode', FeedMode.classic)
+              .having((s) => s.videos.length, 'videos count', 2)
+              .having((s) => s.hasMore, 'hasMore', true)
+              .having((s) => s.paginationCursor, 'cursor', 'next-page'),
+        ],
+        verify: (_) {
+          verify(
+            () => mockVideosRepository.getClassicVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).called(1);
+          verifyNever(
+            () => mockVideosRepository.getNewVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoFeedBloc, VideoFeedBlocState>(
+        'classic load-more paginates with the stored cursor (no until)',
+        setUp: () {
+          when(
+            () => mockVideosRepository.getClassicVideos(
+              limit: any(named: 'limit'),
+              until: any(named: 'until'),
+              cursor: any(named: 'cursor'),
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).thenAnswer((invocation) async {
+            final cursor =
+                invocation.namedArguments[const Symbol('cursor')] as String?;
+            if (cursor == 'cursor-2') {
+              return HomeFeedResult(
+                videos: createTestVideos(2, idPrefix: 'page2'),
+                hasMore: false,
+              );
+            }
+            return HomeFeedResult(
+              videos: createTestVideos(2, idPrefix: 'page1'),
+              paginationCursor: 'cursor-2',
+              hasMore: true,
+            );
+          });
+        },
+        build: createBloc,
+        act: (bloc) async {
+          bloc.add(const VideoFeedSourceChanged(VideoFeedSource.classic()));
+          await pumpEventQueue();
+          bloc.add(const VideoFeedLoadMoreRequested());
+          await pumpEventQueue();
+        },
+        verify: (bloc) {
+          verify(
+            () => mockVideosRepository.getClassicVideos(
+              limit: any(named: 'limit'),
+              cursor: 'cursor-2',
+              skipCache: any(named: 'skipCache'),
+            ),
+          ).called(1);
+          expect(bloc.state.videos.length, 4);
+          expect(bloc.state.hasMore, isFalse);
         },
       );
 

--- a/mobile/test/screens/feed/feed_mode_switch_test.dart
+++ b/mobile/test/screens/feed/feed_mode_switch_test.dart
@@ -78,6 +78,20 @@ void main() {
         expect(find.text(l10n.feedModeForYou), findsOneWidget);
       });
 
+      testWidgets('displays "Classics" label for the classic source', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          const VideoFeedBlocState(
+            status: VideoFeedStatus.success,
+            source: VideoFeedSource.classic(),
+          ),
+        );
+        await tester.pumpWidget(createTestWidget());
+
+        expect(find.text(l10n.feedModeClassics), findsOneWidget);
+      });
+
       testWidgets('displays selected subscribed-list name for list source', (
         tester,
       ) async {
@@ -114,7 +128,7 @@ void main() {
       });
 
       testWidgets(
-        'dropdown shows For You, Following, New, and subscribed lists',
+        'dropdown shows For You, Following, New, Classics, and subscribed lists',
         (tester) async {
           when(() => mockBloc.state).thenReturn(
             VideoFeedBlocState(
@@ -131,6 +145,7 @@ void main() {
           expect(find.text(l10n.feedModeForYou), findsWidgets);
           expect(find.text(l10n.feedModeFollowing), findsOneWidget);
           expect(find.text(l10n.feedModeNew), findsOneWidget);
+          expect(find.text(l10n.feedModeClassics), findsOneWidget);
           expect(find.text('Best Vines'), findsOneWidget);
         },
       );
@@ -203,6 +218,30 @@ void main() {
         verify(
           () => mockBloc.add(
             const VideoFeedSourceChanged(VideoFeedSource.newVideos()),
+          ),
+        ).called(1);
+      });
+
+      testWidgets('dispatches VideoFeedSourceChanged when Classics selected', (
+        tester,
+      ) async {
+        when(() => mockBloc.state).thenReturn(
+          const VideoFeedBlocState(
+            status: VideoFeedStatus.success,
+            source: VideoFeedSource.forYou(),
+          ),
+        );
+        await tester.pumpWidget(createTestWidget());
+
+        await tester.tap(find.text(l10n.feedModeForYou));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text(l10n.feedModeClassics));
+        await tester.pumpAndSettle();
+
+        verify(
+          () => mockBloc.add(
+            const VideoFeedSourceChanged(VideoFeedSource.classic()),
           ),
         ).called(1);
       });

--- a/mobile/test/screens/feed/video_feed_page_test.dart
+++ b/mobile/test/screens/feed/video_feed_page_test.dart
@@ -139,6 +139,26 @@ void main() {
       expect(find.textContaining('ForYou'), findsNothing);
     });
 
+    testWidgets('uses localized Classics copy for an empty Classics feed', (
+      tester,
+    ) async {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      await tester.pumpWidget(
+        _buildEmptyFeedSubject(
+          const VideoFeedBlocState(
+            status: VideoFeedStatus.success,
+            mode: FeedMode.classic,
+          ),
+        ),
+      );
+
+      expect(find.text(l10n.feedClassicEmpty), findsOneWidget);
+      // Guards against the switch falling through to a neighbouring mode.
+      expect(find.text(l10n.feedLatestEmpty), findsNothing);
+      expect(find.text(l10n.feedForYouEmpty), findsNothing);
+    });
+
     testWidgets('uses localized Following copy for an empty Following feed', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

Adds a **Classics** option to the home feed mode picker, alongside For You / New / Following and subscribed lists. It surfaces popular classic Vine archive videos — the same content as Explore → Classics.

Selecting it from the bottom sheet wires a new feed source through the full stack:

- **State** — new `VideoFeedSourceType.classic` / `FeedMode.classic` / `VideoFeedSource.classic()` with their `mode`, `labelFallback`, and `persistenceValue` cases.
- **Repository** — new `VideosRepository.getClassicVideos()` wrapping `getPopularVideosPage(variant: classic)` into a `HomeFeedResult` (keeps the `PopularVideosVariant` enum out of the bloc layer).
- **Bloc** — `_fetchVideosForSource` classic branch plus a `_usesCursorPagination` helper so Classics paginates via the server cursor (no `createdAt` re-sort), exactly like For You. Classic is cache-eligible for cold-start/resume.
- **Persistence** — `FeedModePreferenceStore` restores the persisted `classic` selection across restarts.
- **UI** — Classics row in the picker, label switches, and a dedicated empty-state message.
- **l10n** — `feedModeClassics` + `feedClassicEmpty` added to all 18 locales (reusing each locale's existing "Classics" noun), regenerated.

**Behavior notes:** Classics has full parity with the other home modes — the selection persists across restarts and it paginates on infinite scroll. Like Explore → Classics, it is Funnelcake-only: when no Funnelcake relay is connected it shows the empty state rather than falling back to relays. It is intentionally excluded from auto-refresh-on-resume (the popular-month window is stable, so refreshing would needlessly reset scroll position).

**Related Issue:** Closes #5486

## Out of Scope

- Auto-refresh-on-resume for the Classics mode (intentional — see behavior notes).

## Verification

- `flutter analyze lib test integration_test` — clean
- `flutter test test/screens/feed/feed_mode_switch_test.dart test/blocs/video_feed/video_feed_bloc_test.dart test/screens/feed/video_feed_page_test.dart` — all pass (added: picker option + dispatch, persistence restore, cursor pagination, classic label/empty-state)
- `packages/videos_repository` full suite with `--coverage` — 453 pass; `getClassicVideos` fully covered (added: classic delegation/mapping + Funnelcake-unavailable paths)

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)