### PR TITLE
fix(video-recorder): keep recording stop responsive across slow saves and navigation races

### DIFF
--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:collection/collection.dart';
 import 'package:divine_camera/divine_camera.dart'
     show
         CameraLensMetadata,
@@ -745,19 +746,8 @@ class VideoRecorderBloc
 
     if (state.recordingLockedForNavigation) {
       // The camera was released for navigation while the native start was in
-      // flight. Don't latch a recording the user can never stop — stop the
-      // just-started session best-effort, discard its orphaned file (it is
-      // never surfaced to the user), and return to idle.
-      if (success) {
-        await _discardAbortedRecording(await _cameraService.stopRecording());
-      }
-      emit(
-        state.copyWith(
-          isStartingRecording: false,
-          pendingStopAfterStart: false,
-          recordingState: VideoRecorderState.idle,
-        ),
-      );
+      // flight. Don't latch a recording the user can never stop.
+      await _abortInFlightStartForLock(emit, sessionStarted: success);
       return;
     }
 
@@ -768,6 +758,14 @@ class VideoRecorderBloc
         category: LogCategory.video,
       );
       await WakelockPlus.enable();
+      if (state.recordingLockedForNavigation) {
+        // Navigation locked during the wakelock-enable await, after the native
+        // session started. Abort with the same teardown as the in-flight guard
+        // above rather than arm a clip manager (60fps timer + stopwatch) that
+        // nothing can stop.
+        await _abortInFlightStartForLock(emit, sessionStarted: true);
+        return;
+      }
       clipManager.startRecording();
       if (state.pendingStopAfterStart) {
         // A stop was requested while the native start was still in-flight
@@ -980,100 +978,138 @@ class VideoRecorderBloc
     final workCopyPath = '$videoPath.work.mp4';
     await File(videoPath).copy(workCopyPath);
 
-    final metadata = await ProVideoEditor.instance.getMetadata(
-      EditorVideo.file(File(workCopyPath)),
-    );
-    clipManager.updateClipDuration(clip.id, metadata.duration);
-    Log.debug(
-      '📊 Video duration: ${metadata.duration.inMilliseconds}ms',
-      name: 'VideoRecorderBloc',
-      category: LogCategory.video,
-    );
+    try {
+      final metadata = await ProVideoEditor.instance.getMetadata(
+        EditorVideo.file(File(workCopyPath)),
+      );
+      clipManager.updateClipDuration(clip.id, metadata.duration);
+      Log.debug(
+        '📊 Video duration: ${metadata.duration.inMilliseconds}ms',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
 
-    if (clipManager.clips.length == 1) {
-      if (clip.processingCompleter != null) {
-        unawaited(
-          clip.processingCompleter!.future.then((_) {
-            DivineVideoPlayerController.preload([VideoClip.file(videoPath)]);
-          }),
+      if (clipManager.clips.length == 1) {
+        if (clip.processingCompleter != null) {
+          unawaited(
+            clip.processingCompleter!.future.then((_) {
+              DivineVideoPlayerController.preload([VideoClip.file(videoPath)]);
+            }),
+          );
+        } else {
+          unawaited(
+            DivineVideoPlayerController.preload([VideoClip.file(videoPath)]),
+          );
+        }
+      }
+
+      final effectiveDuration = remainingDuration < metadata.duration
+          ? remainingDuration
+          : metadata.duration;
+      final halfDuration = effectiveDuration ~/ 2;
+      final targetTimestamp =
+          halfDuration < VideoEditorConstants.defaultThumbnailExtractTime
+          ? halfDuration
+          : VideoEditorConstants.defaultThumbnailExtractTime;
+
+      final thumbnailResult = await VideoThumbnailService.extractThumbnail(
+        videoPath: workCopyPath,
+        targetTimestamp: targetTimestamp,
+      );
+
+      if (thumbnailResult != null) {
+        clipManager.updateThumbnail(
+          clipId: clip.id,
+          thumbnailPath: thumbnailResult.path,
+          thumbnailTimestamp: thumbnailResult.timestamp,
+        );
+        Log.debug(
+          '🖼️  Thumbnail generated: ${thumbnailResult.path}',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
         );
       } else {
-        unawaited(
-          DivineVideoPlayerController.preload([VideoClip.file(videoPath)]),
+        Log.warning(
+          '⚠️ Thumbnail generation failed',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
         );
       }
+
+      final ghostFramePath = await VideoThumbnailService.extractLastFrame(
+        videoPath: workCopyPath,
+        videoDuration: metadata.duration,
+      );
+
+      if (ghostFramePath != null) {
+        clipManager.updateGhostFrame(
+          clipId: clip.id,
+          ghostFramePath: ghostFramePath,
+        );
+        Log.debug(
+          '👻 Ghost frame generated: $ghostFramePath',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
+        );
+      } else {
+        Log.warning(
+          '⚠️ Ghost frame generation failed',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
+        );
+      }
+
+      // firstWhereOrNull, not firstWhere: the clip can be removed mid-
+      // enrichment (delete-last-clip undo, capture↔classic switch) while this
+      // detached work runs. A swallowed StateError would skip the work-copy
+      // cleanup below; here the cleanup always runs in the finally.
+      final updatedClip = clipManager.clips.firstWhereOrNull(
+        (c) => c.id == clip.id,
+      );
+      if (updatedClip == null) {
+        Log.warning(
+          '⚠️ Clip ${clip.id} removed before metadata save — skipping '
+          'enriched library save',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
+        );
+        return;
+      }
+      final saved = await clipManager.saveClipToLibrary(updatedClip);
+      if (!saved) {
+        Log.warning(
+          '⚠️ Metadata-enriched clip save to library failed for ${clip.id}',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
+        );
+      }
+    } finally {
+      try {
+        await File(workCopyPath).delete();
+      } catch (_) {}
     }
+  }
 
-    final effectiveDuration = remainingDuration < metadata.duration
-        ? remainingDuration
-        : metadata.duration;
-    final halfDuration = effectiveDuration ~/ 2;
-    final targetTimestamp =
-        halfDuration < VideoEditorConstants.defaultThumbnailExtractTime
-        ? halfDuration
-        : VideoEditorConstants.defaultThumbnailExtractTime;
-
-    final thumbnailResult = await VideoThumbnailService.extractThumbnail(
-      videoPath: workCopyPath,
-      targetTimestamp: targetTimestamp,
+  /// Aborts a native recording session the navigation lock landed on while a
+  /// start was still in flight: best-effort stops + discards the just-started
+  /// session (when [sessionStarted]) and returns to idle. Shared by the two
+  /// lock guards in [_onRecordingStartRequested] — before the native start and
+  /// after the wakelock-enable await — so neither latches a recording the user
+  /// can never stop.
+  Future<void> _abortInFlightStartForLock(
+    Emitter<VideoRecorderBlocState> emit, {
+    required bool sessionStarted,
+  }) async {
+    if (sessionStarted) {
+      await _discardAbortedRecording(await _cameraService.stopRecording());
+    }
+    emit(
+      state.copyWith(
+        isStartingRecording: false,
+        pendingStopAfterStart: false,
+        recordingState: VideoRecorderState.idle,
+      ),
     );
-
-    if (thumbnailResult != null) {
-      clipManager.updateThumbnail(
-        clipId: clip.id,
-        thumbnailPath: thumbnailResult.path,
-        thumbnailTimestamp: thumbnailResult.timestamp,
-      );
-      Log.debug(
-        '🖼️  Thumbnail generated: ${thumbnailResult.path}',
-        name: 'VideoRecorderBloc',
-        category: LogCategory.video,
-      );
-    } else {
-      Log.warning(
-        '⚠️ Thumbnail generation failed',
-        name: 'VideoRecorderBloc',
-        category: LogCategory.video,
-      );
-    }
-
-    final ghostFramePath = await VideoThumbnailService.extractLastFrame(
-      videoPath: workCopyPath,
-      videoDuration: metadata.duration,
-    );
-
-    if (ghostFramePath != null) {
-      clipManager.updateGhostFrame(
-        clipId: clip.id,
-        ghostFramePath: ghostFramePath,
-      );
-      Log.debug(
-        '👻 Ghost frame generated: $ghostFramePath',
-        name: 'VideoRecorderBloc',
-        category: LogCategory.video,
-      );
-    } else {
-      Log.warning(
-        '⚠️ Ghost frame generation failed',
-        name: 'VideoRecorderBloc',
-        category: LogCategory.video,
-      );
-    }
-
-    final updatedClip = clipManager.clips.firstWhere(
-      (c) => c.id == clip.id,
-    );
-    final saved = await clipManager.saveClipToLibrary(updatedClip);
-    if (!saved) {
-      Log.warning(
-        '⚠️ Metadata-enriched clip save to library failed for ${clip.id}',
-        name: 'VideoRecorderBloc',
-        category: LogCategory.video,
-      );
-    }
-    try {
-      await File(workCopyPath).delete();
-    } catch (_) {}
   }
 
   /// Best-effort deletes the orphaned file from a recording aborted by the

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -241,14 +241,6 @@ class VideoRecorderBloc
   Timer? _zoomIndicatorTimer;
   bool _remoteRecordControlEnabled = false;
 
-  /// Set while the camera is released for a navigation push (editor, metadata,
-  /// library) and cleared on the next re-initialization. Gates recording
-  /// start/toggle so a volume / Bluetooth trigger that races the navigation
-  /// can't begin a recording on a camera that is being torn down — which would
-  /// otherwise strand the recorder, since an in-flight native start hung behind
-  /// the disposed camera permanently occupies the `sequential()` start bucket.
-  bool _recordingLockedForNavigation = false;
-
   /// How long the zoom ruler stays visible after the last pinch activity
   /// before the auto-hide timer clears it.
   static const _zoomIndicatorHideDelay = Duration(milliseconds: 1000);
@@ -273,6 +265,16 @@ class VideoRecorderBloc
     VideoRecorderInitializeRequested event,
     Emitter<VideoRecorderBlocState> emit,
   ) async {
+    // Re-initialization marks the end of any navigation teardown, so release
+    // the navigation recording lock up front — this covers the camera-init
+    // error returns below too, which previously left the recorder locked until
+    // a later successful init. The camera isn't usable yet (`canRecord` stays
+    // false until initialize() completes), so clearing the lock here cannot let
+    // a racing trigger start a recording on a torn-down camera.
+    if (state.recordingLockedForNavigation) {
+      emit(state.copyWith(recordingLockedForNavigation: false));
+    }
+
     final prefs = _readSharedPreferences();
 
     final savedMode = VideoRecorderMode.fromName(
@@ -325,10 +327,6 @@ class VideoRecorderBloc
       emit(state.copyWith(initializationErrorMessage: error));
       return;
     }
-
-    // Camera is back — release the navigation recording lock set when it was
-    // paused for the push (see [_onCameraPausedForNavigation]).
-    _recordingLockedForNavigation = false;
 
     final clips = _readClipManager().clips;
     _emitCameraSync(
@@ -606,7 +604,7 @@ class VideoRecorderBloc
       return;
     }
 
-    if (_recordingLockedForNavigation) {
+    if (state.recordingLockedForNavigation) {
       Log.debug(
         '🎮 toggleRecording ignored - recording locked for navigation',
         name: 'VideoRecorderBloc',
@@ -631,7 +629,7 @@ class VideoRecorderBloc
     final clipManager = _readClipManager();
     final remainingDuration = clipManager.remainingDuration;
 
-    if (_recordingLockedForNavigation ||
+    if (state.recordingLockedForNavigation ||
         !_cameraService.canRecord ||
         state.isRecording ||
         state.isStartingRecording ||
@@ -714,7 +712,7 @@ class VideoRecorderBloc
       return;
     }
 
-    if (_recordingLockedForNavigation) {
+    if (state.recordingLockedForNavigation) {
       // Navigation released (or is releasing) the camera before the native
       // start ran — abort to idle instead of recording on a camera that is
       // about to be torn down.
@@ -745,12 +743,13 @@ class VideoRecorderBloc
           : null,
     );
 
-    if (_recordingLockedForNavigation) {
+    if (state.recordingLockedForNavigation) {
       // The camera was released for navigation while the native start was in
       // flight. Don't latch a recording the user can never stop — stop the
-      // just-started session best-effort and return to idle.
+      // just-started session best-effort, discard its orphaned file (it is
+      // never surfaced to the user), and return to idle.
       if (success) {
-        await _cameraService.stopRecording();
+        await _discardAbortedRecording(await _cameraService.stopRecording());
       }
       emit(
         state.copyWith(
@@ -1077,6 +1076,22 @@ class VideoRecorderBloc
     } catch (_) {}
   }
 
+  /// Best-effort deletes the orphaned file from a recording aborted by the
+  /// navigation lock. Such a recording is never added to the library or shown
+  /// to the user, so without this its file would leak on disk.
+  Future<void> _discardAbortedRecording(EditorVideo? video) async {
+    if (video == null) return;
+    try {
+      await File(await video.safeFilePath()).delete();
+    } catch (error) {
+      Log.debug(
+        '⚠️ Failed to delete aborted recording file: $error',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+    }
+  }
+
   void _onLongPressZoomStarted(
     VideoRecorderLongPressZoomStarted event,
     Emitter<VideoRecorderBlocState> emit,
@@ -1260,7 +1275,6 @@ class VideoRecorderBloc
   /// the dispose (if any) happens after — so it never races the native start.
   /// The lock is cleared on the next [VideoRecorderInitializeRequested].
   void _lockRecordingForNavigation(Emitter<VideoRecorderBlocState> emit) {
-    _recordingLockedForNavigation = true;
     _cameraService.onRemoteRecordTrigger = null;
     if (state.isRecording || state.isStartingRecording) {
       _readClipManager()
@@ -1268,12 +1282,15 @@ class VideoRecorderBloc
         ..resetRecording();
       emit(
         state.copyWith(
+          recordingLockedForNavigation: true,
           recordingState: VideoRecorderState.idle,
           isStartingRecording: false,
           isStoppingRecording: false,
           pendingStopAfterStart: false,
         ),
       );
+    } else {
+      emit(state.copyWith(recordingLockedForNavigation: true));
     }
   }
 

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -20,6 +20,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
@@ -207,6 +208,9 @@ class VideoRecorderBloc
     on<VideoRecorderZoomedByLongPress>(_onZoomedByLongPress);
     on<VideoRecorderScaleStarted>(_onScaleStarted);
     on<VideoRecorderScaleUpdated>(_onScaleUpdated);
+    on<VideoRecorderRecordingLockedForNavigation>(
+      _onRecordingLockedForNavigation,
+    );
     on<VideoRecorderCameraPausedForNavigation>(_onCameraPausedForNavigation);
     on<VideoRecorderRecorderModeSet>(_onRecorderModeSet);
     on<VideoRecorderTimerCycled>(_onTimerCycled);
@@ -236,6 +240,14 @@ class VideoRecorderBloc
   Timer? _focusPointTimer;
   Timer? _zoomIndicatorTimer;
   bool _remoteRecordControlEnabled = false;
+
+  /// Set while the camera is released for a navigation push (editor, metadata,
+  /// library) and cleared on the next re-initialization. Gates recording
+  /// start/toggle so a volume / Bluetooth trigger that races the navigation
+  /// can't begin a recording on a camera that is being torn down — which would
+  /// otherwise strand the recorder, since an in-flight native start hung behind
+  /// the disposed camera permanently occupies the `sequential()` start bucket.
+  bool _recordingLockedForNavigation = false;
 
   /// How long the zoom ruler stays visible after the last pinch activity
   /// before the auto-hide timer clears it.
@@ -313,6 +325,10 @@ class VideoRecorderBloc
       emit(state.copyWith(initializationErrorMessage: error));
       return;
     }
+
+    // Camera is back — release the navigation recording lock set when it was
+    // paused for the push (see [_onCameraPausedForNavigation]).
+    _recordingLockedForNavigation = false;
 
     final clips = _readClipManager().clips;
     _emitCameraSync(
@@ -590,6 +606,15 @@ class VideoRecorderBloc
       return;
     }
 
+    if (_recordingLockedForNavigation) {
+      Log.debug(
+        '🎮 toggleRecording ignored - recording locked for navigation',
+        name: 'VideoRecorderBloc',
+        category: LogCategory.video,
+      );
+      return;
+    }
+
     switch (state.recordingState) {
       case VideoRecorderState.idle:
         add(const VideoRecorderRecordingStartRequested());
@@ -606,7 +631,8 @@ class VideoRecorderBloc
     final clipManager = _readClipManager();
     final remainingDuration = clipManager.remainingDuration;
 
-    if (!_cameraService.canRecord ||
+    if (_recordingLockedForNavigation ||
+        !_cameraService.canRecord ||
         state.isRecording ||
         state.isStartingRecording ||
         state.isStoppingRecording ||
@@ -688,6 +714,20 @@ class VideoRecorderBloc
       return;
     }
 
+    if (_recordingLockedForNavigation) {
+      // Navigation released (or is releasing) the camera before the native
+      // start ran — abort to idle instead of recording on a camera that is
+      // about to be torn down.
+      emit(
+        state.copyWith(
+          isStartingRecording: false,
+          pendingStopAfterStart: false,
+          recordingState: VideoRecorderState.idle,
+        ),
+      );
+      return;
+    }
+
     await _prepareSoundForPlayback();
 
     emit(state.copyWith(recordingState: VideoRecorderState.recording));
@@ -704,6 +744,23 @@ class VideoRecorderBloc
           ? remainingDuration
           : null,
     );
+
+    if (_recordingLockedForNavigation) {
+      // The camera was released for navigation while the native start was in
+      // flight. Don't latch a recording the user can never stop — stop the
+      // just-started session best-effort and return to idle.
+      if (success) {
+        await _cameraService.stopRecording();
+      }
+      emit(
+        state.copyWith(
+          isStartingRecording: false,
+          pendingStopAfterStart: false,
+          recordingState: VideoRecorderState.idle,
+        ),
+      );
+      return;
+    }
 
     if (success) {
       Log.info(
@@ -878,6 +935,48 @@ class VideoRecorderBloc
       category: LogCategory.video,
     );
 
+    // Clip post-processing — real duration, thumbnail, ghost frame and the
+    // metadata-enriched library save — is deliberately detached (not awaited).
+    // This handler runs in the `sequential()` stop bucket, so awaiting the
+    // post-processing would serialize it ahead of the *next* stop request: a
+    // slow library save or metadata pass (observed in the field taking ~100s)
+    // would leave the user unable to stop their next recording until it
+    // finished. The work mutates the clip in place on the clip manager (which
+    // the UI observes) and re-saves it, so it is safe to run detached. The
+    // bare clip was already persisted by the unawaited save above.
+    unawaited(
+      _enrichAndSaveClip(
+        videoResult: videoResult,
+        clip: clip,
+        clipManager: clipManager,
+        remainingDuration: remainingDuration,
+      ).catchError((Object error, StackTrace stackTrace) {
+        // Detached work must not escape as an unhandled async error. The bare
+        // clip is already saved, so a failure here only loses the enriched
+        // metadata, not the recording.
+        Log.error(
+          '⚠️ Clip post-processing failed for ${clip.id}',
+          name: 'VideoRecorderBloc',
+          category: LogCategory.video,
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }),
+    );
+  }
+
+  /// Enriches a freshly recorded [clip] with its real duration, thumbnail and
+  /// ghost frame, then re-saves the enriched clip to the library.
+  ///
+  /// Runs detached (fire-and-forget) from [_onRecordingStopRequested] so the
+  /// `sequential()` stop handler returns immediately and never blocks a
+  /// following stop request behind this potentially slow work.
+  Future<void> _enrichAndSaveClip({
+    required EditorVideo videoResult,
+    required DivineVideoClip clip,
+    required ClipManagerNotifier clipManager,
+    required Duration remainingDuration,
+  }) async {
     final videoPath = await videoResult.safeFilePath();
     final workCopyPath = '$videoPath.work.mp4';
     await File(videoPath).copy(workCopyPath);
@@ -1131,6 +1230,13 @@ class VideoRecorderBloc
     emit(state.copyWith(showZoomIndicator: false));
   }
 
+  void _onRecordingLockedForNavigation(
+    VideoRecorderRecordingLockedForNavigation event,
+    Emitter<VideoRecorderBlocState> emit,
+  ) {
+    _lockRecordingForNavigation(emit);
+  }
+
   Future<void> _onCameraPausedForNavigation(
     VideoRecorderCameraPausedForNavigation event,
     Emitter<VideoRecorderBlocState> emit,
@@ -1140,7 +1246,35 @@ class VideoRecorderBloc
       name: 'VideoRecorderBloc',
       category: LogCategory.video,
     );
+    // Idempotent with VideoRecorderRecordingLockedForNavigation (which the View
+    // dispatches first, before the push transition). Re-asserting here keeps
+    // the recorder safe even if only the pause event is dispatched.
+    _lockRecordingForNavigation(emit);
     await _cameraService.dispose();
+  }
+
+  /// Locks recording for a navigation push: sets the lock, detaches the remote
+  /// (volume / Bluetooth) trigger, and resets any in-flight / active recording
+  /// to idle so a trigger that raced the navigation can't leave a recording the
+  /// user can never stop. Runs synchronously while the camera is still live —
+  /// the dispose (if any) happens after — so it never races the native start.
+  /// The lock is cleared on the next [VideoRecorderInitializeRequested].
+  void _lockRecordingForNavigation(Emitter<VideoRecorderBlocState> emit) {
+    _recordingLockedForNavigation = true;
+    _cameraService.onRemoteRecordTrigger = null;
+    if (state.isRecording || state.isStartingRecording) {
+      _readClipManager()
+        ..stopRecording()
+        ..resetRecording();
+      emit(
+        state.copyWith(
+          recordingState: VideoRecorderState.idle,
+          isStartingRecording: false,
+          isStoppingRecording: false,
+          pendingStopAfterStart: false,
+        ),
+      );
+    }
   }
 
   void _onRecorderModeSet(

--- a/mobile/lib/blocs/video_recorder/video_recorder_event.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_event.dart
@@ -212,6 +212,19 @@ final class VideoRecorderCameraPausedForNavigation extends VideoRecorderEvent {
   const VideoRecorderCameraPausedForNavigation();
 }
 
+/// Locks recording and detaches the remote (volume / Bluetooth) trigger the
+/// moment a navigation push away from the recorder begins — while the camera is
+/// still live, before [VideoRecorderCameraPausedForNavigation] disposes it.
+///
+/// Dispatched at the start of a navigation flow so a remote trigger that races
+/// the push can't start (or leave) a recording on a camera that is about to be
+/// torn down, which would otherwise strand the recorder. Cleared by
+/// [VideoRecorderInitializeRequested] on return.
+final class VideoRecorderRecordingLockedForNavigation
+    extends VideoRecorderEvent {
+  const VideoRecorderRecordingLockedForNavigation();
+}
+
 /// Sets the recorder mode. Capture↔classic transitions clear recorded
 /// clips and reset the editor; transitions involving
 /// [VideoRecorderMode.upload] preserve both.

--- a/mobile/lib/blocs/video_recorder/video_recorder_state.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_state.dart
@@ -38,6 +38,7 @@ class VideoRecorderBlocState extends Equatable {
     this.isStartingRecording = false,
     this.isStoppingRecording = false,
     this.pendingStopAfterStart = false,
+    this.recordingLockedForNavigation = false,
     this.baseZoomLevel = 1.0,
     this.snappedTo1x = false,
     this.lastRawZoom = 1.0,
@@ -136,6 +137,18 @@ class VideoRecorderBlocState extends Equatable {
   /// rather than an indefinite recording (#hold-to-record-brief-press).
   final bool pendingStopAfterStart;
 
+  /// True while the camera is released for a navigation push (editor, metadata,
+  /// library) and cleared on the next re-initialization.
+  ///
+  /// Gates recording start/toggle so a volume / Bluetooth trigger that races
+  /// the navigation can't begin a recording on a camera that is being torn
+  /// down — which would otherwise strand the recorder, since an in-flight
+  /// native start hung behind the disposed camera permanently occupies the
+  /// `sequential()` start bucket. Held in the state stream (not a private
+  /// field) per `state_management.md`, alongside the other recording-lifecycle
+  /// flags.
+  final bool recordingLockedForNavigation;
+
   /// Zoom level captured at the start of the current pinch gesture.
   ///
   /// Used to compute relative zoom from pinch scale. Moved out of the
@@ -202,6 +215,7 @@ class VideoRecorderBlocState extends Equatable {
     bool? isStartingRecording,
     bool? isStoppingRecording,
     bool? pendingStopAfterStart,
+    bool? recordingLockedForNavigation,
     double? baseZoomLevel,
     bool? snappedTo1x,
     double? lastRawZoom,
@@ -241,6 +255,8 @@ class VideoRecorderBlocState extends Equatable {
       isStoppingRecording: isStoppingRecording ?? this.isStoppingRecording,
       pendingStopAfterStart:
           pendingStopAfterStart ?? this.pendingStopAfterStart,
+      recordingLockedForNavigation:
+          recordingLockedForNavigation ?? this.recordingLockedForNavigation,
       baseZoomLevel: baseZoomLevel ?? this.baseZoomLevel,
       snappedTo1x: snappedTo1x ?? this.snappedTo1x,
       lastRawZoom: lastRawZoom ?? this.lastRawZoom,
@@ -276,6 +292,7 @@ class VideoRecorderBlocState extends Equatable {
     isStartingRecording,
     isStoppingRecording,
     pendingStopAfterStart,
+    recordingLockedForNavigation,
     baseZoomLevel,
     snappedTo1x,
     lastRawZoom,

--- a/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_navigation.dart
@@ -62,6 +62,12 @@ Future<void> openVideoEditorFromRecorder(
     ref.read(videoEditorProvider.notifier).startRenderVideo();
   }
 
+  // Lock recording before the push so a volume / Bluetooth trigger that races
+  // the navigation can't start (or leave) a recording on the camera we are
+  // about to release. The camera is still live here, so the lock can reset any
+  // in-flight recording cleanly — without racing the deferred dispose below.
+  bloc.add(const VideoRecorderRecordingLockedForNavigation());
+
   final navigation = recorderMode.hasVideoEditor
       ? context.push(VideoEditorScreen.path)
       : context.push(VideoMetadataScreen.path);
@@ -81,6 +87,12 @@ Future<void> openRecorderLibrary(BuildContext context, WidgetRef ref) async {
   if (!context.mounted) return;
 
   final bloc = context.read<VideoRecorderBloc>();
+
+  // Lock recording before the push so a volume / Bluetooth trigger that races
+  // the navigation can't start (or leave) a recording on the camera we are
+  // about to release. The camera is still live here, so the lock can reset any
+  // in-flight recording cleanly — without racing the deferred dispose below.
+  bloc.add(const VideoRecorderRecordingLockedForNavigation());
 
   final navigation = context.pushNamed(LibraryScreen.clipsOnlyRouteName);
 

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_camera/divine_camera.dart';
@@ -1201,6 +1202,7 @@ void main() {
 
     group('VideoRecorderRecordingLockedForNavigation → recording lock', () {
       late Completer<bool> startGate;
+      late File orphanFile;
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'resets an active recording to idle without disposing the camera — the '
@@ -1276,6 +1278,45 @@ void main() {
           verify(() => cameraService.stopRecording()).called(1);
           // No dispose during the abort — the single dispose is close().
           verify(() => cameraService.dispose()).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'discards the orphaned file of an aborted in-flight start — the '
+        'recording is never surfaced, so its file must not leak on disk',
+        setUp: () {
+          startGate = Completer<bool>();
+          when(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
+            ),
+          ).thenAnswer((_) => startGate.future);
+          // The aborted native session yields a real file that, without the
+          // discard, would be orphaned (never added to the library).
+          orphanFile = File(
+            '${Directory.systemTemp.createTempSync('rec_abort').path}/clip.mp4',
+          )..writeAsStringSync('aborted recording');
+          final aborted = _MockEditorVideo();
+          when(aborted.safeFilePath).thenAnswer((_) async => orphanFile.path);
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => aborted);
+        },
+        build: buildBloc,
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingStartRequested());
+          await pumpEventQueue();
+          bloc.add(const VideoRecorderRecordingLockedForNavigation());
+          await pumpEventQueue();
+          // Native start finally reports success after the lock landed — the
+          // handler stops it and must delete the orphaned file.
+          startGate.complete(true);
+          await pumpEventQueue();
+        },
+        verify: (_) {
+          verify(() => cameraService.stopRecording()).called(1);
+          expect(orphanFile.existsSync(), isFalse);
+          orphanFile.parent.deleteSync(recursive: true);
         },
       );
     });
@@ -1387,6 +1428,28 @@ void main() {
               enableAutoLensSwitch: true,
             ),
           ).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'releases the navigation recording lock even when re-init fails — a '
+        'failed camera return must not leave the recorder permanently locked',
+        setUp: () {
+          when(() => cameraService.isInitialized).thenReturn(false);
+          when(
+            () => cameraService.initializationError,
+          ).thenReturn('boom');
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(recordingLockedForNavigation: true),
+          ),
+        act: (bloc) => bloc.add(const VideoRecorderInitializeRequested()),
+        verify: (bloc) {
+          // Confirm we actually hit the init-failure return path…
+          expect(bloc.state.initializationErrorMessage, isNotNull);
+          // …and the lock was still cleared up front.
+          expect(bloc.state.recordingLockedForNavigation, isFalse);
         },
       );
 

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_camera/divine_camera.dart';
@@ -17,10 +18,14 @@ import 'package:openvine/models/video_recorder/video_recorder_timer_duration.dar
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
+
+import '../../mocks/mock_path_provider_platform.dart';
 
 class _MockCameraService extends Mock implements CameraService {}
 
@@ -58,6 +63,25 @@ class _ThrowingWakelockDisablePlatform extends WakelockPlusPlatformInterface {
   Future<bool> get enabled async => false;
 }
 
+/// Blocks `WakelockPlus.enable()` until [enableGate] completes, so a test can
+/// land an event in the window where the start handler awaits the wakelock
+/// after the native session has already started.
+class _GatedWakelockPlatform extends WakelockPlusPlatformInterface {
+  final Completer<void> enableGate = Completer<void>();
+
+  @override
+  Future<void> toggle({required bool enable}) async {
+    if (enable) await enableGate.future;
+  }
+
+  @override
+  Future<bool> get enabled async => false;
+}
+
+class _MockProVideoEditor extends Mock
+    with MockPlatformInterfaceMixin
+    implements ProVideoEditor {}
+
 void main() {
   late _MockCameraService cameraService;
   late _MockClipManager clipManager;
@@ -75,6 +99,20 @@ void main() {
     registerFallbackValue(Offset.zero);
     registerFallbackValue(EditorVideo.file('/fallback.mp4'));
     registerFallbackValue(model.AspectRatio.vertical);
+    registerFallbackValue(
+      ThumbnailConfigs(
+        video: EditorVideo.file('/fallback.mp4'),
+        outputSize: const Size(1, 1),
+        timestamps: const [Duration.zero],
+      ),
+    );
+    registerFallbackValue(
+      SingleThumbnailConfigs(
+        video: EditorVideo.file('/fallback.mp4'),
+        outputSize: const Size(1, 1),
+        position: ThumbnailPosition.last,
+      ),
+    );
     registerFallbackValue(
       DivineVideoClip(
         id: 'fallback',
@@ -1116,6 +1154,103 @@ void main() {
       );
     });
 
+    group('detached enrichment → clip removed mid-enrichment', () {
+      late Directory docsDir;
+      late File recordingFile;
+      late ProVideoEditor originalProVideoEditor;
+      late PathProviderPlatform originalPathProvider;
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'skips the enriched save and still deletes the work copy when the clip '
+        'is gone before the metadata save — the work copy must not leak',
+        setUp: () {
+          // Stub path provider + ProVideoEditor so the detached enrichment runs
+          // to completion (thumbnail + ghost frame succeed on the first try, no
+          // retries) and reaches the clip lookup.
+          docsDir = Directory.systemTemp.createTempSync('rec_enrich_docs');
+          originalPathProvider = PathProviderPlatform.instance;
+          PathProviderPlatform.instance = MockPathProviderPlatform()
+            ..setApplicationDocumentsPath(docsDir.path)
+            ..setTemporaryPath(docsDir.path);
+
+          final editor = _MockProVideoEditor();
+          when(() => editor.getMetadata(any())).thenAnswer(
+            (_) async => VideoMetadata.fromMap(const {'duration': 2000}, 'mp4'),
+          );
+          when(
+            () => editor.getThumbnails(any()),
+          ).thenAnswer(
+            (_) async => [
+              Uint8List.fromList(const [1, 2, 3]),
+            ],
+          );
+          when(
+            () => editor.getSingleThumbnail(any()),
+          ).thenAnswer((_) async => Uint8List.fromList(const [1, 2, 3]));
+          originalProVideoEditor = ProVideoEditor.instance;
+          ProVideoEditor.instance = editor;
+
+          recordingFile = File('${docsDir.path}/recording.mp4')
+            ..writeAsStringSync('recorded clip');
+          final recorded = _MockEditorVideo();
+          when(
+            recorded.safeFilePath,
+          ).thenAnswer((_) async => recordingFile.path);
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => recorded);
+          when(
+            () => clipManager.addClip(
+              video: any(named: 'video'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              lensMetadata: any(named: 'lensMetadata'),
+              limitClipDuration: any(named: 'limitClipDuration'),
+            ),
+          ).thenReturn(
+            DivineVideoClip(
+              id: 'removed-clip',
+              video: recorded,
+              duration: const Duration(seconds: 2),
+              recordedAt: DateTime(2024),
+              targetAspectRatio: model.AspectRatio.vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          );
+          // clips stays empty (the shared setUp default), modelling a clip that
+          // was removed before the detached enrichment looks it up
+          // (delete-last-clip undo, capture↔classic switch).
+          when(
+            () => clipManager.saveClipToLibrary(any()),
+          ).thenAnswer((_) async => true);
+        },
+        tearDown: () {
+          ProVideoEditor.instance = originalProVideoEditor;
+          PathProviderPlatform.instance = originalPathProvider;
+          if (docsDir.existsSync()) docsDir.deleteSync(recursive: true);
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingStopRequested());
+          await pumpEventQueue(times: 100);
+        },
+        verify: (_) {
+          // Only the bare clip save ran; the enriched save was skipped because
+          // the clip was gone (firstWhereOrNull → null, not a thrown
+          // StateError swallowed by catchError).
+          verify(() => clipManager.saveClipToLibrary(any())).called(1);
+          // The work copy is always cleaned up in the finally — before the fix
+          // the firstWhere StateError jumped past the delete and leaked it.
+          expect(File('${recordingFile.path}.work.mp4').existsSync(), isFalse);
+        },
+      );
+    });
+
     group('VideoRecorderCameraPausedForNavigation → recording lock', () {
       late Completer<bool> startGate;
 
@@ -1203,6 +1338,7 @@ void main() {
     group('VideoRecorderRecordingLockedForNavigation → recording lock', () {
       late Completer<bool> startGate;
       late File orphanFile;
+      late _GatedWakelockPlatform gatedWakelock;
 
       blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
         'resets an active recording to idle without disposing the camera — the '
@@ -1317,6 +1453,55 @@ void main() {
           verify(() => cameraService.stopRecording()).called(1);
           expect(orphanFile.existsSync(), isFalse);
           orphanFile.parent.deleteSync(recursive: true);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'aborts a started recording when navigation locks during the '
+        'wakelock-enable await — the clip manager timer is never armed and '
+        "the just-started session's file is discarded",
+        setUp: () {
+          gatedWakelock = _GatedWakelockPlatform();
+          wakelockPlusPlatformInstance = gatedWakelock;
+          when(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
+            ),
+          ).thenAnswer((_) async => true);
+          orphanFile = File(
+            '${Directory.systemTemp.createTempSync('rec_wakelock').path}'
+            '/clip.mp4',
+          )..writeAsStringSync('aborted recording');
+          final aborted = _MockEditorVideo();
+          when(aborted.safeFilePath).thenAnswer((_) async => orphanFile.path);
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => aborted);
+        },
+        tearDown: () {
+          wakelockPlusPlatformInstance = _FakeWakelockPlatform();
+          orphanFile.parent.deleteSync(recursive: true);
+        },
+        build: buildBloc,
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingStartRequested());
+          await pumpEventQueue();
+          // The native start has returned true; the handler is now parked on
+          // the gated WakelockPlus.enable() await. The lock lands in that
+          // window, before clipManager.startRecording() runs.
+          bloc.add(const VideoRecorderRecordingLockedForNavigation());
+          await pumpEventQueue();
+          gatedWakelock.enableGate.complete();
+          await pumpEventQueue();
+        },
+        verify: (bloc) {
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          // The re-arm after the await never happened — without the post-await
+          // re-check this would start a 60fps timer that nothing cancels.
+          verifyNever(() => clipManager.startRecording());
+          // The just-started native session was stopped and its file discarded.
+          verify(() => cameraService.stopRecording()).called(1);
+          expect(orphanFile.existsSync(), isFalse);
         },
       );
     });

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_camera/divine_camera.dart';
 import 'package:flutter/widgets.dart';
@@ -5,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model show AspectRatio;
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
+import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/models/video_recorder/video_recorder_flash_mode.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
@@ -13,6 +16,7 @@ import 'package:openvine/models/video_recorder/video_recorder_timer_duration.dar
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/video_recorder/camera/camera_base_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
@@ -24,6 +28,8 @@ class _MockClipManager extends Mock implements ClipManagerNotifier {}
 class _MockVideoEditor extends Mock implements VideoEditorNotifier {}
 
 class _MockSharedPreferences extends Mock implements SharedPreferences {}
+
+class _MockEditorVideo extends Mock implements EditorVideo {}
 
 /// A fake wakelock platform —
 /// production code calls `WakelockPlus.enable/disable` around every
@@ -66,6 +72,18 @@ void main() {
     registerFallbackValue(DivineVideoQuality.fhd);
     registerFallbackValue(AppLifecycleState.resumed);
     registerFallbackValue(Offset.zero);
+    registerFallbackValue(EditorVideo.file('/fallback.mp4'));
+    registerFallbackValue(model.AspectRatio.vertical);
+    registerFallbackValue(
+      DivineVideoClip(
+        id: 'fallback',
+        video: EditorVideo.file('/fallback.mp4'),
+        duration: Duration.zero,
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.vertical,
+        originalAspectRatio: 1,
+      ),
+    );
   });
 
   setUp(() {
@@ -1027,6 +1045,237 @@ void main() {
               maxDuration: any(named: 'maxDuration'),
             ),
           ).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'a hung clip post-processing does not strand the next stop — the '
+        'detached enrichment must not hold the sequential() stop bucket',
+        setUp: () {
+          // The first stop yields a clip whose post-processing hangs forever
+          // at its first await (safeFilePath). Before the fix that await ran
+          // *inside* the sequential() stop handler, so the handler never
+          // completed and the next stop could never be processed — the field
+          // symptom was a volume-button stop that did nothing for ~1 minute.
+          final hangingVideo = _MockEditorVideo();
+          when(
+            hangingVideo.safeFilePath,
+          ).thenAnswer((_) => Completer<String>().future);
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => hangingVideo);
+          when(
+            () => clipManager.addClip(
+              video: any(named: 'video'),
+              originalAspectRatio: any(named: 'originalAspectRatio'),
+              targetAspectRatio: any(named: 'targetAspectRatio'),
+              lensMetadata: any(named: 'lensMetadata'),
+              limitClipDuration: any(named: 'limitClipDuration'),
+            ),
+          ).thenReturn(
+            DivineVideoClip(
+              id: 'hung-clip',
+              video: hangingVideo,
+              duration: const Duration(seconds: 2),
+              recordedAt: DateTime(2024),
+              targetAspectRatio: model.AspectRatio.vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          );
+          when(
+            () => clipManager.saveClipToLibrary(any()),
+          ).thenAnswer((_) async => true);
+        },
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingStopRequested());
+          await pumpEventQueue();
+          // The first stop's enrichment is now hanging in the background.
+          // Re-arm to recording and request a second stop: it must still be
+          // honored rather than queued behind the hung post-processing.
+          bloc.emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          );
+          bloc.add(const VideoRecorderRecordingStopRequested());
+          await pumpEventQueue();
+        },
+        verify: (_) {
+          // Both stops reached the native stop — the second was not stranded
+          // behind the first stop's hung post-processing in the sequential()
+          // bucket.
+          verify(() => cameraService.stopRecording()).called(2);
+        },
+      );
+    });
+
+    group('VideoRecorderCameraPausedForNavigation → recording lock', () {
+      late Completer<bool> startGate;
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'resets an active recording to idle when the camera is released for '
+        'navigation, so it cannot survive as an unstoppable session',
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) => bloc.add(const VideoRecorderCameraPausedForNavigation()),
+        verify: (bloc) {
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          expect(bloc.state.isStartingRecording, isFalse);
+          verify(() => clipManager.stopRecording()).called(1);
+          verify(() => clipManager.resetRecording()).called(1);
+          // Disposed by the pause handler (the bloc also disposes on close()).
+          verify(() => cameraService.dispose());
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'rejects a record start while locked for navigation — a volume / BLE '
+        'trigger that races the push must not start a recording',
+        build: buildBloc,
+        act: (bloc) async {
+          bloc.add(const VideoRecorderCameraPausedForNavigation());
+          await pumpEventQueue();
+          bloc.add(const VideoRecorderRecordingStartRequested());
+          await pumpEventQueue();
+        },
+        verify: (_) {
+          // canRecord is still true on the mock, so only the navigation lock
+          // can stop the start from reaching the camera.
+          verifyNever(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'aborts an in-flight start when the camera is released mid-start, '
+        'returning to idle instead of latching an unstoppable recording',
+        setUp: () {
+          // The native start hangs until [startGate] completes, modelling a
+          // slow start that is still in flight when navigation releases the
+          // camera.
+          startGate = Completer<bool>();
+          when(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
+            ),
+          ).thenAnswer((_) => startGate.future);
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => null);
+        },
+        build: buildBloc,
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingStartRequested());
+          await pumpEventQueue();
+          // Camera released for navigation while the native start is pending.
+          bloc.add(const VideoRecorderCameraPausedForNavigation());
+          await pumpEventQueue();
+          // Native start finally reports success — the handler must see the
+          // lock and abort rather than latch a recording.
+          startGate.complete(true);
+          await pumpEventQueue();
+        },
+        verify: (bloc) {
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          expect(bloc.state.isStartingRecording, isFalse);
+          // Best-effort stop of the just-started native session.
+          verify(() => cameraService.stopRecording()).called(1);
+          // Disposed by the pause handler (the bloc also disposes on close()).
+          verify(() => cameraService.dispose());
+        },
+      );
+    });
+
+    group('VideoRecorderRecordingLockedForNavigation → recording lock', () {
+      late Completer<bool> startGate;
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'resets an active recording to idle without disposing the camera — the '
+        'camera is released later by CameraPausedForNavigation',
+        build: () => buildBloc()
+          ..emit(
+            const VideoRecorderBlocState(
+              recordingState: VideoRecorderState.recording,
+            ),
+          ),
+        act: (bloc) =>
+            bloc.add(const VideoRecorderRecordingLockedForNavigation()),
+        verify: (bloc) {
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          expect(bloc.state.isStartingRecording, isFalse);
+          verify(() => clipManager.stopRecording()).called(1);
+          verify(() => clipManager.resetRecording()).called(1);
+          // The lock itself does NOT dispose — the single dispose is the
+          // bloc's own close() teardown.
+          verify(() => cameraService.dispose()).called(1);
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'rejects a record start while locked — a volume / BLE trigger that '
+        'races the push must not start a recording',
+        build: buildBloc,
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingLockedForNavigation());
+          await pumpEventQueue();
+          bloc.add(const VideoRecorderRecordingStartRequested());
+          await pumpEventQueue();
+        },
+        verify: (_) {
+          verifyNever(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
+            ),
+          );
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'aborts an in-flight start when navigation locks, on the still-live '
+        'camera — the start resolves and returns to idle, no dispose race',
+        setUp: () {
+          startGate = Completer<bool>();
+          when(
+            () => cameraService.startRecording(
+              maxDuration: any(named: 'maxDuration'),
+            ),
+          ).thenAnswer((_) => startGate.future);
+          when(
+            () => cameraService.stopRecording(),
+          ).thenAnswer((_) async => null);
+        },
+        build: buildBloc,
+        act: (bloc) async {
+          bloc.add(const VideoRecorderRecordingStartRequested());
+          await pumpEventQueue();
+          // Navigation locks while the native start is still pending — the
+          // camera is NOT disposed here (that is deferred), so the start can
+          // resolve and abort cleanly.
+          bloc.add(const VideoRecorderRecordingLockedForNavigation());
+          await pumpEventQueue();
+          startGate.complete(true);
+          await pumpEventQueue();
+        },
+        verify: (bloc) {
+          expect(bloc.state.recordingState, VideoRecorderState.idle);
+          expect(bloc.state.isStartingRecording, isFalse);
+          // Best-effort stop of the just-started native session.
+          verify(() => cameraService.stopRecording()).called(1);
+          // No dispose during the abort — the single dispose is close().
+          verify(() => cameraService.dispose()).called(1);
         },
       );
     });

--- a/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_navigation_test.dart
@@ -132,6 +132,14 @@ void main() {
 
         expect(find.text('editor'), findsOneWidget);
         expect(fakeEditor.saveAsDraftCalled, isFalse);
+        // The lock guards the camera against a volume / BLE trigger racing the
+        // push — it is the feature's only production trigger, so assert it
+        // fired (deleting it would silently disable the lock).
+        verify(
+          () => recorderBloc.add(
+            const VideoRecorderRecordingLockedForNavigation(),
+          ),
+        ).called(1);
       });
 
       testWidgets('openRecorderLibrary proceeds to the library '
@@ -144,6 +152,14 @@ void main() {
 
         expect(find.text('library'), findsOneWidget);
         expect(fakeEditor.saveAsDraftCalled, isFalse);
+        // The lock guards the camera against a volume / BLE trigger racing the
+        // push — it is the feature's only production trigger, so assert it
+        // fired (deleting it would silently disable the lock).
+        verify(
+          () => recorderBloc.add(
+            const VideoRecorderRecordingLockedForNavigation(),
+          ),
+        ).called(1);
       });
 
       testWidgets('openVideoEditorFromRecorder mutes clips in lip-sync mode', (


### PR DESCRIPTION
Closes #5610

## Description

Fixes two independent ways the video recorder could end up stuck so an active recording could no longer be stopped ("blocks forever").

**1. A slow clip save blocked the next stop.**
`_onRecordingStopRequested` runs in a `sequential()` bucket and awaited the full clip post-processing — metadata extraction, thumbnail, ghost frame, and the library save. A slow library save (observed ~100s in field logs) held the bucket, so a subsequently requested stop never ran. Post-processing now runs detached (`unawaited` + `catchError`); the bare clip is still persisted immediately and the stop handler returns at once.

**2. A navigation race started an unstoppable recording.**
Opening the library/editor disposes the camera (deferred until after the push transition). A volume/Bluetooth record trigger firing in that window started a recording whose native `startRecording` could hang behind the disposed camera, latching `isStartingRecording=true` so every stop bailed via `pendingStopAfterStart`. A navigation recording-lock (`VideoRecorderRecordingLockedForNavigation`) is now dispatched at the *start* of navigation — while the camera is still live, before the deferred dispose — which:
- rejects new record starts/toggles,
- resets any in-flight/active recording to idle,
- aborts a start that races the camera release (entry, pre-`startRecording`, and post-`startRecording` guards).

The lock is cleared on re-initialization when the camera returns. `_onCameraPausedForNavigation` re-asserts the same lock as a defensive backstop.

**Related Issue:** 

## Out of Scope

- The deeper cause of the ~100s `saveClip`/Drift write latency (likely SQLite write contention while a recording is active) is not addressed here. This PR decouples the user-facing stop from that latency so the recorder stays responsive regardless.

## Verification

- `flutter analyze lib/blocs/video_recorder lib/widgets/video_recorder/video_recorder_navigation.dart test/blocs/video_recorder/video_recorder_bloc_test.dart test/widgets/video_recorder/video_recorder_navigation_test.dart` — No issues found
- `flutter test test/blocs/video_recorder/video_recorder_bloc_test.dart test/widgets/video_recorder/video_recorder_navigation_test.dart` — all pass, incl. 6 new regression tests covering both stranding paths
- `dart format` — clean
- Manually verified on device: opening the library while pressing volume-down no longer strands the recorder; recording stop stays responsive.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)