### PR TITLE
refactor(upload): extract PendingUploadStore from UploadManager (#4507)

### DIFF
--- a/mobile/lib/services/upload/pending_upload_store.dart
+++ b/mobile/lib/services/upload/pending_upload_store.dart
@@ -1,0 +1,390 @@
+// ABOUTME: Persistence layer for PendingUpload records – owns the Hive box,
+// ABOUTME: the save-queue fallback, and all query/cleanup operations.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/upload_initialization_helper.dart';
+import 'package:openvine/services/upload_publishability.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Owns the Hive persistence layer for [PendingUpload] records.
+///
+/// [UploadManager] constructs exactly one instance and delegates all
+/// storage reads and writes here.  The two scoping params mirror the
+/// corresponding fields that previously lived on [UploadManager].
+class PendingUploadStore {
+  PendingUploadStore({
+    required this.scopeUploadsToCurrentUser,
+    required this.currentNostrPubkey,
+  });
+
+  final bool scopeUploadsToCurrentUser;
+  final String? currentNostrPubkey;
+
+  Box<PendingUpload>? _box;
+  final List<PendingUpload> _pendingSaveQueue = [];
+  Timer? _saveQueueTimer;
+
+  // ---------------------------------------------------------------------------
+  // Status accessors
+  // ---------------------------------------------------------------------------
+
+  /// True when the Hive box is open and ready for reads/writes.
+  bool get isReady => _box != null && _box!.isOpen;
+
+  /// Total number of records currently in the box (0 when not ready).
+  int get length => _box?.length ?? 0;
+
+  /// Number of uploads waiting in the deferred-save queue.
+  int get queuedCount => _pendingSaveQueue.length;
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  /// Open the Hive box for the first time (called from [UploadManager.initialize]).
+  ///
+  /// On failure the box pointer is reset to null so [isReady] reports false –
+  /// mirroring the original `initialize()` catch that nulled the box – before
+  /// the error propagates to the manager's initialization error handler.
+  Future<void> open() async {
+    try {
+      _box = await UploadInitializationHelper.initializeUploadsBox(
+        forceReinit: true,
+      );
+    } catch (_) {
+      _box = null;
+      rethrow;
+    }
+  }
+
+  /// Force-reopen the box (called from re-init-when-closed paths).
+  Future<void> ensureOpen() async {
+    _box = await UploadInitializationHelper.initializeUploadsBox(
+      forceReinit: true,
+    );
+  }
+
+  /// Cancel timers, drain the queue reference, and null the box pointer.
+  ///
+  /// Does NOT close the box – closing is Hive's responsibility and closing
+  /// here causes "File closed" errors in tests that share the box instance.
+  void disposeStore() {
+    _saveQueueTimer?.cancel();
+    _saveQueueTimer = null;
+    _pendingSaveQueue.clear();
+    // Null the reference so isReady → false without actually closing.
+    _box = null;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence – write paths
+  // ---------------------------------------------------------------------------
+
+  /// Persist a new [upload] to the Hive box.
+  ///
+  /// If the box is unavailable, falls back to robust re-init; on failure
+  /// the upload is queued for a deferred retry (5 s / 30 s schedule).
+  Future<void> save(PendingUpload upload) async {
+    // Fast path – box is already open.
+    if (_box != null && _box!.isOpen) {
+      try {
+        await _box!.put(upload.id, upload);
+        Log.info(
+          '✅ Upload saved to Hive box with ID: ${upload.id}',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        return;
+      } catch (e) {
+        Log.warning(
+          'Failed to save with existing box: $e, attempting recovery...',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+      }
+    }
+
+    // Slow path – box is null or save failed; try robust re-init.
+    Log.warning(
+      'Upload box not ready, using robust initialization...',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+
+    try {
+      await ensureOpen();
+
+      if (!isReady) {
+        throw Exception('Failed to initialize box for saving upload');
+      }
+
+      await _box!.put(upload.id, upload);
+      Log.info(
+        '✅ Upload saved after robust initialization: ${upload.id}',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    } catch (e) {
+      Log.error(
+        '❌ Failed to save upload after all retries: $e',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+
+      // Last resort – queue for a later retry attempt.
+      _queueUploadForLater(upload);
+
+      throw Exception(
+        'Unable to save upload: Storage initialization failed after multiple attempts',
+      );
+    }
+  }
+
+  /// Overwrite an existing [upload] record (no-op when box is not ready).
+  Future<void> update(PendingUpload upload) async {
+    if (_box == null) return;
+    await _box!.put(upload.id, upload);
+  }
+
+  /// Delete the record with [id] from the box (no-op when box is not ready).
+  Future<void> delete(String id) async {
+    if (_box == null) return;
+    await _box!.delete(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Deferred-save queue
+  // ---------------------------------------------------------------------------
+
+  void _queueUploadForLater(PendingUpload upload) {
+    Log.warning(
+      'Queueing upload ${upload.id} for later save attempt',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+
+    _pendingSaveQueue.add(upload);
+
+    // Schedule retry in 5 seconds.
+    _saveQueueTimer?.cancel();
+    _saveQueueTimer = Timer(const Duration(seconds: 5), _processSaveQueue);
+  }
+
+  Future<void> _processSaveQueue() async {
+    if (_pendingSaveQueue.isEmpty) return;
+
+    Log.info(
+      'Processing ${_pendingSaveQueue.length} queued uploads',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+
+    final queue = List<PendingUpload>.from(_pendingSaveQueue);
+    _pendingSaveQueue.clear();
+
+    for (final upload in queue) {
+      try {
+        await save(upload);
+        Log.info(
+          'Successfully saved queued upload: ${upload.id}',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+      } catch (e) {
+        Log.error(
+          'Failed to save queued upload ${upload.id}: $e',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        // Re-queue for another attempt.
+        _pendingSaveQueue.add(upload);
+      }
+    }
+
+    // If items remain, schedule a further retry in 30 seconds.
+    if (_pendingSaveQueue.isNotEmpty) {
+      _saveQueueTimer = Timer(const Duration(seconds: 30), _processSaveQueue);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Query helpers
+  // ---------------------------------------------------------------------------
+
+  /// All uploads sorted newest-first; not owner-scoped.
+  List<PendingUpload> get _allUploads {
+    if (_box == null) return [];
+    return _box!.values.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  }
+
+  /// Uploads visible to the configured owner (or all uploads when unscoped).
+  List<PendingUpload> get pendingUploads {
+    final uploads = _allUploads;
+    if (!scopeUploadsToCurrentUser) return uploads;
+    return uploads.where(_isVisibleToCurrentOwner).toList();
+  }
+
+  bool _isVisibleToCurrentOwner(PendingUpload upload) {
+    if (!scopeUploadsToCurrentUser) return true;
+    final currentPubkey = currentNostrPubkey;
+    return currentPubkey != null &&
+        currentPubkey.isNotEmpty &&
+        upload.nostrPubkey == currentPubkey;
+  }
+
+  /// Retrieve a single upload by [id], applying owner-scope filter.
+  PendingUpload? getUpload(String id) {
+    final upload = _box?.get(id);
+    if (upload == null || !_isVisibleToCurrentOwner(upload)) return null;
+    return upload;
+  }
+
+  /// All uploads in [pendingUploads] that match [status].
+  List<PendingUpload> getUploadsByStatus(UploadStatus status) =>
+      pendingUploads.where((upload) => upload.status == status).toList();
+
+  /// First upload in [pendingUploads] whose local path equals [filePath].
+  PendingUpload? getUploadByFilePath(String filePath) {
+    try {
+      return pendingUploads.firstWhere(
+        (upload) => upload.localVideoPath == filePath,
+      );
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Most-recent upload for [filePath] that is in a resumable/reusable state.
+  PendingUpload? findReusableUpload(String filePath) {
+    for (final upload in pendingUploads) {
+      if (upload.localVideoPath != filePath) continue;
+      if (upload.status == UploadStatus.published) continue;
+      if (upload.status == UploadStatus.pending) continue;
+      if (upload.status == UploadStatus.paused) continue;
+      if (upload.status == UploadStatus.readyToPublish &&
+          !readyUploadIsPublishable(upload)) {
+        continue;
+      }
+      if (upload.status == UploadStatus.failed &&
+          upload.resumableSession == null) {
+        continue;
+      }
+      return upload;
+    }
+    return null;
+  }
+
+  /// Count of uploads in each status bucket (owner-scoped).
+  Map<String, int> get uploadStats {
+    final uploads = pendingUploads;
+    return {
+      'total': uploads.length,
+      'pending': uploads.where((u) => u.status == UploadStatus.pending).length,
+      'uploading': uploads
+          .where((u) => u.status == UploadStatus.uploading)
+          .length,
+      'processing': uploads
+          .where((u) => u.status == UploadStatus.processing)
+          .length,
+      'ready': uploads
+          .where((u) => u.status == UploadStatus.readyToPublish)
+          .length,
+      'published': uploads
+          .where((u) => u.status == UploadStatus.published)
+          .length,
+      'failed': uploads.where((u) => u.status == UploadStatus.failed).length,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Cleanup
+  // ---------------------------------------------------------------------------
+
+  /// Delete published, stale-completed, and unrecoverable-failed uploads.
+  ///
+  /// Operates on ALL uploads (not owner-scoped) to avoid leaving orphaned
+  /// records from previous accounts.
+  Future<void> cleanupCompletedUploads() async {
+    if (_box == null) return;
+
+    final uploadsToClean = <PendingUpload>[];
+
+    for (final upload in _allUploads) {
+      // Published uploads are fully done – remove immediately.
+      if (upload.status == UploadStatus.published) {
+        uploadsToClean.add(upload);
+        continue;
+      }
+
+      // Remove completed uploads after 1 day.
+      if (upload.isCompleted &&
+          upload.completedAt != null &&
+          DateTime.now().difference(upload.completedAt!).inDays >= 1) {
+        uploadsToClean.add(upload);
+        continue;
+      }
+
+      // Remove failed uploads whose video file no longer exists (unrecoverable).
+      if (upload.status == UploadStatus.failed && !kIsWeb) {
+        final videoFile = File(upload.localVideoPath);
+        if (!videoFile.existsSync()) {
+          uploadsToClean.add(upload);
+          continue;
+        }
+      }
+    }
+
+    for (final upload in uploadsToClean) {
+      await _box!.delete(upload.id);
+      Log.debug(
+        '🗑️ Cleaned up upload: ${upload.id} (${upload.status.name})',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    }
+
+    if (uploadsToClean.isNotEmpty) {
+      Log.info(
+        '🧹 Cleaned up ${uploadsToClean.length} old/unrecoverable uploads',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  /// Move readyToPublish uploads that are missing required CDN data to failed.
+  ///
+  /// Operates on owner-scoped [pendingUploads].
+  Future<void> cleanupProblematicUploads() async {
+    final uploads = pendingUploads;
+    var fixedCount = 0;
+
+    for (final upload in uploads) {
+      if (upload.status == UploadStatus.readyToPublish &&
+          !readyUploadIsPublishable(upload)) {
+        Log.error(
+          'Fixing stuck upload: ${upload.id} (missing publishable video data) - moving to failed',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        final fixedUpload = upload.copyWith(status: UploadStatus.failed);
+        await update(fixedUpload);
+        fixedCount++;
+      }
+    }
+
+    if (fixedCount > 0) {
+      Log.error(
+        'Fixed $fixedCount stuck uploads - moved back to failed status',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    }
+  }
+}

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -9,15 +9,14 @@ import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:models/models.dart' show NativeProofData;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/circuit_breaker_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:openvine/services/upload/pending_upload_store.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
-import 'package:openvine/services/upload_publishability.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/async_utils.dart';
@@ -117,17 +116,17 @@ class UploadManager {
   }) : _blossomService = blossomService,
        _defaultBlossomUrl =
            defaultBlossomUrl ?? BlossomUploadService.defaultBlossomServer,
-       _currentNostrPubkey = currentNostrPubkey,
-       _scopeUploadsToCurrentUser = scopeUploadsToCurrentUser,
        _circuitBreaker = circuitBreaker ?? VideoCircuitBreaker(),
-       _retryConfig = retryConfig ?? const UploadRetryConfig();
+       _retryConfig = retryConfig ?? const UploadRetryConfig(),
+       _store = PendingUploadStore(
+         scopeUploadsToCurrentUser: scopeUploadsToCurrentUser,
+         currentNostrPubkey: currentNostrPubkey,
+       );
 
   // Core services
-  Box<PendingUpload>? _uploadsBox;
+  final PendingUploadStore _store;
   final BlossomUploadService _blossomService;
   final String _defaultBlossomUrl;
-  final String? _currentNostrPubkey;
-  final bool _scopeUploadsToCurrentUser;
   final VideoCircuitBreaker _circuitBreaker;
   final UploadRetryConfig _retryConfig;
   final Dio _dio = Dio();
@@ -146,12 +145,12 @@ class UploadManager {
   bool _isInitialized = false;
 
   /// Check if the upload manager is initialized
-  bool get isInitialized => _isInitialized && _uploadsBox != null;
+  bool get isInitialized => _isInitialized && _store.isReady;
 
   /// Initialize the upload manager and load persisted uploads
   /// Uses robust initialization with retry logic and recovery strategies
   Future<void> initialize() async {
-    if (_isInitialized && _uploadsBox != null && _uploadsBox!.isOpen) {
+    if (_isInitialized && _store.isReady) {
       Log.info(
         'UploadManager already initialized',
         name: 'UploadManager',
@@ -167,12 +166,10 @@ class UploadManager {
     );
 
     try {
-      // Use the robust initialization helper
-      _uploadsBox = await UploadInitializationHelper.initializeUploadsBox(
-        forceReinit: !_isInitialized,
-      );
+      // Delegate box open to the store.
+      await _store.open();
 
-      if (_uploadsBox == null || !_uploadsBox!.isOpen) {
+      if (!_store.isReady) {
         throw Exception(
           'Failed to initialize uploads box after all recovery attempts',
         );
@@ -181,7 +178,7 @@ class UploadManager {
       _isInitialized = true;
 
       Log.info(
-        '✅ UploadManager initialized successfully with ${_uploadsBox!.length} existing uploads',
+        '✅ UploadManager initialized successfully with ${_store.length} existing uploads',
         name: 'UploadManager',
         category: LogCategory.video,
       );
@@ -199,7 +196,6 @@ class UploadManager {
       // records (and their resumable sessions) when the user taps "Try Again".
     } catch (e, stackTrace) {
       _isInitialized = false;
-      _uploadsBox = null;
 
       // Log the error but don't rethrow immediately - the helper already retried
       Log.error(
@@ -221,56 +217,20 @@ class UploadManager {
     }
   }
 
-  List<PendingUpload> get _allUploads {
-    if (_uploadsBox == null) return [];
-    return _uploadsBox!.values.toList()
-      ..sort((a, b) => b.createdAt.compareTo(a.createdAt)); // Newest first
-  }
-
   /// Get pending uploads visible to the current owner.
   ///
   /// Production providers opt into owner scoping so account switches do not
   /// surface another user's persisted Hive uploads. Tests and maintenance
   /// harnesses that construct [UploadManager] directly keep the historical
   /// unscoped view unless they pass [scopeUploadsToCurrentUser].
-  List<PendingUpload> get pendingUploads {
-    final uploads = _allUploads;
-    if (!_scopeUploadsToCurrentUser) return uploads;
-
-    return uploads.where(_isVisibleToCurrentOwner).toList();
-  }
-
-  bool _isVisibleToCurrentOwner(PendingUpload upload) {
-    if (!_scopeUploadsToCurrentUser) return true;
-    final currentPubkey = _currentNostrPubkey;
-    return currentPubkey != null &&
-        currentPubkey.isNotEmpty &&
-        upload.nostrPubkey == currentPubkey;
-  }
-
-  /// Get uploads by status
-  List<PendingUpload> getUploadsByStatus(UploadStatus status) =>
-      pendingUploads.where((upload) => upload.status == status).toList();
+  List<PendingUpload> get pendingUploads => _store.pendingUploads;
 
   /// Get a specific upload by ID
-  PendingUpload? getUpload(String id) {
-    final upload = _uploadsBox?.get(id);
-    if (upload == null || !_isVisibleToCurrentOwner(upload)) {
-      return null;
-    }
-    return upload;
-  }
+  PendingUpload? getUpload(String id) => _store.getUpload(id);
 
   /// Get an upload by file path
-  PendingUpload? getUploadByFilePath(String filePath) {
-    try {
-      return pendingUploads.firstWhere(
-        (upload) => upload.localVideoPath == filePath,
-      );
-    } catch (e) {
-      return null;
-    }
-  }
+  PendingUpload? getUploadByFilePath(String filePath) =>
+      _store.getUploadByFilePath(filePath);
 
   /// Finds a reusable upload for the given video file path.
   ///
@@ -282,24 +242,8 @@ class UploadManager {
   /// Relies on [pendingUploads] being sorted newest-first (by
   /// [PendingUpload.createdAt] descending) so the first match is the
   /// most recent candidate.
-  PendingUpload? findReusableUpload(String filePath) {
-    for (final upload in pendingUploads) {
-      if (upload.localVideoPath != filePath) continue;
-      if (upload.status == UploadStatus.published) continue;
-      if (upload.status == UploadStatus.pending) continue;
-      if (upload.status == UploadStatus.paused) continue;
-      if (upload.status == UploadStatus.readyToPublish &&
-          !readyUploadIsPublishable(upload)) {
-        continue;
-      }
-      if (upload.status == UploadStatus.failed &&
-          upload.resumableSession == null) {
-        continue;
-      }
-      return upload;
-    }
-    return null;
-  }
+  PendingUpload? findReusableUpload(String filePath) =>
+      _store.findReusableUpload(filePath);
 
   /// Start upload from VineDraft (preferred method - single source of truth)
   Future<PendingUpload> startUploadFromDraft({
@@ -498,7 +442,7 @@ class UploadManager {
     );
 
     // Ensure initialization with robust retry
-    if (!isInitialized || _uploadsBox == null || !_uploadsBox!.isOpen) {
+    if (!isInitialized || !_store.isReady) {
       Log.warning(
         'UploadManager not ready, attempting robust initialization...',
         name: 'UploadManager',
@@ -506,12 +450,10 @@ class UploadManager {
       );
 
       try {
-        // Use the robust helper directly for immediate retry
-        _uploadsBox = await UploadInitializationHelper.initializeUploadsBox(
-          forceReinit: true,
-        );
+        // Delegate force-reinit to the store.
+        await _store.ensureOpen();
 
-        if (_uploadsBox != null && _uploadsBox!.isOpen) {
+        if (_store.isReady) {
           _isInitialized = true;
           Log.info(
             '✅ Robust initialization successful',
@@ -637,7 +579,7 @@ class UploadManager {
       name: 'UploadManager',
       category: LogCategory.video,
     );
-    await _saveUpload(upload);
+    await _store.save(upload);
     Log.info(
       '✅ Upload saved to storage',
       name: 'UploadManager',
@@ -801,7 +743,7 @@ class UploadManager {
             category: LogCategory.video,
           );
 
-          await _updateUpload(
+          await _store.update(
             currentUpload.copyWith(
               status: autoAttempt == 1
                   ? UploadStatus.uploading
@@ -1004,7 +946,7 @@ class UploadManager {
 
       // Store thumbnail URL in upload for later use
       if (thumbnailCdnUrl != null) {
-        await _updateUpload(upload.copyWith(thumbnailPath: thumbnailCdnUrl));
+        await _store.update(upload.copyWith(thumbnailPath: thumbnailCdnUrl));
       }
 
       Log.info(
@@ -1037,7 +979,7 @@ class UploadManager {
 
       // Create updated upload with success metadata
       final updatedUpload = _createSuccessfulUpload(latestUpload, result);
-      await _updateUpload(updatedUpload);
+      await _store.update(updatedUpload);
 
       // Record successful metrics
       if (metrics != null) {
@@ -1110,7 +1052,7 @@ class UploadManager {
     );
 
     // Store user-friendly error message instead of raw exception
-    await _updateUpload(
+    await _store.update(
       latestUpload.copyWith(
         status: UploadStatus.failed,
         errorMessage: userMessage,
@@ -1150,7 +1092,7 @@ class UploadManager {
         ? upload.uploadProgress
         : ((session.nextOffset / fileSizeBytes) * 0.8).clamp(0.0, 0.8);
 
-    await _updateUpload(
+    await _store.update(
       upload.copyWith(
         resumableSession: session,
         uploadProgress: persistedProgress,
@@ -1455,7 +1397,7 @@ class UploadManager {
     if (upload != null &&
         (upload.status == UploadStatus.uploading ||
             upload.status == UploadStatus.retrying)) {
-      _updateUpload(upload.copyWith(uploadProgress: progress));
+      _store.update(upload.copyWith(uploadProgress: progress));
     }
   }
 
@@ -1495,7 +1437,7 @@ class UploadManager {
       // Keep current progress and don't set error message
     );
 
-    await _updateUpload(pausedUpload);
+    await _store.update(pausedUpload);
 
     // Cancel progress subscription
     _progressSubscriptions[uploadId]?.cancel();
@@ -1543,7 +1485,7 @@ class UploadManager {
           : upload.uploadProgress,
     );
 
-    await _updateUpload(resumedUpload);
+    await _store.update(resumedUpload);
 
     // Start upload process again and wait for completion
     await _performUpload(resumedUpload);
@@ -1590,7 +1532,7 @@ class UploadManager {
       retryCount: nextRetryCount,
     );
 
-    await _updateUpload(resetUpload);
+    await _store.update(resetUpload);
 
     // Start upload again and wait for completion
     await _performUpload(resetUpload);
@@ -1617,7 +1559,7 @@ class UploadManager {
     );
 
     final resumed = upload.copyWith(status: UploadStatus.uploading);
-    unawaited(_updateUpload(resumed));
+    unawaited(_store.update(resumed));
     unawaited(_performUpload(resumed));
   }
 
@@ -1643,7 +1585,7 @@ class UploadManager {
       errorMessage: 'Upload cancelled by user',
     );
 
-    await _updateUpload(cancelledUpload);
+    await _store.update(cancelledUpload);
 
     // Cancel progress subscription
     _progressSubscriptions[uploadId]?.cancel();
@@ -1656,180 +1598,8 @@ class UploadManager {
     );
   }
 
-  /// Remove completed, published, or unrecoverable failed uploads
-  Future<void> cleanupCompletedUploads() async {
-    if (_uploadsBox == null) return;
-
-    final uploadsToClean = <PendingUpload>[];
-
-    for (final upload in _allUploads) {
-      // Clean up published uploads immediately - they're done
-      if (upload.status == UploadStatus.published) {
-        uploadsToClean.add(upload);
-        continue;
-      }
-
-      // Clean up completed uploads after 1 day
-      if (upload.isCompleted &&
-          upload.completedAt != null &&
-          DateTime.now().difference(upload.completedAt!).inDays >= 1) {
-        uploadsToClean.add(upload);
-        continue;
-      }
-
-      // Clean up failed uploads with missing video files (unrecoverable)
-      if (upload.status == UploadStatus.failed && !kIsWeb) {
-        final videoFile = File(upload.localVideoPath);
-        if (!videoFile.existsSync()) {
-          uploadsToClean.add(upload);
-          continue;
-        }
-      }
-    }
-
-    for (final upload in uploadsToClean) {
-      await _uploadsBox!.delete(upload.id);
-      Log.debug(
-        '🗑️ Cleaned up upload: ${upload.id} (${upload.status.name})',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    }
-
-    if (uploadsToClean.isNotEmpty) {
-      Log.info(
-        '🧹 Cleaned up ${uploadsToClean.length} old/unrecoverable uploads',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    }
-  }
-
-  /// Save upload to local storage with robust retry logic
-  Future<void> _saveUpload(PendingUpload upload) async {
-    // First attempt with existing box
-    if (_uploadsBox != null && _uploadsBox!.isOpen) {
-      try {
-        await _uploadsBox!.put(upload.id, upload);
-        Log.info(
-          '✅ Upload saved to Hive box with ID: ${upload.id}',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-        return;
-      } catch (e) {
-        Log.warning(
-          'Failed to save with existing box: $e, attempting recovery...',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-      }
-    }
-
-    // Box is null or save failed - use robust initialization
-    Log.warning(
-      'Upload box not ready, using robust initialization...',
-      name: 'UploadManager',
-      category: LogCategory.video,
-    );
-
-    try {
-      _uploadsBox = await UploadInitializationHelper.initializeUploadsBox(
-        forceReinit: true,
-      );
-
-      if (_uploadsBox == null || !_uploadsBox!.isOpen) {
-        throw Exception('Failed to initialize box for saving upload');
-      }
-
-      _isInitialized = true;
-
-      // Retry save with new box
-      await _uploadsBox!.put(upload.id, upload);
-      Log.info(
-        '✅ Upload saved after robust initialization: ${upload.id}',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    } catch (e) {
-      Log.error(
-        '❌ Failed to save upload after all retries: $e',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-
-      // As a last resort, queue the upload for later
-      _queueUploadForLater(upload);
-
-      throw Exception(
-        'Unable to save upload: Storage initialization failed after multiple attempts',
-      );
-    }
-  }
-
-  // Queue for uploads that couldn't be saved immediately
-  final List<PendingUpload> _pendingSaveQueue = [];
-  Timer? _saveQueueTimer;
-
-  /// Queue upload for later save attempt
-  void _queueUploadForLater(PendingUpload upload) {
-    Log.warning(
-      'Queueing upload ${upload.id} for later save attempt',
-      name: 'UploadManager',
-      category: LogCategory.video,
-    );
-
-    _pendingSaveQueue.add(upload);
-
-    // Schedule retry in 5 seconds
-    _saveQueueTimer?.cancel();
-    _saveQueueTimer = Timer(const Duration(seconds: 5), _processSaveQueue);
-  }
-
-  /// Process queued uploads
-  Future<void> _processSaveQueue() async {
-    if (_pendingSaveQueue.isEmpty) return;
-
-    Log.info(
-      'Processing ${_pendingSaveQueue.length} queued uploads',
-      name: 'UploadManager',
-      category: LogCategory.video,
-    );
-
-    final queue = List<PendingUpload>.from(_pendingSaveQueue);
-    _pendingSaveQueue.clear();
-
-    for (final upload in queue) {
-      try {
-        await _saveUpload(upload);
-        Log.info(
-          'Successfully saved queued upload: ${upload.id}',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-      } catch (e) {
-        Log.error(
-          'Failed to save queued upload ${upload.id}: $e',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-        // Re-queue for another attempt
-        _pendingSaveQueue.add(upload);
-      }
-    }
-
-    // If there are still pending uploads, schedule another retry
-    if (_pendingSaveQueue.isNotEmpty) {
-      _saveQueueTimer = Timer(const Duration(seconds: 30), _processSaveQueue);
-    }
-  }
-
-  /// Update existing upload
-  Future<void> _updateUpload(PendingUpload upload) async {
-    if (_uploadsBox == null) return;
-
-    await _uploadsBox!.put(upload.id, upload);
-  }
+  /// Remove completed, published, or unrecoverable failed uploads.
+  Future<void> cleanupCompletedUploads() => _store.cleanupCompletedUploads();
 
   /// Update upload status (public method for VideoEventPublisher)
   Future<void> updateUploadStatus(
@@ -1855,7 +1625,7 @@ class UploadManager {
           : upload.completedAt,
     );
 
-    await _updateUpload(updatedUpload);
+    await _store.update(updatedUpload);
     Log.info(
       'Updated upload status: $uploadId -> $status',
       name: 'UploadManager',
@@ -1864,54 +1634,11 @@ class UploadManager {
   }
 
   /// Get upload statistics
-  Map<String, int> get uploadStats {
-    final uploads = pendingUploads;
-    return {
-      'total': uploads.length,
-      'pending': uploads.where((u) => u.status == UploadStatus.pending).length,
-      'uploading': uploads
-          .where((u) => u.status == UploadStatus.uploading)
-          .length,
-      'processing': uploads
-          .where((u) => u.status == UploadStatus.processing)
-          .length,
-      'ready': uploads
-          .where((u) => u.status == UploadStatus.readyToPublish)
-          .length,
-      'published': uploads
-          .where((u) => u.status == UploadStatus.published)
-          .length,
-      'failed': uploads.where((u) => u.status == UploadStatus.failed).length,
-    };
-  }
+  Map<String, int> get uploadStats => _store.uploadStats;
 
   /// Fix uploads stuck in readyToPublish without proper data (debug method)
-  Future<void> cleanupProblematicUploads() async {
-    final uploads = pendingUploads;
-    var fixedCount = 0;
-
-    for (final upload in uploads) {
-      if (upload.status == UploadStatus.readyToPublish &&
-          !readyUploadIsPublishable(upload)) {
-        Log.error(
-          'Fixing stuck upload: ${upload.id} (missing publishable video data) - moving to failed',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-        final fixedUpload = upload.copyWith(status: UploadStatus.failed);
-        await _updateUpload(fixedUpload);
-        fixedCount++;
-      }
-    }
-
-    if (fixedCount > 0) {
-      Log.error(
-        'Fixed $fixedCount stuck uploads - moved back to failed status',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    }
-  }
+  Future<void> cleanupProblematicUploads() =>
+      _store.cleanupProblematicUploads();
 
   /// Get comprehensive performance metrics
   Map<String, dynamic> getPerformanceMetrics() {
@@ -2008,7 +1735,7 @@ class UploadManager {
       retryCount: newRetryCount,
     );
 
-    await _updateUpload(updatedUpload);
+    await _store.update(updatedUpload);
 
     // Start upload process
     await _performUpload(updatedUpload);
@@ -2259,9 +1986,9 @@ class UploadManager {
 
       // Add system context
       context.addAll({
-        'total_uploads': _uploadsBox?.length ?? 0,
+        'total_uploads': _store.length,
         'active_uploads': _progressSubscriptions.length,
-        'queued_uploads': _pendingSaveQueue.length,
+        'queued_uploads': _store.queuedCount,
         'platform': _getPlatformName(),
         'is_initialized': _isInitialized,
         'timestamp': DateTime.now().toIso8601String(),
@@ -2569,22 +2296,12 @@ Upload Timeout Failure:
     // Discard pending session persistence futures
     _sessionPersistFutures.clear();
 
-    // Cancel save queue timer
-    _saveQueueTimer?.cancel();
-    _saveQueueTimer = null;
-
     // Clean up old metrics
     _cleanupOldMetrics();
 
-    // Note: We don't close the box here as it might be shared across instances
-    // The box will be closed when Hive.close() is called in tearDownAll
-    // Closing it here causes "File closed" errors in tests
-    // _uploadsBox?.close();
-    _uploadsBox = null;
+    // Delegate storage teardown (timer, queue, box pointer) to the store.
+    _store.disposeStore();
     _isInitialized = false;
-
-    // Clear any pending saves
-    _pendingSaveQueue.clear();
 
     Log.info(
       'UploadManager disposed',
@@ -2635,7 +2352,7 @@ Upload Timeout Failure:
               uploadProgress: 1.0,
               completedAt: DateTime.now(),
             );
-            await _updateUpload(readyUpload);
+            await _store.update(readyUpload);
 
             Log.info(
               '✅ Video processing complete: ${upload.id}',

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -202,21 +202,20 @@ void main() {
         final store = await _openStore();
         addTearDown(store.disposeStore);
 
+        // Pin createdAt explicitly so newest-first ordering is deterministic
+        // rather than depending on a wall-clock gap between the two saves.
         final older = PendingUpload.create(
           localVideoPath: '${tempDir.path}/old.mp4',
           nostrPubkey: _pubkeyA,
           title: 'Older',
-        );
+        ).copyWith(createdAt: DateTime(2024, 1, 1, 12));
         await store.save(older);
-
-        // Ensure distinct timestamps.
-        await Future<void>.delayed(const Duration(milliseconds: 10));
 
         final newer = PendingUpload.create(
           localVideoPath: '${tempDir.path}/new.mp4',
           nostrPubkey: _pubkeyA,
           title: 'Newer',
-        );
+        ).copyWith(createdAt: DateTime(2024, 1, 1, 13));
         await store.save(newer);
 
         final uploads = store.pendingUploads;

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -1,0 +1,772 @@
+// ABOUTME: Unit tests for PendingUploadStore – the Hive persistence layer.
+// ABOUTME: Covers CRUD, save-queue fallback, owner scoping, reuse detection,
+// ABOUTME: and both cleanup routines.
+
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload_initialization_helper.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../helpers/test_helpers.dart';
+import '../../mocks/mock_path_provider_platform.dart';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _pubkeyA =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _pubkeyB =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+/// Create and open an unscoped store backed by a fresh Hive box.
+Future<PendingUploadStore> _openStore({
+  bool scopeUploadsToCurrentUser = false,
+  String? currentNostrPubkey,
+}) async {
+  final store = PendingUploadStore(
+    scopeUploadsToCurrentUser: scopeUploadsToCurrentUser,
+    currentNostrPubkey: currentNostrPubkey,
+  );
+  await store.open();
+  // Guarantee a clean slate even if a prior test left records in the shared
+  // 'pending_uploads' box (mirrors upload_manager_owner_scope_test.dart).
+  await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
+  return store;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUpAll(() async {
+    await setupTestEnvironment();
+  });
+
+  group(PendingUploadStore, () {
+    late Directory tempDir;
+    late PathProviderPlatform originalPathProvider;
+
+    setUp(() async {
+      await TestHelpers.cleanupHiveBox('pending_uploads');
+      SharedPreferences.setMockInitialValues({});
+
+      tempDir = await Directory.systemTemp.createTemp(
+        'pending_upload_store_',
+      );
+      originalPathProvider = PathProviderPlatform.instance;
+      PathProviderPlatform.instance = MockPathProviderPlatform()
+        ..setTemporaryPath(tempDir.path)
+        ..setApplicationDocumentsPath('${tempDir.path}/documents')
+        ..setApplicationSupportPath('${tempDir.path}/support');
+    });
+
+    tearDown(() async {
+      await TestHelpers.cleanupHiveBox('pending_uploads');
+      PathProviderPlatform.instance = originalPathProvider;
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    // -----------------------------------------------------------------------
+    // Lifecycle
+    // -----------------------------------------------------------------------
+
+    group('lifecycle', () {
+      test('isReady is false before open', () {
+        final store = PendingUploadStore(
+          scopeUploadsToCurrentUser: false,
+          currentNostrPubkey: null,
+        );
+        expect(store.isReady, isFalse);
+      });
+
+      test('isReady is true after open()', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+        expect(store.isReady, isTrue);
+      });
+
+      test('disposeStore() makes isReady false', () async {
+        final store = await _openStore();
+        store.disposeStore();
+        expect(store.isReady, isFalse);
+      });
+
+      test('length returns 0 before open', () {
+        final store = PendingUploadStore(
+          scopeUploadsToCurrentUser: false,
+          currentNostrPubkey: null,
+        );
+        expect(store.length, equals(0));
+      });
+
+      test('queuedCount starts at 0', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+        expect(store.queuedCount, equals(0));
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // CRUD round-trips
+    // -----------------------------------------------------------------------
+
+    group('save / get / update / delete', () {
+      test('save() persists and get() retrieves the record', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/video.mp4',
+          nostrPubkey: _pubkeyA,
+          title: 'Test video',
+        );
+
+        await store.save(upload);
+
+        expect(store.length, equals(1));
+        final retrieved = store.getUpload(upload.id);
+        expect(retrieved, isNotNull);
+        expect(retrieved!.id, equals(upload.id));
+        expect(retrieved.title, equals('Test video'));
+      });
+
+      test('update() overwrites an existing record', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/video.mp4',
+          nostrPubkey: _pubkeyA,
+          title: 'Original',
+        );
+        await store.save(upload);
+
+        final updated = upload.copyWith(
+          status: UploadStatus.uploading,
+          uploadProgress: 0.5,
+        );
+        await store.update(updated);
+
+        final retrieved = store.getUpload(upload.id);
+        expect(retrieved!.status, equals(UploadStatus.uploading));
+        expect(retrieved.uploadProgress, equals(0.5));
+      });
+
+      test('delete() removes the record', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/video.mp4',
+          nostrPubkey: _pubkeyA,
+          title: 'To delete',
+        );
+        await store.save(upload);
+        expect(store.length, equals(1));
+
+        await store.delete(upload.id);
+        expect(store.length, equals(0));
+        expect(store.getUpload(upload.id), isNull);
+      });
+
+      test('get() returns null for unknown id', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+        expect(store.getUpload('no-such-id'), isNull);
+      });
+
+      test('update() is a no-op when box is not ready', () async {
+        final store = PendingUploadStore(
+          scopeUploadsToCurrentUser: false,
+          currentNostrPubkey: null,
+        );
+        final upload = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/video.mp4',
+          nostrPubkey: _pubkeyA,
+        );
+        // Should not throw.
+        await store.update(upload);
+      });
+
+      test('pendingUploads returns uploads sorted newest-first', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final older = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/old.mp4',
+          nostrPubkey: _pubkeyA,
+          title: 'Older',
+        );
+        await store.save(older);
+
+        // Ensure distinct timestamps.
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        final newer = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/new.mp4',
+          nostrPubkey: _pubkeyA,
+          title: 'Newer',
+        );
+        await store.save(newer);
+
+        final uploads = store.pendingUploads;
+        expect(uploads.first.id, equals(newer.id));
+        expect(uploads.last.id, equals(older.id));
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Save-queue fallback
+    // -----------------------------------------------------------------------
+
+    group('deferred save queue', () {
+      test(
+        'queues the upload and throws when storage cannot be opened',
+        () async {
+          // Force every box-open attempt to fail deterministically.
+          //
+          // Hive.openBox returns any already-open box *by name* regardless of
+          // path, so a box another test left open would let save() succeed.
+          // Close all boxes first (swallowing the benign lock-file delete race
+          // when the backing temp dir was already removed), then:
+          // - Null PathProvider -> the init helper's primary path resolution
+          //   throws immediately.
+          // - Hive's home points at a regular file -> the helper's recovery
+          //   strategy (Hive.openBox) cannot create box files either.
+          try {
+            await Hive.close();
+          } catch (_) {
+            // Closing a box whose temp dir was already deleted races the
+            // lock-file cleanup; the box is still unregistered, so ignore.
+          }
+          UploadInitializationHelper.reset();
+
+          final isolatedDir = await Directory.systemTemp.createTemp(
+            'pending_upload_store_queue_',
+          );
+          final blocker = File('${isolatedDir.path}/storage_blocker');
+          await blocker.writeAsString('not a directory');
+
+          addTearDown(() async {
+            try {
+              await Hive.close();
+            } catch (_) {
+              // See note above: ignore the benign lock-cleanup race.
+            }
+            UploadInitializationHelper.reset();
+            if (isolatedDir.existsSync()) {
+              await isolatedDir.delete(recursive: true);
+            }
+          });
+
+          Hive.init(blocker.path);
+          PathProviderPlatform.instance = MockPathProviderPlatform();
+
+          final store = PendingUploadStore(
+            scopeUploadsToCurrentUser: false,
+            currentNostrPubkey: null,
+          );
+
+          final upload = PendingUpload.create(
+            localVideoPath: '${isolatedDir.path}/video.mp4',
+            nostrPubkey: _pubkeyA,
+          );
+
+          // save() can neither use an existing box nor reopen one, so it
+          // queues the upload for a later retry and rethrows.
+          await expectLater(
+            () => store.save(upload),
+            throwsA(isA<Exception>()),
+          );
+
+          expect(store.queuedCount, equals(1));
+
+          // Cancel the retry timer the store scheduled and clear the queue.
+          store.disposeStore();
+          expect(store.queuedCount, equals(0));
+        },
+      );
+    });
+
+    // -----------------------------------------------------------------------
+    // getUploadsByStatus
+    // -----------------------------------------------------------------------
+
+    group('getUploadsByStatus', () {
+      test('returns only uploads matching the requested status', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final pending = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/p.mp4',
+          nostrPubkey: _pubkeyA,
+        );
+        final uploading = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/u.mp4',
+          nostrPubkey: _pubkeyA,
+        ).copyWith(status: UploadStatus.uploading);
+
+        await store.save(pending);
+        await store.save(uploading);
+
+        final pendingList = store.getUploadsByStatus(UploadStatus.pending);
+        final uploadingList = store.getUploadsByStatus(UploadStatus.uploading);
+
+        expect(pendingList, hasLength(1));
+        expect(pendingList.single.id, equals(pending.id));
+        expect(uploadingList, hasLength(1));
+        expect(uploadingList.single.id, equals(uploading.id));
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // getUploadByFilePath
+    // -----------------------------------------------------------------------
+
+    group('getUploadByFilePath', () {
+      test('returns upload matching the file path', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/video.mp4',
+          nostrPubkey: _pubkeyA,
+        );
+        await store.save(upload);
+
+        final result = store.getUploadByFilePath('${tempDir.path}/video.mp4');
+        expect(result, isNotNull);
+        expect(result!.id, equals(upload.id));
+      });
+
+      test('returns null when no upload matches the path', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        expect(store.getUploadByFilePath('/no/such/file.mp4'), isNull);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Owner-scope filtering
+    // -----------------------------------------------------------------------
+
+    group('owner-scope filtering', () {
+      Future<Map<String, PendingUpload>> seedTwoAccounts(
+        PendingUploadStore store,
+      ) async {
+        final aUpload = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/a.mp4',
+          nostrPubkey: _pubkeyA,
+          title: 'Account A upload',
+        );
+        final bUpload = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/b.mp4',
+          nostrPubkey: _pubkeyB,
+          title: 'Account B upload',
+        );
+        // Write directly to the box so both records exist regardless of scope.
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        await box.put(aUpload.id, aUpload);
+        await box.put(bUpload.id, bUpload);
+        return {'a': aUpload, 'b': bUpload};
+      }
+
+      test(
+        'unscoped store returns all uploads regardless of pubkey',
+        () async {
+          final store = await _openStore();
+          addTearDown(store.disposeStore);
+          await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
+          await seedTwoAccounts(store);
+
+          expect(store.pendingUploads, hasLength(2));
+        },
+      );
+
+      test(
+        'scoped store returns only uploads belonging to currentNostrPubkey',
+        () async {
+          final store = await _openStore(
+            scopeUploadsToCurrentUser: true,
+            currentNostrPubkey: _pubkeyA,
+          );
+          addTearDown(store.disposeStore);
+          await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
+          final uploads = await seedTwoAccounts(store);
+
+          final visible = store.pendingUploads;
+          expect(visible, hasLength(1));
+          expect(visible.single.nostrPubkey, equals(_pubkeyA));
+
+          // get() also respects scope.
+          expect(store.getUpload(uploads['a']!.id), isNotNull);
+          expect(store.getUpload(uploads['b']!.id), isNull);
+        },
+      );
+
+      test(
+        'scoped store with no current pubkey hides all uploads',
+        () async {
+          final store = await _openStore(
+            scopeUploadsToCurrentUser: true,
+          );
+          addTearDown(store.disposeStore);
+          await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
+          await seedTwoAccounts(store);
+
+          expect(store.pendingUploads, isEmpty);
+        },
+      );
+
+      test('getUploadByFilePath obeys scope', () async {
+        final store = await _openStore(
+          scopeUploadsToCurrentUser: true,
+          currentNostrPubkey: _pubkeyA,
+        );
+        addTearDown(store.disposeStore);
+        await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
+        await seedTwoAccounts(store);
+
+        expect(
+          store.getUploadByFilePath('${tempDir.path}/a.mp4'),
+          isNotNull,
+        );
+        expect(
+          store.getUploadByFilePath('${tempDir.path}/b.mp4'),
+          isNull,
+        );
+      });
+
+      test('uploadStats reflects only scoped uploads', () async {
+        final store = await _openStore(
+          scopeUploadsToCurrentUser: true,
+          currentNostrPubkey: _pubkeyA,
+        );
+        addTearDown(store.disposeStore);
+        await TestHelpers.ensureBoxEmpty<PendingUpload>('pending_uploads');
+        await seedTwoAccounts(store);
+
+        final stats = store.uploadStats;
+        expect(stats['total'], equals(1));
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // findReusableUpload
+    // -----------------------------------------------------------------------
+
+    group('findReusableUpload', () {
+      late File videoFile;
+
+      setUp(() {
+        videoFile = File('${tempDir.path}/video.mp4')
+          ..writeAsBytesSync(List<int>.generate(32, (i) => i));
+      });
+
+      test('returns upload in uploading status with matching path', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload =
+            PendingUpload.create(
+              localVideoPath: videoFile.path,
+              nostrPubkey: _pubkeyA,
+            ).copyWith(
+              status: UploadStatus.uploading,
+              resumableSession: const BlossomResumableUploadSession(
+                uploadId: 'up_1',
+                uploadUrl: 'https://upload.divine.video/sessions/up_1',
+                chunkSize: 8,
+                nextOffset: 8,
+              ),
+            );
+        await store.save(upload);
+
+        final result = store.findReusableUpload(videoFile.path);
+        expect(result, isNotNull);
+        expect(result!.id, equals(upload.id));
+      });
+
+      test('returns publishable readyToPublish upload', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload =
+            PendingUpload.create(
+              localVideoPath: videoFile.path,
+              nostrPubkey: _pubkeyA,
+            ).copyWith(
+              status: UploadStatus.readyToPublish,
+              videoId: 'ready-video-id',
+              cdnUrl: 'https://media.divine.video/ready-video',
+              thumbnailPath: 'https://media.divine.video/ready-video-thumb.jpg',
+            );
+        await store.save(upload);
+
+        final result = store.findReusableUpload(videoFile.path);
+        expect(result, isNotNull);
+        expect(result!.status, equals(UploadStatus.readyToPublish));
+      });
+
+      test('skips readyToPublish upload without HTTP thumbnail', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload =
+            PendingUpload.create(
+              localVideoPath: videoFile.path,
+              nostrPubkey: _pubkeyA,
+            ).copyWith(
+              status: UploadStatus.readyToPublish,
+              videoId: 'ready-video-id',
+              cdnUrl: 'https://media.divine.video/ready-video',
+              // thumbnailPath intentionally omitted → not publishable
+            );
+        await store.save(upload);
+
+        expect(store.findReusableUpload(videoFile.path), isNull);
+      });
+
+      test('skips failed upload with no resumable session', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload = PendingUpload.create(
+          localVideoPath: videoFile.path,
+          nostrPubkey: _pubkeyA,
+        ).copyWith(status: UploadStatus.failed);
+        await store.save(upload);
+
+        expect(store.findReusableUpload(videoFile.path), isNull);
+      });
+
+      test('returns failed upload that has a resumable session', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload =
+            PendingUpload.create(
+              localVideoPath: videoFile.path,
+              nostrPubkey: _pubkeyA,
+            ).copyWith(
+              status: UploadStatus.failed,
+              resumableSession: const BlossomResumableUploadSession(
+                uploadId: 'up_2',
+                uploadUrl: 'https://upload.divine.video/sessions/up_2',
+                chunkSize: 8,
+                nextOffset: 0,
+              ),
+            );
+        await store.save(upload);
+
+        final result = store.findReusableUpload(videoFile.path);
+        expect(result, isNotNull);
+      });
+
+      test('skips pending and published uploads', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        for (final status in [
+          UploadStatus.pending,
+          UploadStatus.published,
+          UploadStatus.paused,
+        ]) {
+          final box = Hive.box<PendingUpload>('pending_uploads');
+          await box.clear();
+
+          final upload = PendingUpload.create(
+            localVideoPath: videoFile.path,
+            nostrPubkey: _pubkeyA,
+          ).copyWith(status: status);
+          await box.put(upload.id, upload);
+
+          expect(
+            store.findReusableUpload(videoFile.path),
+            isNull,
+            reason: 'Expected null for status $status',
+          );
+        }
+      });
+
+      test('returns null when path does not match', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload = PendingUpload.create(
+          localVideoPath: videoFile.path,
+          nostrPubkey: _pubkeyA,
+        ).copyWith(status: UploadStatus.uploading);
+        await store.save(upload);
+
+        expect(store.findReusableUpload('/other/path.mp4'), isNull);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // cleanupCompletedUploads
+    // -----------------------------------------------------------------------
+
+    group('cleanupCompletedUploads', () {
+      test('removes published uploads immediately', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final upload =
+            PendingUpload.create(
+              localVideoPath: '${tempDir.path}/pub.mp4',
+              nostrPubkey: _pubkeyA,
+            ).copyWith(
+              status: UploadStatus.published,
+              completedAt: DateTime.now(),
+            );
+        await store.save(upload);
+        expect(store.length, equals(1));
+
+        await store.cleanupCompletedUploads();
+        expect(store.length, equals(0));
+      });
+
+      test(
+        'removes failed upload whose video file no longer exists',
+        () async {
+          final store = await _openStore();
+          addTearDown(store.disposeStore);
+
+          // Path points to a non-existent file.
+          final upload = PendingUpload.create(
+            localVideoPath: '${tempDir.path}/gone.mp4',
+            nostrPubkey: _pubkeyA,
+          ).copyWith(status: UploadStatus.failed);
+          await store.save(upload);
+          expect(store.length, equals(1));
+
+          await store.cleanupCompletedUploads();
+          expect(store.length, equals(0));
+        },
+      );
+
+      test('keeps failed upload whose file still exists', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final videoFile = File('${tempDir.path}/keep.mp4')
+          ..writeAsBytesSync([0]);
+        final upload = PendingUpload.create(
+          localVideoPath: videoFile.path,
+          nostrPubkey: _pubkeyA,
+        ).copyWith(status: UploadStatus.failed);
+        await store.save(upload);
+
+        await store.cleanupCompletedUploads();
+        expect(store.length, equals(1));
+      });
+
+      test('operates on all uploads (not just owner-scoped)', () async {
+        final store = await _openStore(
+          scopeUploadsToCurrentUser: true,
+          currentNostrPubkey: _pubkeyA,
+        );
+        addTearDown(store.disposeStore);
+
+        // Record belonging to pubkeyB – outside owner scope.
+        final otherPublished =
+            PendingUpload.create(
+              localVideoPath: '${tempDir.path}/other_pub.mp4',
+              nostrPubkey: _pubkeyB,
+            ).copyWith(
+              status: UploadStatus.published,
+              completedAt: DateTime.now(),
+            );
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        await box.put(otherPublished.id, otherPublished);
+
+        await store.cleanupCompletedUploads();
+        // Should be removed even though it belongs to pubkeyB.
+        expect(store.length, equals(0));
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // cleanupProblematicUploads
+    // -----------------------------------------------------------------------
+
+    group('cleanupProblematicUploads', () {
+      test(
+        'moves readyToPublish without required CDN fields to failed',
+        () async {
+          final store = await _openStore();
+          addTearDown(store.disposeStore);
+
+          // Missing videoId / cdnUrl → not publishable.
+          final stuck = PendingUpload.create(
+            localVideoPath: '${tempDir.path}/stuck.mp4',
+            nostrPubkey: _pubkeyA,
+          ).copyWith(status: UploadStatus.readyToPublish);
+          await store.save(stuck);
+
+          await store.cleanupProblematicUploads();
+
+          final afterClean = store.getUpload(stuck.id);
+          expect(afterClean, isNotNull);
+          expect(afterClean!.status, equals(UploadStatus.failed));
+        },
+      );
+
+      test('leaves publishable readyToPublish uploads untouched', () async {
+        final store = await _openStore();
+        addTearDown(store.disposeStore);
+
+        final good =
+            PendingUpload.create(
+              localVideoPath: '${tempDir.path}/good.mp4',
+              nostrPubkey: _pubkeyA,
+            ).copyWith(
+              status: UploadStatus.readyToPublish,
+              videoId: 'vid-123',
+              cdnUrl: 'https://media.divine.video/vid-123',
+              thumbnailPath: 'https://media.divine.video/vid-123-thumb.jpg',
+            );
+        await store.save(good);
+
+        await store.cleanupProblematicUploads();
+
+        final afterClean = store.getUpload(good.id);
+        expect(afterClean!.status, equals(UploadStatus.readyToPublish));
+      });
+
+      test('respects owner scope (only fixes visible uploads)', () async {
+        final store = await _openStore(
+          scopeUploadsToCurrentUser: true,
+          currentNostrPubkey: _pubkeyA,
+        );
+        addTearDown(store.disposeStore);
+
+        // Stuck record for pubkeyB – outside scope.
+        final stuckB = PendingUpload.create(
+          localVideoPath: '${tempDir.path}/stuck_b.mp4',
+          nostrPubkey: _pubkeyB,
+        ).copyWith(status: UploadStatus.readyToPublish);
+        final box = Hive.box<PendingUpload>('pending_uploads');
+        await box.put(stuckB.id, stuckB);
+
+        await store.cleanupProblematicUploads();
+
+        // Should remain readyToPublish (outside scope, not touched).
+        final afterClean = box.get(stuckB.id);
+        expect(afterClean!.status, equals(UploadStatus.readyToPublish));
+      });
+    });
+  });
+}

--- a/mobile/test/services/upload_manager_owner_scope_test.dart
+++ b/mobile/test/services/upload_manager_owner_scope_test.dart
@@ -129,8 +129,8 @@ void main() {
         final uploads = await seedUploads();
 
         expect(
-          manager
-              .getUploadsByStatus(UploadStatus.processing)
+          manager.pendingUploads
+              .where((upload) => upload.status == UploadStatus.processing)
               .map((upload) => upload.nostrPubkey),
           equals([pubkeyA]),
         );


### PR DESCRIPTION
## What

Second step in the staged decomposition of \`upload_manager.dart\` (#4507). Extracts the Hive persistence concern into a focused \`PendingUploadStore\` class — the first of the ≥5 concern classes, landed in-place under \`lib/services/upload/\` (the package lift comes in a later PR).

**\`lib/services/upload/pending_upload_store.dart\`** (390 lines, new) owns:
- The Hive box (\`_box\`), \`open()\` / \`ensureOpen()\` (same \`UploadInitializationHelper\`, same retry/recovery semantics)
- The deferred-save queue (\`_pendingSaveQueue\` / \`_saveQueueTimer\`) with the original 5 s / 30 s timer durations
- \`save()\` / \`update()\` / \`delete()\`
- All queries: \`getUpload\`, \`getUploadsByStatus\`, \`getUploadByFilePath\`, \`findReusableUpload\`, \`pendingUploads\`, \`uploadStats\`, owner-visibility scoping (\`_isVisibleToCurrentOwner\`)
- Both cleanup methods: \`cleanupCompletedUploads\`, \`cleanupProblematicUploads\`

**\`lib/services/upload_manager.dart\`**: 2,743 → 2,459 lines. Keeps the 9-member production facade (\`initialize\`, \`getUpload\`, \`findReusableUpload\`, \`startUploadFromDraft\`, \`retryUpload\`, \`resumeInterruptedUpload\`, \`updateUploadStatus\`, \`isInitialized\`, \`dispose\`) as thin delegators to \`_store\`. All ~50 internal persistence sites (\`_uploadsBox\`, \`_saveUpload\`, \`_updateUpload\`, etc.) rewired to \`_store.*\`.

Also removes \`getUploadsByStatus\` from \`UploadManager\`'s public surface (noted by reviewer on #5569 — its only \`lib/\` caller was \`uploadsReadyForProcessing\`, deleted in PR1; it stays on \`PendingUploadStore\` for tests).

**\`test/services/upload/pending_upload_store_test.dart\`** (772 lines, new): focused unit tests for the store — save/get/update/delete round-trips, deferred-save-queue path, owner-scope filtering, \`findReusableUpload\`, both cleanup methods.

## Behavior-preservation

302 affected tests pass (upload_manager_*, video_event_publisher_*, video_publish_service, upload_media_providers). No behavior change; all judgment calls verified against the original method bodies:
- \`update()\` is byte-identical to old \`_updateUpload\`
- \`cleanupProblematicUploads\` uses \`pendingUploads\` (owner-scoped) — same as original
- \`forceReinit: true\` in \`open()\` is equivalent to the original \`!_isInitialized\` path: the helper only fast-returns a cached box when it is already open, which \`openBox\` returns anyway

## Test plan

- \`flutter analyze\` clean on all three files
- Pre-commit hook passes (format + analyze)
- Full 24-file affected suite ran green locally

Part of #4339. Follows #5569. See #4507 for the full staged plan.