### PR TITLE
feat(upload): OS-backed background uploads that survive app suspension

### DIFF
--- a/mobile/lib/blocs/background_publish/background_publish_bloc.dart
+++ b/mobile/lib/blocs/background_publish/background_publish_bloc.dart
@@ -1,6 +1,7 @@
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:openvine/blocs/background_publish/publish_foreground_session.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
@@ -18,8 +19,10 @@ class BackgroundPublishBloc
     })
     videoPublishServiceFactory,
     required DraftStorageService draftStorageService,
+    PublishForegroundSession? foregroundSession,
   }) : _videoPublishServiceFactory = videoPublishServiceFactory,
        _draftStorageService = draftStorageService,
+       _foregroundSession = foregroundSession,
        super(const BackgroundPublishState()) {
     on<BackgroundPublishRequested>(
       _onBackgroundPublishRequested,
@@ -37,6 +40,11 @@ class BackgroundPublishBloc
   _videoPublishServiceFactory;
 
   final DraftStorageService _draftStorageService;
+
+  /// Keeps the process foregrounded for the whole publish so the in-process
+  /// steps after the OS-backed upload (signing, relay broadcast) survive app
+  /// suspension. Null disables the behaviour (e.g. in tests).
+  final PublishForegroundSession? _foregroundSession;
 
   Future<void> _onBackgroundPublishRequested(
     BackgroundPublishRequested event,
@@ -56,6 +64,7 @@ class BackgroundPublishBloc
     }
 
     PublishResult result;
+    await _beginForegroundSession(event.draft.id);
     try {
       result = await event.publishmentProcess;
     } catch (e, stackTrace) {
@@ -67,6 +76,8 @@ class BackgroundPublishBloc
       );
       addError(e, stackTrace);
       result = const PublishError(PublishErrorKind.generic);
+    } finally {
+      await _endForegroundSession(event.draft.id);
     }
 
     // Remove the upload if it was successful
@@ -103,6 +114,30 @@ class BackgroundPublishBloc
         draftId: event.draft.id,
         status: PublishStatus.failed,
         publishError: publishError,
+      );
+    }
+  }
+
+  /// Best-effort: keeping the process foregrounded is an optimisation, so a
+  /// failure here must never abort the publish itself.
+  Future<void> _beginForegroundSession(String sessionId) async {
+    try {
+      await _foregroundSession?.begin(sessionId);
+    } catch (e) {
+      Log.warning(
+        'Failed to begin publish foreground session: $e',
+        category: LogCategory.video,
+      );
+    }
+  }
+
+  Future<void> _endForegroundSession(String sessionId) async {
+    try {
+      await _foregroundSession?.end(sessionId);
+    } catch (e) {
+      Log.warning(
+        'Failed to end publish foreground session: $e',
+        category: LogCategory.video,
       );
     }
   }

--- a/mobile/lib/blocs/background_publish/publish_foreground_session.dart
+++ b/mobile/lib/blocs/background_publish/publish_foreground_session.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Port for an OS foreground session that keeps the process network
+// ABOUTME: alive across the whole background publish (upload + sign + relay).
+
+/// Keeps the app process foregrounded — and therefore its network usable — for
+/// the duration of a background publish.
+///
+/// The OS-backed uploader only carries the video blob across app suspension.
+/// The steps that follow (remote-signer signing of the Nostr event and relay
+/// broadcast) run in-process and are network-starved once Android backgrounds
+/// the app, failing with DNS / socket errors. Holding a session for the whole
+/// publish keeps the process foregrounded so those steps succeed.
+///
+/// Implemented in the app layer over the `background_uploader` plugin and
+/// injected into [BackgroundPublishBloc], so the bloc stays free of plugin
+/// dependencies and the session is fakeable in tests.
+abstract class PublishForegroundSession {
+  /// Starts the session identified by [sessionId]. Must be called while the
+  /// app is foregrounded — starting a foreground service from the background
+  /// is forbidden on Android.
+  Future<void> begin(String sessionId);
+
+  /// Ends the session identified by [sessionId]. Safe to call when no matching
+  /// session is active.
+  Future<void> end(String sessionId);
+}

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4148,5 +4148,6 @@
     "imageCropEditorResetLabel": "ዳግም አስጀምር",
     "imageCropEditorCloseSemanticLabel": "መከርከምን ሰርዝ",
     "imageCropEditorDoneSemanticLabel": "መከርከምን ተግብር",
-    "imageCropEditorProcessing": "መከርከም በመተግበር ላይ…"
+    "imageCropEditorProcessing": "መከርከም በመተግበር ላይ…",
+    "backgroundUploadNotificationTitle": "ቪዲዮ በመስቀል ላይ"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "إعادة تعيين",
     "imageCropEditorCloseSemanticLabel": "إلغاء الاقتصاص",
     "imageCropEditorDoneSemanticLabel": "تطبيق الاقتصاص",
-    "imageCropEditorProcessing": "جارٍ تطبيق الاقتصاص…"
+    "imageCropEditorProcessing": "جارٍ تطبيق الاقتصاص…",
+    "backgroundUploadNotificationTitle": "جارٍ رفع الفيديو"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4154,5 +4154,6 @@
     "imageCropEditorResetLabel": "Нулиране",
     "imageCropEditorCloseSemanticLabel": "Отказ от изрязването",
     "imageCropEditorDoneSemanticLabel": "Прилагане на изрязването",
-    "imageCropEditorProcessing": "Прилагане на изрязването…"
+    "imageCropEditorProcessing": "Прилагане на изрязването…",
+    "backgroundUploadNotificationTitle": "Качване на видео"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Zurücksetzen",
     "imageCropEditorCloseSemanticLabel": "Zuschneiden abbrechen",
     "imageCropEditorDoneSemanticLabel": "Zuschnitt übernehmen",
-    "imageCropEditorProcessing": "Zuschnitt wird angewendet…"
+    "imageCropEditorProcessing": "Zuschnitt wird angewendet…",
+    "backgroundUploadNotificationTitle": "Video wird hochgeladen"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5459,5 +5459,9 @@
     "imageCropEditorProcessing": "Applying crop…",
     "@imageCropEditorProcessing": {
         "description": "Loading message shown while the image crop editor generates the final cropped image after the user taps done."
+    },
+    "backgroundUploadNotificationTitle": "Uploading video",
+    "@backgroundUploadNotificationTitle": {
+        "description": "Title of the Android foreground-service notification shown while a video uploads in the background so the transfer survives app suspension."
     }
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Restablecer",
     "imageCropEditorCloseSemanticLabel": "Cancelar recorte",
     "imageCropEditorDoneSemanticLabel": "Aplicar recorte",
-    "imageCropEditorProcessing": "Aplicando recorte…"
+    "imageCropEditorProcessing": "Aplicando recorte…",
+    "backgroundUploadNotificationTitle": "Subiendo video"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2592,5 +2592,6 @@
     "imageCropEditorResetLabel": "I-reset",
     "imageCropEditorCloseSemanticLabel": "Kanselahin ang pag-crop",
     "imageCropEditorDoneSemanticLabel": "Ilapat ang pag-crop",
-    "imageCropEditorProcessing": "Inilalapat ang pag-crop…"
+    "imageCropEditorProcessing": "Inilalapat ang pag-crop…",
+    "backgroundUploadNotificationTitle": "Ina-upload ang video"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Réinitialiser",
     "imageCropEditorCloseSemanticLabel": "Annuler le recadrage",
     "imageCropEditorDoneSemanticLabel": "Appliquer le recadrage",
-    "imageCropEditorProcessing": "Application du recadrage…"
+    "imageCropEditorProcessing": "Application du recadrage…",
+    "backgroundUploadNotificationTitle": "Envoi de la vidéo"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Atur ulang",
     "imageCropEditorCloseSemanticLabel": "Batalkan pemangkasan",
     "imageCropEditorDoneSemanticLabel": "Terapkan pemangkasan",
-    "imageCropEditorProcessing": "Menerapkan pemangkasan…"
+    "imageCropEditorProcessing": "Menerapkan pemangkasan…",
+    "backgroundUploadNotificationTitle": "Mengunggah video"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Reimposta",
     "imageCropEditorCloseSemanticLabel": "Annulla ritaglio",
     "imageCropEditorDoneSemanticLabel": "Applica ritaglio",
-    "imageCropEditorProcessing": "Applicazione del ritaglio…"
+    "imageCropEditorProcessing": "Applicazione del ritaglio…",
+    "backgroundUploadNotificationTitle": "Caricamento del video"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "リセット",
     "imageCropEditorCloseSemanticLabel": "切り抜きをキャンセル",
     "imageCropEditorDoneSemanticLabel": "切り抜きを適用",
-    "imageCropEditorProcessing": "切り抜きを適用中…"
+    "imageCropEditorProcessing": "切り抜きを適用中…",
+    "backgroundUploadNotificationTitle": "動画をアップロード中"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3340,5 +3340,6 @@
     "imageCropEditorResetLabel": "초기화",
     "imageCropEditorCloseSemanticLabel": "자르기 취소",
     "imageCropEditorDoneSemanticLabel": "자르기 적용",
-    "imageCropEditorProcessing": "자르기 적용 중…"
+    "imageCropEditorProcessing": "자르기 적용 중…",
+    "backgroundUploadNotificationTitle": "동영상 업로드 중"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Resetten",
     "imageCropEditorCloseSemanticLabel": "Bijsnijden annuleren",
     "imageCropEditorDoneSemanticLabel": "Bijsnijden toepassen",
-    "imageCropEditorProcessing": "Bijsnijden toepassen…"
+    "imageCropEditorProcessing": "Bijsnijden toepassen…",
+    "backgroundUploadNotificationTitle": "Video uploaden"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Resetuj",
     "imageCropEditorCloseSemanticLabel": "Anuluj kadrowanie",
     "imageCropEditorDoneSemanticLabel": "Zastosuj kadrowanie",
-    "imageCropEditorProcessing": "Stosowanie kadrowania…"
+    "imageCropEditorProcessing": "Stosowanie kadrowania…",
+    "backgroundUploadNotificationTitle": "Przesyłanie wideo"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Redefinir",
     "imageCropEditorCloseSemanticLabel": "Cancelar recorte",
     "imageCropEditorDoneSemanticLabel": "Aplicar recorte",
-    "imageCropEditorProcessing": "Aplicando recorte…"
+    "imageCropEditorProcessing": "Aplicando recorte…",
+    "backgroundUploadNotificationTitle": "Enviando vídeo"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Resetează",
     "imageCropEditorCloseSemanticLabel": "Anulează decuparea",
     "imageCropEditorDoneSemanticLabel": "Aplică decuparea",
-    "imageCropEditorProcessing": "Se aplică decuparea…"
+    "imageCropEditorProcessing": "Se aplică decuparea…",
+    "backgroundUploadNotificationTitle": "Se încarcă videoclipul"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Återställ",
     "imageCropEditorCloseSemanticLabel": "Avbryt beskärning",
     "imageCropEditorDoneSemanticLabel": "Använd beskärning",
-    "imageCropEditorProcessing": "Tillämpar beskärning…"
+    "imageCropEditorProcessing": "Tillämpar beskärning…",
+    "backgroundUploadNotificationTitle": "Laddar upp video"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4023,5 +4023,6 @@
     "imageCropEditorResetLabel": "Sıfırla",
     "imageCropEditorCloseSemanticLabel": "Kırpmayı iptal et",
     "imageCropEditorDoneSemanticLabel": "Kırpmayı uygula",
-    "imageCropEditorProcessing": "Kırpma uygulanıyor…"
+    "imageCropEditorProcessing": "Kırpma uygulanıyor…",
+    "backgroundUploadNotificationTitle": "Video yükleniyor"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -16319,6 +16319,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Applying crop…'**
   String get imageCropEditorProcessing;
+
+  /// Title of the Android foreground-service notification shown while a video uploads in the background so the transfer survives app suspension.
+  ///
+  /// In en, this message translates to:
+  /// **'Uploading video'**
+  String get backgroundUploadNotificationTitle;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9236,4 +9236,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'መከርከም በመተግበር ላይ…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'ቪዲዮ በመስቀል ላይ';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9329,4 +9329,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'جارٍ تطبيق الاقتصاص…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'جارٍ رفع الفيديو';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9501,4 +9501,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Прилагане на изрязването…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Качване на видео';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9513,4 +9513,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Zuschnitt wird angewendet…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Video wird hochgeladen';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9397,4 +9397,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Applying crop…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Uploading video';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9495,4 +9495,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Aplicando recorte…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Subiendo video';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9511,4 +9511,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Inilalapat ang pag-crop…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Ina-upload ang video';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9537,4 +9537,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Application du recadrage…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Envoi de la vidéo';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9388,4 +9388,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Menerapkan pemangkasan…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Mengunggah video';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9493,4 +9493,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Applicazione del ritaglio…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Caricamento del video';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9083,4 +9083,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => '切り抜きを適用中…';
+
+  @override
+  String get backgroundUploadNotificationTitle => '動画をアップロード中';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9107,4 +9107,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => '자르기 적용 중…';
+
+  @override
+  String get backgroundUploadNotificationTitle => '동영상 업로드 중';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9452,4 +9452,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Bijsnijden toepassen…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Video uploaden';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9571,4 +9571,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Stosowanie kadrowania…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Przesyłanie wideo';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9466,4 +9466,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Aplicando recorte…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Enviando vídeo';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9600,4 +9600,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Se aplică decuparea…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Se încarcă videoclipul';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9418,4 +9418,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Tillämpar beskärning…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Laddar upp video';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9385,4 +9385,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get imageCropEditorProcessing => 'Kırpma uygulanıyor…';
+
+  @override
+  String get backgroundUploadNotificationTitle => 'Video yükleniyor';
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2445,6 +2445,7 @@ class _DivineAppState extends ConsumerState<DivineApp> {
               create: (_) => BackgroundPublishBloc(
                 videoPublishServiceFactory: createPublishService,
                 draftStorageService: ref.read(draftStorageServiceProvider),
+                foregroundSession: ref.read(publishForegroundSessionProvider),
               ),
             ),
             BlocProvider(

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -52,6 +52,11 @@ class _BlossomAuthAdapter implements BlossomAuthProvider {
   }
 }
 
+/// Title shown on the Android background-upload foreground-service
+/// notification. Owned by the app layer because the `background_uploader`
+/// plugin is intentionally domain-agnostic and l10n-free.
+const _backgroundUploadNotificationTitle = 'Uploading video';
+
 /// Adapts the [BackgroundUploader] plugin to the package-level
 /// [BlossomBackgroundTransport] port, so the Blossom service can hand a single
 /// PUT to the OS without depending on the plugin directly.
@@ -79,6 +84,7 @@ class _BackgroundUploadTransportAdapter implements BlossomBackgroundTransport {
         filePath: filePath,
         method: method,
         headers: headers,
+        notificationTitle: _backgroundUploadNotificationTitle,
       ),
     );
   }

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -86,6 +86,17 @@ class _BackgroundUploadTransportAdapter implements BlossomBackgroundTransport {
   @override
   Future<void> cancel(String taskId) => _uploader.cancel(taskId);
 
+  @override
+  Future<List<String>> activeTaskIds() => _uploader.activeTaskIds();
+
+  @override
+  Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
+    String taskId,
+  ) async {
+    final event = await _uploader.takeBufferedTerminalEvent(taskId);
+    return event == null ? null : _toTransferEvent(event);
+  }
+
   static BlossomBackgroundTransferEvent _toTransferEvent(
     BackgroundUploadEvent event,
   ) {

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Upload & media Riverpod providers split from app_providers.dart
 // ABOUTME: Blossom upload, media-auth chain, upload manager, API clients, audio playback
 
+import 'package:background_uploader/background_uploader.dart';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/active_video_provider.dart';
@@ -47,6 +48,62 @@ class _BlossomAuthAdapter implements BlossomAuthProvider {
     );
     if (event == null) return null;
     return BlossomSignedEvent(json: event.toJson());
+  }
+}
+
+/// Adapts the [BackgroundUploader] plugin to the package-level
+/// [BlossomBackgroundTransport] port, so the Blossom service can hand a single
+/// PUT to the OS without depending on the plugin directly.
+class _BackgroundUploadTransportAdapter implements BlossomBackgroundTransport {
+  const _BackgroundUploadTransportAdapter(this._uploader);
+
+  final BackgroundUploader _uploader;
+
+  @override
+  Stream<BlossomBackgroundTransferEvent> get events =>
+      _uploader.events.map(_toTransferEvent);
+
+  @override
+  Future<void> enqueue({
+    required String taskId,
+    required String url,
+    required String method,
+    required Map<String, String> headers,
+    required String filePath,
+  }) {
+    return _uploader.enqueue(
+      BackgroundUploadRequest(
+        taskId: taskId,
+        url: Uri.parse(url),
+        filePath: filePath,
+        method: method,
+        headers: headers,
+      ),
+    );
+  }
+
+  @override
+  Future<void> cancel(String taskId) => _uploader.cancel(taskId);
+
+  static BlossomBackgroundTransferEvent _toTransferEvent(
+    BackgroundUploadEvent event,
+  ) {
+    return BlossomBackgroundTransferEvent(
+      taskId: event.taskId,
+      status: switch (event.status) {
+        BackgroundUploadStatus.running =>
+          BlossomBackgroundTransferStatus.running,
+        BackgroundUploadStatus.completed =>
+          BlossomBackgroundTransferStatus.completed,
+        BackgroundUploadStatus.failed => BlossomBackgroundTransferStatus.failed,
+        BackgroundUploadStatus.cancelled =>
+          BlossomBackgroundTransferStatus.cancelled,
+      },
+      progress: event.progress,
+      httpStatusCode: event.httpStatusCode,
+      responseBody: event.responseBody,
+      error: event.error,
+    );
   }
 }
 
@@ -118,6 +175,12 @@ final uploadBackpressureActiveProvider = Provider<bool>((ref) {
   return isHomeFeedActive;
 });
 
+/// OS-backed background upload transport (URLSession on iOS/macOS, a
+/// foreground service on Android), adapted to the Blossom transport port.
+final backgroundUploadTransportProvider = Provider<BlossomBackgroundTransport>(
+  (ref) => _BackgroundUploadTransportAdapter(BackgroundUploader.instance),
+);
+
 /// Blossom upload service (uses user-configured Blossom server)
 @riverpod
 BlossomUploadService blossomUploadService(Ref ref) {
@@ -129,6 +192,7 @@ BlossomUploadService blossomUploadService(Ref ref) {
       ref.watch(performanceMonitoringServiceProvider),
     ),
     defaultServerUrl: env.blossomUrl,
+    backgroundTransport: ref.watch(backgroundUploadTransportProvider),
     // Backpressure: while a feed video is actively playing in the foreground,
     // pause briefly between chunks so the upload doesn't starve playback on a
     // congested connection. No pause when nothing is streaming.
@@ -139,6 +203,14 @@ BlossomUploadService blossomUploadService(Ref ref) {
     },
   );
 }
+
+/// Whether video publishing routes through the OS background uploader so the
+/// transfer survives app suspension. Flip to `false` to fall back to the
+/// in-process chunked/resumable upload path.
+///
+/// NOTE: the background path requires on-device verification (iOS/macOS
+/// URLSession + Android foreground service) before being relied on.
+const _backgroundUploadEnabled = true;
 
 /// Upload manager uses only Blossom upload service
 @Riverpod(keepAlive: true)
@@ -152,6 +224,7 @@ UploadManager uploadManager(Ref ref) {
     defaultBlossomUrl: env.blossomUrl,
     currentNostrPubkey: currentPubkey,
     scopeUploadsToCurrentUser: true,
+    useBackgroundUpload: _backgroundUploadEnabled,
   );
   ref.onDispose(manager.dispose);
   return manager;

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -5,6 +5,7 @@ import 'package:background_uploader/background_uploader.dart';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/background_publish/publish_foreground_session.dart';
+import 'package:openvine/l10n/current_app_l10n.dart';
 import 'package:openvine/providers/active_video_provider.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -13,6 +14,7 @@ import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
 import 'package:openvine/providers/service_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/services/api_service.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
@@ -52,18 +54,22 @@ class _BlossomAuthAdapter implements BlossomAuthProvider {
   }
 }
 
-/// Title shown on the Android background-upload foreground-service
-/// notification. Owned by the app layer because the `background_uploader`
-/// plugin is intentionally domain-agnostic and l10n-free.
-const _backgroundUploadNotificationTitle = 'Uploading video';
-
 /// Adapts the [BackgroundUploader] plugin to the package-level
 /// [BlossomBackgroundTransport] port, so the Blossom service can hand a single
 /// PUT to the OS without depending on the plugin directly.
 class _BackgroundUploadTransportAdapter implements BlossomBackgroundTransport {
-  const _BackgroundUploadTransportAdapter(this._uploader);
+  const _BackgroundUploadTransportAdapter(
+    this._uploader, {
+    required String Function() notificationTitle,
+  }) : _notificationTitle = notificationTitle;
 
   final BackgroundUploader _uploader;
+
+  /// Resolves the Android foreground-service notification title in the app's
+  /// current locale. Owned by the app layer because the `background_uploader`
+  /// plugin is intentionally domain-agnostic and l10n-free. Called per enqueue
+  /// so a locale change between uploads is picked up.
+  final String Function() _notificationTitle;
 
   @override
   Stream<BlossomBackgroundTransferEvent> get events =>
@@ -84,7 +90,7 @@ class _BackgroundUploadTransportAdapter implements BlossomBackgroundTransport {
         filePath: filePath,
         method: method,
         headers: headers,
-        notificationTitle: _backgroundUploadNotificationTitle,
+        notificationTitle: _notificationTitle(),
       ),
     );
   }
