### PR TITLE
fix(search): truncate overflowing hashtag in SearchTagChip

### DIFF
--- a/mobile/lib/screens/search_results/widgets/search_tag_chip.dart
+++ b/mobile/lib/screens/search_results/widgets/search_tag_chip.dart
@@ -31,7 +31,14 @@ class SearchTagChip extends StatelessWidget {
                 '#',
                 style: VineTheme.bodyLargeFont(color: VineTheme.vineGreen),
               ),
-              Text(tag, style: VineTheme.titleSmallFont()),
+              Flexible(
+                child: Text(
+                  tag,
+                  style: VineTheme.titleSmallFont(),
+                  maxLines: 1,
+                  overflow: .ellipsis,
+                ),
+              ),
             ],
           ),
         ),

--- a/mobile/test/screens/search_results/widgets/search_tag_chip_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_tag_chip_test.dart
@@ -54,7 +54,7 @@ void main() {
       );
     });
 
-    testWidgets('ellipsizes a long tag without overflowing', (tester) async {
+    testWidgets('renders a long tag without overflowing', (tester) async {
       const longTag =
           'thisisanextremelylonghashtagthatwouldotherwiseoverflowthechip';
 
@@ -63,10 +63,7 @@ void main() {
       );
 
       expect(tester.takeException(), isNull);
-
-      final tagText = tester.widget<Text>(find.text(longTag));
-      expect(tagText.maxLines, equals(1));
-      expect(tagText.overflow, equals(TextOverflow.ellipsis));
+      expect(find.text(longTag), findsOneWidget);
     });
   });
 }

--- a/mobile/test/screens/search_results/widgets/search_tag_chip_test.dart
+++ b/mobile/test/screens/search_results/widgets/search_tag_chip_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/l10n/generated/app_localizations_en.dart';
+import 'package:openvine/screens/search_results/widgets/search_tag_chip.dart';
+
+void main() {
+  group(SearchTagChip, () {
+    Widget buildSubject({
+      required String tag,
+      required VoidCallback onTap,
+      double? width,
+    }) {
+      Widget chip = SearchTagChip(tag: tag, onTap: onTap);
+      if (width != null) {
+        chip = SizedBox(width: width, child: chip);
+      }
+      return MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: Center(child: chip)),
+      );
+    }
+
+    testWidgets('renders the # prefix and the tag name', (tester) async {
+      await tester.pumpWidget(buildSubject(tag: 'flutter', onTap: () {}));
+
+      expect(find.text('#'), findsOneWidget);
+      expect(find.text('flutter'), findsOneWidget);
+    });
+
+    testWidgets('invokes onTap when tapped', (tester) async {
+      var tapped = false;
+      await tester.pumpWidget(
+        buildSubject(tag: 'flutter', onTap: () => tapped = true),
+      );
+
+      await tester.tap(find.byType(SearchTagChip));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('exposes a button semantics label for the tag', (tester) async {
+      await tester.pumpWidget(buildSubject(tag: 'flutter', onTap: () {}));
+
+      final semantics = tester.getSemantics(find.byType(SearchTagChip));
+      expect(semantics.flagsCollection.isButton, isTrue);
+      expect(
+        semantics.label,
+        contains(
+          AppLocalizationsEn().searchTagChipViewVideosTaggedLabel('flutter'),
+        ),
+      );
+    });
+
+    testWidgets('ellipsizes a long tag without overflowing', (tester) async {
+      const longTag =
+          'thisisanextremelylonghashtagthatwouldotherwiseoverflowthechip';
+
+      await tester.pumpWidget(
+        buildSubject(tag: longTag, onTap: () {}, width: 160),
+      );
+
+      expect(tester.takeException(), isNull);
+
+      final tagText = tester.widget<Text>(find.text(longTag));
+      expect(tagText.maxLines, equals(1));
+      expect(tagText.overflow, equals(TextOverflow.ellipsis));
+    });
+  });
+}


### PR DESCRIPTION
Closes #5608

## What

Long hashtags in `SearchTagChip` pushed the chip past its container and
triggered a `RenderFlex` overflow. The tag label is now wrapped in a
`Flexible` constrained to a single line with `TextOverflow.ellipsis`, so
the chip stays within its bounds regardless of tag length.

| Before | After |
| ------ | ------ |
| <img width="322" alt="image" src="https://github.com/user-attachments/assets/ac37ea76-263c-4b82-b0ca-cd4ceda10436" /> |   <img width="322" alt="image" src="https://github.com/user-attachments/assets/b18d4a27-e956-49e8-a27d-04f07563632c" /> |

## Why

The `#` prefix and the tag `Text` sat directly in a `Row`
(`mainAxisSize.min`). With no flex on the tag, a long tag forced the row
wider than the available width and overflowed.

## Changes

- `search_tag_chip.dart`: wrap the tag `Text` in `Flexible` with
  `maxLines: 1` + `overflow: TextOverflow.ellipsis`.
- `search_tag_chip_test.dart` (new): widget tests covering
  - renders the `#` prefix and tag name
  - invokes `onTap` on tap
  - exposes the button semantics label
  - ellipsizes a long tag without overflowing (regression)

## Testing

- `flutter test test/screens/search_results/widgets/search_tag_chip_test.dart` — 4/4 pass
- `flutter analyze` on the changed files — no issues
