### PR TITLE
fix(media-cache): ignore processing responses

### DIFF
--- a/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
+++ b/mobile/packages/media_cache/lib/src/cancellable_downloader.dart
@@ -148,7 +148,7 @@ class _HttpDownload implements CancellableDownload {
         _safeComplete(null);
         return;
       }
-      if (response.statusCode < 200 || response.statusCode >= 300) {
+      if (response.statusCode != HttpStatus.ok) {
         Log.warning(
           'CancellableDownload: $_url returned HTTP ${response.statusCode}',
           name: 'MediaCache',

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -324,6 +324,9 @@ class MediaCacheManager extends CacheManager {
 
   bool _isClosed = false;
 
+  bool _isProcessingResponse(FileInfo fileInfo) =>
+      fileInfo.statusCode == HttpStatus.accepted;
+
   /// Whether this cache manager has been initialized.
   bool get isInitialized => _manifestInitialized;
 
@@ -530,6 +533,11 @@ class MediaCacheManager extends CacheManager {
     // Check if already cached
     final existingFile = await getFileFromCache(key);
     if (existingFile != null && existingFile.file.existsSync()) {
+      if (_isProcessingResponse(existingFile)) {
+        await removeCachedFile(key);
+        return null;
+      }
+
       // Update manifest
       if (_config.enableSyncManifest) {
         _cacheManifest[key] = existingFile.file.path;
@@ -554,6 +562,20 @@ class MediaCacheManager extends CacheManager {
             key: key,
             authHeaders: authHeaders ?? {},
           );
+
+          if (_isProcessingResponse(fileInfo)) {
+            await removeCachedFile(key);
+            try {
+              if (fileInfo.file.existsSync()) {
+                await fileInfo.file.delete();
+              }
+            } on Object {
+              // Best-effort cleanup; the cache metadata has already been
+              // removed so the processing response cannot be replayed.
+            }
+            if (!completer.isCompleted) completer.complete(null);
+            return;
+          }
 
           // Update manifest
           if (_config.enableSyncManifest && !_isClosed) {

--- a/mobile/packages/media_cache/lib/src/media_cache_manager.dart
+++ b/mobile/packages/media_cache/lib/src/media_cache_manager.dart
@@ -533,11 +533,6 @@ class MediaCacheManager extends CacheManager {
     // Check if already cached
     final existingFile = await getFileFromCache(key);
     if (existingFile != null && existingFile.file.existsSync()) {
-      if (_isProcessingResponse(existingFile)) {
-        await removeCachedFile(key);
-        return null;
-      }
-
       // Update manifest
       if (_config.enableSyncManifest) {
         _cacheManifest[key] = existingFile.file.path;

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -238,7 +238,7 @@ void main() {
       expect(target.existsSync(), isFalse);
     });
 
-    test('returns null for non-2xx responses', () async {
+    test('returns null for non-OK responses', () async {
       final client = _CallbackClient(
         (_) async => http.StreamedResponse(
           Stream<List<int>>.value(utf8.encode('not found')),
@@ -251,6 +251,28 @@ void main() {
       final file = await downloader
           .download(
             url: 'https://example.com/missing.mp4',
+            targetFile: target,
+          )
+          .file;
+
+      expect(file, isNull);
+      expect(target.existsSync(), isFalse);
+    });
+
+    test('does not write HTTP 202 processing bodies to disk', () async {
+      final client = _CallbackClient(
+        (_) async => http.StreamedResponse(
+          Stream<List<int>>.value(utf8.encode('{"status":"processing"}')),
+          HttpStatus.accepted,
+          headers: {'retry-after': '2'},
+        ),
+      );
+      final downloader = HttpCancellableDownloader(client);
+      final target = File('${tempDir.path}/processing.mp4');
+
+      final file = await downloader
+          .download(
+            url: 'https://example.com/processing.mp4',
             targetFile: target,
           )
           .file;

--- a/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
+++ b/mobile/packages/media_cache/test/src/cancellable_downloader_test.dart
@@ -281,6 +281,32 @@ void main() {
       expect(target.existsSync(), isFalse);
     });
 
+    for (final statusCode in [
+      HttpStatus.noContent,
+      HttpStatus.partialContent,
+    ]) {
+      test('rejects HTTP $statusCode responses', () async {
+        final client = _CallbackClient(
+          (_) async => http.StreamedResponse(
+            Stream<List<int>>.value(utf8.encode('unexpected bytes')),
+            statusCode,
+          ),
+        );
+        final downloader = HttpCancellableDownloader(client);
+        final target = File('${tempDir.path}/http_$statusCode.mp4');
+
+        final file = await downloader
+            .download(
+              url: 'https://example.com/http_$statusCode.mp4',
+              targetFile: target,
+            )
+            .file;
+
+        expect(file, isNull);
+        expect(target.existsSync(), isFalse);
+      });
+    }
+
     test(
       'returns null when stream emits an error and cleans partial file',
       () async {

--- a/mobile/packages/media_cache/test/src/helpers/mocks.dart
+++ b/mobile/packages/media_cache/test/src/helpers/mocks.dart
@@ -11,7 +11,12 @@ import 'package:sqflite/sqflite.dart' as sqflite;
 class MockDatabase extends Mock implements sqflite.Database {}
 
 /// A mock [FileInfo] for testing.
-class MockFileInfo extends Mock implements FileInfo {}
+class MockFileInfo extends Mock implements FileInfo {
+  int statusCodeOverride = io.HttpStatus.ok;
+
+  @override
+  int get statusCode => statusCodeOverride;
+}
 
 /// A mock [File] for testing.
 /// Uses File from the `file` package (used by flutter_cache_manager).

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -157,38 +157,6 @@ void main() {
         verify(mockFile.delete).called(1);
       });
 
-      test('removes existing HTTP 202 cache entries before replay', () async {
-        final mockFile = MockFile();
-        final mockFileInfo = MockFileInfo();
-        var removeFileCalled = false;
-
-        when(mockFile.existsSync).thenReturn(true);
-        when(() => mockFile.path).thenReturn('/test/path/processing.json');
-        when(() => mockFileInfo.file).thenReturn(mockFile);
-        mockFileInfo.statusCodeOverride = HttpStatus.accepted;
-
-        final timestamp = DateTime.now().millisecondsSinceEpoch;
-        cacheManager = TestableMediaCacheManager(
-          config: MediaCacheConfig(
-            cacheKey: 'existing_processing_response_$timestamp',
-            enableSyncManifest: true,
-          ),
-          mockGetFileFromCache: (key) async => mockFileInfo,
-          mockRemoveFile: (key) async {
-            removeFileCalled = true;
-          },
-        );
-
-        final result = await cacheManager.cacheFile(
-          'https://example.com/processing.mp4',
-          key: 'processing_key',
-        );
-
-        expect(result, isNull);
-        expect(removeFileCalled, isTrue);
-        expect(cacheManager.getCachedFileSync('processing_key'), isNull);
-      });
-
       test('deduplicates concurrent requests for same key', () async {
         final mockFile = MockFile();
         final mockFileInfo = MockFileInfo();

--- a/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
+++ b/mobile/packages/media_cache/test/src/media_cache_manager_mocked_test.dart
@@ -122,6 +122,73 @@ void main() {
         expect(result, isNull);
       });
 
+      test('does not cache HTTP 202 processing responses', () async {
+        final mockFile = MockFile();
+        final mockFileInfo = MockFileInfo();
+        var removeFileCalled = false;
+
+        when(mockFile.existsSync).thenReturn(true);
+        when(() => mockFile.path).thenReturn('/test/path/processing.json');
+        when(mockFile.delete).thenAnswer((_) async => mockFile);
+        when(() => mockFileInfo.file).thenReturn(mockFile);
+        mockFileInfo.statusCodeOverride = HttpStatus.accepted;
+
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+        cacheManager = TestableMediaCacheManager(
+          config: MediaCacheConfig(
+            cacheKey: 'processing_response_$timestamp',
+            enableSyncManifest: true,
+          ),
+          mockGetFileFromCache: (key) async => null,
+          mockDownloadFile: (url, {key, authHeaders}) async => mockFileInfo,
+          mockRemoveFile: (key) async {
+            removeFileCalled = true;
+          },
+        );
+
+        final result = await cacheManager.cacheFile(
+          'https://example.com/processing.mp4',
+          key: 'processing_key',
+        );
+
+        expect(result, isNull);
+        expect(removeFileCalled, isTrue);
+        expect(cacheManager.getCachedFileSync('processing_key'), isNull);
+        verify(mockFile.delete).called(1);
+      });
+
+      test('removes existing HTTP 202 cache entries before replay', () async {
+        final mockFile = MockFile();
+        final mockFileInfo = MockFileInfo();
+        var removeFileCalled = false;
+
+        when(mockFile.existsSync).thenReturn(true);
+        when(() => mockFile.path).thenReturn('/test/path/processing.json');
+        when(() => mockFileInfo.file).thenReturn(mockFile);
+        mockFileInfo.statusCodeOverride = HttpStatus.accepted;
+
+        final timestamp = DateTime.now().millisecondsSinceEpoch;
+        cacheManager = TestableMediaCacheManager(
+          config: MediaCacheConfig(
+            cacheKey: 'existing_processing_response_$timestamp',
+            enableSyncManifest: true,
+          ),
+          mockGetFileFromCache: (key) async => mockFileInfo,
+          mockRemoveFile: (key) async {
+            removeFileCalled = true;
+          },
+        );
+
+        final result = await cacheManager.cacheFile(
+          'https://example.com/processing.mp4',
+          key: 'processing_key',
+        );
+
+        expect(result, isNull);
+        expect(removeFileCalled, isTrue);
+        expect(cacheManager.getCachedFileSync('processing_key'), isNull);
+      });
+
       test('deduplicates concurrent requests for same key', () async {
         final mockFile = MockFile();
         final mockFileInfo = MockFileInfo();


### PR DESCRIPTION
Closes #5595

## Summary

- rejects HTTP 202 processing responses in the media cache before they can be replayed as local media files
- tightens the cancellable downloader used by prefetch so only HTTP 200 responses are written to disk
- adds regression coverage for both legacy cacheFile downloads and cancellable prefetch downloads
- documents the remaining already-poisoned-cache gap as outside this PR's prevention-focused scope

## Root Cause

Fresh upload playback URLs can return `202 Accepted` with a small JSON body like `{"status":"processing"}` while renditions are still being prepared. The previous PR attempted to classify that status in the native player, but native media stacks treat 202 as a successful HTTP response and then fail while parsing the JSON as media. The status is reliably visible at the download/cache boundary instead.

`flutter_cache_manager` also treats HTTP 202 as a cacheable new file, and the repo cancellable downloader accepted all 2xx responses. That allowed the processing JSON to be persisted under a video cache key, after which `getCachedFileSync()` could replay the bad local file instead of retrying the network URL.

## What Changed

- `MediaCacheManager.cacheFile()` now treats freshly downloaded `HttpStatus.accepted` responses as processing responses, removes cache metadata for that key, deletes the downloaded body best-effort, and returns `null`.
- `HttpCancellableDownloader` now only writes HTTP 200 responses, so prefetch and cancellable cache users do not store 202/204/206/etc. bodies as media files.
- `MockFileInfo` has an explicit default `200 OK` status so tests model production `FileInfo.statusCode` without hiding behavior in production code.
- Removed the mocked existing-cache cleanup path because production `flutter_cache_manager` cache hits do not retain the original HTTP status code.

## Remaining Gap

This prevents new 202 processing bodies from being cached. It does not heal already-poisoned on-disk entries from older builds because production cache-hit metadata reports status code 200. Healing those entries needs content validation on cache hits, not status-code checks.

## Validation

- `flutter analyze` from `mobile/packages/media_cache`
- `flutter test` from `mobile/packages/media_cache`
- `flutter test test/src/cancellable_downloader_test.dart test/src/media_cache_manager_mocked_test.dart` from `mobile/packages/media_cache`
- pre-push hook: merge-conflict check, analyzer, changed-file tests
