### PR TITLE
refactor(upload): invert crash-reporting blocker behind a port (#4507)

### DIFF
--- a/mobile/lib/services/upload/upload_ports.dart
+++ b/mobile/lib/services/upload/upload_ports.dart
@@ -1,0 +1,19 @@
+// ABOUTME: Port interfaces decoupling the extracted upload concerns from
+// ABOUTME: app-layer services (Firebase crash reporting) for the package lift.
+
+/// Crash/diagnostics reporting port for the upload pipeline.
+///
+/// Lets the extracted upload concerns (e.g. `UploadProgressReporter`) record
+/// diagnostics without importing the Firebase-backed `CrashReportingService`,
+/// so they can move into a pure-Dart package. The app layer supplies an
+/// adapter that forwards to `CrashReportingService.instance`.
+abstract interface class UploadCrashReporter {
+  /// Attach a custom key/value to subsequent crash reports.
+  Future<void> setCustomKey(String key, Object value);
+
+  /// Log a breadcrumb message to the crash reporter.
+  void log(String message);
+
+  /// Record a non-fatal error with an optional [reason].
+  Future<void> recordError(Object error, StackTrace? stack, {String? reason});
+}

--- a/mobile/lib/services/upload/upload_progress_reporter.dart
+++ b/mobile/lib/services/upload/upload_progress_reporter.dart
@@ -9,8 +9,8 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/circuit_breaker_service.dart';
-import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload/upload_ports.dart';
 import 'package:openvine/services/upload/upload_session_errors.dart';
 import 'package:openvine/services/upload_manager.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -35,13 +35,16 @@ class UploadProgressReporter {
     required PendingUploadStore store,
     required VideoCircuitBreaker circuitBreaker,
     required UploadRetryConfig retryConfig,
+    required UploadCrashReporter crashReporter,
   }) : _store = store,
        _circuitBreaker = circuitBreaker,
-       _retryConfig = retryConfig;
+       _retryConfig = retryConfig,
+       _crashReporter = crashReporter;
 
   final PendingUploadStore _store;
   final VideoCircuitBreaker _circuitBreaker;
   final UploadRetryConfig _retryConfig;
+  final UploadCrashReporter _crashReporter;
 
   final Map<String, StreamSubscription<double>> _progressSubscriptions = {};
   final Map<String, UploadMetrics> _uploadMetrics = {};
