### PR TITLE
chore(media-cache): surface the cause of failed media downloads

### DIFF
--- a/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
@@ -149,6 +149,11 @@ class _HttpDownload implements CancellableDownload {
         return;
       }
       if (response.statusCode < 200 || response.statusCode >= 300) {
+        Log.warning(
+          'CancellableDownload: $_url returned HTTP ${response.statusCode}',
+          name: 'MediaCache',
+          category: LogCategory.video,
+        );
         unawaited(response.stream.drain<void>());
         _safeComplete(null);
         return;
@@ -168,7 +173,12 @@ class _HttpDownload implements CancellableDownload {
             // Sink errors surface in onError.
           }
         },
-        onError: (Object _) async {
+        onError: (Object error) async {
+          Log.warning(
+            'CancellableDownload: stream error for $_url: $error',
+            name: 'MediaCache',
+            category: LogCategory.video,
+          );
           await _cleanupPartial();
           _safeComplete(null);
         },
@@ -194,7 +204,12 @@ class _HttpDownload implements CancellableDownload {
         },
         cancelOnError: true,
       );
-    } on Object {
+    } on Object catch (error) {
+      Log.warning(
+        'CancellableDownload: request failed for $_url: $error',
+        name: 'MediaCache',
+        category: LogCategory.video,
+      );
       await _cleanupPartial();
       _safeComplete(null);
     }

--- a/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
@@ -174,11 +174,15 @@ class _HttpDownload implements CancellableDownload {
           }
         },
         onError: (Object error) async {
-          Log.warning(
-            'CancellableDownload: stream error for $_url: $error',
-            name: 'MediaCache',
-            category: LogCategory.video,
-          );
+          // A stream error that races with our own cancel() is expected
+          // teardown, not a download failure — only warn for real errors.
+          if (!_isCancelled) {
+            Log.warning(
+              'CancellableDownload: stream error for $_url: $error',
+              name: 'MediaCache',
+              category: LogCategory.video,
+            );
+          }
           await _cleanupPartial();
           _safeComplete(null);
         },
@@ -205,11 +209,16 @@ class _HttpDownload implements CancellableDownload {
         cancelOnError: true,
       );
     } on Object catch (error) {
-      Log.warning(
-        'CancellableDownload: request failed for $_url: $error',
-        name: 'MediaCache',
-        category: LogCategory.video,
-      );
+      // cancel() fires the abort trigger, so a pending request surfaces here
+      // as RequestAbortedException — that is intentional teardown, not a
+      // failure, and must not pollute bug-report logs with false warnings.
+      if (!_isCancelled) {
+        Log.warning(
+          'CancellableDownload: request failed for $_url: $error',
+          name: 'MediaCache',
+          category: LogCategory.video,
+        );
+      }
       await _cleanupPartial();
       _safeComplete(null);
     }

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -11,6 +11,7 @@ import 'package:media_cache/src/platform_downloader_factory.dart';
 import 'package:media_cache/src/safe_cache_info_repository.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// {@template media_cache_config}
 /// Configuration for [MediaCacheManager].
@@ -715,7 +716,12 @@ class MediaCacheManager extends CacheManager {
           }
         }
         if (!completer.isCompleted) completer.complete(file);
-      } on Object {
+      } on Object catch (error) {
+        Log.warning(
+          'MediaCacheManager: download setup failed for $url: $error',
+          name: 'MediaCache',
+          category: LogCategory.video,
+        );
         if (!completer.isCompleted) completer.complete();
       } finally {
         _pendingCacheOperations.remove(key);

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -172,6 +172,39 @@ void main() {
       expect(downloaderWarnings, isEmpty);
     });
 
