### PR TITLE
fix(video): keep clips and drafts loading past one corrupt row

### DIFF
--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -278,20 +278,34 @@ class DivineVideoClip {
         (json['targetAspectRatio'] ?? json['aspectRatio']) as String?;
     final thumbnailTimestampMs = json['thumbnailTimestampMs'] as int?;
 
+    // A clip's only persisted video source is its file path; without it the
+    // clip can't be reconstructed (`EditorVideo` requires a non-null source).
+    // Validate the required fields up front and throw a typed error so the
+    // loader can skip this single corrupt row instead of a cryptic
+    // `Null is not a subtype of String` cast aborting the whole library/draft
+    // load.
+    final id = json['id'] as String?;
+    final filePath = json['filePath'] as String?;
+    final rawRecordedAt = (json['recordedAt'] ?? json['createdAt']) as String?;
+    if (id == null || filePath == null || rawRecordedAt == null) {
+      throw const FormatException(
+        'DivineVideoClip JSON is missing a required field '
+        '(id, filePath, or recordedAt); cannot reconstruct the clip.',
+      );
+    }
+
     return DivineVideoClip(
-      id: json['id'] as String,
+      id: id,
       video: EditorVideo.file(
         resolvePath(
-          json['filePath'] as String,
+          filePath,
           documentsPath,
           useOriginalPath: useOriginalPath,
         ),
       ),
       libraryTitle: json['libraryTitle'] as String?,
       duration: Duration(milliseconds: json['durationMs'] as int),
-      recordedAt: DateTime.parse(
-        (json['recordedAt'] ?? json['createdAt']) as String,
-      ),
+      recordedAt: DateTime.parse(rawRecordedAt),
       thumbnailPath: resolvePath(
         json['thumbnailPath'] as String?,
         documentsPath,

--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -287,10 +287,15 @@ class DivineVideoClip {
     final id = json['id'] as String?;
     final filePath = json['filePath'] as String?;
     final rawRecordedAt = (json['recordedAt'] ?? json['createdAt']) as String?;
-    if (id == null || filePath == null || rawRecordedAt == null) {
+    final durationMs = json['durationMs'] as int?;
+    if (id == null ||
+        filePath == null ||
+        rawRecordedAt == null ||
+        durationMs == null) {
       throw const FormatException(
         'DivineVideoClip JSON is missing a required field '
-        '(id, filePath, or recordedAt); cannot reconstruct the clip.',
+        '(id, filePath, recordedAt, or durationMs); cannot reconstruct '
+        'the clip.',
       );
     }
 
@@ -304,7 +309,7 @@ class DivineVideoClip {
         ),
       ),
       libraryTitle: json['libraryTitle'] as String?,
-      duration: Duration(milliseconds: json['durationMs'] as int),
+      duration: Duration(milliseconds: durationMs),
       recordedAt: DateTime.parse(rawRecordedAt),
       thumbnailPath: resolvePath(
         json['thumbnailPath'] as String?,

--- a/mobile/lib/services/clip_library_service.dart
+++ b/mobile/lib/services/clip_library_service.dart
@@ -131,7 +131,10 @@ class ClipLibraryService {
     try {
       final rows = await _clipsDao.getLibraryClips(ownerPubkey: ownerPubkey);
       final documentsPath = await getDocumentsPath();
-      return _parseClipRows(rows, documentsPath);
+      return rows
+          .map((row) => _tryParseClipRow(row, documentsPath, label: 'clip'))
+          .whereType<DivineVideoClip>()
+          .toList();
     } catch (e) {
       Log.error(
         '❌ Failed to load clips: $e',
@@ -142,26 +145,24 @@ class ClipLibraryService {
     }
   }
 
-  /// Parse [rows] into clips, skipping (and logging) any row that fails to
-  /// deserialize so one corrupt clip can't abort the whole load.
-  List<DivineVideoClip> _parseClipRows(
-    List<ClipRow> rows,
-    String documentsPath,
-  ) {
-    final clips = <DivineVideoClip>[];
-    for (final row in rows) {
-      try {
-        final clipJson = json.decode(row.data) as Map<String, dynamic>;
-        clips.add(DivineVideoClip.fromJson(clipJson, documentsPath));
-      } catch (e) {
-        Log.error(
-          '❌ Skipping corrupt clip ${row.id}: $e',
-          name: 'ClipLibraryService',
-          category: LogCategory.video,
-        );
-      }
+  /// Deserialize a single clip [row], returning `null` (and logging) when the
+  /// row is corrupt so one bad clip can't abort the whole list load.
+  DivineVideoClip? _tryParseClipRow(
+    ClipRow row,
+    String documentsPath, {
+    required String label,
+  }) {
+    try {
+      final clipJson = json.decode(row.data) as Map<String, dynamic>;
+      return DivineVideoClip.fromJson(clipJson, documentsPath);
+    } catch (e) {
+      Log.error(
+        '❌ Skipping corrupt $label ${row.id}: $e',
+        name: 'ClipLibraryService',
+        category: LogCategory.video,
+      );
+      return null;
     }
-    return clips;
   }
 
   /// Get a single clip by ID
@@ -254,20 +255,13 @@ class ClipLibraryService {
       final documentsPath = await getDocumentsPath();
       final clips = <DivineVideoClip>[];
       for (final row in rows) {
-        try {
-          final clipJson = json.decode(row.data) as Map<String, dynamic>;
-          clips.add(
-            DivineVideoClip.fromJson(
-              clipJson,
-              documentsPath,
-            ).copyWith(deletedAt: row.deletedAt),
-          );
-        } catch (e) {
-          Log.error(
-            '❌ Skipping corrupt trashed clip ${row.id}: $e',
-            name: 'ClipLibraryService',
-            category: LogCategory.video,
-          );
+        final clip = _tryParseClipRow(
+          row,
+          documentsPath,
+          label: 'trashed clip',
+        );
+        if (clip != null) {
+          clips.add(clip.copyWith(deletedAt: row.deletedAt));
         }
       }
       return clips;

--- a/mobile/lib/services/clip_library_service.dart
+++ b/mobile/lib/services/clip_library_service.dart
@@ -165,14 +165,17 @@ class ClipLibraryService {
     }
   }
 
-  /// Get a single clip by ID
+  /// Get a single clip by ID.
+  ///
+  /// Returns `null` when the row is missing or corrupt, matching the
+  /// list loaders' skip-and-log behaviour so a single bad row can't throw
+  /// out of a lookup. Callers already treat `null` as "no clip".
   Future<DivineVideoClip?> getClipById(String id) async {
     final row = await _clipsDao.getClipById(id);
     if (row == null) return null;
 
     final documentsPath = await getDocumentsPath();
-    final clipJson = json.decode(row.data) as Map<String, dynamic>;
-    return DivineVideoClip.fromJson(clipJson, documentsPath);
+    return _tryParseClipRow(row, documentsPath, label: 'clip');
   }
 
   /// Move a clip to the trash. The clip is hidden from active queries

--- a/mobile/lib/services/clip_library_service.dart
+++ b/mobile/lib/services/clip_library_service.dart
@@ -122,16 +122,16 @@ class ClipLibraryService {
     );
   }
 
-  /// Get all clips from the library, sorted by creation date (newest first)
+  /// Get all clips from the library, sorted by creation date (newest first).
+  ///
+  /// A single corrupt row (e.g. a clip persisted without a file path) is
+  /// skipped and logged rather than discarding the entire library — one bad
+  /// row must never hide every other clip.
   Future<List<DivineVideoClip>> getAllClips() async {
     try {
       final rows = await _clipsDao.getLibraryClips(ownerPubkey: ownerPubkey);
       final documentsPath = await getDocumentsPath();
-
-      return rows.map((row) {
-        final clipJson = json.decode(row.data) as Map<String, dynamic>;
-        return DivineVideoClip.fromJson(clipJson, documentsPath);
-      }).toList();
+      return _parseClipRows(rows, documentsPath);
     } catch (e) {
       Log.error(
         '❌ Failed to load clips: $e',
@@ -140,6 +140,28 @@ class ClipLibraryService {
       );
       return [];
     }
+  }
+
+  /// Parse [rows] into clips, skipping (and logging) any row that fails to
+  /// deserialize so one corrupt clip can't abort the whole load.
+  List<DivineVideoClip> _parseClipRows(
+    List<ClipRow> rows,
+    String documentsPath,
+  ) {
+    final clips = <DivineVideoClip>[];
+    for (final row in rows) {
+      try {
+        final clipJson = json.decode(row.data) as Map<String, dynamic>;
+        clips.add(DivineVideoClip.fromJson(clipJson, documentsPath));
+      } catch (e) {
+        Log.error(
+          '❌ Skipping corrupt clip ${row.id}: $e',
+          name: 'ClipLibraryService',
+          category: LogCategory.video,
+        );
+      }
+    }
+    return clips;
   }
 
   /// Get a single clip by ID
@@ -230,13 +252,25 @@ class ClipLibraryService {
         ownerPubkey: ownerPubkey,
       );
       final documentsPath = await getDocumentsPath();
-      return rows.map((row) {
-        final clipJson = json.decode(row.data) as Map<String, dynamic>;
-        return DivineVideoClip.fromJson(
-          clipJson,
-          documentsPath,
-        ).copyWith(deletedAt: row.deletedAt);
-      }).toList();
+      final clips = <DivineVideoClip>[];
+      for (final row in rows) {
+        try {
+          final clipJson = json.decode(row.data) as Map<String, dynamic>;
+          clips.add(
+            DivineVideoClip.fromJson(
+              clipJson,
+              documentsPath,
+            ).copyWith(deletedAt: row.deletedAt),
+          );
+        } catch (e) {
+          Log.error(
+            '❌ Skipping corrupt trashed clip ${row.id}: $e',
+            name: 'ClipLibraryService',
+            category: LogCategory.video,
+          );
+        }
+      }
+      return clips;
     } catch (e) {
       Log.error(
         '❌ Failed to load trashed clips: $e',

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -281,20 +281,13 @@ class DraftStorageService {
           continue;
         }
 
-        try {
-          drafts.add(
-            DivineVideoDraft.fromDriftRow(
-              row: row,
-              clipRows: clipRows,
-              documentsPath: documentsPath,
-            ),
-          );
-        } catch (e) {
-          Log.error(
-            '🧹 Skipping corrupt draft ${row.id}: $e',
-            name: 'DraftStorageService',
-            category: LogCategory.video,
-          );
+        final draft = _tryParseDraftRow(
+          row: row,
+          clipRows: clipRows,
+          documentsPath: documentsPath,
+        );
+        if (draft != null) {
+          drafts.add(draft);
         }
       }
     }

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -340,11 +340,35 @@ class DraftStorageService {
 
     final clipRows = await _clipsDao.getClipsByDraftId(id);
     final documentsPath = await getDocumentsPath();
-    return DivineVideoDraft.fromDriftRow(
+    return _tryParseDraftRow(
       row: row,
       clipRows: clipRows,
       documentsPath: documentsPath,
     );
+  }
+
+  /// Deserialize a single draft [row] with its [clipRows], returning `null`
+  /// (and logging) when the row is corrupt so one bad draft can't abort a
+  /// list load or throw out of a single-draft lookup.
+  DivineVideoDraft? _tryParseDraftRow({
+    required DraftRow row,
+    required List<ClipRow> clipRows,
+    required String documentsPath,
+  }) {
+    try {
+      return DivineVideoDraft.fromDriftRow(
+        row: row,
+        clipRows: clipRows,
+        documentsPath: documentsPath,
+      );
+    } catch (e) {
+      Log.error(
+        '🧹 Skipping corrupt draft ${row.id}: $e',
+        name: 'DraftStorageService',
+        category: LogCategory.video,
+      );
+      return null;
+    }
   }
 
   /// Get draft by ID with validation - filters out clips with missing video files.
@@ -427,19 +451,13 @@ class DraftStorageService {
           continue;
         }
 
-        try {
-          final draft = DivineVideoDraft.fromDriftRow(
-            row: row,
-            clipRows: clipRows,
-            documentsPath: documentsPath,
-          );
+        final draft = _tryParseDraftRow(
+          row: row,
+          clipRows: clipRows,
+          documentsPath: documentsPath,
+        );
+        if (draft != null) {
           drafts.add(_clearMissingFinalRenderedClip(draft));
-        } catch (e) {
-          Log.error(
-            '🧹 Skipping corrupt draft ${row.id}: $e',
-            name: 'DraftStorageService',
-            category: LogCategory.video,
-          );
         }
       }
 

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -281,13 +281,21 @@ class DraftStorageService {
           continue;
         }
 
-        drafts.add(
-          DivineVideoDraft.fromDriftRow(
-            row: row,
-            clipRows: clipRows,
-            documentsPath: documentsPath,
-          ),
-        );
+        try {
+          drafts.add(
+            DivineVideoDraft.fromDriftRow(
+              row: row,
+              clipRows: clipRows,
+              documentsPath: documentsPath,
+            ),
+          );
+        } catch (e) {
+          Log.error(
+            '🧹 Skipping corrupt draft ${row.id}: $e',
+            name: 'DraftStorageService',
+            category: LogCategory.video,
+          );
+        }
       }
     }
 
@@ -419,12 +427,20 @@ class DraftStorageService {
           continue;
         }
 
-        final draft = DivineVideoDraft.fromDriftRow(
-          row: row,
-          clipRows: clipRows,
-          documentsPath: documentsPath,
-        );
-        drafts.add(_clearMissingFinalRenderedClip(draft));
+        try {
+          final draft = DivineVideoDraft.fromDriftRow(
+            row: row,
+            clipRows: clipRows,
+            documentsPath: documentsPath,
+          );
+          drafts.add(_clearMissingFinalRenderedClip(draft));
+        } catch (e) {
+          Log.error(
+            '🧹 Skipping corrupt draft ${row.id}: $e',
+            name: 'DraftStorageService',
+            category: LogCategory.video,
+          );
+        }
       }
 
       // Clean up corrupted drafts (0 clips) in the background

--- a/mobile/test/models/divine_video_clip_corrupt_json_test.dart
+++ b/mobile/test/models/divine_video_clip_corrupt_json_test.dart
@@ -58,5 +58,21 @@ void main() {
         throwsA(isA<FormatException>()),
       );
     });
+
+    test('throws FormatException when durationMs is null', () {
+      final json = validClip().toJson()..['durationMs'] = null;
+      expect(
+        () => DivineVideoClip.fromJson(json, '/docs', useOriginalPath: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException when durationMs is absent', () {
+      final json = validClip().toJson()..remove('durationMs');
+      expect(
+        () => DivineVideoClip.fromJson(json, '/docs', useOriginalPath: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
   });
 }

--- a/mobile/test/models/divine_video_clip_corrupt_json_test.dart
+++ b/mobile/test/models/divine_video_clip_corrupt_json_test.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' as editor;
+
+void main() {
+  DivineVideoClip validClip() => DivineVideoClip(
+    id: 'c1',
+    video: editor.EditorVideo.file(File('/docs/clip.mp4')),
+    duration: const Duration(seconds: 5),
+    recordedAt: DateTime(2024),
+    targetAspectRatio: model.AspectRatio.square,
+    originalAspectRatio: 1,
+  );
+
+  group('DivineVideoClip.fromJson corrupt data', () {
+    test('round-trips a valid clip', () {
+      final restored = DivineVideoClip.fromJson(
+        validClip().toJson(),
+        '/docs',
+        useOriginalPath: true,
+      );
+      expect(restored.id, equals('c1'));
+    });
+
+    test('throws FormatException when filePath is null', () {
+      final json = validClip().toJson()..['filePath'] = null;
+      expect(
+        () => DivineVideoClip.fromJson(json, '/docs', useOriginalPath: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException when filePath is absent', () {
+      final json = validClip().toJson()..remove('filePath');
+      expect(
+        () => DivineVideoClip.fromJson(json, '/docs', useOriginalPath: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException when id is null', () {
+      final json = validClip().toJson()..['id'] = null;
+      expect(
+        () => DivineVideoClip.fromJson(json, '/docs', useOriginalPath: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException when recordedAt/createdAt is absent', () {
+      final json = validClip().toJson()
+        ..remove('recordedAt')
+        ..remove('createdAt');
+      expect(
+        () => DivineVideoClip.fromJson(json, '/docs', useOriginalPath: true),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -109,6 +109,43 @@ void main() {
         final result = await service.softDelete('nonexistent_clip');
         expect(result, isFalse);
       });
+
+      test(
+        'getTrashedClips skips a corrupt clip and returns valid ones',
+        () async {
+          final validClip = DivineVideoClip(
+            id: 'valid_trashed',
+            video: EditorVideo.file('/tmp/valid.mp4'),
+            duration: const Duration(seconds: 1),
+            recordedAt: DateTime.now(),
+            targetAspectRatio: .square,
+            originalAspectRatio: 9 / 16,
+          );
+          await service.saveClip(validClip);
+
+          // A trashed library row whose JSON has no filePath: fromJson throws,
+          // so it must be skipped rather than wiping the whole trash view
+          // (regression for #fix/drafts-clips-fail-to-load).
+          final corruptData = validClip.toJson()
+            ..['id'] = 'corrupt_trashed'
+            ..['filePath'] = null;
+          await database.clipsDao.upsertClip(
+            id: 'corrupt_trashed',
+            orderIndex: 0,
+            durationMs: 1000,
+            recordedAt: DateTime.now(),
+            data: jsonEncode(corruptData),
+            filePath: null,
+            thumbnailPath: null,
+          );
+
+          await service.softDelete('valid_trashed');
+          await service.softDelete('corrupt_trashed');
+
+          final trashed = await service.getTrashedClips();
+          expect(trashed.map((c) => c.id), ['valid_trashed']);
+        },
+      );
     });
 
     group('restore', () {

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for ClipLibraryService - persistent storage for video clips
 // ABOUTME: Covers save, load, delete, and thumbnail generation for clips
 
+import 'dart:convert';
+
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -252,6 +254,37 @@ void main() {
         final clips = await service.getAllClips();
         expect(clips.first.id, 'new_clip');
         expect(clips.last.id, 'old_clip');
+      });
+
+      test('skips a corrupt clip and still returns valid ones', () async {
+        final validClip = DivineVideoClip(
+          id: 'valid_clip',
+          video: EditorVideo.file('/tmp/valid.mp4'),
+          duration: const Duration(seconds: 1),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: .square,
+          originalAspectRatio: 9 / 16,
+        );
+        await service.saveClip(validClip);
+
+        // Insert a corrupt row directly: its JSON has no filePath, so
+        // DivineVideoClip.fromJson throws. It must be skipped, not wipe the
+        // whole library load (regression for #fix/drafts-clips-fail-to-load).
+        final corruptData = validClip.toJson()
+          ..['id'] = 'corrupt_clip'
+          ..['filePath'] = null;
+        await database.clipsDao.upsertClip(
+          id: 'corrupt_clip',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime.now(),
+          data: jsonEncode(corruptData),
+          filePath: null,
+          thumbnailPath: null,
+        );
+
+        final clips = await service.getAllClips();
+        expect(clips.map((c) => c.id), ['valid_clip']);
       });
     });
 

--- a/mobile/test/services/clip_library_service_test.dart
+++ b/mobile/test/services/clip_library_service_test.dart
@@ -348,6 +348,33 @@ void main() {
         final found = await service.getClipById('nonexistent');
         expect(found, isNull);
       });
+
+      test('returns null for a corrupt clip row', () async {
+        final validClip = DivineVideoClip(
+          id: 'corrupt_clip',
+          video: EditorVideo.file('/tmp/corrupt.mp4'),
+          duration: const Duration(seconds: 1),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: .square,
+          originalAspectRatio: 9 / 16,
+        );
+
+        // Drop the filePath so DivineVideoClip.fromJson throws. getClipById
+        // must skip-and-log and return null instead of throwing out of the
+        // lookup, matching the list loaders' behaviour.
+        final corruptData = validClip.toJson()..['filePath'] = null;
+        await database.clipsDao.upsertClip(
+          id: 'corrupt_clip',
+          orderIndex: 0,
+          durationMs: 1000,
+          recordedAt: DateTime.now(),
+          data: jsonEncode(corruptData),
+          filePath: null,
+          thumbnailPath: null,
+        );
+
+        expect(await service.getClipById('corrupt_clip'), isNull);
+      });
     });
 
     group('clearAllClips', () {

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -753,6 +753,41 @@ void main() {
         expect(row, isNull);
       });
 
+      test(
+        'skips a draft with a corrupt clip and keeps valid matching drafts',
+        () async {
+          final validDraft = createDraftWithStatus(
+            'valid_failed',
+            PublishStatus.failed,
+          );
+          final corruptDraft = createDraftWithStatus(
+            'corrupt_failed',
+            PublishStatus.failed,
+          );
+          await service.saveDraft(validDraft);
+          await service.saveDraft(corruptDraft);
+
+          final corruptClipData = corruptDraft.clips.first.toJson()
+            ..['filePath'] = null;
+          await database.clipsDao.upsertClip(
+            id: 'clip_corrupt_failed',
+            draftId: 'corrupt_failed',
+            orderIndex: 0,
+            durationMs: 6000,
+            recordedAt: DateTime.now(),
+            data: jsonEncode(corruptClipData),
+            filePath: null,
+            thumbnailPath: null,
+          );
+
+          final results = await service.getDraftsByPublishStatuses({
+            PublishStatus.failed,
+          });
+
+          expect(results.map((draft) => draft.id), ['valid_failed']);
+        },
+      );
+
       test('should return drafts for a single status', () async {
         await service.saveDraft(
           createDraftWithStatus('d1', PublishStatus.failed),

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -347,6 +347,51 @@ void main() {
       });
     });
 
+    group('getDraftById', () {
+      test('returns null for a draft with a corrupt clip', () async {
+        final now = DateTime.now();
+        final draft = DivineVideoDraft(
+          id: 'draft_corrupt',
+          clips: [
+            DivineVideoClip(
+              id: 'clip_corrupt',
+              video: EditorVideo.file('/path/to/clip_corrupt.mp4'),
+              duration: const Duration(seconds: 6),
+              recordedAt: now,
+              targetAspectRatio: AspectRatio.square,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'draft_corrupt',
+          description: '',
+          hashtags: {},
+          selectedApproach: 'hybrid',
+          createdAt: now,
+          lastModified: now,
+          publishStatus: PublishStatus.draft,
+          publishAttempts: 0,
+        );
+        await service.saveDraft(draft);
+
+        // Drop the clip's filePath so DivineVideoClip.fromJson throws when
+        // the single draft is reconstructed. getDraftById must skip-and-log
+        // and return null rather than throwing out of the lookup.
+        final corruptData = draft.clips.first.toJson()..['filePath'] = null;
+        await database.clipsDao.upsertClip(
+          id: 'clip_corrupt',
+          draftId: 'draft_corrupt',
+          orderIndex: 0,
+          durationMs: 6000,
+          recordedAt: now,
+          data: jsonEncode(corruptData),
+          filePath: null,
+          thumbnailPath: null,
+        );
+
+        expect(await service.getDraftById('draft_corrupt'), isNull);
+      });
+    });
+
     group('deleteDraft', () {
       test('should delete draft by ID', () async {
         final now = DateTime.now();

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -258,6 +258,60 @@ void main() {
         expect(rowAfter, isNull);
       });
 
+      test(
+        'skips a draft with a corrupt clip and keeps valid drafts',
+        () async {
+          final now = DateTime.now();
+          DivineVideoDraft draftWith(String draftId, String clipId) =>
+              DivineVideoDraft(
+                id: draftId,
+                clips: [
+                  DivineVideoClip(
+                    id: clipId,
+                    video: EditorVideo.file('/path/to/$clipId.mp4'),
+                    duration: const Duration(seconds: 6),
+                    recordedAt: now,
+                    targetAspectRatio: AspectRatio.square,
+                    originalAspectRatio: 9 / 16,
+                  ),
+                ],
+                title: draftId,
+                description: '',
+                hashtags: {},
+                selectedApproach: 'hybrid',
+                createdAt: now,
+                lastModified: now,
+                publishStatus: PublishStatus.draft,
+                publishAttempts: 0,
+              );
+
+          await service.saveDraft(draftWith('draft_valid', 'clip_valid'));
+          await service.saveDraft(draftWith('draft_corrupt', 'clip_corrupt'));
+
+          // Corrupt the clip row of draft_corrupt: drop its filePath so
+          // DivineVideoClip.fromJson throws when the draft is reconstructed.
+          // That draft must be skipped while draft_valid still loads
+          // (regression for #fix/drafts-clips-fail-to-load).
+          final corruptData = draftWith(
+            'draft_corrupt',
+            'clip_corrupt',
+          ).clips.first.toJson()..['filePath'] = null;
+          await database.clipsDao.upsertClip(
+            id: 'clip_corrupt',
+            draftId: 'draft_corrupt',
+            orderIndex: 0,
+            durationMs: 6000,
+            recordedAt: now,
+            data: jsonEncode(corruptData),
+            filePath: null,
+            thumbnailPath: null,
+          );
+
+          final drafts = await service.getAllDrafts();
+          expect(drafts.map((d) => d.id), ['draft_valid']);
+        },
+      );
+
       test('clears missing final rendered clip references', () async {
         final draft = DivineVideoDraft.create(
           clips: [


### PR DESCRIPTION
Closes #5614

## Description

Drafts and clips could fail to load with
`type 'Null' is not a subtype of type 'String' in type cast`, leaving the
Library empty even when most persisted rows were still valid.

Root cause: `DivineVideoClip.fromJson` cast required persisted fields directly,
including `json['filePath'] as String`. `DivineVideoClip.toJson` can write
`filePath: null` whenever a clip has no video file. A single corrupt row then
threw during deserialization, and because the loaders parsed every row in one
pass, that one throw aborted the whole load. Drafts were affected too because
they reconstruct their clips through the same clip model parser.

Fix:
- `DivineVideoClip.fromJson` now validates the unreconstructable required
  fields (`id`, `filePath`, `recordedAt`/`createdAt`, and `durationMs`) up
  front and throws a typed `FormatException`.
- Clip and draft list loaders skip and log corrupt rows instead of discarding
  the whole list: `getAllClips`, `getTrashedClips`, `getAllDrafts`, and
  `getDraftsByPublishStatuses`.
- Single-row lookups now match that behavior: corrupt rows return `null` from
  `getClipById` / `getDraftById` instead of throwing.
- The draft publish-status loader now shares the same `_tryParseDraftRow`
  helper as the other draft loaders, with regression coverage for a corrupt
  clip row in that path.

Net effect: one corrupt clip/draft is dropped and logged while valid clips and
drafts continue loading.

## Out of Scope

- Investigating why a clip was persisted without a `filePath` in the first
  place. This PR makes the read side resilient; such a clip has no recoverable
  video source regardless.

## Verification

- `flutter test test/models/divine_video_clip_corrupt_json_test.dart test/services/clip_library_service_test.dart test/services/draft_storage_service_test.dart`
- `flutter analyze`
- Pre-push hook: analyzer plus changed-file tests

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
