### PR TITLE
fix(nostr): recover failed client initialization

### DIFF
--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -116,6 +116,11 @@ typedef NostrClientFactory =
 
 typedef NostrInitRetryDelay = Duration Function(int attempt);
 
+const _nostrInitRetryBaseDelay = Duration(seconds: 5);
+const _nostrInitRetryMaxDelay = Duration(seconds: 60);
+const _nostrInitRetryExponentCap = 4;
+const _nostrInitializationTimeout = Duration(seconds: 90);
+
 /// Indirection layer over [NostrServiceFactory.create] so tests can
 /// substitute a fake factory without touching the real relay/network
 /// code path. Production builds use this provider transparently.
@@ -129,10 +134,17 @@ NostrClientFactory nostrClientFactory(Ref ref) => NostrServiceFactory.create;
 /// recovery path can be exercised without wall-clock sleeps.
 final nostrInitRetryDelayProvider = Provider<NostrInitRetryDelay>((ref) {
   return (attempt) {
-    final seconds = 5 * (1 << (attempt - 1).clamp(0, 4));
-    return Duration(seconds: seconds.clamp(5, 60));
+    final exponent = (attempt - 1).clamp(0, _nostrInitRetryExponentCap);
+    final seconds = _nostrInitRetryBaseDelay.inSeconds * (1 << exponent);
+    return Duration(
+      seconds: seconds.clamp(0, _nostrInitRetryMaxDelay.inSeconds),
+    );
   };
 });
