### PR TITLE
fix(moderation): wait for ready nostr session

### DIFF
--- a/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
@@ -63,7 +63,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
   Future<void> load() async {
     emit(state.copyWith(status: SafetySettingsStatus.loading));
     await _ageVerificationService.initialize();
-    await _moderationLabelService.initialize();
+    await _moderationLabelService.ensureLoaded();
     emit(
       state.copyWith(
         status: SafetySettingsStatus.ready,

--- a/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
@@ -63,6 +63,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
   Future<void> load() async {
     emit(state.copyWith(status: SafetySettingsStatus.loading));
     await _ageVerificationService.initialize();
+    await _moderationLabelService.initialize();
     emit(
       state.copyWith(
         status: SafetySettingsStatus.ready,

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -136,28 +136,45 @@ AccountLabelService accountLabelService(Ref ref) {
 @Riverpod(keepAlive: true)
 ModerationLabelService moderationLabelService(Ref ref) {
   final nostrClient = ref.watch(nostrServiceProvider);
-  final readiness = ref.watch(nostrSessionProvider);
   final authService = ref.watch(authServiceProvider);
   final prefs = ref.watch(sharedPreferencesProvider);
   final service = ModerationLabelService(
     nostrClient: nostrClient,
     authService: authService,
     sharedPreferences: prefs,
+    canQueryRelays: () {
+      if (!ref.mounted) return false;
+      final readiness = ref.read(nostrSessionProvider);
+      return readiness.isReadyForActiveClient &&
+          identical(readiness.client, nostrClient);
+    },
   );
 
   StreamSubscription<List<String>>? followingSubscription;
-  if (readiness.isReadyForActiveClient &&
-      identical(readiness.client, nostrClient)) {
-    final followRepository = ref.watch(followRepositoryProvider);
-    unawaited(
-      service.initialize().then((_) {
-        return service.syncFollowedLabelers(followRepository.followingPubkeys);
-      }),
-    );
-    followingSubscription = followRepository.followingStream.listen((pubkeys) {
+
+  Future<void> startRelaySync(NostrSessionReadiness readiness) async {
+    if (!readiness.isReadyForActiveClient ||
+        !identical(readiness.client, nostrClient)) {
+      return;
+    }
+
+    final followRepository = ref.read(followRepositoryProvider);
+    await service.initialize();
+    await service.syncFollowedLabelers(followRepository.followingPubkeys);
+    followingSubscription ??= followRepository.followingStream.listen((
+      pubkeys,
+    ) {
       unawaited(service.syncFollowedLabelers(pubkeys));
     });
   }
+
+  unawaited(startRelaySync(ref.read(nostrSessionProvider)));
+
+  ref.listen<NostrSessionReadiness>(nostrSessionProvider, (_, next) {
+    unawaited(
+      startRelaySync(next),
+    );
+  });
 
   ref.onDispose(() {
     unawaited(followingSubscription?.cancel());

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -136,26 +136,31 @@ AccountLabelService accountLabelService(Ref ref) {
 @Riverpod(keepAlive: true)
 ModerationLabelService moderationLabelService(Ref ref) {
   final nostrClient = ref.watch(nostrServiceProvider);
+  final readiness = ref.watch(nostrSessionProvider);
   final authService = ref.watch(authServiceProvider);
   final prefs = ref.watch(sharedPreferencesProvider);
-  final followRepository = ref.watch(followRepositoryProvider);
   final service = ModerationLabelService(
     nostrClient: nostrClient,
     authService: authService,
     sharedPreferences: prefs,
   );
-  unawaited(
-    service.initialize().then((_) {
-      return service.syncFollowedLabelers(followRepository.followingPubkeys);
-    }),
-  );
-  final followingSubscription = followRepository.followingStream.listen((
-    pubkeys,
-  ) {
-    unawaited(service.syncFollowedLabelers(pubkeys));
-  });
+
+  StreamSubscription<List<String>>? followingSubscription;
+  if (readiness.isReadyForActiveClient &&
+      identical(readiness.client, nostrClient)) {
+    final followRepository = ref.watch(followRepositoryProvider);
+    unawaited(
+      service.initialize().then((_) {
+        return service.syncFollowedLabelers(followRepository.followingPubkeys);
+      }),
+    );
+    followingSubscription = followRepository.followingStream.listen((pubkeys) {
+      unawaited(service.syncFollowedLabelers(pubkeys));
+    });
+  }
+
   ref.onDispose(() {
-    followingSubscription.cancel();
+    unawaited(followingSubscription?.cancel());
     service.dispose();
   });
   return service;

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -456,7 +456,7 @@ final class ModerationLabelServiceProvider
 }
 
 String _$moderationLabelServiceHash() =>
-    r'29250a03d39851a0bb66b8995d1a1de66e464040';
+    r'3a30421dc30c969f723bed27cd7eaec78ea8e37d';
 
 /// Content blocklist service for filtering unwanted content from feeds
 ///

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -456,7 +456,7 @@ final class ModerationLabelServiceProvider
 }
 
 String _$moderationLabelServiceHash() =>
-    r'45b724bac4937ca6647a775d5dc7e4d87ad27c23';
+    r'29250a03d39851a0bb66b8995d1a1de66e464040';
 
 /// Content blocklist service for filtering unwanted content from feeds
 ///

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -150,6 +150,9 @@ class ModerationLabelService {
   /// Labelers whose historical labels have already been loaded.
   final Set<String> _loadedLabelers = {};
 
+  /// Labelers currently being loaded from relays.
+  final Map<String, Future<void>> _loadingLabelers = {};
+
   /// Active subscriptions.
   final Map<String, StreamSubscription<dynamic>> _subscriptions = {};
 
@@ -168,9 +171,15 @@ class ModerationLabelService {
 
   /// Initialize by loading persisted labeler subscriptions and subscribing.
   Future<void> initialize() async {
-    await _ensurePersistedStateLoaded();
+    await ensureLoaded();
+    if (_canQueryRelays()) {
+      await _refreshModerationPubkey();
+    }
     await _syncSubscribedLabelersWithRelays();
   }
+
+  /// Load persisted moderation settings without touching relays or NIP-05.
+  Future<void> ensureLoaded() => _ensurePersistedStateLoaded();
 
   Future<void> _ensurePersistedStateLoaded() {
     if (_loadedPersistedState) return Future<void>.value();
@@ -179,8 +188,9 @@ class ModerationLabelService {
 
   Future<void> _loadPersistedState() async {
     try {
-      // Resolve Divine moderation pubkey (cache → NIP-05 → fallback)
-      _divineModerationPubkey = await _resolveModerationPubkey(_prefs);
+      // Use cache or fallback only. Remote NIP-05 refresh happens from
+      // initialize(), which is called only from relay-ready paths.
+      _divineModerationPubkey = _cachedModerationPubkey(_prefs);
 
       final saved = _prefs.getStringList(_subscribedLabelersKey);
       if (saved != null) {
@@ -226,6 +236,22 @@ class ModerationLabelService {
   /// Subscribe to Kind 1985 events from a labeler pubkey.
   Future<void> subscribeToLabeler(String pubkey) async {
     if (_loadedLabelers.contains(pubkey)) return;
+    final inFlight = _loadingLabelers[pubkey];
+    if (inFlight != null) {
+      await inFlight;
+      return;
+    }
+
+    final future = _subscribeToLabelerInternal(pubkey);
+    _loadingLabelers[pubkey] = future;
+    try {
+      await future;
+    } finally {
+      _loadingLabelers.remove(pubkey);
+    }
+  }
+
+  Future<void> _subscribeToLabelerInternal(String pubkey) async {
     if (!_canQueryRelays()) {
       Log.debug(
         'Deferring labeler subscription until Nostr session is ready: $pubkey',
@@ -517,7 +543,6 @@ class ModerationLabelService {
         .toSet();
 
     final toRemove = _followedLabelers.difference(normalized);
-    final toAdd = normalized.difference(_followedLabelers);
 
     for (final pubkey in toRemove) {
       _followedLabelers.remove(pubkey);
@@ -526,9 +551,10 @@ class ModerationLabelService {
       }
     }
 
-    for (final pubkey in toAdd) {
+    for (final pubkey in normalized) {
       _followedLabelers.add(pubkey);
-      if (!_subscribedLabelers.contains(pubkey)) {
+      if (!_subscribedLabelers.contains(pubkey) &&
+          !_loadedLabelers.contains(pubkey)) {
         await subscribeToLabeler(pubkey);
       }
     }
@@ -599,6 +625,32 @@ class ModerationLabelService {
       return cachedPubkey;
     }
     return fallbackModerationPubkeyHex;
+  }
+
+  String _cachedModerationPubkey(SharedPreferences prefs) {
+    final cachedPubkey = prefs.getString(_resolvedPubkeyKey);
+    if (cachedPubkey != null && cachedPubkey.isNotEmpty) {
+      return cachedPubkey;
+    }
+    return fallbackModerationPubkeyHex;
+  }
+
+  Future<void> _refreshModerationPubkey() async {
+    final previousPubkey = _divineModerationPubkey;
+    final resolvedPubkey = await _resolveModerationPubkey(_prefs);
+    if (resolvedPubkey == previousPubkey) return;
+
+    _divineModerationPubkey = resolvedPubkey;
+    _subscribedLabelers.remove(previousPubkey);
+    _subscribedLabelers.add(resolvedPubkey);
+    await _saveSubscribedLabelers();
+    await _unloadLabeler(previousPubkey);
+
+    Log.info(
+      'Updated moderation labeler from $previousPubkey to $resolvedPubkey',
+      name: 'ModerationLabelService',
+      category: LogCategory.system,
+    );
   }
 
   /// Migrate the legacy moderation pubkey out of stored subscriptions.

--- a/mobile/lib/services/moderation_label_service.dart
+++ b/mobile/lib/services/moderation_label_service.dart
@@ -76,14 +76,17 @@ class ModerationLabelService {
     required NostrClient nostrClient,
     required AuthService authService,
     required SharedPreferences sharedPreferences,
+    bool Function()? canQueryRelays,
   }) : _nostrClient = nostrClient,
        _authService = authService,
-       _prefs = sharedPreferences;
+       _prefs = sharedPreferences,
+       _canQueryRelays = canQueryRelays ?? (() => true);
 
   final NostrClient _nostrClient;
   // ignore: unused_field
   final AuthService _authService;
   final SharedPreferences _prefs;
+  final bool Function() _canQueryRelays;
 
   /// SharedPreferences key for subscribed labeler pubkeys.
   static const String _subscribedLabelersKey = 'subscribed_labeler_pubkeys';
@@ -150,8 +153,9 @@ class ModerationLabelService {
   /// Active subscriptions.
   final Map<String, StreamSubscription<dynamic>> _subscriptions = {};
 
-  /// Whether the service has been initialized.
-  bool _initialized = false;
+  /// Whether persisted settings have been loaded.
+  bool _loadedPersistedState = false;
+  Future<void>? _loadPersistedStateFuture;
 
   /// Whether followed accounts should act as trusted labelers.
   bool _isFollowingModerationEnabled = false;
@@ -164,9 +168,16 @@ class ModerationLabelService {
 
   /// Initialize by loading persisted labeler subscriptions and subscribing.
   Future<void> initialize() async {
-    if (_initialized) return;
-    _initialized = true;
+    await _ensurePersistedStateLoaded();
+    await _syncSubscribedLabelersWithRelays();
+  }
 
+  Future<void> _ensurePersistedStateLoaded() {
+    if (_loadedPersistedState) return Future<void>.value();
+    return _loadPersistedStateFuture ??= _loadPersistedState();
+  }
+
+  Future<void> _loadPersistedState() async {
     try {
       // Resolve Divine moderation pubkey (cache → NIP-05 → fallback)
       _divineModerationPubkey = await _resolveModerationPubkey(_prefs);
@@ -186,13 +197,10 @@ class ModerationLabelService {
         _subscribedLabelers.add(_divineModerationPubkey);
       }
 
-      // Subscribe to all labelers
-      for (final pubkey in _subscribedLabelers) {
-        await subscribeToLabeler(pubkey);
-      }
+      _loadedPersistedState = true;
 
       Log.info(
-        'ModerationLabelService initialized with '
+        'ModerationLabelService loaded '
         '${_subscribedLabelers.length} labelers '
         '(moderation pubkey: $_divineModerationPubkey)',
         name: 'ModerationLabelService',
@@ -204,12 +212,28 @@ class ModerationLabelService {
         name: 'ModerationLabelService',
         category: LogCategory.system,
       );
+    } finally {
+      _loadPersistedStateFuture = null;
+    }
+  }
+
+  Future<void> _syncSubscribedLabelersWithRelays() async {
+    for (final pubkey in _subscribedLabelers) {
+      await subscribeToLabeler(pubkey);
     }
   }
 
   /// Subscribe to Kind 1985 events from a labeler pubkey.
   Future<void> subscribeToLabeler(String pubkey) async {
     if (_loadedLabelers.contains(pubkey)) return;
+    if (!_canQueryRelays()) {
+      Log.debug(
+        'Deferring labeler subscription until Nostr session is ready: $pubkey',
+        name: 'ModerationLabelService',
+        category: LogCategory.system,
+      );
+      return;
+    }
 
     try {
       final filter = Filter(
@@ -242,6 +266,7 @@ class ModerationLabelService {
 
   /// Add a new labeler and persist.
   Future<void> addLabeler(String pubkey) async {
+    await _ensurePersistedStateLoaded();
     _subscribedLabelers.add(pubkey);
     await _saveSubscribedLabelers();
     await subscribeToLabeler(pubkey);
@@ -249,6 +274,7 @@ class ModerationLabelService {
 
   /// Remove a labeler and clean up.
   Future<void> removeLabeler(String pubkey) async {
+    await _ensurePersistedStateLoaded();
     // Don't allow removing the built-in Divine labeler
     if (pubkey == _divineModerationPubkey) return;
 
@@ -264,6 +290,7 @@ class ModerationLabelService {
     bool enabled, {
     Iterable<String> followedPubkeys = const [],
   }) async {
+    await _ensurePersistedStateLoaded();
     _isFollowingModerationEnabled = enabled;
     await _saveFollowingModerationEnabled();
     await _syncFollowedLabelersInternal(
@@ -273,6 +300,7 @@ class ModerationLabelService {
 
   /// Sync the currently followed pubkeys that should act as trusted labelers.
   Future<void> syncFollowedLabelers(Iterable<String> followedPubkeys) async {
+    await _ensurePersistedStateLoaded();
     if (!_isFollowingModerationEnabled) return;
     await _syncFollowedLabelersInternal(followedPubkeys);
   }

--- a/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
+++ b/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
@@ -79,7 +79,9 @@ void main() {
       when(
         () => moderationLabelService.isFollowingModerationEnabled,
       ).thenReturn(false);
-      when(() => moderationLabelService.initialize()).thenAnswer((_) async {});
+      when(
+        () => moderationLabelService.ensureLoaded(),
+      ).thenAnswer((_) async {});
       when(() => moderationLabelService.customLabelers).thenReturn(<String>{});
       when(
         () => moderationLabelService.setFollowingModerationEnabled(
@@ -168,6 +170,8 @@ void main() {
       ],
       verify: (_) {
         verify(ageService.initialize).called(1);
+        verify(() => moderationLabelService.ensureLoaded()).called(1);
+        verifyNever(() => moderationLabelService.initialize());
       },
     );
 

--- a/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
+++ b/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
@@ -79,6 +79,7 @@ void main() {
       when(
         () => moderationLabelService.isFollowingModerationEnabled,
       ).thenReturn(false);
+      when(() => moderationLabelService.initialize()).thenAnswer((_) async {});
       when(() => moderationLabelService.customLabelers).thenReturn(<String>{});
       when(
         () => moderationLabelService.setFollowingModerationEnabled(

--- a/mobile/test/providers/moderation_label_provider_session_test.dart
+++ b/mobile/test/providers/moderation_label_provider_session_test.dart
@@ -1,0 +1,124 @@
+// ABOUTME: Regression tests for moderation label provider session readiness.
+// ABOUTME: Ensures label subscriptions do not start on disposable Nostr clients.
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:follow_repository/follow_repository.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/moderation_providers.dart';
+import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/moderation_label_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockAuthService extends Mock implements AuthService {}
+
+class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _FakeFilter extends Fake implements Filter {}
+
+class _TestNostrSession extends NostrSession {
+  _TestNostrSession(this._readiness);
+
+  final NostrSessionReadiness _readiness;
+
+  @override
+  NostrSessionReadiness build() => _readiness;
+}
+
+void main() {
+  const testPubkey =
+      '0edc2f474484769bc9bf6d471d180e4e280b0bcd719b6da791001beb730cff1b';
+
+  setUpAll(() {
+    registerFallbackValue(<Filter>[_FakeFilter()]);
+  });
+
+  Future<ProviderContainer> createContainer({
+    required NostrSessionReadiness readiness,
+    required _MockNostrClient nostrClient,
+    _MockFollowRepository? followRepository,
+  }) async {
+    SharedPreferences.setMockInitialValues({
+      'divine_moderation_resolved_pubkey':
+          ModerationLabelService.fallbackModerationPubkeyHex,
+      'divine_moderation_resolved_at': DateTime.now().toIso8601String(),
+    });
+    final prefs = await SharedPreferences.getInstance();
+    final authService = _MockAuthService();
+
+    when(() => authService.currentIdentity).thenReturn(null);
+    when(() => authService.currentPublicKeyHex).thenReturn(testPubkey);
+    when(() => authService.isAuthenticated).thenReturn(true);
+
+    return ProviderContainer(
+      overrides: [
+        authServiceProvider.overrideWithValue(authService),
+        nostrServiceProvider.overrideWithValue(nostrClient),
+        nostrSessionProvider.overrideWith(() => _TestNostrSession(readiness)),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+        if (followRepository != null)
+          followRepositoryProvider.overrideWithValue(followRepository),
+      ],
+    );
+  }
+
+  group('moderationLabelServiceProvider', () {
+    test('does not query labelers before Nostr session is ready', () async {
+      final nostrClient = _MockNostrClient();
+      when(() => nostrClient.hasKeys).thenReturn(false);
+
+      final container = await createContainer(
+        readiness: const NostrSessionReadiness.identityKnown(
+          pubkey: testPubkey,
+        ),
+        nostrClient: nostrClient,
+      );
+      addTearDown(container.dispose);
+
+      container.read(moderationLabelServiceProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      verifyNever(() => nostrClient.queryEvents(any()));
+    });
+
+    test('subscribes labelers once active Nostr client is ready', () async {
+      final nostrClient = _MockNostrClient();
+      final followRepository = _MockFollowRepository();
+      final followingController = StreamController<List<String>>.broadcast();
+      addTearDown(followingController.close);
+
+      when(() => nostrClient.hasKeys).thenReturn(true);
+      when(() => nostrClient.publicKey).thenReturn(testPubkey);
+      when(() => nostrClient.queryEvents(any())).thenAnswer((_) async => []);
+      when(() => followRepository.followingPubkeys).thenReturn(const []);
+      when(
+        () => followRepository.followingStream,
+      ).thenAnswer((_) => followingController.stream);
+
+      final container = await createContainer(
+        readiness: NostrSessionReadiness.nostrReady(
+          pubkey: testPubkey,
+          client: nostrClient,
+        ),
+        nostrClient: nostrClient,
+        followRepository: followRepository,
+      );
+      addTearDown(container.dispose);
+
+      container.read(moderationLabelServiceProvider);
+      await Future<void>.delayed(Duration.zero);
+
+      verify(() => nostrClient.queryEvents(any())).called(1);
+    });
+  });
+}

--- a/mobile/test/providers/moderation_label_provider_session_test.dart
+++ b/mobile/test/providers/moderation_label_provider_session_test.dart
@@ -120,5 +120,31 @@ void main() {
 
       verify(() => nostrClient.queryEvents(any())).called(1);
     });
+
+    test(
+      'does not query when readiness holds a stale client instance',
+      () async {
+        final activeClient = _MockNostrClient();
+        final staleReadyClient = _MockNostrClient();
+
+        when(() => staleReadyClient.hasKeys).thenReturn(true);
+        when(() => staleReadyClient.publicKey).thenReturn(testPubkey);
+
+        final container = await createContainer(
+          readiness: NostrSessionReadiness.nostrReady(
+            pubkey: testPubkey,
+            client: staleReadyClient,
+          ),
+          nostrClient: activeClient,
+        );
+        addTearDown(container.dispose);
+
+        container.read(moderationLabelServiceProvider);
+        await Future<void>.delayed(Duration.zero);
+
+        verifyNever(() => activeClient.queryEvents(any()));
+        verifyNever(() => staleReadyClient.queryEvents(any()));
+      },
+    );
   });
 }

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -121,7 +121,7 @@ void main() {
       divineHostFilterService = DivineHostFilterService(prefs);
 
       when(
-        () => mockModerationLabelService.initialize(),
+        () => mockModerationLabelService.ensureLoaded(),
       ).thenAnswer((_) async {});
       when(
         () => mockModerationLabelService.divineModerationPubkeyHex,

--- a/mobile/test/screens/settings/settings_taxonomy_test.dart
+++ b/mobile/test/screens/settings/settings_taxonomy_test.dart
@@ -132,7 +132,7 @@ void main() {
     when(
       () => moderationLabelService.isDivineLabelerSubscribed,
     ).thenReturn(true);
-    when(() => moderationLabelService.initialize()).thenAnswer((_) async {});
+    when(() => moderationLabelService.ensureLoaded()).thenAnswer((_) async {});
     when(
       () => moderationLabelService.isFollowingModerationEnabled,
     ).thenReturn(false);

--- a/mobile/test/screens/settings/settings_taxonomy_test.dart
+++ b/mobile/test/screens/settings/settings_taxonomy_test.dart
@@ -132,6 +132,7 @@ void main() {
     when(
       () => moderationLabelService.isDivineLabelerSubscribed,
     ).thenReturn(true);
+    when(() => moderationLabelService.initialize()).thenAnswer((_) async {});
     when(
       () => moderationLabelService.isFollowingModerationEnabled,
     ).thenReturn(false);

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -50,6 +50,43 @@ void main() {
   });
 
   group(ModerationLabelService, () {
+    test(
+      'addLabeler preserves saved labelers before relay session is ready',
+      () async {
+        const existingLabeler =
+            '1111111111111111111111111111111111111111111111111111111111111111';
+        const newLabeler =
+            '2222222222222222222222222222222222222222222222222222222222222222';
+
+        SharedPreferences.setMockInitialValues({
+          'subscribed_labeler_pubkeys': [existingLabeler],
+          'divine_moderation_resolved_pubkey':
+              ModerationLabelService.fallbackModerationPubkeyHex,
+          'divine_moderation_resolved_at': DateTime.now().toIso8601String(),
+        });
+        final prefs = await SharedPreferences.getInstance();
+        final gatedService = ModerationLabelService(
+          nostrClient: mockNostrClient,
+          authService: mockAuthService,
+          sharedPreferences: prefs,
+          canQueryRelays: () => false,
+        );
+
+        await gatedService.addLabeler(newLabeler);
+
+        final saved = prefs.getStringList('subscribed_labeler_pubkeys');
+        expect(
+          saved,
+          containsAll([
+            existingLabeler,
+            newLabeler,
+            ModerationLabelService.fallbackModerationPubkeyHex,
+          ]),
+        );
+        verifyNever(() => mockNostrClient.queryEvents(any()));
+      },
+    );
+
     group('_processLabelEvent', () {
       test('parses basic content-warning label', () async {
         when(() => mockNostrClient.queryEvents(any())).thenAnswer(

--- a/mobile/test/services/moderation_label_service_test.dart
+++ b/mobile/test/services/moderation_label_service_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for ModerationLabelService
 // ABOUTME: Validates Kind 1985 label parsing including AI confidence metadata
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -86,6 +88,29 @@ void main() {
         verifyNever(() => mockNostrClient.queryEvents(any()));
       },
     );
+
+    test('ensureLoaded hydrates prefs without querying relays', () async {
+      const existingLabeler =
+          '1111111111111111111111111111111111111111111111111111111111111111';
+
+      SharedPreferences.setMockInitialValues({
+        'subscribed_labeler_pubkeys': [existingLabeler],
+        'following_moderation_enabled': true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final localOnlyService = ModerationLabelService(
+        nostrClient: mockNostrClient,
+        authService: mockAuthService,
+        sharedPreferences: prefs,
+        canQueryRelays: () => false,
+      );
+
+      await localOnlyService.ensureLoaded();
+
+      expect(localOnlyService.isFollowingModerationEnabled, isTrue);
+      expect(localOnlyService.customLabelers, contains(existingLabeler));
+      verifyNever(() => mockNostrClient.queryEvents(any()));
+    });
 
     group('_processLabelEvent', () {
       test('parses basic content-warning label', () async {
@@ -371,6 +396,83 @@ void main() {
 
         expect(service.isFollowingModerationEnabled, isTrue);
         expect(service.getContentWarnings('followed_event'), hasLength(1));
+      });
+
+      test(
+        'retries followed labelers enabled before relay readiness',
+        () async {
+          const followedLabeler =
+              'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+          var canQueryRelays = false;
+          final gatedService = ModerationLabelService(
+            nostrClient: mockNostrClient,
+            authService: mockAuthService,
+            sharedPreferences: mockPrefs,
+            canQueryRelays: () => canQueryRelays,
+          );
+          when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+            (_) async => [
+              _FakeLabelEvent(
+                pubkey: followedLabeler,
+                tags: [
+                  ['L', 'content-warning'],
+                  ['l', 'nudity', 'content-warning'],
+                  ['e', 'deferred_followed_event'],
+                ],
+              ),
+            ],
+          );
+
+          await gatedService.setFollowingModerationEnabled(
+            true,
+            followedPubkeys: [followedLabeler],
+          );
+
+          expect(gatedService.isFollowingModerationEnabled, isTrue);
+          expect(
+            gatedService.getContentWarnings('deferred_followed_event'),
+            isEmpty,
+          );
+          verifyNever(() => mockNostrClient.queryEvents(any()));
+
+          canQueryRelays = true;
+          await gatedService.syncFollowedLabelers([followedLabeler]);
+
+          expect(
+            gatedService.getContentWarnings('deferred_followed_event'),
+            hasLength(1),
+          );
+          verify(() => mockNostrClient.queryEvents(any())).called(1);
+        },
+      );
+
+      test('coalesces concurrent labeler subscriptions', () async {
+        const labeler =
+            'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+        final events = Completer<List<Event>>();
+        when(() => mockNostrClient.queryEvents(any())).thenAnswer(
+          (_) => events.future,
+        );
+
+        final firstSubscribe = service.subscribeToLabeler(labeler);
+        final secondSubscribe = service.subscribeToLabeler(labeler);
+        await Future<void>.delayed(Duration.zero);
+
+        verify(() => mockNostrClient.queryEvents(any())).called(1);
+
+        events.complete([
+          _FakeLabelEvent(
+            pubkey: labeler,
+            tags: [
+              ['L', 'content-warning'],
+              ['l', 'nudity', 'content-warning'],
+              ['e', 'coalesced_event'],
+            ],
+          ),
+        ]);
+        await Future.wait([firstSubscribe, secondSubscribe]);
+
+        expect(service.getContentWarnings('coalesced_event'), hasLength(1));
       });
 
       test('disabling followed labelers removes their cached labels', () async {


### PR DESCRIPTION
Closes #5594

## Summary

- moves moderation labeler startup safety into `ModerationLabelService` so every caller shares the same hydration and relay-readiness rules
- loads persisted labeler settings before any save path can overwrite SharedPreferences, preventing saved custom labelers from being wiped during startup
- gates only relay-backed label queries on the active signer-backed `NostrClient`, including direct `addLabeler` / followed-labeler sync paths
- switches `moderationLabelServiceProvider` from `ref.watch(nostrSessionProvider)` to `ref.listen(...)` so readiness transitions no longer rebuild the keepAlive service or recreate `VideoEventService`
- hydrates moderation settings before `SafetySettingsCubit.load()` snapshots labeler state
- adds regressions for not-ready startup, stale ready-client identity, and saved-labeler preservation before relay readiness

## Root Cause

On restored sessions the app can briefly build a keyless or disposable NostrClient before auth restoration installs the signer-backed client. The original provider immediately initialized `ModerationLabelService`, so labeler queries could run against a client that was disposed during auth restoration, producing the closed Pool startup error.

The first fix moved that gate into the provider, but review caught that user mutation paths could still save against an unhydrated in-memory labeler set and could still call relay queries directly. The final fix separates local prefs hydration from relay work inside the service: local state loads first for all mutators, while relay queries run only when the current service client is the ready active session client.

## Validation

- `flutter test test/screens/settings/settings_taxonomy_test.dart`
- `flutter test test/services/moderation_label_service_test.dart test/providers/moderation_label_provider_session_test.dart test/blocs/safety_settings/safety_settings_cubit_test.dart test/screens/settings/settings_taxonomy_test.dart`
- `flutter analyze`
- `dart run build_runner build --delete-conflicting-outputs`
- pre-push hook: merge-conflict check, analyzer, generated-file verification, changed-file tests
- GitHub checks green: Mobile CI, Tests, Analyze, Format, Generated Files, VGV Tag Gate, Web Preview, mergeability, semantic PR, linked issue, CLA
