### PR TITLE
fix(comments): keep just-posted comment visible while REST index lags

### DIFF
--- a/mobile/packages/comments_repository/lib/src/comments_repository.dart
+++ b/mobile/packages/comments_repository/lib/src/comments_repository.dart
@@ -67,17 +67,23 @@ class CommentsRepository {
   ///
   /// Parameters:
   /// - [nostrClient]: Client for Nostr relay communication (handles signing)
+  /// - [clock]: Injectable time source for the recently-posted-comment
+  ///   self-heal window (see [_recentlyPostedComments]). Defaults to
+  ///   [DateTime.now]; override in tests for deterministic TTL behaviour.
   CommentsRepository({
     required NostrClient nostrClient,
     FunnelcakeApiClient? funnelcakeApiClient,
     BlockedCommentFilter? blockFilter,
+    DateTime Function()? clock,
   }) : _nostrClient = nostrClient,
        _funnelcakeApiClient = funnelcakeApiClient,
-       _blockFilter = blockFilter;
+       _blockFilter = blockFilter,
+       _now = clock ?? DateTime.now;
 
   final NostrClient _nostrClient;
   final FunnelcakeApiClient? _funnelcakeApiClient;
   final BlockedCommentFilter? _blockFilter;
+  final DateTime Function() _now;
 
   /// In-memory cache of comment counts keyed by root event ID.
   ///
@@ -102,6 +108,26 @@ class CommentsRepository {
   /// `rootAddressableId` is in scope; reads check this map when the
   /// event-id cache misses ([_readCachedCommentCount]).
   final Map<String, int> _commentCountCacheByAddressableId = {};
+
+  /// Comments this user has just posted, retained briefly so the user's own
+  /// comment stays visible when the comment sheet is reopened before the
+  /// Funnelcake REST index (the primary read source in [loadComments]) has
+  /// ingested it. Keyed by root event id.
+  ///
+  /// Issue #5598 (recurrence of #211): a comment publishes to relays
+  /// instantly, but [loadComments] reads REST-first and only falls back to
+  /// relays when REST is unavailable. A stale-but-non-empty REST response
+  /// short-circuits, so a fresh read after posting omits the user's own
+  /// comment until the index catches up. Entries are merged into read results
+  /// and pruned once the fetched thread contains them or after
+  /// [_recentlyPostedRetention].
+  final Map<String, List<_RecentlyPostedComment>> _recentlyPostedComments = {};
+
+  /// How long a just-posted comment is retained for the self-heal merge before
+  /// it is assumed stale. Long enough to cover worst-case REST index lag, short
+  /// enough that a never-indexed comment (relay-rejected, or deleted from
+  /// another client) cannot linger locally indefinitely.
+  static const _recentlyPostedRetention = Duration(minutes: 10);
 
   /// Subscription ID for the active comment watch, if any.
   String? _watchSubscriptionId;
@@ -159,7 +185,12 @@ class CommentsRepository {
               rootEventKind,
               rootAddressableId: rootAddressableId,
             );
-            final thread = restThread;
+            // Merge the user's own just-posted comment when the REST index has
+            // not yet ingested it, so a sheet reopen doesn't drop it (#5598).
+            final thread = _mergeRecentlyPostedComments(
+              restThread,
+              rootEventId,
+            );
             if (thread.hasExactTotal) {
               // Auto-update the count cache with the authoritative REST total.
               // Zero is written too so a previously cached positive value
@@ -232,6 +263,12 @@ class CommentsRepository {
           rootEventId,
           rootEventKind,
         );
+      }
+
+      // Merge the user's own just-posted comment on first-page loads when the
+      // relay query has not yet returned it, mirroring the REST path (#5598).
+      if (before == null) {
+        thread = _mergeRecentlyPostedComments(thread, rootEventId);
       }
 
       // Auto-update the count cache with the authoritative total so that
@@ -353,7 +390,7 @@ class CommentsRepository {
       );
       final videoMetadata = _parseVideoMetadataFromImetaTags(sentEvent.tags);
 
-      return Comment(
+      final comment = Comment(
         id: sentEvent.id,
         content: trimmedContent,
         authorPubkey: sentEvent.pubkey,
@@ -369,6 +406,12 @@ class CommentsRepository {
         videoDuration: videoMetadata.videoDuration,
         videoBlurhash: videoMetadata.videoBlurhash,
       );
+
+      // Retain so a comment-sheet reopen shows the user's own comment even
+      // while the REST read source has not yet indexed it (#5598).
+      _recordRecentlyPostedComment(rootEventId, comment);
+
+      return comment;
     } on CommentsRepositoryException {
       rethrow;
     } on Exception catch (e) {
@@ -471,13 +514,15 @@ class CommentsRepository {
     );
   }
 
-  /// Clears the in-memory comment count cache.
+  /// Clears the in-memory comment count cache and the recently-posted-comment
+  /// self-heal buffer.
   ///
-  /// Should be called on logout so stale counts from a previous user's
-  /// session are not served after re-login.
+  /// Should be called on logout so stale counts and a previous user's pending
+  /// comments are not served after re-login.
   void clearCommentCountCache() {
     _commentCountCache.clear();
     _commentCountCacheByAddressableId.clear();
+    _recentlyPostedComments.clear();
   }
 
   /// Reads the cached comment count, checking event-id first then the
@@ -523,6 +568,55 @@ class CommentsRepository {
       rootEventId,
       updated < 0 ? 0 : updated,
       rootAddressableId: rootAddressableId,
+    );
+  }
+
+  /// Records a just-posted [comment] so [loadComments] can keep it visible on
+  /// a comment-sheet reopen while the REST read source catches up (#5598).
+  void _recordRecentlyPostedComment(String rootEventId, Comment comment) {
+    _recentlyPostedComments.putIfAbsent(rootEventId, () => [])
+      ..removeWhere((p) => p.comment.id == comment.id)
+      ..add(_RecentlyPostedComment(comment, _now()));
+  }
+
+  /// Merges any retained just-posted comments for [rootEventId] into [thread]
+  /// when the fetched thread does not already contain them (#5598).
+  ///
+  /// Self-pruning: entries already present in [thread] (the backend caught up)
+  /// or older than [_recentlyPostedRetention] are dropped. Deduplication is by
+  /// event id, so a later relay echo or REST refresh cannot create a duplicate
+  /// row. [CommentThread.totalCount] is bumped by the number of injected
+  /// comments so the count badge stays consistent with the rendered list.
+  CommentThread _mergeRecentlyPostedComments(
+    CommentThread thread,
+    String rootEventId,
+  ) {
+    final pending = _recentlyPostedComments[rootEventId];
+    if (pending == null || pending.isEmpty) return thread;
+
+    final now = _now();
+    pending
+      ..removeWhere(
+        (p) => now.difference(p.postedAt) > _recentlyPostedRetention,
+      )
+      ..removeWhere((p) => thread.commentCache.containsKey(p.comment.id));
+
+    if (pending.isEmpty) {
+      _recentlyPostedComments.remove(rootEventId);
+      return thread;
+    }
+
+    final mergedCache = <String, Comment>{
+      ...thread.commentCache,
+      for (final p in pending) p.comment.id: p.comment,
+    };
+    final mergedComments = mergedCache.values.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+    return thread.copyWith(
+      comments: mergedComments,
+      commentCache: Map<String, Comment>.unmodifiable(mergedCache),
+      totalCount: thread.totalCount + pending.length,
     );
   }
 
@@ -1087,4 +1181,15 @@ class _CommentVideoMetadata {
   final String? videoDimensions;
   final int? videoDuration;
   final String? videoBlurhash;
+}
+
+/// A comment the local user just posted, retained briefly in
+/// [CommentsRepository] so it survives a comment-sheet reopen while the REST
+/// read source catches up. See [CommentsRepository] field
+/// `_recentlyPostedComments` and issue #5598.
+class _RecentlyPostedComment {
+  _RecentlyPostedComment(this.comment, this.postedAt);
+
+  final Comment comment;
+  final DateTime postedAt;
 }

--- a/mobile/packages/comments_repository/test/src/recently_posted_comment_merge_test.dart
+++ b/mobile/packages/comments_repository/test/src/recently_posted_comment_merge_test.dart
@@ -1,0 +1,181 @@
+import 'package:comments_repository/comments_repository.dart';
+import 'package:funnelcake_api_client/funnelcake_api_client.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:test/test.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockFunnelcakeApiClient extends Mock implements FunnelcakeApiClient {}
+
+class _FakeEvent extends Fake implements Event {}
+
+const int _commentKind = EventKind.comment;
+const int _rootEventKind = EventKind.videoVertical;
+
+void main() {
+  // Self-heal merge: a just-posted comment publishes to relays instantly, but
+  // loadComments reads the Funnelcake REST index first and only falls back to
+  // relays when REST is unavailable. While the REST index lags, the repository
+  // keeps the user's own comment visible on a sheet reopen. See issue #5598
+  // (recurrence of #211).
+  group('CommentsRepository recently-posted self-heal (#5598)', () {
+    late _MockNostrClient nostrClient;
+    late _MockFunnelcakeApiClient funnelcakeClient;
+    late DateTime now;
+    late CommentsRepository repository;
+
+    const rootEventId =
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const rootAuthorPubkey =
+        'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const userPubkey =
+        'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+    setUpAll(() {
+      registerFallbackValue(<Filter>[]);
+      registerFallbackValue(_FakeEvent());
+    });
+
+    setUp(() {
+      nostrClient = _MockNostrClient();
+      funnelcakeClient = _MockFunnelcakeApiClient();
+      now = DateTime.utc(2026, 6, 27, 13, 35, 38);
+      when(() => nostrClient.publicKey).thenReturn(userPubkey);
+      when(() => nostrClient.publishEvent(any())).thenAnswer((inv) async {
+        final event = inv.positionalArguments.first as Event;
+        return PublishSuccess(event: event);
+      });
+      when(
+        () => nostrClient.queryEvents(any()),
+      ).thenAnswer((_) async => <Event>[]);
+      repository = CommentsRepository(
+        nostrClient: nostrClient,
+        funnelcakeApiClient: funnelcakeClient,
+        clock: () => now,
+      );
+    });
+
+    void stubRest(List<VideoComment> comments, {required int total}) {
+      when(() => funnelcakeClient.isAvailable).thenReturn(true);
+      when(
+        () => funnelcakeClient.getVideoComments(
+          videoId: any(named: 'videoId'),
+          sort: any(named: 'sort'),
+          limit: any(named: 'limit'),
+          offset: any(named: 'offset'),
+        ),
+      ).thenAnswer(
+        (_) async => VideoCommentsResponse(comments: comments, total: total),
+      );
+    }
+
+    VideoComment restComment(String id, {String content = 'rest'}) =>
+        VideoComment(
+          id: id,
+          pubkey: userPubkey,
+          createdAt: 1000,
+          kind: _commentKind,
+          content: content,
+          sig: 'sig',
+          tags: [
+            ['E', rootEventId],
+            ['K', _rootEventKind.toString()],
+            ['P', rootAuthorPubkey],
+            ['e', rootEventId],
+            ['k', _rootEventKind.toString()],
+            ['p', rootAuthorPubkey],
+          ],
+        );
+
+    Future<Comment> postOne({String content = 'my new comment'}) {
+      return repository.postComment(
+        content: content,
+        rootEventId: rootEventId,
+        rootEventKind: _rootEventKind,
+        rootEventAuthorPubkey: rootAuthorPubkey,
+      );
+    }
+
+    Future<CommentThread> load({DateTime? before}) {
+      return repository.loadComments(
+        rootEventId: rootEventId,
+        rootEventKind: _rootEventKind,
+        before: before,
+      );
+    }
+
+    test(
+      'merges the just-posted comment into a REST load that omits it',
+      () async {
+        final posted = await postOne();
+        stubRest([restComment('other_comment')], total: 1);
+
+        final thread = await load();
+
+        expect(thread.commentCache.containsKey(posted.id), isTrue);
+        expect(thread.comments, hasLength(2));
+        // Just-posted comment is newest, so it sorts first.
+        expect(thread.comments.first.id, equals(posted.id));
+        // Count badge reflects the injected comment beyond the server total.
+        expect(thread.totalCount, equals(2));
+      },
+    );
+
+    test('does not duplicate once REST returns the posted comment', () async {
+      final posted = await postOne();
+      stubRest([restComment(posted.id)], total: 1);
+
+      final first = await load();
+      expect(first.comments, hasLength(1));
+      expect(first.totalCount, equals(1));
+
+      // The pending entry was pruned (backend caught up); a later read that
+      // momentarily omits it again does not resurrect a stale copy.
+      stubRest(<VideoComment>[], total: 0);
+      final second = await load();
+      expect(second.comments, isEmpty);
+    });
+
+    test('drops the pending comment after the retention window', () async {
+      await postOne();
+      now = now.add(const Duration(minutes: 11));
+      stubRest(<VideoComment>[], total: 0);
+
+      final thread = await load();
+
+      expect(thread.comments, isEmpty);
+      expect(thread.totalCount, equals(0));
+    });
+
+    test('merges into a relay-path load when REST is unavailable', () async {
+      when(() => funnelcakeClient.isAvailable).thenReturn(false);
+      final posted = await postOne();
+
+      final thread = await load();
+
+      expect(thread.comments.map((c) => c.id), contains(posted.id));
+      expect(thread.totalCount, equals(1));
+    });
+
+    test('does not merge into paginated (before != null) loads', () async {
+      when(() => funnelcakeClient.isAvailable).thenReturn(false);
+      await postOne();
+
+      final thread = await load(before: DateTime.utc(2030));
+
+      expect(thread.comments, isEmpty);
+    });
+
+    test('clearCommentCountCache drops the pending buffer', () async {
+      await postOne();
+      repository.clearCommentCountCache();
+      stubRest(<VideoComment>[], total: 0);
+
+      final thread = await load();
+
+      expect(thread.comments, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## What & why

Fixes #5598.

A comment publishes to Nostr relays instantly, but the comment sheet reads the **Funnelcake REST index first** (`CommentsRepository.loadComments`) and only falls back to relays when REST is unavailable. While the REST index lags ingesting the just-posted comment, a sheet **reopen** short-circuits on the stale-but-non-empty REST snapshot and never consults the relays (which already have the comment) — so the user's own comment "doesn't appear" until the index catches up. Same user-visible symptom as #211 (whose #836 fix addressed only the relay/websocket reflection path; this is the REST-first read added afterward).

### Verified root cause

Reconstructed from a device log export + a direct relay read of the actual event:

- comment `d4d0ca1a…`, kind 1111, `created_at` 2026-06-27 06:35:38 PDT — **durably on `wss://relay.divine.video`**
- 06:35:38 published (HTTP 200) → 06:35:43 sheet reopened, REST returned in 66 ms **without** the 5-second-old comment → "didn't appear" → later REST caught up → "now it's there"
- single device, no restart, no re-publish (comments have no retry queue) ⇒ the event was durable at post time; only the **read** lagged

## The fix (read path)

The app-scoped (`keepAlive`) repository retains the user's just-posted comment and merges it into `loadComments` results until the read source returns it:

- **Reopen shows the user's own comment immediately**, regardless of REST index lag (both REST-first and relay-fallback first-page loads).
- **Self-pruning**: an entry is dropped as soon as the fetched thread contains it (backend caught up) or after a 10-minute TTL.
- **No duplicates**: dedup is by event id; the comments list bloc already keys by id and reconciles placeholders, so a later relay echo / REST refresh can't create a second row.
- `totalCount` is bumped by the number of injected comments so the count badge stays consistent.

No bloc/UI changes. Optional follow-up (not in this PR): have `postComment` await a relay NIP-20 `OK` so "sent" provably means "stored."

## Testing

- New `test/src/recently_posted_comment_merge_test.dart` (6 tests): merges into a REST load that omits the comment; no duplicate once REST returns it; TTL expiry; relay-path merge when REST is unavailable; no merge on paginated loads; `clearCommentCountCache` drops the buffer.
- Full package suite green: **139 tests pass** (133 existing + 6 new).
- `dart format` clean, `flutter analyze` clean.

## Manual test plan

1. Post a comment on a video (top-level or reply).
2. Immediately close and reopen the comment sheet on the same video.
3. The comment stays visible (previously it would be missing until the REST index caught up).
4. Confirm no duplicate row once the backend indexes it and the sheet refreshes.