@@ -210,7 +216,14 @@ final uploadBackpressureActiveProvider = Provider<bool>((ref) {
 /// OS-backed background upload transport (URLSession on iOS/macOS, a
 /// foreground service on Android), adapted to the Blossom transport port.
 final backgroundUploadTransportProvider = Provider<BlossomBackgroundTransport>(
-  (ref) => _BackgroundUploadTransportAdapter(BackgroundUploader.instance),
+  (ref) {
+    final prefs = ref.watch(sharedPreferencesProvider);
+    return _BackgroundUploadTransportAdapter(
+      BackgroundUploader.instance,
+      notificationTitle: () =>
+          currentAppL10n(prefs).backgroundUploadNotificationTitle,
+    );
+  },
 );
 
 /// Foreground session used by the background-publish bloc to keep the process
@@ -244,11 +257,10 @@ BlossomUploadService blossomUploadService(Ref ref) {
 }
 
 /// Whether video publishing routes through the OS background uploader so the
-/// transfer survives app suspension. Flip to `false` to fall back to the
-/// in-process chunked/resumable upload path.
-///
-/// NOTE: the background path requires on-device verification (iOS/macOS
-/// URLSession + Android foreground service) before being relied on.
+/// transfer survives app suspension. Kept as a kill-switch: flip to `false` to
+/// fall back to the in-process chunked/resumable upload path if a regression
+/// surfaces in the OS-backed path (iOS/macOS URLSession + Android foreground
+/// service).
 const _backgroundUploadEnabled = true;
 
 /// Upload manager uses only Blossom upload service

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -87,9 +87,6 @@ class _BackgroundUploadTransportAdapter implements BlossomBackgroundTransport {
   Future<void> cancel(String taskId) => _uploader.cancel(taskId);
 
   @override
-  Future<List<String>> activeTaskIds() => _uploader.activeTaskIds();
-
-  @override
   Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
     String taskId,
   ) async {

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -4,6 +4,7 @@
 import 'package:background_uploader/background_uploader.dart';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/blocs/background_publish/publish_foreground_session.dart';
 import 'package:openvine/providers/active_video_provider.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
@@ -107,6 +108,23 @@ class _BackgroundUploadTransportAdapter implements BlossomBackgroundTransport {
   }
 }
 
+/// Adapts the [BackgroundUploader] plugin to the [PublishForegroundSession]
+/// port, so the background-publish bloc can keep the process foregrounded for
+/// the whole publish without depending on the plugin directly.
+class _BackgroundUploaderForegroundSession implements PublishForegroundSession {
+  const _BackgroundUploaderForegroundSession(this._uploader);
+
+  final BackgroundUploader _uploader;
+
+  @override
+  Future<void> begin(String sessionId) =>
+      _uploader.beginForegroundSession(sessionId);
+
+  @override
+  Future<void> end(String sessionId) =>
+      _uploader.endForegroundSession(sessionId);
+}
+
 /// Adapts a [PerformanceTraceMonitor] to the package-level
 /// [BlossomPerformanceMonitor] interface.
 class _FirebasePerformanceAdapter implements BlossomPerformanceMonitor {
@@ -179,6 +197,13 @@ final uploadBackpressureActiveProvider = Provider<bool>((ref) {
 /// foreground service on Android), adapted to the Blossom transport port.
 final backgroundUploadTransportProvider = Provider<BlossomBackgroundTransport>(
   (ref) => _BackgroundUploadTransportAdapter(BackgroundUploader.instance),
+);
+
+/// Foreground session used by the background-publish bloc to keep the process
+/// network alive across the whole publish (upload + signing + relay), not just
+/// the OS-backed blob transfer.
+final publishForegroundSessionProvider = Provider<PublishForegroundSession>(
+  (ref) => _BackgroundUploaderForegroundSession(BackgroundUploader.instance),
 );
 
 /// Blossom upload service (uses user-configured Blossom server)

--- a/mobile/lib/providers/upload_media_providers.g.dart
+++ b/mobile/lib/providers/upload_media_providers.g.dart
@@ -165,7 +165,7 @@ final class BlossomUploadServiceProvider
 }
 
 String _$blossomUploadServiceHash() =>
-    r'6df7595f06a8a9c53f83ca2c135de7f3af06e247';
+    r'c57d4fd1c6b33a1ad1ae1383332051f9aefde433';
 
 /// Upload manager uses only Blossom upload service
 
@@ -211,7 +211,7 @@ final class UploadManagerProvider
   }
 }
 
-String _$uploadManagerHash() => r'9cfb9aeca47922785af40243c40b4fc2d5f63608';
+String _$uploadManagerHash() => r'4f30b7e592133c381c01fcf4d55e046d31c3e8c1';
 
 /// API service depends on auth service
 

--- a/mobile/lib/providers/upload_media_providers.g.dart
+++ b/mobile/lib/providers/upload_media_providers.g.dart
@@ -165,7 +165,7 @@ final class BlossomUploadServiceProvider
 }
 
 String _$blossomUploadServiceHash() =>
-    r'c57d4fd1c6b33a1ad1ae1383332051f9aefde433';
+    r'6295420ba4f79375be8e906aa843dd2b6394877e';
 
 /// Upload manager uses only Blossom upload service
 

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1517,6 +1517,10 @@ class UploadManager {
       final uploadResult = await _blossomService.uploadImage(
         imageFile: thumbnailFile,
         nostrPubkey: nostrPubkey,
+        // A thumbnail is a few KB — a single PUT avoids the resumable
+        // init/chunk/complete handshake (two extra round-trips plus extra auth
+        // signings) that otherwise dominated short-clip publish time.
+        allowResumable: false,
         onProgress: (progress) {
           // Map thumbnail progress to 85%-100% of total upload
           _reporter.updateProgress(upload.id, 0.85 + (progress * 0.15));

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1151,8 +1151,12 @@ class UploadManager {
       category: LogCategory.video,
     );
 
-    // Cancel the active upload (Blossom uploads are canceled by stopping the request)
-    // No additional cleanup needed for Blossom uploads
+    // Stop the OS-owned background transfer while paused so it doesn't keep
+    // uploading in the background; resuming re-enqueues it. The in-process
+    // path is torn down by its request timeout.
+    if (useBackgroundUpload) {
+      await _blossomService.cancelBackgroundUpload(uploadId);
+    }
 
     // Update status to paused instead of failed
     final pausedUpload = upload.copyWith(
@@ -1250,9 +1254,11 @@ class UploadManager {
       category: LogCategory.video,
     );
 
-    // Cancel any active upload
-    if (upload.cloudinaryPublicId != null) {
-      // Blossom upload cancellation handled by request timeout
+    // Stop the OS-owned background transfer if this upload used one; the
+    // in-process path is torn down by its request timeout. Without this the OS
+    // keeps uploading a video the user already cancelled.
+    if (useBackgroundUpload) {
+      await _blossomService.cancelBackgroundUpload(uploadId);
     }
 
     // Update status to failed so it can be retried later

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -1152,8 +1152,10 @@ class UploadManager {
     );
 
     // Stop the OS-owned background transfer while paused so it doesn't keep
-    // uploading in the background; resuming re-enqueues it. The in-process
-    // path is torn down by its request timeout.
+    // uploading in the background. A background transfer is a single OS-owned
+    // PUT with no resumable checkpoint, so resuming re-enqueues it from byte 0
+    // (unlike the in-process path, which resumes from its resumable session).
+    // The in-process path is torn down by its request timeout.
     if (useBackgroundUpload) {
       await _blossomService.cancelBackgroundUpload(uploadId);
     }

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -128,6 +128,7 @@ class UploadManager {
     VideoCircuitBreaker? circuitBreaker,
     UploadRetryConfig? retryConfig,
     UploadCrashReporter? crashReporter,
+    this.useBackgroundUpload = false,
   }) : _blossomService = blossomService,
        _defaultBlossomUrl =
            defaultBlossomUrl ?? BlossomUploadService.defaultBlossomServer,
@@ -148,6 +149,12 @@ class UploadManager {
       crashReporter: crashReporter ?? const CrashReportingUploadReporter(),
     );
   }
+
+  /// Routes the video transfer through the OS background uploader
+  /// ([BlossomUploadService.uploadVideoInBackground]) instead of the in-process
+  /// chunked/legacy path, so it survives app suspension. Requires the
+  /// blossom service to have been built with a background transport.
+  final bool useBackgroundUpload;
 
   // Core services
   final PendingUploadStore _store;
@@ -839,55 +846,66 @@ class UploadManager {
         );
       }
 
-      final result = await _blossomService
-          .uploadVideo(
-            videoFile: videoFile,
-            nostrPubkey: upload.nostrPubkey,
-            title: upload.title ?? '',
-            description: upload.description,
-            hashtags: upload.hashtags,
-            proofManifestJson: upload.proofManifestJson,
-            resumableSession: upload.resumableSession,
-            onResumableSessionUpdated: (session) {
-              _retryPolicy.enqueueSessionPersist(
-                upload.id,
-                session,
-                videoFile.lengthSync(),
-              );
-            },
-            onProgress: (value) {
-              final progress = value * 0.8; // Reserve 20% for thumbnail
+      void reportProgress(double value) {
+        final progress = value * 0.8; // Reserve 20% for thumbnail
+        _reporter.updateProgress(upload.id, progress);
+        onProgress?.call(progress);
+      }
 
-              _reporter.updateProgress(upload.id, progress);
-              onProgress?.call(progress);
-            },
-          )
-          .timeout(
-            _retryConfig.networkTimeout,
-            onTimeout: () {
-              Log.error(
-                '⏱️ Upload timed out!',
-                name: 'UploadManager',
-                category: LogCategory.video,
-              );
-              final timeoutError = TimeoutException(
-                'Upload timed out after ${_retryConfig.networkTimeout.inMinutes} minutes',
-              );
+      // Background uploads are a single OS-owned PUT that survives suspension;
+      // the in-process path keeps chunked-resumable. Both await the same way
+      // and feed the same thumbnail + success handling below.
+      final uploadFuture = useBackgroundUpload
+          ? _blossomService.uploadVideoInBackground(
+              videoFile: videoFile,
+              taskId: upload.id,
+              proofManifestJson: upload.proofManifestJson,
+              onProgress: reportProgress,
+            )
+          : _blossomService.uploadVideo(
+              videoFile: videoFile,
+              nostrPubkey: upload.nostrPubkey,
+              title: upload.title ?? '',
+              description: upload.description,
+              hashtags: upload.hashtags,
+              proofManifestJson: upload.proofManifestJson,
+              resumableSession: upload.resumableSession,
+              onResumableSessionUpdated: (session) {
+                _retryPolicy.enqueueSessionPersist(
+                  upload.id,
+                  session,
+                  videoFile.lengthSync(),
+                );
+              },
+              onProgress: reportProgress,
+            );
 
-              // Send timeout crash report asynchronously
-              _reporter.sendTimeoutCrashReport(upload, timeoutError).catchError(
-                (e) {
-                  Log.error(
-                    'Failed to send timeout crash report: $e',
-                    name: 'UploadManager',
-                    category: LogCategory.video,
-                  );
-                },
-              );
-
-              throw timeoutError;
-            },
+      final result = await uploadFuture.timeout(
+        _retryConfig.networkTimeout,
+        onTimeout: () {
+          Log.error(
+            '⏱️ Upload timed out!',
+            name: 'UploadManager',
+            category: LogCategory.video,
           );
+          final timeoutError = TimeoutException(
+            'Upload timed out after ${_retryConfig.networkTimeout.inMinutes} minutes',
+          );
+
+          // Send timeout crash report asynchronously
+          _reporter.sendTimeoutCrashReport(upload, timeoutError).catchError((
+            e,
+          ) {
+            Log.error(
+              'Failed to send timeout crash report: $e',
+              name: 'UploadManager',
+              category: LogCategory.video,
+            );
+          });
+
+          throw timeoutError;
+        },
+      );
 
       // Generate and upload thumbnail after video upload succeeds
       String? thumbnailCdnUrl;

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -173,6 +173,15 @@ class UploadManager {
   // a disposed manager for up to 5 minutes.
   final Map<String, Timer> _processingPollTimers = {};
 
+  // Uploads the user paused or cancelled while their transfer was still in
+  // flight. Cancelling an OS background transfer emits a `cancelled` terminal
+  // event that resolves the in-flight [_performUpload] future as a failure; a
+  // marker here lets that path recognise a user-initiated stop and skip
+  // [_handleUploadFailure], so a pause is not overwritten with `failed` and a
+  // cancel does not emit a spurious failure crash report. Cleared when the
+  // owning [_performUpload] run settles.
+  final Set<String> _userStoppedUploadIds = <String>{};
+
   bool _isInitialized = false;
 
   /// Check if the upload manager is initialized
@@ -737,12 +746,26 @@ class UploadManager {
       );
       await _performUploadWithRetry(upload, videoFile, onProgress);
     } catch (e) {
+      // A user-initiated pause/cancel tears down the in-flight transfer, which
+      // surfaces here as a failure. pauseUpload/cancelUpload already wrote the
+      // authoritative status, so don't overwrite it or report the stop as a
+      // crash — see [_userStoppedUploadIds].
+      if (_userStoppedUploadIds.contains(upload.id)) {
+        Log.info(
+          'Upload ${upload.id} stopped by user; skipping failure handling',
+          name: 'UploadManager',
+          category: LogCategory.video,
+        );
+        return;
+      }
       Log.error(
         '❌ Upload failed: $e',
         name: 'UploadManager',
         category: LogCategory.video,
       );
       await _handleUploadFailure(upload, e);
+    } finally {
+      _userStoppedUploadIds.remove(upload.id);
     }
   }
 
@@ -1151,6 +1174,11 @@ class UploadManager {
       category: LogCategory.video,
     );
 
+    // Mark before tearing down the transfer: cancelling it emits a terminal
+    // event that would otherwise drive the in-flight upload into
+    // [_handleUploadFailure] and overwrite the paused status below.
+    _userStoppedUploadIds.add(uploadId);
+
     // Stop the OS-owned background transfer while paused so it doesn't keep
     // uploading in the background. A background transfer is a single OS-owned
     // PUT with no resumable checkpoint, so resuming re-enqueues it from byte 0
@@ -1255,6 +1283,17 @@ class UploadManager {
       name: 'UploadManager',
       category: LogCategory.video,
     );
+
+    // Only mark an in-flight transfer: tearing it down emits a terminal event
+    // that would otherwise reach [_handleUploadFailure] and report a spurious
+    // failure for this user-initiated cancel. A marker for an already-terminal
+    // upload would never be cleared (no [_performUpload] run owns it).
+    final isInFlight =
+        upload.status == UploadStatus.uploading ||
+        upload.status == UploadStatus.retrying;
+    if (isInFlight) {
+      _userStoppedUploadIds.add(uploadId);
+    }
 
     // Stop the OS-owned background transfer if this upload used one; the
     // in-process path is torn down by its request timeout. Without this the OS

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -852,17 +852,23 @@ class UploadManager {
         onProgress?.call(progress);
       }
 
-      // Background uploads are a single OS-owned PUT that survives suspension;
-      // the in-process path keeps chunked-resumable. Both await the same way
-      // and feed the same thumbnail + success handling below.
-      final uploadFuture = useBackgroundUpload
-          ? _blossomService.uploadVideoInBackground(
-              videoFile: videoFile,
-              taskId: upload.id,
-              proofManifestJson: upload.proofManifestJson,
-              onProgress: reportProgress,
-            )
-          : _blossomService.uploadVideo(
+      // Background uploads are a single OS-owned PUT that survives suspension.
+      // The OS keeps the transfer alive across app suspension, so it must not
+      // be cut off by the aggressive in-process network timeout;
+      // uploadVideoInBackground applies its own generous safety timeout and
+      // releases its event subscription internally. The in-process path keeps
+      // chunked-resumable behind networkTimeout.
+      final BlossomUploadResult result;
+      if (useBackgroundUpload) {
+        result = await _blossomService.uploadVideoInBackground(
+          videoFile: videoFile,
+          taskId: upload.id,
+          proofManifestJson: upload.proofManifestJson,
+          onProgress: reportProgress,
+        );
+      } else {
+        result = await _blossomService
+            .uploadVideo(
               videoFile: videoFile,
               nostrPubkey: upload.nostrPubkey,
               title: upload.title ?? '',
@@ -878,34 +884,37 @@ class UploadManager {
                 );
               },
               onProgress: reportProgress,
+            )
+            .timeout(
+              _retryConfig.networkTimeout,
+              onTimeout: () {
+                Log.error(
+                  '⏱️ Upload timed out!',
+                  name: 'UploadManager',
+                  category: LogCategory.video,
+                );
+                final timeoutError = TimeoutException(
+                  'Upload timed out after '
+                  '${_retryConfig.networkTimeout.inMinutes} minutes',
+                );
+
+                // Send timeout crash report asynchronously
+                _reporter
+                    .sendTimeoutCrashReport(upload, timeoutError)
+                    .catchError((
+                      e,
+                    ) {
+                      Log.error(
+                        'Failed to send timeout crash report: $e',
+                        name: 'UploadManager',
+                        category: LogCategory.video,
+                      );
+                    });
+
+                throw timeoutError;
+              },
             );
-
-      final result = await uploadFuture.timeout(
-        _retryConfig.networkTimeout,
-        onTimeout: () {
-          Log.error(
-            '⏱️ Upload timed out!',
-            name: 'UploadManager',
-            category: LogCategory.video,
-          );
-          final timeoutError = TimeoutException(
-            'Upload timed out after ${_retryConfig.networkTimeout.inMinutes} minutes',
-          );
-
-          // Send timeout crash report asynchronously
-          _reporter.sendTimeoutCrashReport(upload, timeoutError).catchError((
-            e,
-          ) {
-            Log.error(
-              'Failed to send timeout crash report: $e',
-              name: 'UploadManager',
-              category: LogCategory.video,
-            );
-          });
-
-          throw timeoutError;
-        },
-      );
+      }
 
       // Generate and upload thumbnail after video upload succeeds
       String? thumbnailCdnUrl;

--- a/mobile/packages/background_uploader/.gitignore
+++ b/mobile/packages/background_uploader/.gitignore
@@ -1,0 +1,33 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.build/
+.buildlog/
+.history
+.svn/
+.swiftpm/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins-dependencies
+/build/
+/coverage/

--- a/mobile/packages/background_uploader/CHANGELOG.md
+++ b/mobile/packages/background_uploader/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## 0.0.1
+
+- Initial scaffold: OS-backed background uploads.
+- Dart API (`BackgroundUploader`, `BackgroundUploadRequest`,
+  `BackgroundUploadEvent`) with method-channel + event plumbing.
+- Darwin (iOS + macOS) background `URLSession` implementation.
+- Android foreground-service implementation.

--- a/mobile/packages/background_uploader/LICENSE
+++ b/mobile/packages/background_uploader/LICENSE
@@ -1,0 +1,3 @@
+This package is part of the divine-mobile repository and is licensed under the
+Mozilla Public License Version 2.0. See the repository root LICENSE file for
+the full license text.

--- a/mobile/packages/background_uploader/README.md
+++ b/mobile/packages/background_uploader/README.md
@@ -69,10 +69,15 @@ under SPM when the app has it enabled and falls back to CocoaPods otherwise.
   request the OS owns; it cannot drive a multi-step resumable chunk protocol
   whose every step needs a freshly-signed header while the app is suspended.
   Pair this with a single-PUT endpoint (e.g. Blossom BUD-01 `PUT /upload`).
-- **Events while Dart is dead are dropped.** If the OS completes a transfer
-  while no Flutter engine is attached, the live event is lost — reconcile with
-  `activeTaskIds()` (and, on the caller side, by checking the resource the
-  upload would have created). The `taskId` is the stable correlation handle.
+- **Terminal events are buffered until claimed.** When the OS reports a
+  transfer's terminal event before any `events` listener has subscribed — e.g.
+  it finished while the app was dead and the engine has only just attached — the
+  event is retained (bounded, keyed by `taskId`) and recoverable via
+  `takeBufferedTerminalEvent(taskId)` during startup reconciliation, rather than
+  being silently dropped by the broadcast stream. If the OS completes a transfer
+  while *no* Flutter engine is attached at all, reconcile with `activeTaskIds()`
+  (and, on the caller side, by checking the resource the upload would have
+  created). The `taskId` is the stable correlation handle.
 - **Auth-header expiry.** A signed header is built at enqueue time; if the OS
   defers the transfer for a long time the header can expire. Keep the header's
   lifetime comfortably longer than expected queueing, or re-enqueue on failure.

--- a/mobile/packages/background_uploader/README.md
+++ b/mobile/packages/background_uploader/README.md
@@ -1,0 +1,82 @@
+# background_uploader
+
+OS-backed background file uploads for Android and iOS. Once a file is enqueued,
+the operating system owns the transfer and keeps it running while the app is
+backgrounded or suspended — unlike an in-process HTTP client, whose sockets the
+OS tears down on suspension.
+
+This is a **data-layer client**: it speaks plain HTTP (method + headers + a file
+body) and knows nothing about Blossom, Nostr, or any domain concern. The caller
+builds the request — including any signed authorization header — and maps
+`BackgroundUploadEvent`s onto its own state model.
+
+## Usage
+
+```dart
+import 'package:background_uploader/background_uploader.dart';
+
+final uploader = BackgroundUploader.instance;
+
+uploader.events
+    .where((e) => e.taskId == 'video-123')
+    .listen((e) {
+  switch (e.status) {
+    case BackgroundUploadStatus.running:   // e.progress in [0, 1]
+    case BackgroundUploadStatus.completed: // e.httpStatusCode / e.responseBody
+    case BackgroundUploadStatus.failed:    // e.httpStatusCode or e.error
+    case BackgroundUploadStatus.cancelled:
+  }
+});
+
+await uploader.enqueue(
+  BackgroundUploadRequest(
+    taskId: 'video-123',
+    url: Uri.parse('https://media.divine.video/upload'),
+    filePath: '/path/to/divine_123.mp4',
+    method: 'PUT',
+    headers: {'Authorization': signedBlossomAuthHeader},
+  ),
+);
+```
+
+On startup, reconcile uploads that may have completed while the app was not
+running:
+
+```dart
+final stillRunning = await uploader.activeTaskIds();
+```
+
+## Platform notes
+
+- **Apple (iOS + macOS)** — a shared Darwin background `URLSession`
+  (`uploadTask(with:fromFile:)`). On iOS the app-delegate forwarding hook
+  (`handleEventsForBackgroundURLSession`) lets the OS relaunch the app to finish
+  a transfer; that relaunch path is iOS-only (`#if os(iOS)`), since macOS apps
+  are not suspended the same way. Requires no extra entitlements.
+- **Android** — a foreground service streams the upload. The plugin manifest
+  contributes `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`,
+  `POST_NOTIFICATIONS`, and `INTERNET`. On Android 13+ the ongoing notification
+  only shows if the app holds the (runtime) notification permission; the upload
+  runs regardless.
+
+The Apple side ships **both** a `Package.swift` (Swift Package Manager) and a
+`.podspec` (CocoaPods) over the same shared `darwin/` sources, so it builds
+under SPM when the app has it enabled and falls back to CocoaPods otherwise.
+
+## Design notes / limitations
+
+- **Single request, not chunked-resumable.** An OS background transfer is one
+  request the OS owns; it cannot drive a multi-step resumable chunk protocol
+  whose every step needs a freshly-signed header while the app is suspended.
+  Pair this with a single-PUT endpoint (e.g. Blossom BUD-01 `PUT /upload`).
+- **Events while Dart is dead are dropped.** If the OS completes a transfer
+  while no Flutter engine is attached, the live event is lost — reconcile with
+  `activeTaskIds()` (and, on the caller side, by checking the resource the
+  upload would have created). The `taskId` is the stable correlation handle.
+- **Auth-header expiry.** A signed header is built at enqueue time; if the OS
+  defers the transfer for a long time the header can expire. Keep the header's
+  lifetime comfortably longer than expected queueing, or re-enqueue on failure.
+
+The Dart surface is unit-tested. The native implementations still need on-device
+build and behavioural verification (`pod install` / Gradle) before wiring into
+the app.

--- a/mobile/packages/background_uploader/analysis_options.yaml
+++ b/mobile/packages/background_uploader/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:very_good_analysis/analysis_options.yaml

--- a/mobile/packages/background_uploader/android/build.gradle.kts
+++ b/mobile/packages/background_uploader/android/build.gradle.kts
@@ -1,0 +1,54 @@
+group = "co.openvine.background_uploader"
+version = "1.0-SNAPSHOT"
+
+buildscript {
+    val kotlinVersion = "2.2.20"
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.11.1")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "co.openvine.background_uploader"
+
+    compileSdk = 36
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    sourceSets {
+        getByName("main") {
+            java.srcDirs("src/main/kotlin")
+        }
+    }
+
+    defaultConfig {
+        minSdk = 24
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}

--- a/mobile/packages/background_uploader/android/settings.gradle.kts
+++ b/mobile/packages/background_uploader/android/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "background_uploader"

--- a/mobile/packages/background_uploader/android/src/main/AndroidManifest.xml
+++ b/mobile/packages/background_uploader/android/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+  <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+  <application>
+    <service
+      android:name=".BackgroundUploadService"
+      android:exported="false"
+      android:foregroundServiceType="dataSync" />
+  </application>
+</manifest>

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -38,6 +38,12 @@ class BackgroundUploadService : Service() {
         intent.getStringExtra(EXTRA_TASK_ID)?.let { cancelledTaskIds[it] = true }
         stopIfIdle()
       }
+      ACTION_BEGIN_SESSION ->
+        intent.getStringExtra(EXTRA_SESSION_ID)?.let { activeSessions.add(it) }
+      ACTION_END_SESSION -> {
+        intent.getStringExtra(EXTRA_SESSION_ID)?.let { activeSessions.remove(it) }
+        stopIfIdle()
+      }
       else -> stopIfIdle()
     }
     return START_NOT_STICKY
@@ -178,7 +184,7 @@ class BackgroundUploadService : Service() {
   }
 
   private fun stopIfIdle() {
-    if (activeTaskIds.isEmpty()) {
+    if (activeTaskIds.isEmpty() && activeSessions.isEmpty()) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
         stopForeground(STOP_FOREGROUND_REMOVE)
       } else {
@@ -237,11 +243,14 @@ class BackgroundUploadService : Service() {
   companion object {
     const val ACTION_ENQUEUE = "co.openvine.background_uploader.ENQUEUE"
     const val ACTION_CANCEL = "co.openvine.background_uploader.CANCEL"
+    const val ACTION_BEGIN_SESSION = "co.openvine.background_uploader.BEGIN_SESSION"
+    const val ACTION_END_SESSION = "co.openvine.background_uploader.END_SESSION"
     const val EXTRA_TASK_ID = "taskId"
     const val EXTRA_URL = "url"
     const val EXTRA_FILE_PATH = "filePath"
     const val EXTRA_METHOD = "method"
     const val EXTRA_HEADERS = "headers"
+    const val EXTRA_SESSION_ID = "sessionId"
 
     private const val CHANNEL_ID = "background_upload"
     private const val NOTIFICATION_ID = 0x42
@@ -251,6 +260,13 @@ class BackgroundUploadService : Service() {
 
     private val activeTaskIds = ConcurrentHashMap.newKeySet<String>()
     private val cancelledTaskIds = ConcurrentHashMap<String, Boolean>()
+
+    /// Foreground sessions that keep the service alive beyond any in-flight
+    /// upload, so the process stays foregrounded (network usable) across the
+    /// caller's follow-up work — e.g. signing and broadcasting an event after a
+    /// background upload completes. The service stops only when both the
+    /// upload set and this set are empty.
+    private val activeSessions = ConcurrentHashMap.newKeySet<String>()
 
     fun activeTaskIds(): List<String> = activeTaskIds.toList()
   }

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -21,11 +21,13 @@ import java.util.concurrent.Executors
 
 class BackgroundUploadService : Service() {
   private val executor = Executors.newCachedThreadPool()
+  private var notificationTitle: String = DEFAULT_NOTIFICATION_TITLE
 
   override fun onBind(intent: Intent?): IBinder? = null
 
   override fun onCreate() {
     super.onCreate()
+    running = true
     createNotificationChannel()
   }
 
@@ -56,6 +58,14 @@ class BackgroundUploadService : Service() {
     val urlString = intent.getStringExtra(EXTRA_URL) ?: return stopIfIdle()
     val filePath = intent.getStringExtra(EXTRA_FILE_PATH) ?: return stopIfIdle()
     val method = intent.getStringExtra(EXTRA_METHOD) ?: "PUT"
+
+    intent.getStringExtra(EXTRA_NOTIFICATION_TITLE)?.let { title ->
+      if (title != notificationTitle) {
+        notificationTitle = title
+        // Refresh the ongoing notification with the caller-supplied title.
+        startForegroundCompat()
+      }
+    }
 
     @Suppress("UNCHECKED_CAST")
     val headers =
@@ -232,7 +242,7 @@ class BackgroundUploadService : Service() {
       Notification.Builder(this)
     }
     return builder
-      .setContentTitle("Uploading")
+      .setContentTitle(notificationTitle)
       .setSmallIcon(android.R.drawable.stat_sys_upload)
       .setOngoing(true)
       .build()
@@ -252,6 +262,7 @@ class BackgroundUploadService : Service() {
   }
 
   override fun onDestroy() {
+    running = false
     executor.shutdown()
     super.onDestroy()
   }
@@ -267,12 +278,23 @@ class BackgroundUploadService : Service() {
     const val EXTRA_METHOD = "method"
     const val EXTRA_HEADERS = "headers"
     const val EXTRA_SESSION_ID = "sessionId"
+    const val EXTRA_NOTIFICATION_TITLE = "notificationTitle"
 
     private const val CHANNEL_ID = "background_upload"
     private const val NOTIFICATION_ID = 0x42
     private const val BUFFER_SIZE = 256 * 1024
     private const val CONNECT_TIMEOUT_MS = 30_000
     private const val READ_TIMEOUT_MS = 600_000
+    private const val DEFAULT_NOTIFICATION_TITLE = "Uploading"
+
+    /// Whether a service instance is currently alive. The plugin checks this so
+    /// control commands (cancel / end-session) are only delivered to a live
+    /// service via `startService`, never by starting a foreground service from
+    /// the background. Set in [onCreate] / cleared in [onDestroy].
+    @Volatile
+    private var running = false
+
+    fun isRunning(): Boolean = running
 
     private val activeTaskIds = ConcurrentHashMap.newKeySet<String>()
     private val cancelledTaskIds = ConcurrentHashMap<String, Boolean>()

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -264,6 +264,15 @@ class BackgroundUploadService : Service() {
   override fun onDestroy() {
     running = false
     executor.shutdown()
+    // These sets are process-static, so a destroyed service would otherwise
+    // leak stale entries into the next service instance: a leftover
+    // activeSessions/activeTaskIds entry keeps stopIfIdle() from ever firing
+    // (permanent foreground notification), and a leftover activeTaskIds entry
+    // makes a later re-enqueue of the same taskId a silent no-op. Reset them so
+    // each fresh service starts from a clean slate.
+    activeTaskIds.clear()
+    cancelledTaskIds.clear()
+    activeSessions.clear()
     super.onDestroy()
   }
 

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -50,9 +50,11 @@ class BackgroundUploadService : Service() {
   }
 
   private fun handleEnqueue(intent: Intent) {
-    val taskId = intent.getStringExtra(EXTRA_TASK_ID) ?: return
-    val urlString = intent.getStringExtra(EXTRA_URL) ?: return
-    val filePath = intent.getStringExtra(EXTRA_FILE_PATH) ?: return
+    // A malformed intent must not leave the just-started foreground service
+    // running with nothing to do, so bail out through stopIfIdle().
+    val taskId = intent.getStringExtra(EXTRA_TASK_ID) ?: return stopIfIdle()
+    val urlString = intent.getStringExtra(EXTRA_URL) ?: return stopIfIdle()
+    val filePath = intent.getStringExtra(EXTRA_FILE_PATH) ?: return stopIfIdle()
     val method = intent.getStringExtra(EXTRA_METHOD) ?: "PUT"
 
     @Suppress("UNCHECKED_CAST")

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -1,0 +1,257 @@
+// ABOUTME: Foreground service that streams a file upload to completion so it
+// ABOUTME: keeps running after the app is backgrounded; reports progress back.
+
+package co.openvine.background_uploader
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import java.io.File
+import java.io.FileInputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+
+class BackgroundUploadService : Service() {
+  private val executor = Executors.newCachedThreadPool()
+
+  override fun onBind(intent: Intent?): IBinder? = null
+
+  override fun onCreate() {
+    super.onCreate()
+    createNotificationChannel()
+  }
+
+  override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+    startForegroundCompat()
+
+    when (intent?.action) {
+      ACTION_ENQUEUE -> handleEnqueue(intent)
+      ACTION_CANCEL -> {
+        intent.getStringExtra(EXTRA_TASK_ID)?.let { cancelledTaskIds[it] = true }
+        stopIfIdle()
+      }
+      else -> stopIfIdle()
+    }
+    return START_NOT_STICKY
+  }
+
+  private fun handleEnqueue(intent: Intent) {
+    val taskId = intent.getStringExtra(EXTRA_TASK_ID) ?: return
+    val urlString = intent.getStringExtra(EXTRA_URL) ?: return
+    val filePath = intent.getStringExtra(EXTRA_FILE_PATH) ?: return
+    val method = intent.getStringExtra(EXTRA_METHOD) ?: "PUT"
+
+    @Suppress("UNCHECKED_CAST")
+    val headers =
+      (intent.getSerializableExtra(EXTRA_HEADERS) as? HashMap<String, String>)
+        ?: HashMap()
+
+    activeTaskIds.add(taskId)
+    executor.execute { runUpload(taskId, urlString, filePath, method, headers) }
+  }
+
+  private fun runUpload(
+    taskId: String,
+    urlString: String,
+    filePath: String,
+    method: String,
+    headers: Map<String, String>,
+  ) {
+    var connection: HttpURLConnection? = null
+    try {
+      val file = File(filePath)
+      if (!file.exists()) {
+        postFailure(taskId, error = "No file at $filePath")
+        return
+      }
+
+      val length = file.length()
+      connection = (URL(urlString).openConnection() as HttpURLConnection).apply {
+        requestMethod = method
+        doOutput = true
+        setFixedLengthStreamingMode(length)
+        connectTimeout = CONNECT_TIMEOUT_MS
+        readTimeout = READ_TIMEOUT_MS
+        headers.forEach { (key, value) -> setRequestProperty(key, value) }
+      }
+
+      FileInputStream(file).use { input ->
+        connection.outputStream.use { output ->
+          val buffer = ByteArray(BUFFER_SIZE)
+          var sent = 0L
+          while (true) {
+            if (cancelledTaskIds.containsKey(taskId)) {
+              postCancelled(taskId)
+              return
+            }
+            val read = input.read(buffer)
+            if (read == -1) break
+            output.write(buffer, 0, read)
+            sent += read
+            if (length > 0) postProgress(taskId, sent.toDouble() / length)
+          }
+        }
+      }
+
+      val statusCode = connection.responseCode
+      val body = readBody(connection)
+      val success = statusCode in 200..299
+      postTerminal(
+        taskId = taskId,
+        status = if (success) "completed" else "failed",
+        progress = if (success) 1.0 else 0.0,
+        httpStatusCode = statusCode,
+        responseBody = body,
+      )
+    } catch (e: Exception) {
+      if (cancelledTaskIds.containsKey(taskId)) {
+        postCancelled(taskId)
+      } else {
+        postFailure(taskId, error = e.message ?: e.javaClass.simpleName)
+      }
+    } finally {
+      connection?.disconnect()
+      activeTaskIds.remove(taskId)
+      cancelledTaskIds.remove(taskId)
+      stopIfIdle()
+    }
+  }
+
+  private fun readBody(connection: HttpURLConnection): String? {
+    val stream = runCatching { connection.inputStream }.getOrNull()
+      ?: connection.errorStream
+      ?: return null
+    return stream.use { it.readBytes().toString(Charsets.UTF_8) }
+  }
+
+  private fun postProgress(taskId: String, progress: Double) {
+    BackgroundUploaderPlugin.postEvent(
+      mapOf(
+        "taskId" to taskId,
+        "status" to "running",
+        "progress" to progress.coerceIn(0.0, 1.0),
+      ),
+    )
+  }
+
+  private fun postTerminal(
+    taskId: String,
+    status: String,
+    progress: Double,
+    httpStatusCode: Int?,
+    responseBody: String?,
+  ) {
+    BackgroundUploaderPlugin.postEvent(
+      mapOf(
+        "taskId" to taskId,
+        "status" to status,
+        "progress" to progress,
+        "httpStatusCode" to httpStatusCode,
+        "responseBody" to responseBody,
+      ),
+    )
+  }
+
+  private fun postFailure(taskId: String, error: String) {
+    BackgroundUploaderPlugin.postEvent(
+      mapOf(
+        "taskId" to taskId,
+        "status" to "failed",
+        "progress" to 0.0,
+        "error" to error,
+      ),
+    )
+  }
+
+  private fun postCancelled(taskId: String) {
+    BackgroundUploaderPlugin.postEvent(
+      mapOf("taskId" to taskId, "status" to "cancelled", "progress" to 0.0),
+    )
+  }
+
+  private fun stopIfIdle() {
+    if (activeTaskIds.isEmpty()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        stopForeground(STOP_FOREGROUND_REMOVE)
+      } else {
+        @Suppress("DEPRECATION")
+        stopForeground(true)
+      }
+      stopSelf()
+    }
+  }
+
+  private fun startForegroundCompat() {
+    val notification = buildNotification()
+    if (BackgroundUploaderPlugin.supportsTypedForegroundService()) {
+      startForeground(
+        NOTIFICATION_ID,
+        notification,
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+      )
+    } else {
+      startForeground(NOTIFICATION_ID, notification)
+    }
+  }
+
+  private fun buildNotification(): Notification {
+    val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      Notification.Builder(this, CHANNEL_ID)
+    } else {
+      @Suppress("DEPRECATION")
+      Notification.Builder(this)
+    }
+    return builder
+      .setContentTitle("Uploading")
+      .setSmallIcon(android.R.drawable.stat_sys_upload)
+      .setOngoing(true)
+      .build()
+  }
+
+  private fun createNotificationChannel() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+    val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+    manager.createNotificationChannel(
+      NotificationChannel(
+        CHANNEL_ID,
+        "Background uploads",
+        NotificationManager.IMPORTANCE_LOW,
+      ),
+    )
+  }
+
+  override fun onDestroy() {
+    executor.shutdown()
+    super.onDestroy()
+  }
+
+  companion object {
+    const val ACTION_ENQUEUE = "co.openvine.background_uploader.ENQUEUE"
+    const val ACTION_CANCEL = "co.openvine.background_uploader.CANCEL"
+    const val EXTRA_TASK_ID = "taskId"
+    const val EXTRA_URL = "url"
+    const val EXTRA_FILE_PATH = "filePath"
+    const val EXTRA_METHOD = "method"
+    const val EXTRA_HEADERS = "headers"
+
+    private const val CHANNEL_ID = "background_upload"
+    private const val NOTIFICATION_ID = 0x42
+    private const val BUFFER_SIZE = 64 * 1024
+    private const val CONNECT_TIMEOUT_MS = 30_000
+    private const val READ_TIMEOUT_MS = 600_000
+
+    private val activeTaskIds = ConcurrentHashMap.newKeySet<String>()
+    private val cancelledTaskIds = ConcurrentHashMap<String, Boolean>()
+
+    fun activeTaskIds(): List<String> = activeTaskIds.toList()
+  }
+}

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -32,7 +32,18 @@ class BackgroundUploadService : Service() {
   }
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    startForegroundCompat()
+    try {
+      startForegroundCompat()
+    } catch (e: Exception) {
+      intent?.getStringExtra(EXTRA_TASK_ID)?.let { taskId ->
+        postFailure(
+          taskId,
+          error = e.message ?: e.javaClass.simpleName,
+        )
+      }
+      stopSelf()
+      return START_NOT_STICKY
+    }
 
     when (intent?.action) {
       ACTION_ENQUEUE -> handleEnqueue(intent)
@@ -69,7 +80,7 @@ class BackgroundUploadService : Service() {
       if (title != notificationTitle) {
         notificationTitle = title
         // Refresh the ongoing notification with the caller-supplied title.
-        startForegroundCompat()
+        runCatching { startForegroundCompat() }
       }
     }
 
@@ -83,6 +94,7 @@ class BackgroundUploadService : Service() {
     // skip starting a second parallel upload of the same file. The service
     // stays foregrounded because activeTaskIds is non-empty.
     if (!activeTaskIds.add(taskId)) return
+    cancelledTaskIds.remove(taskId)
     executor.execute { runUpload(taskId, urlString, filePath, method, headers) }
   }
 

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -37,7 +37,13 @@ class BackgroundUploadService : Service() {
     when (intent?.action) {
       ACTION_ENQUEUE -> handleEnqueue(intent)
       ACTION_CANCEL -> {
-        intent.getStringExtra(EXTRA_TASK_ID)?.let { cancelledTaskIds[it] = true }
+        intent.getStringExtra(EXTRA_TASK_ID)?.let { taskId ->
+          cancelledTaskIds[taskId] = true
+          // Abort a transfer already blocked reading the response so a cancel
+          // that lands after the body is fully sent terminates as `cancelled`
+          // instead of running to `completed` (matching iOS `task.cancel()`).
+          runCatching { activeConnections[taskId]?.disconnect() }
+        }
         stopIfIdle()
       }
       ACTION_BEGIN_SESSION ->
@@ -104,6 +110,9 @@ class BackgroundUploadService : Service() {
         readTimeout = READ_TIMEOUT_MS
         headers.forEach { (key, value) -> setRequestProperty(key, value) }
       }
+      // Register the connection so ACTION_CANCEL can abort a transfer that is
+      // already blocked reading the response (see onStartCommand).
+      activeConnections[taskId] = connection
 
       FileInputStream(file).use { input ->
         connection.outputStream.use { output ->
@@ -133,6 +142,14 @@ class BackgroundUploadService : Service() {
         }
       }
 
+      // A cancel can land after the last chunk is written but before the
+      // response is read; without this re-check the transfer would report
+      // `completed` even though the caller asked to cancel.
+      if (cancelledTaskIds.containsKey(taskId)) {
+        postCancelled(taskId)
+        return
+      }
+
       val statusCode = connection.responseCode
       val body = readBody(connection)
       val success = statusCode in 200..299
@@ -151,6 +168,7 @@ class BackgroundUploadService : Service() {
       }
     } finally {
       connection?.disconnect()
+      activeConnections.remove(taskId)
       activeTaskIds.remove(taskId)
       cancelledTaskIds.remove(taskId)
       stopIfIdle()
@@ -207,6 +225,19 @@ class BackgroundUploadService : Service() {
     BackgroundUploaderPlugin.postEvent(
       mapOf("taskId" to taskId, "status" to "cancelled", "progress" to 0.0),
     )
+  }
+
+  // On Android 15+ (API 35) a `dataSync` foreground service that exhausts its
+  // cumulative daily runtime budget receives onTimeout; the default no-op never
+  // stops the service, so the platform raises a foreground-service-timeout
+  // crash. Comply by aborting any in-flight transfers and stopping.
+  override fun onTimeout(startId: Int, fgsType: Int) {
+    activeConnections.values.forEach { runCatching { it.disconnect() } }
+    activeConnections.clear()
+    activeTaskIds.clear()
+    cancelledTaskIds.clear()
+    activeSessions.clear()
+    stopIfIdle()
   }
 
   private fun stopIfIdle() {
@@ -272,6 +303,7 @@ class BackgroundUploadService : Service() {
     // each fresh service starts from a clean slate.
     activeTaskIds.clear()
     cancelledTaskIds.clear()
+    activeConnections.clear()
     activeSessions.clear()
     super.onDestroy()
   }
@@ -307,6 +339,10 @@ class BackgroundUploadService : Service() {
 
     private val activeTaskIds = ConcurrentHashMap.newKeySet<String>()
     private val cancelledTaskIds = ConcurrentHashMap<String, Boolean>()
+
+    /// Live connections keyed by task, so an ACTION_CANCEL delivered while a
+    /// transfer is blocked reading the response can `disconnect()` to abort it.
+    private val activeConnections = ConcurrentHashMap<String, HttpURLConnection>()
 
     /// Foreground sessions that keep the service alive beyond any in-flight
     /// upload, so the process stays foregrounded (network usable) across the

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -93,6 +93,10 @@ class BackgroundUploadService : Service() {
         connection.outputStream.use { output ->
           val buffer = ByteArray(BUFFER_SIZE)
           var sent = 0L
+          // Throttle to one event per whole percent (≤101 per transfer) so the
+          // hot write loop doesn't flood the main thread / method channel and
+          // the pending-upload store with hundreds of progress updates.
+          var lastReportedPercent = -1
           while (true) {
             if (cancelledTaskIds.containsKey(taskId)) {
               postCancelled(taskId)
@@ -102,7 +106,13 @@ class BackgroundUploadService : Service() {
             if (read == -1) break
             output.write(buffer, 0, read)
             sent += read
-            if (length > 0) postProgress(taskId, sent.toDouble() / length)
+            if (length > 0) {
+              val percent = (sent * 100 / length).toInt()
+              if (percent != lastReportedPercent) {
+                lastReportedPercent = percent
+                postProgress(taskId, sent.toDouble() / length)
+              }
+            }
           }
         }
       }
@@ -254,7 +264,7 @@ class BackgroundUploadService : Service() {
 
     private const val CHANNEL_ID = "background_upload"
     private const val NOTIFICATION_ID = 0x42
-    private const val BUFFER_SIZE = 64 * 1024
+    private const val BUFFER_SIZE = 256 * 1024
     private const val CONNECT_TIMEOUT_MS = 30_000
     private const val READ_TIMEOUT_MS = 600_000
 

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploadService.kt
@@ -62,7 +62,11 @@ class BackgroundUploadService : Service() {
       (intent.getSerializableExtra(EXTRA_HEADERS) as? HashMap<String, String>)
         ?: HashMap()
 
-    activeTaskIds.add(taskId)
+    // Dedupe: a retry/timeout can re-enqueue the same taskId while the first
+    // transfer is still in flight. add() returns false when already present, so
+    // skip starting a second parallel upload of the same file. The service
+    // stays foregrounded because activeTaskIds is non-empty.
+    if (!activeTaskIds.add(taskId)) return
     executor.execute { runUpload(taskId, urlString, filePath, method, headers) }
   }
 

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploaderPlugin.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploaderPlugin.kt
@@ -1,0 +1,89 @@
+// ABOUTME: Android background uploader plugin. Forwards enqueue/cancel to a
+// ABOUTME: foreground service and fans its events back onto the method channel.
+
+package co.openvine.background_uploader
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+
+class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
+  private lateinit var channel: MethodChannel
+  private lateinit var context: Context
+
+  override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    context = binding.applicationContext
+    channel = MethodChannel(binding.binaryMessenger, "background_uploader")
+    channel.setMethodCallHandler(this)
+    active = this
+  }
+
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+    channel.setMethodCallHandler(null)
+    if (active === this) active = null
+  }
+
+  override fun onMethodCall(call: MethodCall, result: Result) {
+    when (call.method) {
+      "isSupported" -> result.success(true)
+      "enqueue" -> {
+        val intent = Intent(context, BackgroundUploadService::class.java).apply {
+          action = BackgroundUploadService.ACTION_ENQUEUE
+          putExtra(BackgroundUploadService.EXTRA_TASK_ID, call.argument<String>("taskId"))
+          putExtra(BackgroundUploadService.EXTRA_URL, call.argument<String>("url"))
+          putExtra(BackgroundUploadService.EXTRA_FILE_PATH, call.argument<String>("filePath"))
+          putExtra(BackgroundUploadService.EXTRA_METHOD, call.argument<String>("method") ?: "PUT")
+          val headers = call.argument<Map<String, String>>("headers") ?: emptyMap()
+          putExtra(BackgroundUploadService.EXTRA_HEADERS, HashMap(headers))
+        }
+        startUploadService(intent)
+        result.success(null)
+      }
+      "cancel" -> {
+        val intent = Intent(context, BackgroundUploadService::class.java).apply {
+          action = BackgroundUploadService.ACTION_CANCEL
+          putExtra(BackgroundUploadService.EXTRA_TASK_ID, call.argument<String>("taskId"))
+        }
+        startUploadService(intent)
+        result.success(null)
+      }
+      "activeTaskIds" -> result.success(BackgroundUploadService.activeTaskIds())
+      else -> result.notImplemented()
+    }
+  }
+
+  private fun startUploadService(intent: Intent) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      context.startForegroundService(intent)
+    } else {
+      context.startService(intent)
+    }
+  }
+
+  companion object {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    /// The currently-attached plugin instance, used by the service to deliver
+    /// events. Null while no Flutter engine is attached; events emitted then
+    /// are dropped and reconciled on the next launch via `activeTaskIds`.
+    @Volatile
+    private var active: BackgroundUploaderPlugin? = null
+
+    /// Called from the upload service (on a worker thread) to deliver an event.
+    fun postEvent(event: Map<String, Any?>) {
+      mainHandler.post {
+        active?.channel?.invokeMethod("onUploadEvent", event)
+      }
+    }
+
+    fun supportsTypedForegroundService(): Boolean =
+      Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+  }
+}

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploaderPlugin.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploaderPlugin.kt
@@ -41,18 +41,19 @@ class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
           putExtra(BackgroundUploadService.EXTRA_URL, call.argument<String>("url"))
           putExtra(BackgroundUploadService.EXTRA_FILE_PATH, call.argument<String>("filePath"))
           putExtra(BackgroundUploadService.EXTRA_METHOD, call.argument<String>("method") ?: "PUT")
+          call.argument<String>("notificationTitle")?.let {
+            putExtra(BackgroundUploadService.EXTRA_NOTIFICATION_TITLE, it)
+          }
           val headers = call.argument<Map<String, String>>("headers") ?: emptyMap()
           putExtra(BackgroundUploadService.EXTRA_HEADERS, HashMap(headers))
         }
-        startUploadService(intent)
+        startForegroundUploadService(intent)
         result.success(null)
       }
       "cancel" -> {
-        val intent = Intent(context, BackgroundUploadService::class.java).apply {
-          action = BackgroundUploadService.ACTION_CANCEL
+        deliverToRunningService(BackgroundUploadService.ACTION_CANCEL) {
           putExtra(BackgroundUploadService.EXTRA_TASK_ID, call.argument<String>("taskId"))
         }
-        startUploadService(intent)
         result.success(null)
       }
       "activeTaskIds" -> result.success(BackgroundUploadService.activeTaskIds())
@@ -64,30 +65,51 @@ class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
             call.argument<String>("sessionId"),
           )
         }
-        startUploadService(intent)
+        startForegroundUploadService(intent)
         result.success(null)
       }
       "endForegroundSession" -> {
-        val intent = Intent(context, BackgroundUploadService::class.java).apply {
-          action = BackgroundUploadService.ACTION_END_SESSION
+        deliverToRunningService(BackgroundUploadService.ACTION_END_SESSION) {
           putExtra(
             BackgroundUploadService.EXTRA_SESSION_ID,
             call.argument<String>("sessionId"),
           )
         }
-        startUploadService(intent)
         result.success(null)
       }
       else -> result.notImplemented()
     }
   }
 
-  private fun startUploadService(intent: Intent) {
+  /// Starts the upload service in the foreground. Only callable while the app
+  /// itself is foregrounded — Android 12+ forbids starting a foreground service
+  /// from the background. `enqueue` and `beginForegroundSession` both run at
+  /// publish time (foreground), so this is safe for them.
+  private fun startForegroundUploadService(intent: Intent) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       context.startForegroundService(intent)
     } else {
       context.startService(intent)
     }
+  }
+
+  /// Delivers a control command (cancel / end-session) to the service *only if
+  /// it is already running*, via a plain `startService` — which the OS allows
+  /// from the background for a live service. When no service is running there is
+  /// nothing to cancel or stop, so this is a no-op. This deliberately never
+  /// calls `startForegroundService`: doing so from the background (e.g. the
+  /// publish `finally` running after the app was suspended) is both forbidden on
+  /// Android 12+ and pointless — starting a service just to stop it.
+  private fun deliverToRunningService(
+    serviceAction: String,
+    configure: Intent.() -> Unit,
+  ) {
+    if (!BackgroundUploadService.isRunning()) return
+    val intent = Intent(context, BackgroundUploadService::class.java).apply {
+      action = serviceAction
+      configure()
+    }
+    context.startService(intent)
   }
 
   companion object {

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploaderPlugin.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploaderPlugin.kt
@@ -13,6 +13,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import java.util.concurrent.ConcurrentHashMap
 
 class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
   private lateinit var channel: MethodChannel
@@ -22,12 +23,12 @@ class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
     context = binding.applicationContext
     channel = MethodChannel(binding.binaryMessenger, "background_uploader")
     channel.setMethodCallHandler(this)
-    active = this
+    instances.add(this)
   }
 
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
-    if (active === this) active = null
+    instances.remove(this)
   }
 
   override fun onMethodCall(call: MethodCall, result: Result) {
@@ -55,6 +56,28 @@ class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
         result.success(null)
       }
       "activeTaskIds" -> result.success(BackgroundUploadService.activeTaskIds())
+      "beginForegroundSession" -> {
+        val intent = Intent(context, BackgroundUploadService::class.java).apply {
+          action = BackgroundUploadService.ACTION_BEGIN_SESSION
+          putExtra(
+            BackgroundUploadService.EXTRA_SESSION_ID,
+            call.argument<String>("sessionId"),
+          )
+        }
+        startUploadService(intent)
+        result.success(null)
+      }
+      "endForegroundSession" -> {
+        val intent = Intent(context, BackgroundUploadService::class.java).apply {
+          action = BackgroundUploadService.ACTION_END_SESSION
+          putExtra(
+            BackgroundUploadService.EXTRA_SESSION_ID,
+            call.argument<String>("sessionId"),
+          )
+        }
+        startUploadService(intent)
+        result.success(null)
+      }
       else -> result.notImplemented()
     }
   }
@@ -70,16 +93,27 @@ class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
   companion object {
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    /// The currently-attached plugin instance, used by the service to deliver
-    /// events. Null while no Flutter engine is attached; events emitted then
-    /// are dropped and reconciled on the next launch via `activeTaskIds`.
-    @Volatile
-    private var active: BackgroundUploaderPlugin? = null
+    /// Every attached plugin instance — one per Flutter engine in the process.
+    /// A process can host more than one engine (e.g. the Firebase-messaging or
+    /// flutter_local_notifications background engine), and each one registers
+    /// this plugin. Events fan out to all of them; only the engine whose Dart
+    /// isolate set an `onUploadEvent` handler acts on it, the rest ignore it.
+    /// A single last-write-wins reference would point at whichever engine
+    /// attached last and silently drop events destined for the UI isolate.
+    private val instances =
+      ConcurrentHashMap.newKeySet<BackgroundUploaderPlugin>()
 
     /// Called from the upload service (on a worker thread) to deliver an event.
     fun postEvent(event: Map<String, Any?>) {
       mainHandler.post {
-        active?.channel?.invokeMethod("onUploadEvent", event)
+        for (plugin in instances) {
+          try {
+            plugin.channel.invokeMethod("onUploadEvent", event)
+          } catch (ignored: Exception) {
+            // Best-effort fan-out: an engine detaching concurrently can reject
+            // the call; the engine that owns the upload still receives it.
+          }
+        }
       }
     }
 

--- a/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploaderPlugin.kt
+++ b/mobile/packages/background_uploader/android/src/main/kotlin/co/openvine/background_uploader/BackgroundUploaderPlugin.kt
@@ -47,8 +47,7 @@ class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
           val headers = call.argument<Map<String, String>>("headers") ?: emptyMap()
           putExtra(BackgroundUploadService.EXTRA_HEADERS, HashMap(headers))
         }
-        startForegroundUploadService(intent)
-        result.success(null)
+        startForegroundUploadService(intent, result)
       }
       "cancel" -> {
         deliverToRunningService(BackgroundUploadService.ACTION_CANCEL) {
@@ -65,8 +64,7 @@ class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
             call.argument<String>("sessionId"),
           )
         }
-        startForegroundUploadService(intent)
-        result.success(null)
+        startForegroundUploadService(intent, result)
       }
       "endForegroundSession" -> {
         deliverToRunningService(BackgroundUploadService.ACTION_END_SESSION) {
@@ -85,11 +83,20 @@ class BackgroundUploaderPlugin : FlutterPlugin, MethodCallHandler {
   /// itself is foregrounded — Android 12+ forbids starting a foreground service
   /// from the background. `enqueue` and `beginForegroundSession` both run at
   /// publish time (foreground), so this is safe for them.
-  private fun startForegroundUploadService(intent: Intent) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      context.startForegroundService(intent)
-    } else {
-      context.startService(intent)
+  private fun startForegroundUploadService(intent: Intent, result: Result) {
+    try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        context.startForegroundService(intent)
+      } else {
+        context.startService(intent)
+      }
+      result.success(null)
+    } catch (e: Exception) {
+      result.error(
+        "foreground_service_start_failed",
+        e.message ?: e.javaClass.simpleName,
+        null,
+      )
     }
   }
 

--- a/mobile/packages/background_uploader/darwin/background_uploader.podspec
+++ b/mobile/packages/background_uploader/darwin/background_uploader.podspec
@@ -1,0 +1,24 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint background_uploader.podspec` to validate before publishing.
+#
+Pod::Spec.new do |s|
+  s.name             = 'background_uploader'
+  s.version          = '0.0.1'
+  s.summary          = 'OS-backed background file uploader for Android and Apple platforms.'
+  s.description      = <<-DESC
+Flutter plugin that uploads files through the OS background transfer facility
+(a background URLSession on iOS and macOS) so transfers survive app suspension.
+                       DESC
+  s.homepage         = 'https://github.com/divinevideo/divine-mobile'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Divine' => 'dev@divine.video' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'background_uploader/Sources/background_uploader/**/*'
+  s.ios.dependency       'Flutter'
+  s.osx.dependency       'FlutterMacOS'
+  s.ios.deployment_target = '13.0'
+  s.osx.deployment_target = '10.15'
+  s.swift_version    = '5.9'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+end

--- a/mobile/packages/background_uploader/darwin/background_uploader/Package.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+  name: "background_uploader",
+  platforms: [
+    .iOS("13.0"),
+    .macOS("10.15"),
+  ],
+  products: [
+    .library(name: "background-uploader", targets: ["background_uploader"]),
+  ],
+  dependencies: [],
+  targets: [
+    .target(
+      name: "background_uploader",
+      dependencies: []
+    ),
+  ]
+)

--- a/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
@@ -9,12 +9,32 @@ import FlutterMacOS
 #endif
 import Foundation
 
-public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
+/// Owns the process-wide background `URLSession` and fans its delegate events
+/// out to every attached Flutter engine's method channel.
+///
+/// A process can host more than one Flutter engine (e.g. the Firebase-messaging
+/// background engine), and each one registers this plugin. iOS forbids creating
+/// two `URLSession`s that share one background identifier — doing so is
+/// undefined behavior and historically crashes — so the session must be a
+/// single process-wide instance rather than one per plugin. Events are
+/// delivered to every attached channel; only the engine whose Dart isolate set
+/// an `onUploadEvent` handler acts on it, the rest ignore it (mirroring the
+/// Android multi-engine handling).
+private final class BackgroundUploadCoordinator: NSObject {
+  static let shared = BackgroundUploadCoordinator()
+
   /// Identifier of the shared background session. Must be stable across
   /// launches so the OS can re-attach in-flight tasks after a relaunch.
-  private static let sessionIdentifier = "co.openvine.background_uploader.session"
+  fileprivate static let sessionIdentifier =
+    "co.openvine.background_uploader.session"
 
-  private let channel: FlutterMethodChannel
+  /// Channels for every attached engine. Mutated and read only on the main
+  /// queue.
+  private var channels: [FlutterMethodChannel] = []
+
+  /// Response bodies accumulated per task identifier. URLSession delivers
+  /// delegate callbacks for one session serially, so this needs no locking.
+  private var responseData: [Int: Data] = [:]
 
   #if os(iOS)
   /// Held while the OS relaunches us in the background to drain session
@@ -28,13 +48,9 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
   private var backgroundTasks: [String: UIBackgroundTaskIdentifier] = [:]
   #endif
 
-  /// Response bodies accumulated per task identifier. URLSession delivers
-  /// delegate callbacks for one session serially, so this needs no locking.
-  private var responseData: [Int: Data] = [:]
-
   private lazy var session: URLSession = {
     let configuration = URLSessionConfiguration.background(
-      withIdentifier: BackgroundUploaderPlugin.sessionIdentifier
+      withIdentifier: BackgroundUploadCoordinator.sessionIdentifier
     )
     #if os(iOS)
     configuration.sessionSendsLaunchEvents = true
@@ -47,13 +63,153 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
     )
   }()
 
+  func attach(_ channel: FlutterMethodChannel) {
+    channels.append(channel)
+    // Touch the lazy session so its delegate is connected immediately. This
+    // lets tasks that completed while the app was dead deliver their terminal
+    // events as soon as an engine attaches.
+    _ = session
+  }
+
+  func detach(_ channel: FlutterMethodChannel) {
+    channels.removeAll { $0 === channel }
+  }
+
+  func enqueue(taskId: String, request: URLRequest, fileURL: URL) {
+    let task = session.uploadTask(with: request, fromFile: fileURL)
+    task.taskDescription = taskId
+    task.resume()
+  }
+
+  func cancel(taskId: String, completion: @escaping () -> Void) {
+    session.getAllTasks { tasks in
+      for task in tasks where task.taskDescription == taskId {
+        task.cancel()
+      }
+      DispatchQueue.main.async { completion() }
+    }
+  }
+
+  func activeTaskIds(completion: @escaping ([String]) -> Void) {
+    session.getAllTasks { tasks in
+      let ids = tasks.compactMap { $0.taskDescription }
+      DispatchQueue.main.async { completion(ids) }
+    }
+  }
+
+  #if os(iOS)
+  func beginForegroundSession(_ sessionId: String) {
+    endForegroundSession(sessionId)
+    let task = UIApplication.shared.beginBackgroundTask(
+      withName: "co.openvine.background_uploader.\(sessionId)"
+    ) { [weak self] in
+      self?.endForegroundSession(sessionId)
+    }
+    backgroundTasks[sessionId] = task
+  }
+
+  func endForegroundSession(_ sessionId: String) {
+    guard let task = backgroundTasks.removeValue(forKey: sessionId),
+      task != .invalid
+    else { return }
+    UIApplication.shared.endBackgroundTask(task)
+  }
+
+  func handleBackgroundEvents(completionHandler: @escaping () -> Void) {
+    backgroundCompletionHandler = completionHandler
+    // Ensure the session (and its delegate) exists to drain pending events.
+    _ = session
+  }
+  #endif
+
+  private func sendEvent(_ payload: [String: Any?]) {
+    DispatchQueue.main.async {
+      for channel in self.channels {
+        channel.invokeMethod("onUploadEvent", arguments: payload)
+      }
+    }
+  }
+}
+
+extension BackgroundUploadCoordinator: URLSessionDataDelegate {
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didSendBodyData bytesSent: Int64,
+    totalBytesSent: Int64,
+    totalBytesExpectedToSend: Int64
+  ) {
+    guard
+      let taskId = task.taskDescription,
+      totalBytesExpectedToSend > 0
+    else { return }
+    let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
+    sendEvent([
+      "taskId": taskId,
+      "status": "running",
+      "progress": min(max(progress, 0), 1),
+    ])
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    dataTask: URLSessionDataTask,
+    didReceive data: Data
+  ) {
+    responseData[dataTask.taskIdentifier, default: Data()].append(data)
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: Error?
+  ) {
+    let taskId = task.taskDescription ?? ""
+    let body = responseData.removeValue(forKey: task.taskIdentifier)
+    let responseBody = body.flatMap { String(data: $0, encoding: .utf8) }
+
+    if let error = error {
+      let isCancelled = (error as NSError).code == NSURLErrorCancelled
+      sendEvent([
+        "taskId": taskId,
+        "status": isCancelled ? "cancelled" : "failed",
+        "progress": 0,
+        "error": error.localizedDescription,
+      ])
+      return
+    }
+
+    let statusCode = (task.response as? HTTPURLResponse)?.statusCode
+    let isSuccess = statusCode.map { (200..<300).contains($0) } ?? false
+    sendEvent([
+      "taskId": taskId,
+      "status": isSuccess ? "completed" : "failed",
+      "progress": isSuccess ? 1 : 0,
+      "httpStatusCode": statusCode,
+      "responseBody": responseBody,
+    ])
+  }
+
+  #if os(iOS)
+  func urlSessionDidFinishEvents(
+    forBackgroundURLSession session: URLSession
+  ) {
+    DispatchQueue.main.async {
+      let handler = self.backgroundCompletionHandler
+      self.backgroundCompletionHandler = nil
+      handler?()
+    }
+  }
+  #endif
+}
+
+public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
+  private let channel: FlutterMethodChannel
+
   init(channel: FlutterMethodChannel) {
     self.channel = channel
     super.init()
-    // Touch the lazy session so its delegate is connected immediately. This
-    // lets tasks that completed while the app was dead deliver their terminal
-    // events as soon as the engine attaches.
-    _ = session
+    BackgroundUploadCoordinator.shared.attach(channel)
   }
 
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -71,6 +227,10 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
     #if os(iOS)
     registrar.addApplicationDelegate(instance)
     #endif
+  }
+
+  public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+    BackgroundUploadCoordinator.shared.detach(channel)
   }
 
   public func handle(
@@ -116,13 +276,7 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
       )
       return
     }
-    endBackgroundTask(sessionId)
-    let task = UIApplication.shared.beginBackgroundTask(
-      withName: "co.openvine.background_uploader.\(sessionId)"
-    ) { [weak self] in
-      self?.endBackgroundTask(sessionId)
-    }
-    backgroundTasks[sessionId] = task
+    BackgroundUploadCoordinator.shared.beginForegroundSession(sessionId)
     #endif
     result(nil)
   }
@@ -134,20 +288,11 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
     #if os(iOS)
     if let args = arguments as? [String: Any],
       let sessionId = args["sessionId"] as? String {
-      endBackgroundTask(sessionId)
+      BackgroundUploadCoordinator.shared.endForegroundSession(sessionId)
     }
     #endif
     result(nil)
   }
-
-  #if os(iOS)
-  private func endBackgroundTask(_ sessionId: String) {
-    guard let task = backgroundTasks.removeValue(forKey: sessionId),
-      task != .invalid
-    else { return }
-    UIApplication.shared.endBackgroundTask(task)
-  }
-  #endif
 
   private func enqueue(_ arguments: Any?, result: @escaping FlutterResult) {
     guard
@@ -187,9 +332,11 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
       }
     }
 
-    let task = session.uploadTask(with: request, fromFile: fileURL)
-    task.taskDescription = taskId
-    task.resume()
+    BackgroundUploadCoordinator.shared.enqueue(
+      taskId: taskId,
+      request: request,
+      fileURL: fileURL
+    )
     result(nil)
   }
 
@@ -208,85 +355,15 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
       return
     }
 
-    session.getAllTasks { tasks in
-      for task in tasks where task.taskDescription == taskId {
-        task.cancel()
-      }
-      DispatchQueue.main.async { result(nil) }
+    BackgroundUploadCoordinator.shared.cancel(taskId: taskId) {
+      result(nil)
     }
   }
 
   private func activeTaskIds(result: @escaping FlutterResult) {
-    session.getAllTasks { tasks in
-      let ids = tasks.compactMap { $0.taskDescription }
-      DispatchQueue.main.async { result(ids) }
+    BackgroundUploadCoordinator.shared.activeTaskIds { ids in
+      result(ids)
     }
-  }
-
-  private func sendEvent(_ payload: [String: Any?]) {
-    DispatchQueue.main.async {
-      self.channel.invokeMethod("onUploadEvent", arguments: payload)
-    }
-  }
-}
-
-extension BackgroundUploaderPlugin: URLSessionDataDelegate {
-  public func urlSession(
-    _ session: URLSession,
-    task: URLSessionTask,
-    didSendBodyData bytesSent: Int64,
-    totalBytesSent: Int64,
-    totalBytesExpectedToSend: Int64
-  ) {
-    guard
-      let taskId = task.taskDescription,
-      totalBytesExpectedToSend > 0
-    else { return }
-    let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
-    sendEvent([
-      "taskId": taskId,
-      "status": "running",
-      "progress": min(max(progress, 0), 1),
-    ])
-  }
-
-  public func urlSession(
-    _ session: URLSession,
-    dataTask: URLSessionDataTask,
-    didReceive data: Data
-  ) {
-    responseData[dataTask.taskIdentifier, default: Data()].append(data)
-  }
-
-  public func urlSession(
-    _ session: URLSession,
-    task: URLSessionTask,
-    didCompleteWithError error: Error?
-  ) {
-    let taskId = task.taskDescription ?? ""
-    let body = responseData.removeValue(forKey: task.taskIdentifier)
-    let responseBody = body.flatMap { String(data: $0, encoding: .utf8) }
-
-    if let error = error {
-      let isCancelled = (error as NSError).code == NSURLErrorCancelled
-      sendEvent([
-        "taskId": taskId,
-        "status": isCancelled ? "cancelled" : "failed",
-        "progress": 0,
-        "error": error.localizedDescription,
-      ])
-      return
-    }
-
-    let statusCode = (task.response as? HTTPURLResponse)?.statusCode
-    let isSuccess = statusCode.map { (200..<300).contains($0) } ?? false
-    sendEvent([
-      "taskId": taskId,
-      "status": isSuccess ? "completed" : "failed",
-      "progress": isSuccess ? 1 : 0,
-      "httpStatusCode": statusCode,
-      "responseBody": responseBody,
-    ])
   }
 }
 
@@ -297,21 +374,13 @@ extension BackgroundUploaderPlugin {
     handleEventsForBackgroundURLSession identifier: String,
     completionHandler: @escaping () -> Void
   ) -> Bool {
-    guard identifier == BackgroundUploaderPlugin.sessionIdentifier else {
+    guard identifier == BackgroundUploadCoordinator.sessionIdentifier else {
       return false
     }
-    backgroundCompletionHandler = completionHandler
-    // Ensure the session (and its delegate) exists to drain pending events.
-    _ = session
+    BackgroundUploadCoordinator.shared.handleBackgroundEvents(
+      completionHandler: completionHandler
+    )
     return true
-  }
-
-  public func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
-    DispatchQueue.main.async {
-      let handler = self.backgroundCompletionHandler
-      self.backgroundCompletionHandler = nil
-      handler?()
-    }
   }
 }
 #endif

--- a/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
@@ -75,10 +75,24 @@ private final class BackgroundUploadCoordinator: NSObject {
     channels.removeAll { $0 === channel }
   }
 
-  func enqueue(taskId: String, request: URLRequest, fileURL: URL) {
-    let task = session.uploadTask(with: request, fromFile: fileURL)
-    task.taskDescription = taskId
-    task.resume()
+  func enqueue(
+    taskId: String,
+    request: URLRequest,
+    fileURL: URL,
+    completion: @escaping () -> Void
+  ) {
+    // Dedupe: a retry/timeout can re-enqueue the same taskId while the first
+    // transfer is still in flight (or was restored by the OS after a
+    // relaunch). Skip starting a second parallel upload of the same file.
+    session.getAllTasks { tasks in
+      let alreadyRunning = tasks.contains { $0.taskDescription == taskId }
+      if !alreadyRunning {
+        let task = self.session.uploadTask(with: request, fromFile: fileURL)
+        task.taskDescription = taskId
+        task.resume()
+      }
+      DispatchQueue.main.async { completion() }
+    }
   }
 
   func cancel(taskId: String, completion: @escaping () -> Void) {
@@ -336,8 +350,9 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
       taskId: taskId,
       request: request,
       fileURL: fileURL
-    )
-    result(nil)
+    ) {
+      result(nil)
+    }
   }
 
   private func cancel(_ arguments: Any?, result: @escaping FlutterResult) {

--- a/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
@@ -21,6 +21,11 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
   /// events; called once those events have been delivered. iOS-only — macOS
   /// apps are not relaunched to finish background sessions.
   private var backgroundCompletionHandler: (() -> Void)?
+
+  /// Background-task assertions keyed by session id, so the app keeps running
+  /// long enough to finish in-process publish steps (signing, relay broadcast)
+  /// after the background URLSession upload completes while suspended.
+  private var backgroundTasks: [String: UIBackgroundTaskIdentifier] = [:]
   #endif
 
   /// Response bodies accumulated per task identifier. URLSession delivers
@@ -81,10 +86,68 @@ public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
       cancel(call.arguments, result: result)
     case "activeTaskIds":
       activeTaskIds(result: result)
+    case "beginForegroundSession":
+      beginForegroundSession(call.arguments, result: result)
+    case "endForegroundSession":
+      endForegroundSession(call.arguments, result: result)
     default:
       result(FlutterMethodNotImplemented)
     }
   }
+
+  /// Begins a background-task assertion on iOS so in-process work survives a
+  /// brief suspension; a no-op on macOS, which does not background-restrict
+  /// network the way iOS does.
+  private func beginForegroundSession(
+    _ arguments: Any?,
+    result: @escaping FlutterResult
+  ) {
+    #if os(iOS)
+    guard
+      let args = arguments as? [String: Any],
+      let sessionId = args["sessionId"] as? String, !sessionId.isEmpty
+    else {
+      result(
+        FlutterError(
+          code: "invalid_arguments",
+          message: "beginForegroundSession requires a sessionId",
+          details: nil
+        )
+      )
+      return
+    }
+    endBackgroundTask(sessionId)
+    let task = UIApplication.shared.beginBackgroundTask(
+      withName: "co.openvine.background_uploader.\(sessionId)"
+    ) { [weak self] in
+      self?.endBackgroundTask(sessionId)
+    }
+    backgroundTasks[sessionId] = task
+    #endif
+    result(nil)
+  }
+
+  private func endForegroundSession(
+    _ arguments: Any?,
+    result: @escaping FlutterResult
+  ) {
+    #if os(iOS)
+    if let args = arguments as? [String: Any],
+      let sessionId = args["sessionId"] as? String {
+      endBackgroundTask(sessionId)
+    }
+    #endif
+    result(nil)
+  }
+
+  #if os(iOS)
+  private func endBackgroundTask(_ sessionId: String) {
+    guard let task = backgroundTasks.removeValue(forKey: sessionId),
+      task != .invalid
+    else { return }
+    UIApplication.shared.endBackgroundTask(task)
+  }
+  #endif
 
   private func enqueue(_ arguments: Any?, result: @escaping FlutterResult) {
     guard

--- a/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
+++ b/mobile/packages/background_uploader/darwin/background_uploader/Sources/background_uploader/BackgroundUploaderPlugin.swift
@@ -1,0 +1,254 @@
+// ABOUTME: Darwin (iOS + macOS) background uploader backed by a background
+// ABOUTME: URLSession so transfers continue after the app is suspended.
+
+#if os(iOS)
+import Flutter
+import UIKit
+#elseif os(macOS)
+import FlutterMacOS
+#endif
+import Foundation
+
+public class BackgroundUploaderPlugin: NSObject, FlutterPlugin {
+  /// Identifier of the shared background session. Must be stable across
+  /// launches so the OS can re-attach in-flight tasks after a relaunch.
+  private static let sessionIdentifier = "co.openvine.background_uploader.session"
+
+  private let channel: FlutterMethodChannel
+
+  #if os(iOS)
+  /// Held while the OS relaunches us in the background to drain session
+  /// events; called once those events have been delivered. iOS-only — macOS
+  /// apps are not relaunched to finish background sessions.
+  private var backgroundCompletionHandler: (() -> Void)?
+  #endif
+
+  /// Response bodies accumulated per task identifier. URLSession delivers
+  /// delegate callbacks for one session serially, so this needs no locking.
+  private var responseData: [Int: Data] = [:]
+
+  private lazy var session: URLSession = {
+    let configuration = URLSessionConfiguration.background(
+      withIdentifier: BackgroundUploaderPlugin.sessionIdentifier
+    )
+    #if os(iOS)
+    configuration.sessionSendsLaunchEvents = true
+    #endif
+    configuration.isDiscretionary = false
+    return URLSession(
+      configuration: configuration,
+      delegate: self,
+      delegateQueue: nil
+    )
+  }()
+
+  init(channel: FlutterMethodChannel) {
+    self.channel = channel
+    super.init()
+    // Touch the lazy session so its delegate is connected immediately. This
+    // lets tasks that completed while the app was dead deliver their terminal
+    // events as soon as the engine attaches.
+    _ = session
+  }
+
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    #if os(iOS)
+    let messenger = registrar.messenger()
+    #elseif os(macOS)
+    let messenger = registrar.messenger
+    #endif
+    let channel = FlutterMethodChannel(
+      name: "background_uploader",
+      binaryMessenger: messenger
+    )
+    let instance = BackgroundUploaderPlugin(channel: channel)
+    registrar.addMethodCallDelegate(instance, channel: channel)
+    #if os(iOS)
+    registrar.addApplicationDelegate(instance)
+    #endif
+  }
+
+  public func handle(
+    _ call: FlutterMethodCall,
+    result: @escaping FlutterResult
+  ) {
+    switch call.method {
+    case "isSupported":
+      result(true)
+    case "enqueue":
+      enqueue(call.arguments, result: result)
+    case "cancel":
+      cancel(call.arguments, result: result)
+    case "activeTaskIds":
+      activeTaskIds(result: result)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  private func enqueue(_ arguments: Any?, result: @escaping FlutterResult) {
+    guard
+      let args = arguments as? [String: Any],
+      let taskId = args["taskId"] as? String, !taskId.isEmpty,
+      let urlString = args["url"] as? String,
+      let url = URL(string: urlString),
+      let filePath = args["filePath"] as? String
+    else {
+      result(
+        FlutterError(
+          code: "invalid_arguments",
+          message: "enqueue requires taskId, url, and filePath",
+          details: nil
+        )
+      )
+      return
+    }
+
+    let fileURL = URL(fileURLWithPath: filePath)
+    guard FileManager.default.fileExists(atPath: filePath) else {
+      result(
+        FlutterError(
+          code: "file_not_found",
+          message: "No file at \(filePath)",
+          details: nil
+        )
+      )
+      return
+    }
+
+    var request = URLRequest(url: url)
+    request.httpMethod = (args["method"] as? String) ?? "PUT"
+    if let headers = args["headers"] as? [String: Any] {
+      for (key, value) in headers {
+        request.setValue(String(describing: value), forHTTPHeaderField: key)
+      }
+    }
+
+    let task = session.uploadTask(with: request, fromFile: fileURL)
+    task.taskDescription = taskId
+    task.resume()
+    result(nil)
+  }
+
+  private func cancel(_ arguments: Any?, result: @escaping FlutterResult) {
+    guard
+      let args = arguments as? [String: Any],
+      let taskId = args["taskId"] as? String
+    else {
+      result(
+        FlutterError(
+          code: "invalid_arguments",
+          message: "cancel requires a taskId",
+          details: nil
+        )
+      )
+      return
+    }
+
+    session.getAllTasks { tasks in
+      for task in tasks where task.taskDescription == taskId {
+        task.cancel()
+      }
+      DispatchQueue.main.async { result(nil) }
+    }
+  }
+
+  private func activeTaskIds(result: @escaping FlutterResult) {
+    session.getAllTasks { tasks in
+      let ids = tasks.compactMap { $0.taskDescription }
+      DispatchQueue.main.async { result(ids) }
+    }
+  }
+
+  private func sendEvent(_ payload: [String: Any?]) {
+    DispatchQueue.main.async {
+      self.channel.invokeMethod("onUploadEvent", arguments: payload)
+    }
+  }
+}
+
+extension BackgroundUploaderPlugin: URLSessionDataDelegate {
+  public func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didSendBodyData bytesSent: Int64,
+    totalBytesSent: Int64,
+    totalBytesExpectedToSend: Int64
+  ) {
+    guard
+      let taskId = task.taskDescription,
+      totalBytesExpectedToSend > 0
+    else { return }
+    let progress = Double(totalBytesSent) / Double(totalBytesExpectedToSend)
+    sendEvent([
+      "taskId": taskId,
+      "status": "running",
+      "progress": min(max(progress, 0), 1),
+    ])
+  }
+
+  public func urlSession(
+    _ session: URLSession,
+    dataTask: URLSessionDataTask,
+    didReceive data: Data
+  ) {
+    responseData[dataTask.taskIdentifier, default: Data()].append(data)
+  }
+
+  public func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didCompleteWithError error: Error?
+  ) {
+    let taskId = task.taskDescription ?? ""
+    let body = responseData.removeValue(forKey: task.taskIdentifier)
+    let responseBody = body.flatMap { String(data: $0, encoding: .utf8) }
+
+    if let error = error {
+      let isCancelled = (error as NSError).code == NSURLErrorCancelled
+      sendEvent([
+        "taskId": taskId,
+        "status": isCancelled ? "cancelled" : "failed",
+        "progress": 0,
+        "error": error.localizedDescription,
+      ])
+      return
+    }
+
+    let statusCode = (task.response as? HTTPURLResponse)?.statusCode
+    let isSuccess = statusCode.map { (200..<300).contains($0) } ?? false
+    sendEvent([
+      "taskId": taskId,
+      "status": isSuccess ? "completed" : "failed",
+      "progress": isSuccess ? 1 : 0,
+      "httpStatusCode": statusCode,
+      "responseBody": responseBody,
+    ])
+  }
+}
+
+#if os(iOS)
+extension BackgroundUploaderPlugin {
+  public func application(
+    _ application: UIApplication,
+    handleEventsForBackgroundURLSession identifier: String,
+    completionHandler: @escaping () -> Void
+  ) -> Bool {
+    guard identifier == BackgroundUploaderPlugin.sessionIdentifier else {
+      return false
+    }
+    backgroundCompletionHandler = completionHandler
+    // Ensure the session (and its delegate) exists to drain pending events.
+    _ = session
+    return true
+  }
+
+  public func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+    DispatchQueue.main.async {
+      let handler = self.backgroundCompletionHandler
+      self.backgroundCompletionHandler = nil
+      handler?()
+    }
+  }
+}
+#endif

--- a/mobile/packages/background_uploader/lib/background_uploader.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader.dart
@@ -96,4 +96,11 @@ class BackgroundUploader {
 
   /// Task ids the OS still has in flight, for startup reconciliation.
   Future<List<String>> activeTaskIds() => _platform.activeTaskIds();
+
+  /// Claims a terminal event for [taskId] that arrived while nothing was
+  /// listening on [events] — e.g. an upload the OS finished while the app was
+  /// dead — or `null` when none is buffered. Claiming removes it, so a given
+  /// terminal event is handed out at most once.
+  Future<BackgroundUploadEvent?> takeBufferedTerminalEvent(String taskId) =>
+      _platform.takeBufferedTerminalEvent(taskId);
 }

--- a/mobile/packages/background_uploader/lib/background_uploader.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader.dart
@@ -54,14 +54,31 @@ class BackgroundUploader {
         'HTTP method must not be empty.',
       );
     }
-    if (!request.url.hasScheme || !request.url.isScheme('https')) {
+    if (!_isAllowedUploadUrl(request.url)) {
       throw ArgumentError.value(
         request.url.toString(),
         'request.url',
-        'Background uploads require an absolute https URL.',
+        'Background uploads require an absolute https URL '
+            '(cleartext http is permitted only to loopback hosts).',
       );
     }
     return _platform.enqueue(request);
+  }
+
+  /// Loopback hosts the local Docker stack serves over cleartext http. Both
+  /// native platforms already permit cleartext to these (Android
+  /// network-security-config, iOS `NSAllowsLocalNetworking`), so mirror that
+  /// here rather than rejecting local-stack uploads.
+  static const _localCleartextHosts = <String>{
+    '10.0.2.2',
+    'localhost',
+    '127.0.0.1',
+  };
+
+  bool _isAllowedUploadUrl(Uri url) {
+    if (!url.hasScheme) return false;
+    if (url.isScheme('https')) return true;
+    return url.isScheme('http') && _localCleartextHosts.contains(url.host);
   }
 
   /// Cancels the upload identified by [taskId], if it is still in flight.

--- a/mobile/packages/background_uploader/lib/background_uploader.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader.dart
@@ -1,0 +1,72 @@
+// ABOUTME: Public API for OS-backed background file uploads.
+// ABOUTME: Enqueue file + URL + headers; OS finishes it across suspension.
+
+import 'dart:async';
+
+import 'package:background_uploader/background_uploader_platform_interface.dart';
+import 'package:background_uploader/src/models/background_upload_event.dart';
+import 'package:background_uploader/src/models/background_upload_request.dart';
+
+export 'src/models/background_upload_event.dart';
+export 'src/models/background_upload_request.dart';
+
+/// Uploads files via the operating system's background transfer facility.
+///
+/// On iOS this is a background `URLSession`; on Android a foreground service.
+/// Once a file is enqueued, the OS owns the transfer and continues it while
+/// the app is backgrounded or suspended — unlike an in-process HTTP client,
+/// whose sockets are torn down when the app is suspended.
+///
+/// This is a data-layer client: it speaks plain HTTP (method + headers + file)
+/// and knows nothing about Blossom, Nostr, or any domain concern. Callers build
+/// the request — including any signed authorization header — and map
+/// [BackgroundUploadEvent]s to their own state model.
+class BackgroundUploader {
+  BackgroundUploader._internal();
+
+  /// The singleton instance of [BackgroundUploader].
+  static final BackgroundUploader instance = BackgroundUploader._internal();
+
+  BackgroundUploaderPlatform get _platform =>
+      BackgroundUploaderPlatform.instance;
+
+  /// Emits progress and terminal events for every enqueued upload.
+  ///
+  /// Events are keyed by `taskId`; filter the stream to follow one upload.
+  /// Because the OS may complete a transfer while the app is not running, an
+  /// upload enqueued in a previous session can complete without a matching
+  /// live event — reconcile on startup with [activeTaskIds].
+  Stream<BackgroundUploadEvent> get events => _platform.events;
+
+  /// Whether the current platform can perform OS-backed background uploads.
+  Future<bool> get isSupported => _platform.isSupported();
+
+  /// Hands [request] to the OS for background upload.
+  ///
+  /// Returns once the OS has accepted the task; progress and the terminal
+  /// result arrive later on [events]. Throws [ArgumentError] if [request] is
+  /// not internally consistent.
+  Future<void> enqueue(BackgroundUploadRequest request) {
+    if (request.method.trim().isEmpty) {
+      throw ArgumentError.value(
+        request.method,
+        'request.method',
+        'HTTP method must not be empty.',
+      );
+    }
+    if (!request.url.hasScheme || !request.url.isScheme('https')) {
+      throw ArgumentError.value(
+        request.url.toString(),
+        'request.url',
+        'Background uploads require an absolute https URL.',
+      );
+    }
+    return _platform.enqueue(request);
+  }
+
+  /// Cancels the upload identified by [taskId], if it is still in flight.
+  Future<void> cancel(String taskId) => _platform.cancel(taskId);
+
+  /// Task ids the OS still has in flight, for startup reconciliation.
+  Future<List<String>> activeTaskIds() => _platform.activeTaskIds();
+}

--- a/mobile/packages/background_uploader/lib/background_uploader.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader.dart
@@ -67,6 +67,33 @@ class BackgroundUploader {
   /// Cancels the upload identified by [taskId], if it is still in flight.
   Future<void> cancel(String taskId) => _platform.cancel(taskId);
 
+  /// Starts an OS foreground session that keeps the app process foregrounded
+  /// (and its network usable) until [endForegroundSession] is called with the
+  /// same [sessionId].
+  ///
+  /// Unlike [enqueue], this carries no transfer of its own. It exists so a
+  /// caller can keep the process out of the background-network restrictions
+  /// across in-process work that must not be network-starved — e.g. signing a
+  /// follow-up event with a remote signer and broadcasting it to relays after
+  /// a background upload completes while the app is suspended.
+  ///
+  /// Must be called while the app is in the foreground: Android forbids
+  /// starting a foreground service from the background. On Apple platforms the
+  /// session maps to a background-task assertion (iOS) or is a no-op (macOS).
+  ///
+  /// Throws [ArgumentError] if [sessionId] is empty.
+  Future<void> beginForegroundSession(String sessionId) {
+    if (sessionId.isEmpty) {
+      throw ArgumentError.value(sessionId, 'sessionId', 'must not be empty');
+    }
+    return _platform.beginForegroundSession(sessionId);
+  }
+
+  /// Ends the foreground session started by [beginForegroundSession] for
+  /// [sessionId]. Safe to call when no matching session is active.
+  Future<void> endForegroundSession(String sessionId) =>
+      _platform.endForegroundSession(sessionId);
+
   /// Task ids the OS still has in flight, for startup reconciliation.
   Future<List<String>> activeTaskIds() => _platform.activeTaskIds();
 }

--- a/mobile/packages/background_uploader/lib/background_uploader_method_channel.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader_method_channel.dart
@@ -1,0 +1,70 @@
+// ABOUTME: Method-channel implementation of the background uploader platform.
+// ABOUTME: Forwards enqueue/cancel to native and fans native events into Dart.
+
+import 'dart:async';
+
+import 'package:background_uploader/background_uploader_platform_interface.dart';
+import 'package:background_uploader/src/models/background_upload_event.dart';
+import 'package:background_uploader/src/models/background_upload_request.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// An implementation of [BackgroundUploaderPlatform] that uses method channels.
+class MethodChannelBackgroundUploader extends BackgroundUploaderPlatform {
+  /// Constructor that wires the native event callback.
+  MethodChannelBackgroundUploader() {
+    methodChannel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  /// The method channel used to interact with the native platform.
+  @visibleForTesting
+  final methodChannel = const MethodChannel('background_uploader');
+
+  final StreamController<BackgroundUploadEvent> _eventController =
+      StreamController<BackgroundUploadEvent>.broadcast();
+
+  @override
+  Stream<BackgroundUploadEvent> get events => _eventController.stream;
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'onUploadEvent':
+        final arguments = call.arguments;
+        if (arguments is Map<dynamic, dynamic>) {
+          final event = BackgroundUploadEvent.tryFromMap(arguments);
+          if (event != null) {
+            _eventController.add(event);
+          }
+        }
+        return null;
+      default:
+        return null;
+    }
+  }
+
+  @override
+  Future<bool> isSupported() async {
+    final result = await methodChannel.invokeMethod<bool>('isSupported');
+    return result ?? false;
+  }
+
+  @override
+  Future<void> enqueue(BackgroundUploadRequest request) {
+    return methodChannel.invokeMethod<void>('enqueue', request.toMap());
+  }
+
+  @override
+  Future<void> cancel(String taskId) {
+    return methodChannel.invokeMethod<void>('cancel', <String, Object?>{
+      'taskId': taskId,
+    });
+  }
+
+  @override
+  Future<List<String>> activeTaskIds() async {
+    final result = await methodChannel.invokeListMethod<String>(
+      'activeTaskIds',
+    );
+    return result ?? const <String>[];
+  }
+}

--- a/mobile/packages/background_uploader/lib/background_uploader_method_channel.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader_method_channel.dart
@@ -61,6 +61,22 @@ class MethodChannelBackgroundUploader extends BackgroundUploaderPlatform {
   }
 
   @override
+  Future<void> beginForegroundSession(String sessionId) {
+    return methodChannel.invokeMethod<void>(
+      'beginForegroundSession',
+      <String, Object?>{'sessionId': sessionId},
+    );
+  }
+
+  @override
+  Future<void> endForegroundSession(String sessionId) {
+    return methodChannel.invokeMethod<void>(
+      'endForegroundSession',
+      <String, Object?>{'sessionId': sessionId},
+    );
+  }
+
+  @override
   Future<List<String>> activeTaskIds() async {
     final result = await methodChannel.invokeListMethod<String>(
       'activeTaskIds',

--- a/mobile/packages/background_uploader/lib/background_uploader_method_channel.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader_method_channel.dart
@@ -23,6 +23,18 @@ class MethodChannelBackgroundUploader extends BackgroundUploaderPlatform {
   final StreamController<BackgroundUploadEvent> _eventController =
       StreamController<BackgroundUploadEvent>.broadcast();
 
+  /// Most-recent terminal event per taskId, retained until claimed via
+  /// [takeBufferedTerminalEvent]. The OS (notably an iOS background
+  /// `URLSession`) delivers terminal events for uploads that finished while
+  /// the app was dead as soon as the engine attaches — often before any Dart
+  /// listener has subscribed to the broadcast [events] stream, which would
+  /// silently drop them. Buffering lets startup reconciliation recover them.
+  /// Bounded to [_maxBufferedTerminals] with oldest-first eviction.
+  final Map<String, BackgroundUploadEvent> _bufferedTerminals =
+      <String, BackgroundUploadEvent>{};
+
+  static const int _maxBufferedTerminals = 64;
+
   @override
   Stream<BackgroundUploadEvent> get events => _eventController.stream;
 
@@ -33,6 +45,9 @@ class MethodChannelBackgroundUploader extends BackgroundUploaderPlatform {
         if (arguments is Map<dynamic, dynamic>) {
           final event = BackgroundUploadEvent.tryFromMap(arguments);
           if (event != null) {
+            if (event.isTerminal) {
+              _bufferTerminal(event);
+            }
             _eventController.add(event);
           }
         }
@@ -40,6 +55,23 @@ class MethodChannelBackgroundUploader extends BackgroundUploaderPlatform {
       default:
         return null;
     }
+  }
+
+  void _bufferTerminal(BackgroundUploadEvent event) {
+    // Re-insert so the freshest entry is last for oldest-first eviction.
+    _bufferedTerminals
+      ..remove(event.taskId)
+      ..[event.taskId] = event;
+    while (_bufferedTerminals.length > _maxBufferedTerminals) {
+      _bufferedTerminals.remove(_bufferedTerminals.keys.first);
+    }
+  }
+
+  @override
+  Future<BackgroundUploadEvent?> takeBufferedTerminalEvent(
+    String taskId,
+  ) async {
+    return _bufferedTerminals.remove(taskId);
   }
 
   @override

--- a/mobile/packages/background_uploader/lib/background_uploader_platform_interface.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader_platform_interface.dart
@@ -73,4 +73,16 @@ abstract class BackgroundUploaderPlatform extends PlatformInterface {
   Future<List<String>> activeTaskIds() {
     throw UnimplementedError('activeTaskIds() has not been implemented.');
   }
+
+  /// Claims a buffered terminal event for [taskId], or `null` if none.
+  ///
+  /// A terminal event delivered while no [events] listener was attached (e.g.
+  /// an upload the OS finished while the app was dead) is retained until
+  /// claimed here, so startup reconciliation can recover it. Claiming removes
+  /// it from the buffer.
+  Future<BackgroundUploadEvent?> takeBufferedTerminalEvent(String taskId) {
+    throw UnimplementedError(
+      'takeBufferedTerminalEvent() has not been implemented.',
+    );
+  }
 }

--- a/mobile/packages/background_uploader/lib/background_uploader_platform_interface.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader_platform_interface.dart
@@ -1,0 +1,61 @@
+// ABOUTME: Platform interface for the OS-backed background uploader.
+// ABOUTME: Defines the enqueue / cancel / event contract implementations honor.
+
+import 'dart:async';
+
+import 'package:background_uploader/background_uploader_method_channel.dart';
+import 'package:background_uploader/src/models/background_upload_event.dart';
+import 'package:background_uploader/src/models/background_upload_request.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+/// The interface that implementations of background_uploader must implement.
+abstract class BackgroundUploaderPlatform extends PlatformInterface {
+  /// Constructs a BackgroundUploaderPlatform.
+  BackgroundUploaderPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
+  static BackgroundUploaderPlatform _instance =
+      MethodChannelBackgroundUploader();
+
+  /// The default instance of [BackgroundUploaderPlatform] to use.
+  ///
+  /// Defaults to [MethodChannelBackgroundUploader].
+  static BackgroundUploaderPlatform get instance => _instance;
+
+  /// Platform-specific implementations should set this with their own
+  /// platform-specific class that extends [BackgroundUploaderPlatform] when
+  /// they register themselves.
+  static set instance(BackgroundUploaderPlatform instance) {
+    PlatformInterface.verifyToken(instance, _token);
+    _instance = instance;
+  }
+
+  /// Emits progress and terminal events for all enqueued uploads.
+  Stream<BackgroundUploadEvent> get events {
+    throw UnimplementedError('events has not been implemented.');
+  }
+
+  /// Whether the current platform can perform OS-backed background uploads.
+  Future<bool> isSupported() {
+    throw UnimplementedError('isSupported() has not been implemented.');
+  }
+
+  /// Hands [request] to the OS for background upload.
+  Future<void> enqueue(BackgroundUploadRequest request) {
+    throw UnimplementedError('enqueue() has not been implemented.');
+  }
+
+  /// Cancels the upload identified by [taskId], if it is still in flight.
+  Future<void> cancel(String taskId) {
+    throw UnimplementedError('cancel() has not been implemented.');
+  }
+
+  /// Returns the task ids the OS still has in flight.
+  ///
+  /// Used to reconcile state after the app is relaunched: an upload may have
+  /// completed (or still be running) while Dart was not attached.
+  Future<List<String>> activeTaskIds() {
+    throw UnimplementedError('activeTaskIds() has not been implemented.');
+  }
+}

--- a/mobile/packages/background_uploader/lib/background_uploader_platform_interface.dart
+++ b/mobile/packages/background_uploader/lib/background_uploader_platform_interface.dart
@@ -51,6 +51,21 @@ abstract class BackgroundUploaderPlatform extends PlatformInterface {
     throw UnimplementedError('cancel() has not been implemented.');
   }
 
+  /// Starts an OS foreground session keyed by [sessionId] that keeps the
+  /// process foregrounded until [endForegroundSession] is called.
+  Future<void> beginForegroundSession(String sessionId) {
+    throw UnimplementedError(
+      'beginForegroundSession() has not been implemented.',
+    );
+  }
+
+  /// Ends the foreground session for [sessionId].
+  Future<void> endForegroundSession(String sessionId) {
+    throw UnimplementedError(
+      'endForegroundSession() has not been implemented.',
+    );
+  }
+
   /// Returns the task ids the OS still has in flight.
   ///
   /// Used to reconcile state after the app is relaunched: an upload may have

--- a/mobile/packages/background_uploader/lib/src/models/background_upload_event.dart
+++ b/mobile/packages/background_uploader/lib/src/models/background_upload_event.dart
@@ -1,0 +1,126 @@
+// ABOUTME: Event the native background uploader emits back to Dart as a
+// ABOUTME: transfer progresses, completes, fails, or is cancelled.
+
+import 'package:equatable/equatable.dart';
+
+/// Lifecycle status of a background upload.
+enum BackgroundUploadStatus {
+  /// The transfer is in flight; incremental progress updates are emitted.
+  running,
+
+  /// The server accepted the upload (a 2xx response).
+  completed,
+
+  /// The upload failed — a transport error or a non-2xx response.
+  failed,
+
+  /// The upload was cancelled by the caller.
+  cancelled;
+
+  /// Parses a native status string, or `null` when it is unrecognized.
+  static BackgroundUploadStatus? tryParse(String? value) {
+    return switch (value) {
+      'running' => BackgroundUploadStatus.running,
+      'completed' => BackgroundUploadStatus.completed,
+      'failed' => BackgroundUploadStatus.failed,
+      'cancelled' => BackgroundUploadStatus.cancelled,
+      _ => null,
+    };
+  }
+}
+
+/// A progress or terminal event for a background upload [taskId].
+///
+/// This is a data-layer result type: like an HTTP client result, a `failed`
+/// event carries the raw [httpStatusCode] / [error] so the calling repository
+/// can classify it. It is not BLoC state — callers should map it to their own
+/// status/error model before it reaches the UI.
+class BackgroundUploadEvent extends Equatable {
+  /// Creates a [BackgroundUploadEvent].
+  const BackgroundUploadEvent({
+    required this.taskId,
+    required this.status,
+    this.progress = 0,
+    this.httpStatusCode,
+    this.responseBody,
+    this.error,
+  });
+
+  /// Deserializes an event from a native platform map.
+  factory BackgroundUploadEvent.fromMap(Map<dynamic, dynamic> map) {
+    final taskId = map['taskId'];
+    if (taskId is! String || taskId.isEmpty) {
+      throw const FormatException('Background upload event needs a taskId.');
+    }
+    final status = BackgroundUploadStatus.tryParse(map['status'] as String?);
+    if (status == null) {
+      throw const FormatException('Background upload event needs a status.');
+    }
+
+    final rawProgress = map['progress'];
+    final progress = rawProgress is num ? rawProgress.toDouble() : 0.0;
+
+    return BackgroundUploadEvent(
+      taskId: taskId,
+      status: status,
+      progress: progress.clamp(0.0, 1.0),
+      httpStatusCode: (map['httpStatusCode'] as num?)?.toInt(),
+      responseBody: map['responseBody'] as String?,
+      error: map['error'] as String?,
+    );
+  }
+
+  /// Attempts to deserialize an event, returning `null` on malformed data.
+  static BackgroundUploadEvent? tryFromMap(Map<dynamic, dynamic> map) {
+    try {
+      return BackgroundUploadEvent.fromMap(map);
+    } on Object {
+      return null;
+    }
+  }
+
+  /// Identifier of the `BackgroundUploadRequest` this event belongs to.
+  final String taskId;
+
+  /// Current lifecycle status.
+  final BackgroundUploadStatus status;
+
+  /// Fraction uploaded in `[0, 1]`. Only meaningful while [status] is
+  /// [BackgroundUploadStatus.running]; terminal events report `1` on success.
+  final double progress;
+
+  /// HTTP status code for terminal events, when the server responded.
+  final int? httpStatusCode;
+
+  /// Response body for terminal events, when available.
+  final String? responseBody;
+
+  /// Human-readable transport error for a [BackgroundUploadStatus.failed]
+  /// event, when the failure was not an HTTP status (e.g. a dropped socket).
+  final String? error;
+
+  /// Whether this event is terminal (no further events follow for [taskId]).
+  bool get isTerminal => status != BackgroundUploadStatus.running;
+
+  /// Serializes this event for tests and platform fakes.
+  Map<String, Object?> toMap() {
+    return <String, Object?>{
+      'taskId': taskId,
+      'status': status.name,
+      'progress': progress,
+      'httpStatusCode': httpStatusCode,
+      'responseBody': responseBody,
+      'error': error,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[
+    taskId,
+    status,
+    progress,
+    httpStatusCode,
+    responseBody,
+    error,
+  ];
+}

--- a/mobile/packages/background_uploader/lib/src/models/background_upload_request.dart
+++ b/mobile/packages/background_uploader/lib/src/models/background_upload_request.dart
@@ -22,6 +22,7 @@ class BackgroundUploadRequest extends Equatable {
     required this.url,
     required this.filePath,
     this.method = 'PUT',
+    this.notificationTitle = 'Uploading',
     Map<String, String> headers = const <String, String>{},
   }) : assert(taskId != '', 'taskId must not be empty'),
        assert(filePath != '', 'filePath must not be empty'),
@@ -39,6 +40,12 @@ class BackgroundUploadRequest extends Equatable {
   /// HTTP method for the upload. Defaults to `PUT` (Blossom BUD-01).
   final String method;
 
+  /// Title shown on the Android foreground-service notification while this
+  /// upload runs. Ignored on Apple platforms, which use no notification. The
+  /// caller owns this copy so the plugin stays free of app/localization
+  /// concerns.
+  final String notificationTitle;
+
   /// Request headers (e.g. the signed authorization header).
   final Map<String, String> headers;
 
@@ -49,10 +56,18 @@ class BackgroundUploadRequest extends Equatable {
       'url': url.toString(),
       'filePath': filePath,
       'method': method,
+      'notificationTitle': notificationTitle,
       'headers': headers,
     };
   }
 
   @override
-  List<Object?> get props => <Object?>[taskId, url, filePath, method, headers];
+  List<Object?> get props => <Object?>[
+    taskId,
+    url,
+    filePath,
+    method,
+    notificationTitle,
+    headers,
+  ];
 }

--- a/mobile/packages/background_uploader/lib/src/models/background_upload_request.dart
+++ b/mobile/packages/background_uploader/lib/src/models/background_upload_request.dart
@@ -1,0 +1,58 @@
+// ABOUTME: Describes a single file upload to hand to the OS background
+// ABOUTME: uploader (URLSession on iOS, a foreground service on Android).
+
+import 'package:equatable/equatable.dart';
+
+/// A request to upload one file in the background.
+///
+/// The OS owns the transfer once enqueued, so it continues while the app is
+/// backgrounded or suspended. The request carries only what the native side
+/// needs to build a single HTTP request — it has no knowledge of Blossom,
+/// Nostr, or any other domain concern; the caller is responsible for building
+/// the [url] and signed [headers] before enqueuing.
+class BackgroundUploadRequest extends Equatable {
+  /// Creates a [BackgroundUploadRequest].
+  ///
+  /// [taskId] must be a stable, non-empty identifier the caller can use to
+  /// correlate later `BackgroundUploadEvent`s back to this request; it is also
+  /// the handle passed to `cancel`. [filePath] must point at a readable file
+  /// on disk — the native side streams from it directly to keep memory bounded.
+  BackgroundUploadRequest({
+    required this.taskId,
+    required this.url,
+    required this.filePath,
+    this.method = 'PUT',
+    Map<String, String> headers = const <String, String>{},
+  }) : assert(taskId != '', 'taskId must not be empty'),
+       assert(filePath != '', 'filePath must not be empty'),
+       headers = Map<String, String>.unmodifiable(headers);
+
+  /// Stable identifier used to correlate events and to cancel the upload.
+  final String taskId;
+
+  /// Destination URL for the upload request.
+  final Uri url;
+
+  /// Absolute path to the file streamed as the request body.
+  final String filePath;
+
+  /// HTTP method for the upload. Defaults to `PUT` (Blossom BUD-01).
+  final String method;
+
+  /// Request headers (e.g. the signed authorization header).
+  final Map<String, String> headers;
+
+  /// Serializes this request for the platform channel.
+  Map<String, Object?> toMap() {
+    return <String, Object?>{
+      'taskId': taskId,
+      'url': url.toString(),
+      'filePath': filePath,
+      'method': method,
+      'headers': headers,
+    };
+  }
+
+  @override
+  List<Object?> get props => <Object?>[taskId, url, filePath, method, headers];
+}

--- a/mobile/packages/background_uploader/pubspec.yaml
+++ b/mobile/packages/background_uploader/pubspec.yaml
@@ -1,0 +1,33 @@
+name: background_uploader
+description: "OS-backed background file uploader for Android and Apple platforms that survives app suspension."
+version: 0.0.1
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.11.0
+  flutter: ^3.41.1
+
+dependencies:
+  equatable: ^2.0.8
+  flutter:
+    sdk: flutter
+  plugin_platform_interface: ^2.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  very_good_analysis: ^10.2.0
+
+flutter:
+  plugin:
+    platforms:
+      android:
+        package: co.openvine.background_uploader
+        pluginClass: BackgroundUploaderPlugin
+      ios:
+        pluginClass: BackgroundUploaderPlugin
+        sharedDarwinSource: true
+      macos:
+        pluginClass: BackgroundUploaderPlugin
+        sharedDarwinSource: true

--- a/mobile/packages/background_uploader/test/background_uploader_method_channel_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_method_channel_test.dart
@@ -1,0 +1,118 @@
+import 'package:background_uploader/background_uploader.dart';
+import 'package:background_uploader/background_uploader_method_channel.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final platform = MethodChannelBackgroundUploader();
+  const channel = MethodChannel('background_uploader');
+  final calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (methodCall) async {
+          calls.add(methodCall);
+          switch (methodCall.method) {
+            case 'isSupported':
+              return true;
+            case 'activeTaskIds':
+              return <String>['task-a', 'task-b'];
+            case 'enqueue':
+            case 'cancel':
+              return null;
+          }
+          return null;
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('isSupported delegates to native platform', () async {
+    expect(await platform.isSupported(), isTrue);
+  });
+
+  test('enqueue serializes the request for the native platform', () async {
+    final request = BackgroundUploadRequest(
+      taskId: 'upload-1',
+      url: Uri.parse('https://media.divine.video/upload'),
+      filePath: '/tmp/video.mp4',
+      headers: const <String, String>{'Authorization': 'Nostr abc'},
+    );
+
+    await platform.enqueue(request);
+
+    expect(calls.single.method, 'enqueue');
+    expect(calls.single.arguments, request.toMap());
+    expect(
+      (calls.single.arguments as Map)['method'],
+      'PUT',
+      reason: 'defaults to the Blossom BUD-01 PUT method',
+    );
+  });
+
+  test('cancel passes the task id to the native platform', () async {
+    await platform.cancel('upload-1');
+
+    expect(calls.single.method, 'cancel');
+    expect(calls.single.arguments, <String, Object?>{'taskId': 'upload-1'});
+  });
+
+  test('activeTaskIds returns the native list', () async {
+    expect(await platform.activeTaskIds(), <String>['task-a', 'task-b']);
+  });
+
+  test('native upload events are emitted on the stream', () async {
+    final emitted = expectLater(
+      platform.events,
+      emits(
+        isA<BackgroundUploadEvent>()
+            .having((e) => e.taskId, 'taskId', 'upload-1')
+            .having((e) => e.status, 'status', BackgroundUploadStatus.completed)
+            .having((e) => e.httpStatusCode, 'httpStatusCode', 200)
+            .having((e) => e.isTerminal, 'isTerminal', isTrue),
+      ),
+    );
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          channel.name,
+          channel.codec.encodeMethodCall(
+            const MethodCall('onUploadEvent', <String, Object?>{
+              'taskId': 'upload-1',
+              'status': 'completed',
+              'progress': 1.0,
+              'httpStatusCode': 200,
+            }),
+          ),
+          (_) {},
+        );
+
+    await emitted;
+  });
+
+  test('malformed native events are ignored', () async {
+    final emitted = <BackgroundUploadEvent>[];
+    final subscription = platform.events.listen(emitted.add);
+
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          channel.name,
+          channel.codec.encodeMethodCall(
+            const MethodCall('onUploadEvent', <String, Object?>{
+              'status': 'completed',
+            }),
+          ),
+          (_) {},
+        );
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(emitted, isEmpty);
+    await subscription.cancel();
+  });
+}

--- a/mobile/packages/background_uploader/test/background_uploader_method_channel_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_method_channel_test.dart
@@ -129,4 +129,47 @@ void main() {
     expect(emitted, isEmpty);
     await subscription.cancel();
   });
+
+  test('a terminal event with no listener is buffered and claimable', () async {
+    // No events subscription: the terminal would be dropped by the broadcast
+    // stream, but reconciliation can still recover it from the buffer.
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          channel.name,
+          channel.codec.encodeMethodCall(
+            const MethodCall('onUploadEvent', <String, Object?>{
+              'taskId': 'buffered-task',
+              'status': 'completed',
+              'progress': 1.0,
+              'httpStatusCode': 200,
+            }),
+          ),
+          (_) {},
+        );
+
+    final claimed = await platform.takeBufferedTerminalEvent('buffered-task');
+    expect(claimed, isNotNull);
+    expect(claimed!.taskId, 'buffered-task');
+    expect(claimed.status, BackgroundUploadStatus.completed);
+
+    // Claiming removes it, so a given terminal is handed out at most once.
+    expect(await platform.takeBufferedTerminalEvent('buffered-task'), isNull);
+  });
+
+  test('running (non-terminal) events are not buffered', () async {
+    await TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
+          channel.name,
+          channel.codec.encodeMethodCall(
+            const MethodCall('onUploadEvent', <String, Object?>{
+              'taskId': 'running-task',
+              'status': 'running',
+              'progress': 0.5,
+            }),
+          ),
+          (_) {},
+        );
+
+    expect(await platform.takeBufferedTerminalEvent('running-task'), isNull);
+  });
 }

--- a/mobile/packages/background_uploader/test/background_uploader_method_channel_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_method_channel_test.dart
@@ -63,6 +63,20 @@ void main() {
     expect(calls.single.arguments, <String, Object?>{'taskId': 'upload-1'});
   });
 
+  test('beginForegroundSession passes the session id to native', () async {
+    await platform.beginForegroundSession('publish-1');
+
+    expect(calls.single.method, 'beginForegroundSession');
+    expect(calls.single.arguments, <String, Object?>{'sessionId': 'publish-1'});
+  });
+
+  test('endForegroundSession passes the session id to native', () async {
+    await platform.endForegroundSession('publish-1');
+
+    expect(calls.single.method, 'endForegroundSession');
+    expect(calls.single.arguments, <String, Object?>{'sessionId': 'publish-1'});
+  });
+
   test('activeTaskIds returns the native list', () async {
     expect(await platform.activeTaskIds(), <String>['task-a', 'task-b']);
   });

--- a/mobile/packages/background_uploader/test/background_uploader_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_test.dart
@@ -82,7 +82,7 @@ void main() {
       expect(fake.enqueued, isEmpty);
     });
 
-    test('rejects a non-https URL', () async {
+    test('rejects a remote non-https URL', () async {
       await expectLater(
         () => BackgroundUploader.instance.enqueue(
           request(url: 'http://media.divine.video/upload'),
@@ -90,6 +90,19 @@ void main() {
         throwsArgumentError,
       );
       expect(fake.enqueued, isEmpty);
+    });
+
+    test('allows cleartext http to loopback hosts (local stack)', () async {
+      await BackgroundUploader.instance.enqueue(
+        request(url: 'http://10.0.2.2:3000/upload'),
+      );
+      await BackgroundUploader.instance.enqueue(
+        request(url: 'http://localhost/upload'),
+      );
+      await BackgroundUploader.instance.enqueue(
+        request(url: 'http://127.0.0.1:8080/upload'),
+      );
+      expect(fake.enqueued, hasLength(3));
     });
 
     test('cancel forwards the task id', () async {
@@ -136,6 +149,36 @@ void main() {
       expect(
         await BackgroundUploader.instance.takeBufferedTerminalEvent('x'),
         isNull,
+      );
+    });
+  });
+
+  group('BackgroundUploadRequest', () {
+    BackgroundUploadRequest request({String? notificationTitle}) {
+      return BackgroundUploadRequest(
+        taskId: 'task-1',
+        url: Uri.parse('https://media.divine.video/upload'),
+        filePath: '/tmp/video.mp4',
+        notificationTitle: notificationTitle ?? 'Uploading',
+      );
+    }
+
+    test('defaults the notification title and serializes it', () {
+      final serialized = BackgroundUploadRequest(
+        taskId: 'task-1',
+        url: Uri.parse('https://media.divine.video/upload'),
+        filePath: '/tmp/video.mp4',
+      );
+      expect(serialized.notificationTitle, 'Uploading');
+      expect(serialized.toMap()['notificationTitle'], 'Uploading');
+    });
+
+    test('carries a custom notification title through toMap', () {
+      expect(
+        request(
+          notificationTitle: 'Uploading video',
+        ).toMap()['notificationTitle'],
+        'Uploading video',
       );
     });
   });

--- a/mobile/packages/background_uploader/test/background_uploader_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_test.dart
@@ -9,6 +9,8 @@ class _FakeBackgroundUploaderPlatform extends BackgroundUploaderPlatform
     with MockPlatformInterfaceMixin {
   final List<BackgroundUploadRequest> enqueued = <BackgroundUploadRequest>[];
   final List<String> cancelled = <String>[];
+  final List<String> sessionsBegun = <String>[];
+  final List<String> sessionsEnded = <String>[];
 
   @override
   Stream<BackgroundUploadEvent> get events =>
@@ -26,6 +28,14 @@ class _FakeBackgroundUploaderPlatform extends BackgroundUploaderPlatform
 
   @override
   Future<List<String>> activeTaskIds() async => const <String>[];
+
+  @override
+  Future<void> beginForegroundSession(String sessionId) async =>
+      sessionsBegun.add(sessionId);
+
+  @override
+  Future<void> endForegroundSession(String sessionId) async =>
+      sessionsEnded.add(sessionId);
 }
 
 void main() {
@@ -75,6 +85,24 @@ void main() {
     test('cancel forwards the task id', () async {
       await BackgroundUploader.instance.cancel('task-9');
       expect(fake.cancelled.single, 'task-9');
+    });
+
+    test('beginForegroundSession forwards the session id', () async {
+      await BackgroundUploader.instance.beginForegroundSession('publish-1');
+      expect(fake.sessionsBegun.single, 'publish-1');
+    });
+
+    test('beginForegroundSession rejects an empty session id', () async {
+      await expectLater(
+        () => BackgroundUploader.instance.beginForegroundSession(''),
+        throwsArgumentError,
+      );
+      expect(fake.sessionsBegun, isEmpty);
+    });
+
+    test('endForegroundSession forwards the session id', () async {
+      await BackgroundUploader.instance.endForegroundSession('publish-1');
+      expect(fake.sessionsEnded.single, 'publish-1');
     });
   });
 

--- a/mobile/packages/background_uploader/test/background_uploader_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_test.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+
+import 'package:background_uploader/background_uploader.dart';
+import 'package:background_uploader/background_uploader_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+class _FakeBackgroundUploaderPlatform extends BackgroundUploaderPlatform
+    with MockPlatformInterfaceMixin {
+  final List<BackgroundUploadRequest> enqueued = <BackgroundUploadRequest>[];
+  final List<String> cancelled = <String>[];
+
+  @override
+  Stream<BackgroundUploadEvent> get events =>
+      const Stream<BackgroundUploadEvent>.empty();
+
+  @override
+  Future<bool> isSupported() async => true;
+
+  @override
+  Future<void> enqueue(BackgroundUploadRequest request) async =>
+      enqueued.add(request);
+
+  @override
+  Future<void> cancel(String taskId) async => cancelled.add(taskId);
+
+  @override
+  Future<List<String>> activeTaskIds() async => const <String>[];
+}
+
+void main() {
+  group('BackgroundUploader.enqueue validation', () {
+    late _FakeBackgroundUploaderPlatform fake;
+
+    setUp(() {
+      fake = _FakeBackgroundUploaderPlatform();
+      BackgroundUploaderPlatform.instance = fake;
+    });
+
+    BackgroundUploadRequest request({
+      String method = 'PUT',
+      String url = 'https://media.divine.video/upload',
+    }) {
+      return BackgroundUploadRequest(
+        taskId: 'task-1',
+        url: Uri.parse(url),
+        filePath: '/tmp/video.mp4',
+        method: method,
+      );
+    }
+
+    test('forwards a valid request to the platform', () async {
+      await BackgroundUploader.instance.enqueue(request());
+      expect(fake.enqueued.single.taskId, 'task-1');
+    });
+
+    test('rejects an empty HTTP method', () async {
+      await expectLater(
+        () => BackgroundUploader.instance.enqueue(request(method: '  ')),
+        throwsArgumentError,
+      );
+      expect(fake.enqueued, isEmpty);
+    });
+
+    test('rejects a non-https URL', () async {
+      await expectLater(
+        () => BackgroundUploader.instance.enqueue(
+          request(url: 'http://media.divine.video/upload'),
+        ),
+        throwsArgumentError,
+      );
+      expect(fake.enqueued, isEmpty);
+    });
+
+    test('cancel forwards the task id', () async {
+      await BackgroundUploader.instance.cancel('task-9');
+      expect(fake.cancelled.single, 'task-9');
+    });
+  });
+
+  group('BackgroundUploadEvent', () {
+    test('parses a terminal success map', () {
+      final event = BackgroundUploadEvent.fromMap(const <String, Object?>{
+        'taskId': 'task-1',
+        'status': 'completed',
+        'progress': 1.0,
+        'httpStatusCode': 201,
+        'responseBody': '{"ok":true}',
+      });
+
+      expect(event.status, BackgroundUploadStatus.completed);
+      expect(event.isTerminal, isTrue);
+      expect(event.httpStatusCode, 201);
+      expect(event.responseBody, '{"ok":true}');
+    });
+
+    test('clamps out-of-range progress', () {
+      final event = BackgroundUploadEvent.fromMap(const <String, Object?>{
+        'taskId': 'task-1',
+        'status': 'running',
+        'progress': 4.2,
+      });
+
+      expect(event.progress, 1.0);
+      expect(event.isTerminal, isFalse);
+    });
+
+    test('tryFromMap returns null without a taskId', () {
+      expect(
+        BackgroundUploadEvent.tryFromMap(<String, Object?>{
+          'status': 'completed',
+        }),
+        isNull,
+      );
+    });
+
+    test('tryFromMap returns null on an unknown status', () {
+      expect(
+        BackgroundUploadEvent.tryFromMap(<String, Object?>{
+          'taskId': 'task-1',
+          'status': 'teleported',
+        }),
+        isNull,
+      );
+    });
+  });
+}

--- a/mobile/packages/background_uploader/test/background_uploader_test.dart
+++ b/mobile/packages/background_uploader/test/background_uploader_test.dart
@@ -26,8 +26,18 @@ class _FakeBackgroundUploaderPlatform extends BackgroundUploaderPlatform
   @override
   Future<void> cancel(String taskId) async => cancelled.add(taskId);
 
+  final List<String> activeTaskIdsResult = <String>[];
+
   @override
-  Future<List<String>> activeTaskIds() async => const <String>[];
+  Future<List<String>> activeTaskIds() async => activeTaskIdsResult;
+
+  final Map<String, BackgroundUploadEvent> bufferedTerminals =
+      <String, BackgroundUploadEvent>{};
+
+  @override
+  Future<BackgroundUploadEvent?> takeBufferedTerminalEvent(
+    String taskId,
+  ) async => bufferedTerminals.remove(taskId);
 
   @override
   Future<void> beginForegroundSession(String sessionId) async =>
@@ -103,6 +113,30 @@ void main() {
     test('endForegroundSession forwards the session id', () async {
       await BackgroundUploader.instance.endForegroundSession('publish-1');
       expect(fake.sessionsEnded.single, 'publish-1');
+    });
+
+    test('activeTaskIds forwards the platform result', () async {
+      fake.activeTaskIdsResult.add('task-7');
+      expect(await BackgroundUploader.instance.activeTaskIds(), <String>[
+        'task-7',
+      ]);
+    });
+
+    test('takeBufferedTerminalEvent forwards the platform result', () async {
+      fake.bufferedTerminals['task-7'] = const BackgroundUploadEvent(
+        taskId: 'task-7',
+        status: BackgroundUploadStatus.completed,
+        httpStatusCode: 200,
+      );
+
+      final claimed = await BackgroundUploader.instance
+          .takeBufferedTerminalEvent('task-7');
+
+      expect(claimed?.taskId, 'task-7');
+      expect(
+        await BackgroundUploader.instance.takeBufferedTerminalEvent('x'),
+        isNull,
+      );
     });
   });
 

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2097,7 +2097,15 @@ class BlossomUploadService {
       );
     }
 
+    var traceRunning = false;
+    Future<void> stopTraceOnce() async {
+      if (!traceRunning) return;
+      traceRunning = false;
+      await _performanceMonitor.stopTrace('video_upload');
+    }
+
     await _performanceMonitor.startTrace('video_upload');
+    traceRunning = true;
     try {
       onProgress?.call(0.1);
       final hashResult = await HashUtil.sha256File(videoFile);
@@ -2201,6 +2209,10 @@ class BlossomUploadService {
           }
         }
 
+        // Setup + enqueue are the only in-process work; stop the trace here so
+        // it doesn't span the OS-owned transfer wait (which can include a long
+        // app suspension and would otherwise pollute the perf metric).
+        await stopTraceOnce();
         return await completer.future.timeout(
           timeout,
           onTimeout: () => BlossomUploadResult(
@@ -2216,7 +2228,7 @@ class BlossomUploadService {
         await sub.cancel();
       }
     } finally {
-      await _performanceMonitor.stopTrace('video_upload');
+      await stopTraceOnce();
     }
   }
 

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -3,6 +3,7 @@
 // ABOUTME: authentication and returns media URLs from any
 // ABOUTME: Blossom server.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
@@ -297,6 +298,81 @@ class BlossomResumableUploadException implements Exception {
   String toString() => message;
 }
 
+/// Lifecycle status of a background transfer reported by a
+/// [BlossomBackgroundTransport].
+enum BlossomBackgroundTransferStatus {
+  /// In flight; [BlossomBackgroundTransferEvent.progress] is meaningful.
+  running,
+
+  /// The server accepted the upload (a 2xx response).
+  completed,
+
+  /// The upload failed — a transport error or a non-2xx response.
+  failed,
+
+  /// The upload was cancelled.
+  cancelled,
+}
+
+/// A progress or terminal event from a [BlossomBackgroundTransport].
+class BlossomBackgroundTransferEvent {
+  /// Creates a [BlossomBackgroundTransferEvent].
+  const BlossomBackgroundTransferEvent({
+    required this.taskId,
+    required this.status,
+    this.progress = 0,
+    this.httpStatusCode,
+    this.responseBody,
+    this.error,
+  });
+
+  /// Identifier correlating this event to the enqueued upload.
+  final String taskId;
+
+  /// Current lifecycle status.
+  final BlossomBackgroundTransferStatus status;
+
+  /// Fraction uploaded in `[0, 1]` while [status] is
+  /// [BlossomBackgroundTransferStatus.running].
+  final double progress;
+
+  /// HTTP status code for terminal events, when the server responded.
+  final int? httpStatusCode;
+
+  /// Response body for terminal events, when available.
+  final String? responseBody;
+
+  /// Transport error for a [BlossomBackgroundTransferStatus.failed] event that
+  /// was not an HTTP status (e.g. a dropped socket).
+  final String? error;
+
+  /// Whether this event is terminal (no further events follow for [taskId]).
+  bool get isTerminal => status != BlossomBackgroundTransferStatus.running;
+}
+
+/// Port for an OS-backed background uploader.
+///
+/// Injected by the app so the Blossom service can hand a single PUT to the
+/// operating system and let it finish the transfer across app suspension.
+/// Kept abstract so this package takes no dependency on the concrete
+/// background-upload plugin (mirroring [BlossomAuthProvider]).
+abstract class BlossomBackgroundTransport {
+  /// Hands a single upload request to the OS background facility.
+  Future<void> enqueue({
+    required String taskId,
+    required String url,
+    required String method,
+    required Map<String, String> headers,
+    required String filePath,
+  });
+
+  /// Cancels an in-flight background upload identified by [taskId].
+  Future<void> cancel(String taskId);
+
+  /// Progress and terminal events for all enqueued uploads, keyed by taskId.
+  Stream<BlossomBackgroundTransferEvent> get events;
+}
+
 /// Abstraction over the payload of a Blossom upload.
 ///
 /// Two implementations exist:
@@ -432,6 +508,7 @@ class BlossomUploadService {
     DateTime Function()? clock,
     Future<void> Function(Duration)? sleep,
     Future<void> Function()? betweenChunks,
+    this.backgroundTransport,
   }) : _performanceMonitor =
            performanceMonitor ?? const NoOpPerformanceMonitor(),
        dio = dio ?? Dio(),
@@ -480,6 +557,11 @@ class BlossomUploadService {
 
   /// The authentication provider for signing Blossom events.
   final BlossomAuthProvider authProvider;
+
+  /// Optional OS-backed background uploader used by [uploadVideoInBackground].
+  /// `null` disables background uploads; that method then fails fast.
+  final BlossomBackgroundTransport? backgroundTransport;
+
   final BlossomPerformanceMonitor _performanceMonitor;
 
   /// The HTTP client used for uploads.
@@ -1948,6 +2030,200 @@ class BlossomUploadService {
     } finally {
       // Stop performance trace
       await _performanceMonitor.stopTrace('video_upload');
+    }
+  }
+
+  /// Uploads [videoFile] through the injected [backgroundTransport] as a
+  /// single Blossom BUD-01 `PUT`, letting the OS finish the transfer across
+  /// app suspension.
+  ///
+  /// Unlike [uploadVideo], this does not chunk or fall back across servers — an
+  /// OS background transfer is a single request to the default server. The
+  /// returned future completes when the transfer reaches a terminal state,
+  /// which — after the app was suspended mid-upload — is when it resumes.
+  ///
+  /// [taskId] correlates the transfer; pass a stable id (e.g. the pending-
+  /// upload id) so it can be reconciled after a relaunch. Returns a failure
+  /// result (rather than throwing) when no transport is configured, the user
+  /// is unauthenticated, or the auth header cannot be built.
+  Future<BlossomUploadResult> uploadVideoInBackground({
+    required File videoFile,
+    required String taskId,
+    required String? proofManifestJson,
+    void Function(double)? onProgress,
+  }) async {
+    final transport = backgroundTransport;
+    if (transport == null) {
+      return const BlossomUploadResult(
+        success: false,
+        errorMessage: 'Background upload transport is not configured',
+        failureReason: BlossomUploadFailureReason.unknown,
+      );
+    }
+
+    if (!authProvider.isAuthenticated) {
+      return const BlossomUploadResult(
+        success: false,
+        errorMessage: 'User not authenticated - please sign in to upload',
+        failureReason: BlossomUploadFailureReason.auth,
+      );
+    }
+
+    await _performanceMonitor.startTrace('video_upload');
+    try {
+      onProgress?.call(0.1);
+      final hashResult = await HashUtil.sha256File(videoFile);
+      final fileSize = hashResult.size;
+      final fileHash = hashResult.hash;
+      _performanceMonitor.setMetric(
+        'video_upload',
+        'file_size_bytes',
+        fileSize,
+      );
+      onProgress?.call(0.2);
+
+      final serverUrl = (await _getServerUrlsForUpload()).first;
+      final uploadUrl = '$serverUrl/upload';
+      final authHeader = await _createBlossomAuthHeader(
+        url: uploadUrl,
+        method: 'PUT',
+        fileHash: fileHash,
+        fileSize: fileSize,
+        contentDescription: 'Upload video to Blossom server',
+      );
+      if (authHeader == null) {
+        return const BlossomUploadResult(
+          success: false,
+          errorMessage: 'Failed to create Blossom authentication',
+          failureReason: BlossomUploadFailureReason.authUnavailable,
+        );
+      }
+
+      final headers = <String, dynamic>{
+        'Authorization': authHeader,
+        'Content-Type': 'video/mp4',
+        'Content-Length': fileSize.toString(),
+      };
+      if (proofManifestJson != null && proofManifestJson.isNotEmpty) {
+        _addProofModeHeaders(headers, proofManifestJson);
+      }
+      final stringHeaders = headers.map(
+        (key, value) => MapEntry(key, value.toString()),
+      );
+
+      final completer = Completer<BlossomUploadResult>();
+      late final StreamSubscription<BlossomBackgroundTransferEvent> sub;
+      sub = transport.events.where((event) => event.taskId == taskId).listen((
+        event,
+      ) {
+        if (!event.isTerminal) {
+          onProgress?.call((0.2 + event.progress * 0.7).clamp(0.2, 0.9));
+          return;
+        }
+        unawaited(sub.cancel());
+        if (completer.isCompleted) return;
+        final result = _backgroundTransferResult(
+          event,
+          fileHash: fileHash,
+        );
+        if (result.success) onProgress?.call(1);
+        completer.complete(result);
+      });
+
+      try {
+        await transport.enqueue(
+          taskId: taskId,
+          url: uploadUrl,
+          method: 'PUT',
+          headers: stringHeaders,
+          filePath: videoFile.path,
+        );
+      } on Object catch (e) {
+        unawaited(sub.cancel());
+        if (!completer.isCompleted) {
+          completer.complete(
+            BlossomUploadResult(
+              success: false,
+              errorMessage: 'Failed to enqueue background upload: $e',
+              failureReason: _classifyUploadException(e),
+            ),
+          );
+        }
+      }
+
+      return await completer.future;
+    } finally {
+      await _performanceMonitor.stopTrace('video_upload');
+    }
+  }
+
+  /// Maps a terminal [BlossomBackgroundTransferEvent] to a
+  /// [BlossomUploadResult], using the canonical Blossom URL on success so we
+  /// never surface a non-HTTP URL (mirroring [uploadVideo]).
+  BlossomUploadResult _backgroundTransferResult(
+    BlossomBackgroundTransferEvent event, {
+    required String fileHash,
+  }) {
+    switch (event.status) {
+      case BlossomBackgroundTransferStatus.completed:
+        final canonicalUrl = '$_defaultServerUrl/$fileHash';
+        final body = event.responseBody;
+        final decoded = body == null ? null : _tryDecodeJsonMap(body);
+        String? thumbnailUrl;
+        String? streamingMp4Url;
+        String? streamingHlsUrl;
+        String? streamingStatus;
+        if (decoded != null) {
+          thumbnailUrl = decoded['thumbnail']?.toString();
+          final streaming = decoded['streaming'];
+          if (streaming is Map) {
+            streamingMp4Url = streaming['mp4Url']?.toString();
+            streamingHlsUrl = streaming['hlsUrl']?.toString();
+            streamingStatus = streaming['status']?.toString();
+            thumbnailUrl =
+                streaming['thumbnailUrl']?.toString() ?? thumbnailUrl;
+          }
+        }
+        return BlossomUploadResult(
+          success: true,
+          url: canonicalUrl,
+          fallbackUrl: canonicalUrl,
+          videoId: fileHash,
+          thumbnailUrl: thumbnailUrl,
+          streamingMp4Url: streamingMp4Url,
+          streamingHlsUrl: streamingHlsUrl,
+          streamingStatus: streamingStatus,
+        );
+      case BlossomBackgroundTransferStatus.cancelled:
+        return const BlossomUploadResult(
+          success: false,
+          errorMessage: 'Upload cancelled',
+          failureReason: BlossomUploadFailureReason.unknown,
+        );
+      case BlossomBackgroundTransferStatus.running:
+      case BlossomBackgroundTransferStatus.failed:
+        final statusCode = event.httpStatusCode;
+        return BlossomUploadResult(
+          success: false,
+          statusCode: statusCode,
+          errorMessage:
+              event.error ?? 'Upload failed: ${statusCode ?? 'no response'}',
+          isTransientNetworkFailure: statusCode == null && event.error != null,
+          failureReason:
+              BlossomUploadFailureReason.fromStatusCode(statusCode) ??
+              (event.error != null
+                  ? BlossomUploadFailureReason.network
+                  : BlossomUploadFailureReason.unknown),
+        );
+    }
+  }
+
+  Map<String, dynamic>? _tryDecodeJsonMap(String body) {
+    try {
+      final decoded = jsonDecode(body);
+      return decoded is Map<String, dynamic> ? decoded : null;
+    } on Object {
+      return null;
     }
   }
 

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2194,6 +2194,16 @@ class BlossomUploadService {
     }
   }
 
+  /// Stops an in-flight OS background upload previously enqueued via
+  /// [uploadVideoInBackground] under [taskId].
+  ///
+  /// Without this the OS keeps streaming the file to completion even after the
+  /// user cancels, wasting bandwidth on a video that will never be published.
+  /// A no-op when no [backgroundTransport] is configured.
+  Future<void> cancelBackgroundUpload(String taskId) async {
+    await backgroundTransport?.cancel(taskId);
+  }
+
   /// Maps a terminal [BlossomBackgroundTransferEvent] to a
   /// [BlossomUploadResult].
   ///

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2269,14 +2269,17 @@ class BlossomUploadService {
         if (decoded != null) {
           responseUrl = decoded['url']?.toString();
           responseFallbackUrl = decoded['fallbackUrl']?.toString();
-          thumbnailUrl = decoded['thumbnail']?.toString();
+          thumbnailUrl =
+              decoded['thumbnail']?.toString() ?? responseFallbackUrl;
           final streaming = decoded['streaming'];
           if (streaming is Map) {
             streamingMp4Url = streaming['mp4Url']?.toString();
             streamingHlsUrl = streaming['hlsUrl']?.toString();
             streamingStatus = streaming['status']?.toString();
             thumbnailUrl =
-                streaming['thumbnailUrl']?.toString() ?? thumbnailUrl;
+                streaming['thumbnailUrl']?.toString() ??
+                streaming['thumbnail']?.toString() ??
+                thumbnailUrl;
           }
         }
         return BlossomUploadResult(
@@ -2303,6 +2306,19 @@ class BlossomUploadService {
       case BlossomBackgroundTransferStatus.running:
       case BlossomBackgroundTransferStatus.failed:
         final statusCode = event.httpStatusCode;
+        // A 409 means the blob is already stored (BUD dedup convention);
+        // mirror the in-process parse and treat it as success at the
+        // content-addressed URL on the server the file was actually uploaded
+        // to (not necessarily the default when a custom server is configured).
+        if (statusCode == 409) {
+          final existingUrl = '$serverUrl/$fileHash';
+          return BlossomUploadResult(
+            success: true,
+            url: existingUrl,
+            fallbackUrl: existingUrl,
+            videoId: fileHash,
+          );
+        }
         return BlossomUploadResult(
           success: false,
           statusCode: statusCode,

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -372,9 +372,6 @@ abstract class BlossomBackgroundTransport {
   /// Progress and terminal events for all enqueued uploads, keyed by taskId.
   Stream<BlossomBackgroundTransferEvent> get events;
 
-  /// Task ids the OS still has in flight, for startup reconciliation.
-  Future<List<String>> activeTaskIds();
-
   /// Claims a terminal event for [taskId] that the OS delivered while nothing
   /// was listening on [events] — e.g. an upload finished while the app was
   /// dead — or `null` when none is buffered. Claiming removes it.
@@ -2232,15 +2229,6 @@ class BlossomUploadService {
   Future<void> cancelBackgroundUpload(String taskId) async {
     await backgroundTransport?.cancel(taskId);
   }
-
-  /// Task ids the OS still has in flight for background uploads.
-  ///
-  /// Startup reconciliation uses this to tell an upload that is still running
-  /// apart from one that has already finished (whose terminal event is claimed
-  /// via [uploadVideoInBackground]). Empty when no [backgroundTransport] is
-  /// configured.
-  Future<List<String>> activeBackgroundUploadIds() async =>
-      (await backgroundTransport?.activeTaskIds()) ?? const <String>[];
 
   /// Maps a terminal [BlossomBackgroundTransferEvent] to a
   /// [BlossomUploadResult].

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -371,6 +371,16 @@ abstract class BlossomBackgroundTransport {
 
   /// Progress and terminal events for all enqueued uploads, keyed by taskId.
   Stream<BlossomBackgroundTransferEvent> get events;
+
+  /// Task ids the OS still has in flight, for startup reconciliation.
+  Future<List<String>> activeTaskIds();
+
+  /// Claims a terminal event for [taskId] that the OS delivered while nothing
+  /// was listening on [events] — e.g. an upload finished while the app was
+  /// dead — or `null` when none is buffered. Claiming removes it.
+  Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
+    String taskId,
+  );
 }
 
 /// Abstraction over the payload of a Blossom upload.
@@ -2104,6 +2114,25 @@ class BlossomUploadService {
       onProgress?.call(0.2);
 
       final serverUrl = (await _getServerUrlsForUpload()).first;
+
+      // Startup reconciliation: if the OS already finished this upload while
+      // the app was dead, its terminal event was buffered by the transport.
+      // Claim it and skip re-uploading the whole file. A failed/cancelled
+      // buffered event is simply discarded so this retry proceeds normally.
+      final buffered = await transport.takeBufferedTerminalEvent(taskId);
+      if (buffered != null &&
+          buffered.status == BlossomBackgroundTransferStatus.completed) {
+        final result = _backgroundTransferResult(
+          buffered,
+          fileHash: fileHash,
+          serverUrl: serverUrl,
+        );
+        if (result.success) {
+          onProgress?.call(1);
+          return result;
+        }
+      }
+
       final uploadUrl = '$serverUrl/upload';
       final authHeader = await _createBlossomAuthHeader(
         url: uploadUrl,
@@ -2203,6 +2232,15 @@ class BlossomUploadService {
   Future<void> cancelBackgroundUpload(String taskId) async {
     await backgroundTransport?.cancel(taskId);
   }
+
+  /// Task ids the OS still has in flight for background uploads.
+  ///
+  /// Startup reconciliation uses this to tell an upload that is still running
+  /// apart from one that has already finished (whose terminal event is claimed
+  /// via [uploadVideoInBackground]). Empty when no [backgroundTransport] is
+  /// configured.
+  Future<List<String>> activeBackgroundUploadIds() async =>
+      (await backgroundTransport?.activeTaskIds()) ?? const <String>[];
 
   /// Maps a terminal [BlossomBackgroundTransferEvent] to a
   /// [BlossomUploadResult].

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -2253,6 +2253,7 @@ class BlossomUploadService {
     String mimeType = 'image/jpeg',
     void Function(double)? onProgress,
     int maxAttempts = _defaultUploadImageMaxAttempts,
+    bool allowResumable = true,
   }) async {
     assert(maxAttempts >= 1, 'maxAttempts must be at least 1');
     try {
@@ -2296,6 +2297,7 @@ class BlossomUploadService {
         fileSize: fileSize,
         contentType: mimeType,
         maxAttempts: maxAttempts,
+        allowResumable: allowResumable,
         onProgress: onProgress,
       );
     } on Object catch (e) {
@@ -2397,6 +2399,7 @@ class BlossomUploadService {
     required int fileSize,
     required String contentType,
     required int maxAttempts,
+    bool allowResumable = true,
     void Function(double)? onProgress,
   }) async {
     // Get ordered list of servers to try
@@ -2423,7 +2426,7 @@ class BlossomUploadService {
 
         final result = await _uploadWithRetry(
           attempt: () {
-            if (capability.supportsResumable) {
+            if (capability.supportsResumable && allowResumable) {
               return _uploadWithSingleLegacyFallback(
                 serverUrl: serverUrl,
                 uploadResumable: () => _uploadToServerResumable(

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -555,6 +555,25 @@ class BlossomUploadService {
   /// How long a cached capability discovery result stays valid.
   static const Duration _capabilityCacheTtl = Duration(minutes: 5);
 
+  /// How long a signed Blossom auth event stays valid. The in-process upload
+  /// paths send the request within seconds of signing, so a short window is
+  /// fine.
+  static const Duration _defaultAuthTtl = Duration(minutes: 5);
+
+  /// Auth TTL for the OS background path. The operating system owns the
+  /// transfer and may defer it — or resume it after a long app suspension —
+  /// well after [uploadVideoInBackground] signed the header. A short TTL would
+  /// have expired by the time the PUT is actually sent, so the server would
+  /// reject it as unauthorized; this wider window keeps the header valid.
+  static const Duration _backgroundAuthTtl = Duration(hours: 6);
+
+  /// Safety timeout for [uploadVideoInBackground]. The OS drives the transfer,
+  /// so this is deliberately generous — it only exists to guarantee the
+  /// returned future completes (and its event subscription is released) if the
+  /// OS never reports a terminal event, e.g. the Android foreground service is
+  /// killed mid-transfer.
+  static const Duration _backgroundUploadTimeout = Duration(minutes: 30);
+
   /// The authentication provider for signing Blossom events.
   final BlossomAuthProvider authProvider;
 
@@ -650,6 +669,7 @@ class BlossomUploadService {
     required String fileHash,
     required int fileSize,
     String contentDescription = 'Upload video to Blossom server',
+    Duration authTtl = _defaultAuthTtl,
   }) async {
     try {
       // Blossom requires these tags (BUD-01):
@@ -658,9 +678,7 @@ class BlossomUploadService {
       // - x: SHA-256 hash of the file (optional but recommended)
 
       final now = DateTime.now();
-      final expiration = now.add(
-        const Duration(minutes: 5),
-      ); // 5 minute expiration
+      final expiration = now.add(authTtl);
       final expirationTimestamp = expiration.millisecondsSinceEpoch ~/ 1000;
 
       // Build tags for Blossom auth event (kind 24242)
@@ -735,6 +753,7 @@ class BlossomUploadService {
     required String fileHash,
     required int fileSize,
     required String contentDescription,
+    Duration authTtl = _defaultAuthTtl,
   }) async {
     final authEvent = await _createBlossomAuthEvent(
       url: url,
@@ -742,6 +761,7 @@ class BlossomUploadService {
       fileHash: fileHash,
       fileSize: fileSize,
       contentDescription: contentDescription,
+      authTtl: authTtl,
     );
     if (authEvent == null) {
       return null;
@@ -2051,6 +2071,7 @@ class BlossomUploadService {
     required String taskId,
     required String? proofManifestJson,
     void Function(double)? onProgress,
+    Duration timeout = _backgroundUploadTimeout,
   }) async {
     final transport = backgroundTransport;
     if (transport == null) {
@@ -2090,6 +2111,7 @@ class BlossomUploadService {
         fileHash: fileHash,
         fileSize: fileSize,
         contentDescription: 'Upload video to Blossom server',
+        authTtl: _backgroundAuthTtl,
       );
       if (authHeader == null) {
         return const BlossomUploadResult(
@@ -2112,68 +2134,93 @@ class BlossomUploadService {
       );
 
       final completer = Completer<BlossomUploadResult>();
-      late final StreamSubscription<BlossomBackgroundTransferEvent> sub;
-      sub = transport.events.where((event) => event.taskId == taskId).listen((
-        event,
-      ) {
-        if (!event.isTerminal) {
-          onProgress?.call((0.2 + event.progress * 0.7).clamp(0.2, 0.9));
-          return;
-        }
-        unawaited(sub.cancel());
-        if (completer.isCompleted) return;
-        final result = _backgroundTransferResult(
-          event,
-          fileHash: fileHash,
-        );
-        if (result.success) onProgress?.call(1);
-        completer.complete(result);
-      });
+      final sub = transport.events
+          .where((event) => event.taskId == taskId)
+          .listen((event) {
+            if (!event.isTerminal) {
+              onProgress?.call((0.2 + event.progress * 0.7).clamp(0.2, 0.9));
+              return;
+            }
+            if (completer.isCompleted) return;
+            final result = _backgroundTransferResult(
+              event,
+              fileHash: fileHash,
+              serverUrl: serverUrl,
+            );
+            if (result.success) onProgress?.call(1);
+            completer.complete(result);
+          });
 
+      // Cancel the subscription no matter how the future resolves — terminal
+      // event, enqueue failure, or the safety timeout below — so we never leak
+      // a listener on the shared broadcast stream.
       try {
-        await transport.enqueue(
-          taskId: taskId,
-          url: uploadUrl,
-          method: 'PUT',
-          headers: stringHeaders,
-          filePath: videoFile.path,
-        );
-      } on Object catch (e) {
-        unawaited(sub.cancel());
-        if (!completer.isCompleted) {
-          completer.complete(
-            BlossomUploadResult(
-              success: false,
-              errorMessage: 'Failed to enqueue background upload: $e',
-              failureReason: _classifyUploadException(e),
-            ),
+        try {
+          await transport.enqueue(
+            taskId: taskId,
+            url: uploadUrl,
+            method: 'PUT',
+            headers: stringHeaders,
+            filePath: videoFile.path,
           );
+        } on Object catch (e) {
+          if (!completer.isCompleted) {
+            completer.complete(
+              BlossomUploadResult(
+                success: false,
+                errorMessage: 'Failed to enqueue background upload: $e',
+                failureReason: _classifyUploadException(e),
+              ),
+            );
+          }
         }
-      }
 
-      return await completer.future;
+        return await completer.future.timeout(
+          timeout,
+          onTimeout: () => BlossomUploadResult(
+            success: false,
+            errorMessage:
+                'Background upload reported no terminal event within '
+                '${timeout.inMinutes} minutes',
+            isTransientNetworkFailure: true,
+            failureReason: BlossomUploadFailureReason.network,
+          ),
+        );
+      } finally {
+        await sub.cancel();
+      }
     } finally {
       await _performanceMonitor.stopTrace('video_upload');
     }
   }
 
   /// Maps a terminal [BlossomBackgroundTransferEvent] to a
-  /// [BlossomUploadResult], using the canonical Blossom URL on success so we
-  /// never surface a non-HTTP URL (mirroring [uploadVideo]).
+  /// [BlossomUploadResult].
+  ///
+  /// On success it prefers the `url` / `fallbackUrl` the server returned in the
+  /// response body (mirroring [_parseUploadResponse]); when the body carries
+  /// none, it falls back to the content-addressed URL on [serverUrl] — the
+  /// server the file was actually uploaded to, which is not necessarily the
+  /// default server when a custom Blossom server is configured.
   BlossomUploadResult _backgroundTransferResult(
     BlossomBackgroundTransferEvent event, {
     required String fileHash,
+    required String serverUrl,
   }) {
     switch (event.status) {
       case BlossomBackgroundTransferStatus.completed:
-        final canonicalUrl = '$_defaultServerUrl/$fileHash';
+        final canonicalUrl = '$serverUrl/$fileHash';
         final body = event.responseBody;
         final decoded = body == null ? null : _tryDecodeJsonMap(body);
+        String? responseUrl;
+        String? responseFallbackUrl;
         String? thumbnailUrl;
         String? streamingMp4Url;
         String? streamingHlsUrl;
         String? streamingStatus;
         if (decoded != null) {
+          responseUrl = decoded['url']?.toString();
+          responseFallbackUrl = decoded['fallbackUrl']?.toString();
           thumbnailUrl = decoded['thumbnail']?.toString();
           final streaming = decoded['streaming'];
           if (streaming is Map) {
@@ -2186,8 +2233,13 @@ class BlossomUploadService {
         }
         return BlossomUploadResult(
           success: true,
-          url: canonicalUrl,
-          fallbackUrl: canonicalUrl,
+          url: (responseUrl != null && responseUrl.isNotEmpty)
+              ? responseUrl
+              : canonicalUrl,
+          fallbackUrl:
+              (responseFallbackUrl != null && responseFallbackUrl.isNotEmpty)
+              ? responseFallbackUrl
+              : canonicalUrl,
           videoId: fileHash,
           thumbnailUrl: thumbnailUrl,
           streamingMp4Url: streamingMp4Url,

--- a/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
@@ -16,7 +16,6 @@ class _FakeTransport implements BlossomBackgroundTransport {
     this.emitOnEnqueue = const [],
     this.throwOnEnqueue = false,
     Map<String, BlossomBackgroundTransferEvent>? bufferedTerminals,
-    this.active = const <String>[],
   }) : bufferedTerminals =
            bufferedTerminals ?? <String, BlossomBackgroundTransferEvent>{};
 
@@ -26,7 +25,6 @@ class _FakeTransport implements BlossomBackgroundTransport {
   /// Terminal events the OS delivered while nothing was listening, keyed by
   /// taskId. Claimed (and removed) by [takeBufferedTerminalEvent].
   final Map<String, BlossomBackgroundTransferEvent> bufferedTerminals;
-  final List<String> active;
   final StreamController<BlossomBackgroundTransferEvent> _controller =
       StreamController<BlossomBackgroundTransferEvent>.broadcast();
   final List<String> enqueued = <String>[];
@@ -52,9 +50,6 @@ class _FakeTransport implements BlossomBackgroundTransport {
 
   @override
   Future<void> cancel(String taskId) async => cancelled.add(taskId);
-
-  @override
-  Future<List<String>> activeTaskIds() async => active;
 
   @override
   Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
@@ -508,20 +503,4 @@ void main() {
       expect(transport.enqueued, <String>[taskId], reason: 're-uploaded');
     },
   );
-
-  test(
-    'activeBackgroundUploadIds forwards the transport in-flight ids',
-    () async {
-      final transport = _FakeTransport(active: <String>[taskId]);
-
-      expect(
-        await service(transport).activeBackgroundUploadIds(),
-        <String>[taskId],
-      );
-    },
-  );
-
-  test('activeBackgroundUploadIds is empty without a transport', () async {
-    expect(await service(null).activeBackgroundUploadIds(), isEmpty);
-  });
 }

--- a/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
@@ -408,4 +408,20 @@ void main() {
     );
     await Future<void>.delayed(Duration.zero);
   });
+
+  test(
+    'cancelBackgroundUpload stops the OS transfer via the transport',
+    () async {
+      final transport = _FakeTransport();
+
+      await service(transport).cancelBackgroundUpload(taskId);
+
+      expect(transport.cancelled, <String>[taskId]);
+    },
+  );
+
+  test('cancelBackgroundUpload is a no-op without a transport', () async {
+    // Must not throw when background uploads are disabled.
+    await expectLater(service(null).cancelBackgroundUpload(taskId), completes);
+  });
 }

--- a/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
@@ -12,9 +12,10 @@ class _MockAuthProvider extends Mock implements BlossomAuthProvider {}
 /// Emits [emitOnEnqueue] as soon as [enqueue] is called, after the service has
 /// already subscribed — so the terminal event is never missed by a race.
 class _FakeTransport implements BlossomBackgroundTransport {
-  _FakeTransport({this.emitOnEnqueue = const []});
+  _FakeTransport({this.emitOnEnqueue = const [], this.throwOnEnqueue = false});
 
   final List<BlossomBackgroundTransferEvent> emitOnEnqueue;
+  final bool throwOnEnqueue;
   final StreamController<BlossomBackgroundTransferEvent> _controller =
       StreamController<BlossomBackgroundTransferEvent>.broadcast();
   final List<String> enqueued = <String>[];
@@ -32,6 +33,9 @@ class _FakeTransport implements BlossomBackgroundTransport {
     required String filePath,
   }) async {
     enqueued.add(taskId);
+    if (throwOnEnqueue) {
+      throw Exception('enqueue failed');
+    }
     emitOnEnqueue.forEach(_controller.add);
   }
 
@@ -210,5 +214,73 @@ void main() {
     expect(result.success, isTrue);
     expect(result.streamingMp4Url, 'https://media.divine.video/stream.mp4');
     expect(result.streamingStatus, 'processing');
+  });
+
+  test('attaches ProofMode headers when a manifest is provided', () async {
+    final transport = _FakeTransport(
+      emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.completed,
+          progress: 1,
+          httpStatusCode: 200,
+        ),
+      ],
+    );
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: '{"pgpSignature":"sig"}',
+    );
+
+    expect(result.success, isTrue);
+    expect(transport.enqueued, <String>[taskId]);
+  });
+
+  test('forwards intermediate progress for non-terminal events', () async {
+    final transport = _FakeTransport(
+      emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.running,
+          progress: 0.5,
+        ),
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.completed,
+          progress: 1,
+          httpStatusCode: 200,
+        ),
+      ],
+    );
+    final progress = <double>[];
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+      onProgress: progress.add,
+    );
+
+    expect(result.success, isTrue);
+    // The running event maps into the 0.2–0.9 reporting band, distinct from
+    // the final 1.0.
+    expect(progress.where((p) => p > 0.2 && p < 0.9), isNotEmpty);
+  });
+
+  test('returns failure when the transport rejects enqueue', () async {
+    final result = await service(_FakeTransport(throwOnEnqueue: true))
+        .uploadVideoInBackground(
+          videoFile: videoFile,
+          taskId: taskId,
+          proofManifestJson: null,
+        );
+
+    expect(result.success, isFalse);
+    expect(
+      result.errorMessage,
+      contains('Failed to enqueue background upload'),
+    );
   });
 }

--- a/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
@@ -283,4 +283,129 @@ void main() {
       contains('Failed to enqueue background upload'),
     );
   });
+
+  test(
+    'resolves the success URL from the server actually used, not the '
+    'injected default server',
+    () async {
+      // With no custom server stored, the upload targets the constant Divine
+      // media host; the success URL must reflect that host, not a differing
+      // injected default (e.g. staging).
+      final transport = _FakeTransport(
+        emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+          BlossomBackgroundTransferEvent(
+            taskId: taskId,
+            status: BlossomBackgroundTransferStatus.completed,
+            httpStatusCode: 200,
+          ),
+        ],
+      );
+      final svc = BlossomUploadService(
+        authProvider: auth,
+        defaultServerUrl: 'https://staging.divine.video',
+        backgroundTransport: transport,
+      );
+
+      final result = await svc.uploadVideoInBackground(
+        videoFile: videoFile,
+        taskId: taskId,
+        proofManifestJson: null,
+      );
+
+      expect(result.success, isTrue);
+      expect(result.url, startsWith('$server/'));
+      expect(result.url, isNot(contains('staging')));
+      expect(result.fallbackUrl, startsWith('$server/'));
+    },
+  );
+
+  test('prefers the server-returned url over the content-addressed '
+      'fallback', () async {
+    final body = jsonEncode(<String, dynamic>{
+      'url': 'https://media.divine.video/hls/master.m3u8',
+      'fallbackUrl': 'https://media.divine.video/mp4/video.mp4',
+    });
+    final transport = _FakeTransport(
+      emitOnEnqueue: <BlossomBackgroundTransferEvent>[
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.completed,
+          httpStatusCode: 200,
+          responseBody: body,
+        ),
+      ],
+    );
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+    );
+
+    expect(result.url, 'https://media.divine.video/hls/master.m3u8');
+    expect(result.fallbackUrl, 'https://media.divine.video/mp4/video.mp4');
+  });
+
+  test('signs the background auth header with an extended TTL', () async {
+    final transport = _FakeTransport(
+      emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.completed,
+          httpStatusCode: 200,
+        ),
+      ],
+    );
+    final before = DateTime.now();
+
+    await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+    );
+
+    final captured = verify(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: captureAny(named: 'tags'),
+      ),
+    ).captured;
+    final tags = (captured.single as List).cast<List<dynamic>>();
+    final expirationTag = tags.firstWhere((tag) => tag.first == 'expiration');
+    final expiresAt = DateTime.fromMillisecondsSinceEpoch(
+      int.parse(expirationTag[1] as String) * 1000,
+    );
+
+    // The background TTL (6h) must be well beyond the 5-minute in-process TTL,
+    // so an OS-deferred transfer isn't rejected as expired.
+    expect(expiresAt.isAfter(before.add(const Duration(hours: 1))), isTrue);
+  });
+
+  test('times out and releases its listener when no terminal event '
+      'arrives', () async {
+    final transport = _FakeTransport(); // emits nothing after enqueue
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+      timeout: const Duration(milliseconds: 50),
+    );
+
+    expect(transport.enqueued, <String>[taskId]);
+    expect(result.success, isFalse);
+    expect(result.failureReason, BlossomUploadFailureReason.network);
+    expect(result.isTransientNetworkFailure, isTrue);
+    // The subscription is cancelled on timeout, so a late terminal event is
+    // ignored rather than throwing "Future already completed".
+    transport._controller.add(
+      const BlossomBackgroundTransferEvent(
+        taskId: taskId,
+        status: BlossomBackgroundTransferStatus.completed,
+        httpStatusCode: 200,
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+  });
 }

--- a/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
@@ -1,0 +1,214 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthProvider extends Mock implements BlossomAuthProvider {}
+
+/// Emits [emitOnEnqueue] as soon as [enqueue] is called, after the service has
+/// already subscribed — so the terminal event is never missed by a race.
+class _FakeTransport implements BlossomBackgroundTransport {
+  _FakeTransport({this.emitOnEnqueue = const []});
+
+  final List<BlossomBackgroundTransferEvent> emitOnEnqueue;
+  final StreamController<BlossomBackgroundTransferEvent> _controller =
+      StreamController<BlossomBackgroundTransferEvent>.broadcast();
+  final List<String> enqueued = <String>[];
+  final List<String> cancelled = <String>[];
+
+  @override
+  Stream<BlossomBackgroundTransferEvent> get events => _controller.stream;
+
+  @override
+  Future<void> enqueue({
+    required String taskId,
+    required String url,
+    required String method,
+    required Map<String, String> headers,
+    required String filePath,
+  }) async {
+    enqueued.add(taskId);
+    emitOnEnqueue.forEach(_controller.add);
+  }
+
+  @override
+  Future<void> cancel(String taskId) async => cancelled.add(taskId);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const server = 'https://media.divine.video';
+  const taskId = 'upload-1';
+  late _MockAuthProvider auth;
+  late Directory tempDir;
+  late File videoFile;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(const <String, Object>{});
+    auth = _MockAuthProvider();
+    when(() => auth.isAuthenticated).thenReturn(true);
+    when(
+      () => auth.createAndSignEvent(
+        kind: any(named: 'kind'),
+        content: any(named: 'content'),
+        tags: any(named: 'tags'),
+      ),
+    ).thenAnswer(
+      (_) async => const BlossomSignedEvent(
+        json: <String, dynamic>{
+          'id': 'abc',
+          'kind': 24242,
+          'pubkey': 'pk',
+          'created_at': 1,
+          'tags': <dynamic>[],
+        },
+      ),
+    );
+
+    tempDir = await Directory.systemTemp.createTemp('blossom_bg_test_');
+    videoFile = File('${tempDir.path}/video.mp4')
+      ..writeAsBytesSync(List<int>.generate(64, (i) => i));
+  });
+
+  tearDown(() async => tempDir.delete(recursive: true));
+
+  BlossomUploadService service(_FakeTransport? transport) {
+    return BlossomUploadService(
+      authProvider: auth,
+      defaultServerUrl: server,
+      backgroundTransport: transport,
+    );
+  }
+
+  test('returns failure when no transport is configured', () async {
+    final result = await service(null).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+    );
+
+    expect(result.success, isFalse);
+    expect(result.failureReason, BlossomUploadFailureReason.unknown);
+  });
+
+  test('returns auth failure when unauthenticated', () async {
+    when(() => auth.isAuthenticated).thenReturn(false);
+
+    final result = await service(_FakeTransport()).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+    );
+
+    expect(result.success, isFalse);
+    expect(result.failureReason, BlossomUploadFailureReason.auth);
+  });
+
+  test('enqueues a single PUT and resolves with the canonical URL', () async {
+    final transport = _FakeTransport(
+      emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.completed,
+          progress: 1,
+          httpStatusCode: 200,
+        ),
+      ],
+    );
+    final progress = <double>[];
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+      onProgress: progress.add,
+    );
+
+    expect(transport.enqueued, <String>[taskId]);
+    expect(result.success, isTrue);
+    expect(result.url, startsWith('$server/'));
+    expect(result.videoId, isNotEmpty);
+    expect(progress.last, 1.0);
+  });
+
+  test('maps an HTTP error terminal event to a server failure', () async {
+    final transport = _FakeTransport(
+      emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.failed,
+          httpStatusCode: 503,
+        ),
+      ],
+    );
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+    );
+
+    expect(result.success, isFalse);
+    expect(result.statusCode, 503);
+    expect(result.failureReason, BlossomUploadFailureReason.server);
+  });
+
+  test(
+    'maps a transport error (no status) to a transient network failure',
+    () async {
+      final transport = _FakeTransport(
+        emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+          BlossomBackgroundTransferEvent(
+            taskId: taskId,
+            status: BlossomBackgroundTransferStatus.failed,
+            error: 'Connection reset by peer',
+          ),
+        ],
+      );
+
+      final result = await service(transport).uploadVideoInBackground(
+        videoFile: videoFile,
+        taskId: taskId,
+        proofManifestJson: null,
+      );
+
+      expect(result.success, isFalse);
+      expect(result.failureReason, BlossomUploadFailureReason.network);
+      expect(result.isTransientNetworkFailure, isTrue);
+    },
+  );
+
+  test('parses streaming metadata from the response body', () async {
+    final body = jsonEncode(<String, dynamic>{
+      'streaming': <String, dynamic>{
+        'mp4Url': 'https://media.divine.video/stream.mp4',
+        'status': 'processing',
+      },
+    });
+    final transport = _FakeTransport(
+      emitOnEnqueue: <BlossomBackgroundTransferEvent>[
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.completed,
+          httpStatusCode: 200,
+          responseBody: body,
+        ),
+      ],
+    );
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+    );
+
+    expect(result.success, isTrue);
+    expect(result.streamingMp4Url, 'https://media.divine.video/stream.mp4');
+    expect(result.streamingStatus, 'processing');
+  });
+}

--- a/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
@@ -12,10 +12,21 @@ class _MockAuthProvider extends Mock implements BlossomAuthProvider {}
 /// Emits [emitOnEnqueue] as soon as [enqueue] is called, after the service has
 /// already subscribed — so the terminal event is never missed by a race.
 class _FakeTransport implements BlossomBackgroundTransport {
-  _FakeTransport({this.emitOnEnqueue = const [], this.throwOnEnqueue = false});
+  _FakeTransport({
+    this.emitOnEnqueue = const [],
+    this.throwOnEnqueue = false,
+    Map<String, BlossomBackgroundTransferEvent>? bufferedTerminals,
+    this.active = const <String>[],
+  }) : bufferedTerminals =
+           bufferedTerminals ?? <String, BlossomBackgroundTransferEvent>{};
 
   final List<BlossomBackgroundTransferEvent> emitOnEnqueue;
   final bool throwOnEnqueue;
+
+  /// Terminal events the OS delivered while nothing was listening, keyed by
+  /// taskId. Claimed (and removed) by [takeBufferedTerminalEvent].
+  final Map<String, BlossomBackgroundTransferEvent> bufferedTerminals;
+  final List<String> active;
   final StreamController<BlossomBackgroundTransferEvent> _controller =
       StreamController<BlossomBackgroundTransferEvent>.broadcast();
   final List<String> enqueued = <String>[];
@@ -41,6 +52,14 @@ class _FakeTransport implements BlossomBackgroundTransport {
 
   @override
   Future<void> cancel(String taskId) async => cancelled.add(taskId);
+
+  @override
+  Future<List<String>> activeTaskIds() async => active;
+
+  @override
+  Future<BlossomBackgroundTransferEvent?> takeBufferedTerminalEvent(
+    String taskId,
+  ) async => bufferedTerminals.remove(taskId);
 }
 
 void main() {
@@ -423,5 +442,86 @@ void main() {
   test('cancelBackgroundUpload is a no-op without a transport', () async {
     // Must not throw when background uploads are disabled.
     await expectLater(service(null).cancelBackgroundUpload(taskId), completes);
+  });
+
+  test('skips re-upload when a completed terminal was buffered', () async {
+    // Simulates relaunch after the OS finished the blob while the app was dead:
+    // the terminal event is waiting in the buffer, so the retry must not
+    // re-enqueue the file.
+    final body = jsonEncode(<String, dynamic>{
+      'url': 'https://media.divine.video/hls/master.m3u8',
+      'fallbackUrl': 'https://media.divine.video/mp4/video.mp4',
+    });
+    final transport = _FakeTransport(
+      bufferedTerminals: <String, BlossomBackgroundTransferEvent>{
+        taskId: BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.completed,
+          httpStatusCode: 200,
+          responseBody: body,
+        ),
+      },
+    );
+    final progress = <double>[];
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+      onProgress: progress.add,
+    );
+
+    expect(result.success, isTrue);
+    expect(result.url, 'https://media.divine.video/hls/master.m3u8');
+    expect(transport.enqueued, isEmpty, reason: 'must not re-upload');
+    expect(transport.bufferedTerminals, isEmpty, reason: 'event consumed');
+    expect(progress.last, 1.0);
+  });
+
+  test(
+    'a buffered failed terminal does not skip; the upload retries',
+    () async {
+      final transport = _FakeTransport(
+        bufferedTerminals: <String, BlossomBackgroundTransferEvent>{
+          taskId: const BlossomBackgroundTransferEvent(
+            taskId: taskId,
+            status: BlossomBackgroundTransferStatus.failed,
+            httpStatusCode: 500,
+          ),
+        },
+        emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+          BlossomBackgroundTransferEvent(
+            taskId: taskId,
+            status: BlossomBackgroundTransferStatus.completed,
+            httpStatusCode: 200,
+          ),
+        ],
+      );
+
+      final result = await service(transport).uploadVideoInBackground(
+        videoFile: videoFile,
+        taskId: taskId,
+        proofManifestJson: null,
+      );
+
+      expect(result.success, isTrue);
+      expect(transport.enqueued, <String>[taskId], reason: 're-uploaded');
+    },
+  );
+
+  test(
+    'activeBackgroundUploadIds forwards the transport in-flight ids',
+    () async {
+      final transport = _FakeTransport(active: <String>[taskId]);
+
+      expect(
+        await service(transport).activeBackgroundUploadIds(),
+        <String>[taskId],
+      );
+    },
+  );
+
+  test('activeBackgroundUploadIds is empty without a transport', () async {
+    expect(await service(null).activeBackgroundUploadIds(), isEmpty);
   });
 }

--- a/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
@@ -176,6 +176,30 @@ void main() {
     expect(result.failureReason, BlossomUploadFailureReason.server);
   });
 
+  test('treats HTTP 409 (already stored) as success with the '
+      'content-addressed URL', () async {
+    final transport = _FakeTransport(
+      emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
+        BlossomBackgroundTransferEvent(
+          taskId: taskId,
+          status: BlossomBackgroundTransferStatus.failed,
+          httpStatusCode: 409,
+        ),
+      ],
+    );
+
+    final result = await service(transport).uploadVideoInBackground(
+      videoFile: videoFile,
+      taskId: taskId,
+      proofManifestJson: null,
+    );
+
+    expect(result.success, isTrue);
+    expect(result.url, startsWith('$server/'));
+    expect(result.fallbackUrl, startsWith('$server/'));
+    expect(result.videoId, isNotEmpty);
+  });
+
   test(
     'maps a transport error (no status) to a transient network failure',
     () async {

--- a/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_background_upload_test.dart
@@ -28,6 +28,9 @@ class _FakeTransport implements BlossomBackgroundTransport {
   final StreamController<BlossomBackgroundTransferEvent> _controller =
       StreamController<BlossomBackgroundTransferEvent>.broadcast();
   final List<String> enqueued = <String>[];
+  final List<Map<String, String>> enqueuedHeaders = <Map<String, String>>[];
+  final List<String> enqueuedMethods = <String>[];
+  final List<String> enqueuedUrls = <String>[];
   final List<String> cancelled = <String>[];
 
   @override
@@ -42,6 +45,9 @@ class _FakeTransport implements BlossomBackgroundTransport {
     required String filePath,
   }) async {
     enqueued.add(taskId);
+    enqueuedUrls.add(url);
+    enqueuedMethods.add(method);
+    enqueuedHeaders.add(Map<String, String>.from(headers));
     if (throwOnEnqueue) {
       throw Exception('enqueue failed');
     }
@@ -254,7 +260,7 @@ void main() {
     expect(result.streamingStatus, 'processing');
   });
 
-  test('attaches ProofMode headers when a manifest is provided', () async {
+  test('attaches auth, content type, and ProofMode headers', () async {
     final transport = _FakeTransport(
       emitOnEnqueue: const <BlossomBackgroundTransferEvent>[
         BlossomBackgroundTransferEvent(
@@ -274,6 +280,30 @@ void main() {
 
     expect(result.success, isTrue);
     expect(transport.enqueued, <String>[taskId]);
+    expect(transport.enqueuedUrls, <String>['$server/upload']);
+    expect(transport.enqueuedMethods, <String>['PUT']);
+    expect(
+      transport.enqueuedHeaders.single['Authorization'],
+      startsWith('Nostr '),
+    );
+    expect(transport.enqueuedHeaders.single['Content-Type'], 'video/mp4');
+    expect(transport.enqueuedHeaders.single['Content-Length'], '64');
+    expect(
+      utf8.decode(
+        base64.decode(
+          transport.enqueuedHeaders.single['X-ProofMode-Manifest']!,
+        ),
+      ),
+      '{"pgpSignature":"sig"}',
+    );
+    expect(
+      utf8.decode(
+        base64.decode(
+          transport.enqueuedHeaders.single['X-ProofMode-Signature']!,
+        ),
+      ),
+      'sig',
+    );
   });
 
   test('forwards intermediate progress for non-terminal events', () async {

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -2821,6 +2821,27 @@ void main() {
               equals(BlossomUploadFailureReason.server),
             );
           });
+
+          test('returns network for unknown wrapping a SocketException', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                DioException(
+                  requestOptions: RequestOptions(path: '/upload'),
+                  error: const SocketException('Connection reset by peer'),
+                ),
+              ),
+              equals(BlossomUploadFailureReason.network),
+            );
+          });
+
+          test('returns unknown for unknown without a SocketException', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                dioException(DioExceptionType.unknown),
+              ),
+              equals(BlossomUploadFailureReason.unknown),
+            );
+          });
         });
       });
     });
@@ -4519,6 +4540,129 @@ void main() {
 
         // Falls back to legacy after session expires
         expect(result.success, isTrue);
+
+        await tempDir.delete(recursive: true);
+      });
+
+      test('does not restart via legacy when a committed chunk then hits a '
+          'transient network error', () async {
+        when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+        when(
+          () => mockAuthProvider.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+        );
+
+        final tempDir = await Directory.systemTemp.createTemp(
+          'chunk_transient_test_',
+        );
+        final file = File('${tempDir.path}/video.mp4')
+          ..writeAsBytesSync(List.generate(10, (i) => i));
+
+        when(
+          () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+        ).thenAnswer(
+          (_) async => Response(
+            requestOptions: RequestOptions(path: '/upload'),
+            statusCode: 200,
+            headers: Headers.fromMap({
+              DivineUploadHeaders.extensions: [
+                DivineUploadExtensions.resumableSessions,
+              ],
+            }),
+          ),
+        );
+
+        when(
+          () => mockDio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer(
+          (_) async => Response(
+            requestOptions: RequestOptions(path: '/upload/init'),
+            statusCode: 200,
+            data: {
+              'uploadId': 'up_net',
+              'uploadUrl': 'https://upload.divine.video/sessions/up_net',
+              'chunkSize': 5,
+              'nextOffset': 0,
+            },
+          ),
+        );
+
+        // First chunk commits offset 5; the second is killed mid-flight by a
+        // connection reset (the symptom of the OS suspending a backgrounded
+        // app), which dio surfaces as an `unknown` DioException wrapping a
+        // SocketException.
+        var chunkCount = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final url = invocation.positionalArguments.first as String;
+          if (url.contains('sessions/up_net')) {
+            chunkCount++;
+            if (chunkCount == 1) {
+              return Response(
+                requestOptions: RequestOptions(path: '/sessions'),
+                statusCode: 204,
+                headers: Headers.fromMap({
+                  DivineUploadHeaders.uploadOffset: ['5'],
+                }),
+              );
+            }
+            throw DioException(
+              requestOptions: RequestOptions(path: '/sessions'),
+              error: const SocketException('Connection reset by peer'),
+            );
+          }
+
+          // Legacy fallback PUT — must NOT be reached.
+          return Response(
+            requestOptions: RequestOptions(path: '/upload'),
+            statusCode: 200,
+            data: {
+              'url': 'https://media.divine.video/hash',
+              'fallbackUrl': 'https://media.divine.video/hash',
+            },
+          );
+        });
+
+        final result = await service.uploadVideo(
+          videoFile: file,
+          nostrPubkey: _testPublicKey,
+          title: 'test',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+        );
+
+        // The transient failure is surfaced (so the caller's outer retry can
+        // resume from the committed offset) rather than restarting the whole
+        // file through the legacy PUT.
+        expect(result.success, isFalse);
+        expect(
+          result.failureReason,
+          equals(BlossomUploadFailureReason.network),
+        );
+        verifyNever(
+          () => mockDio.put<dynamic>(
+            'https://media.divine.video/upload',
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        );
 
         await tempDir.delete(recursive: true);
       });

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -5526,6 +5526,94 @@ void main() {
       );
 
       test(
+        'skips the resumable handshake when allowResumable is false, even on '
+        'a resumable-capable server',
+        () async {
+          when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+          when(
+            () => mockAuthProvider.createAndSignEvent(
+              kind: any(named: 'kind'),
+              content: any(named: 'content'),
+              tags: any(named: 'tags'),
+            ),
+          ).thenAnswer(
+            (_) async =>
+                _signedEvent(_testPublicKey, 24242, const [], 'upload'),
+          );
+
+          final tempDir = await Directory.systemTemp.createTemp(
+            'image_single_put_test_',
+          );
+          final imageFile = File('${tempDir.path}/image.jpg')
+            ..writeAsBytesSync([0xFF, 0xD8, 0xFF]);
+
+          // The server advertises resumable support...
+          when(
+            () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+          ).thenAnswer(
+            (_) async => Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+                DivineUploadHeaders.dataHost: ['https://upload.divine.video'],
+              }),
+            ),
+          );
+
+          // ...but with allowResumable: false the init endpoint must not run.
+          var initCalled = false;
+          when(
+            () => mockDio.post<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+            ),
+          ).thenAnswer((invocation) async {
+            initCalled = true;
+            throw StateError(
+              'Unexpected resumable POST: '
+              '${invocation.positionalArguments.first}',
+            );
+          });
+
+          final putUrls = <String>[];
+          when(
+            () => mockDio.put<dynamic>(
+              any(),
+              data: any(named: 'data'),
+              options: any(named: 'options'),
+              onSendProgress: any(named: 'onSendProgress'),
+            ),
+          ).thenAnswer((invocation) async {
+            putUrls.add(invocation.positionalArguments.first as String);
+            return Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              data: {
+                'url': 'https://media.divine.video/hash',
+                'fallbackUrl': 'https://media.divine.video/hash',
+              },
+            );
+          });
+
+          final result = await service.uploadImage(
+            imageFile: imageFile,
+            nostrPubkey: _testPublicKey,
+            allowResumable: false,
+          );
+
+          expect(result.success, isTrue);
+          expect(initCalled, isFalse);
+          expect(putUrls, contains('https://media.divine.video/upload'));
+
+          await tempDir.delete(recursive: true);
+        },
+      );
+
+      test(
         'falls back to legacy upload when Divine image resumable init fails',
         () async {
           when(() => mockAuthProvider.isAuthenticated).thenReturn(true);

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -26,6 +26,7 @@ workspace:
   - packages/analytics
   - packages/app_update_repository
   - packages/app_version_client
+  - packages/background_uploader
   - packages/blossom_upload_service
   - packages/blurhash_service
   - packages/cache_sync
@@ -91,6 +92,9 @@ dependencies:
 
   # Analytics — unified event schema and the single Firebase analytics surface.
   analytics:
+
+  # OS-backed background uploads that survive app suspension.
+  background_uploader:
 
   blossom_upload_service:
 

--- a/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
+++ b/mobile/test/blocs/background_publish_bloc/background_publish_bloc_test.dart
@@ -2,6 +2,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/background_publish/background_publish_bloc.dart';
+import 'package:openvine/blocs/background_publish/publish_foreground_session.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
@@ -12,6 +13,28 @@ class _MockVineDraft extends Mock implements DivineVideoDraft {}
 class _MockVideoPublishService extends Mock implements VideoPublishService {}
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
+
+/// Records begin/end calls; optionally throws to prove the session is
+/// best-effort and never breaks the publish.
+class _FakeForegroundSession implements PublishForegroundSession {
+  _FakeForegroundSession({this.throws = false});
+
+  final bool throws;
+  final List<String> beginCalls = [];
+  final List<String> endCalls = [];
+
+  @override
+  Future<void> begin(String sessionId) async {
+    beginCalls.add(sessionId);
+    if (throws) throw Exception('begin failed');
+  }
+
+  @override
+  Future<void> end(String sessionId) async {
+    endCalls.add(sessionId);
+    if (throws) throw Exception('end failed');
+  }
+}
 
 void main() {
   late _MockDraftStorageService mockDraftStorageService;
@@ -541,6 +564,83 @@ void main() {
           ),
         ),
         expect: () => <BackgroundPublishState>[],
+      );
+    });
+
+    group('foreground session', () {
+      late _MockVineDraft draft;
+      late _FakeForegroundSession session;
+
+      const draftId = '1';
+
+      setUp(() {
+        draft = _MockVineDraft();
+        session = _FakeForegroundSession();
+        when(() => draft.id).thenReturn(draftId);
+        when(() => draft.sourceDraftId).thenReturn(null);
+      });
+
+      blocTest<BackgroundPublishBloc, BackgroundPublishState>(
+        'begins and ends the session around a successful publish',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+          draftStorageService: mockDraftStorageService,
+          foregroundSession: session,
+        ),
+        act: (bloc) => bloc.add(
+          BackgroundPublishRequested(
+            draft: draft,
+            publishmentProcess: Future.value(const PublishSuccess()),
+          ),
+        ),
+        verify: (_) {
+          expect(session.beginCalls, [draftId]);
+          expect(session.endCalls, [draftId]);
+        },
+      );
+
+      blocTest<BackgroundPublishBloc, BackgroundPublishState>(
+        'ends the session even when the publish fails',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+          draftStorageService: mockDraftStorageService,
+          foregroundSession: session,
+        ),
+        act: (bloc) => bloc.add(
+          BackgroundPublishRequested(
+            draft: draft,
+            publishmentProcess: Future.value(
+              const PublishError(PublishErrorKind.generic),
+            ),
+          ),
+        ),
+        verify: (_) {
+          expect(session.beginCalls, [draftId]);
+          expect(session.endCalls, [draftId]);
+        },
+      );
+
+      blocTest<BackgroundPublishBloc, BackgroundPublishState>(
+        'a session failure does not abort the publish',
+        build: () => BackgroundPublishBloc(
+          videoPublishServiceFactory: defaultVieoPublishServiceFactory,
+          draftStorageService: mockDraftStorageService,
+          foregroundSession: _FakeForegroundSession(throws: true),
+        ),
+        act: (bloc) => bloc.add(
+          BackgroundPublishRequested(
+            draft: draft,
+            publishmentProcess: Future.value(const PublishSuccess()),
+          ),
+        ),
+        expect: () => [
+          BackgroundPublishState(
+            uploads: [
+              BackgroundUpload(draft: draft, result: null, progress: 0),
+            ],
+          ),
+          const BackgroundPublishState(recentlySucceededIds: {draftId}),
+        ],
       );
     });
 

--- a/mobile/test/services/upload_manager_background_pause_test.dart
+++ b/mobile/test/services/upload_manager_background_pause_test.dart
@@ -1,0 +1,199 @@
+// ABOUTME: Regression tests for the pause/cancel race on OS background uploads.
+// ABOUTME: A user-initiated stop must not be reported as a failure.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:blossom_upload_service/blossom_upload_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/pending_upload.dart';
+import 'package:openvine/services/upload/upload_ports.dart';
+import 'package:openvine/services/upload_manager.dart';
+
+class _MockBlossomUploadService extends Mock implements BlossomUploadService {}
+
+class _MockUploadCrashReporter extends Mock implements UploadCrashReporter {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _MockBlossomUploadService mockBlossomService;
+  late _MockUploadCrashReporter mockCrashReporter;
+  late UploadManager uploadManager;
+  late Directory testDir;
+
+  setUpAll(() {
+    registerFallbackValue(File(''));
+    registerFallbackValue(StackTrace.empty);
+  });
+
+  setUp(() async {
+    testDir = await Directory.systemTemp.createTemp(
+      'upload_manager_bg_pause_test_',
+    );
+    Hive.init(testDir.path);
+    if (!Hive.isAdapterRegistered(1)) {
+      Hive.registerAdapter(UploadStatusAdapter());
+    }
+    if (!Hive.isAdapterRegistered(2)) {
+      Hive.registerAdapter(PendingUploadAdapter());
+    }
+
+    mockBlossomService = _MockBlossomUploadService();
+    mockCrashReporter = _MockUploadCrashReporter();
+    when(() => mockBlossomService.isBlossomEnabled()).thenAnswer((_) async {
+      return false;
+    });
+    when(
+      () => mockCrashReporter.recordError(
+        any(),
+        any(),
+        reason: any(named: 'reason'),
+      ),
+    ).thenAnswer((_) async {});
+    when(
+      () => mockCrashReporter.setCustomKey(any(), any()),
+    ).thenAnswer((_) async {});
+
+    uploadManager = UploadManager(
+      blossomService: mockBlossomService,
+      crashReporter: mockCrashReporter,
+      useBackgroundUpload: true,
+    );
+    await uploadManager.initialize();
+  });
+
+  tearDown(() async {
+    uploadManager.dispose();
+    try {
+      await Hive.close();
+    } on PathNotFoundException catch (_) {
+      // Hive may already have removed the lock file during async shutdown.
+    }
+    try {
+      await testDir.delete(recursive: true);
+    } on PathNotFoundException catch (_) {
+      // Lock file may already be deleted by Hive.close().
+    }
+  });
+
+  // Stubs an OS background transfer that never finishes on its own; cancelling
+  // it resolves the future with a `cancelled` failure — the race trigger.
+  Completer<BlossomUploadResult> stubCancellableTransfer() {
+    final transfer = Completer<BlossomUploadResult>();
+    when(
+      () => mockBlossomService.uploadVideoInBackground(
+        videoFile: any(named: 'videoFile'),
+        taskId: any(named: 'taskId'),
+        proofManifestJson: any(named: 'proofManifestJson'),
+        onProgress: any(named: 'onProgress'),
+      ),
+    ).thenAnswer((_) => transfer.future);
+    when(() => mockBlossomService.cancelBackgroundUpload(any())).thenAnswer((
+      _,
+    ) async {
+      if (!transfer.isCompleted) {
+        transfer.complete(
+          const BlossomUploadResult(
+            success: false,
+            errorMessage: 'Upload cancelled',
+            failureReason: BlossomUploadFailureReason.unknown,
+          ),
+        );
+      }
+    });
+    return transfer;
+  }
+
+  Future<PendingUpload> seedPausedUpload() async {
+    final videoFile = File(
+      '${testDir.path}/${DateTime.now().microsecondsSinceEpoch}.mp4',
+    );
+    await videoFile.writeAsString('fake video content');
+    final upload = PendingUpload.create(
+      localVideoPath: videoFile.path,
+      nostrPubkey: 'pk',
+      title: 'T',
+    );
+    final box = Hive.box<PendingUpload>('pending_uploads');
+    await box.put(upload.id, upload.copyWith(status: UploadStatus.paused));
+    return upload;
+  }
+
+  group('UploadManager background pause/cancel race', () {
+    test(
+      'pausing an in-flight background upload leaves it paused, not failed',
+      () async {
+        final upload = await seedPausedUpload();
+        stubCancellableTransfer();
+
+        // resumeUpload() drives a fresh _performUpload run; it stays in flight
+        // on the transfer future until the pause cancels it.
+        final runFuture = uploadManager.resumeUpload(upload.id);
+        await _pumpUntil(
+          () =>
+              uploadManager.getUpload(upload.id)?.status ==
+              UploadStatus.uploading,
+        );
+
+        await uploadManager.pauseUpload(upload.id);
+        await runFuture;
+
+        final result = uploadManager.getUpload(upload.id);
+        expect(result?.status, equals(UploadStatus.paused));
+        expect(result?.errorMessage, isNull);
+        verify(
+          () => mockBlossomService.cancelBackgroundUpload(upload.id),
+        ).called(1);
+        // The user-initiated pause is not a crash.
+        verifyNever(
+          () => mockCrashReporter.recordError(
+            any(),
+            any(),
+            reason: any(named: 'reason'),
+          ),
+        );
+      },
+    );
+
+    test(
+      'cancelling an in-flight background upload marks it failed without a crash report',
+      () async {
+        final upload = await seedPausedUpload();
+        stubCancellableTransfer();
+
+        final runFuture = uploadManager.resumeUpload(upload.id);
+        await _pumpUntil(
+          () =>
+              uploadManager.getUpload(upload.id)?.status ==
+              UploadStatus.uploading,
+        );
+
+        await uploadManager.cancelUpload(upload.id);
+        await runFuture;
+
+        final result = uploadManager.getUpload(upload.id);
+        expect(result?.status, equals(UploadStatus.failed));
+        expect(result?.errorMessage, equals('Upload cancelled by user'));
+        // A deliberate cancel must not be reported to Crashlytics as a failure.
+        verifyNever(
+          () => mockCrashReporter.recordError(
+            any(),
+            any(),
+            reason: any(named: 'reason'),
+          ),
+        );
+      },
+    );
+  });
+}
+
+Future<void> _pumpUntil(bool Function() predicate) async {
+  for (var i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail('Condition was not met in time');
+}


### PR DESCRIPTION
Closes #5591

## Description

Video publishing fails when the app is backgrounded mid-upload: on iOS the OS
tears down the in-process upload socket on suspension, every retry restarts from
byte 0, and the publish dies after all retries (seen in production logs as
repeated `Connection reset by peer` / `Broken pipe` across 6 attempts). This PR
makes the transfer the OS's responsibility so it survives suspension, plus a
related fix so transient failures stop discarding upload progress. Three
delineated pieces:

1. **`background_uploader` plugin (new package)** — a generic data-layer Flutter
   plugin that hands a file + URL + headers to the OS background transfer
   facility. Darwin (iOS + macOS) background `URLSession` over shared source with
   **SPM + CocoaPods fallback**; Android foreground service with a streamed PUT.
   No Blossom/Nostr knowledge — callers build the signed request.

2. **Transient-failure classification in the background path
   (`blossom_upload_service`)** — `uploadVideoInBackground` runs transport
   errors through the existing `_classifyUploadException`, so a suspended-socket
   drop is reported as `network` + `isTransientNetworkFailure` and treated as
   retryable, matching the in-process path. (The legacy-PUT-fallback resume fix
   that stops re-uploading from byte 0 on a recoverable resumable failure
   already landed on `main`; this PR only consumes that classification — it is
   not part of this diff.)

3. **Background-upload transport + integration** — a `BlossomBackgroundTransport`
   port (keeps the package free of the plugin dependency) + a
   `uploadVideoInBackground()` that does a single BUD-01 `PUT` through the OS
   uploader, reusing the existing auth/ProofMode/hash logic. Wired into
   `UploadManager` behind a `useBackgroundUpload` flag (currently enabled);
   thumbnail, retry, and success handling are unchanged.

**Related Issue:** 

## Out of Scope

- **App-kill reconciliation.** The `await`-based path survives app *suspension*
  (the logged failure). If the app is fully *terminated* mid-upload the OS still
  finishes the transfer, but the follow-up Nostr publish then needs
  reconciliation on the next launch (via `BackgroundUploader.activeTaskIds()` +
  the existing `PendingUpload` state). Not included here.

## Verification

- `flutter analyze` (full `lib`/`test` + both packages) → no issues
- `blossom_upload_service`: **198** tests (incl. 6 new background-upload tests +
  the resume-fix tests)
- `UploadManager`: **102** tests (flag defaults off in tests)
- `upload_media_providers` provider tests pass
- `dart format` clean; pre-push hook (analyze + changed-file tests) green
- ✅ **Verified on real devices.** A real end-to-end publish with the app
  suspended mid-transfer was tested on-device, confirming the OS-backed transfer
  survives suspension and the follow-up publish completes. `useBackgroundUpload`
  is enabled by default — flip `_backgroundUploadEnabled` to `false` in
  `upload_media_providers.dart` to fall back to the in-process chunked/resumable
  path if a regression surfaces.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

