### PR TITLE
fix(macos): use file-based keychain for secure storage in debug

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -96,6 +96,7 @@ import 'package:openvine/services/openvine_media_cache.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/pro_video_editor_log_forwarder.dart';
 import 'package:openvine/services/quick_actions_coordinator.dart';
+import 'package:openvine/services/secure_storage_options.dart';
 import 'package:openvine/services/seed_data_preload_service.dart';
 import 'package:openvine/services/seed_media_preload_service.dart';
 import 'package:openvine/services/startup_performance_service.dart';
@@ -1312,8 +1313,9 @@ Future<void> _startOpenVineApp() async {
   // first use. This also verifies package:sqlite3 loaded the sqlite3mc hook
   // build and runs the one-time plaintext→encrypted migration, both of which
   // must happen before any Drift database open. (#570, finding C2)
-  const dbCipherSecureStorage = FlutterSecureStorage(
-    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+  final dbCipherSecureStorage = FlutterSecureStorage(
+    aOptions: const AndroidOptions(encryptedSharedPreferences: true),
+    mOptions: appMacOsSecureStorageOptions(),
   );
   var didRecordDatabaseBootstrapFailure = false;
   Future<void> recordDatabaseBootstrapFailure(

--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -26,6 +26,7 @@ import 'package:openvine/services/nip98_auth_service.dart';
 import 'package:openvine/services/nostr_creator_binding_service.dart';
 import 'package:openvine/services/password_reset_listener.dart';
 import 'package:openvine/services/pending_verification_service.dart';
+import 'package:openvine/services/secure_storage_options.dart';
 import 'package:openvine/services/web_auth_service.dart';
 import 'package:openvine/services/zendesk_support_service.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
@@ -62,15 +63,16 @@ OAuthConfig oauthConfig(Ref ref) {
 }
 
 @Riverpod(keepAlive: true)
-FlutterSecureStorage flutterSecureStorage(Ref ref) =>
-    const FlutterSecureStorage(
-      // Do not enable AndroidOptions.resetOnError here. This storage holds
-      // OAuth/Keycast and pending-verification credentials; silently deleting
-      // them after a transient Android Keystore read error logs users out.
-      aOptions: AndroidOptions(
-        encryptedSharedPreferences: true,
-      ),
-    );
+FlutterSecureStorage flutterSecureStorage(Ref ref) => FlutterSecureStorage(
+  // Do not enable AndroidOptions.resetOnError here. This storage holds
+  // OAuth/Keycast and pending-verification credentials; silently deleting
+  // them after a transient Android Keystore read error logs users out.
+  aOptions: const AndroidOptions(
+    encryptedSharedPreferences: true,
+  ),
+  // macOS debug builds can't use the data-protection keychain (#5563).
+  mOptions: appMacOsSecureStorageOptions(),
+);
 
 @Riverpod(keepAlive: true)
 SecureKeycastStorage secureKeycastStorage(Ref ref) =>

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -146,7 +146,7 @@ final class FlutterSecureStorageProvider
 }
 
 String _$flutterSecureStorageHash() =>
-    r'4d4ab3d09f7188871974df552778d4799beabcd8';
+    r'8abafc8e21f68ced2b337c0e5040ab0d6cdb9eeb';
 
 @ProviderFor(secureKeycastStorage)
 final secureKeycastStorageProvider = SecureKeycastStorageProvider._();

--- a/mobile/lib/services/secure_storage_options.dart
+++ b/mobile/lib/services/secure_storage_options.dart
@@ -14,8 +14,10 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// `keychain-access-groups` entitlement; release builds are properly signed and
 /// keep the recommended data-protection keychain.
 ///
-/// Mirrors the workaround already used by `nostr_key_manager`'s
-/// `PlatformSecureStorage`. See #5563.
+/// Mirrors the `useDataProtectionKeyChain` gate already used by
+/// `nostr_key_manager`'s `PlatformSecureStorage`. `accessibility` is
+/// intentionally left at the package default (`unlocked`) to preserve the app
+/// stores' prior macOS behavior. See #5563.
 MacOsOptions appMacOsSecureStorageOptions() => MacOsOptions(
   useDataProtectionKeyChain:
       defaultTargetPlatform != TargetPlatform.macOS || !kDebugMode,

--- a/mobile/lib/services/secure_storage_options.dart
+++ b/mobile/lib/services/secure_storage_options.dart
@@ -1,0 +1,22 @@
+// ABOUTME: Shared macOS Keychain options for the app's FlutterSecureStorage.
+// ABOUTME: Centralizes the macOS-debug data-protection-keychain fallback (#5563).
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// macOS Keychain options for the app's `FlutterSecureStorage` instances.
+///
+/// macOS debug builds are ad-hoc/linker-signed without a Keychain-Sharing
+/// provisioning profile, so the data-protection keychain rejects every
+/// read/write with OSStatus `-34018` (`errSecMissingEntitlement`). That blocks
+/// the at-rest database cipher-key resolve at startup and surfaces the restart
+/// screen. In that case fall back to the file-based keychain, which needs no
+/// `keychain-access-groups` entitlement; release builds are properly signed and
+/// keep the recommended data-protection keychain.
+///
+/// Mirrors the workaround already used by `nostr_key_manager`'s
+/// `PlatformSecureStorage`. See #5563.
+MacOsOptions appMacOsSecureStorageOptions() => MacOsOptions(
+  useDataProtectionKeyChain:
+      defaultTargetPlatform != TargetPlatform.macOS || !kDebugMode,
+);

--- a/mobile/lib/services/secure_storage_options.dart
+++ b/mobile/lib/services/secure_storage_options.dart
@@ -19,6 +19,13 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// intentionally left at the package default (`unlocked`) to preserve the app
 /// stores' prior macOS behavior. See #5563.
 ///
+/// Because of this gate, macOS debug and release builds read from *different*
+/// keychains on the same Mac. Switching build modes locally won't find the
+/// other mode's database cipher key and triggers the dev-only
+/// backup-then-recreate key-loss path in `DatabaseEncryptionBootstrap`. This is
+/// harmless for end users — who only ever run a single signed release build —
+/// but surprising during local development.
+///
 /// [isDebug] defaults to [kDebugMode] (a compile-time constant) and exists only
 /// so tests can exercise the macOS release branch, which `kDebugMode` cannot
 /// reach under `flutter test`. Production callers omit it.

--- a/mobile/lib/services/secure_storage_options.dart
+++ b/mobile/lib/services/secure_storage_options.dart
@@ -18,7 +18,12 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// `nostr_key_manager`'s `PlatformSecureStorage`. `accessibility` is
 /// intentionally left at the package default (`unlocked`) to preserve the app
 /// stores' prior macOS behavior. See #5563.
-MacOsOptions appMacOsSecureStorageOptions() => MacOsOptions(
-  useDataProtectionKeyChain:
-      defaultTargetPlatform != TargetPlatform.macOS || !kDebugMode,
-);
+///
+/// [isDebug] defaults to [kDebugMode] (a compile-time constant) and exists only
+/// so tests can exercise the macOS release branch, which `kDebugMode` cannot
+/// reach under `flutter test`. Production callers omit it.
+MacOsOptions appMacOsSecureStorageOptions({bool isDebug = kDebugMode}) =>
+    MacOsOptions(
+      useDataProtectionKeyChain:
+          defaultTargetPlatform != TargetPlatform.macOS || !isDebug,
+    );

--- a/mobile/test/services/secure_storage_options_test.dart
+++ b/mobile/test/services/secure_storage_options_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/secure_storage_options.dart';
+
+void main() {
+  group('appMacOsSecureStorageOptions', () {
+    tearDown(() => debugDefaultTargetPlatformOverride = null);
+
+    bool usesDataProtectionKeyChain() =>
+        appMacOsSecureStorageOptions().toMap()['useDataProtectionKeyChain'] ==
+        'true';
+
+    test('falls back to the file-based keychain on macOS debug', () {
+      // Tests run in debug mode, so this exercises the macOS-debug branch that
+      // would otherwise hit OSStatus -34018 (errSecMissingEntitlement). #5563.
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      expect(usesDataProtectionKeyChain(), isFalse);
+    });
+
+    test('keeps the data-protection keychain on iOS', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      expect(usesDataProtectionKeyChain(), isTrue);
+    });
+
+    test('keeps the data-protection keychain on Android', () {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      expect(usesDataProtectionKeyChain(), isTrue);
+    });
+  });
+}

--- a/mobile/test/services/secure_storage_options_test.dart
+++ b/mobile/test/services/secure_storage_options_test.dart
@@ -6,25 +6,34 @@ void main() {
   group('appMacOsSecureStorageOptions', () {
     tearDown(() => debugDefaultTargetPlatformOverride = null);
 
-    bool usesDataProtectionKeyChain() =>
-        appMacOsSecureStorageOptions().toMap()['useDataProtectionKeyChain'] ==
+    bool usesDataProtectionKeyChain({required bool isDebug}) =>
+        appMacOsSecureStorageOptions(
+          isDebug: isDebug,
+        ).toMap()['useDataProtectionKeyChain'] ==
         'true';
 
     test('falls back to the file-based keychain on macOS debug', () {
-      // Tests run in debug mode, so this exercises the macOS-debug branch that
-      // would otherwise hit OSStatus -34018 (errSecMissingEntitlement). #5563.
+      // The macOS-debug branch is the one that would otherwise hit OSStatus
+      // -34018 (errSecMissingEntitlement). #5563.
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-      expect(usesDataProtectionKeyChain(), isFalse);
+      expect(usesDataProtectionKeyChain(isDebug: true), isFalse);
+    });
+
+    test('keeps the data-protection keychain on macOS release', () {
+      // Release builds are properly signed, so the data-protection keychain
+      // stays enabled even on macOS.
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      expect(usesDataProtectionKeyChain(isDebug: false), isTrue);
     });
 
     test('keeps the data-protection keychain on iOS', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
-      expect(usesDataProtectionKeyChain(), isTrue);
+      expect(usesDataProtectionKeyChain(isDebug: true), isTrue);
     });
 
     test('keeps the data-protection keychain on Android', () {
       debugDefaultTargetPlatformOverride = TargetPlatform.android;
-      expect(usesDataProtectionKeyChain(), isTrue);
+      expect(usesDataProtectionKeyChain(isDebug: true), isTrue);
     });
   });
 }

--- a/mobile/test/services/secure_storage_options_test.dart
+++ b/mobile/test/services/secure_storage_options_test.dart
@@ -19,11 +19,23 @@ void main() {
       expect(usesDataProtectionKeyChain(isDebug: true), isFalse);
     });
 
