### PR TITLE
fix(nostr): guard ref after async gap in NostrService._initializeClient

### DIFF
--- a/mobile/lib/providers/nostr_client_provider.dart
+++ b/mobile/lib/providers/nostr_client_provider.dart
@@ -270,6 +270,10 @@ class NostrService extends _$NostrService {
   }) async {
     try {
       await _runClientInitialization(client, userRelayUrls);
+      // The provider can be disposed during the await (e.g. a rapid identity
+      // switch rebuilds it, or a test container is torn down mid-init). Reading
+      // `ref` after disposal throws, so bail before the ref-backed checks below.
+      if (!ref.mounted) return;
       if (_isCurrentClientForPubkey(client, pubkey, clientGeneration)) {
         _lastPubkey = pubkey;
         _initializationFailureCount = 0;
@@ -283,6 +287,9 @@ class NostrService extends _$NostrService {
         category: LogCategory.system,
       );
     } catch (e) {
+      // Same disposal hazard as the success path: a provider torn down mid-init
+      // makes the ref-backed recovery below throw. Bail before touching `ref`.
+      if (!ref.mounted) return;
       Log.error(
         '[NostrService] Failed to initialize client in $source(): $e',
         name: 'NostrService',

--- a/mobile/lib/providers/nostr_client_provider.g.dart
+++ b/mobile/lib/providers/nostr_client_provider.g.dart
@@ -109,7 +109,7 @@ final class NostrServiceProvider
   }
 }
 
-String _$nostrServiceHash() => r'58e0dc3a58d063faeec5669d21b86d66f233bd08';
+String _$nostrServiceHash() => r'090b2e8cd2adf62b7406e3472ab857c1091fa4de';
 
 /// Core Nostr service via NostrClient for relay communication
 /// Uses a Notifier to react to auth state changes and recreate the client

--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -1167,4 +1167,59 @@ void main() {
       },
     );
   });
+
+  group('disposed-ref guard (#5602 / #5600 regression)', () {
+    test('does not touch ref after the container is disposed mid-init '
+        '(success path)', () async {
+      when(() => mockAuth.currentIdentity).thenReturn(identityA);
+      // Gate initialize() so _initializeClient parks on the await.
+      factory.initializeCompleters[pubkeyA] = Completer<void>();
+
+      final container = createContainer();
+      container.read(nostrServiceProvider); // schedules _initializeClient
+
+      // Let the scheduled microtask reach `await client.initialize()`.
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        factory.initializePubkeys,
+        contains(pubkeyA),
+        reason: '_initializeClient must be parked on the gated initialize()',
+      );
+
+      // Dispose mid-init, then let init resume. Without the ref.mounted guard,
+      // the resumed _isCurrentClientForPubkey reads a disposed ref and throws
+      // ("Cannot use the Ref ... after it has been disposed"), surfacing as an
+      // uncaught async error that fails this test. The guard makes it bail.
+      container.dispose();
+      factory.initializeCompleters[pubkeyA]!.complete();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(factory.initializeCompleters[pubkeyA]!.isCompleted, isTrue);
+    });
+
+    test('does not touch ref after the container is disposed mid-init '
+        '(error path)', () async {
+      when(() => mockAuth.currentIdentity).thenReturn(identityA);
+      factory.initializeCompleters[pubkeyA] = Completer<void>();
+
+      final container = createContainer();
+      container.read(nostrServiceProvider);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(factory.initializePubkeys, contains(pubkeyA));
+
+      // Dispose mid-init, then fail init so _initializeClient enters its catch
+      // block. Without the guard the catch path's ref reads throw on the
+      // disposed provider; the guard makes it bail.
+      container.dispose();
+      factory.initializeCompleters[pubkeyA]!.completeError(
+        StateError('init failed'),
+      );
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(factory.initializeCompleters[pubkeyA]!.isCompleted, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## Description

`NostrService.build()` fire-and-forgets `_initializeClient` via `Future.microtask`. After `await _runClientInitialization(...)`, both the success and catch paths read `ref` (e.g. `_isCurrentClientForPubkey` → `ref.read(authServiceProvider)`). If the provider/container is disposed mid-init — a rapid identity switch in the app, or a test tearing down its container — the resumed `ref` read throws `Cannot use the Ref of nostrServiceProvider after it has been disposed`.

In the merged-isolate test suite (`very_good test --optimization`), that uncaught async error is reported as "This test failed after it had already completed" against whatever test happens to be current, reddening the `Tests` job at random seeds. #5602 was originally filed against `email_verification_cubit_test` ("zombie cubit") — that was a misdiagnosed victim; the stack trace + `git blame` point at this provider (introduced by #5600).

**Fix:** add `if (!ref.mounted) return;` after the async gap on both the success and catch paths in `_initializeClient`, per Riverpod's own guidance ("check `ref.mounted` after async gaps"). `ref.onDispose` cannot cover this — `_isCurrentClientForPubkey` calls `ref.read` before its generation check, so it throws first.

**Related Issue:** Closes #5602

Regression from #5600.

## Out of Scope

- A second merged-isolate failure observed at the same seed (`user_data_cleanup_service_test`) is collateral from the same leaked async; it goes green once this guard lands, so no separate change is needed.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `flutter test test/providers/nostr_service_identity_source_test.dart` — green, including 2 new regression tests (`disposed-ref guard (#5602 / #5600 regression)`, success + error paths). Verified both new tests FAIL without the guard with `Cannot use the Ref ... after it has been disposed`.
- `very_good test --optimization --concurrency=4 --exclude-tags integration --test-randomize-ordering-seed 1143762132` (the seed that reddens `Tests` on `main`) — all tests pass (was `-2` without the fix).
- No new `skip_very_good_optimization` tags.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
