### PR TITLE
refactor(upload): delete dead getUploadsByStatus query helper

### DIFF
--- a/mobile/lib/services/upload/pending_upload_store.dart
+++ b/mobile/lib/services/upload/pending_upload_store.dart
@@ -245,10 +245,6 @@ class PendingUploadStore {
     return upload;
   }
 
-  /// All uploads in [pendingUploads] that match [status].
-  List<PendingUpload> getUploadsByStatus(UploadStatus status) =>
-      pendingUploads.where((upload) => upload.status == status).toList();
-
   /// First upload in [pendingUploads] whose local path equals [filePath].
   PendingUpload? getUploadByFilePath(String filePath) {
     try {

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -298,37 +298,6 @@ void main() {
     });
 
     // -----------------------------------------------------------------------
-    // getUploadsByStatus
-    // -----------------------------------------------------------------------
-
-    group('getUploadsByStatus', () {
-      test('returns only uploads matching the requested status', () async {
-        final store = await _openStore();
-        addTearDown(store.disposeStore);
-
-        final pending = PendingUpload.create(
-          localVideoPath: '${tempDir.path}/p.mp4',
-          nostrPubkey: _pubkeyA,
-        );
-        final uploading = PendingUpload.create(
-          localVideoPath: '${tempDir.path}/u.mp4',
-          nostrPubkey: _pubkeyA,
-        ).copyWith(status: UploadStatus.uploading);
-
-        await store.save(pending);
-        await store.save(uploading);
-
-        final pendingList = store.getUploadsByStatus(UploadStatus.pending);
-        final uploadingList = store.getUploadsByStatus(UploadStatus.uploading);
-
-        expect(pendingList, hasLength(1));
-        expect(pendingList.single.id, equals(pending.id));
-        expect(uploadingList, hasLength(1));
-        expect(uploadingList.single.id, equals(uploading.id));
-      });
-    });
-
-    // -----------------------------------------------------------------------
     // getUploadByFilePath
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Follow-up to the [#5569 review](https://github.com/divinevideo/divine-mobile/pull/5569#pullrequestreview-4580110527), re-scoped per the [#5580 review](https://github.com/divinevideo/divine-mobile/pull/5580#pullrequestreview-4584497325). Purely subtractive: deletes the now-dead `PendingUploadStore.getUploadsByStatus` and its dedicated test group.

This branch was originally cut to delete `UploadManager.getUploadsByStatus`, but #5574 (extract `PendingUploadStore`) landed on `main` first and relocated that helper to `PendingUploadStore.getUploadsByStatus` (`lib/services/upload/pending_upload_store.dart`). Rebased onto fresh `origin/main` and re-targeted to the surface where the dead method now lives — which also resolves the prior `CONFLICTING` state.

## Why

After the #5574 extraction, `PendingUploadStore.getUploadsByStatus` has zero `lib/` callers. It's a trivial `.where` filter over the already owner-scoped `pendingUploads` getter, so it holds no logic of its own — "tested-but-unused public store API." Trimming it keeps the store's surface tight ahead of the package lift later in #4507.

Removed:
- `PendingUploadStore.getUploadsByStatus` (`lib/services/upload/pending_upload_store.dart`) — zero production callers.
- Its dedicated `group('getUploadsByStatus')` in `test/services/upload/pending_upload_store_test.dart`.

## Notes

- **No coverage loss.** Owner-scoping lives in the `pendingUploads` getter (covered by its own tests); the deleted method added no scoping of its own, so the removed group only exercised a one-line `.where`.
- The separate, live `PendingUploadsDao.getUploadsByStatus` in `packages/db_client` is a different, tested method and is **untouched**.
- `UploadManager`'s owner-scope test on `main` already inlines its status query (`pendingUploads.where(...)`), so status-scoping coverage there is unaffected by this PR.

## Test plan

- `flutter analyze lib/services/upload/pending_upload_store.dart test/services/upload/pending_upload_store_test.dart` → No issues found.
- `flutter test test/services/upload/pending_upload_store_test.dart` → all pass (33).
- `flutter test test/services/upload_manager_owner_scope_test.dart test/services/upload_manager*_test.dart` → all pass (121, 11 pre-existing skips).

Part of #4507.
