### PR TITLE
fix(comments): open author profile when tapping the comment avatar

### DIFF
--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "am",
+    "commentAuthorAvatarSemanticLabel": "የ{name}ን መገለጫ ይመልከቱ",
     "publishErrorNotSignedIn": "ቪዲዮዎችን ለማተም እባክዎ ይግቡ።",
     "publishErrorNoRetry": "እንደገና የሚሞከር ስቀላ የለም።",
     "publishErrorNoInternet": "የበይነመረብ ግንኙነት የለም። ዋይ ፋይዎን ወይም የሞባይል ዳታዎን ይፈትሹ እና እንደገና ይሞክሩ።",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ar",
+    "commentAuthorAvatarSemanticLabel": "عرض ملف {name} الشخصي",
     "publishErrorNotSignedIn": "يرجى تسجيل الدخول لنشر الفيديوهات.",
     "publishErrorNoRetry": "لا يوجد رفع لإعادة محاولته.",
     "publishErrorNoInternet": "لا يوجد اتصال بالإنترنت. تحقّق من Wi-Fi أو بيانات الجوال وحاول مرّة أخرى.",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "bg",
+    "commentAuthorAvatarSemanticLabel": "Преглед на профила на {name}",
     "publishErrorNotSignedIn": "Влез, за да публикуваш видеа.",
     "publishErrorNoRetry": "Няма качване, което да повториш.",
     "publishErrorNoInternet": "Няма връзка с интернет. Провери Wi-Fi или мобилните данни и опитай пак.",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "de",
+    "commentAuthorAvatarSemanticLabel": "Profil von {name} ansehen",
     "publishErrorNotSignedIn": "Melde dich an, um Videos zu veröffentlichen.",
     "publishErrorNoRetry": "Kein Upload zum Wiederholen.",
     "publishErrorNoInternet": "Keine Internetverbindung. Prüfe dein WLAN oder deine mobilen Daten und versuch es erneut.",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -3544,6 +3544,15 @@
   "keyImportSubtitle": "Import your existing Nostr identity using your private key or a bunker URL.",
   "keyImportTitle": "Import your\nNostr identity",
   "commentAuthorYouIndicator": "You",
+  "commentAuthorAvatarSemanticLabel": "View {name}'s profile",
+  "@commentAuthorAvatarSemanticLabel": {
+    "description": "Screen-reader label for the tappable comment author avatar, which opens the author's profile. {name} is the author's display name.",
+    "placeholders": {
+      "name": {
+        "type": "String"
+      }
+    }
+  },
   "commentOptionsDeleteSemanticLabel": "Delete comment",
   "commentOptionsEditSemanticLabel": "Edit comment",
   "commentOptionsFlagContentLabel": "Flag Content",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "es",
+    "commentAuthorAvatarSemanticLabel": "Ver el perfil de {name}",
     "publishErrorNotSignedIn": "Iniciá sesión para publicar vídeos.",
     "publishErrorNoRetry": "No hay ninguna subida para reintentar.",
     "publishErrorNoInternet": "Sin conexión a internet. Revisá tu Wi-Fi o los datos móviles e intentá de nuevo.",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fil",
+    "commentAuthorAvatarSemanticLabel": "Tingnan ang profile ni {name}",
     "publishErrorNotSignedIn": "Mag-sign in muna para makapag-publish ng video.",
     "publishErrorNoRetry": "Walang upload na puwedeng subukan ulit.",
     "publishErrorNoInternet": "Walang internet connection. Tingnan ang iyong Wi-Fi o mobile data at subukan ulit.",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "fr",
+    "commentAuthorAvatarSemanticLabel": "Voir le profil de {name}",
     "publishErrorNotSignedIn": "Connecte-toi pour publier des vidéos.",
     "publishErrorNoRetry": "Aucun envoi à relancer.",
     "publishErrorNoInternet": "Pas de connexion internet. Vérifie ton Wi-Fi ou tes données mobiles et réessaie.",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "id",
+    "commentAuthorAvatarSemanticLabel": "Lihat profil {name}",
     "publishErrorNotSignedIn": "Silakan masuk untuk mempublikasikan video.",
     "publishErrorNoRetry": "Tidak ada unggahan untuk dicoba ulang.",
     "publishErrorNoInternet": "Tidak ada koneksi internet. Periksa Wi-Fi atau data selulermu dan coba lagi.",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "it",
