### PR TITLE
refactor(upload): extract UploadRetryPolicy + UploadProgressReporter (#4507)

### DIFF
--- a/mobile/lib/services/upload/upload_progress_reporter.dart
+++ b/mobile/lib/services/upload/upload_progress_reporter.dart
@@ -11,6 +11,7 @@ import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/circuit_breaker_service.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload/upload_session_errors.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -71,15 +72,6 @@ class UploadProgressReporter {
   // ---------------------------------------------------------------------------
   // Progress subscriptions
   // ---------------------------------------------------------------------------
-
-  /// Return the active progress subscription for [uploadId], if any.
-  StreamSubscription<double>? subscriptionFor(String uploadId) =>
-      _progressSubscriptions[uploadId];
-
-  /// Register [sub] as the active progress subscription for [uploadId].
-  void setSubscription(String uploadId, StreamSubscription<double> sub) {
-    _progressSubscriptions[uploadId] = sub;
-  }
 
   /// Cancel and remove the progress subscription for [uploadId].
   void cancelAndRemoveSubscription(String uploadId) {
@@ -160,7 +152,7 @@ class UploadProgressReporter {
 
   /// Categorise [error] into a string category constant for monitoring.
   Future<String> categorizeError(dynamic error) async {
-    if (_isExpiredResumableSessionError(error)) {
+    if (isExpiredResumableSessionError(error)) {
       return 'UPLOAD_SESSION_EXPIRED';
     }
 
@@ -171,6 +163,10 @@ class UploadProgressReporter {
     }
 
     if (error is BlossomUploadFailureException) {
+      // A failure to *produce* the signed auth header (the signer was briefly
+      // unreachable) is a connectivity problem, not a server rejection. It
+      // carries no HTTP status, so classify it on the typed reason and surface
+      // the retry-friendly network copy instead of the generic UNKNOWN message.
       if (error.failureReason == BlossomUploadFailureReason.authUnavailable) {
         return 'NETWORK_ERROR';
       }
@@ -272,25 +268,6 @@ class UploadProgressReporter {
         return 'Upload failed. Please check your connection and try again.';
     }
   }
-
-  // ---------------------------------------------------------------------------
-  // Expired-session helper (public surface for UploadManager._handleUploadFailure)
-  // ---------------------------------------------------------------------------
-
-  // Duplicated from UploadRetryPolicy to avoid cross-class import.
-  bool _isExpiredResumableSessionError(dynamic error) {
-    if (error is BlossomResumableUploadException) {
-      return error.statusCode == 404 || error.statusCode == 410;
-    }
-
-    final errorMessage = error.toString().toLowerCase();
-    return errorMessage.contains('session expired') ||
-        errorMessage.contains('session is no longer available');
-  }
-
-  /// Return true if [error] represents an expired resumable-upload session.
-  bool isExpiredResumableSessionError(dynamic error) =>
-      _isExpiredResumableSessionError(error);
 
   // ---------------------------------------------------------------------------
   // Metrics computation (replaces _createSuccessMetrics / _logUploadSuccess)
@@ -613,7 +590,8 @@ Upload Timeout Failure:
       subscription.cancel();
     }
     _progressSubscriptions.clear();
-    _cleanupOldMetrics();
+    // Drop all metrics (not just the 7-day prune) so a later initialize()
+    // starts from a clean slate and the disposed reporter frees its memory.
     _uploadMetrics.clear();
   }
 

--- a/mobile/lib/services/upload/upload_progress_reporter.dart
+++ b/mobile/lib/services/upload/upload_progress_reporter.dart
@@ -1,0 +1,648 @@
+// ABOUTME: Progress tracking, network diagnostics, error categorisation, and
+// ABOUTME: crash-report concerns extracted from UploadManager.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/circuit_breaker_service.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
+import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Get platform name for logging (web-safe).
+///
+/// Duplicated from upload_manager.dart top-level helper to avoid
+/// cross-file dependency on a private top-level function.
+String _getPlatformName() {
+  if (kIsWeb) return 'web';
+  try {
+    return defaultTargetPlatform.name;
+  } catch (_) {
+    return 'unknown';
+  }
+}
+
+/// Owns the progress-tracking, network-diagnostic, error-categorisation, and
+/// crash-report concerns extracted from [UploadManager].
+class UploadProgressReporter {
+  UploadProgressReporter({
+    required PendingUploadStore store,
+    required VideoCircuitBreaker circuitBreaker,
+    required UploadRetryConfig retryConfig,
+  }) : _store = store,
+       _circuitBreaker = circuitBreaker,
+       _retryConfig = retryConfig;
+
+  final PendingUploadStore _store;
+  final VideoCircuitBreaker _circuitBreaker;
+  final UploadRetryConfig _retryConfig;
+
+  final Map<String, StreamSubscription<double>> _progressSubscriptions = {};
+  final Map<String, UploadMetrics> _uploadMetrics = {};
+
+  // ---------------------------------------------------------------------------
+  // Metrics lifecycle
+  // ---------------------------------------------------------------------------
+
+  /// Record the start of an upload (replaces the initial `_uploadMetrics[id] =` assignment).
+  void recordStart(String uploadId, UploadMetrics metrics) {
+    _uploadMetrics[uploadId] = metrics;
+  }
+
+  /// Record a successful upload result and prune stale metrics.
+  void recordSuccess(String uploadId, UploadMetrics metrics) {
+    _uploadMetrics[uploadId] = metrics;
+    _cleanupOldMetrics();
+  }
+
+  /// Record a failed upload result.
+  void recordFailure(String uploadId, UploadMetrics metrics) {
+    _uploadMetrics[uploadId] = metrics;
+  }
+
+  /// Return the in-memory metrics for [uploadId], or null if not present.
+  UploadMetrics? metricsFor(String uploadId) => _uploadMetrics[uploadId];
+
+  // ---------------------------------------------------------------------------
+  // Progress subscriptions
+  // ---------------------------------------------------------------------------
+
+  /// Return the active progress subscription for [uploadId], if any.
+  StreamSubscription<double>? subscriptionFor(String uploadId) =>
+      _progressSubscriptions[uploadId];
+
+  /// Register [sub] as the active progress subscription for [uploadId].
+  void setSubscription(String uploadId, StreamSubscription<double> sub) {
+    _progressSubscriptions[uploadId] = sub;
+  }
+
+  /// Cancel and remove the progress subscription for [uploadId].
+  void cancelAndRemoveSubscription(String uploadId) {
+    _progressSubscriptions[uploadId]?.cancel();
+    _progressSubscriptions.remove(uploadId);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Progress update (replaces _updateUploadProgress)
+  // ---------------------------------------------------------------------------
+
+  /// Update the persisted [progress] for [uploadId] when the upload is active.
+  void updateProgress(String uploadId, double progress) {
+    final upload = _store.getUpload(uploadId);
+    if (upload != null &&
+        (upload.status == UploadStatus.uploading ||
+            upload.status == UploadStatus.retrying)) {
+      _store.update(upload.copyWith(uploadProgress: progress));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Network helpers (replaces _checkNetworkConnectivity / getNetworkTypeString)
+  // ---------------------------------------------------------------------------
+
+  /// Check current network connectivity, preferring WiFi > Cellular > Ethernet.
+  Future<ConnectivityResult> checkNetworkConnectivity() async {
+    try {
+      final connectivity = Connectivity();
+      final result = await connectivity.checkConnectivity();
+
+      // connectivity_plus 7.x returns List<ConnectivityResult>
+      final resultList = result.cast<ConnectivityResult>();
+      if (resultList.contains(ConnectivityResult.wifi)) {
+        return ConnectivityResult.wifi;
+      }
+      if (resultList.contains(ConnectivityResult.mobile)) {
+        return ConnectivityResult.mobile;
+      }
+      if (resultList.contains(ConnectivityResult.ethernet)) {
+        return ConnectivityResult.ethernet;
+      }
+      if (resultList.contains(ConnectivityResult.vpn)) {
+        return ConnectivityResult.vpn;
+      }
+      return ConnectivityResult.none;
+    } catch (e) {
+      Log.error(
+        'Failed to check network connectivity: $e',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+      return ConnectivityResult.none;
+    }
+  }
+
+  /// Convert a [ConnectivityResult] enum value to a human-readable string.
+  String getNetworkTypeString(ConnectivityResult connectivity) {
+    switch (connectivity) {
+      case ConnectivityResult.wifi:
+        return 'WiFi';
+      case ConnectivityResult.mobile:
+        return 'Cellular';
+      case ConnectivityResult.ethernet:
+        return 'Ethernet';
+      case ConnectivityResult.vpn:
+        return 'VPN';
+      case ConnectivityResult.none:
+        return 'Offline';
+      default:
+        return 'Unknown';
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Error categorisation (replaces categorizeError / getUserFriendlyErrorMessage)
+  // ---------------------------------------------------------------------------
+
+  /// Categorise [error] into a string category constant for monitoring.
+  Future<String> categorizeError(dynamic error) async {
+    if (_isExpiredResumableSessionError(error)) {
+      return 'UPLOAD_SESSION_EXPIRED';
+    }
+
+    final connectivity = await checkNetworkConnectivity();
+
+    if (connectivity == ConnectivityResult.none) {
+      return 'NO_INTERNET';
+    }
+
+    if (error is BlossomUploadFailureException) {
+      if (error.failureReason == BlossomUploadFailureReason.authUnavailable) {
+        return 'NETWORK_ERROR';
+      }
+
+      final code = error.statusCode;
+      if (code != null) {
+        if (code == 408) return 'TIMEOUT';
+        if (code == 413) return 'FILE_TOO_LARGE';
+        if (code == 429) return 'RATE_LIMITED';
+        if (code == 401 || code == 403) return 'AUTHENTICATION';
+        if (code == 502 || code == 503 || code == 504) {
+          return 'SERVER_UNAVAILABLE';
+        }
+        if (code >= 500) return 'SERVER_ERROR';
+        if (code >= 400) return 'CLIENT_ERROR';
+      }
+    }
+
+    final errorStr = error.toString().toLowerCase();
+
+    if (errorStr.contains('timeout')) {
+      if (connectivity == ConnectivityResult.mobile) {
+        return 'SLOW_CONNECTION';
+      }
+      return 'TIMEOUT';
+    }
+
+    if (errorStr.contains('host') || errorStr.contains('dns')) {
+      return 'DNS_ERROR';
+    }
+
+    if (errorStr.contains('cannot connect') ||
+        errorStr.contains('network error') ||
+        errorStr.contains('connection')) {
+      return 'NETWORK_ERROR';
+    }
+
+    if (errorStr.contains('file not found')) return 'FILE_NOT_FOUND';
+    if (errorStr.contains('memory')) return 'OUT_OF_MEMORY';
+    if (errorStr.contains('permission')) return 'PERMISSION_DENIED';
+
+    return 'UNKNOWN';
+  }
+
+  /// Return a user-friendly error message for the given [category].
+  String getUserFriendlyErrorMessage(
+    String category,
+    ConnectivityResult connectivity,
+  ) {
+    switch (category) {
+      case 'NO_INTERNET':
+        return 'No internet connection. Check your WiFi or cellular data and try again.';
+
+      case 'SLOW_CONNECTION':
+        return 'Upload timed out on cellular data. Try connecting to WiFi for faster uploads.';
+
+      case 'TIMEOUT':
+        return 'Upload timed out. Your connection might be slow. Try again or connect to WiFi.';
+
+      case 'NETWORK_ERROR':
+        final networkType = getNetworkTypeString(connectivity);
+        return 'Network error on $networkType. Check your connection and try again.';
+
+      case 'DNS_ERROR':
+        return 'Could not reach the upload server. Check your connection or try a different network.';
+
+      case 'FILE_NOT_FOUND':
+        return 'Video file not found. Please record the video again.';
+
+      case 'FILE_TOO_LARGE':
+        return 'Video is too large to upload. Try recording a shorter video.';
+
+      case 'OUT_OF_MEMORY':
+        return 'Not enough memory to upload. Close other apps and try again.';
+
+      case 'PERMISSION_DENIED':
+        return 'Permission denied. Check app permissions in Settings.';
+
+      case 'AUTHENTICATION':
+        return 'Authentication failed. Please sign in again.';
+
+      case 'UPLOAD_SESSION_EXPIRED':
+        return 'Upload session expired. Please retry the upload.';
+
+      case 'RATE_LIMITED':
+        return 'Too many uploads. Please wait a moment and try again.';
+
+      case 'SERVER_UNAVAILABLE':
+        return 'Upload server is temporarily unavailable. '
+            'It will retry automatically.';
+
+      case 'SERVER_ERROR':
+        return 'Upload server encountered an error. Please try again later.';
+
+      case 'CLIENT_ERROR':
+        return 'Upload request failed. Please try again.';
+
+      default:
+        return 'Upload failed. Please check your connection and try again.';
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Expired-session helper (public surface for UploadManager._handleUploadFailure)
+  // ---------------------------------------------------------------------------
+
+  // Duplicated from UploadRetryPolicy to avoid cross-class import.
+  bool _isExpiredResumableSessionError(dynamic error) {
+    if (error is BlossomResumableUploadException) {
+      return error.statusCode == 404 || error.statusCode == 410;
+    }
+
+    final errorMessage = error.toString().toLowerCase();
+    return errorMessage.contains('session expired') ||
+        errorMessage.contains('session is no longer available');
+  }
+
+  /// Return true if [error] represents an expired resumable-upload session.
+  bool isExpiredResumableSessionError(dynamic error) =>
+      _isExpiredResumableSessionError(error);
+
+  // ---------------------------------------------------------------------------
+  // Metrics computation (replaces _createSuccessMetrics / _logUploadSuccess)
+  // ---------------------------------------------------------------------------
+
+  /// Compute success metrics from [currentMetrics] at [endTime].
+  UploadMetrics createSuccessMetrics(
+    UploadMetrics currentMetrics,
+    DateTime endTime,
+    int retryCount,
+  ) {
+    final duration = endTime.difference(currentMetrics.startTime);
+    final throughput = _calculateThroughput(
+      currentMetrics.fileSizeMB,
+      duration,
+    );
+
+    return UploadMetrics(
+      uploadId: currentMetrics.uploadId,
+      startTime: currentMetrics.startTime,
+      endTime: endTime,
+      uploadDuration: duration,
+      retryCount: retryCount,
+      fileSizeMB: currentMetrics.fileSizeMB,
+      throughputMBps: throughput,
+      wasSuccessful: true,
+    );
+  }
+
+  /// Log upload-success details at debug level.
+  void logUploadSuccess(dynamic result, UploadMetrics metrics) {
+    Log.info(
+      'Direct upload successful: ${result.videoId}',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+    Log.debug(
+      '🎬 CDN URL: ${result.cdnUrl}',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+
+    final durationStr = metrics.uploadDuration?.inSeconds ?? 0;
+    final throughputStr = metrics.throughputMBps?.toStringAsFixed(2) ?? '0.00';
+
+    Log.debug(
+      'Upload metrics: ${metrics.fileSizeMB.toStringAsFixed(1)}MB in ${durationStr}s ($throughputStr MB/s)',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Performance metrics (replaces getPerformanceMetrics)
+  // ---------------------------------------------------------------------------
+
+  /// Return aggregate performance statistics for all tracked uploads.
+  Map<String, dynamic> getPerformanceMetrics() {
+    final metrics = _uploadMetrics.values.toList();
+    final successful = metrics.where((m) => m.wasSuccessful).toList();
+    final failed = metrics.where((m) => !m.wasSuccessful).toList();
+
+    return {
+      'total_uploads': metrics.length,
+      'successful_uploads': successful.length,
+      'failed_uploads': failed.length,
+      'success_rate': metrics.isNotEmpty
+          ? (successful.length / metrics.length * 100)
+          : 0,
+      'average_throughput_mbps': successful.isNotEmpty
+          ? successful
+                    .map((m) => m.throughputMBps ?? 0)
+                    .reduce((a, b) => a + b) /
+                successful.length
+          : 0,
+      'average_retry_count': metrics.isNotEmpty
+          ? metrics.map((m) => m.retryCount).reduce((a, b) => a + b) /
+                metrics.length
+          : 0,
+      'error_categories': _getErrorCategoriesCount(failed),
+      'circuit_breaker_state': _circuitBreaker.state.toString(),
+      'circuit_breaker_failure_rate': _circuitBreaker.failureRate,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Crash reports (replaces _sendUpload/Initialization/TimeoutCrashReport)
+  // ---------------------------------------------------------------------------
+
+  /// Send a comprehensive upload-failure report to Crashlytics.
+  Future<void> sendUploadFailureCrashReport(
+    PendingUpload upload,
+    dynamic error,
+    String errorCategory,
+    UploadMetrics? metrics,
+    ConnectivityResult connectivity, {
+    required bool isManagerInitialized,
+  }) async {
+    try {
+      final crashReporting = CrashReportingService.instance;
+
+      final context = {
+        'upload_id': upload.id,
+        'upload_status': upload.status.toString(),
+        'error_category': errorCategory,
+        'retry_count': upload.retryCount ?? 0,
+        'can_retry': upload.canRetry,
+        'upload_target': 'blossomServer',
+        'circuit_breaker_state': _circuitBreaker.state.toString(),
+        'circuit_breaker_failure_rate': _circuitBreaker.failureRate,
+        'local_file_path': upload.localVideoPath,
+        'video_id': upload.videoId,
+        'cdn_url': upload.cdnUrl,
+        'upload_progress': upload.uploadProgress,
+        'created_at': upload.createdAt.toIso8601String(),
+        'file_exists': !kIsWeb && File(upload.localVideoPath).existsSync(),
+        // Network connectivity information
+        'network_type': getNetworkTypeString(connectivity),
+        'network_status': connectivity.toString(),
+        'is_offline': connectivity == ConnectivityResult.none,
+        'is_cellular': connectivity == ConnectivityResult.mobile,
+        'is_wifi': connectivity == ConnectivityResult.wifi,
+      };
+
+      if (metrics != null) {
+        context.addAll({
+          'file_size_mb': metrics.fileSizeMB,
+          'start_time': metrics.startTime.toIso8601String(),
+          'upload_duration_seconds': metrics.uploadDuration?.inSeconds,
+          'throughput_mbps': metrics.throughputMBps,
+          'metrics_retry_count': metrics.retryCount,
+        });
+      }
+
+      context.addAll({
+        'total_uploads': _store.length,
+        'active_uploads': _progressSubscriptions.length,
+        'queued_uploads': _store.queuedCount,
+        'platform': _getPlatformName(),
+        'is_initialized': isManagerInitialized,
+        'timestamp': DateTime.now().toIso8601String(),
+      });
+
+      for (final entry in context.entries) {
+        await crashReporting.setCustomKey(
+          'upload_failure_${entry.key}',
+          entry.value.toString(),
+        );
+      }
+
+      final stackTrace = StackTrace.current;
+
+      final fileExists = kIsWeb
+          ? 'N/A (web)'
+          : '${File(upload.localVideoPath).existsSync()}';
+      final detailedError =
+          '''
+Upload Failure Report:
+- Upload ID: ${upload.id}
+- Error Category: $errorCategory
+- Error: $error
+- Network: ${getNetworkTypeString(connectivity)} (${connectivity == ConnectivityResult.none ? 'OFFLINE' : 'ONLINE'})
+- File: ${upload.localVideoPath}
+- File Exists: $fileExists
+- Upload Status: ${upload.status}
+- Retry Count: ${upload.retryCount ?? 0}
+- Can Retry: ${upload.canRetry}
+- Circuit Breaker: ${_circuitBreaker.state} (${_circuitBreaker.failureRate}% failure rate)
+- Upload Target: blossomServer
+${metrics != null ? '- File Size: ${metrics.fileSizeMB} MB\n- Duration: ${metrics.uploadDuration}\n- Throughput: ${metrics.throughputMBps} MB/s' : ''}
+''';
+
+      crashReporting.log('UPLOAD_FAILURE: $detailedError');
+
+      await crashReporting.recordError(
+        error,
+        stackTrace,
+        reason: 'Video upload failure - $errorCategory',
+      );
+
+      Log.info(
+        '📊 Sent comprehensive upload failure report to Crashlytics',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    } catch (crashReportingError) {
+      Log.error(
+        'Failed to send crash report for upload failure: $crashReportingError',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  /// Send an initialization-failure report to Crashlytics.
+  Future<void> sendInitializationFailureCrashReport(
+    dynamic error,
+    StackTrace stackTrace,
+  ) async {
+    try {
+      final crashReporting = CrashReportingService.instance;
+
+      await crashReporting.setCustomKey('init_failure_error', error.toString());
+      await crashReporting.setCustomKey(
+        'init_failure_platform',
+        _getPlatformName(),
+      );
+      await crashReporting.setCustomKey(
+        'init_failure_timestamp',
+        DateTime.now().toIso8601String(),
+      );
+      await crashReporting.setCustomKey(
+        'init_failure_retry_attempts',
+        'multiple',
+      );
+
+      final detailedError =
+          '''
+UploadManager Initialization Failure:
+- Error: $error
+- Platform: ${_getPlatformName()}
+- Timestamp: ${DateTime.now().toIso8601String()}
+- Context: Failed after all retry attempts in UploadInitializationHelper
+''';
+
+      crashReporting.log('INIT_FAILURE: $detailedError');
+
+      await crashReporting.recordError(
+        error,
+        stackTrace,
+        reason: 'UploadManager initialization failure after retries',
+      );
+
+      Log.info(
+        '📊 Sent UploadManager initialization failure report to Crashlytics',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    } catch (crashReportingError) {
+      Log.error(
+        'Failed to send initialization crash report: $crashReportingError',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  /// Send an upload-timeout failure report to Crashlytics.
+  Future<void> sendTimeoutCrashReport(
+    PendingUpload upload,
+    TimeoutException timeoutError,
+  ) async {
+    try {
+      final crashReporting = CrashReportingService.instance;
+
+      final context = {
+        'timeout_upload_id': upload.id,
+        'timeout_file_path': upload.localVideoPath,
+        'timeout_upload_target': 'blossomServer',
+        'timeout_network_timeout_minutes':
+            _retryConfig.networkTimeout.inMinutes,
+        'timeout_retry_count': upload.retryCount ?? 0,
+        'timeout_upload_status': upload.status.toString(),
+        'timeout_platform': _getPlatformName(),
+        'timeout_file_exists':
+            !kIsWeb && File(upload.localVideoPath).existsSync(),
+        'timeout_timestamp': DateTime.now().toIso8601String(),
+      };
+
+      for (final entry in context.entries) {
+        await crashReporting.setCustomKey(entry.key, entry.value.toString());
+      }
+
+      final fileExists = kIsWeb
+          ? 'N/A (web)'
+          : '${File(upload.localVideoPath).existsSync()}';
+      final detailedError =
+          '''
+Upload Timeout Failure:
+- Upload ID: ${upload.id}
+- File: ${upload.localVideoPath}
+- File Exists: $fileExists
+- Upload Target: blossomServer
+- Timeout Duration: ${_retryConfig.networkTimeout.inMinutes} minutes
+- Retry Count: ${upload.retryCount ?? 0}
+- Upload Status: ${upload.status}
+- Platform: ${_getPlatformName()}
+- Timestamp: ${DateTime.now().toIso8601String()}
+''';
+
+      crashReporting.log('TIMEOUT_FAILURE: $detailedError');
+
+      await crashReporting.recordError(
+        timeoutError,
+        StackTrace.current,
+        reason:
+            'Video upload timeout after ${_retryConfig.networkTimeout.inMinutes} minutes',
+      );
+
+      Log.info(
+        '📊 Sent upload timeout failure report to Crashlytics',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    } catch (crashReportingError) {
+      Log.error(
+        'Failed to send timeout crash report: $crashReportingError',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Dispose
+  // ---------------------------------------------------------------------------
+
+  void dispose() {
+    for (final subscription in _progressSubscriptions.values) {
+      subscription.cancel();
+    }
+    _progressSubscriptions.clear();
+    _cleanupOldMetrics();
+    _uploadMetrics.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  Map<String, int> _getErrorCategoriesCount(List<UploadMetrics> failedMetrics) {
+    final categories = <String, int>{};
+    for (final metric in failedMetrics) {
+      final category = metric.errorCategory ?? 'UNKNOWN';
+      categories[category] = (categories[category] ?? 0) + 1;
+    }
+    return categories;
+  }
+
+  void _cleanupOldMetrics() {
+    final now = DateTime.now();
+    final cutoff = now.subtract(const Duration(days: 7));
+
+    _uploadMetrics.removeWhere(
+      (key, metric) => metric.startTime.isBefore(cutoff),
+    );
+  }
+
+  double _calculateThroughput(double fileSizeMB, Duration duration) {
+    if (duration.inMicroseconds == 0) {
+      return fileSizeMB * 1000; // Assume instant = 1ms
+    }
+    return fileSizeMB / (duration.inMicroseconds / 1000000.0);
+  }
+}

--- a/mobile/lib/services/upload/upload_retry_policy.dart
+++ b/mobile/lib/services/upload/upload_retry_policy.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload/upload_session_errors.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:openvine/utils/async_utils.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -21,7 +22,6 @@ class UploadRetryPolicy {
   final PendingUploadStore _store;
   final UploadRetryConfig _retryConfig;
 
-  final Map<String, Timer> _retryTimers = {};
   final Map<String, Future<void>> _sessionPersistFutures = {};
 
   // ---------------------------------------------------------------------------
@@ -33,6 +33,11 @@ class UploadRetryPolicy {
     Future<void> Function() executeUpload, {
     required bool Function(dynamic) isRetriable,
   }) async {
+    // Local-only counter for how many auto-attempts have been made in this
+    // call. Must NOT be persisted to Hive: PendingUpload.retryCount is the
+    // manual-retry budget (canRetry gates on retryCount < 3). Writing
+    // auto-attempt counts there would exhaust the budget and prevent the user
+    // from calling retryUpload() after a failed session.
     var autoAttempt = 0;
 
     try {
@@ -40,6 +45,8 @@ class UploadRetryPolicy {
         operation: () async {
           final currentUpload = _store.getUpload(upload.id) ?? upload;
 
+          // autoAttempt is local to this performWithRetry invocation and is
+          // never written to Hive, so the manual-retry budget is preserved.
           autoAttempt++;
           Log.warning(
             'Upload attempt $autoAttempt/${_retryConfig.maxRetries + 1} for ${currentUpload.id}',
@@ -52,6 +59,8 @@ class UploadRetryPolicy {
               status: autoAttempt == 1
                   ? UploadStatus.uploading
                   : UploadStatus.retrying,
+              // retryCount is intentionally left unchanged here — it is the
+              // manual-retry budget managed exclusively by retryUpload().
             ),
           );
 
@@ -156,6 +165,12 @@ class UploadRetryPolicy {
     unawaited(performUpload(resumed));
   }
 
+  /// Re-run a failed upload, resetting the manual-retry budget when the last
+  /// attempt is at least an hour old and otherwise incrementing it.
+  ///
+  /// Despite the name there is no backoff *timer* — the budget is the
+  /// "backoff": [performUpload] is invoked immediately and the 1-hour reset
+  /// window is what spaces out repeated manual retries.
   Future<void> retryUploadWithBackoff(
     String uploadId, {
     required Future<void> Function(PendingUpload) performUpload,
@@ -178,9 +193,6 @@ class UploadRetryPolicy {
       );
       return;
     }
-
-    _retryTimers[uploadId]?.cancel();
-    _retryTimers.remove(uploadId);
 
     Log.warning(
       'Retrying upload with backoff: $uploadId',
@@ -206,11 +218,16 @@ class UploadRetryPolicy {
   }
 
   bool isRetriableError(dynamic error) {
-    if (_isExpiredResumableSessionError(error)) {
+    if (isExpiredResumableSessionError(error)) {
       return false;
     }
 
+    // Use structured classification when available.
     if (error is BlossomUploadFailureException) {
+      // A transient inability to *produce* a signed auth header (the remote
+      // signer or its network path was briefly unreachable) is retriable —
+      // distinct from a permanent 401/403 rejection handled below. This is
+      // the fix for uploads that died on a momentary signer DNS blip.
       final reason = error.failureReason;
       if (reason == BlossomUploadFailureReason.authUnavailable ||
           reason == BlossomUploadFailureReason.network) {
@@ -223,22 +240,31 @@ class UploadRetryPolicy {
 
       final code = error.statusCode;
       if (code != null) {
+        // 408 request timeout — retriable
         if (code == 408) return true;
+        // 429 rate limited — retriable after backoff
         if (code == 429) return true;
+        // Transient server errors — retriable
         if (code == 500 || code == 502 || code == 503 || code == 504) {
           return true;
         }
+        // Other 5xx (501, 505, etc.) are permanent — not retriable
         if (code >= 500) return false;
+        // 4xx client errors are not retriable
         if (code >= 400) return false;
       }
     }
 
+    // Fall back to string matching for non-HTTP errors
     final errorStr = error.toString().toLowerCase();
 
+    // A missing required thumbnail already exhausted the image upload's own
+    // retry path; retrying here would re-upload the full video.
     if (errorStr.contains('thumbnail upload failed')) {
       return false;
     }
 
+    // Network and timeout errors are retriable
     if (errorStr.contains('timeout') ||
         errorStr.contains('cannot connect') ||
         errorStr.contains('network error') ||
@@ -247,23 +273,26 @@ class UploadRetryPolicy {
       return true;
     }
 
+    // File not found errors are not retriable
     if (errorStr.contains('file not found') ||
         errorStr.contains('does not exist')) {
       return false;
     }
 
+    // Permission and cancellation failures are permanent. Authentication is
+    // classified structurally above (failureReason / 401-403 statusCode): a
+    // failed auth-header *creation* is transient while a server *rejection*
+    // is not, and the bare substring 'auth' cannot tell them apart — so it
+    // no longer gates retries here.
     if (errorStr.contains('permission') || errorStr.contains('cancelled')) {
       return false;
     }
 
+    // Unknown errors are retriable by default
     return true;
   }
 
   void dispose() {
-    for (final timer in _retryTimers.values) {
-      timer.cancel();
-    }
-    _retryTimers.clear();
     _sessionPersistFutures.clear();
   }
 
@@ -289,15 +318,5 @@ class UploadRetryPolicy {
         uploadProgress: persistedProgress,
       ),
     );
-  }
-
-  bool _isExpiredResumableSessionError(dynamic error) {
-    if (error is BlossomResumableUploadException) {
-      return error.statusCode == 404 || error.statusCode == 410;
-    }
-
-    final errorMessage = error.toString().toLowerCase();
-    return errorMessage.contains('session expired') ||
-        errorMessage.contains('session is no longer available');
   }
 }

--- a/mobile/lib/services/upload/upload_retry_policy.dart
+++ b/mobile/lib/services/upload/upload_retry_policy.dart
@@ -1,0 +1,303 @@
+// ABOUTME: Retry policy for video uploads — owns exponential backoff, session
+// ABOUTME: persistence, and manual/automatic retry lifecycle for UploadManager.
+
+import 'dart:async';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/utils/async_utils.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Owns the retry and session-persistence concerns extracted from [UploadManager].
+class UploadRetryPolicy {
+  UploadRetryPolicy({
+    required PendingUploadStore store,
+    required UploadRetryConfig retryConfig,
+  }) : _store = store,
+       _retryConfig = retryConfig;
+
+  final PendingUploadStore _store;
+  final UploadRetryConfig _retryConfig;
+
+  final Map<String, Timer> _retryTimers = {};
+  final Map<String, Future<void>> _sessionPersistFutures = {};
+
+  // ---------------------------------------------------------------------------
+  // Public API
+  // ---------------------------------------------------------------------------
+
+  Future<void> performWithRetry(
+    PendingUpload upload,
+    Future<void> Function() executeUpload, {
+    required bool Function(dynamic) isRetriable,
+  }) async {
+    var autoAttempt = 0;
+
+    try {
+      await AsyncUtils.retryWithBackoff(
+        operation: () async {
+          final currentUpload = _store.getUpload(upload.id) ?? upload;
+
+          autoAttempt++;
+          Log.warning(
+            'Upload attempt $autoAttempt/${_retryConfig.maxRetries + 1} for ${currentUpload.id}',
+            name: 'UploadManager',
+            category: LogCategory.video,
+          );
+
+          await _store.update(
+            currentUpload.copyWith(
+              status: autoAttempt == 1
+                  ? UploadStatus.uploading
+                  : UploadStatus.retrying,
+            ),
+          );
+
+          await executeUpload();
+        },
+        maxRetries: _retryConfig.maxRetries,
+        baseDelay: _retryConfig.initialDelay,
+        maxDelay: _retryConfig.maxDelay,
+        backoffMultiplier: _retryConfig.backoffMultiplier,
+        retryWhen: isRetriable,
+        debugName: 'Upload-${upload.id}',
+      );
+    } catch (e) {
+      Log.error(
+        'Upload failed after all retries: $e',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+      rethrow;
+    }
+  }
+
+  void enqueueSessionPersist(
+    String uploadId,
+    BlossomResumableUploadSession session,
+    int fileSizeBytes,
+  ) {
+    final previous = _sessionPersistFutures[uploadId] ?? Future<void>.value();
+    _sessionPersistFutures[uploadId] = previous.then((_) async {
+      try {
+        await _storeResumableSessionProgress(uploadId, session, fileSizeBytes);
+      } catch (e, s) {
+        Log.error(
+          'Failed to persist resumable session progress for $uploadId: $e',
+          name: 'UploadManager',
+          category: LogCategory.video,
+          error: e,
+          stackTrace: s,
+        );
+      }
+    });
+  }
+
+  Future<void> retryUpload(
+    String uploadId, {
+    required Future<void> Function(PendingUpload) performUpload,
+  }) async {
+    final upload = _store.getUpload(uploadId);
+    if (upload == null) {
+      Log.error(
+        'Upload not found for retry: $uploadId',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    if (!upload.canRetry) {
+      Log.error(
+        'Upload cannot be retried: $uploadId (retries: ${upload.retryCount})',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    Log.warning(
+      'Retrying upload: $uploadId',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+
+    final nextRetryCount = (upload.retryCount ?? 0) + 1;
+    final resetUpload = upload.copyWith(
+      status: UploadStatus.pending,
+      retryCount: nextRetryCount,
+    );
+
+    await _store.update(resetUpload);
+    await performUpload(resetUpload);
+  }
+
+  void resumeInterruptedUpload(
+    String uploadId, {
+    required Future<void> Function(PendingUpload) performUpload,
+  }) {
+    final upload = _store.getUpload(uploadId);
+    if (upload == null) return;
+    if (upload.status != UploadStatus.uploading &&
+        upload.status != UploadStatus.retrying) {
+      return;
+    }
+
+    Log.info(
+      'Resuming interrupted upload: $uploadId',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+
+    final resumed = upload.copyWith(status: UploadStatus.uploading);
+    unawaited(_store.update(resumed));
+    unawaited(performUpload(resumed));
+  }
+
+  Future<void> retryUploadWithBackoff(
+    String uploadId, {
+    required Future<void> Function(PendingUpload) performUpload,
+  }) async {
+    final upload = _store.getUpload(uploadId);
+    if (upload == null) {
+      Log.warning(
+        'Upload not found for retry: $uploadId',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    if (upload.status != UploadStatus.failed) {
+      Log.error(
+        'Upload is not in failed state: ${upload.status}',
+        name: 'UploadManager',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
+    _retryTimers[uploadId]?.cancel();
+    _retryTimers.remove(uploadId);
+
+    Log.warning(
+      'Retrying upload with backoff: $uploadId',
+      name: 'UploadManager',
+      category: LogCategory.video,
+    );
+
+    final now = DateTime.now();
+    final timeSinceLastAttempt = upload.completedAt != null
+        ? now.difference(upload.completedAt!)
+        : now.difference(upload.createdAt);
+
+    final shouldResetRetries = timeSinceLastAttempt.inHours >= 1;
+    final newRetryCount = shouldResetRetries ? 1 : (upload.retryCount ?? 0) + 1;
+
+    final updatedUpload = upload.copyWith(
+      status: UploadStatus.pending,
+      retryCount: newRetryCount,
+    );
+
+    await _store.update(updatedUpload);
+    await performUpload(updatedUpload);
+  }
+
+  bool isRetriableError(dynamic error) {
+    if (_isExpiredResumableSessionError(error)) {
+      return false;
+    }
+
+    if (error is BlossomUploadFailureException) {
+      final reason = error.failureReason;
+      if (reason == BlossomUploadFailureReason.authUnavailable ||
+          reason == BlossomUploadFailureReason.network) {
+        return true;
+      }
+      if (reason == BlossomUploadFailureReason.auth ||
+          reason == BlossomUploadFailureReason.fileTooLarge) {
+        return false;
+      }
+
+      final code = error.statusCode;
+      if (code != null) {
+        if (code == 408) return true;
+        if (code == 429) return true;
+        if (code == 500 || code == 502 || code == 503 || code == 504) {
+          return true;
+        }
+        if (code >= 500) return false;
+        if (code >= 400) return false;
+      }
+    }
+
+    final errorStr = error.toString().toLowerCase();
+
+    if (errorStr.contains('thumbnail upload failed')) {
+      return false;
+    }
+
+    if (errorStr.contains('timeout') ||
+        errorStr.contains('cannot connect') ||
+        errorStr.contains('network error') ||
+        errorStr.contains('connection') ||
+        errorStr.contains('socket')) {
+      return true;
+    }
+
+    if (errorStr.contains('file not found') ||
+        errorStr.contains('does not exist')) {
+      return false;
+    }
+
+    if (errorStr.contains('permission') || errorStr.contains('cancelled')) {
+      return false;
+    }
+
+    return true;
+  }
+
+  void dispose() {
+    for (final timer in _retryTimers.values) {
+      timer.cancel();
+    }
+    _retryTimers.clear();
+    _sessionPersistFutures.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  Future<void> _storeResumableSessionProgress(
+    String uploadId,
+    BlossomResumableUploadSession session,
+    int fileSizeBytes,
+  ) async {
+    final upload = _store.getUpload(uploadId);
+    if (upload == null) return;
+
+    final persistedProgress = fileSizeBytes <= 0
+        ? upload.uploadProgress
+        : ((session.nextOffset / fileSizeBytes) * 0.8).clamp(0.0, 0.8);
+
+    await _store.update(
+      upload.copyWith(
+        resumableSession: session,
+        uploadProgress: persistedProgress,
+      ),
+    );
+  }
+
+  bool _isExpiredResumableSessionError(dynamic error) {
+    if (error is BlossomResumableUploadException) {
+      return error.statusCode == 404 || error.statusCode == 410;
+    }
+
+    final errorMessage = error.toString().toLowerCase();
+    return errorMessage.contains('session expired') ||
+        errorMessage.contains('session is no longer available');
+  }
+}

--- a/mobile/lib/services/upload/upload_session_errors.dart
+++ b/mobile/lib/services/upload/upload_session_errors.dart
@@ -1,0 +1,21 @@
+// ABOUTME: Shared predicate for detecting expired resumable-upload sessions,
+// ABOUTME: used by UploadRetryPolicy, UploadProgressReporter, and UploadManager.
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+
+/// Returns true if [error] represents an expired resumable-upload session — the
+/// server returned 404/410, or the message says the session is gone.
+///
+/// This predicate decides both whether the error is retriable *and* whether the
+/// resumable session is nulled on failure, so the two used to drift between
+/// independent copies in [UploadRetryPolicy] and [UploadProgressReporter]. It
+/// lives here as a single source of truth to keep those callers in lockstep.
+bool isExpiredResumableSessionError(dynamic error) {
+  if (error is BlossomResumableUploadException) {
+    return error.statusCode == 404 || error.statusCode == 410;
+  }
+
+  final errorMessage = error.toString().toLowerCase();
+  return errorMessage.contains('session expired') ||
+      errorMessage.contains('session is no longer available');
+}

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -14,26 +14,16 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/circuit_breaker_service.dart';
-import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload/upload_progress_reporter.dart';
+import 'package:openvine/services/upload/upload_retry_policy.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
-import 'package:openvine/utils/async_utils.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
-
-/// Get platform name for logging (web-safe)
-String _getPlatformName() {
-  if (kIsWeb) return 'web';
-  try {
-    return defaultTargetPlatform.name;
-  } catch (_) {
-    return 'unknown';
-  }
-}
 
 /// Exception thrown when a [BlossomUploadResult] indicates failure.
 ///
@@ -121,7 +111,17 @@ class UploadManager {
        _store = PendingUploadStore(
          scopeUploadsToCurrentUser: scopeUploadsToCurrentUser,
          currentNostrPubkey: currentNostrPubkey,
-       );
+       ) {
+    _retryPolicy = UploadRetryPolicy(
+      store: _store,
+      retryConfig: _retryConfig,
+    );
+    _reporter = UploadProgressReporter(
+      store: _store,
+      circuitBreaker: _circuitBreaker,
+      retryConfig: _retryConfig,
+    );
+  }
 
   // Core services
   final PendingUploadStore _store;
@@ -131,16 +131,14 @@ class UploadManager {
   final UploadRetryConfig _retryConfig;
   final Dio _dio = Dio();
 
-  // State tracking
-  final Map<String, StreamSubscription<double>> _progressSubscriptions = {};
-  final Map<String, UploadMetrics> _uploadMetrics = {};
-  final Map<String, Timer> _retryTimers = {};
+  // Extracted concerns
+  late final UploadRetryPolicy _retryPolicy;
+  late final UploadProgressReporter _reporter;
 
   // Processing-completion polls keyed by upload id, so dispose() can
   // cancel them — an untracked periodic timer would keep firing against
   // a disposed manager for up to 5 minutes.
   final Map<String, Timer> _processingPollTimers = {};
-  final Map<String, Future<void>> _sessionPersistFutures = {};
 
   bool _isInitialized = false;
 
@@ -210,7 +208,7 @@ class UploadManager {
       );
 
       // Send crash report for initialization failure
-      await _sendInitializationFailureCrashReport(e, stackTrace);
+      await _reporter.sendInitializationFailureCrashReport(e, stackTrace);
 
       // Don't rethrow - allow the app to continue and retry on demand
       // rethrow;
@@ -687,12 +685,15 @@ class UploadManager {
       category: LogCategory.video,
     );
 
-    _uploadMetrics[upload.id] = UploadMetrics(
-      uploadId: upload.id,
-      startTime: startTime,
-      retryCount: upload.retryCount ?? 0,
-      fileSizeMB: fileSizeMB,
-      wasSuccessful: false,
+    _reporter.recordStart(
+      upload.id,
+      UploadMetrics(
+        uploadId: upload.id,
+        startTime: startTime,
+        retryCount: upload.retryCount ?? 0,
+        fileSizeMB: fileSizeMB,
+        wasSuccessful: false,
+      ),
     );
 
     try {
@@ -712,77 +713,38 @@ class UploadManager {
     }
   }
 
-  /// Perform upload with exponential backoff retry using proper async patterns
+  /// Perform upload with exponential backoff retry using proper async patterns.
+  ///
+  /// Delegates retry orchestration to [UploadRetryPolicy]. The execute callback
+  /// re-fetches the current upload from the store on each attempt so resumable
+  /// session updates from prior chunk callbacks are picked up automatically.
   Future<void> _performUploadWithRetry(
     PendingUpload upload,
     File videoFile,
     ValueChanged<double>? onProgress,
   ) async {
-    // Local-only counter for how many auto-attempts have been made in this
-    // call. Must NOT be persisted to Hive: PendingUpload.retryCount is the
-    // manual-retry budget (canRetry gates on retryCount < 3). Writing
-    // auto-attempt counts there would exhaust the budget and prevent the user
-    // from calling retryUpload() after a failed session.
-    var autoAttempt = 0;
+    await _retryPolicy.performWithRetry(
+      upload,
+      () async {
+        final currentUpload = _store.getUpload(upload.id) ?? upload;
 
-    try {
-      await AsyncUtils.retryWithBackoff(
-        operation: () async {
-          final currentUpload = getUpload(upload.id) ?? upload;
+        // Validate file still exists
+        if (!videoFile.existsSync()) {
+          throw Exception('Video file not found: ${upload.localVideoPath}');
+        }
 
-          // NOTE: Circuit breaker removed from upload flow - it was blocking legitimate retries
-          // Uploads already have proper retry logic with exponential backoff
-          // Users should be able to retry uploads even if previous attempts failed
+        // Execute upload with timeout
+        final result = await _executeUploadWithTimeout(
+          currentUpload,
+          videoFile,
+          onProgress,
+        );
 
-          // autoAttempt is local to this _performUploadWithRetry invocation and
-          // is never written to Hive, so the manual-retry budget is preserved.
-          autoAttempt++;
-          Log.warning(
-            'Upload attempt $autoAttempt/${_retryConfig.maxRetries + 1} for ${currentUpload.id}',
-            name: 'UploadManager',
-            category: LogCategory.video,
-          );
-
-          await _store.update(
-            currentUpload.copyWith(
-              status: autoAttempt == 1
-                  ? UploadStatus.uploading
-                  : UploadStatus.retrying,
-              // retryCount is intentionally left unchanged here — it is the
-              // manual-retry budget managed exclusively by retryUpload().
-            ),
-          );
-
-          // Validate file still exists
-          if (!videoFile.existsSync()) {
-            throw Exception('Video file not found: ${upload.localVideoPath}');
-          }
-
-          // Execute upload with timeout
-          final result = await _executeUploadWithTimeout(
-            currentUpload,
-            videoFile,
-            onProgress,
-          );
-
-          // Success - record metrics and complete
-          await _handleUploadSuccess(currentUpload, result);
-        },
-        maxRetries: _retryConfig.maxRetries,
-        baseDelay: _retryConfig.initialDelay,
-        maxDelay: _retryConfig.maxDelay,
-        backoffMultiplier: _retryConfig.backoffMultiplier,
-        retryWhen: isRetriableError,
-        debugName: 'Upload-${upload.id}',
-      );
-    } catch (e) {
-      Log.error(
-        'Upload failed after all retries: $e',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-      rethrow;
-    }
+        // Success - record metrics and complete
+        await _handleUploadSuccess(currentUpload, result);
+      },
+      isRetriable: _retryPolicy.isRetriableError,
+    );
   }
 
   /// Execute upload with timeout and progress tracking
@@ -861,7 +823,7 @@ class UploadManager {
             proofManifestJson: upload.proofManifestJson,
             resumableSession: upload.resumableSession,
             onResumableSessionUpdated: (session) {
-              _enqueueSessionPersist(
+              _retryPolicy.enqueueSessionPersist(
                 upload.id,
                 session,
                 videoFile.lengthSync(),
@@ -870,7 +832,7 @@ class UploadManager {
             onProgress: (value) {
               final progress = value * 0.8; // Reserve 20% for thumbnail
 
-              _updateUploadProgress(upload.id, progress);
+              _reporter.updateProgress(upload.id, progress);
               onProgress?.call(progress);
             },
           )
@@ -887,13 +849,15 @@ class UploadManager {
               );
 
               // Send timeout crash report asynchronously
-              _sendTimeoutCrashReport(upload, timeoutError).catchError((e) {
-                Log.error(
-                  'Failed to send timeout crash report: $e',
-                  name: 'UploadManager',
-                  category: LogCategory.video,
-                );
-              });
+              _reporter.sendTimeoutCrashReport(upload, timeoutError).catchError(
+                (e) {
+                  Log.error(
+                    'Failed to send timeout crash report: $e',
+                    name: 'UploadManager',
+                    category: LogCategory.video,
+                  );
+                },
+              );
 
               throw timeoutError;
             },
@@ -940,7 +904,7 @@ class UploadManager {
       }
 
       if (result.success) {
-        _updateUploadProgress(upload.id, 1.0);
+        _reporter.updateProgress(upload.id, 1.0);
         onProgress?.call(1.0);
       }
 
@@ -971,7 +935,7 @@ class UploadManager {
     dynamic result,
   ) async {
     final endTime = DateTime.now();
-    final metrics = _uploadMetrics[upload.id];
+    final metrics = _reporter.metricsFor(upload.id);
 
     if (result.success == true) {
       // Get the LATEST upload record from Hive (may have been updated with thumbnail URL)
@@ -983,15 +947,15 @@ class UploadManager {
 
       // Record successful metrics
       if (metrics != null) {
-        final updatedMetrics = _createSuccessMetrics(
+        final updatedMetrics = _reporter.createSuccessMetrics(
           metrics,
           endTime,
           upload.retryCount ?? 0,
         );
-        _uploadMetrics[upload.id] = updatedMetrics;
+        _reporter.recordSuccess(upload.id, updatedMetrics);
 
         // Log success with formatted output
-        _logUploadSuccess(result, updatedMetrics);
+        _reporter.logUploadSuccess(result, updatedMetrics);
       }
 
       // If upload is in processing state, start polling for completion
@@ -1010,13 +974,13 @@ class UploadManager {
   /// Handle upload failure with comprehensive crash reporting
   Future<void> _handleUploadFailure(PendingUpload upload, dynamic error) async {
     final endTime = DateTime.now();
-    final metrics = _uploadMetrics[upload.id];
+    final metrics = _reporter.metricsFor(upload.id);
     final latestUpload = getUpload(upload.id) ?? upload;
 
     // Check network connectivity and categorize error
-    final connectivity = await _checkNetworkConnectivity();
-    final errorCategory = await categorizeError(error);
-    final userMessage = getUserFriendlyErrorMessage(
+    final connectivity = await _reporter.checkNetworkConnectivity();
+    final errorCategory = await _reporter.categorizeError(error);
+    final userMessage = _reporter.getUserFriendlyErrorMessage(
       errorCategory,
       connectivity,
     );
@@ -1032,7 +996,7 @@ class UploadManager {
       category: LogCategory.video,
     );
     Log.error(
-      'Network: ${getNetworkTypeString(connectivity)}',
+      'Network: ${_reporter.getNetworkTypeString(connectivity)}',
       name: 'UploadManager',
       category: LogCategory.video,
     );
@@ -1043,12 +1007,13 @@ class UploadManager {
     );
 
     // Send comprehensive crash report to Crashlytics with network state
-    await _sendUploadFailureCrashReport(
+    await _reporter.sendUploadFailureCrashReport(
       upload,
       error,
       errorCategory,
       metrics,
       connectivity,
+      isManagerInitialized: _isInitialized,
     );
 
     // Store user-friendly error message instead of raw exception
@@ -1057,7 +1022,7 @@ class UploadManager {
         status: UploadStatus.failed,
         errorMessage: userMessage,
         retryCount: latestUpload.retryCount ?? 0,
-        resumableSession: _isExpiredResumableSessionError(error)
+        resumableSession: _reporter.isExpiredResumableSessionError(error)
             ? null
             : latestUpload.resumableSession,
       ),
@@ -1065,341 +1030,46 @@ class UploadManager {
 
     // Record failure metrics
     if (metrics != null) {
-      _uploadMetrics[upload.id] = UploadMetrics(
-        uploadId: upload.id,
-        startTime: metrics.startTime,
-        endTime: endTime,
-        uploadDuration: endTime.difference(metrics.startTime),
-        retryCount: latestUpload.retryCount ?? 0,
-        fileSizeMB: metrics.fileSizeMB,
-        errorCategory: errorCategory,
-        wasSuccessful: false,
+      _reporter.recordFailure(
+        upload.id,
+        UploadMetrics(
+          uploadId: upload.id,
+          startTime: metrics.startTime,
+          endTime: endTime,
+          uploadDuration: endTime.difference(metrics.startTime),
+          retryCount: latestUpload.retryCount ?? 0,
+          fileSizeMB: metrics.fileSizeMB,
+          errorCategory: errorCategory,
+          wasSuccessful: false,
+        ),
       );
     }
   }
 
-  Future<void> _storeResumableSessionProgress(
-    String uploadId,
-    BlossomResumableUploadSession session,
-    int fileSizeBytes,
-  ) async {
-    final upload = getUpload(uploadId);
-    if (upload == null) {
-      return;
-    }
+  // ---------------------------------------------------------------------------
+  // Thin delegators for moved methods (keep @visibleForTesting annotations)
+  // ---------------------------------------------------------------------------
 
-    final persistedProgress = fileSizeBytes <= 0
-        ? upload.uploadProgress
-        : ((session.nextOffset / fileSizeBytes) * 0.8).clamp(0.0, 0.8);
-
-    await _store.update(
-      upload.copyWith(
-        resumableSession: session,
-        uploadProgress: persistedProgress,
-      ),
-    );
-  }
-
-  /// Enqueues a session persistence write so that rapid chunk callbacks
-  /// are serialized per upload, preventing interleaved Hive writes.
-  void _enqueueSessionPersist(
-    String uploadId,
-    BlossomResumableUploadSession session,
-    int fileSizeBytes,
-  ) {
-    final previous = _sessionPersistFutures[uploadId] ?? Future<void>.value();
-    _sessionPersistFutures[uploadId] = previous.then((_) async {
-      try {
-        await _storeResumableSessionProgress(uploadId, session, fileSizeBytes);
-      } catch (e, s) {
-        Log.error(
-          'Failed to persist resumable session progress for $uploadId: $e',
-          name: 'UploadManager',
-          category: LogCategory.video,
-          error: e,
-          stackTrace: s,
-        );
-      }
-    });
-  }
-
-  bool _isExpiredResumableSessionError(dynamic error) {
-    if (error is BlossomResumableUploadException) {
-      return error.statusCode == 404 || error.statusCode == 410;
-    }
-
-    final errorMessage = error.toString().toLowerCase();
-    return errorMessage.contains('session expired') ||
-        errorMessage.contains('session is no longer available');
-  }
-
-  /// Check if error is retriable
+  /// Delegates to [UploadRetryPolicy.isRetriableError].
   @visibleForTesting
-  bool isRetriableError(dynamic error) {
-    if (_isExpiredResumableSessionError(error)) {
-      return false;
-    }
+  bool isRetriableError(dynamic error) => _retryPolicy.isRetriableError(error);
 
-    // Use structured classification when available.
-    if (error is BlossomUploadFailureException) {
-      // A transient inability to *produce* a signed auth header (the remote
-      // signer or its network path was briefly unreachable) is retriable —
-      // distinct from a permanent 401/403 rejection handled below. This is
-      // the fix for uploads that died on a momentary signer DNS blip.
-      final reason = error.failureReason;
-      if (reason == BlossomUploadFailureReason.authUnavailable ||
-          reason == BlossomUploadFailureReason.network) {
-        return true;
-      }
-      if (reason == BlossomUploadFailureReason.auth ||
-          reason == BlossomUploadFailureReason.fileTooLarge) {
-        return false;
-      }
-
-      final code = error.statusCode;
-      if (code != null) {
-        // 408 request timeout — retriable
-        if (code == 408) return true;
-        // 429 rate limited — retriable after backoff
-        if (code == 429) return true;
-        // Transient server errors — retriable
-        if (code == 500 || code == 502 || code == 503 || code == 504) {
-          return true;
-        }
-        // Other 5xx (501, 505, etc.) are permanent — not retriable
-        if (code >= 500) return false;
-        // 4xx client errors are not retriable
-        if (code >= 400) return false;
-      }
-    }
-
-    // Fall back to string matching for non-HTTP errors
-    final errorStr = error.toString().toLowerCase();
-
-    // A missing required thumbnail already exhausted the image upload's own
-    // retry path; retrying here would re-upload the full video.
-    if (errorStr.contains('thumbnail upload failed')) {
-      return false;
-    }
-
-    // Network and timeout errors are retriable
-    if (errorStr.contains('timeout') ||
-        errorStr.contains('cannot connect') ||
-        errorStr.contains('network error') ||
-        errorStr.contains('connection') ||
-        errorStr.contains('socket')) {
-      return true;
-    }
-
-    // File not found errors are not retriable
-    if (errorStr.contains('file not found') ||
-        errorStr.contains('does not exist')) {
-      return false;
-    }
-
-    // Permission and cancellation failures are permanent. Authentication is
-    // classified structurally above (failureReason / 401-403 statusCode): a
-    // failed auth-header *creation* is transient while a server *rejection*
-    // is not, and the bare substring 'auth' cannot tell them apart — so it
-    // no longer gates retries here.
-    if (errorStr.contains('permission') || errorStr.contains('cancelled')) {
-      return false;
-    }
-
-    // Unknown errors are retriable by default
-    return true;
-  }
-
-  /// Check network connectivity status
-  Future<ConnectivityResult> _checkNetworkConnectivity() async {
-    try {
-      final connectivity = Connectivity();
-      final result = await connectivity.checkConnectivity();
-
-      // connectivity_plus 7.x returns List<ConnectivityResult>
-      // Return first non-none result, or none if all are none
-      final resultList = result.cast<ConnectivityResult>();
-      // Prefer WiFi > Cellular > Ethernet > VPN > None
-      if (resultList.contains(ConnectivityResult.wifi)) {
-        return ConnectivityResult.wifi;
-      }
-      if (resultList.contains(ConnectivityResult.mobile)) {
-        return ConnectivityResult.mobile;
-      }
-      if (resultList.contains(ConnectivityResult.ethernet)) {
-        return ConnectivityResult.ethernet;
-      }
-      if (resultList.contains(ConnectivityResult.vpn)) {
-        return ConnectivityResult.vpn;
-      }
-      return ConnectivityResult.none;
-    } catch (e) {
-      Log.error(
-        'Failed to check network connectivity: $e',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-      return ConnectivityResult.none;
-    }
-  }
-
-  /// Get human-readable network type
+  /// Delegates to [UploadProgressReporter.getNetworkTypeString].
   @visibleForTesting
-  String getNetworkTypeString(ConnectivityResult connectivity) {
-    switch (connectivity) {
-      case ConnectivityResult.wifi:
-        return 'WiFi';
-      case ConnectivityResult.mobile:
-        return 'Cellular';
-      case ConnectivityResult.ethernet:
-        return 'Ethernet';
-      case ConnectivityResult.vpn:
-        return 'VPN';
-      case ConnectivityResult.none:
-        return 'Offline';
-      default:
-        return 'Unknown';
-    }
-  }
+  String getNetworkTypeString(ConnectivityResult connectivity) =>
+      _reporter.getNetworkTypeString(connectivity);
 
-  /// Categorize error for monitoring with network-aware detection
+  /// Delegates to [UploadProgressReporter.categorizeError].
   @visibleForTesting
-  Future<String> categorizeError(dynamic error) async {
-    if (_isExpiredResumableSessionError(error)) {
-      return 'UPLOAD_SESSION_EXPIRED';
-    }
+  Future<String> categorizeError(dynamic error) =>
+      _reporter.categorizeError(error);
 
-    // Check network connectivity for better categorization
-    final connectivity = await _checkNetworkConnectivity();
-
-    // No internet connection
-    if (connectivity == ConnectivityResult.none) {
-      return 'NO_INTERNET';
-    }
-
-    // Use structured classification when available.
-    if (error is BlossomUploadFailureException) {
-      // A failure to *produce* the signed auth header (the signer was briefly
-      // unreachable) is a connectivity problem, not a server rejection. It
-      // carries no HTTP status, so classify it on the typed reason and surface
-      // the retry-friendly network copy instead of the generic UNKNOWN message.
-      if (error.failureReason == BlossomUploadFailureReason.authUnavailable) {
-        return 'NETWORK_ERROR';
-      }
-
-      final code = error.statusCode;
-      if (code != null) {
-        if (code == 408) return 'TIMEOUT';
-        if (code == 413) return 'FILE_TOO_LARGE';
-        if (code == 429) return 'RATE_LIMITED';
-        if (code == 401 || code == 403) return 'AUTHENTICATION';
-        if (code == 502 || code == 503 || code == 504) {
-          return 'SERVER_UNAVAILABLE';
-        }
-        if (code >= 500) return 'SERVER_ERROR';
-        if (code >= 400) return 'CLIENT_ERROR';
-      }
-    }
-
-    // Fall back to string matching for non-HTTP errors
-    // (timeouts, connection errors, DNS, etc.)
-    final errorStr = error.toString().toLowerCase();
-
-    // Timeout variants from BlossomUploadService
-    if (errorStr.contains('timeout')) {
-      if (connectivity == ConnectivityResult.mobile) {
-        return 'SLOW_CONNECTION';
-      }
-      return 'TIMEOUT';
-    }
-
-    if (errorStr.contains('host') || errorStr.contains('dns')) {
-      return 'DNS_ERROR';
-    }
-
-    // "Cannot connect to Blossom server" or generic "Network error:"
-    if (errorStr.contains('cannot connect') ||
-        errorStr.contains('network error') ||
-        errorStr.contains('connection')) {
-      return 'NETWORK_ERROR';
-    }
-
-    // File errors
-    if (errorStr.contains('file not found')) return 'FILE_NOT_FOUND';
-    if (errorStr.contains('memory')) return 'OUT_OF_MEMORY';
-    if (errorStr.contains('permission')) return 'PERMISSION_DENIED';
-
-    return 'UNKNOWN';
-  }
-
-  /// Get user-friendly error message based on category
+  /// Delegates to [UploadProgressReporter.getUserFriendlyErrorMessage].
   @visibleForTesting
   String getUserFriendlyErrorMessage(
     String category,
     ConnectivityResult connectivity,
-  ) {
-    switch (category) {
-      case 'NO_INTERNET':
-        return 'No internet connection. Check your WiFi or cellular data and try again.';
-
-      case 'SLOW_CONNECTION':
-        return 'Upload timed out on cellular data. Try connecting to WiFi for faster uploads.';
-
-      case 'TIMEOUT':
-        return 'Upload timed out. Your connection might be slow. Try again or connect to WiFi.';
-
-      case 'NETWORK_ERROR':
-        final networkType = getNetworkTypeString(connectivity);
-        return 'Network error on $networkType. Check your connection and try again.';
-
-      case 'DNS_ERROR':
-        return 'Could not reach the upload server. Check your connection or try a different network.';
-
-      case 'FILE_NOT_FOUND':
-        return 'Video file not found. Please record the video again.';
-
-      case 'FILE_TOO_LARGE':
-        return 'Video is too large to upload. Try recording a shorter video.';
-
-      case 'OUT_OF_MEMORY':
-        return 'Not enough memory to upload. Close other apps and try again.';
-
-      case 'PERMISSION_DENIED':
-        return 'Permission denied. Check app permissions in Settings.';
-
-      case 'AUTHENTICATION':
-        return 'Authentication failed. Please sign in again.';
-
-      case 'UPLOAD_SESSION_EXPIRED':
-        return 'Upload session expired. Please retry the upload.';
-
-      case 'RATE_LIMITED':
-        return 'Too many uploads. Please wait a moment and try again.';
-
-      case 'SERVER_UNAVAILABLE':
-        return 'Upload server is temporarily unavailable. '
-            'It will retry automatically.';
-
-      case 'SERVER_ERROR':
-        return 'Upload server encountered an error. Please try again later.';
-
-      case 'CLIENT_ERROR':
-        return 'Upload request failed. Please try again.';
-
-      default:
-        return 'Upload failed. Please check your connection and try again.';
-    }
-  }
-
-  /// Update upload progress
-  void _updateUploadProgress(String uploadId, double progress) {
-    final upload = getUpload(uploadId);
-    if (upload != null &&
-        (upload.status == UploadStatus.uploading ||
-            upload.status == UploadStatus.retrying)) {
-      _store.update(upload.copyWith(uploadProgress: progress));
-    }
-  }
+  ) => _reporter.getUserFriendlyErrorMessage(category, connectivity);
 
   /// Pause an active upload
   Future<void> pauseUpload(String uploadId) async {
@@ -1440,8 +1110,7 @@ class UploadManager {
     await _store.update(pausedUpload);
 
     // Cancel progress subscription
-    _progressSubscriptions[uploadId]?.cancel();
-    _progressSubscriptions.remove(uploadId);
+    _reporter.cancelAndRemoveSubscription(uploadId);
 
     Log.info(
       'Upload paused: $uploadId',
@@ -1497,70 +1166,24 @@ class UploadManager {
     );
   }
 
-  /// Retry a failed upload
+  /// Retry a failed upload. Delegates to [UploadRetryPolicy.retryUpload].
   Future<void> retryUpload(String uploadId) async {
-    final upload = getUpload(uploadId);
-    if (upload == null) {
-      Log.error(
-        'Upload not found for retry: $uploadId',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-      return;
-    }
-
-    if (!upload.canRetry) {
-      Log.error(
-        'Upload cannot be retried: $uploadId (retries: ${upload.retryCount})',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-      return;
-    }
-
-    Log.warning(
-      'Retrying upload: $uploadId',
-      name: 'UploadManager',
-      category: LogCategory.video,
+    await _retryPolicy.retryUpload(
+      uploadId,
+      performUpload: _performUpload,
     );
-
-    // retryCount tracks user-triggered retries, so consume one budget slot
-    // before starting a new upload session.
-    final nextRetryCount = (upload.retryCount ?? 0) + 1;
-    final resetUpload = upload.copyWith(
-      status: UploadStatus.pending,
-      retryCount: nextRetryCount,
-    );
-
-    await _store.update(resetUpload);
-
-    // Start upload again and wait for completion
-    await _performUpload(resetUpload);
   }
 
   /// Resumes a single interrupted upload.
   ///
   /// For uploads left in [UploadStatus.uploading] or
-  /// [UploadStatus.retrying] after an app restart. The upload's
-  /// [BlossomResumableUploadSession] (if present) is passed through to
-  /// [BlossomUploadService.uploadVideo] automatically by [_performUpload].
+  /// [UploadStatus.retrying] after an app restart. Delegates to
+  /// [UploadRetryPolicy.resumeInterruptedUpload].
   void resumeInterruptedUpload(String uploadId) {
-    final upload = getUpload(uploadId);
-    if (upload == null) return;
-    if (upload.status != UploadStatus.uploading &&
-        upload.status != UploadStatus.retrying) {
-      return;
-    }
-
-    Log.info(
-      'Resuming interrupted upload: $uploadId',
-      name: 'UploadManager',
-      category: LogCategory.video,
+    _retryPolicy.resumeInterruptedUpload(
+      uploadId,
+      performUpload: _performUpload,
     );
-
-    final resumed = upload.copyWith(status: UploadStatus.uploading);
-    unawaited(_store.update(resumed));
-    unawaited(_performUpload(resumed));
   }
 
   /// Cancel an upload (stops the upload but keeps it for retry)
@@ -1588,8 +1211,7 @@ class UploadManager {
     await _store.update(cancelledUpload);
 
     // Cancel progress subscription
-    _progressSubscriptions[uploadId]?.cancel();
-    _progressSubscriptions.remove(uploadId);
+    _reporter.cancelAndRemoveSubscription(uploadId);
 
     Log.warning(
       'Upload cancelled and available for retry: $uploadId',
@@ -1640,105 +1262,18 @@ class UploadManager {
   Future<void> cleanupProblematicUploads() =>
       _store.cleanupProblematicUploads();
 
-  /// Get comprehensive performance metrics
-  Map<String, dynamic> getPerformanceMetrics() {
-    final metrics = _uploadMetrics.values.toList();
-    final successful = metrics.where((m) => m.wasSuccessful).toList();
-    final failed = metrics.where((m) => !m.wasSuccessful).toList();
+  /// Delegates to [UploadProgressReporter.getPerformanceMetrics].
+  Map<String, dynamic> getPerformanceMetrics() =>
+      _reporter.getPerformanceMetrics();
 
-    return {
-      'total_uploads': metrics.length,
-      'successful_uploads': successful.length,
-      'failed_uploads': failed.length,
-      'success_rate': metrics.isNotEmpty
-          ? (successful.length / metrics.length * 100)
-          : 0,
-      'average_throughput_mbps': successful.isNotEmpty
-          ? successful
-                    .map((m) => m.throughputMBps ?? 0)
-                    .reduce((a, b) => a + b) /
-                successful.length
-          : 0,
-      'average_retry_count': metrics.isNotEmpty
-          ? metrics.map((m) => m.retryCount).reduce((a, b) => a + b) /
-                metrics.length
-          : 0,
-      'error_categories': _getErrorCategoriesCount(failed),
-      'circuit_breaker_state': _circuitBreaker.state.toString(),
-      'circuit_breaker_failure_rate': _circuitBreaker.failureRate,
-    };
-  }
-
-  /// Get error categories breakdown
-  Map<String, int> _getErrorCategoriesCount(List<UploadMetrics> failedMetrics) {
-    final categories = <String, int>{};
-    for (final metric in failedMetrics) {
-      final category = metric.errorCategory ?? 'UNKNOWN';
-      categories[category] = (categories[category] ?? 0) + 1;
-    }
-    return categories;
-  }
-
-  /// Clear old metrics to prevent memory bloat
-  void _cleanupOldMetrics() {
-    final now = DateTime.now();
-    final cutoff = now.subtract(const Duration(days: 7)); // Keep 1 week
-
-    _uploadMetrics.removeWhere(
-      (key, metric) => metric.startTime.isBefore(cutoff),
-    );
-  }
-
-  /// Enhanced retry mechanism for manual retry
+  /// Enhanced retry mechanism for manual retry.
+  ///
+  /// Delegates to [UploadRetryPolicy.retryUploadWithBackoff].
   Future<void> retryUploadWithBackoff(String uploadId) async {
-    final upload = getUpload(uploadId);
-    if (upload == null) {
-      Log.warning(
-        'Upload not found for retry: $uploadId',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-      return;
-    }
-
-    if (upload.status != UploadStatus.failed) {
-      Log.error(
-        'Upload is not in failed state: ${upload.status}',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-      return;
-    }
-
-    // Cancel any existing retry timer
-    _retryTimers[uploadId]?.cancel();
-    _retryTimers.remove(uploadId);
-
-    Log.warning(
-      'Retrying upload with backoff: $uploadId',
-      name: 'UploadManager',
-      category: LogCategory.video,
+    await _retryPolicy.retryUploadWithBackoff(
+      uploadId,
+      performUpload: _performUpload,
     );
-
-    // Reset retry count if it's been more than 1 hour since last attempt
-    final now = DateTime.now();
-    final timeSinceLastAttempt = upload.completedAt != null
-        ? now.difference(upload.completedAt!)
-        : now.difference(upload.createdAt);
-
-    final shouldResetRetries = timeSinceLastAttempt.inHours >= 1;
-    final newRetryCount = shouldResetRetries ? 1 : (upload.retryCount ?? 0) + 1;
-
-    // Update upload with reset retry count if applicable
-    final updatedUpload = upload.copyWith(
-      status: UploadStatus.pending,
-      retryCount: newRetryCount,
-    );
-
-    await _store.update(updatedUpload);
-
-    // Start upload process
-    await _performUpload(updatedUpload);
   }
 
   /// Create successful upload with metadata
@@ -1882,305 +1417,6 @@ class UploadManager {
         _isHttpUrl(existingThumbnailUrl);
   }
 
-  /// Create success metrics with calculated values
-  UploadMetrics _createSuccessMetrics(
-    UploadMetrics currentMetrics,
-    DateTime endTime,
-    int retryCount,
-  ) {
-    final duration = endTime.difference(currentMetrics.startTime);
-    final throughput = _calculateThroughput(
-      currentMetrics.fileSizeMB,
-      duration,
-    );
-
-    return UploadMetrics(
-      uploadId: currentMetrics.uploadId,
-      startTime: currentMetrics.startTime,
-      endTime: endTime,
-      uploadDuration: duration,
-      retryCount: retryCount,
-      fileSizeMB: currentMetrics.fileSizeMB,
-      throughputMBps: throughput,
-      wasSuccessful: true,
-    );
-  }
-
-  /// Calculate upload throughput in MB/s
-  double _calculateThroughput(double fileSizeMB, Duration duration) {
-    // Handle zero duration edge case
-    if (duration.inMicroseconds == 0) {
-      return fileSizeMB * 1000; // Assume instant = 1ms
-    }
-    return fileSizeMB / (duration.inMicroseconds / 1000000.0);
-  }
-
-  /// Log upload success with formatted details
-  void _logUploadSuccess(dynamic result, UploadMetrics metrics) {
-    Log.info(
-      'Direct upload successful: ${result.videoId}',
-      name: 'UploadManager',
-      category: LogCategory.video,
-    );
-    Log.debug(
-      '🎬 CDN URL: ${result.cdnUrl}',
-      name: 'UploadManager',
-      category: LogCategory.video,
-    );
-
-    final durationStr = metrics.uploadDuration?.inSeconds ?? 0;
-    final throughputStr = metrics.throughputMBps?.toStringAsFixed(2) ?? '0.00';
-
-    Log.debug(
-      'Upload metrics: ${metrics.fileSizeMB.toStringAsFixed(1)}MB in ${durationStr}s ($throughputStr MB/s)',
-      name: 'UploadManager',
-      category: LogCategory.video,
-    );
-  }
-
-  /// Send comprehensive upload failure crash report to Crashlytics
-  Future<void> _sendUploadFailureCrashReport(
-    PendingUpload upload,
-    dynamic error,
-    String errorCategory,
-    UploadMetrics? metrics,
-    ConnectivityResult connectivity,
-  ) async {
-    try {
-      final crashReporting = CrashReportingService.instance;
-
-      // Set context for the crash report
-      final context = {
-        'upload_id': upload.id,
-        'upload_status': upload.status.toString(),
-        'error_category': errorCategory,
-        'retry_count': upload.retryCount ?? 0,
-        'can_retry': upload.canRetry,
-        'upload_target': 'blossomServer',
-        'circuit_breaker_state': _circuitBreaker.state.toString(),
-        'circuit_breaker_failure_rate': _circuitBreaker.failureRate,
-        'local_file_path': upload.localVideoPath,
-        'video_id': upload.videoId,
-        'cdn_url': upload.cdnUrl,
-        'upload_progress': upload.uploadProgress,
-        'created_at': upload.createdAt.toIso8601String(),
-        'file_exists': !kIsWeb && File(upload.localVideoPath).existsSync(),
-        // Network connectivity information
-        'network_type': getNetworkTypeString(connectivity),
-        'network_status': connectivity.toString(),
-        'is_offline': connectivity == ConnectivityResult.none,
-        'is_cellular': connectivity == ConnectivityResult.mobile,
-        'is_wifi': connectivity == ConnectivityResult.wifi,
-      };
-
-      // Add metrics if available
-      if (metrics != null) {
-        context.addAll({
-          'file_size_mb': metrics.fileSizeMB,
-          'start_time': metrics.startTime.toIso8601String(),
-          'upload_duration_seconds': metrics.uploadDuration?.inSeconds,
-          'throughput_mbps': metrics.throughputMBps,
-          'metrics_retry_count': metrics.retryCount,
-        });
-      }
-
-      // Add system context
-      context.addAll({
-        'total_uploads': _store.length,
-        'active_uploads': _progressSubscriptions.length,
-        'queued_uploads': _store.queuedCount,
-        'platform': _getPlatformName(),
-        'is_initialized': _isInitialized,
-        'timestamp': DateTime.now().toIso8601String(),
-      });
-
-      // Set all context as custom keys
-      for (final entry in context.entries) {
-        await crashReporting.setCustomKey(
-          'upload_failure_${entry.key}',
-          entry.value.toString(),
-        );
-      }
-
-      // Get stack trace from current context
-      final stackTrace = StackTrace.current;
-
-      // Create detailed error message
-      final fileExists = kIsWeb
-          ? 'N/A (web)'
-          : '${File(upload.localVideoPath).existsSync()}';
-      final detailedError =
-          '''
-Upload Failure Report:
-- Upload ID: ${upload.id}
-- Error Category: $errorCategory
-- Error: $error
-- Network: ${getNetworkTypeString(connectivity)} (${connectivity == ConnectivityResult.none ? 'OFFLINE' : 'ONLINE'})
-- File: ${upload.localVideoPath}
-- File Exists: $fileExists
-- Upload Status: ${upload.status}
-- Retry Count: ${upload.retryCount ?? 0}
-- Can Retry: ${upload.canRetry}
-- Circuit Breaker: ${_circuitBreaker.state} (${_circuitBreaker.failureRate}% failure rate)
-- Upload Target: blossomServer
-${metrics != null ? '- File Size: ${metrics.fileSizeMB} MB\n- Duration: ${metrics.uploadDuration}\n- Throughput: ${metrics.throughputMBps} MB/s' : ''}
-''';
-
-      // Log the detailed error
-      crashReporting.log('UPLOAD_FAILURE: $detailedError');
-
-      // Record the error to Crashlytics
-      await crashReporting.recordError(
-        error,
-        stackTrace,
-        reason: 'Video upload failure - $errorCategory',
-      );
-
-      Log.info(
-        '📊 Sent comprehensive upload failure report to Crashlytics',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    } catch (crashReportingError) {
-      // Don't let crash reporting failures break the upload failure handling
-      Log.error(
-        'Failed to send crash report for upload failure: $crashReportingError',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    }
-  }
-
-  /// Send initialization failure crash report to Crashlytics
-  Future<void> _sendInitializationFailureCrashReport(
-    dynamic error,
-    StackTrace stackTrace,
-  ) async {
-    try {
-      final crashReporting = CrashReportingService.instance;
-
-      // Set context for the crash report
-      await crashReporting.setCustomKey('init_failure_error', error.toString());
-      await crashReporting.setCustomKey(
-        'init_failure_platform',
-        _getPlatformName(),
-      );
-      await crashReporting.setCustomKey(
-        'init_failure_timestamp',
-        DateTime.now().toIso8601String(),
-      );
-      await crashReporting.setCustomKey(
-        'init_failure_retry_attempts',
-        'multiple',
-      );
-
-      // Create detailed error message
-      final detailedError =
-          '''
-UploadManager Initialization Failure:
-- Error: $error
-- Platform: ${_getPlatformName()}
-- Timestamp: ${DateTime.now().toIso8601String()}
-- Context: Failed after all retry attempts in UploadInitializationHelper
-''';
-
-      // Log the detailed error
-      crashReporting.log('INIT_FAILURE: $detailedError');
-
-      // Record the error to Crashlytics
-      await crashReporting.recordError(
-        error,
-        stackTrace,
-        reason: 'UploadManager initialization failure after retries',
-      );
-
-      Log.info(
-        '📊 Sent UploadManager initialization failure report to Crashlytics',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    } catch (crashReportingError) {
-      // Don't let crash reporting failures break the initialization failure handling
-      Log.error(
-        'Failed to send initialization crash report: $crashReportingError',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    }
-  }
-
-  /// Send timeout failure crash report to Crashlytics
-  Future<void> _sendTimeoutCrashReport(
-    PendingUpload upload,
-    TimeoutException timeoutError,
-  ) async {
-    try {
-      final crashReporting = CrashReportingService.instance;
-
-      // Set context for the crash report
-      final context = {
-        'timeout_upload_id': upload.id,
-        'timeout_file_path': upload.localVideoPath,
-        'timeout_upload_target': 'blossomServer',
-        'timeout_network_timeout_minutes':
-            _retryConfig.networkTimeout.inMinutes,
-        'timeout_retry_count': upload.retryCount ?? 0,
-        'timeout_upload_status': upload.status.toString(),
-        'timeout_platform': _getPlatformName(),
-        'timeout_file_exists':
-            !kIsWeb && File(upload.localVideoPath).existsSync(),
-        'timeout_timestamp': DateTime.now().toIso8601String(),
-      };
-
-      // Set all context as custom keys
-      for (final entry in context.entries) {
-        await crashReporting.setCustomKey(entry.key, entry.value.toString());
-      }
-
-      // Create detailed error message
-      final fileExists = kIsWeb
-          ? 'N/A (web)'
-          : '${File(upload.localVideoPath).existsSync()}';
-      final detailedError =
-          '''
-Upload Timeout Failure:
-- Upload ID: ${upload.id}
-- File: ${upload.localVideoPath}
-- File Exists: $fileExists
-- Upload Target: blossomServer
-- Timeout Duration: ${_retryConfig.networkTimeout.inMinutes} minutes
-- Retry Count: ${upload.retryCount ?? 0}
-- Upload Status: ${upload.status}
-- Platform: ${_getPlatformName()}
-- Timestamp: ${DateTime.now().toIso8601String()}
-''';
-
-      // Log the detailed error
-      crashReporting.log('TIMEOUT_FAILURE: $detailedError');
-
-      // Record the error to Crashlytics
-      await crashReporting.recordError(
-        timeoutError,
-        StackTrace.current,
-        reason:
-            'Video upload timeout after ${_retryConfig.networkTimeout.inMinutes} minutes',
-      );
-
-      Log.info(
-        '📊 Sent upload timeout failure report to Crashlytics',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    } catch (crashReportingError) {
-      // Don't let crash reporting failures break the timeout failure handling
-      Log.error(
-        'Failed to send timeout crash report: $crashReportingError',
-        name: 'UploadManager',
-        category: LogCategory.video,
-      );
-    }
-  }
-
   /// Generate and upload thumbnail to Blossom CDN
   Future<String?> _generateAndUploadThumbnail({
     required File videoFile,
@@ -2228,7 +1464,7 @@ Upload Timeout Failure:
         category: LogCategory.video,
       );
 
-      _updateUploadProgress(upload.id, 0.85);
+      _reporter.updateProgress(upload.id, 0.85);
 
       // Upload thumbnail to Blossom server. Divine relay publishing requires
       // a CDN thumbnail, so keep the image upload's own retry enabled here.
@@ -2239,7 +1475,7 @@ Upload Timeout Failure:
         nostrPubkey: nostrPubkey,
         onProgress: (progress) {
           // Map thumbnail progress to 85%-100% of total upload
-          _updateUploadProgress(upload.id, 0.85 + (progress * 0.15));
+          _reporter.updateProgress(upload.id, 0.85 + (progress * 0.15));
         },
       );
 
@@ -2275,29 +1511,16 @@ Upload Timeout Failure:
   }
 
   void dispose() {
-    // Cancel all progress subscriptions
-    for (final subscription in _progressSubscriptions.values) {
-      subscription.cancel();
-    }
-    _progressSubscriptions.clear();
-
-    // Cancel all retry timers
-    for (final timer in _retryTimers.values) {
-      timer.cancel();
-    }
-    _retryTimers.clear();
+    // Delegate to extracted policy/reporter (handles subscriptions, timers,
+    // session futures, and metrics cleanup).
+    _retryPolicy.dispose();
+    _reporter.dispose();
 
     // Cancel all processing-completion polls
     for (final timer in _processingPollTimers.values) {
       timer.cancel();
     }
     _processingPollTimers.clear();
-
-    // Discard pending session persistence futures
-    _sessionPersistFutures.clear();
-
-    // Clean up old metrics
-    _cleanupOldMetrics();
 
     // Delegate storage teardown (timer, queue, box pointer) to the store.
     _store.disposeStore();

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -17,6 +17,7 @@ import 'package:openvine/services/circuit_breaker_service.dart';
 import 'package:openvine/services/upload/pending_upload_store.dart';
 import 'package:openvine/services/upload/upload_progress_reporter.dart';
 import 'package:openvine/services/upload/upload_retry_policy.dart';
+import 'package:openvine/services/upload/upload_session_errors.dart';
 import 'package:openvine/services/upload_initialization_helper.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
@@ -1022,7 +1023,7 @@ class UploadManager {
         status: UploadStatus.failed,
         errorMessage: userMessage,
         retryCount: latestUpload.retryCount ?? 0,
-        resumableSession: _reporter.isExpiredResumableSessionError(error)
+        resumableSession: isExpiredResumableSessionError(error)
             ? null
             : latestUpload.resumableSession,
       ),

--- a/mobile/test/services/upload/upload_progress_reporter_test.dart
+++ b/mobile/test/services/upload/upload_progress_reporter_test.dart
@@ -1,8 +1,6 @@
 // ABOUTME: Unit tests for UploadProgressReporter — covers metrics lifecycle,
 // ABOUTME: subscription management, error categorisation, and progress updates.
 
-import 'dart:async';
-
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -141,39 +139,11 @@ void main() {
 
   // ---------------------------------------------------------------------------
   group('subscription lifecycle', () {
-    test('setSubscription / subscriptionFor roundtrip', () {
-      final controller = StreamController<double>();
-      addTearDown(controller.close);
-
-      final sub = controller.stream.listen((_) {});
-      reporter.setSubscription('upload-1', sub);
-
-      expect(reporter.subscriptionFor('upload-1'), equals(sub));
-    });
-
-    test('cancelAndRemoveSubscription cancels and clears entry', () async {
-      final controller = StreamController<double>();
-      addTearDown(controller.close);
-
-      final sub = controller.stream.listen((_) {});
-
-      reporter.setSubscription('upload-1', sub);
-      reporter.cancelAndRemoveSubscription('upload-1');
-
-      // Give cancellation a microtask to propagate
-      await Future<void>.delayed(Duration.zero);
-
-      expect(reporter.subscriptionFor('upload-1'), isNull);
-    });
-
-    test('subscriptionFor returns null after removal', () {
-      final controller = StreamController<double>();
-      addTearDown(controller.close);
-      final sub = controller.stream.listen((_) {});
-      reporter.setSubscription('upload-1', sub);
-      reporter.cancelAndRemoveSubscription('upload-1');
-
-      expect(reporter.subscriptionFor('upload-1'), isNull);
+    test('cancelAndRemoveSubscription is a safe no-op for an unknown id', () {
+      expect(
+        () => reporter.cancelAndRemoveSubscription('not-tracked'),
+        returnsNormally,
+      );
     });
   });
 
@@ -253,69 +223,14 @@ void main() {
       // check, so we can only test categories that fire before connectivity is
       // needed — but for a reliable test, we use the expired-session fast path.
       //
-      // For code paths that need connectivity, we verify via isExpiredResumableSessionError.
+      // The shared expired-session predicate is covered directly in
+      // upload_session_errors_test.dart.
       const error = BlossomResumableUploadException(
         'Gone',
         statusCode: 410,
       );
       final result = await reporter.categorizeError(error);
       expect(result, equals('UPLOAD_SESSION_EXPIRED'));
-    });
-  });
-
-  // ---------------------------------------------------------------------------
-  group('isExpiredResumableSessionError', () {
-    test('BlossomResumableUploadException 404 → true', () {
-      expect(
-        reporter.isExpiredResumableSessionError(
-          const BlossomResumableUploadException('Not found', statusCode: 404),
-        ),
-        isTrue,
-      );
-    });
-
-    test('BlossomResumableUploadException 410 → true', () {
-      expect(
-        reporter.isExpiredResumableSessionError(
-          const BlossomResumableUploadException('Gone', statusCode: 410),
-        ),
-        isTrue,
-      );
-    });
-
-    test('BlossomResumableUploadException 500 → false', () {
-      expect(
-        reporter.isExpiredResumableSessionError(
-          const BlossomResumableUploadException(
-            'Server error',
-            statusCode: 500,
-          ),
-        ),
-        isFalse,
-      );
-    });
-
-    test('"session expired" string → true', () {
-      expect(
-        reporter.isExpiredResumableSessionError(Exception('session expired')),
-        isTrue,
-      );
-    });
-
-    test('"session is no longer available" string → true', () {
-      expect(
-        reporter.isExpiredResumableSessionError(
-          Exception('session is no longer available'),
-        ),
-        isTrue,
-      );
-    });
-
-    test('generic network error → false', () {
-      expect(
-        reporter.isExpiredResumableSessionError(Exception('network error')),
-        isFalse,
-      );
     });
   });
 
@@ -472,24 +387,9 @@ void main() {
 
   // ---------------------------------------------------------------------------
   group('dispose', () {
-    test('cancels all subscriptions', () async {
-      final controllers = List.generate(3, (_) => StreamController<double>());
-      addTearDown(() {
-        for (final c in controllers) {
-          c.close();
-        }
-      });
-
-      for (var i = 0; i < 3; i++) {
-        reporter.setSubscription('id-$i', controllers[i].stream.listen((_) {}));
-      }
-
-      reporter.dispose();
-
-      // After dispose, subscriptionFor should return null for all
-      for (var i = 0; i < 3; i++) {
-        expect(reporter.subscriptionFor('id-$i'), isNull);
-      }
+    test('can be called without throwing', () {
+      reporter.recordStart('upload-1', _makeMetrics());
+      expect(reporter.dispose, returnsNormally);
     });
 
     test('clears metrics', () {

--- a/mobile/test/services/upload/upload_progress_reporter_test.dart
+++ b/mobile/test/services/upload/upload_progress_reporter_test.dart
@@ -1,0 +1,508 @@
+// ABOUTME: Unit tests for UploadProgressReporter — covers metrics lifecycle,
+// ABOUTME: subscription management, error categorisation, and progress updates.
+
+import 'dart:async';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/circuit_breaker_service.dart';
+import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload/upload_progress_reporter.dart';
+import 'package:openvine/services/upload_manager.dart';
+
+class _MockPendingUploadStore extends Mock implements PendingUploadStore {}
+
+PendingUpload _makeUpload({
+  String id = 'upload-1',
+  UploadStatus status = UploadStatus.uploading,
+}) => PendingUpload(
+  id: id,
+  localVideoPath: '/tmp/video.mp4',
+  nostrPubkey: 'pubkey-abc',
+  status: status,
+  createdAt: DateTime(2024),
+);
+
+UploadMetrics _makeMetrics({
+  String uploadId = 'upload-1',
+  bool wasSuccessful = false,
+  String? errorCategory,
+  DateTime? startTime,
+  double fileSizeMB = 10.0,
+}) => UploadMetrics(
+  uploadId: uploadId,
+  startTime: startTime ?? DateTime.now(),
+  retryCount: 0,
+  fileSizeMB: fileSizeMB,
+  wasSuccessful: wasSuccessful,
+  errorCategory: errorCategory,
+);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      PendingUpload(
+        id: 'fallback',
+        localVideoPath: '/tmp/fallback.mp4',
+        nostrPubkey: 'fallback-key',
+        status: UploadStatus.pending,
+        createdAt: DateTime(2024),
+      ),
+    );
+  });
+
+  late _MockPendingUploadStore store;
+  // Use a real VideoCircuitBreaker — its state/failureRate getters return
+  // non-nullable enum values that are awkward to stub with Mocktail.
+  late VideoCircuitBreaker circuitBreaker;
+  late UploadProgressReporter reporter;
+
+  setUp(() {
+    store = _MockPendingUploadStore();
+    circuitBreaker = VideoCircuitBreaker();
+
+    reporter = UploadProgressReporter(
+      store: store,
+      circuitBreaker: circuitBreaker,
+      retryConfig: const UploadRetryConfig(),
+    );
+  });
+
+  tearDown(() {
+    reporter.dispose();
+  });
+
+  // ---------------------------------------------------------------------------
+  group('recordStart / metricsFor', () {
+    test('stores metrics and retrieves them', () {
+      final metrics = _makeMetrics();
+      reporter.recordStart('upload-1', metrics);
+
+      expect(reporter.metricsFor('upload-1'), equals(metrics));
+    });
+
+    test('returns null for unknown uploadId', () {
+      expect(reporter.metricsFor('not-there'), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('recordSuccess', () {
+    test('overwrites metrics entry', () {
+      final initial = _makeMetrics();
+      reporter.recordStart('upload-1', initial);
+
+      final success = _makeMetrics(wasSuccessful: true);
+      reporter.recordSuccess('upload-1', success);
+
+      expect(reporter.metricsFor('upload-1')!.wasSuccessful, isTrue);
+    });
+
+    test('prunes entries older than 7 days', () {
+      final old = _makeMetrics(
+        uploadId: 'old',
+        startTime: DateTime.now().subtract(const Duration(days: 8)),
+      );
+      reporter.recordStart('old', old);
+      expect(reporter.metricsFor('old'), isNotNull);
+
+      // recordSuccess triggers _cleanupOldMetrics
+      reporter.recordSuccess('upload-1', _makeMetrics());
+
+      expect(reporter.metricsFor('old'), isNull);
+    });
+
+    test('keeps entries within 7 days', () {
+      final recent = _makeMetrics(
+        uploadId: 'recent',
+        startTime: DateTime.now().subtract(const Duration(days: 6)),
+      );
+      reporter.recordStart('recent', recent);
+
+      reporter.recordSuccess('upload-1', _makeMetrics());
+
+      expect(reporter.metricsFor('recent'), isNotNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('recordFailure', () {
+    test('stores failure metrics', () {
+      final metrics = _makeMetrics(errorCategory: 'TIMEOUT');
+      reporter.recordFailure('upload-1', metrics);
+
+      expect(reporter.metricsFor('upload-1')!.errorCategory, equals('TIMEOUT'));
+      expect(reporter.metricsFor('upload-1')!.wasSuccessful, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('subscription lifecycle', () {
+    test('setSubscription / subscriptionFor roundtrip', () {
+      final controller = StreamController<double>();
+      addTearDown(controller.close);
+
+      final sub = controller.stream.listen((_) {});
+      reporter.setSubscription('upload-1', sub);
+
+      expect(reporter.subscriptionFor('upload-1'), equals(sub));
+    });
+
+    test('cancelAndRemoveSubscription cancels and clears entry', () async {
+      final controller = StreamController<double>();
+      addTearDown(controller.close);
+
+      final sub = controller.stream.listen((_) {});
+
+      reporter.setSubscription('upload-1', sub);
+      reporter.cancelAndRemoveSubscription('upload-1');
+
+      // Give cancellation a microtask to propagate
+      await Future<void>.delayed(Duration.zero);
+
+      expect(reporter.subscriptionFor('upload-1'), isNull);
+    });
+
+    test('subscriptionFor returns null after removal', () {
+      final controller = StreamController<double>();
+      addTearDown(controller.close);
+      final sub = controller.stream.listen((_) {});
+      reporter.setSubscription('upload-1', sub);
+      reporter.cancelAndRemoveSubscription('upload-1');
+
+      expect(reporter.subscriptionFor('upload-1'), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('updateProgress', () {
+    test('updates store when status is uploading', () {
+      final upload = _makeUpload();
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+      when(() => store.update(any())).thenAnswer((_) async {});
+
+      reporter.updateProgress('upload-1', 0.5);
+
+      final captured = verify(() => store.update(captureAny())).captured;
+      expect(captured, hasLength(1));
+      expect((captured.first as PendingUpload).uploadProgress, equals(0.5));
+    });
+
+    test('updates store when status is retrying', () {
+      final upload = _makeUpload(status: UploadStatus.retrying);
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+      when(() => store.update(any())).thenAnswer((_) async {});
+
+      reporter.updateProgress('upload-1', 0.75);
+
+      verify(() => store.update(any())).called(1);
+    });
+
+    test('no-op when status is paused', () {
+      final upload = _makeUpload(status: UploadStatus.paused);
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+
+      reporter.updateProgress('upload-1', 0.5);
+
+      verifyNever(() => store.update(any()));
+    });
+
+    test('no-op when upload not found', () {
+      when(() => store.getUpload('upload-1')).thenReturn(null);
+
+      reporter.updateProgress('upload-1', 0.5);
+
+      verifyNever(() => store.update(any()));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('categorizeError', () {
+    // We stub categorizeError's internal connectivity check for most tests
+    // by passing errors that are classified without connectivity (session errors).
+
+    test(
+      'expired session (BlossomResumableUploadException 404) → UPLOAD_SESSION_EXPIRED',
+      () async {
+        const error = BlossomResumableUploadException(
+          'Not found',
+          statusCode: 404,
+        );
+        final result = await reporter.categorizeError(error);
+        expect(result, equals('UPLOAD_SESSION_EXPIRED'));
+      },
+    );
+
+    test('expired session string → UPLOAD_SESSION_EXPIRED', () async {
+      final result = await reporter.categorizeError(
+        Exception('session expired'),
+      );
+      expect(result, equals('UPLOAD_SESSION_EXPIRED'));
+    });
+
+    test('BlossomUploadFailureException 408 → TIMEOUT', () async {
+      // We need connectivity to not be none for status-code branching to fire.
+      // Since the test doesn't mock Connectivity plugin, categorizeError will
+      // call checkNetworkConnectivity which may fail or return none. So we
+      // test with errors that are classified before the connectivity check.
+      //
+      // BlossomUploadFailureException code check happens AFTER the connectivity
+      // check, so we can only test categories that fire before connectivity is
+      // needed — but for a reliable test, we use the expired-session fast path.
+      //
+      // For code paths that need connectivity, we verify via isExpiredResumableSessionError.
+      const error = BlossomResumableUploadException(
+        'Gone',
+        statusCode: 410,
+      );
+      final result = await reporter.categorizeError(error);
+      expect(result, equals('UPLOAD_SESSION_EXPIRED'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('isExpiredResumableSessionError', () {
+    test('BlossomResumableUploadException 404 → true', () {
+      expect(
+        reporter.isExpiredResumableSessionError(
+          const BlossomResumableUploadException('Not found', statusCode: 404),
+        ),
+        isTrue,
+      );
+    });
+
+    test('BlossomResumableUploadException 410 → true', () {
+      expect(
+        reporter.isExpiredResumableSessionError(
+          const BlossomResumableUploadException('Gone', statusCode: 410),
+        ),
+        isTrue,
+      );
+    });
+
+    test('BlossomResumableUploadException 500 → false', () {
+      expect(
+        reporter.isExpiredResumableSessionError(
+          const BlossomResumableUploadException(
+            'Server error',
+            statusCode: 500,
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('"session expired" string → true', () {
+      expect(
+        reporter.isExpiredResumableSessionError(Exception('session expired')),
+        isTrue,
+      );
+    });
+
+    test('"session is no longer available" string → true', () {
+      expect(
+        reporter.isExpiredResumableSessionError(
+          Exception('session is no longer available'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('generic network error → false', () {
+      expect(
+        reporter.isExpiredResumableSessionError(Exception('network error')),
+        isFalse,
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('getUserFriendlyErrorMessage', () {
+    test('NO_INTERNET → offline copy', () {
+      final msg = reporter.getUserFriendlyErrorMessage(
+        'NO_INTERNET',
+        ConnectivityResult.none,
+      );
+      expect(msg, contains('No internet connection'));
+    });
+
+    test('TIMEOUT → timeout copy', () {
+      final msg = reporter.getUserFriendlyErrorMessage(
+        'TIMEOUT',
+        ConnectivityResult.wifi,
+      );
+      expect(msg, contains('timed out'));
+    });
+
+    test('NETWORK_ERROR embeds network type', () {
+      final msg = reporter.getUserFriendlyErrorMessage(
+        'NETWORK_ERROR',
+        ConnectivityResult.mobile,
+      );
+      expect(msg, contains('Cellular'));
+    });
+
+    test('UPLOAD_SESSION_EXPIRED → session copy', () {
+      final msg = reporter.getUserFriendlyErrorMessage(
+        'UPLOAD_SESSION_EXPIRED',
+        ConnectivityResult.wifi,
+      );
+      expect(msg, contains('session expired'));
+    });
+
+    test('unknown category → generic copy', () {
+      final msg = reporter.getUserFriendlyErrorMessage(
+        'SOMETHING_NEW',
+        ConnectivityResult.wifi,
+      );
+      expect(msg, contains('Upload failed'));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('getNetworkTypeString', () {
+    test('wifi → "WiFi"', () {
+      expect(
+        reporter.getNetworkTypeString(ConnectivityResult.wifi),
+        equals('WiFi'),
+      );
+    });
+
+    test('mobile → "Cellular"', () {
+      expect(
+        reporter.getNetworkTypeString(ConnectivityResult.mobile),
+        equals('Cellular'),
+      );
+    });
+
+    test('none → "Offline"', () {
+      expect(
+        reporter.getNetworkTypeString(ConnectivityResult.none),
+        equals('Offline'),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('createSuccessMetrics', () {
+    test('computes duration and throughput', () {
+      final start = DateTime(2024, 1, 1, 12);
+      final end = start.add(const Duration(seconds: 10));
+      final input = _makeMetrics(startTime: start, fileSizeMB: 20.0);
+
+      final result = reporter.createSuccessMetrics(input, end, 1);
+
+      expect(result.wasSuccessful, isTrue);
+      expect(result.uploadDuration?.inSeconds, equals(10));
+      expect(result.throughputMBps, closeTo(2.0, 0.01)); // 20MB / 10s
+      expect(result.retryCount, equals(1));
+    });
+
+    test('handles zero duration without dividing by zero', () {
+      final now = DateTime(2024);
+      final input = _makeMetrics(startTime: now, fileSizeMB: 5.0);
+
+      final result = reporter.createSuccessMetrics(input, now, 0);
+
+      expect(result.throughputMBps, isNotNull);
+      expect(result.throughputMBps, greaterThan(0));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('getPerformanceMetrics', () {
+    test('returns zeros when no metrics recorded', () {
+      final result = reporter.getPerformanceMetrics();
+
+      expect(result['total_uploads'], equals(0));
+      expect(result['successful_uploads'], equals(0));
+      expect(result['failed_uploads'], equals(0));
+      expect(result['success_rate'], equals(0));
+    });
+
+    test('calculates success rate correctly', () {
+      reporter.recordStart('a', _makeMetrics(uploadId: 'a'));
+      reporter.recordFailure('a', _makeMetrics(uploadId: 'a'));
+      reporter.recordStart('b', _makeMetrics(uploadId: 'b'));
+      reporter.recordSuccess(
+        'b',
+        _makeMetrics(uploadId: 'b', wasSuccessful: true),
+      );
+
+      final result = reporter.getPerformanceMetrics();
+
+      expect(result['total_uploads'], equals(2));
+      expect(result['successful_uploads'], equals(1));
+      expect(result['failed_uploads'], equals(1));
+      expect(result['success_rate'], equals(50.0));
+    });
+
+    test('includes circuit breaker state (closed by default)', () {
+      // Real VideoCircuitBreaker starts closed with 0% failure rate.
+      final result = reporter.getPerformanceMetrics();
+
+      expect(result['circuit_breaker_state'], contains('closed'));
+      expect(result['circuit_breaker_failure_rate'], equals(0.0));
+    });
+
+    test('error_categories groups by category', () {
+      reporter.recordFailure(
+        'a',
+        _makeMetrics(uploadId: 'a', errorCategory: 'TIMEOUT'),
+      );
+      reporter.recordFailure(
+        'b',
+        _makeMetrics(uploadId: 'b', errorCategory: 'TIMEOUT'),
+      );
+      reporter.recordFailure(
+        'c',
+        _makeMetrics(uploadId: 'c', errorCategory: 'NETWORK_ERROR'),
+      );
+
+      final result = reporter.getPerformanceMetrics();
+      final categories = result['error_categories'] as Map<String, int>;
+
+      expect(categories['TIMEOUT'], equals(2));
+      expect(categories['NETWORK_ERROR'], equals(1));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('dispose', () {
+    test('cancels all subscriptions', () async {
+      final controllers = List.generate(3, (_) => StreamController<double>());
+      addTearDown(() {
+        for (final c in controllers) {
+          c.close();
+        }
+      });
+
+      for (var i = 0; i < 3; i++) {
+        reporter.setSubscription('id-$i', controllers[i].stream.listen((_) {}));
+      }
+
+      reporter.dispose();
+
+      // After dispose, subscriptionFor should return null for all
+      for (var i = 0; i < 3; i++) {
+        expect(reporter.subscriptionFor('id-$i'), isNull);
+      }
+    });
+
+    test('clears metrics', () {
+      reporter.recordStart('upload-1', _makeMetrics());
+      reporter.dispose();
+
+      // Recreate reporter to verify data is not shared (disposed state is gone)
+      reporter = UploadProgressReporter(
+        store: store,
+        circuitBreaker: circuitBreaker,
+        retryConfig: const UploadRetryConfig(),
+      );
+      expect(reporter.metricsFor('upload-1'), isNull);
+    });
+  });
+}

--- a/mobile/test/services/upload/upload_progress_reporter_test.dart
+++ b/mobile/test/services/upload/upload_progress_reporter_test.dart
@@ -213,25 +213,17 @@ void main() {
       expect(result, equals('UPLOAD_SESSION_EXPIRED'));
     });
 
-    test('BlossomUploadFailureException 408 → TIMEOUT', () async {
-      // We need connectivity to not be none for status-code branching to fire.
-      // Since the test doesn't mock Connectivity plugin, categorizeError will
-      // call checkNetworkConnectivity which may fail or return none. So we
-      // test with errors that are classified before the connectivity check.
-      //
-      // BlossomUploadFailureException code check happens AFTER the connectivity
-      // check, so we can only test categories that fire before connectivity is
-      // needed — but for a reliable test, we use the expired-session fast path.
-      //
-      // The shared expired-session predicate is covered directly in
-      // upload_session_errors_test.dart.
-      const error = BlossomResumableUploadException(
-        'Gone',
-        statusCode: 410,
-      );
-      final result = await reporter.categorizeError(error);
-      expect(result, equals('UPLOAD_SESSION_EXPIRED'));
-    });
+    test(
+      'expired session (BlossomResumableUploadException 410) → UPLOAD_SESSION_EXPIRED',
+      () async {
+        const error = BlossomResumableUploadException(
+          'Gone',
+          statusCode: 410,
+        );
+        final result = await reporter.categorizeError(error);
+        expect(result, equals('UPLOAD_SESSION_EXPIRED'));
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------

--- a/mobile/test/services/upload/upload_retry_policy_test.dart
+++ b/mobile/test/services/upload/upload_retry_policy_test.dart
@@ -15,12 +15,15 @@ PendingUpload _makeUpload({
   String id = 'upload-1',
   UploadStatus status = UploadStatus.uploading,
   int? retryCount = 0,
+  DateTime? createdAt,
+  DateTime? completedAt,
 }) => PendingUpload(
   id: id,
   localVideoPath: '/tmp/video.mp4',
   nostrPubkey: 'pubkey-abc',
   status: status,
-  createdAt: DateTime(2024),
+  createdAt: createdAt ?? DateTime(2024),
+  completedAt: completedAt,
   retryCount: retryCount,
 );
 
@@ -383,6 +386,109 @@ void main() {
 
       await Future<void>.delayed(Duration.zero);
       expect(called, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('retryUploadWithBackoff', () {
+    test('resets retryCount to 1 when last attempt was >= 1h ago', () async {
+      final upload = _makeUpload(
+        status: UploadStatus.failed,
+        retryCount: 2,
+        completedAt: DateTime.now().subtract(const Duration(hours: 2)),
+      );
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+      when(() => store.update(any())).thenAnswer((_) async {});
+
+      PendingUpload? received;
+      await policy.retryUploadWithBackoff(
+        'upload-1',
+        performUpload: (u) async {
+          received = u;
+        },
+      );
+
+      expect(received, isNotNull);
+      expect(received!.retryCount, equals(1));
+      expect(received!.status, equals(UploadStatus.pending));
+    });
+
+    test('increments retryCount when last attempt was < 1h ago', () async {
+      final upload = _makeUpload(
+        status: UploadStatus.failed,
+        retryCount: 1,
+        completedAt: DateTime.now(),
+      );
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+      when(() => store.update(any())).thenAnswer((_) async {});
+
+      PendingUpload? received;
+      await policy.retryUploadWithBackoff(
+        'upload-1',
+        performUpload: (u) async {
+          received = u;
+        },
+      );
+
+      expect(received, isNotNull);
+      expect(received!.retryCount, equals(2));
+      expect(received!.status, equals(UploadStatus.pending));
+    });
+
+    test(
+      'falls back to createdAt for the reset window when completedAt is null',
+      () async {
+        // createdAt defaults to 2024 (well over an hour ago) and completedAt
+        // is null, so the reset window keys off createdAt and resets to 1.
+        final upload = _makeUpload(
+          status: UploadStatus.failed,
+          retryCount: 2,
+        );
+        when(() => store.getUpload('upload-1')).thenReturn(upload);
+        when(() => store.update(any())).thenAnswer((_) async {});
+
+        PendingUpload? received;
+        await policy.retryUploadWithBackoff(
+          'upload-1',
+          performUpload: (u) async {
+            received = u;
+          },
+        );
+
+        expect(received, isNotNull);
+        expect(received!.retryCount, equals(1));
+      },
+    );
+
+    test('no-op when upload is not in failed state', () async {
+      final upload = _makeUpload(status: UploadStatus.paused);
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+
+      var called = false;
+      await policy.retryUploadWithBackoff(
+        'upload-1',
+        performUpload: (_) async {
+          called = true;
+        },
+      );
+
+      expect(called, isFalse);
+      verifyNever(() => store.update(any()));
+    });
+
+    test('no-op when upload not found in store', () async {
+      when(() => store.getUpload('upload-1')).thenReturn(null);
+
+      var called = false;
+      await policy.retryUploadWithBackoff(
+        'upload-1',
+        performUpload: (_) async {
+          called = true;
+        },
+      );
+
+      expect(called, isFalse);
+      verifyNever(() => store.update(any()));
     });
   });
 

--- a/mobile/test/services/upload/upload_retry_policy_test.dart
+++ b/mobile/test/services/upload/upload_retry_policy_test.dart
@@ -1,0 +1,460 @@
+// ABOUTME: Unit tests for UploadRetryPolicy — covers isRetriableError,
+// ABOUTME: retryUpload, resumeInterruptedUpload, and enqueueSessionPersist.
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload/upload_retry_policy.dart';
+import 'package:openvine/services/upload_manager.dart';
+
+class _MockPendingUploadStore extends Mock implements PendingUploadStore {}
+
+PendingUpload _makeUpload({
+  String id = 'upload-1',
+  UploadStatus status = UploadStatus.uploading,
+  int? retryCount = 0,
+}) => PendingUpload(
+  id: id,
+  localVideoPath: '/tmp/video.mp4',
+  nostrPubkey: 'pubkey-abc',
+  status: status,
+  createdAt: DateTime(2024),
+  retryCount: retryCount,
+);
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      PendingUpload(
+        id: 'fallback',
+        localVideoPath: '/tmp/fallback.mp4',
+        nostrPubkey: 'fallback-key',
+        status: UploadStatus.pending,
+        createdAt: DateTime(2024),
+      ),
+    );
+  });
+
+  late _MockPendingUploadStore store;
+  late UploadRetryPolicy policy;
+
+  setUp(() {
+    store = _MockPendingUploadStore();
+    policy = UploadRetryPolicy(
+      store: store,
+      retryConfig: const UploadRetryConfig(),
+    );
+  });
+
+  tearDown(() {
+    policy.dispose();
+  });
+
+  // ---------------------------------------------------------------------------
+  group('isRetriableError', () {
+    group('network / timeout errors → true', () {
+      test('string "timeout" → true', () {
+        expect(policy.isRetriableError(Exception('timeout')), isTrue);
+      });
+
+      test('string "cannot connect" → true', () {
+        expect(policy.isRetriableError(Exception('cannot connect')), isTrue);
+      });
+
+      test('string "connection refused" → true', () {
+        expect(
+          policy.isRetriableError(Exception('connection refused')),
+          isTrue,
+        );
+      });
+
+      test('string "socket" → true', () {
+        expect(policy.isRetriableError(Exception('socket closed')), isTrue);
+      });
+
+      test('string "network error" → true', () {
+        expect(policy.isRetriableError(Exception('network error')), isTrue);
+      });
+
+      test('unknown error → true by default', () {
+        expect(
+          policy.isRetriableError(Exception('some unknown issue')),
+          isTrue,
+        );
+      });
+    });
+
+    group('BlossomUploadFailureException with 5xx status → true', () {
+      test('500 → true', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException(
+              'Server error',
+              statusCode: 500,
+            ),
+          ),
+          isTrue,
+        );
+      });
+
+      test('502 → true', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException('Bad gateway', statusCode: 502),
+          ),
+          isTrue,
+        );
+      });
+
+      test('408 → true', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException('Timeout', statusCode: 408),
+          ),
+          isTrue,
+        );
+      });
+
+      test('429 → true', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException(
+              'Rate limited',
+              statusCode: 429,
+            ),
+          ),
+          isTrue,
+        );
+      });
+
+      test('authUnavailable reason → true', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException(
+              'Signer unavailable',
+              failureReason: BlossomUploadFailureReason.authUnavailable,
+            ),
+          ),
+          isTrue,
+        );
+      });
+
+      test('network reason → true', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException(
+              'Network fail',
+              failureReason: BlossomUploadFailureReason.network,
+            ),
+          ),
+          isTrue,
+        );
+      });
+    });
+
+    group('non-retriable errors → false', () {
+      test('expired session BlossomResumableUploadException (404) → false', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomResumableUploadException('Not found', statusCode: 404),
+          ),
+          isFalse,
+        );
+      });
+
+      test('expired session BlossomResumableUploadException (410) → false', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomResumableUploadException('Gone', statusCode: 410),
+          ),
+          isFalse,
+        );
+      });
+
+      test('session expired string → false', () {
+        expect(
+          policy.isRetriableError(Exception('session expired')),
+          isFalse,
+        );
+      });
+
+      test('session is no longer available → false', () {
+        expect(
+          policy.isRetriableError(Exception('session is no longer available')),
+          isFalse,
+        );
+      });
+
+      test('4xx status (401) → false', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException(
+              'Unauthorized',
+              statusCode: 401,
+            ),
+          ),
+          isFalse,
+        );
+      });
+
+      test('4xx status (400) → false', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException('Bad request', statusCode: 400),
+          ),
+          isFalse,
+        );
+      });
+
+      test('auth reason → false', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException(
+              'Auth rejected',
+              failureReason: BlossomUploadFailureReason.auth,
+            ),
+          ),
+          isFalse,
+        );
+      });
+
+      test('fileTooLarge reason → false', () {
+        expect(
+          policy.isRetriableError(
+            const BlossomUploadFailureException(
+              'Too big',
+              failureReason: BlossomUploadFailureReason.fileTooLarge,
+            ),
+          ),
+          isFalse,
+        );
+      });
+
+      test('"file not found" → false', () {
+        expect(
+          policy.isRetriableError(Exception('file not found')),
+          isFalse,
+        );
+      });
+
+      test('"permission denied" → false', () {
+        expect(
+          policy.isRetriableError(Exception('permission denied')),
+          isFalse,
+        );
+      });
+
+      test('"cancelled" → false', () {
+        expect(
+          policy.isRetriableError(Exception('upload cancelled')),
+          isFalse,
+        );
+      });
+
+      test('"thumbnail upload failed" → false', () {
+        expect(
+          policy.isRetriableError(Exception('thumbnail upload failed')),
+          isFalse,
+        );
+      });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('retryUpload', () {
+    test('no-op when upload not found in store', () async {
+      when(() => store.getUpload('upload-1')).thenReturn(null);
+
+      var called = false;
+      await policy.retryUpload(
+        'upload-1',
+        performUpload: (_) async {
+          called = true;
+        },
+      );
+
+      expect(called, isFalse);
+    });
+
+    test('no-op when canRetry is false (retryCount >= 3)', () async {
+      final upload = _makeUpload(status: UploadStatus.failed, retryCount: 3);
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+
+      var called = false;
+      await policy.retryUpload(
+        'upload-1',
+        performUpload: (_) async {
+          called = true;
+        },
+      );
+
+      expect(called, isFalse);
+      verifyNever(() => store.update(any()));
+    });
+
+    test(
+      'increments retryCount and calls performUpload when canRetry',
+      () async {
+        final upload = _makeUpload(status: UploadStatus.failed);
+        when(() => store.getUpload('upload-1')).thenReturn(upload);
+        when(() => store.update(any())).thenAnswer((_) async {});
+
+        PendingUpload? received;
+        await policy.retryUpload(
+          'upload-1',
+          performUpload: (u) async {
+            received = u;
+          },
+        );
+
+        expect(received, isNotNull);
+        expect(received!.retryCount, equals(1));
+        expect(received!.status, equals(UploadStatus.pending));
+        verify(() => store.update(any())).called(1);
+      },
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  group('resumeInterruptedUpload', () {
+    test('calls performUpload when status is uploading', () async {
+      final upload = _makeUpload();
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+      when(() => store.update(any())).thenAnswer((_) async {});
+
+      var called = false;
+      policy.resumeInterruptedUpload(
+        'upload-1',
+        performUpload: (_) async {
+          called = true;
+        },
+      );
+
+      // Fire microtasks from unawaited calls
+      await Future<void>.delayed(Duration.zero);
+      expect(called, isTrue);
+    });
+
+    test('calls performUpload when status is retrying', () async {
+      final upload = _makeUpload(status: UploadStatus.retrying);
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+      when(() => store.update(any())).thenAnswer((_) async {});
+
+      var called = false;
+      policy.resumeInterruptedUpload(
+        'upload-1',
+        performUpload: (_) async {
+          called = true;
+        },
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(called, isTrue);
+    });
+
+    test('no-op when upload not found', () async {
+      when(() => store.getUpload('upload-1')).thenReturn(null);
+
+      var called = false;
+      policy.resumeInterruptedUpload(
+        'upload-1',
+        performUpload: (_) async {
+          called = true;
+        },
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(called, isFalse);
+    });
+
+    test('no-op when upload is in pending status', () async {
+      final upload = _makeUpload(status: UploadStatus.pending);
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+
+      var called = false;
+      policy.resumeInterruptedUpload(
+        'upload-1',
+        performUpload: (_) async {
+          called = true;
+        },
+      );
+
+      await Future<void>.delayed(Duration.zero);
+      expect(called, isFalse);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('enqueueSessionPersist', () {
+    test('updates store with session and progress', () async {
+      final upload = _makeUpload();
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+      when(() => store.update(any())).thenAnswer((_) async {});
+
+      const session = BlossomResumableUploadSession(
+        uploadId: 'session-1',
+        uploadUrl: 'https://example.com/upload',
+        chunkSize: 1024 * 1024,
+        nextOffset: 512000,
+      );
+
+      policy.enqueueSessionPersist('upload-1', session, 1024000);
+
+      // Allow chained future to run
+      await Future<void>.delayed(Duration.zero);
+
+      final captured = verify(() => store.update(captureAny())).captured;
+      expect(captured, hasLength(1));
+      final updated = captured.first as PendingUpload;
+      expect(updated.resumableSession, equals(session));
+      // progress = (512000 / 1024000) * 0.8 = 0.4
+      expect(updated.uploadProgress, closeTo(0.4, 0.001));
+    });
+
+    test('clamps progress to [0.0, 0.8]', () async {
+      final upload = _makeUpload();
+      when(() => store.getUpload('upload-1')).thenReturn(upload);
+      when(() => store.update(any())).thenAnswer((_) async {});
+
+      // nextOffset > fileSizeBytes (shouldn't happen but guard against it)
+      const session = BlossomResumableUploadSession(
+        uploadId: 'session-1',
+        uploadUrl: 'https://example.com/upload',
+        chunkSize: 1024 * 1024,
+        nextOffset: 2000000,
+      );
+
+      policy.enqueueSessionPersist('upload-1', session, 1000000);
+      await Future<void>.delayed(Duration.zero);
+
+      final captured = verify(() => store.update(captureAny())).captured;
+      final updated = captured.first as PendingUpload;
+      expect(updated.uploadProgress, lessThanOrEqualTo(0.8));
+    });
+
+    test('no-op when upload not found in store', () async {
+      when(() => store.getUpload('upload-1')).thenReturn(null);
+
+      const session = BlossomResumableUploadSession(
+        uploadId: 'session-1',
+        uploadUrl: 'https://example.com/upload',
+        chunkSize: 1024 * 1024,
+        nextOffset: 100,
+      );
+
+      policy.enqueueSessionPersist('upload-1', session, 1000);
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => store.update(any()));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('dispose', () {
+    test('can be called without throwing', () {
+      expect(() => policy.dispose(), returnsNormally);
+    });
+  });
+}

--- a/mobile/test/services/upload/upload_session_errors_test.dart
+++ b/mobile/test/services/upload/upload_session_errors_test.dart
@@ -1,0 +1,63 @@
+// ABOUTME: Unit tests for the shared isExpiredResumableSessionError predicate
+// ABOUTME: used by UploadRetryPolicy, UploadProgressReporter, and UploadManager.
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/upload/upload_session_errors.dart';
+
+void main() {
+  group('isExpiredResumableSessionError', () {
+    test('BlossomResumableUploadException 404 → true', () {
+      expect(
+        isExpiredResumableSessionError(
+          const BlossomResumableUploadException('Not found', statusCode: 404),
+        ),
+        isTrue,
+      );
+    });
+
+    test('BlossomResumableUploadException 410 → true', () {
+      expect(
+        isExpiredResumableSessionError(
+          const BlossomResumableUploadException('Gone', statusCode: 410),
+        ),
+        isTrue,
+      );
+    });
+
+    test('BlossomResumableUploadException 500 → false', () {
+      expect(
+        isExpiredResumableSessionError(
+          const BlossomResumableUploadException(
+            'Server error',
+            statusCode: 500,
+          ),
+        ),
+        isFalse,
+      );
+    });
+
+    test('"session expired" string → true', () {
+      expect(
+        isExpiredResumableSessionError(Exception('session expired')),
+        isTrue,
+      );
+    });
+
+    test('"session is no longer available" string → true', () {
+      expect(
+        isExpiredResumableSessionError(
+          Exception('session is no longer available'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('generic network error → false', () {
+      expect(
+        isExpiredResumableSessionError(Exception('network error')),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Closes #5592.

Third step in the staged `upload_manager.dart` decomposition from #4507. This PR extracts the remaining retry/session-persistence and progress/metrics/error-reporting concerns into focused service classes under `mobile/lib/services/upload/`, while keeping `UploadManager` as the existing public facade.

### Extracted retry/session persistence

`UploadRetryPolicy` now owns:

- automatic retry orchestration through `AsyncUtils.retryWithBackoff`
- manual retry handling, including `retryUpload` and `retryUploadWithBackoff`
- interrupted-upload resume handling
- serialized resumable-session persistence from chunk callbacks
- retriable-error classification

### Extracted progress, metrics, and reporting

`UploadProgressReporter` now owns:

- upload progress persistence
- upload metrics recording and aggregation
- network type helpers and upload error categorization
- user-friendly upload failure messages
- upload failure, timeout, and initialization crash-report builders

### Shared session-expiry predicate

`upload_session_errors.dart` now provides one `isExpiredResumableSessionError` helper used by the retry policy, progress reporter, and manager failure handling. This keeps retry behavior and resumable-session cleanup in lockstep.

## Review follow-up included

- Restored the dropped production-rationale comments around `autoAttempt` vs `retryCount`, transient signer/network auth failures, and thumbnail-upload retry behavior.
- Added focused coverage for `retryUploadWithBackoff`: 1-hour reset window, retry-count increment, `createdAt` fallback, and no-op paths.
- Removed the dead `_retryTimers` map.
- Removed net-new test-only subscription APIs from `UploadProgressReporter`.
- Made dispose-time metrics clearing intentional and removed the redundant prune-before-clear path.
- Cleaned up a misleading progress-reporter test name/comment so the test description matches the expired-session behavior it actually covers.

## Behavior and risk

This is intended to be behavior-preserving. `UploadManager` keeps its existing public API and delegates to the extracted classes. Existing manager tests continue to exercise the facade paths, and the extracted classes now have focused unit coverage.

The remaining import from the extracted classes back to `upload_manager.dart` for shared types is an intentional intermediate state in the staged #4507 extraction; the package/API lift is separate from this PR.

## Test plan

- `dart format test/services/upload/upload_progress_reporter_test.dart`
- `mise exec -- dart format lib test integration_test`
- `flutter analyze lib/services/upload/upload_retry_policy.dart lib/services/upload/upload_progress_reporter.dart lib/services/upload/upload_session_errors.dart lib/services/upload_manager.dart test/services/upload/upload_retry_policy_test.dart test/services/upload/upload_progress_reporter_test.dart test/services/upload/upload_session_errors_test.dart`
- `flutter test test/services/upload/upload_progress_reporter_test.dart`
- `flutter test test/services/upload/upload_retry_policy_test.dart test/services/upload/upload_progress_reporter_test.dart test/services/upload/upload_session_errors_test.dart test/services/upload_manager_error_handling_test.dart test/services/upload_manager_resumable_upload_test.dart test/services/upload_manager_cancel_test.dart test/services/upload_manager_processing_poll_test.dart`
- pre-push hook: changed-file analyze + `test/services/upload/upload_progress_reporter_test.dart`, `test/services/upload/upload_retry_policy_test.dart`, `test/services/upload/upload_session_errors_test.dart`

## Related

- Parent decomposition issue: #4507
- Parent architecture epic: #4339