### PR TITLE
fix(media_cache): build Cronet engine eagerly so dart:io fallback engages

### DIFF
--- a/mobile/packages/media_cache/lib/src/platform_downloader_factory_io.dart
+++ b/mobile/packages/media_cache/lib/src/platform_downloader_factory_io.dart
@@ -142,7 +142,16 @@ CancellableDownloader _createCupertinoDownloader({
 
 // coverage:ignore-start
 CancellableDownloader _createCronetDownloader() {
-  return HttpCancellableDownloader(CronetClient.defaultCronetEngine());
+  // Build the engine eagerly so a missing/disabled Cronet provider throws
+  // here — inside the factory's try/catch, which latches `cronetUnavailable`
+  // and falls back to dart:io. `CronetClient.defaultCronetEngine()` defers
+  // the build to the first request, where the failure is swallowed by the
+  // download error path and the fallback latch never trips, leaving every
+  // media fetch broken for the whole process.
+  final engine = CronetEngine.build();
+  return HttpCancellableDownloader(
+    CronetClient.fromCronetEngine(engine, closeEngine: true),
+  );
 }
 
 // coverage:ignore-end

--- a/mobile/packages/media_cache/lib/src/platform_downloader_factory_io.dart
+++ b/mobile/packages/media_cache/lib/src/platform_downloader_factory_io.dart
@@ -10,6 +10,10 @@ import 'package:unified_logger/unified_logger.dart';
 /// Factory for a platform-native [CancellableDownloader].
 typedef NativeDownloaderFactory = CancellableDownloader Function();
 
+/// Factory for a native Cronet [CronetEngine]. Injectable for tests so the
+/// eager-build + fallback path can be exercised without the Android JNI stack.
+typedef CronetEngineFactory = CronetEngine Function();
+
 final _nativeFallbackState = _NativeDownloaderFallbackState();
 
 final class _NativeDownloaderFallbackState {
@@ -44,6 +48,7 @@ CancellableDownloader createPlatformDownloaderImpl({
   @visibleForTesting bool? isAndroidOverride,
   @visibleForTesting NativeDownloaderFactory? cupertinoDownloaderFactory,
   @visibleForTesting NativeDownloaderFactory? cronetDownloaderFactory,
+  @visibleForTesting CronetEngineFactory? cronetEngineFactory,
 }) {
   if (isWeb) {
     return HttpCancellableDownloader(IOClient(HttpClient()));
@@ -94,7 +99,8 @@ CancellableDownloader createPlatformDownloaderImpl({
       // `cronet_http` does not expose per-client connect/idle timeout knobs.
       // On Android, `connectionTimeout` and `idleTimeout` therefore do not
       // apply while Cronet is active.
-      return cronetDownloaderFactory?.call() ?? _createCronetDownloader();
+      return cronetDownloaderFactory?.call() ??
+          _createCronetDownloader(cronetEngineFactory);
     } on Object catch (e, st) {
       _nativeFallbackState.cronetUnavailable = true;
       Log.warning(
@@ -140,18 +146,19 @@ CancellableDownloader _createCupertinoDownloader({
 }
 // coverage:ignore-end
 
-// coverage:ignore-start
-CancellableDownloader _createCronetDownloader() {
+CancellableDownloader _createCronetDownloader(
+  CronetEngineFactory? engineFactory,
+) {
   // Build the engine eagerly so a missing/disabled Cronet provider throws
   // here — inside the factory's try/catch, which latches `cronetUnavailable`
   // and falls back to dart:io. `CronetClient.defaultCronetEngine()` defers
   // the build to the first request, where the failure is swallowed by the
   // download error path and the fallback latch never trips, leaving every
   // media fetch broken for the whole process.
-  final engine = CronetEngine.build();
+  final engine = (engineFactory ?? CronetEngine.build)();
+  // coverage:ignore-start
   return HttpCancellableDownloader(
     CronetClient.fromCronetEngine(engine, closeEngine: true),
   );
+  // coverage:ignore-end
 }
-
-// coverage:ignore-end

--- a/mobile/packages/media_cache/test/src/platform_downloader_factory_io_test.dart
+++ b/mobile/packages/media_cache/test/src/platform_downloader_factory_io_test.dart
@@ -113,12 +113,12 @@ void main() {
     });
 
     test(
-      'builds the cronet engine eagerly and falls back to dart:io when the '
-      'build throws',
+      'builds the cronet engine eagerly, falls back to dart:io when the '
+      'build throws, and latches the failure for the process',
       () {
         var buildAttempts = 0;
 
-        final downloader = createPlatformDownloaderImpl(
+        CancellableDownloader build() => createPlatformDownloaderImpl(
           connectionTimeout: const Duration(seconds: 2),
           idleTimeout: const Duration(seconds: 2),
           maxConnectionsPerHost: 2,
@@ -134,13 +134,20 @@ void main() {
           },
         );
 
+        final firstDownloader = build();
+        final secondDownloader = build();
+
         // The engine is built during creation (not deferred to the first
         // request), so the throw lands in the factory's try/catch and the
         // dart:io fallback engages. Guards against reverting to the lazy
         // `CronetClient.defaultCronetEngine()`, where the build — and its
-        // throw — would never run at creation time.
+        // throw — would never run at creation time. The first failure trips
+        // the per-process `cronetUnavailable` latch via the engine-factory
+        // path, so the second creation skips Cronet entirely — a single
+        // build attempt across both.
         expect(buildAttempts, 1);
-        expect(downloader, isA<HttpCancellableDownloader>());
+        expect(firstDownloader, isA<HttpCancellableDownloader>());
+        expect(secondDownloader, isA<HttpCancellableDownloader>());
       },
     );
   });

--- a/mobile/packages/media_cache/test/src/platform_downloader_factory_io_test.dart
+++ b/mobile/packages/media_cache/test/src/platform_downloader_factory_io_test.dart
@@ -111,5 +111,37 @@ void main() {
       expect(secondDownloader, isA<HttpCancellableDownloader>());
       expect(nativeAttempts, 1);
     });
+
+    test(
+      'builds the cronet engine eagerly and falls back to dart:io when the '
+      'build throws',
+      () {
+        var buildAttempts = 0;
+
+        final downloader = createPlatformDownloaderImpl(
+          connectionTimeout: const Duration(seconds: 2),
+          idleTimeout: const Duration(seconds: 2),
+          maxConnectionsPerHost: 2,
+          allowBadCertificatesInDebug: false,
+          isDebugMode: false,
+          isWeb: false,
+          isIOSOverride: false,
+          isMacOSOverride: false,
+          isAndroidOverride: true,
+          cronetEngineFactory: () {
+            buildAttempts++;
+            throw StateError('All available Cronet providers are disabled');
+          },
+        );
+
+        // The engine is built during creation (not deferred to the first
+        // request), so the throw lands in the factory's try/catch and the
+        // dart:io fallback engages. Guards against reverting to the lazy
+        // `CronetClient.defaultCronetEngine()`, where the build — and its
+        // throw — would never run at creation time.
+        expect(buildAttempts, 1);
+        expect(downloader, isA<HttpCancellableDownloader>());
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #5583

## Description

On Android devices where no Cronet provider is enabled (AOSP / no-GMS
builds with no embedded Cronet asset bundled), **all** media fetches —
avatars, video thumbnails, and video streams — fail for the entire
process with:

```
java.lang.RuntimeException: All available Cronet providers are disabled.
  at org.chromium.net.CronetEngine$Builder.getEnabledCronetProviders
```

`platform_downloader_factory_io.dart` already has a creation-time
`try/catch` that latches `cronetUnavailable` and falls back to the
`dart:io` `HttpClient`. The problem: `CronetClient.defaultCronetEngine()`
**defers** engine construction to the first request
(`CronetClient.send()`), so the "providers disabled" error is thrown at
request time — inside the download error path, where it is swallowed and
the download just completes `null`. The creation-time `try/catch` never
sees it, the latch never trips, and every subsequent download keeps
retrying the broken Cronet client forever.

Both `MediaCacheManager` instances route through this one factory
(`openVineImageCache` for avatars/images via `MediaCacheImageProvider`,
and `openVineMediaCache` for video), so a single broken Cronet provider
takes down the whole media pipeline — which is why profile pictures
never render.

**Fix:** build the engine eagerly via `CronetEngine.build()` so the
failure surfaces inside the factory's `try/catch`, which latches and
falls back to `dart:io`. `CronetClient.fromCronetEngine(closeEngine:
true)` preserves the engine-close-on-client-close lifecycle of the
previous path. The process-wide fallback latch means once any manager's
eager build fails, every other manager skips Cronet immediately.

No APK size increase. On devices where Cronet works, behaviour is
unchanged (same default engine config that the lazy path would have
built).

**Related Issue:** Relates to #

## Confidence / repro

Diagnosed from `cronet_http` source: the engine is built lazily in
`CronetClient.send()`, and the throw originates in the
`CronetEngine$Builder` constructor — exactly the frame in the device
logs. Corroborated by the same device's log: other HTTPS traffic
succeeds (Keycast RPC `sign_event … HTTP 200`, NIP-98, relay EOSE), so
the network is fine and only the Cronet-backed media downloader is
broken — meaning the `dart:io` fallback will load the images.

Not reproduced on a no-GMS device (none available here); final
confirmation should be a quick check on the affected device.

**Build timing:** the engine now builds at `MediaCacheManager`
construction (during `main()`, after
`WidgetsFlutterBinding.ensureInitialized()`, via
`initializeMediaCache()`) instead of being deferred to the first
request. The failure stays contained — `_initializeVideoCacheManifest`
wraps init in a `try/catch`, and `createPlatformDownloaderImpl` catches
the eager build itself — so an early build failure can't crash startup;
it only trips the `dart:io` latch. The one residual risk is the narrow
window where the JNI app context isn't ready at construction but would
have been at first request, which would latch an otherwise-healthy
device to `dart:io` for the process. The no-GMS device check above
should double as a healthy-device sanity pass (confirm media still
loads over Cronet, i.e. no spurious `cronet_http init failed` warning).

## Out of Scope

Bundling `org.chromium.net:cronet-embedded` so a Cronet provider is
always available (would restore HTTP/3/QUIC on no-GMS devices at a
per-ABI APK-size cost). This PR only restores the existing `dart:io`
fallback so media loads at all; embedded Cronet is a separate decision.

## Verification

From `mobile/packages/media_cache`:

- `flutter analyze lib test` → No issues found
- `flutter test` → 166 passed (2 skipped)

Added a regression test: `_createCronetDownloader` now takes an
injectable `CronetEngineFactory` seam, and a new test asserts the engine
is built **eagerly at creation** and a throwing build falls back to
`dart:io`. The pre-existing "latches cronet init failure" test injected
a whole-downloader factory and never ran the real `_createCronetDownloader`,
so it stayed green even with the bug; the new test fails if anyone reverts
to the lazy `CronetClient.defaultCronetEngine()`. The native
`CronetEngine.build()` success path itself can't be unit-tested (needs
Android JNI) and stays `coverage:ignore`.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