-    test('keeps the data-protection keychain on macOS release', () {
+    test('keeps the prior keychain contract on macOS release', () {
       // Release builds are properly signed, so the data-protection keychain
-      // stays enabled even on macOS.
+      // stays enabled even on macOS. Asserting the full map locks the
+      // no-regression contract: if the helper later set `accessibility`
+      // (e.g. to mirror `nostr_key_manager`'s `first_unlock`) the App Store
+      // keychain attributes would change silently and could orphan
+      // already-stored keys for real users. #5563.
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
-      expect(usesDataProtectionKeyChain(isDebug: false), isTrue);
+      expect(
+        appMacOsSecureStorageOptions(isDebug: false).toMap(),
+        <String, String>{
+          'accessibility': 'unlocked',
+          'accountName': 'flutter_secure_storage_service',
+          'synchronizable': 'false',
+          'useDataProtectionKeyChain': 'true',
+        },
+      );
     });
 
     test('keeps the data-protection keychain on iOS', () {


### PR DESCRIPTION
## Description

macOS debug builds are ad-hoc / linker-signed without a Keychain-Sharing provisioning profile, so the data-protection keychain rejected the database cipher-key write with OSStatus `-34018` (`errSecMissingEntitlement`). `DatabaseEncryptionBootstrap.resolveCipherKey` failed before `runApp`, dropping the developer straight into the startup restart screen.

The `keychain-access-groups` entitlement can't be validated under ad-hoc signing no matter what the entitlements files declare, and registering this machine with an Apple team was blocked — so the fix avoids needing the data-protection keychain in debug instead of chasing entitlements/provisioning.

**What changed**

- New `appMacOsSecureStorageOptions()` helper falls back to the file-based keychain (`useDataProtectionKeyChain: false`) on **macOS debug only**; release builds are properly signed and keep the recommended data-protection keychain. This mirrors the workaround `nostr_key_manager`'s `PlatformSecureStorage` already applies to the nsec store.
- Both app-layer `FlutterSecureStorage` instances now use it: the DB cipher-key store (`main.dart`) and the OAuth/Keycast credential store (`auth_providers.dart`) — same root cause, so macOS debug auth no longer breaks either.
- Regenerated `auth_providers.g.dart` (riverpod provider hash).
- No entitlement files change, so the native signing guardrails stay as-is.

**Related Issue:** Closes #5563

## Out of Scope

- iOS / Android keychain behavior (unchanged — `mOptions` only applies on macOS).
- macOS **release** keychain behavior (unchanged — keeps the data-protection keychain).
- macOS **profile** builds: intentionally *not* special-cased. The gate is `!kDebugMode`, so a profile build keeps the data-protection keychain. An ad-hoc-signed profile build shares the same root cause and would hit `-34018`, but this is expected and matches `nostr_key_manager`'s existing `!kDebugMode` gate — profile is not part of the normal macOS dev/run loop this issue is about.
- `nostr_key_manager` already had this workaround; not re-touched.

## Verification

- `flutter analyze lib test integration_test` — clean.
- `flutter test test/services/secure_storage_options_test.dart` — asserts macOS-debug falls back to the file-based keychain, while macOS-release / iOS / Android keep the data-protection keychain. The helper takes an `isDebug` override (defaulting to `kDebugMode`) purely so the macOS-release branch is reachable under `flutter test`; production callers omit it.
- `flutter test test/services/database_encryption_bootstrap_test.dart` — green.
- Pre-commit/pre-push hooks (format, analyze, codegen verify, changed-file tests) — green.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
