### PR TITLE
fix(upload): stop PendingUploadStore save queue double-enqueuing failed uploads

### DIFF
--- a/mobile/lib/services/upload/pending_upload_store.dart
+++ b/mobile/lib/services/upload/pending_upload_store.dart
@@ -36,6 +36,14 @@ class PendingUploadStore {
   /// drain started by a retry timer firing mid-drain.
   bool _isDraining = false;
 
+  /// Latched true by [disposeStore]; gates every queue mutation and timer-arm
+  /// so a drain suspended on `await save()` at disposal cannot repopulate the
+  /// queue or schedule a retry that outlives the store. Cleared only by [open]
+  /// — the deliberate re-initialization entrypoint, which is never reached from
+  /// the drain's own `save() -> ensureOpen()` path, so a storage recovery
+  /// mid-drain can't silently revive a disposed store.
+  bool _disposed = false;
+
   // ---------------------------------------------------------------------------
   // Status accessors
   // ---------------------------------------------------------------------------
@@ -59,6 +67,10 @@ class PendingUploadStore {
   /// mirroring the original `initialize()` catch that nulled the box – before
   /// the error propagates to the manager's initialization error handler.
   Future<void> open() async {
+    // A fresh lifecycle: clear the disposed latch so a reused store can queue
+    // and retry again. open() is unreachable from the drain (which only calls
+    // ensureOpen), so clearing here can't revive a store mid-drain.
+    _disposed = false;
     try {
       _box = await UploadInitializationHelper.initializeUploadsBox(
         forceReinit: true,
@@ -81,6 +93,10 @@ class PendingUploadStore {
   /// Does NOT close the box – closing is Hive's responsibility and closing
   /// here causes "File closed" errors in tests that share the box instance.
   void disposeStore() {
+    // Latch disposed first: a drain may be suspended on `await save()` right
+    // now, and must see this the instant it resumes so it can't re-enqueue or
+    // re-arm a timer past disposal.
+    _disposed = true;
     _saveQueueTimer?.cancel();
     _saveQueueTimer = null;
     _pendingSaveQueue.clear();
@@ -170,6 +186,11 @@ class PendingUploadStore {
   // ---------------------------------------------------------------------------
 
   void _queueUploadForLater(PendingUpload upload) {
+    // A disposed store must not requeue or re-arm a timer — this runs from the
+    // failure slow path of save(), which a zombie drain re-enters after
+    // disposeStore() nulls the box.
+    if (_disposed) return;
+
     Log.warning(
       'Queueing upload ${upload.id} for later save attempt',
       name: 'UploadManager',
@@ -184,6 +205,9 @@ class PendingUploadStore {
   }
 
   Future<void> _processSaveQueue() async {
+    // A disposed store never drains — defends the @visibleForTesting drain hook
+    // and any retry that races disposal.
+    if (_disposed) return;
     // A retry timer can fire while a drain is still awaiting save() (which can
     // take seconds during a storage outage). Don't start a second drain.
     if (_isDraining) return;
@@ -216,7 +240,9 @@ class PendingUploadStore {
           );
           // Re-queue for another attempt. Keyed by id, so this is idempotent
           // with save()'s own _queueUploadForLater enqueue of the same upload.
-          _pendingSaveQueue[upload.id] = upload;
+          // Skip once disposed so a drain that resumes after disposeStore()
+          // leaves the queue empty.
+          if (!_disposed) _pendingSaveQueue[upload.id] = upload;
         }
       }
     } finally {
@@ -225,7 +251,9 @@ class PendingUploadStore {
 
     // If items remain, schedule a further retry in 30 seconds. Cancel first so
     // the 5 s timer set during this drain (via _queueUploadForLater) can't leak.
-    if (_pendingSaveQueue.isNotEmpty) {
+    // Never re-arm once disposed: a drain that resumed after disposeStore()
+    // must not schedule a retry that outlives the store.
+    if (!_disposed && _pendingSaveQueue.isNotEmpty) {
       _saveQueueTimer?.cancel();
       _saveQueueTimer = Timer(const Duration(seconds: 30), _processSaveQueue);
     }
@@ -239,6 +267,11 @@ class PendingUploadStore {
   /// True while a drain is in flight — test hook for the re-entrancy guard.
   @visibleForTesting
   bool get isDraining => _isDraining;
+
+  /// True once [disposeStore] has latched the store closed and before any
+  /// [open] revives it — test hook for the disposal latch.
+  @visibleForTesting
+  bool get isDisposed => _disposed;
 
   /// True when a deferred-save retry timer is currently scheduled — test hook to
   /// assert exactly one timer is live (no orphaned retry).

--- a/mobile/lib/services/upload/pending_upload_store.dart
+++ b/mobile/lib/services/upload/pending_upload_store.dart
@@ -36,12 +36,13 @@ class PendingUploadStore {
   /// drain started by a retry timer firing mid-drain.
   bool _isDraining = false;
 
-  /// Latched true by [disposeStore]; gates every queue mutation and timer-arm
-  /// so a drain suspended on `await save()` at disposal cannot repopulate the
-  /// queue or schedule a retry that outlives the store. Cleared only by [open]
-  /// — the deliberate re-initialization entrypoint, which is never reached from
-  /// the drain's own `save() -> ensureOpen()` path, so a storage recovery
-  /// mid-drain can't silently revive a disposed store.
+  /// Latched true by [disposeStore]; gates every queue mutation, timer-arm, and
+  /// box revival so a drain suspended on `await save()` at disposal cannot
+  /// repopulate the queue, schedule a retry that outlives the store, or reopen
+  /// the box via [ensureOpen]. Cleared only by [open] — the deliberate
+  /// re-initialization entrypoint, which is never reached from the drain's own
+  /// `save() -> ensureOpen()` path, so a storage recovery mid-drain can't
+  /// silently revive a disposed store.
   bool _disposed = false;
 
   // ---------------------------------------------------------------------------
@@ -83,6 +84,11 @@ class PendingUploadStore {
 
   /// Force-reopen the box (called from re-init-when-closed paths).
   Future<void> ensureOpen() async {
+    // Stay inert once disposed. A drain suspended on `await save()` resumes into
+    // this via save()'s slow path; reviving _box here would leave a disposed
+    // store with a live, open box (isReady → true while _disposed). open() — the
+    // deliberate re-init entrypoint — clears the latch and is the only revival.
+    if (_disposed) return;
     _box = await UploadInitializationHelper.initializeUploadsBox(
       forceReinit: true,
     );

--- a/mobile/lib/services/upload/pending_upload_store.dart
+++ b/mobile/lib/services/upload/pending_upload_store.dart
@@ -4,7 +4,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:hive_ce_flutter/hive_flutter.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
@@ -26,8 +26,15 @@ class PendingUploadStore {
   final String? currentNostrPubkey;
 
   Box<PendingUpload>? _box;
-  final List<PendingUpload> _pendingSaveQueue = [];
+
+  /// Deferred-save retry queue, keyed by [PendingUpload.id] so re-enqueuing the
+  /// same upload is idempotent (the queue can never hold the same upload twice).
+  final Map<String, PendingUpload> _pendingSaveQueue = {};
   Timer? _saveQueueTimer;
+
+  /// True while [_processSaveQueue] is draining; guards against a re-entrant
+  /// drain started by a retry timer firing mid-drain.
+  bool _isDraining = false;
 
   // ---------------------------------------------------------------------------
   // Status accessors
@@ -77,6 +84,7 @@ class PendingUploadStore {
     _saveQueueTimer?.cancel();
     _saveQueueTimer = null;
     _pendingSaveQueue.clear();
+    _isDraining = false;
     // Null the reference so isReady → false without actually closing.
     _box = null;
   }
@@ -168,7 +176,7 @@ class PendingUploadStore {
       category: LogCategory.video,
     );
 
-    _pendingSaveQueue.add(upload);
+    _pendingSaveQueue[upload.id] = upload;
 
     // Schedule retry in 5 seconds.
     _saveQueueTimer?.cancel();
@@ -176,41 +184,66 @@ class PendingUploadStore {
   }
 
   Future<void> _processSaveQueue() async {
+    // A retry timer can fire while a drain is still awaiting save() (which can
+    // take seconds during a storage outage). Don't start a second drain.
+    if (_isDraining) return;
     if (_pendingSaveQueue.isEmpty) return;
 
-    Log.info(
-      'Processing ${_pendingSaveQueue.length} queued uploads',
-      name: 'UploadManager',
-      category: LogCategory.video,
-    );
+    _isDraining = true;
+    try {
+      Log.info(
+        'Processing ${_pendingSaveQueue.length} queued uploads',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
 
-    final queue = List<PendingUpload>.from(_pendingSaveQueue);
-    _pendingSaveQueue.clear();
+      final queue = _pendingSaveQueue.values.toList();
+      _pendingSaveQueue.clear();
 
-    for (final upload in queue) {
-      try {
-        await save(upload);
-        Log.info(
-          'Successfully saved queued upload: ${upload.id}',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-      } catch (e) {
-        Log.error(
-          'Failed to save queued upload ${upload.id}: $e',
-          name: 'UploadManager',
-          category: LogCategory.video,
-        );
-        // Re-queue for another attempt.
-        _pendingSaveQueue.add(upload);
+      for (final upload in queue) {
+        try {
+          await save(upload);
+          Log.info(
+            'Successfully saved queued upload: ${upload.id}',
+            name: 'UploadManager',
+            category: LogCategory.video,
+          );
+        } catch (e) {
+          Log.error(
+            'Failed to save queued upload ${upload.id}: $e',
+            name: 'UploadManager',
+            category: LogCategory.video,
+          );
+          // Re-queue for another attempt. Keyed by id, so this is idempotent
+          // with save()'s own _queueUploadForLater enqueue of the same upload.
+          _pendingSaveQueue[upload.id] = upload;
+        }
       }
+    } finally {
+      _isDraining = false;
     }
 
-    // If items remain, schedule a further retry in 30 seconds.
+    // If items remain, schedule a further retry in 30 seconds. Cancel first so
+    // the 5 s timer set during this drain (via _queueUploadForLater) can't leak.
     if (_pendingSaveQueue.isNotEmpty) {
+      _saveQueueTimer?.cancel();
       _saveQueueTimer = Timer(const Duration(seconds: 30), _processSaveQueue);
     }
   }
+
+  /// Triggers the deferred-save drain. The drain is otherwise invoked only by
+  /// the internal retry timer; tests use this to exercise it deterministically.
+  @visibleForTesting
+  Future<void> drainPendingSaves() => _processSaveQueue();
+
+  /// True while a drain is in flight — test hook for the re-entrancy guard.
+  @visibleForTesting
+  bool get isDraining => _isDraining;
+
+  /// True when a deferred-save retry timer is currently scheduled — test hook to
+  /// assert exactly one timer is live (no orphaned retry).
+  @visibleForTesting
+  bool get hasScheduledRetry => _saveQueueTimer?.isActive ?? false;
 
   // ---------------------------------------------------------------------------
   // Query helpers

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -461,6 +461,30 @@ void main() {
           expect(store.isReady, isTrue);
         },
       );
+
+      test(
+        'ensureOpen() does not revive the box after disposeStore()',
+        () async {
+          final store = await _openStore();
+          addTearDown(store.disposeStore);
+
+          store.disposeStore();
+          expect(store.isReady, isFalse);
+
+          // A zombie drain resumes through save()'s slow path -> ensureOpen()
+          // with storage now healthy. ensureOpen() must stay inert: reviving the
+          // box would leave a disposed store reporting isReady == true (a live,
+          // open box behind a disposed latch). Only open() re-inits.
+          await store.ensureOpen();
+
+          expect(
+            store.isReady,
+            isFalse,
+            reason: 'a disposed store must stay inert until open() re-inits it',
+          );
+          expect(store.isDisposed, isTrue);
+        },
+      );
     });
 
     // -----------------------------------------------------------------------

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -41,6 +41,49 @@ Future<PendingUploadStore> _openStore({
   return store;
 }
 
+/// Force every box-open attempt to fail deterministically, so `save()` cannot
+/// persist and must fall back to the deferred-save queue. Returns the isolated
+/// dir to build upload paths from.
+///
+/// Hive.openBox returns any already-open box *by name* regardless of path, so a
+/// box another test left open would let save() succeed. Close all boxes first
+/// (swallowing the benign lock-file delete race when the backing temp dir was
+/// already removed), then:
+/// - Null PathProvider -> the init helper's primary path resolution throws.
+/// - Hive's home points at a regular file -> the helper's recovery strategy
+///   (Hive.openBox) cannot create box files either.
+Future<Directory> _forceStorageFailure() async {
+  try {
+    await Hive.close();
+  } catch (_) {
+    // Closing a box whose temp dir was already deleted races the lock-file
+    // cleanup; the box is still unregistered, so ignore.
+  }
+  UploadInitializationHelper.reset();
+
+  final isolatedDir = await Directory.systemTemp.createTemp(
+    'pending_upload_store_queue_',
+  );
+  final blocker = File('${isolatedDir.path}/storage_blocker');
+  await blocker.writeAsString('not a directory');
+
+  addTearDown(() async {
+    try {
+      await Hive.close();
+    } catch (_) {
+      // See note above: ignore the benign lock-cleanup race.
+    }
+    UploadInitializationHelper.reset();
+    if (isolatedDir.existsSync()) {
+      await isolatedDir.delete(recursive: true);
+    }
+  });
+
+  Hive.init(blocker.path);
+  PathProviderPlatform.instance = MockPathProviderPlatform();
+  return isolatedDir;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -232,44 +275,7 @@ void main() {
       test(
         'queues the upload and throws when storage cannot be opened',
         () async {
-          // Force every box-open attempt to fail deterministically.
-          //
-          // Hive.openBox returns any already-open box *by name* regardless of
-          // path, so a box another test left open would let save() succeed.
-          // Close all boxes first (swallowing the benign lock-file delete race
-          // when the backing temp dir was already removed), then:
-          // - Null PathProvider -> the init helper's primary path resolution
-          //   throws immediately.
-          // - Hive's home points at a regular file -> the helper's recovery
-          //   strategy (Hive.openBox) cannot create box files either.
-          try {
-            await Hive.close();
-          } catch (_) {
-            // Closing a box whose temp dir was already deleted races the
-            // lock-file cleanup; the box is still unregistered, so ignore.
-          }
-          UploadInitializationHelper.reset();
-
-          final isolatedDir = await Directory.systemTemp.createTemp(
-            'pending_upload_store_queue_',
-          );
-          final blocker = File('${isolatedDir.path}/storage_blocker');
-          await blocker.writeAsString('not a directory');
-
-          addTearDown(() async {
-            try {
-              await Hive.close();
-            } catch (_) {
-              // See note above: ignore the benign lock-cleanup race.
-            }
-            UploadInitializationHelper.reset();
-            if (isolatedDir.existsSync()) {
-              await isolatedDir.delete(recursive: true);
-            }
-          });
-
-          Hive.init(blocker.path);
-          PathProviderPlatform.instance = MockPathProviderPlatform();
+          final isolatedDir = await _forceStorageFailure();
 
           final store = PendingUploadStore(
             scopeUploadsToCurrentUser: false,
@@ -295,6 +301,98 @@ void main() {
           expect(store.queuedCount, equals(0));
         },
       );
+
+      test(
+        'draining a still-failing upload does not double-enqueue it',
+        () async {
+          final isolatedDir = await _forceStorageFailure();
+
+          final store = PendingUploadStore(
+            scopeUploadsToCurrentUser: false,
+            currentNostrPubkey: null,
+          );
+          addTearDown(store.disposeStore);
+
+          final upload = PendingUpload.create(
+            localVideoPath: '${isolatedDir.path}/video.mp4',
+            nostrPubkey: _pubkeyA,
+          );
+
+          // First save fails and enqueues exactly one entry.
+          await expectLater(
+            () => store.save(upload),
+            throwsA(isA<Exception>()),
+          );
+          expect(store.queuedCount, equals(1));
+
+          // The drain retries the save; it re-fails and re-enqueues. Because the
+          // queue is keyed by id, the count stays 1 — a raw List would grow to 2
+          // (save()'s own re-queue + the drain loop's re-queue).
+          await store.drainPendingSaves();
+          expect(store.queuedCount, equals(1));
+        },
+      );
+
+      test(
+        'drain reschedules exactly one store-owned (cancellable) retry timer',
+        () async {
+          final isolatedDir = await _forceStorageFailure();
+
+          final store = PendingUploadStore(
+            scopeUploadsToCurrentUser: false,
+            currentNostrPubkey: null,
+          );
+
+          final upload = PendingUpload.create(
+            localVideoPath: '${isolatedDir.path}/video.mp4',
+            nostrPubkey: _pubkeyA,
+          );
+          await expectLater(
+            () => store.save(upload),
+            throwsA(isA<Exception>()),
+          );
+
+          // After the drain a retry is scheduled, and it is owned by the store:
+          // disposeStore() cancels it. Pre-fix, the 5 s timer set during the
+          // drain was orphaned by the 30 s reschedule and survived disposal.
+          await store.drainPendingSaves();
+          expect(store.hasScheduledRetry, isTrue);
+
+          store.disposeStore();
+          expect(store.hasScheduledRetry, isFalse);
+        },
+      );
+
+      test('a drain is a no-op while another drain is in flight', () async {
+        final isolatedDir = await _forceStorageFailure();
+
+        final store = PendingUploadStore(
+          scopeUploadsToCurrentUser: false,
+          currentNostrPubkey: null,
+        );
+        addTearDown(store.disposeStore);
+
+        final upload = PendingUpload.create(
+          localVideoPath: '${isolatedDir.path}/video.mp4',
+          nostrPubkey: _pubkeyA,
+        );
+        await expectLater(
+          () => store.save(upload),
+          throwsA(isA<Exception>()),
+        );
+
+        // Start a drain but don't await it — it suspends on the failing save().
+        final inFlight = store.drainPendingSaves();
+        expect(store.isDraining, isTrue);
+
+        // A second drain triggered while the first runs returns immediately
+        // (the re-entrancy guard) instead of starting a concurrent drain.
+        await store.drainPendingSaves();
+        expect(store.isDraining, isTrue);
+
+        await inFlight;
+        expect(store.isDraining, isFalse);
+      });
     });
 
     // -----------------------------------------------------------------------

--- a/mobile/test/services/upload/pending_upload_store_test.dart
+++ b/mobile/test/services/upload/pending_upload_store_test.dart
@@ -393,6 +393,74 @@ void main() {
         await inFlight;
         expect(store.isDraining, isFalse);
       });
+
+      test(
+        'a drain that resumes after disposeStore() leaves no timer and an '
+        'empty queue',
+        () async {
+          final isolatedDir = await _forceStorageFailure();
+
+          final store = PendingUploadStore(
+            scopeUploadsToCurrentUser: false,
+            currentNostrPubkey: null,
+          );
+
+          final upload = PendingUpload.create(
+            localVideoPath: '${isolatedDir.path}/video.mp4',
+            nostrPubkey: _pubkeyA,
+          );
+          await expectLater(
+            () => store.save(upload),
+            throwsA(isA<Exception>()),
+          );
+          expect(store.queuedCount, equals(1));
+
+          // Start a drain; it suspends on the still-failing save().
+          final inFlight = store.drainPendingSaves();
+          expect(store.isDraining, isTrue);
+
+          // Tear the store down mid-drain. disposeStore() cancels the timer and
+          // clears the queue, but the drain is still parked on `await save()`.
+          store.disposeStore();
+          expect(store.isDisposed, isTrue);
+
+          // The drain resumes and re-fails. Pre-fix it would re-queue the upload
+          // (via save()'s _queueUploadForLater and the loop catch) and arm a
+          // fresh 30 s timer that disposeStore() can no longer cancel — a
+          // self-perpetuating retry surviving disposal. The disposed latch makes
+          // the resumed drain inert.
+          await inFlight;
+
+          expect(
+            store.queuedCount,
+            equals(0),
+            reason: 'a disposed store must not repopulate its queue',
+          );
+          expect(
+            store.hasScheduledRetry,
+            isFalse,
+            reason: 'no retry timer may survive disposal',
+          );
+        },
+      );
+
+      test(
+        'open() clears the disposed latch so a reused store can queue again',
+        () async {
+          final store = await _openStore();
+          addTearDown(store.disposeStore);
+
+          store.disposeStore();
+          expect(store.isDisposed, isTrue);
+
+          // Re-initialising the same instance (the manager's initialize() path)
+          // must restore a fully usable store — including the deferred-save
+          // queue, which the disposed latch otherwise keeps inert.
+          await store.open();
+          expect(store.isDisposed, isFalse);
+          expect(store.isReady, isTrue);
+        },
+      );
     });
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Description

`PendingUploadStore`'s deferred save-retry queue had three compounding defects that turn a *persistent* local-storage failure (disk full, Hive corruption, FS permission error) into a self-reinforcing retry storm. All three landed together when the queue was first introduced (`528dd6c3c`, 2025-09-10) and were carried over verbatim by the #5574 extraction.

**D1 — double-enqueue.** On the retry drain, a still-failing item was added to the queue **twice**: once by `save()`'s `_queueUploadForLater` (which enqueues *and* reschedules) and again by `_processSaveQueue`'s loop `catch`. With a raw `List` the queue grew multiplicatively (1 → 2 → 4 → …) for as long as storage stayed broken.
→ Fixed by keying the queue on `upload.id` (`Map<String, PendingUpload>`), so re-enqueue is **idempotent regardless of how many code paths enqueue** the same upload. FIFO order is preserved (Dart map literal is a `LinkedHashMap`; re-`put` keeps the original position).

**D2 — orphaned, uncancellable timer.** The drain tail reassigned `_saveQueueTimer` to a 30 s timer **without cancelling** the 5 s timer set during the drain, leaking a timer that not even `disposeStore()` could reach.
→ Fixed by cancelling before rescheduling. Exactly one store-owned timer is live at a time; cadence (5 s → 30 s) is unchanged.

**D3 — re-entrancy.** `_processSaveQueue` is invoked only by the retry timer and had no guard. Because `save()` on the failure slow-path can run >5 s (`UploadInitializationHelper` backoff + a 10 s `openBox` timeout), the orphaned 5 s timer could fire **while the first drain was still suspended on `await save(...)`**, starting a second drain concurrently.
→ Fixed with an `_isDraining` guard so a re-entrant drain is a no-op.

No happy-path behavior change. Idempotent on recovery either way (`PendingUpload` is keyed by `id`, so duplicate `put`s collapse to one Hive record — there was never data loss/corruption; the harm was unbounded in-memory queue growth + leaked/overlapping timers during the outage). The infinite-retry policy is unchanged (see Out of Scope).

**Related Issue:** Closes #5584

## Out of Scope

- **Retry cap / give-up policy.** The queue still retries forever; bounding it (e.g. via `PendingUpload.retryCount`) is a behavior change and a separate product decision, not part of this bug fix.

## Verification

- New drain-path regression tests (this path was previously uncovered — the one existing queue test only exercised a single `save()` enqueue and passed with the bug present):
  - `draining a still-failing upload does not double-enqueue it` — asserts `queuedCount == 1` after a re-failing drain (the bug produced 2).
  - `drain reschedules exactly one store-owned (cancellable) retry timer` — asserts `hasScheduledRetry` after a drain and that `disposeStore()` cancels it.
  - `a drain is a no-op while another drain is in flight` — asserts the `_isDraining` re-entrancy guard.
- `flutter test test/services/upload/pending_upload_store_test.dart` → 37 passing.
- `flutter test` across `upload_manager_*` suites (owner-scope, cancel, error-handling, from-draft, resumable) → green (facade delegation unaffected).
- `flutter analyze lib test` clean; pre-commit + pre-push hooks pass.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