+
+final nostrInitializationTimeoutProvider = Provider<Duration>(
+  (ref) => _nostrInitializationTimeout,
+);
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client
@@ -257,10 +269,7 @@ class NostrService extends _$NostrService {
     required String source,
   }) async {
     try {
-      if (userRelayUrls.isNotEmpty) {
-        await client.addRelays(userRelayUrls);
-      }
-      await client.initialize();
+      await _runClientInitialization(client, userRelayUrls);
       if (_isCurrentClientForPubkey(client, pubkey, clientGeneration)) {
         _lastPubkey = pubkey;
         _initializationFailureCount = 0;
@@ -290,6 +299,18 @@ class NostrService extends _$NostrService {
     }
   }
 
+  Future<void> _runClientInitialization(
+    NostrClient client,
+    List<String> userRelayUrls,
+  ) {
+    return (() async {
+      if (userRelayUrls.isNotEmpty) {
+        await client.addRelays(userRelayUrls);
+      }
+      await client.initialize();
+    })().timeout(ref.read(nostrInitializationTimeoutProvider));
+  }
+
   void _scheduleInitializationRetry(String? pubkey) {
     if (pubkey == null) return;
     if (_initializationRetryTimer?.isActive ?? false) return;
@@ -303,7 +324,9 @@ class NostrService extends _$NostrService {
     );
     _initializationRetryTimer = Timer(delay, () {
       _initializationRetryTimer = null;
-      unawaited(_retryInitializeCurrentIdentity(pubkey));
+      _enqueueClientLifecycleMutation(
+        () => _retryInitializeCurrentIdentity(pubkey),
+      );
     });
   }
 
@@ -314,40 +337,68 @@ class NostrService extends _$NostrService {
       return;
     }
 
-    authService.registerUserRelaysDiscoveredCallback(null);
-    authService.registerBootstrapRelayListCallback(null);
     final oldClient = state;
     _invalidateClientGeneration();
-    _disposeClient(oldClient);
 
     final userRelayUrls = authService.userRelays
         .map((relay) => relay.url)
         .toList();
     final client = _createClient(identity);
     final clientGeneration = _nextClientGeneration();
-    state = client;
-    _setSessionIdentityState(pubkey);
-    _registerClientCallbacks(
-      authService: authService,
-      client: client,
-      pubkey: pubkey,
-      clientGeneration: clientGeneration,
-    );
-    await _initializeClient(
-      client: client,
-      pubkey: pubkey,
-      clientGeneration: clientGeneration,
-      userRelayUrls: userRelayUrls,
-      source: 'retry',
-    );
+    try {
+      await _runClientInitialization(client, userRelayUrls);
+      if (!_isActiveIdentity(pubkey, clientGeneration)) {
+        _disposeClient(client);
+        return;
+      }
+      authService.registerUserRelaysDiscoveredCallback(null);
+      authService.registerBootstrapRelayListCallback(null);
+      _disposeClient(oldClient);
+      state = client;
+      _lastPubkey = pubkey;
+      _initializationFailureCount = 0;
+      _initializationRetryTimer?.cancel();
+      _initializationRetryTimer = null;
+      _registerClientCallbacks(
+        authService: authService,
+        client: client,
+        pubkey: pubkey,
+        clientGeneration: clientGeneration,
+      );
+      _markClientReadyIfCurrent(client, pubkey, clientGeneration);
+      Log.info(
+        '[NostrService] Client initialized via retry()',
+        name: 'NostrService',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      Log.error(
+        '[NostrService] Failed to initialize client in retry(): $e',
+        name: 'NostrService',
+        category: LogCategory.system,
+      );
+      _disposeClient(client);
+      if (!_isActiveIdentity(pubkey, clientGeneration)) {
+        return;
+      }
+      if (_lastPubkey == pubkey) {
+        _lastPubkey = null;
+      }
+      _setSessionIdentityState(pubkey);
+      _scheduleInitializationRetry(pubkey);
+    }
   }
 
   void _enqueueAuthStateChanged(AuthState newState) {
+    _enqueueClientLifecycleMutation(() => _onAuthStateChanged(newState));
+  }
+
+  void _enqueueClientLifecycleMutation(Future<void> Function() mutation) {
     _authStateChangeQueue = _authStateChangeQueue
         .catchError(_logAuthTransitionFailure)
         .then((_) async {
           try {
-            await _onAuthStateChanged(newState);
+            await mutation();
           } catch (e, st) {
             _logAuthTransitionFailure(e, st);
           }
@@ -481,6 +532,11 @@ class NostrService extends _$NostrService {
     return clientGeneration == _clientGeneration &&
         identical(state, client) &&
         currentPubkey == pubkey;
+  }
+
+  bool _isActiveIdentity(String pubkey, int clientGeneration) {
+    final currentPubkey = ref.read(authServiceProvider).currentIdentity?.pubkey;
+    return clientGeneration == _clientGeneration && currentPubkey == pubkey;
   }
 
   /// Builds the NIP-65 discovered-relays callback bound to [client].

--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -114,11 +114,25 @@ typedef NostrClientFactory =
       AppDbClient? dbClient,
     });
 
+typedef NostrInitRetryDelay = Duration Function(int attempt);
+
 /// Indirection layer over [NostrServiceFactory.create] so tests can
 /// substitute a fake factory without touching the real relay/network
 /// code path. Production builds use this provider transparently.
 @Riverpod(keepAlive: true)
 NostrClientFactory nostrClientFactory(Ref ref) => NostrServiceFactory.create;
+
+/// Backoff policy for recovering the app-wide Nostr session after startup
+/// relay or signer initialization fails.
+///
+/// Attempts are one-indexed. Tests override this with [Duration.zero] so the
+/// recovery path can be exercised without wall-clock sleeps.
+final nostrInitRetryDelayProvider = Provider<NostrInitRetryDelay>((ref) {
+  return (attempt) {
+    final seconds = 5 * (1 << (attempt - 1).clamp(0, 4));
+    return Duration(seconds: seconds.clamp(5, 60));
+  };
+});
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client
@@ -126,9 +140,12 @@ NostrClientFactory nostrClientFactory(Ref ref) => NostrServiceFactory.create;
 @Riverpod(keepAlive: true)
 class NostrService extends _$NostrService {
   StreamSubscription<AuthState>? _authSubscription;
+  Timer? _initializationRetryTimer;
   String? _lastPubkey;
   Future<void> _authStateChangeQueue = Future<void>.value();
   int _clientGeneration = 0;
+  int _initializationFailureCount = 0;
+  final Set<NostrClient> _trackedClients = {};
 
   int _nextClientGeneration() => ++_clientGeneration;
 
@@ -139,10 +156,10 @@ class NostrService extends _$NostrService {
   @override
   NostrClient build() {
     final authService = ref.watch(authServiceProvider);
-    final statisticsService = ref.watch(relayStatisticsServiceProvider);
-    final environmentConfig = ref.watch(currentEnvironmentProvider);
-    final dbClient = ref.watch(appDbClientProvider);
-    final factory = ref.watch(nostrClientFactoryProvider);
+    ref.watch(relayStatisticsServiceProvider);
+    ref.watch(currentEnvironmentProvider);
+    ref.watch(appDbClientProvider);
+    ref.watch(nostrClientFactoryProvider);
 
     final initialPubkey = authService.currentIdentity?.pubkey;
 
@@ -162,72 +179,167 @@ class NostrService extends _$NostrService {
     // currentIdentity is nullable — before auth completes, the factory falls
     // back to a no-op LocalKeySigner. _onAuthStateChanged recreates the client
     // once the user authenticates.
-    final client = factory(
-      signer: authService.currentIdentity,
-      statisticsService: statisticsService,
-      environmentConfig: environmentConfig,
-      dbClient: dbClient,
-    );
+    final client = _createClient(authService.currentIdentity);
     final clientGeneration = _nextClientGeneration();
 
     // NIP-65 discovered-relays callback — see _userRelaysDiscoveredCallbackFor.
-    authService.registerUserRelaysDiscoveredCallback(
-      _userRelaysDiscoveredCallbackFor(client, initialPubkey, clientGeneration),
-    );
-
-    // Bootstrap kind:10002 publisher — see _bootstrapCallbackFor.
-    authService.registerBootstrapRelayListCallback(
-      _bootstrapCallbackFor(client),
+    _registerClientCallbacks(
+      authService: authService,
+      client: client,
+      pubkey: initialPubkey,
+      clientGeneration: clientGeneration,
     );
 
     // Schedule initialization after build completes
     // Add user relays BEFORE initialize() to avoid race condition
-    Future.microtask(() async {
-      try {
-        // Add user relays first (must complete before initialize)
-        if (userRelayUrls.isNotEmpty) {
-          await client.addRelays(userRelayUrls);
-        }
-        // Then initialize the client
-        await client.initialize();
-        if (_isCurrentClientForPubkey(
-          client,
-          initialPubkey,
-          clientGeneration,
-        )) {
-          _lastPubkey = initialPubkey;
-        }
-        _markClientReadyIfCurrent(client, initialPubkey, clientGeneration);
-        Log.info(
-          '[NostrService] Client initialized via build()',
-          name: 'NostrService',
-          category: LogCategory.system,
-        );
-      } catch (e) {
-        Log.error(
-          '[NostrService] Failed to initialize client in build(): $e',
-          name: 'NostrService',
-          category: LogCategory.system,
-        );
-        if (_lastPubkey == initialPubkey &&
-            ref.read(authServiceProvider).currentIdentity?.pubkey ==
-                initialPubkey) {
-          _lastPubkey = null;
-          _setSessionIdentityState(initialPubkey);
-        }
-      }
-    });
+    Future.microtask(
+      () => _initializeClient(
+        client: client,
+        pubkey: initialPubkey,
+        clientGeneration: clientGeneration,
+        userRelayUrls: userRelayUrls,
+        source: 'build',
+      ),
+    );
 
-    // Capture client reference for disposal - can't access state inside onDispose
     ref.onDispose(() {
+      _initializationRetryTimer?.cancel();
+      _initializationRetryTimer = null;
       authService.registerUserRelaysDiscoveredCallback(null);
       authService.registerBootstrapRelayListCallback(null);
       _authSubscription?.cancel();
       _invalidateClientGeneration();
-      client.dispose();
+      for (final trackedClient in _trackedClients.toList()) {
+        trackedClient.dispose();
+      }
+      _trackedClients.clear();
     });
 
     return client;
+  }
+
+  NostrClient _createClient(NostrSigner? signer) {
+    final client = ref.read(nostrClientFactoryProvider)(
+      signer: signer,
+      statisticsService: ref.read(relayStatisticsServiceProvider),
+      environmentConfig: ref.read(currentEnvironmentProvider),
+      dbClient: ref.read(appDbClientProvider),
+    );
+    _trackedClients.add(client);
+    return client;
+  }
+
+  void _disposeClient(NostrClient client) {
+    if (_trackedClients.remove(client)) {
+      client.dispose();
+    }
+  }
+
+  void _registerClientCallbacks({
+    required AuthService authService,
+    required NostrClient client,
+    required String? pubkey,
+    required int clientGeneration,
+  }) {
+    authService.registerUserRelaysDiscoveredCallback(
+      _userRelaysDiscoveredCallbackFor(client, pubkey, clientGeneration),
+    );
+    authService.registerBootstrapRelayListCallback(
+      _bootstrapCallbackFor(client),
+    );
+  }
+
+  Future<void> _initializeClient({
+    required NostrClient client,
+    required String? pubkey,
+    required int clientGeneration,
+    required List<String> userRelayUrls,
+    required String source,
+  }) async {
+    try {
+      if (userRelayUrls.isNotEmpty) {
+        await client.addRelays(userRelayUrls);
+      }
+      await client.initialize();
+      if (_isCurrentClientForPubkey(client, pubkey, clientGeneration)) {
+        _lastPubkey = pubkey;
+        _initializationFailureCount = 0;
+        _initializationRetryTimer?.cancel();
+        _initializationRetryTimer = null;
+      }
+      _markClientReadyIfCurrent(client, pubkey, clientGeneration);
+      Log.info(
+        '[NostrService] Client initialized via $source()',
+        name: 'NostrService',
+        category: LogCategory.system,
+      );
+    } catch (e) {
+      Log.error(
+        '[NostrService] Failed to initialize client in $source(): $e',
+        name: 'NostrService',
+        category: LogCategory.system,
+      );
+      if (!_isCurrentClientForPubkey(client, pubkey, clientGeneration)) {
+        return;
+      }
+      if (_lastPubkey == pubkey) {
+        _lastPubkey = null;
+      }
+      _setSessionIdentityState(pubkey);
+      _scheduleInitializationRetry(pubkey);
+    }
+  }
+
+  void _scheduleInitializationRetry(String? pubkey) {
+    if (pubkey == null) return;
+    if (_initializationRetryTimer?.isActive ?? false) return;
+
+    final attempt = ++_initializationFailureCount;
+    final delay = ref.read(nostrInitRetryDelayProvider)(attempt);
+    Log.warning(
+      '[NostrService] Scheduling initialization retry $attempt in $delay',
+      name: 'NostrService',
+      category: LogCategory.system,
+    );
+    _initializationRetryTimer = Timer(delay, () {
+      _initializationRetryTimer = null;
+      unawaited(_retryInitializeCurrentIdentity(pubkey));
+    });
+  }
+
+  Future<void> _retryInitializeCurrentIdentity(String pubkey) async {
+    final authService = ref.read(authServiceProvider);
+    final identity = authService.currentIdentity;
+    if (identity == null || identity.pubkey != pubkey) {
+      return;
+    }
+
+    authService.registerUserRelaysDiscoveredCallback(null);
+    authService.registerBootstrapRelayListCallback(null);
+    final oldClient = state;
+    _invalidateClientGeneration();
+    _disposeClient(oldClient);
+
+    final userRelayUrls = authService.userRelays
+        .map((relay) => relay.url)
+        .toList();
+    final client = _createClient(identity);
+    final clientGeneration = _nextClientGeneration();
+    state = client;
+    _setSessionIdentityState(pubkey);
+    _registerClientCallbacks(
+      authService: authService,
+      client: client,
+      pubkey: pubkey,
+      clientGeneration: clientGeneration,
+    );
+    await _initializeClient(
+      client: client,
+      pubkey: pubkey,
+      clientGeneration: clientGeneration,
+      userRelayUrls: userRelayUrls,
+      source: 'retry',
+    );
   }
 
   void _enqueueAuthStateChanged(AuthState newState) {
@@ -288,14 +400,11 @@ class NostrService extends _$NostrService {
       // Unregister callback for old client before disposing it
       authService.registerUserRelaysDiscoveredCallback(null);
       authService.registerBootstrapRelayListCallback(null);
-      state.dispose();
+      _initializationRetryTimer?.cancel();
+      _initializationRetryTimer = null;
+      _initializationFailureCount = 0;
+      _disposeClient(state);
       _invalidateClientGeneration();
-
-      // Create new client with updated signer and public key
-      final statisticsService = ref.read(relayStatisticsServiceProvider);
-      final environmentConfig = ref.read(currentEnvironmentProvider);
-      final dbClient = ref.read(appDbClientProvider);
-      final factory = ref.read(nostrClientFactoryProvider);
 
       // Get user relay URLs from discovered relays (NIP-65)
       // Include all relays - NostrClient needs both read and write capable relays
@@ -304,39 +413,27 @@ class NostrService extends _$NostrService {
           .map((relay) => relay.url)
           .toList();
 
-      final newClient = factory(
-        signer: newIdentity,
-        statisticsService: statisticsService,
-        environmentConfig: environmentConfig,
-        dbClient: dbClient,
-      );
+      final newClient = _createClient(newIdentity);
       final clientGeneration = _nextClientGeneration();
 
       // NIP-65 discovered-relays callback — see _userRelaysDiscoveredCallbackFor.
-      authService.registerUserRelaysDiscoveredCallback(
-        _userRelaysDiscoveredCallbackFor(
-          newClient,
-          newPubkey,
-          clientGeneration,
-        ),
-      );
-
-      // Bootstrap kind:10002 publisher — see _bootstrapCallbackFor.
-      authService.registerBootstrapRelayListCallback(
-        _bootstrapCallbackFor(newClient),
+      _registerClientCallbacks(
+        authService: authService,
+        client: newClient,
+        pubkey: newPubkey,
+        clientGeneration: clientGeneration,
       );
 
       state = newClient;
       _setSessionIdentityState(newPubkey);
 
-      // Add user relays first (must complete before initialize)
-      if (userRelayUrls.isNotEmpty) {
-        await newClient.addRelays(userRelayUrls);
-      }
-      // Then initialize the new client
-      await newClient.initialize();
-      _lastPubkey = newPubkey;
-      _markClientReadyIfCurrent(newClient, newPubkey, clientGeneration);
+      await _initializeClient(
+        client: newClient,
+        pubkey: newPubkey,
+        clientGeneration: clientGeneration,
+        userRelayUrls: userRelayUrls,
+        source: 'authStateChanged',
+      );
     }
   }
 

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'302c7d353b93b1f9e526b3f51fadbe7ccd6170b5';
+String _$nostrServiceHash() => r'58e0dc3a58d063faeec5669d21b86d66f233bd08';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'f5e6b389ce5b64cc92118c00054e009cf98eec60';
+String _$nostrServiceHash() => r'302c7d353b93b1f9e526b3f51fadbe7ccd6170b5';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -137,6 +137,21 @@ void main() {
     );
   }
 
+  ProviderContainer createRetryContainer() {
+    return ProviderContainer(
+      overrides: [
+        authServiceProvider.overrideWithValue(mockAuth),
+        relayStatisticsServiceProvider.overrideWithValue(mockStats),
+        currentEnvironmentProvider.overrideWithValue(
+          EnvironmentConfig.production,
+        ),
+        appDbClientProvider.overrideWithValue(mockDbClient),
+        nostrClientFactoryProvider.overrideWithValue(factory.call),
+        nostrInitRetryDelayProvider.overrideWithValue((_) => Duration.zero),
+      ],
+    );
+  }
+
   group('NostrService uses NostrIdentity as source of truth', () {
     test('does not recreate with null-signer placeholder when authenticating '
         'emits while currentIdentity is still null', () async {
@@ -534,107 +549,148 @@ void main() {
       },
     );
 
+    test('failed same-pubkey transition can retry client creation', () async {
+      when(() => mockAuth.currentIdentity).thenReturn(identityA);
+      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      container.read(nostrServiceProvider);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      expect(factory.callCount, equals(1));
+
+      final failedBInitialize = Completer<void>();
+      factory.initializeCompleters[pubkeyB] = failedBInitialize;
+
+      when(() => mockAuth.currentIdentity).thenReturn(identityB);
+      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
+      authStream.add(AuthState.authenticated);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(factory.callCount, equals(2));
+
+      failedBInitialize.completeError(StateError('B initialize failed'));
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      factory.initializeCompleters.remove(pubkeyB);
+      authStream.add(AuthState.authenticated);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        factory.callCount,
+        equals(3),
+        reason:
+            'A failed transition must not mark pubkey B complete; a later '
+            'auth emission for B should recreate and initialize a new client.',
+      );
+      expect(factory.clients.last.publicKey, equals(pubkeyB));
+      expect(container.read(nostrServiceProvider), same(factory.clients.last));
+      expect(
+        container.read(nostrSessionProvider),
+        isA<NostrSessionReadiness>()
+            .having(
+              (readiness) => readiness.phase,
+              'phase',
+              NostrSessionPhase.nostrReady,
+            )
+            .having((readiness) => readiness.pubkey, 'pubkey', pubkeyB)
+            .having(
+              (readiness) => readiness.client,
+              'client',
+              same(factory.clients.last),
+            ),
+      );
+    });
+
+    test('failed initial same-pubkey build can retry client creation', () async {
+      final failedInitialAInitialize = Completer<void>();
+      factory.initializeCompleters[pubkeyA] = failedInitialAInitialize;
+      when(() => mockAuth.currentIdentity).thenReturn(identityA);
+      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+
+      final container = createContainer();
+      addTearDown(container.dispose);
+
+      container.read(nostrServiceProvider);
+      await Future<void>.delayed(Duration.zero);
+      expect(factory.callCount, equals(1));
+
+      failedInitialAInitialize.completeError(
+        StateError('initial A initialize failed'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        container.read(nostrSessionProvider),
+        isA<NostrSessionReadiness>()
+            .having(
+              (readiness) => readiness.phase,
+              'phase',
+              NostrSessionPhase.identityKnown,
+            )
+            .having((readiness) => readiness.pubkey, 'pubkey', pubkeyA),
+        reason:
+            'A failed initial client must leave readiness non-ready for the '
+            'known identity.',
+      );
+
+      factory.initializeCompleters.remove(pubkeyA);
+      authStream.add(AuthState.authenticated);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        factory.callCount,
+        equals(2),
+        reason:
+            'A failed initial build must not mark pubkey A complete; a later '
+            'auth emission for A should recreate and initialize a new client.',
+      );
+      expect(factory.clients.last.publicKey, equals(pubkeyA));
+      expect(container.read(nostrServiceProvider), same(factory.clients.last));
+      expect(
+        container.read(nostrSessionProvider),
+        isA<NostrSessionReadiness>()
+            .having(
+              (readiness) => readiness.phase,
+              'phase',
+              NostrSessionPhase.nostrReady,
+            )
+            .having((readiness) => readiness.pubkey, 'pubkey', pubkeyA)
+            .having(
+              (readiness) => readiness.client,
+              'client',
+              same(factory.clients.last),
+            ),
+      );
+    });
+
     test(
-      'failed same-pubkey transition can retry client creation',
-      () async {
-        when(() => mockAuth.currentIdentity).thenReturn(identityA);
-        when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
-
-        final container = createContainer();
-        addTearDown(container.dispose);
-
-        container.read(nostrServiceProvider);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        expect(factory.callCount, equals(1));
-
-        final failedBInitialize = Completer<void>();
-        factory.initializeCompleters[pubkeyB] = failedBInitialize;
-
-        when(() => mockAuth.currentIdentity).thenReturn(identityB);
-        when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
-        authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-
-        expect(factory.callCount, equals(2));
-
-        failedBInitialize.completeError(StateError('B initialize failed'));
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-
-        factory.initializeCompleters.remove(pubkeyB);
-        authStream.add(AuthState.authenticated);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-
-        expect(
-          factory.callCount,
-          equals(3),
-          reason:
-              'A failed transition must not mark pubkey B complete; a later '
-              'auth emission for B should recreate and initialize a new client.',
-        );
-        expect(factory.clients.last.publicKey, equals(pubkeyB));
-        expect(
-          container.read(nostrServiceProvider),
-          same(factory.clients.last),
-        );
-        expect(
-          container.read(nostrSessionProvider),
-          isA<NostrSessionReadiness>()
-              .having(
-                (readiness) => readiness.phase,
-                'phase',
-                NostrSessionPhase.nostrReady,
-              )
-              .having((readiness) => readiness.pubkey, 'pubkey', pubkeyB)
-              .having(
-                (readiness) => readiness.client,
-                'client',
-                same(factory.clients.last),
-              ),
-        );
-      },
-    );
-
-    test(
-      'failed initial same-pubkey build can retry client creation',
+      'failed initial build retries automatically for same identity',
       () async {
         final failedInitialAInitialize = Completer<void>();
         factory.initializeCompleters[pubkeyA] = failedInitialAInitialize;
         when(() => mockAuth.currentIdentity).thenReturn(identityA);
         when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
 
-        final container = createContainer();
+        final container = createRetryContainer();
         addTearDown(container.dispose);
 
-        container.read(nostrServiceProvider);
+        final failedClient = container.read(nostrServiceProvider);
         await Future<void>.delayed(Duration.zero);
         expect(factory.callCount, equals(1));
 
         failedInitialAInitialize.completeError(
           StateError('initial A initialize failed'),
         );
-        await Future<void>.delayed(Duration.zero);
-        await Future<void>.delayed(Duration.zero);
-
-        expect(
-          container.read(nostrSessionProvider),
-          isA<NostrSessionReadiness>()
-              .having(
-                (readiness) => readiness.phase,
-                'phase',
-                NostrSessionPhase.identityKnown,
-              )
-              .having((readiness) => readiness.pubkey, 'pubkey', pubkeyA),
-          reason:
-              'A failed initial client must leave readiness non-ready for the '
-              'known identity.',
-        );
-
         factory.initializeCompleters.remove(pubkeyA);
-        authStream.add(AuthState.authenticated);
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
         await Future<void>.delayed(Duration.zero);
@@ -643,10 +699,12 @@ void main() {
           factory.callCount,
           equals(2),
           reason:
-              'A failed initial build must not mark pubkey A complete; a later '
-              'auth emission for A should recreate and initialize a new client.',
+              'The same authenticated identity should get a fresh NostrClient '
+              'after the first startup initialize fails.',
         );
-        expect(factory.clients.last.publicKey, equals(pubkeyA));
+        expect(factory.signers.last, same(identityA));
+        expect(factory.clients.last, isNot(same(failedClient)));
+        verify(failedClient.dispose).called(1);
         expect(
           container.read(nostrServiceProvider),
           same(factory.clients.last),
@@ -665,6 +723,9 @@ void main() {
                 'client',
                 same(factory.clients.last),
               ),
+          reason:
+              'Profile and publish providers gated on nostrReady must recover '
+              'without requiring an app restart.',
         );
       },
     );

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -18,6 +18,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_identity.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:openvine/services/relay_statistics_service.dart';
 
 class _MockAuthService extends Mock implements AuthService {}
@@ -37,6 +38,23 @@ class _RecordingFactory {
   final List<NostrSigner?> signers = [];
   final List<_MockNostrClient> clients = [];
   final Map<String?, Completer<void>> initializeCompleters = {};
+  final Map<String?, List<Completer<void>>> initializeCompleterQueues = {};
+  final Map<String?, Completer<void>> addRelaysCompleters = {};
+  final Map<String?, List<Completer<void>>> addRelaysCompleterQueues = {};
+  final List<String?> initializePubkeys = [];
+  final List<String?> addRelaysPubkeys = [];
+
+  Completer<void>? _takeCompleter(
+    Map<String?, Completer<void>> singleCompleters,
+    Map<String?, List<Completer<void>>> queuedCompleters,
+    String? pubkey,
+  ) {
+    final queue = queuedCompleters[pubkey];
+    if (queue != null && queue.isNotEmpty) {
+      return queue.removeAt(0);
+    }
+    return singleCompleters[pubkey];
+  }
 
   NostrClient call({
     NostrSigner? signer,
@@ -48,18 +66,31 @@ class _RecordingFactory {
     final client = _MockNostrClient();
     // hasKeys reflects whether we got a real signer or a null placeholder.
     final hasKeys = signer != null;
+    final pubkey = signer is NostrIdentity ? signer.pubkey : null;
+    final initializeCompleter = _takeCompleter(
+      initializeCompleters,
+      initializeCompleterQueues,
+      pubkey,
+    );
+    final addRelaysCompleter = _takeCompleter(
+      addRelaysCompleters,
+      addRelaysCompleterQueues,
+      pubkey,
+    );
     when(() => client.hasKeys).thenReturn(hasKeys);
     when(
       () => client.publicKey,
-    ).thenReturn(signer is NostrIdentity ? signer.pubkey : '');
+    ).thenReturn(pubkey ?? '');
     // ignore: unnecessary_lambdas
-    when(() => client.initialize()).thenAnswer(
-      (_) =>
-          initializeCompleters[signer is NostrIdentity ? signer.pubkey : null]
-              ?.future ??
-          Future<void>.value(),
-    );
-    when(() => client.addRelays(any())).thenAnswer((_) => Future.value(0));
+    when(() => client.initialize()).thenAnswer((_) {
+      initializePubkeys.add(pubkey);
+      return initializeCompleter?.future ?? Future<void>.value();
+    });
+    when(() => client.addRelays(any())).thenAnswer((_) async {
+      addRelaysPubkeys.add(pubkey);
+      await addRelaysCompleter?.future;
+      return 0;
+    });
     // ignore: unnecessary_lambdas
     when(() => client.dispose()).thenAnswer((_) => Future<void>.value());
     clients.add(client);
@@ -76,6 +107,7 @@ void main() {
       'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
   const pubkeyC =
       'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+  const discoveredRelay = DiscoveredRelay(url: 'wss://relay.example');
 
   setUpAll(() {
     registerFallbackValue(<String>[]);
@@ -137,7 +169,10 @@ void main() {
     );
   }
 
-  ProviderContainer createRetryContainer() {
+  ProviderContainer createRetryContainer({
+    Duration Function(int attempt)? retryDelay,
+    Duration initializationTimeout = const Duration(seconds: 90),
+  }) {
     return ProviderContainer(
       overrides: [
         authServiceProvider.overrideWithValue(mockAuth),
@@ -147,12 +182,36 @@ void main() {
         ),
         appDbClientProvider.overrideWithValue(mockDbClient),
         nostrClientFactoryProvider.overrideWithValue(factory.call),
-        nostrInitRetryDelayProvider.overrideWithValue((_) => Duration.zero),
+        nostrInitRetryDelayProvider.overrideWithValue(
+          retryDelay ?? (_) => Duration.zero,
+        ),
+        nostrInitializationTimeoutProvider.overrideWithValue(
+          initializationTimeout,
+        ),
       ],
     );
   }
 
   group('NostrService uses NostrIdentity as source of truth', () {
+    test('initialization retry backoff is bounded exponential policy', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final retryDelay = container.read(nostrInitRetryDelayProvider);
+
+      expect(
+        [for (var attempt = 1; attempt <= 6; attempt++) retryDelay(attempt)],
+        const [
+          Duration(seconds: 5),
+          Duration(seconds: 10),
+          Duration(seconds: 20),
+          Duration(seconds: 40),
+          Duration(seconds: 60),
+          Duration(seconds: 60),
+        ],
+      );
+    });
+
     test('does not recreate with null-signer placeholder when authenticating '
         'emits while currentIdentity is still null', () async {
       // Simulate the auth-screen transient state described in PR #2833:
@@ -729,6 +788,175 @@ void main() {
         );
       },
     );
+
+    test(
+      'timed out startup relay setup retries automatically for same identity',
+      () async {
+        final stalledAddRelays = Completer<void>();
+        factory.addRelaysCompleters[pubkeyA] = stalledAddRelays;
+        when(() => mockAuth.currentIdentity).thenReturn(identityA);
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+        when(() => mockAuth.userRelays).thenReturn([discoveredRelay]);
+
+        final container = createRetryContainer(
+          initializationTimeout: Duration.zero,
+        );
+        addTearDown(container.dispose);
+
+        final timedOutClient = container.read(nostrServiceProvider);
+        factory.addRelaysCompleters.remove(pubkeyA);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(factory.callCount, equals(2));
+        expect(factory.addRelaysPubkeys, equals([pubkeyA, pubkeyA]));
+        expect(factory.initializePubkeys, equals([pubkeyA]));
+        verify(timedOutClient.dispose).called(1);
+        expect(
+          container.read(nostrServiceProvider),
+          same(factory.clients.last),
+        );
+        expect(
+          container.read(nostrSessionProvider),
+          isA<NostrSessionReadiness>()
+              .having(
+                (readiness) => readiness.phase,
+                'phase',
+                NostrSessionPhase.nostrReady,
+              )
+              .having((readiness) => readiness.pubkey, 'pubkey', pubkeyA)
+              .having(
+                (readiness) => readiness.client,
+                'client',
+                same(factory.clients.last),
+              ),
+        );
+      },
+    );
+
+    test(
+      'repeated initial failures preserve active client until retry succeeds',
+      () async {
+        final firstFailure = Completer<void>();
+        final secondFailure = Completer<void>();
+        factory.initializeCompleterQueues[pubkeyA] = [
+          firstFailure,
+          secondFailure,
+        ];
+        final retryAttempts = <int>[];
+        when(() => mockAuth.currentIdentity).thenReturn(identityA);
+        when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+
+        final container = createRetryContainer(
+          retryDelay: (attempt) {
+            retryAttempts.add(attempt);
+            return Duration.zero;
+          },
+        );
+        addTearDown(container.dispose);
+
+        final initialClient = container.read(nostrServiceProvider);
+        await Future<void>.delayed(Duration.zero);
+        expect(factory.callCount, equals(1));
+
+        firstFailure.completeError(StateError('first initialize failed'));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(factory.callCount, equals(2));
+        expect(
+          container.read(nostrServiceProvider),
+          same(initialClient),
+          reason:
+              'A retry candidate should not rebuild consumers until it is ready.',
+        );
+
+        secondFailure.completeError(StateError('second initialize failed'));
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(factory.callCount, equals(3));
+        expect(retryAttempts, equals([1, 2]));
+        verify(initialClient.dispose).called(1);
+        verify(factory.clients[1].dispose).called(1);
+        expect(
+          container.read(nostrServiceProvider),
+          same(factory.clients.last),
+        );
+        expect(
+          container.read(nostrSessionProvider).phase,
+          equals(NostrSessionPhase.nostrReady),
+        );
+      },
+    );
+
+    test('auth change cancels pending initialization retry', () async {
+      final failedInitialAInitialize = Completer<void>();
+      factory.initializeCompleters[pubkeyA] = failedInitialAInitialize;
+      when(() => mockAuth.currentIdentity).thenReturn(identityA);
+      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+
+      final container = createRetryContainer(
+        retryDelay: (_) => const Duration(hours: 1),
+      );
+      addTearDown(container.dispose);
+
+      container.read(nostrServiceProvider);
+      await Future<void>.delayed(Duration.zero);
+      failedInitialAInitialize.completeError(
+        StateError('initial A initialize failed'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      factory.initializeCompleters.remove(pubkeyA);
+      when(() => mockAuth.currentIdentity).thenReturn(identityB);
+      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyB);
+      authStream.add(AuthState.authenticated);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(factory.callCount, equals(2));
+      expect(factory.signers.last, same(identityB));
+      expect(container.read(nostrServiceProvider), same(factory.clients.last));
+      expect(
+        container.read(nostrSessionProvider).pubkey,
+        equals(pubkeyB),
+      );
+      expect(
+        container.read(nostrSessionProvider).phase,
+        equals(NostrSessionPhase.nostrReady),
+      );
+    });
+
+    test('dispose cancels pending initialization retry', () async {
+      final failedInitialAInitialize = Completer<void>();
+      factory.initializeCompleters[pubkeyA] = failedInitialAInitialize;
+      when(() => mockAuth.currentIdentity).thenReturn(identityA);
+      when(() => mockAuth.currentPublicKeyHex).thenReturn(pubkeyA);
+
+      final container = createRetryContainer(
+        retryDelay: (_) => const Duration(hours: 1),
+      );
+
+      final failedClient = container.read(nostrServiceProvider);
+      await Future<void>.delayed(Duration.zero);
+      failedInitialAInitialize.completeError(
+        StateError('initial A initialize failed'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      container.dispose();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(factory.callCount, equals(1));
+      verify(failedClient.dispose).called(1);
+    });
 
     test(
       'stale build initialization cannot mark a disposed client ready',


### PR DESCRIPTION
## Summary

Fixes #5577 by hardening the app-wide Nostr startup path when an authenticated identity is known but the signer-backed NostrClient never reaches nostrReady. The recovery path now handles both thrown initialization failures and non-throwing startup stalls.

This PR:
- centralizes NostrClient creation, callback registration, initialization, and disposal in NostrService
- wraps the addRelays() + initialize() startup sequence in a bounded timeout so a stalled setup becomes retryable
- retries failed or timed-out initialization with named, bounded backoff policy values
- serializes retry work through the same lifecycle queue as auth-state changes
- initializes retry candidates before publishing them to provider state, avoiding repeated consumer graph rebuilds during sustained failures
- cancels pending retries on auth changes and provider disposal so stale clients cannot overwrite newer sessions
- keeps the existing generation and pubkey guards for stale init completions and relay discovery callbacks
- adds regression coverage for startup timeout recovery, fail-fail-succeed retry, retry backoff, auth-change cancellation, and dispose cancellation

## Root Cause

The initial NostrService build path initialized the shared NostrClient once in a microtask. If that setup failed or stalled, the provider stayed at identityKnown and nothing recreated or retried the signer-backed client. Downstream providers such as profileRepositoryProvider stayed unavailable because they require nostrSessionProvider.isReadyForActiveClient.

The issue log for #5577 showed the app reporting Nostr service not initialized for multiple minutes without an initialization failure log. That points at a non-throwing startup stall rather than only a thrown initialize() failure, so this PR now turns that stalled startup sequence into a bounded timeout and routes it through the same recovery path.

## Validation

- dart run build_runner build --delete-conflicting-outputs
- flutter test test/providers/nostr_service_identity_source_test.dart
- flutter test test/providers
- flutter analyze
- dart format --output=none --set-exit-if-changed lib test integration_test
- git diff --check
- pre-push hook: merge-conflict check, analyzer, generated-file verification, changed provider test

Closes #5577