### PR TITLE
fix(video-editor): surface the real cause of draft-save failures

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -23,6 +23,7 @@ import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/providers/video_reply_context_provider.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
@@ -31,6 +32,27 @@ import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
 import 'package:pro_video_editor/core/models/video/progress_model.dart';
 import 'package:unified_logger/unified_logger.dart';
+
+/// Result of a [VideoEditorNotifier.saveAsDraft] attempt.
+///
+/// Replaces a bare `bool` so the UI can tell a real failure apart from a
+/// no-op, and so the failure cause stops hiding behind a generic snackbar.
+enum DraftSaveOutcome {
+  /// The draft was persisted to local storage.
+  saved,
+
+  /// A save was already in flight, so this call did nothing. The save button is
+  /// normally disabled while saving, so this is a defensive case.
+  alreadyInProgress,
+
+  /// The write exceeded [VideoEditorConstants.draftSaveTimeout] — typically
+  /// slow or wedged local storage.
+  timedOut,
+
+  /// The write threw an unexpected error. The cause is logged and reported to
+  /// Crashlytics.
+  failed,
+}
 
 final videoEditorProvider =
     NotifierProvider<VideoEditorNotifier, VideoEditorProviderState>(
@@ -678,16 +700,21 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
   /// Save the current video project as a draft.
   ///
-  /// Persists clips and metadata to local storage for later editing.
-  /// Returns `true` on success, `false` on failure — including when the write
-  /// exceeds [VideoEditorConstants.draftSaveTimeout].
+  /// Persists clips and metadata to local storage for later editing and returns
+  /// a [DraftSaveOutcome] describing the result — [DraftSaveOutcome.saved],
+  /// [DraftSaveOutcome.alreadyInProgress] (a save was already running, so this
+  /// call was a no-op), [DraftSaveOutcome.timedOut] (the write exceeded
+  /// [VideoEditorConstants.draftSaveTimeout]), or [DraftSaveOutcome.failed] (the
+  /// write threw; the cause is logged and reported to Crashlytics).
   ///
   /// The write is bounded so a stalled save can't wedge the button. The
   /// autosave cleanup that follows is deliberately *not* bounded (see the call
   /// site): it must run to completion, so a stalled cleanup keeps the save in
   /// flight — and the button disabled — until it lands.
-  Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
-    if (state.isSavingDraft) return false;
+  Future<DraftSaveOutcome> saveAsDraft({
+    bool enforceCreateNewDraft = false,
+  }) async {
+    if (state.isSavingDraft) return DraftSaveOutcome.alreadyInProgress;
 
     state = state.copyWith(isSavingDraft: true);
 
@@ -719,7 +746,23 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         name: 'VideoEditorNotifier',
         category: .video,
       );
+      return DraftSaveOutcome.saved;
+    } on TimeoutException catch (e, stackTrace) {
+      // Slow/wedged local storage is an environmental failure, not a bug — log
+      // it for the unified log export but keep it out of Crashlytics.
+      Log.error(
+        '❌ Draft save timed out after '
+        '${VideoEditorConstants.draftSaveTimeout.inSeconds}s: $draftId',
+        name: 'VideoEditorNotifier',
+        category: .video,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return DraftSaveOutcome.timedOut;
     } catch (e, stackTrace) {
+      // An unexpected write failure: origin/main always saves, so this is a real
+      // defect. Report it so the actual cause stops hiding behind a generic
+      // "Failed to save" snackbar.
       Log.error(
         '❌ Failed to save draft: $e',
         name: 'VideoEditorNotifier',
@@ -727,7 +770,14 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         error: e,
         stackTrace: stackTrace,
       );
-      return false;
+      unawaited(
+        CrashReportingService.instance.recordError(
+          e,
+          stackTrace,
+          reason: 'VideoEditorNotifier.saveAsDraft',
+        ),
+      );
+      return DraftSaveOutcome.failed;
     } finally {
       // Always clear the flag — a timed-out or failed save must re-enable the
       // save button. Guard against a dispose that races the timeout.
@@ -735,8 +785,6 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         state = state.copyWith(isSavingDraft: false);
       }
     }