+    "commentAuthorAvatarSemanticLabel": "Visualizza il profilo di {name}",
   "publishErrorNotSignedIn": "Accedi per pubblicare i video.",
   "publishErrorNoRetry": "Nessun caricamento da riprovare.",
   "publishErrorNoInternet": "Nessuna connessione a internet. Controlla il Wi-Fi o i dati mobili e riprova.",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ja",
+    "commentAuthorAvatarSemanticLabel": "{name}のプロフィールを表示",
     "publishErrorNotSignedIn": "動画を投稿するにはサインインしてね。",
     "publishErrorNoRetry": "やり直せるアップロードがないよ。",
     "publishErrorNoInternet": "ネットに接続できないよ。Wi-Fi かモバイルデータを確認して、もう一回試してみて。",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ko",
+    "commentAuthorAvatarSemanticLabel": "{name}님의 프로필 보기",
     "publishErrorNotSignedIn": "영상을 게시하려면 로그인해주세요.",
     "publishErrorNoRetry": "다시 시도할 업로드가 없어요.",
     "publishErrorNoInternet": "인터넷에 연결되어 있지 않아요. 와이파이나 모바일 데이터를 확인하고 다시 시도해주세요.",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "nl",
+    "commentAuthorAvatarSemanticLabel": "Profiel van {name} bekijken",
     "publishErrorNotSignedIn": "Log in om video's te publiceren.",
     "publishErrorNoRetry": "Geen upload om opnieuw te proberen.",
     "publishErrorNoInternet": "Geen internetverbinding. Controleer je wifi of mobiele data en probeer het opnieuw.",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "pl",
+    "commentAuthorAvatarSemanticLabel": "Zobacz profil użytkownika {name}",
     "publishErrorNotSignedIn": "Zaloguj się, aby publikować filmy.",
     "publishErrorNoRetry": "Brak przesyłania do ponowienia.",
     "publishErrorNoInternet": "Brak połączenia z internetem. Sprawdź Wi-Fi lub dane komórkowe i spróbuj ponownie.",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "pt",
+    "commentAuthorAvatarSemanticLabel": "Ver o perfil de {name}",
     "publishErrorNotSignedIn": "Entre na sua conta para publicar vídeos.",
     "publishErrorNoRetry": "Nenhum envio para tentar novamente.",
     "publishErrorNoInternet": "Sem conexão com a internet. Verifique seu Wi-Fi ou dados móveis e tente novamente.",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "ro",
+    "commentAuthorAvatarSemanticLabel": "Vezi profilul lui {name}",
     "publishErrorNotSignedIn": "Autentifică-te ca să publici videoclipuri.",
     "publishErrorNoRetry": "Nu există nicio încărcare de reîncercat.",
     "publishErrorNoInternet": "Nu există conexiune la internet. Verifică Wi-Fi-ul sau datele mobile și încearcă din nou.",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "sv",
