### PR TITLE
test(nostr): assert disposed-ref leak explicitly in init guard tests

### DIFF
--- a/mobile/test/providers/nostr_service_identity_source_test.dart
+++ b/mobile/test/providers/nostr_service_identity_source_test.dart
@@ -1172,54 +1172,85 @@ void main() {
     test('does not touch ref after the container is disposed mid-init '
         '(success path)', () async {
       when(() => mockAuth.currentIdentity).thenReturn(identityA);
-      // Gate initialize() so _initializeClient parks on the await.
-      factory.initializeCompleters[pubkeyA] = Completer<void>();
 
-      final container = createContainer();
-      container.read(nostrServiceProvider); // schedules _initializeClient
+      // The leak under test is the fire-and-forgotten `Future.microtask` that
+      // build() schedules for _initializeClient. An uncaught async error is
+      // reported to the zone that was current when the future was *created*,
+      // so container.read() (and the gating completer) must run inside this
+      // guarded zone for the leak to land in [errors]. Without the ref.mounted
+      // guard, the resumed _isCurrentClientForPubkey reads a disposed ref and
+      // throws ("Cannot use the Ref ... after it has been disposed").
+      final errors = <Object>[];
+      await runZonedGuarded(
+        () async {
+          // Gate initialize() so _initializeClient parks on the await.
+          factory.initializeCompleters[pubkeyA] = Completer<void>();
 
-      // Let the scheduled microtask reach `await client.initialize()`.
-      await Future<void>.delayed(Duration.zero);
-      expect(
-        factory.initializePubkeys,
-        contains(pubkeyA),
-        reason: '_initializeClient must be parked on the gated initialize()',
+          final container = createContainer();
+          container.read(nostrServiceProvider); // schedules _initializeClient
+
+          // Let the scheduled microtask reach `await client.initialize()`.
+          await Future<void>.delayed(Duration.zero);
+          expect(
+            factory.initializePubkeys,
+            contains(pubkeyA),
+            reason:
+                '_initializeClient must be parked on the gated initialize()',
+          );
+
+          // Dispose mid-init, then let init resume past the await.
+          container.dispose();
+          factory.initializeCompleters[pubkeyA]!.complete();
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+        },
+        (error, _) => errors.add(error),
       );
 
-      // Dispose mid-init, then let init resume. Without the ref.mounted guard,
-      // the resumed _isCurrentClientForPubkey reads a disposed ref and throws
-      // ("Cannot use the Ref ... after it has been disposed"), surfacing as an
-      // uncaught async error that fails this test. The guard makes it bail.
-      container.dispose();
-      factory.initializeCompleters[pubkeyA]!.complete();
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
-
-      expect(factory.initializeCompleters[pubkeyA]!.isCompleted, isTrue);
+      expect(
+        errors,
+        isEmpty,
+        reason: 'a disposed-ref read leaked past the guard: $errors',
+      );
     });
 
     test('does not touch ref after the container is disposed mid-init '
         '(error path)', () async {
       when(() => mockAuth.currentIdentity).thenReturn(identityA);
-      factory.initializeCompleters[pubkeyA] = Completer<void>();
 
-      final container = createContainer();
-      container.read(nostrServiceProvider);
+      // Same zone rule as the success path: container.read() runs inside the
+      // guarded zone so the fire-and-forgotten init microtask reports any
+      // leaked error into [errors]. The gating completer is created inside the
+      // zone too, so the StateError used to fail init is owned by this zone and
+      // not the outer flutter_test zone. Failing init mid-disposal drives
+      // _initializeClient into its catch block; without the guard the catch
+      // path's ref reads throw on the disposed provider.
+      final errors = <Object>[];
+      await runZonedGuarded(
+        () async {
+          factory.initializeCompleters[pubkeyA] = Completer<void>();
 
-      await Future<void>.delayed(Duration.zero);
-      expect(factory.initializePubkeys, contains(pubkeyA));
+          final container = createContainer();
+          container.read(nostrServiceProvider);
 
-      // Dispose mid-init, then fail init so _initializeClient enters its catch
-      // block. Without the guard the catch path's ref reads throw on the
-      // disposed provider; the guard makes it bail.
-      container.dispose();
-      factory.initializeCompleters[pubkeyA]!.completeError(
-        StateError('init failed'),
+          await Future<void>.delayed(Duration.zero);
+          expect(factory.initializePubkeys, contains(pubkeyA));
+
+          container.dispose();
+          factory.initializeCompleters[pubkeyA]!.completeError(
+            StateError('init failed'),
+          );
+          await Future<void>.delayed(Duration.zero);
+          await Future<void>.delayed(Duration.zero);
+        },
+        (error, _) => errors.add(error),
       );
-      await Future<void>.delayed(Duration.zero);
-      await Future<void>.delayed(Duration.zero);
 
-      expect(factory.initializeCompleters[pubkeyA]!.isCompleted, isTrue);
+      expect(
+        errors,
+        isEmpty,
+        reason: 'a disposed-ref read leaked past the guard: $errors',
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

Follow-up to #5615 addressing @hm21's review nit on the two `#5602 / #5600` regression tests for `NostrService._initializeClient`.

Those tests asserted `expect(completer.isCompleted, isTrue)`, which is tautological — the completer is completed just above, so the assertion holds whether or not the `ref.mounted` guard works. The real contract ("no uncaught async error after mid-init disposal") was verified only implicitly, by flutter_test's zone failing the test when the leaked init future rejected.

This wraps each test body in `runZonedGuarded` and asserts the captured error list is empty. Two subtleties make the assertion real (and make the naive "wrap only the teardown" form a no-op):

- An uncaught async error is reported to the zone that was current when the **future was created**. The leak is the fire-and-forgotten `Future.microtask` that `build()` schedules during `container.read(nostrServiceProvider)`, so the `read` must run **inside** the guarded zone — otherwise the leak escapes to the outer flutter_test zone and `errors` stays empty.
- For the error path, the gating `Completer` is also created inside the zone, so the `StateError` used to fail init is owned by this zone rather than the outer one.

With the guard removed, both tests now fail on the explicit `expect(errors, isEmpty)` with the captured `UnmountedRefException`, so they self-document what they guarantee. No production change.

**Related Issue:** Relates to #5602, follow-up to #5615

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` — no issues.
- `flutter test test/providers/nostr_service_identity_source_test.dart` — all 21 green.
- Guard-removed check: with both `if (!ref.mounted) return;` guards disabled, both tests fail on `expect(errors, isEmpty)` showing the captured `UnmountedRefException` (success + error paths). Restoring the guard makes them green again.

## Type of Change

- [x] 🧹 Code refactor (test-only; no production change)
