### PR TITLE
chore(macos): ignore Xcode-generated SwiftPM lockfiles

### DIFF
--- a/mobile/macos/.gitignore
+++ b/mobile/macos/.gitignore
@@ -5,3 +5,8 @@
 # Xcode-related
 **/dgph
 **/xcuserdata/
+
+# SwiftPM lockfiles: macOS builds via CocoaPods, so Xcode regenerates these
+# per-machine on open as untracked noise. (iOS deliberately tracks its own —
+# see ios/.gitignore.)
+**/xcshareddata/swiftpm/


### PR DESCRIPTION
Closes #5573

## Description

Xcode regenerates `xcshareddata/swiftpm/Package.resolved` under the macOS
Runner workspaces every time the project is opened. Because macOS still builds
via CocoaPods (not Flutter SPM), these lockfiles aren't tracked — so they show
up as untracked noise in `git status` and risk being committed into unrelated
PRs.

**What changed**

- Add `**/xcshareddata/swiftpm/` to `mobile/macos/.gitignore`, scoped to the
  macOS folder.

**Why scoped to macOS:** iOS *deliberately* tracks its own
`xcshareddata/swiftpm/Package.resolved` for reproducible Flutter SPM builds
(see the comment in `mobile/ios/.gitignore`). A repo-wide rule would be
inconsistent with that intent, so this rule lives in `mobile/macos/.gitignore`
and leaves the iOS lockfiles untouched.

**Related Issue:** 

## Out of Scope

- iOS SwiftPM lockfiles (intentionally tracked — unchanged).
- macOS CocoaPods / `Podfile.lock` (unchanged).

## Verification

- `git check-ignore -v` confirms both macOS `Package.resolved` paths are now
  ignored, while the two tracked iOS `Package.resolved` paths are not matched
  and remain tracked.
- Recreating the macOS lockfile leaves `git status` clean (only the
  `.gitignore` change shows).

## Type of Change

- [x] 🧹 Chore (tooling/repo hygiene, no production code change)