@@ -360,14 +363,14 @@ class UploadProgressReporter {
   /// Send a comprehensive upload-failure report to Crashlytics.
   Future<void> sendUploadFailureCrashReport(
     PendingUpload upload,
-    dynamic error,
+    Object error,
     String errorCategory,
     UploadMetrics? metrics,
     ConnectivityResult connectivity, {
     required bool isManagerInitialized,
   }) async {
     try {
-      final crashReporting = CrashReportingService.instance;
+      final crashReporting = _crashReporter;
 
       final context = {
         'upload_id': upload.id,
@@ -464,11 +467,11 @@ ${metrics != null ? '- File Size: ${metrics.fileSizeMB} MB\n- Duration: ${metric
 
   /// Send an initialization-failure report to Crashlytics.
   Future<void> sendInitializationFailureCrashReport(
-    dynamic error,
+    Object error,
     StackTrace stackTrace,
   ) async {
     try {
-      final crashReporting = CrashReportingService.instance;
+      final crashReporting = _crashReporter;
 
       await crashReporting.setCustomKey('init_failure_error', error.toString());
       await crashReporting.setCustomKey(
@@ -521,7 +524,7 @@ UploadManager Initialization Failure:
     TimeoutException timeoutError,
   ) async {
     try {
-      final crashReporting = CrashReportingService.instance;
+      final crashReporting = _crashReporter;
 
       final context = {
         'timeout_upload_id': upload.id,

--- a/mobile/lib/services/upload_manager.dart
+++ b/mobile/lib/services/upload_manager.dart
@@ -14,7 +14,9 @@ import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/circuit_breaker_service.dart';
+import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload/upload_ports.dart';
 import 'package:openvine/services/upload/upload_progress_reporter.dart';
 import 'package:openvine/services/upload/upload_retry_policy.dart';
 import 'package:openvine/services/upload/upload_session_errors.dart';
@@ -94,6 +96,27 @@ class UploadMetrics {
 
 /// Upload target options
 
+/// App-layer adapter forwarding the upload pipeline's [UploadCrashReporter]
+/// port to the Firebase-backed [CrashReportingService].
+///
+/// Keeps the extracted upload concerns free of a direct Firebase import so
+/// they can move into a pure-Dart package; the manager injects this adapter
+/// by default.
+class CrashReportingUploadReporter implements UploadCrashReporter {
+  const CrashReportingUploadReporter();
+
+  @override
+  Future<void> setCustomKey(String key, Object value) =>
+      CrashReportingService.instance.setCustomKey(key, value);
+
+  @override
+  void log(String message) => CrashReportingService.instance.log(message);
+
+  @override
+  Future<void> recordError(Object error, StackTrace? stack, {String? reason}) =>
+      CrashReportingService.instance.recordError(error, stack, reason: reason);
+}
+
 /// Manages video uploads and their persistent state with enhanced reliability
 /// REFACTORED: Removed ChangeNotifier - now uses pure state management via Riverpod
 class UploadManager {
@@ -104,6 +127,7 @@ class UploadManager {
     bool scopeUploadsToCurrentUser = false,
     VideoCircuitBreaker? circuitBreaker,
     UploadRetryConfig? retryConfig,
+    UploadCrashReporter? crashReporter,
   }) : _blossomService = blossomService,
        _defaultBlossomUrl =
            defaultBlossomUrl ?? BlossomUploadService.defaultBlossomServer,
@@ -121,6 +145,7 @@ class UploadManager {
       store: _store,
       circuitBreaker: _circuitBreaker,
       retryConfig: _retryConfig,
+      crashReporter: crashReporter ?? const CrashReportingUploadReporter(),
     );
   }
 
@@ -973,7 +998,7 @@ class UploadManager {
   }
 
   /// Handle upload failure with comprehensive crash reporting
-  Future<void> _handleUploadFailure(PendingUpload upload, dynamic error) async {
+  Future<void> _handleUploadFailure(PendingUpload upload, Object error) async {
     final endTime = DateTime.now();
     final metrics = _reporter.metricsFor(upload.id);
     final latestUpload = getUpload(upload.id) ?? upload;

--- a/mobile/test/services/upload/upload_ports_test.dart
+++ b/mobile/test/services/upload/upload_ports_test.dart
@@ -1,0 +1,79 @@
+// ABOUTME: Contract tests for the UploadCrashReporter port — verifies the
+// ABOUTME: interface is implementable and forwards its arguments faithfully.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/upload/upload_ports.dart';
+
+/// Records every call so the test can assert faithful argument forwarding.
+class _RecordingReporter implements UploadCrashReporter {
+  final List<(String, Object)> customKeys = [];
+  final List<String> logs = [];
+  final List<(Object, StackTrace?, String?)> recordedErrors = [];
+
+  @override
+  Future<void> setCustomKey(String key, Object value) async {
+    customKeys.add((key, value));
+  }
+
+  @override
+  void log(String message) {
+    logs.add(message);
+  }
+
+  @override
+  Future<void> recordError(
+    Object error,
+    StackTrace? stack, {
+    String? reason,
+  }) async {
+    recordedErrors.add((error, stack, reason));
+  }
+}
+
+void main() {
+  group(UploadCrashReporter, () {
+    late _RecordingReporter reporter;
+
+    setUp(() => reporter = _RecordingReporter());
+
+    test('a conforming implementation satisfies the interface', () {
+      expect(reporter, isA<UploadCrashReporter>());
+    });
+
+    test('setCustomKey forwards key and value', () async {
+      await reporter.setCustomKey('upload_id', 'abc-123');
+      await reporter.setCustomKey('retry_count', 4);
+
+      expect(reporter.customKeys, [
+        ('upload_id', 'abc-123'),
+        ('retry_count', 4),
+      ]);
+    });
+
+    test('log forwards the breadcrumb message', () {
+      reporter.log('upload started');
+
+      expect(reporter.logs, ['upload started']);
+    });
+
+    test('recordError forwards error, stack, and reason', () async {
+      final error = StateError('boom');
+      final stack = StackTrace.current;
+
+      await reporter.recordError(error, stack, reason: 'upload failure');
+
+      expect(reporter.recordedErrors, hasLength(1));
+      final (recordedError, recordedStack, recordedReason) =
+          reporter.recordedErrors.single;
+      expect(recordedError, same(error));
+      expect(recordedStack, same(stack));
+      expect(recordedReason, 'upload failure');
+    });
+
+    test('recordError accepts a null stack and omitted reason', () async {
+      await reporter.recordError('failure', null);
+
+      expect(reporter.recordedErrors, [('failure', null, null)]);
+    });
+  });
+}

--- a/mobile/test/services/upload/upload_progress_reporter_test.dart
+++ b/mobile/test/services/upload/upload_progress_reporter_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Unit tests for UploadProgressReporter — covers metrics lifecycle,
 // ABOUTME: subscription management, error categorisation, and progress updates.
 
+import 'dart:async';
+
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -8,10 +10,13 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/services/circuit_breaker_service.dart';
 import 'package:openvine/services/upload/pending_upload_store.dart';
+import 'package:openvine/services/upload/upload_ports.dart';
 import 'package:openvine/services/upload/upload_progress_reporter.dart';
 import 'package:openvine/services/upload_manager.dart';
 
 class _MockPendingUploadStore extends Mock implements PendingUploadStore {}
+
+class _MockUploadCrashReporter extends Mock implements UploadCrashReporter {}
 
 PendingUpload _makeUpload({
   String id = 'upload-1',
@@ -50,22 +55,38 @@ void main() {
         createdAt: DateTime(2024),
       ),
     );
+    registerFallbackValue(StackTrace.empty);
+    const Object objectFallback = 'fallback-error';
+    registerFallbackValue(objectFallback);
   });
 
   late _MockPendingUploadStore store;
   // Use a real VideoCircuitBreaker — its state/failureRate getters return
   // non-nullable enum values that are awkward to stub with Mocktail.
   late VideoCircuitBreaker circuitBreaker;
+  late _MockUploadCrashReporter crashReporter;
   late UploadProgressReporter reporter;
 
   setUp(() {
     store = _MockPendingUploadStore();
     circuitBreaker = VideoCircuitBreaker();
+    crashReporter = _MockUploadCrashReporter();
+    when(
+      () => crashReporter.setCustomKey(any(), any()),
+    ).thenAnswer((_) async {});
+    when(
+      () => crashReporter.recordError(
+        any(),
+        any(),
+        reason: any(named: 'reason'),
+      ),
+    ).thenAnswer((_) async {});
 
     reporter = UploadProgressReporter(
       store: store,
       circuitBreaker: circuitBreaker,
       retryConfig: const UploadRetryConfig(),
+      crashReporter: crashReporter,
     );
   });
 
@@ -393,8 +414,86 @@ void main() {
         store: store,
         circuitBreaker: circuitBreaker,
         retryConfig: const UploadRetryConfig(),
+        crashReporter: crashReporter,
       );
       expect(reporter.metricsFor('upload-1'), isNull);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('crash reporting', () {
+    test(
+      'sendUploadFailureCrashReport routes the error to the crash port',
+      () async {
+        when(() => store.length).thenReturn(3);
+        when(() => store.queuedCount).thenReturn(1);
+        final upload = _makeUpload();
+        final error = Exception('boom');
+
+        await reporter.sendUploadFailureCrashReport(
+          upload,
+          error,
+          'NETWORK_ERROR',
+          null,
+          ConnectivityResult.wifi,
+          isManagerInitialized: true,
+        );
+
+        final captured = verify(
+          () => crashReporter.recordError(
+            captureAny(),
+            any(),
+            reason: captureAny(named: 'reason'),
+          ),
+        ).captured;
+        expect(captured[0], same(error));
+        expect(captured[1], equals('Video upload failure - NETWORK_ERROR'));
+        verify(
+          () => crashReporter.setCustomKey(any(), any()),
+        ).called(greaterThan(0));
+      },
+    );
+
+    test(
+      'sendInitializationFailureCrashReport routes the error to the port',
+      () async {
+        final error = StateError('init boom');
+
+        await reporter.sendInitializationFailureCrashReport(
+          error,
+          StackTrace.current,
+        );
+
+        final captured = verify(
+          () => crashReporter.recordError(
+            captureAny(),
+            any(),
+            reason: captureAny(named: 'reason'),
+          ),
+        ).captured;
+        expect(captured[0], same(error));
+        expect(
+          captured[1],
+          equals('UploadManager initialization failure after retries'),
+        );
+      },
+    );
+
+    test('sendTimeoutCrashReport routes the timeout to the port', () async {
+      final upload = _makeUpload();
+      final timeout = TimeoutException('too slow');
+
+      await reporter.sendTimeoutCrashReport(upload, timeout);
+
+      final captured = verify(
+        () => crashReporter.recordError(
+          captureAny(),
+          any(),
+          reason: captureAny(named: 'reason'),
+        ),
+      ).captured;
+      expect(captured[0], same(timeout));
+      expect(captured[1], equals('Video upload timeout after 10 minutes'));
     });
   });
 }


### PR DESCRIPTION
Closes #4507

## What

Inverts the Firebase crash-reporting dependency in the extracted upload
pipeline behind a small `UploadCrashReporter` port, so the upload core stops
importing `CrashReportingService` directly.

- New `lib/services/upload/upload_ports.dart` — `UploadCrashReporter` port
  (`setCustomKey` / `log` / `recordError`).
- `UploadProgressReporter` now takes an injected `UploadCrashReporter` instead
  of reaching for `CrashReportingService.instance`. It no longer imports the
  Firebase-backed service.
- `UploadManager` gains an optional `crashReporter` param and, by default,
  injects a top-level `CrashReportingUploadReporter` adapter that forwards to
  `CrashReportingService.instance`.
- The two crash-report methods and `_handleUploadFailure` narrow from
  `dynamic error` to `Object error` to match the port contract (errors on
  these paths are never null — all call sites pass `Exception`s or caught
  `Object`s).

## Why

`crash_reporting_service` (Firebase) is one of the five hard blockers keeping
the upload core out of a pure-Dart package. Routing it through a port + adapter
removes the import from the reporter without changing runtime behaviour — the
app layer still wires it to Crashlytics by default. This is the clean,
self-contained first cut of the dependency-inversion work; the orchestrator
extraction and the package lift follow in later PRs.

## Behaviour

Unchanged. The default-injected adapter forwards every call to the same
`CrashReportingService.instance` the reporter used before.

## Testing

- `flutter analyze lib test` — clean.
- `flutter test test/services/upload/upload_progress_reporter_test.dart` — adds
  coverage asserting all three crash-report methods (`sendUploadFailureCrashReport`,
  `sendInitializationFailureCrashReport`, `sendTimeoutCrashReport`) route the
  error and reason through the injected port.
- Full upload suite (`upload_manager_*`, `upload/*`) green.

## Part of

Staged decomposition of `upload_manager.dart` (#4507). Follows #5569, #5574,
#5589.