+    "commentAuthorAvatarSemanticLabel": "Visa {name}s profil",
     "publishErrorNotSignedIn": "Logga in för att publicera videor.",
     "publishErrorNoRetry": "Ingen uppladdning att försöka igen med.",
     "publishErrorNoInternet": "Ingen internetanslutning. Kontrollera ditt wifi eller mobildata och försök igen.",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -1,5 +1,6 @@
 {
     "@@locale": "tr",
+    "commentAuthorAvatarSemanticLabel": "{name} kullanıcısının profilini görüntüle",
     "publishErrorNotSignedIn": "Video yayınlamak için lütfen giriş yap.",
     "publishErrorNoRetry": "Yeniden denenecek bir yükleme yok.",
     "publishErrorNoInternet": "İnternet bağlantısı yok. Wi-Fi'ını veya mobil verini kontrol edip tekrar dene.",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -10856,6 +10856,12 @@ abstract class AppLocalizations {
   /// **'You'**
   String get commentAuthorYouIndicator;
 
+  /// Screen-reader label for the tappable comment author avatar, which opens the author's profile. {name} is the author's display name.
+  ///
+  /// In en, this message translates to:
+  /// **'View {name}\'s profile'**
+  String commentAuthorAvatarSemanticLabel(String name);
+
   /// No description provided for @commentOptionsDeleteSemanticLabel.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -6070,6 +6070,11 @@ class AppLocalizationsAm extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'የ$nameን መገለጫ ይመልከቱ';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -6129,6 +6129,11 @@ class AppLocalizationsAr extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'عرض ملف $name الشخصي';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -6246,6 +6246,11 @@ class AppLocalizationsBg extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Преглед на профила на $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -6256,6 +6256,11 @@ class AppLocalizationsDe extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Profil von $name ansehen';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -6182,6 +6182,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'View $name\'s profile';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -6234,6 +6234,11 @@ class AppLocalizationsEs extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Ver el perfil de $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -6255,6 +6255,11 @@ class AppLocalizationsFil extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Tingnan ang profile ni $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -6262,6 +6262,11 @@ class AppLocalizationsFr extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Voir le profil de $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -6158,6 +6158,11 @@ class AppLocalizationsId extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Lihat profil $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -6234,6 +6234,11 @@ class AppLocalizationsIt extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Visualizza il profilo di $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -5946,6 +5946,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return '$nameのプロフィールを表示';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -5969,6 +5969,11 @@ class AppLocalizationsKo extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return '$name님의 프로필 보기';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -6211,6 +6211,11 @@ class AppLocalizationsNl extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Profiel van $name bekijken';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -6326,6 +6326,11 @@ class AppLocalizationsPl extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Zobacz profil użytkownika $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -6219,6 +6219,11 @@ class AppLocalizationsPt extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Ver o perfil de $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -6334,6 +6334,11 @@ class AppLocalizationsRo extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Vezi profilul lui $name';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -6184,6 +6184,11 @@ class AppLocalizationsSv extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return 'Visa ${name}s profil';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -6160,6 +6160,11 @@ class AppLocalizationsTr extends AppLocalizations {
   String get commentAuthorYouIndicator => 'You';
 
   @override
+  String commentAuthorAvatarSemanticLabel(String name) {
+    return '$name kullanıcısının profilini görüntüle';
+  }
+
+  @override
   String get commentOptionsDeleteSemanticLabel => 'Delete comment';
 
   @override

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -289,10 +289,11 @@ class _CommentHeader extends ConsumerWidget {
     final isCurrentUser =
         currentUserPubkey.isNotEmpty && currentUserPubkey == authorPubkey;
 
-    final displayName =
-        profile?.displayName ??
-        profile?.name ??
-        UserProfile.generatedNameFor(authorPubkey);
+    final profileLabel =
+        profile?.bestDisplayName ?? UserProfile.generatedNameFor(authorPubkey);
+    final openProfileLabel = context.l10n.commentAuthorAvatarSemanticLabel(
+      profileLabel,
+    );
 
     void openAuthorProfile() => context.pushOtherProfile(authorPubkey);
 
@@ -306,9 +307,7 @@ class _CommentHeader extends ConsumerWidget {
             imageUrl: profile?.picture,
             placeholderSeed: authorPubkey,
             onTap: openAuthorProfile,
-            semanticLabel: context.l10n.commentAuthorAvatarSemanticLabel(
-              displayName,
-            ),
+            semanticLabel: openProfileLabel,
           ),
           Expanded(
             child: Column(
@@ -338,23 +337,27 @@ class _CommentHeader extends ConsumerWidget {
                     ],
                   ],
                 ),
-                GestureDetector(
-                  onTap: openAuthorProfile,
-                  child: profile == null
-                      ? Text(
-                          UserProfile.generatedNameFor(authorPubkey),
-                          style: VineTheme.titleSmallFont(
-                            color: VineTheme.onSurface,
+                Semantics(
+                  button: true,
+                  label: openProfileLabel,
+                  child: GestureDetector(
+                    onTap: openAuthorProfile,
+                    child: profile == null
+                        ? Text(
+                            UserProfile.generatedNameFor(authorPubkey),
+                            style: VineTheme.titleSmallFont(
+                              color: VineTheme.onSurface,
+                            ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          )
+                        : UserName.fromUserProfile(
+                            profile,
+                            style: VineTheme.titleSmallFont(
+                              color: VineTheme.onSurface,
+                            ),
                           ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        )
-                      : UserName.fromUserProfile(
-                          profile,
-                          style: VineTheme.titleSmallFont(
-                            color: VineTheme.onSurface,
-                          ),
-                        ),
+                  ),
                 ),
               ],
             ),

--- a/mobile/lib/screens/comments/widgets/comment_item.dart
+++ b/mobile/lib/screens/comments/widgets/comment_item.dart
@@ -18,12 +18,11 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/l10n/localized_time_formatter.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
+import 'package:openvine/router/nav_extensions.dart';
 import 'package:openvine/screens/comments/comment_synthetic_video_event.dart';
 import 'package:openvine/screens/comments/widgets/comment_options_modal.dart';
 import 'package:openvine/screens/comments/widgets/video_comment_player.dart';
-import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
-import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:openvine/widgets/user_name.dart';
@@ -290,6 +289,13 @@ class _CommentHeader extends ConsumerWidget {
     final isCurrentUser =
         currentUserPubkey.isNotEmpty && currentUserPubkey == authorPubkey;
 
+    final displayName =
+        profile?.displayName ??
+        profile?.name ??
+        UserProfile.generatedNameFor(authorPubkey);
+
+    void openAuthorProfile() => context.pushOtherProfile(authorPubkey);
+
     return IdentitySkeletonizer(
       isLoading: profile == null,
       child: Row(
@@ -299,6 +305,10 @@ class _CommentHeader extends ConsumerWidget {
             size: avatarSize,
             imageUrl: profile?.picture,
             placeholderSeed: authorPubkey,
+            onTap: openAuthorProfile,
+            semanticLabel: context.l10n.commentAuthorAvatarSemanticLabel(
+              displayName,
+            ),
           ),
           Expanded(
             child: Column(
@@ -329,10 +339,7 @@ class _CommentHeader extends ConsumerWidget {
                   ],
                 ),
                 GestureDetector(
-                  onTap: () {
-                    final npub = NostrKeyUtils.encodePubKey(authorPubkey);
-                    context.push(OtherProfileScreen.pathForNpub(npub));
-                  },
+                  onTap: openAuthorProfile,
                   child: profile == null
                       ? Text(
                           UserProfile.generatedNameFor(authorPubkey),

--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -57,9 +57,7 @@ void main() {
   setUpAll(() {
     VisibilityDetectorController.instance.updateInterval = Duration.zero;
     registerFallbackValue(const CommentReplyToggled(''));
-    registerFallbackValue(
-      const CommentReactionsErrorCleared(),
-    );
+    registerFallbackValue(const CommentReactionsErrorCleared());
   });
 
   ({_MockComposerBloc composer, _MockReactionsBloc reactions}) buildMocks() {
@@ -343,9 +341,11 @@ void main() {
       // Resolve the author profile so IdentitySkeletonizer is disabled —
       // Skeletonizer.ignorePointers defaults to true, so a still-loading
       // (null) profile would swallow the avatar tap.
+      const cleanedName = 'Ada\u0300\u0301';
       final profile = UserProfile(
         pubkey: _testHexPubkey,
-        displayName: 'Ada Lovelace',
+        displayName: '',
+        name: '$cleanedName\u0302\u0303',
         rawData: const {},
         createdAt: DateTime.utc(2026, 6, 28),
         eventId:
@@ -353,6 +353,7 @@ void main() {
       );
 
       final expectedNpub = NostrKeyUtils.encodePubKey(_testHexPubkey);
+      const expectedProfileLabel = "View $cleanedName's profile";
 
       final router = GoRouter(
         routes: [
@@ -376,9 +377,8 @@ void main() {
           ),
           GoRoute(
             path: OtherProfileScreen.pathWithNpub,
-            builder: (context, state) => Scaffold(
-              body: Text('profile:${state.pathParameters['npub']}'),
-            ),
+            builder: (context, state) =>
+                Scaffold(body: Text('profile:${state.pathParameters['npub']}')),
           ),
         ],
       );
@@ -399,6 +399,19 @@ void main() {
         ),
       );
       await tester.pumpAndSettle();
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is Semantics &&
+              widget.properties.label == expectedProfileLabel &&
+              widget.properties.button == true,
+        ),
+        findsNWidgets(2),
+        reason:
+            'The avatar and visible author name should both be announced as '
+            'profile-opening buttons with the same sanitized display name.',
+      );
 
       await tester.tap(find.byType(UserAvatar));
       await tester.pumpAndSettle();

--- a/mobile/test/screens/comments/comment_item_test.dart
+++ b/mobile/test/screens/comments/comment_item_test.dart
@@ -16,11 +16,14 @@ import 'package:openvine/blocs/comments/comment_composer/comment_composer_bloc.d
 import 'package:openvine/blocs/comments/comment_reactions/comment_reactions_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/comments/widgets/comment_item.dart';
 import 'package:openvine/screens/comments/widgets/video_comment_player.dart';
+import 'package:openvine/screens/other_profile_screen.dart';
 import 'package:openvine/screens/video_detail_screen.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/widgets/linkified_text/linkified_text_widgets.dart';
+import 'package:openvine/widgets/user_avatar.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
 import '../../builders/comment_builder.dart';
@@ -322,5 +325,85 @@ void main() {
         await tester.pumpAndSettle();
       },
     );
+  });
+
+  group('author navigation', () {
+    testWidgets('tapping the author avatar opens the author profile', (
+      tester,
+    ) async {
+      final mocks = buildMocks();
+
+      final comment = CommentBuilder()
+          .withAuthorPubkey(_testHexPubkey)
+          .withRootEventId(_testRootEventId)
+          .withRootAuthorPubkey(_testRootAuthorPubkey)
+          .withContent('hello')
+          .build();
+
+      // Resolve the author profile so IdentitySkeletonizer is disabled —
+      // Skeletonizer.ignorePointers defaults to true, so a still-loading
+      // (null) profile would swallow the avatar tap.
+      final profile = UserProfile(
+        pubkey: _testHexPubkey,
+        displayName: 'Ada Lovelace',
+        rawData: const {},
+        createdAt: DateTime.utc(2026, 6, 28),
+        eventId:
+            'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210',
+      );
+
+      final expectedNpub = NostrKeyUtils.encodePubKey(_testHexPubkey);
+
+      final router = GoRouter(
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: MultiBlocProvider(
+                providers: [
+                  BlocProvider<CommentComposerBloc>.value(
+                    value: mocks.composer,
+                  ),
+                  BlocProvider<CommentReactionsBloc>.value(
+                    value: mocks.reactions,
+                  ),
+                ],
+                child: SingleChildScrollView(
+                  child: CommentItem(comment: comment),
+                ),
+              ),
+            ),
+          ),
+          GoRoute(
+            path: OtherProfileScreen.pathWithNpub,
+            builder: (context, state) => Scaffold(
+              body: Text('profile:${state.pathParameters['npub']}'),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            nostrServiceProvider.overrideWithValue(const _FakeNostrClient()),
+            userProfileReactiveProvider(
+              _testHexPubkey,
+            ).overrideWith((ref) => Stream.value(profile)),
+          ],
+          child: MaterialApp.router(
+            routerConfig: router,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(UserAvatar));
+      await tester.pumpAndSettle();
+
+      expect(find.text('profile:$expectedNpub'), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
## Description

In the comments bottom sheet, tapping a comment author's **name** opened their profile, but tapping their **avatar** did nothing. That's inconsistent with the feed, notifications, and conversation rows, where the avatar is the canonical profile-open target — and with user expectation generally.

This wires the avatar to the same navigation as the name:

- Lifts the navigation into one shared `openAuthorProfile()` closure in `_CommentHeader` → `context.pushOtherProfile(authorPubkey)` (the purpose-built extension; byte-identical to the name's previous inline encode+push, so the now-orphaned `nostr_key_utils` + `other_profile_screen` imports are dropped in favor of `nav_extensions`).
- `UserAvatar` gets `onTap` + a `semanticLabel`. It auto-promotes the tap target to a screen-reader `button`, so the label is action-describing: **"View {name}'s profile"** via the new `commentAuthorAvatarSemanticLabel` key.
- The name reuses the same closure — its navigation is unchanged.

**Navigation primitive:** plain `push` (not `pushWithVideoPause`) is deliberate and matches the name. The comments sheet is opened via `showVideoPausingVineBottomSheet`, which already pauses **and retains** the feed player; `pushWithVideoPause` would set `isPageOpen`, flipping `shouldRetainPlayer` to false and forcing a full player release.

**Loading state:** the avatar behaves bit-for-bit like the name — during the identity skeleton shimmer the header is intentionally non-interactive (`IdentitySkeletonizer` → `Skeletonizer(ignorePointers: true)`); navigation fires once the profile resolves or after the 7s fallthrough. This is parity, not a regression.

**Related Issue:** Closes #5618

## Out of Scope

- The author **name**'s tap target has no semantic label today (pre-existing gap, unrelated to this change). Left as a separate follow-up rather than widening the diff with a second l10n key.

## Verification

- `flutter analyze lib/screens/comments/widgets/comment_item.dart test/screens/comments/comment_item_test.dart lib/l10n` — No issues found
- `flutter test test/screens/comments/` (88 tests) + `test/l10n/arb_consistency_test.dart` — all pass, including the new `tapping the author avatar opens the author profile` test
- New ARB key `commentAuthorAvatarSemanticLabel` translated across all 18 locales; `flutter gen-l10n` regenerated and committed
- No layout change (avatar geometry unchanged when `onTap` is added); no golden tests touch the comment header

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)