### PR TITLE
fix(video-editor): bump pro_video_editor to 2.1.1 for speed-effect export

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "22fa69a8f4e3c100e6bb25691694f3127e34d3019cdd0d575d8d2cda0f9d7819"
+      sha256: "6fc9e07232ce289cf6671e695e904758ea5ec841ea351d6807adb97941ac8b52"
       url: "https://pub.dev"
     source: hosted
-    version: "1.21.5"
+    version: "2.1.1"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -307,7 +307,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^1.21.5
+  pro_video_editor: ^2.1.1
   pro_image_editor: ^12.8.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
## Description

Bumps `pro_video_editor` from `^1.21.5` to `^2.1.1` to fix the speed-effect
export duration bug.

On Android, the native global output-trim was applied on the **source**
timeline and ignored each clip's `playbackSpeed`. The editor passes a ~6.3s
global output cap (`VideoRenderData.endTime`). For a sped-up composition whose
**source** length exceeds 6.3s — but whose **output** length (after speed-up)
is within the cap — the clip was cut at 6.3s of *source* and then sped up,
producing a too-short, truncated export. iOS was unaffected (it trims the
post-speed composition via `export.timeRange`).

`pro_video_editor` 2.1.1 makes the Android global trim speed-aware (operates on
the post-speed output timeline, matching iOS), so the exported clip uses the
full duration shown in the editor.

This PR is dependency-only — no app code changes were needed; the major version
bump is API-compatible with the current call sites.

**Related Issue:** Closes #5576

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` → No issues found
- `flutter test test/services/video_editor_render_service_test.dart test/services/video_editor/video_editor_merge_service_test.dart` → all pass
- `flutter pub get` reproduces the locked `pro_video_editor` 2.1.1 with no further lockfile churn

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change