### PR TITLE
fix(comments): dismiss keyboard when the comments sheet closes

### DIFF
--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -238,7 +238,10 @@ abstract final class CommentsScreen {
             },
           ),
           trailing: const _CommentsSortToggle(),
-          bottomInput: const _MainCommentInput(),
+          // Wrap the input so the keyboard is dropped the instant the sheet
+          // starts dismissing (drag / scrim / back), otherwise iOS leaves it
+          // stranded over the feed below (#5604).
+          bottomInput: const UnfocusOnSheetDismiss(child: _MainCommentInput()),
           buildScrollBody: (scrollController) {
             activeScrollController = scrollController;
             return CommentsSheetLoadTelemetry(

--- a/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
+++ b/mobile/lib/screens/comments/widgets/unfocus_on_sheet_dismiss.dart
@@ -1,0 +1,62 @@
+// ABOUTME: Drops the keyboard when the enclosing modal sheet starts dismissing
+// ABOUTME: so iOS does not strand an orphaned keyboard over the screen below.
+
+import 'package:flutter/material.dart';
+
+/// Unfocuses the active text field the moment the enclosing [ModalRoute] begins
+/// its dismiss transition.
+///
+/// The comments bottom sheet has no close button — it is dismissed by dragging
+/// it down, tapping the scrim, or the system back gesture. Every one of those
+/// vectors reverses the modal route's transition animation (the same
+/// `AnimationStatus.reverse` signal Flutter's own `_dismissUnderway` checks in
+/// `material/bottom_sheet.dart`). On iOS, tearing the route down does not
+/// reliably resign first responder, so the software keyboard is left visible
+/// over the feed below (#5604). Reacting to [AnimationStatus.reverse] unfocuses
+/// while the field is still mounted and focused, which closes the text-input
+/// connection in time for the keyboard to animate away with the sheet.
+///
+/// Renders [child] unchanged; it only observes the route animation. No-op when
+/// there is no enclosing modal route (e.g. a non-modal host).
+class UnfocusOnSheetDismiss extends StatefulWidget {
+  const UnfocusOnSheetDismiss({required this.child, super.key});
+
+  /// The sheet subtree this widget wraps and renders unchanged.
+  final Widget child;
+
+  @override
+  State<UnfocusOnSheetDismiss> createState() => _UnfocusOnSheetDismissState();
+}
+
+class _UnfocusOnSheetDismissState extends State<UnfocusOnSheetDismiss> {
+  Animation<double>? _animation;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final animation = ModalRoute.of(context)?.animation;
+    if (animation != _animation) {
+      _animation?.removeStatusListener(_onStatusChanged);
+      _animation = animation;
+      _animation?.addStatusListener(_onStatusChanged);
+    }
+  }
+
+  void _onStatusChanged(AnimationStatus status) {
+    // The route only reverses when it is actually being dismissed (partial
+    // sheet resizes do not touch the route animation), so this fires once per
+    // dismiss, while the comment field still holds focus.
+    if (status == AnimationStatus.reverse) {
+      FocusManager.instance.primaryFocus?.unfocus();
+    }
+  }
+
+  @override
+  void dispose() {
+    _animation?.removeStatusListener(_onStatusChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.child;
+}

--- a/mobile/lib/screens/comments/widgets/widgets.dart
+++ b/mobile/lib/screens/comments/widgets/widgets.dart
@@ -11,4 +11,5 @@ export 'comments_header.dart';
 export 'comments_list.dart';
 export 'mention_overlay.dart';
 export 'new_comments_pill.dart';
+export 'unfocus_on_sheet_dismiss.dart';
 export 'video_comment_player.dart';

--- a/mobile/test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart
+++ b/mobile/test/screens/comments/widgets/unfocus_on_sheet_dismiss_test.dart
@@ -1,0 +1,67 @@
+// ABOUTME: Verifies UnfocusOnSheetDismiss drops the keyboard when the sheet
+// ABOUTME: starts closing, so iOS does not strand an orphaned keyboard (#5604).
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/comments/widgets/unfocus_on_sheet_dismiss.dart';
+
+void main() {
+  group(UnfocusOnSheetDismiss, () {
+    testWidgets(
+      'unfocuses the active field when the enclosing sheet starts dismissing',
+      (tester) async {
+        final focusNode = FocusNode();
+        addTearDown(focusNode.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) => Center(
+                  child: ElevatedButton(
+                    onPressed: () => showModalBottomSheet<void>(
+                      context: context,
+                      isScrollControlled: true,
+                      builder: (_) => UnfocusOnSheetDismiss(
+                        child: TextField(focusNode: focusNode, autofocus: true),
+                      ),
+                    ),
+                    child: const Text('open'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+
+        // The comment field is focused and the keyboard connection is open.
+        expect(focusNode.hasFocus, isTrue);
+        expect(tester.testTextInput.isVisible, isTrue);
+
+        // Dismiss the sheet. The route's transition reverses immediately —
+        // the signal UnfocusOnSheetDismiss reacts to — while the field is
+        // still mounted and focused.
+        Navigator.of(tester.element(find.byType(UnfocusOnSheetDismiss))).pop();
+        await tester.pump();
+
+        // Unfocus fired at dismiss-initiation (before teardown), so the
+        // text-input connection is closed rather than left orphaned (#5604).
+        expect(focusNode.hasFocus, isFalse);
+        expect(tester.testTextInput.isVisible, isFalse);
+
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets('renders its child unchanged', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: UnfocusOnSheetDismiss(child: Text('hello'))),
+      );
+
+      expect(find.text('hello'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Description

On iOS, dismissing the comments bottom sheet while its text field is focused
left the software keyboard stranded over the feed below (see the reporter's
screenshot on the issue).

The comments sheet has no close button — it is dismissed by dragging it down,
tapping the scrim, or the system back gesture. Nothing on any of those paths
unfocused the comment field, and on iOS tearing the modal route down does not
reliably resign first responder, so the keyboard is left orphaned.

This adds `UnfocusOnSheetDismiss`, a small widget wrapping the sheet's input
that listens to the enclosing `ModalRoute`'s animation and unfocuses the active
field on `AnimationStatus.reverse` — the same dismiss signal Flutter's own
`_dismissUnderway` checks in `material/bottom_sheet.dart`. It fires once at
dismiss-initiation, while the field is still focused, so the keyboard animates
away with the sheet across every dismiss vector (drag / scrim / back).

A post-pop (`whenComplete`) or `dispose()`-time unfocus would be too late: by
then the field is torn down and `primaryFocus` is null, which is exactly why
the existing route teardown already failed to hide the keyboard.

**Related Issue:** Closes #5604

## Out of Scope

The audio-search bottom sheet and the inline comment composer bar on the
fullscreen feed share the same latent navigate-away gap but are separate
surfaces; not touched here. `UnfocusOnSheetDismiss` is written generically and
can be promoted (e.g. into `VineBottomSheet`) if those are addressed later.

## Verification

- `flutter analyze lib/screens/comments test/screens/comments/...` — no issues.
- `flutter test test/screens/comments/` — all pass, including the new
  `unfocus_on_sheet_dismiss_test.dart`, which asserts the field unfocuses and
  the text-input connection closes at dismiss-initiation
  (`tester.testTextInput.isVisible` flips to `false`).
- Manual on-device (iOS): keyboard now dismisses with the sheet via drag-down,
  scrim tap, and back gesture; reply / edit / mention / send and the existing
  in-field dismiss button are unaffected. Android behavior unchanged.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
