### PR TITLE
fix(models): ignore "unverified" verification tag in hasProofMode

### DIFF
--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1159,7 +1159,8 @@ class VideoEvent {
 
   /// ProofMode: Check if video has any proof
   bool get hasProofMode {
-    return proofModeVerificationLevel != null ||
+    return (proofModeVerificationLevel != null &&
+            proofModeVerificationLevel != 'unverified') ||
         hasProofModeManifest ||
         hasProofModePgpFingerprint ||
         hasProofModeDeviceAttestation ||

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1139,9 +1139,16 @@ class VideoEvent {
   }
 
   bool get _rawProofModeManifestCarriesProof {
-    if (proofModeManifest == null) return false;
-    final manifest = proofModeManifestJson;
-    if (manifest == null) return true;
+    final rawManifest = proofModeManifest;
+    if (rawManifest == null) return false;
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(rawManifest);
+    } on FormatException {
+      return true;
+    }
+    if (decoded is! Map<String, dynamic>) return false;
+    final manifest = decoded;
     return _proofManifestSignalFields.any((field) {
       final value = manifest[field];
       return value is String && value.isNotEmpty;

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1114,11 +1114,38 @@ class VideoEvent {
     return rawTags['identity_portable'] == 'cawg';
   }
 
+  /// Field names inside a `proofmode` manifest JSON that represent an actual
+  /// proof signal. A manifest that carries none of these (e.g. only a
+  /// `videoHash`) is an empty `unverified` shell, not proof.
+  static const _proofManifestSignalFields = <String>[
+    'pgpSignature',
+    'deviceAttestation',
+    'c2paManifestId',
+    'sensorDataCsv',
+  ];
+
   /// Whether this video has any ProofMode manifest signal, either as a raw tag
   /// or as a compact backend summary.
+  ///
+  /// The publisher writes a `proofmode` tag unconditionally — even for an
+  /// `unverified` upload whose manifest holds only a `videoHash` — so the raw
+  /// branch inspects the manifest *content* rather than mere tag presence. A
+  /// manifest that parses to JSON without any proof field is not a signal; an
+  /// opaque (non-JSON) value is kept as a signal so older or third-party
+  /// manifests are not silently dropped.
   bool get hasProofModeManifest {
-    return proofModeManifest != null ||
+    return _rawProofModeManifestCarriesProof ||
         proofSummary?.hasUsableProofmode == true;
+  }
+
+  bool get _rawProofModeManifestCarriesProof {
+    if (proofModeManifest == null) return false;
+    final manifest = proofModeManifestJson;
+    if (manifest == null) return true;
+    return _proofManifestSignalFields.any((field) {
+      final value = manifest[field];
+      return value is String && value.isNotEmpty;
+    });
   }
 
   /// Whether this video has any device-attestation signal, either as a raw tag

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -1086,8 +1086,8 @@ class VideoEvent {
   ///
   /// The `proofmode` Nostr tag carries the full `NativeProofData` JSON, so
   /// it is the source of truth for proof signals (`pgpSignature`,
-  /// `publicKey`, `deviceAttestation`, `c2paManifestId`) that the publisher
-  /// may not have additionally surfaced as standalone tags.
+  /// `sensorDataCsv`, `deviceAttestation`, `c2paManifestId`) that the
+  /// publisher may not have additionally surfaced as standalone tags.
   Map<String, dynamic>? get proofModeManifestJson {
     final manifest = proofModeManifest;
     if (manifest == null || manifest.isEmpty) return null;

--- a/mobile/packages/models/test/src/video_event_proofmode_test.dart
+++ b/mobile/packages/models/test/src/video_event_proofmode_test.dart
@@ -70,6 +70,21 @@ void main() {
     );
 
     test(
+      'returns false when an "unverified" upload carries non-object JSON',
+      () {
+        expect(
+          build(
+            rawTags: const {
+              'verification': 'unverified',
+              'proofmode': '[]',
+            },
+          ).hasProofMode,
+          isFalse,
+        );
+      },
+    );
+
+    test(
       'returns true when an "unverified" upload carries a proofmode manifest '
       'whose JSON holds a real proof field (sensorDataCsv)',
       () {

--- a/mobile/packages/models/test/src/video_event_proofmode_test.dart
+++ b/mobile/packages/models/test/src/video_event_proofmode_test.dart
@@ -38,14 +38,62 @@ void main() {
     });
 
     test(
-      'returns true when verification is "unverified" but a proofmode '
-      'manifest tag is present',
+      'returns true when verification is "unverified" but an opaque '
+      '(non-JSON) proofmode manifest tag is present',
       () {
         expect(
           build(
             rawTags: const {
               'verification': 'unverified',
               'proofmode': 'manifest-blob',
+            },
+          ).hasProofMode,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'returns false when an "unverified" upload carries an empty-shell '
+      'proofmode manifest (only a videoHash, no proof field)',
+      () {
+        expect(
+          build(
+            rawTags: const {
+              'verification': 'unverified',
+              'proofmode': '{"videoHash":"abc123"}',
+            },
+          ).hasProofMode,
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'returns true when an "unverified" upload carries a proofmode manifest '
+      'whose JSON holds a real proof field (sensorDataCsv)',
+      () {
+        expect(
+          build(
+            rawTags: const {
+              'verification': 'unverified',
+              'proofmode': '{"videoHash":"abc123","sensorDataCsv":"a,b,c"}',
+            },
+          ).hasProofMode,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'returns true when an "unverified" upload carries a proofmode manifest '
+      'whose JSON holds a pgpSignature',
+      () {
+        expect(
+          build(
+            rawTags: const {
+              'verification': 'unverified',
+              'proofmode': '{"videoHash":"abc123","pgpSignature":"sig"}',
             },
           ).hasProofMode,
           isTrue,

--- a/mobile/packages/models/test/src/video_event_proofmode_test.dart
+++ b/mobile/packages/models/test/src/video_event_proofmode_test.dart
@@ -1,0 +1,126 @@
+// ABOUTME: Tests for VideoEvent.hasProofMode, ensuring an "unverified"
+// ABOUTME: verification tag is not mistaken for a genuine ProofMode signal.
+
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  VideoEvent build({
+    Map<String, String> rawTags = const {},
+    ProofVerificationSummary? proofSummary,
+  }) => VideoEvent(
+    id: 'a' * 64,
+    pubkey: 'b' * 64,
+    createdAt: 1735689600,
+    content: '',
+    timestamp: DateTime.utc(2026),
+    rawTags: rawTags,
+    proofSummary: proofSummary,
+  );
+
+  group('VideoEvent.hasProofMode', () {
+    test('returns false when there is no proof signal at all', () {
+      expect(build().hasProofMode, isFalse);
+    });
+
+    test('returns false when verification tag is "unverified"', () {
+      expect(
+        build(rawTags: const {'verification': 'unverified'}).hasProofMode,
+        isFalse,
+      );
+    });
+
+    test('returns true when verification tag is a real level', () {
+      expect(
+        build(rawTags: const {'verification': 'verified_mobile'}).hasProofMode,
+        isTrue,
+      );
+    });
+
+    test(
+      'returns true when verification is "unverified" but a proofmode '
+      'manifest tag is present',
+      () {
+        expect(
+          build(
+            rawTags: const {
+              'verification': 'unverified',
+              'proofmode': 'manifest-blob',
+            },
+          ).hasProofMode,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'returns true when verification is "unverified" but a device '
+      'attestation tag is present',
+      () {
+        expect(
+          build(
+            rawTags: const {
+              'verification': 'unverified',
+              'device_attestation': 'attestation-blob',
+            },
+          ).hasProofMode,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'returns true when verification is "unverified" but a C2PA manifest '
+      'id tag is present',
+      () {
+        expect(
+          build(
+            rawTags: const {
+              'verification': 'unverified',
+              'c2pa_manifest_id': 'urn:c2pa:1234',
+            },
+          ).hasProofMode,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'returns true when verification is "unverified" but the proof summary '
+      'carries a usable proofmode signal',
+      () {
+        expect(
+          build(
+            rawTags: const {'verification': 'unverified'},
+            proofSummary: const ProofVerificationSummary(
+              status: 'verified',
+              version: 1,
+              checks: {
+                'proofmode_present': true,
+                'proofmode_parse_ok': true,
+              },
+            ),
+          ).hasProofMode,
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'returns false when verification is "unverified" and the proof summary '
+      'has no usable signal',
+      () {
+        expect(
+          build(
+            rawTags: const {'verification': 'unverified'},
+            proofSummary: const ProofVerificationSummary(
+              status: 'unknown',
+              version: 1,
+            ),
+          ).hasProofMode,
+          isFalse,
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/utils/proofmode_helpers_test.dart
+++ b/mobile/test/utils/proofmode_helpers_test.dart
@@ -91,8 +91,9 @@ void main() {
       expect(video.shouldShowProofModeBadge, isFalse);
     });
 
-    test('hasProofMode returns true with any proof tag', () {
-      // Test with manifest only
+    test('hasProofMode reflects manifest proof content', () {
+      // A proofmode manifest with no proof-signal field is an unverified
+      // shell, not proof — tag presence alone is not enough.
       var video = VideoEvent(
         id: 'test5',
         pubkey: 'pubkey5',
@@ -102,9 +103,9 @@ void main() {
         rawTags: const {'proofmode': '{"test": "data"}'},
       );
 
-      expect(video.hasProofMode, isTrue);
+      expect(video.hasProofMode, isFalse);
 
-      // Test with PGP signature in manifest only
+      // A manifest carrying a real proof signal (PGP signature) is proof.
       video = VideoEvent(
         id: 'test6',
         pubkey: 'pubkey6',


### PR DESCRIPTION
Closes #5612
Closes #5605

## Description

`VideoEvent.hasProofMode` previously treated any non-null verification tag or any non-empty `proofmode` tag as proof. That made videos with `verification: "unverified"` and empty ProofMode manifest shells show the ProofMode / Human Made badge even though no real proof signal was present.

This PR makes the proof detection content-aware:

- ignores `verification: "unverified"` as a proof signal
- treats parsed ProofMode JSON as proof only when it contains a real signal field: `pgpSignature`, `deviceAttestation`, `c2paManifestId`, or `sensorDataCsv`
- keeps opaque non-JSON ProofMode manifests as proof for backwards compatibility
- keeps standalone device-attestation, PGP, C2PA, and usable proof-summary fallbacks intact
- updates the stale app-level helper test and adds model-level regression coverage

## User Impact

Unverified videos no longer incorrectly display the ProofMode / Human Made badge. Videos with actual ProofMode evidence continue to show the badge.

## Verification

- `flutter test test/src/video_event_proofmode_test.dart test/src/proof_verification_summary_test.dart` from `mobile/packages/models`
- `flutter test test/utils/proofmode_helpers_test.dart test/blocs/video_feed/video_feed_bloc_test.dart` from `mobile`
- `flutter analyze` from `mobile`

## Type of Change

- [x] Bug fix