-
-    return true;
   }
 
   /// Restore a draft from local storage.

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -145,6 +145,13 @@ class DraftStorageService {
   /// Save a draft to storage. If a draft with the same ID exists, it will be
   /// updated. When updating, orphaned clip files (video/thumbnail) from the
   /// old draft are deleted.
+  ///
+  /// Throws a `SqliteException` if the underlying Drift read/write fails —
+  /// e.g. the database is locked, the disk is full, or the file is corrupt.
+  /// These are environmental IO failures (an `Exception`, not an `Error`), so
+  /// per the reportability matrix they are expected rather than bugs. Orphaned
+  /// clip-file deletions are best-effort: their failures are logged and
+  /// swallowed, never thrown.
   Future<void> saveDraft(DivineVideoDraft draft) async {
     Log.debug(
       '💾 Saving draft: ${draft.id}',

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_main_overlay_actions.dart
@@ -12,7 +12,6 @@ import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_publish_provider.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/video_editor_toolbar.dart';
-import 'package:unified_logger/unified_logger.dart';
 
 /// Top action bar for the video editor.
 ///
@@ -126,26 +125,16 @@ class _TopActions extends ConsumerWidget {
     required BuildContext context,
     required WidgetRef ref,
   }) async {
-    var draftSaved = true;
-    try {
-      // Save the draft to the library.
-      final draftSuccess = await ref
-          .read(videoEditorProvider.notifier)
-          .saveAsDraft(enforceCreateNewDraft: true);
-      if (!draftSuccess) {
-        throw StateError('Failed to save draft');
-      }
-    } catch (e, stackTrace) {
-      Log.error(
-        'Failed to save: $e',
-        name: 'VideoMetadataCaptureBottomBar',
-        category: LogCategory.video,
-        error: e,
-        stackTrace: stackTrace,
-      );
-      draftSaved = false;
-    }
+    final outcome = await ref
+        .read(videoEditorProvider.notifier)
+        .saveAsDraft(enforceCreateNewDraft: true);
+
+    // A save was already in flight (the button is normally disabled
+    // meanwhile); leave the prompt as-is.
+    if (outcome == DraftSaveOutcome.alreadyInProgress) return;
     if (!context.mounted) return;
+
+    final draftSaved = outcome == DraftSaveOutcome.saved;
 
     if (draftSaved) {
       // Success: close prompt + close editor.

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart
@@ -11,7 +11,6 @@ import 'package:openvine/screens/feed/video_feed_page.dart';
 import 'package:openvine/screens/library_screen.dart';
 import 'package:openvine/services/gallery_save_service.dart';
 import 'package:openvine/utils/gallery_save_utils.dart';
-import 'package:unified_logger/unified_logger.dart';
 
 /// Bottom bar with "Save for Later" and "Post" buttons for video metadata.
 ///
@@ -53,29 +52,17 @@ class VideoMetadataCaptureBottomBar extends ConsumerWidget {
 
   Future<void> _onSaveForLater(BuildContext context, WidgetRef ref) async {
     await saveToGallery(context, ref);
-    var draftSaved = true;
 
-    try {
-      // Save the draft to the library.
-      final draftSuccess = await ref
-          .read(videoEditorProvider.notifier)
-          .saveAsDraft(enforceCreateNewDraft: true);
-      if (!draftSuccess) {
-        throw StateError('Failed to save draft');
-      }
-    } catch (e, stackTrace) {
-      Log.error(
-        'Failed to save: $e',
-        name: 'VideoMetadataCaptureBottomBar',
-        category: LogCategory.video,
-        error: e,
-        stackTrace: stackTrace,
-      );
-      draftSaved = false;
-    }
+    final outcome = await ref
+        .read(videoEditorProvider.notifier)
+        .saveAsDraft(enforceCreateNewDraft: true);
 
+    // A save was already in flight (the button is normally disabled
+    // meanwhile); there's nothing to report or navigate.
+    if (outcome == DraftSaveOutcome.alreadyInProgress) return;
     if (!context.mounted) return;
 
+    final draftSaved = outcome == DraftSaveOutcome.saved;
     final router = GoRouter.of(context);
 
     _showStatusSnackBar(

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart
@@ -51,6 +51,9 @@ class VideoMetadataCaptureBottomBar extends ConsumerWidget {
   }
 
   Future<void> _onSaveForLater(BuildContext context, WidgetRef ref) async {
+    // Gallery save runs first, before the alreadyInProgress guard below: the
+    // Save-for-later button is disabled while a draft save is in flight, so a
+    // concurrent tap landing here is a narrow race, not the common path.
     await saveToGallery(context, ref);
 
     final outcome = await ref

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -119,10 +119,10 @@ Future<bool> _ensureAuthenticatedForRecorderExit(
   final outcome = await ref
       .read(videoEditorProvider.notifier)
       .saveAsDraft(enforceCreateNewDraft: true);
-  if (!context.mounted) return false;
 
   // A save was already in flight; don't double-report or navigate.
   if (outcome == DraftSaveOutcome.alreadyInProgress) return false;
+  if (!context.mounted) return false;
 
   final saved = outcome == DraftSaveOutcome.saved;
   ScaffoldMessenger.of(context).showSnackBar(

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -116,11 +116,15 @@ Future<bool> _ensureAuthenticatedForRecorderExit(
 
   if (authenticated) return true;
 
-  final saved = await ref
+  final outcome = await ref
       .read(videoEditorProvider.notifier)
       .saveAsDraft(enforceCreateNewDraft: true);
   if (!context.mounted) return false;
 
+  // A save was already in flight; don't double-report or navigate.
+  if (outcome == DraftSaveOutcome.alreadyInProgress) return false;
+
+  final saved = outcome == DraftSaveOutcome.saved;
   ScaffoldMessenger.of(context).showSnackBar(
     SnackBar(
       content: Text(

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1609,7 +1609,7 @@ void main() {
       container.dispose();
     });
 
-    test('returns true and clears isSavingDraft on success', () async {
+    test('returns saved and clears isSavingDraft on success', () async {
       when(() => mockDraftStorage.saveDraft(any())).thenAnswer((_) async {});
       when(() => mockDraftStorage.deleteDraft(any())).thenAnswer((_) async {});
 
@@ -1617,7 +1617,7 @@ void main() {
           .read(videoEditorProvider.notifier)
           .saveAsDraft(enforceCreateNewDraft: true);
 
-      expect(result, isTrue);
+      expect(result, equals(DraftSaveOutcome.saved));
       expect(
         container.read(videoEditorProvider).isSavingDraft,
         isFalse,
@@ -1625,7 +1625,7 @@ void main() {
       );
     });
 
-    test('clears isSavingDraft and returns false when the write hangs', () {
+    test('clears isSavingDraft and returns timedOut when the write hangs', () {
       // Reproduces the dead "Save for later" button: a draft write that never
       // resolves must not leave isSavingDraft stuck true for the session.
       when(
@@ -1634,7 +1634,7 @@ void main() {
 
       fakeAsync((async) {
         final notifier = container.read(videoEditorProvider.notifier);
-        bool? result;
+        DraftSaveOutcome? result;
         notifier
             .saveAsDraft(enforceCreateNewDraft: true)
             .then((value) => result = value);
@@ -1649,7 +1649,11 @@ void main() {
           VideoEditorConstants.draftSaveTimeout + const Duration(seconds: 1),
         );
 
-        expect(result, isFalse, reason: 'a timed-out save reports failure');
+        expect(
+          result,
+          equals(DraftSaveOutcome.timedOut),
+          reason: 'a timed-out save reports failure',
+        );
         expect(
           container.read(videoEditorProvider).isSavingDraft,
           isFalse,
@@ -1658,29 +1662,56 @@ void main() {
       });
     });
 
-    test('returns false while a previous save is still in flight', () {
+    test('returns failed and clears isSavingDraft when the write throws', () {
+      // The cause of an unexpected write failure must surface (logged +
+      // reported) instead of hiding behind a generic snackbar.
       when(
         () => mockDraftStorage.saveDraft(any()),
-      ).thenAnswer((_) => Completer<void>().future);
+      ).thenThrow(StateError('database is locked'));
 
       fakeAsync((async) {
         final notifier = container.read(videoEditorProvider.notifier);
-        unawaited(notifier.saveAsDraft(enforceCreateNewDraft: true));
-        async.flushMicrotasks();
-
-        bool? secondResult;
+        DraftSaveOutcome? result;
         notifier
             .saveAsDraft(enforceCreateNewDraft: true)
-            .then((value) => secondResult = value);
+            .then((value) => result = value);
         async.flushMicrotasks();
 
+        expect(result, equals(DraftSaveOutcome.failed));
         expect(
-          secondResult,
+          container.read(videoEditorProvider).isSavingDraft,
           isFalse,
-          reason: 'concurrent saves are rejected by the in-flight guard',
+          reason: 'a failed save must re-enable the save button',
         );
       });
     });
+
+    test(
+      'returns alreadyInProgress while a previous save is still in flight',
+      () {
+        when(
+          () => mockDraftStorage.saveDraft(any()),
+        ).thenAnswer((_) => Completer<void>().future);
+
+        fakeAsync((async) {
+          final notifier = container.read(videoEditorProvider.notifier);
+          unawaited(notifier.saveAsDraft(enforceCreateNewDraft: true));
+          async.flushMicrotasks();
+
+          DraftSaveOutcome? secondResult;
+          notifier
+              .saveAsDraft(enforceCreateNewDraft: true)
+              .then((value) => secondResult = value);
+          async.flushMicrotasks();
+
+          expect(
+            secondResult,
+            equals(DraftSaveOutcome.alreadyInProgress),
+            reason: 'concurrent saves are rejected by the in-flight guard',
+          );
+        });
+      },
+    );
 
     test('does not abandon autosave cleanup after a successful draft save', () {
       // The autosave delete must run to completion: an abandoned delete could
@@ -1697,7 +1728,7 @@ void main() {
         ).thenAnswer((_) => cleanup.future);
 
         final notifier = container.read(videoEditorProvider.notifier);
-        bool? result;
+        DraftSaveOutcome? result;
         notifier
             .saveAsDraft(enforceCreateNewDraft: true)
             .then((value) => result = value);
@@ -1723,7 +1754,7 @@ void main() {
         cleanup.complete();
         async.flushMicrotasks();
 
-        expect(result, isTrue);
+        expect(result, equals(DraftSaveOutcome.saved));
         expect(
           container.read(videoEditorProvider).isSavingDraft,
           isFalse,

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -28,6 +28,7 @@ import 'package:pro_image_editor/pro_image_editor.dart'
     show CompleteParameters, WidgetLayer, WidgetLayerExportConfigs;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sqlite3/sqlite3.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
@@ -1664,10 +1665,13 @@ void main() {
 
     test('returns failed and clears isSavingDraft when the write throws', () {
       // The cause of an unexpected write failure must surface (logged +
-      // reported) instead of hiding behind a generic snackbar.
-      when(
-        () => mockDraftStorage.saveDraft(any()),
-      ).thenThrow(StateError('database is locked'));
+      // reported) instead of hiding behind a generic snackbar. Use a
+      // SqliteException — the shape a real DB-lock / disk-full write actually
+      // throws up from the Drift DAO — so the test exercises the production
+      // failure mode rather than a StateError the cause will rarely be.
+      when(() => mockDraftStorage.saveDraft(any())).thenThrow(
+        SqliteException(extendedResultCode: 5, message: 'database is locked'),
+      );
 
       fakeAsync((async) {
         final notifier = container.read(videoEditorProvider.notifier);

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
@@ -31,14 +31,12 @@ class _FakeVideoEditorNotifier extends VideoEditorNotifier {
   _FakeVideoEditorNotifier({
     required this.initialState,
     required this.activeDraft,
-    this.saveAsDraftSucceeds = true,
-    this.saveAsDraftThrows = false,
+    this.saveAsDraftResult = DraftSaveOutcome.saved,
   });
 
   final VideoEditorProviderState initialState;
   final DivineVideoDraft activeDraft;
-  final bool saveAsDraftSucceeds;
-  final bool saveAsDraftThrows;
+  final DraftSaveOutcome saveAsDraftResult;
 
   int saveAsDraftCalls = 0;
 
@@ -50,12 +48,11 @@ class _FakeVideoEditorNotifier extends VideoEditorNotifier {
       activeDraft;
 
   @override
-  Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
+  Future<DraftSaveOutcome> saveAsDraft({
+    bool enforceCreateNewDraft = false,
+  }) async {
     saveAsDraftCalls++;
-    if (saveAsDraftThrows) {
-      throw StateError('save failed');
-    }
-    return saveAsDraftSucceeds;
+    return saveAsDraftResult;
   }
 }
 
@@ -95,8 +92,7 @@ void main() {
       VideoEditorMainState? state,
       bool isAutosavedDraft = false,
       bool hasBeenEdited = false,
-      bool saveAsDraftSucceeds = true,
-      bool saveAsDraftThrows = false,
+      DraftSaveOutcome saveAsDraftResult = DraftSaveOutcome.saved,
     }) {
       if (state != null) {
         when(() => mockBloc.state).thenReturn(state);
@@ -110,8 +106,7 @@ void main() {
           isAutosavedDraft: isAutosavedDraft,
         ),
         activeDraft: mockDraft,
-        saveAsDraftSucceeds: saveAsDraftSucceeds,
-        saveAsDraftThrows: saveAsDraftThrows,
+        saveAsDraftResult: saveAsDraftResult,
       );
       fakeVideoPublishNotifier = _FakeVideoPublishNotifier();
 
@@ -324,7 +319,7 @@ void main() {
             buildWidget(
               isAutosavedDraft: true,
               hasBeenEdited: true,
-              saveAsDraftThrows: true,
+              saveAsDraftResult: DraftSaveOutcome.failed,
             ),
           );
 

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_main_overlay_actions_test.dart
@@ -335,6 +335,33 @@ void main() {
           expect(find.bySemanticsLabel('Close'), findsOneWidget);
         },
       );
+
+      testWidgets(
+        'save draft already in flight leaves the prompt open with no '
+        'snackbar or navigation',
+        (tester) async {
+          await tester.pumpWidget(
+            buildWidget(
+              isAutosavedDraft: true,
+              hasBeenEdited: true,
+              saveAsDraftResult: DraftSaveOutcome.alreadyInProgress,
+            ),
+          );
+
+          await tester.tap(find.bySemanticsLabel('Close'));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.text('Save draft'));
+          await tester.pumpAndSettle();
+
+          expect(fakeVideoEditorNotifier.saveAsDraftCalls, equals(1));
+          verifyNever(() => mockGoRouter.pop<Object?>(any()));
+          expect(find.text('Saved to library'), findsNothing);
+          expect(find.text('Failed to save'), findsNothing);
+          // The prompt stays open so the in-flight save can land.
+          expect(find.text('Save your draft?'), findsOneWidget);
+        },
+      );
     });
   });
 }

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
@@ -446,7 +446,7 @@ void main() {
 
         final mockNotifier = _MockVideoEditorNotifier(
           validState0(),
-          saveAsDraftResult: false,
+          saveAsDraftResult: DraftSaveOutcome.failed,
         );
 
         await tester.pumpWidget(
@@ -510,7 +510,7 @@ void main() {
 
         final mockNotifier = _MockVideoEditorNotifier(
           validState0(),
-          saveAsDraftResult: false,
+          saveAsDraftResult: DraftSaveOutcome.failed,
         );
 
         await tester.pumpWidget(
@@ -539,7 +539,7 @@ void main() {
         // State without finalRenderedClip so gallery save returns null.
         final mockNotifier = _MockVideoEditorNotifier(
           VideoEditorProviderState(title: 'Test'),
-          saveAsDraftResult: false,
+          saveAsDraftResult: DraftSaveOutcome.failed,
         );
 
         await tester.pumpWidget(
@@ -631,7 +631,7 @@ void main() {
 
         final mockNotifier = _MockVideoEditorNotifier(
           validState0(),
-          saveAsDraftResult: false,
+          saveAsDraftResult: DraftSaveOutcome.failed,
         );
 
         await tester.pumpWidget(
@@ -726,13 +726,13 @@ class _MockVideoEditorNotifier extends VideoEditorNotifier {
     this._state, {
     this.onPostVideo,
     this.onSaveAsDraft,
-    this.saveAsDraftResult = true,
+    this.saveAsDraftResult = DraftSaveOutcome.saved,
   });
 
   final VideoEditorProviderState _state;
   final VoidCallback? onPostVideo;
   final VoidCallback? onSaveAsDraft;
-  final bool saveAsDraftResult;
+  final DraftSaveOutcome saveAsDraftResult;
 
   @override
   VideoEditorProviderState build() => _state;
@@ -743,7 +743,9 @@ class _MockVideoEditorNotifier extends VideoEditorNotifier {
   }
 
   @override
-  Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
+  Future<DraftSaveOutcome> saveAsDraft({
+    bool enforceCreateNewDraft = false,
+  }) async {
     onSaveAsDraft?.call();
     return saveAsDraftResult;
   }

--- a/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
+++ b/mobile/test/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar_test.dart
@@ -653,6 +653,37 @@ void main() {
         expect(find.byType(VideoMetadataCaptureBottomBar), findsOneWidget);
       });
 
+      testWidgets('save for later with a save already in flight shows no '
+          'snackbar and does not navigate', (tester) async {
+        when(
+          () => mockGallerySaveService.saveVideoToGallery(any()),
+        ).thenAnswer((_) async => const GallerySaveSuccess());
+
+        final mockNotifier = _MockVideoEditorNotifier(
+          validState0(),
+          saveAsDraftResult: DraftSaveOutcome.alreadyInProgress,
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              videoEditorProvider.overrideWith(() => mockNotifier),
+              gallerySaveServiceProvider.overrideWith(
+                (ref) => mockGallerySaveService,
+              ),
+            ],
+            child: _createTestApp(const VideoMetadataCaptureBottomBar()),
+          ),
+        );
+
+        await tester.tap(find.text('Save for Later'));
+        await tester.pumpAndSettle();
+
+        // A concurrent save is a silent no-op: no snackbar, stays on the page.
+        expect(find.byType(DivineSnackbarContainer), findsNothing);
+        expect(find.byType(VideoMetadataCaptureBottomBar), findsOneWidget);
+      });
+
       testWidgets('post shows no snackbar when gallery save succeeds', (
         tester,
       ) async {

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -34,13 +34,15 @@ class _MockVideoRecorderBloc
 class _FakeVideoEditorNotifier extends VideoEditorNotifier {
   bool saveAsDraftCalled = false;
   bool startRenderVideoCalled = false;
-  bool saveResult = true;
+  DraftSaveOutcome saveResult = DraftSaveOutcome.saved;
 
   @override
   VideoEditorProviderState build() => VideoEditorProviderState();
 
   @override
-  Future<bool> saveAsDraft({bool enforceCreateNewDraft = false}) async {
+  Future<DraftSaveOutcome> saveAsDraft({
+    bool enforceCreateNewDraft = false,
+  }) async {
     saveAsDraftCalled = true;
     return saveResult;
   }

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -223,6 +223,28 @@ void main() {
 
         await tester.pumpAndSettle(const Duration(seconds: 5));
       });
+
+      testWidgets('openVideoEditorFromRecorder with a save already in flight '
+          'shows no snackbar and stays on the recorder', (tester) async {
+        fakeEditor.saveResult = DraftSaveOutcome.alreadyInProgress;
+
+        await tester.pumpWidget(buildHarness());
+        await tester.pumpAndSettle();
+        final l10n = lookupAppLocalizations(const Locale('en'));
+
+        await tester.tap(find.byKey(const Key('open-editor')));
+        await tester.pumpAndSettle();
+
+        expect(fakeEditor.saveAsDraftCalled, isTrue);
+        expect(
+          find.text(l10n.uploadFailureSheetSavedToDraftsSnackbar),
+          findsNothing,
+        );
+        expect(find.text(l10n.videoMetadataFailedToSaveSnackbar), findsNothing);
+        expect(find.text('welcome'), findsNothing);
+        expect(find.text('editor'), findsNothing);
+        expect(find.byKey(const Key('open-editor')), findsOneWidget);
+      });
     });
   });
 }


### PR DESCRIPTION
Closes #5588

## Description

A user reported that pressing **Save for later / Save draft** always showed a
generic "Failed to save" snackbar, with no way to tell *why*. Root cause: the
real exception was swallowed — `saveAsDraft` returned a bare `bool`, the
failure was only logged locally (never sent to Crashlytics), and the call
sites fabricated a generic `StateError`, so the actual cause never surfaced.

This is a **diagnostics** change so the next real failure tells us the cause:

- `VideoEditorNotifier.saveAsDraft` now returns a `DraftSaveOutcome`
  (`saved` / `alreadyInProgress` / `timedOut` / `failed`) instead of `bool`.
- The `catch` is typed: a `TimeoutException` (slow/wedged local storage) is
  logged but **kept out of Crashlytics** per the reportability matrix, while
  an unexpected write failure is reported via
  `CrashReportingService.instance.recordError(..., reason: 'VideoEditorNotifier.saveAsDraft')`
  so the real exception + stack reach the dashboard.
- The three call sites map the outcome to the snackbar/navigation, drop the
  fabricated `StateError` + duplicate widget-level log (and now-unused
  `unified_logger` imports), and treat `alreadyInProgress` as a silent no-op
  instead of a false "Failed to save".

User-facing copy is unchanged (timeout and failure still share "Failed to
save"); the diagnostic distinction lives in logs/Crashlytics, so no l10n churn.

**Related Issue:** 

## Out of Scope

This surfaces the cause; it does **not** fix the underlying draft-write
failure (DB lock/corruption, disk pressure, etc.) — that needs a real
occurrence's Crashlytics report / timeout log line to root-cause. No other
follow-up bundled here.

## Verification

- `flutter analyze` on the 4 changed `lib/` files + 4 test files — **clean**
- `flutter test` on the 4 affected test files — **105 passing**
  (incl. a new `returns failed and clears isSavingDraft when the write throws`)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 🧹 Code refactor