+    // Canary for the negative assertion above: a genuine failure must
+    // surface a captured warning. If the capture path is ever gated or
+    // refactored away, this fails loudly instead of letting the
+    // "does not log a warning" test quietly go vacuous.
+    test('a genuine non-2xx failure logs a captured warning', () async {
+      await LogCaptureService().clearAllLogs();
+
+      final client = _CallbackClient(
+        (_) async => http.StreamedResponse(
+          Stream<List<int>>.value(utf8.encode('not found')),
+          404,
+        ),
+      );
+      final downloader = HttpCancellableDownloader(client);
+      final target = File('${tempDir.path}/non_success_warns.mp4');
+
+      final file = await downloader
+          .download(
+            url: 'https://example.com/missing.mp4',
+            targetFile: target,
+          )
+          .file;
+
+      expect(file, isNull);
+
+      final downloaderWarnings = LogCaptureService()
+          .getRecentLogs()
+          .where((entry) => entry.message.contains('CancellableDownload'))
+          .toList();
+      expect(downloaderWarnings, isNotEmpty);
+      expect(downloaderWarnings.first.message, contains('returned HTTP 404'));
+    });
+
     test('close waits for active response stream cancellation', () async {
       var streamCancelled = false;
       var closedAfterStreamCancel = false;

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:media_cache/src/cancellable_downloader.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 class _CallbackClient extends http.BaseClient {
   _CallbackClient(this._onSend, {this.onClose});
@@ -142,6 +143,33 @@ void main() {
       expect(client.closed, isTrue);
       expect(closedAfterAbort, isTrue);
       expect(target.existsSync(), isFalse);
+    });
+
+    test('cancelling an in-flight request does not log a warning', () async {
+      await LogCaptureService().clearAllLogs();
+
+      final client = _CallbackClient((request) async {
+        await (request as http.AbortableRequest).abortTrigger;
+        throw http.RequestAbortedException(request.url);
+      });
+      final downloader = HttpCancellableDownloader(client);
+      final target = File('${tempDir.path}/cancel_no_warning.mp4');
+
+      final download = downloader.download(
+        url: 'https://example.com/cancel_no_warning.mp4',
+        targetFile: target,
+      );
+      await Future<void>.delayed(Duration.zero);
+      download.cancel();
+
+      expect(await download.file, isNull);
+      expect(download.isCancelled, isTrue);
+
+      final downloaderWarnings = LogCaptureService()
+          .getRecentLogs()
+          .where((entry) => entry.message.contains('CancellableDownload'))
+          .toList();
+      expect(downloaderWarnings, isEmpty);
     });
 
     test('close waits for active response stream cancellation', () async {


### PR DESCRIPTION
Closes #5568

## Description

Debugging a report of a "blurry" profile — blank avatars and video
thumbnails that only ever render their blurhash placeholder — traced
the symptom to the shared `MediaCache` HTTP download path. Avatars,
grid thumbnails and video prefetch all go through it, and in the
affected session **every** download returned `file=null`. The native
video player uses a separate stack, so playback still worked while
nothing image-shaped loaded.

The blocker for a real fix was observability: every null-returning
branch on that path was swallowed silently, so the only trace was a
misleading `MediaCacheImageProvider load cancelled` even though
`cancelled=false`. That hid whether downloads fail on an HTTP status,
a transport error, or a local exception.

This PR makes each silent failure point log its cause:

- `CancellableDownload` — non-2xx status, stream error, and the
  request-level exception catch.
- `MediaCacheManager.startDownload` — the download-setup catch (this
  file had no logger at all, so failures before the request even
  started were completely invisible).

A fresh log export from the affected device will now name the failure
(`returned HTTP <code>` vs `request failed: <exception>` vs
`download setup failed`), which determines the targeted fix.

**Related Issue:** 

## Out of Scope

The behavioral fix itself. It depends on which cause the new logs
surface (HTTP status → header/auth; transport exception → client;
setup failure → cache-dir handling), and shipping a speculative change
now would risk the working playback path. Follow-up once we have a log
export.

## Verification

- `dart format` — clean
- `flutter analyze packages/media_cache/lib` — No issues found
- `flutter test` (media_cache): `cancellable_downloader_test.dart`,
  `media_cache_manager_test.dart`, `media_cache_manager_mocked_test.dart`
  — all 94 tests pass

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)