### PR TITLE
fix(auth): preserve NIP-46 signer callback sessions

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -2091,7 +2091,11 @@ class _DivineAppState extends ConsumerState<DivineApp> {
                 name: 'DeepLinkHandler',
                 category: LogCategory.auth,
               );
-              ref.read(authServiceProvider).onSignerCallbackReceived();
+              ref
+                  .read(authServiceProvider)
+                  .onSignerCallbackReceived(
+                    relayUrl: deepLink.signerCallbackRelay,
+                  );
             case DeepLinkType.unknown:
               Log.warning(
                 '📱 Unknown deep link type',

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -124,6 +124,9 @@ String? signerCallbackRedirectTarget(Uri uri, AuthService authService) {
     return null;
   }
 
+  // The app-links stream handles this too, but GoRouter may see Android
+  // custom-scheme callbacks first. Keep this idempotent: it only preserves
+  // an already-listening NIP-46 session while routing back to its screen.
   authService.onSignerCallbackReceived(relayUrl: deepLink.signerCallbackRelay);
   return authService.nostrConnectUrl != null
       ? NostrConnectScreen.path

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -90,7 +90,9 @@ import 'package:openvine/screens/video_metadata/video_metadata_edit_screen.dart'
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/video_stop_navigator_observer.dart';
+import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Global route observer for [RouteAware] subscribers (e.g. pausing video
@@ -113,6 +115,19 @@ void suppressNextAuthenticatedAuthRouteRedirect() {
 /// Clears a pending authenticated auth-route redirect suppression.
 void clearAuthenticatedAuthRouteRedirectSuppression() {
   _suppressNextAuthenticatedAuthRouteRedirect = false;
+}
+
+@visibleForTesting
+String? signerCallbackRedirectTarget(Uri uri, AuthService authService) {
+  final deepLink = DeepLinkService.parseDeepLink(uri.toString());
+  if (deepLink.type != DeepLinkType.signerCallback) {
+    return null;
+  }
+
+  authService.onSignerCallbackReceived(relayUrl: deepLink.signerCallbackRelay);
+  return authService.nostrConnectUrl != null
+      ? NostrConnectScreen.path
+      : WelcomeScreen.path;
 }
 
 /// Reset navigation state for testing purposes
@@ -307,6 +322,22 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     errorBuilder: (context, state) =>
         RouteErrorScreen(message: context.l10n.routeUnknownPath),
     redirect: (context, state) {
+      final authService = ref.read(authServiceProvider);
+      final signerCallbackRedirect = signerCallbackRedirectTarget(
+        state.uri,
+        authService,
+      );
+      if (signerCallbackRedirect != null) {
+        Log.info(
+          'Router redirect: signer callback '
+          '${redactUriStringForLogs(state.uri.toString())} -> '
+          '$signerCallbackRedirect',
+          name: 'AppRouter',
+          category: LogCategory.auth,
+        );
+        return signerCallbackRedirect;
+      }
+
       // Rewrite divine.video universal-link URLs to internal paths before the
       // auth/match logic runs. Android delivers the full intent URL (scheme +
       // host + path) to GoRouter, which only matches on path. Without this
@@ -324,7 +355,6 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       }
 
       final location = state.matchedLocation;
-      final authService = ref.read(authServiceProvider);
       final authState = authService.authState;
       final reviewStatusAsync = ref.read(
         currentMinorAccountReviewStatusProvider,

--- a/mobile/lib/router/providers/route_normalization_provider.dart
+++ b/mobile/lib/router/providers/route_normalization_provider.dart
@@ -33,7 +33,16 @@ bool shouldSkipRouteNormalization(String loc) {
   }
 
   final uri = Uri.tryParse(loc);
-  if (uri == null || !uri.scheme.startsWith('http')) {
+  if (uri == null) {
+    return false;
+  }
+
+  final deepLinkType = DeepLinkService.parseDeepLink(loc).type;
+  if (deepLinkType == DeepLinkType.signerCallback) {
+    return true;
+  }
+
+  if (!uri.scheme.startsWith('http')) {
     return false;
   }
 
@@ -48,7 +57,7 @@ bool shouldSkipRouteNormalization(String loc) {
   // redirect or in the app-wide DeepLinkService listener. They are not part
   // of the internal parseRoute/buildRoute contract, so normalizing them here
   // can rewrite a valid deep link into an unrelated internal fallback.
-  return DeepLinkService.parseDeepLink(loc).type != DeepLinkType.unknown;
+  return deepLinkType != DeepLinkType.unknown;
 }
 
 /// Watches router location changes and redirects to canonical URLs when needed.

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -39,6 +39,7 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
   StreamSubscription<NostrConnectState>? _stateSubscription;
   bool _isWaiting = false;
   bool _switchedToBunker = false;
+  int _sessionAttempt = 0;
   final Stopwatch _elapsedTimer = Stopwatch();
   Timer? _uiTimer;
 
@@ -49,7 +50,7 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
   void initState() {
     super.initState();
     _authService = ref.read(authServiceProvider);
-    _startSession();
+    _startOrResumeSession();
   }
 
   @override
@@ -57,13 +58,86 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
     _stateSubscription?.cancel();
     _uiTimer?.cancel();
     _elapsedTimer.stop();
-    // Cancel the session if user leaves the screen
-    _authService.cancelNostrConnect();
+    // Android can route the signer callback through GoRouter before the
+    // app-links stream finishes handling it. In that short handoff, preserve
+    // the active NIP-46 session so the replacement route can reattach.
+    if (!_authService.isNostrConnectCallbackHandoffActive) {
+      _authService.cancelNostrConnect();
+    }
     super.dispose();
   }
 
-  Future<void> _startSession() async {
+  void _startOrResumeSession() {
+    final activeUrl = _authService.nostrConnectUrl;
+    final activeState = _authService.nostrConnectState;
+    if (activeUrl != null &&
+        (activeState == NostrConnectState.generating ||
+            activeState == NostrConnectState.listening)) {
+      _resumeActiveSession(activeUrl, activeState ?? NostrConnectState.idle);
+      return;
+    }
+
+    _startSession();
+  }
+
+  void _resumeActiveSession(String activeUrl, NostrConnectState activeState) {
+    final attempt = ++_sessionAttempt;
+    unawaited(_stateSubscription?.cancel());
+    _stateSubscription = null;
+    _uiTimer?.cancel();
+    _uiTimer = null;
+    _elapsedTimer
+      ..stop()
+      ..reset()
+      ..start();
+    _isWaiting = false;
+    _switchedToBunker = false;
+
+    Log.info(
+      'Resuming active nostrconnect session after signer callback',
+      name: 'NostrConnectScreen',
+      category: LogCategory.auth,
+    );
+
     setState(() {
+      _connectUrl = activeUrl;
+      _sessionState = activeState;
+      _errorMessage = null;
+    });
+
+    _stateSubscription = _authService.nostrConnectStateStream?.listen((state) {
+      if (!mounted || attempt != _sessionAttempt) return;
+      setState(() {
+        _sessionState = state;
+      });
+      if (state == NostrConnectState.listening) {
+        unawaited(_waitForConnection(attempt));
+      }
+    });
+
+    _uiTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (mounted && attempt == _sessionAttempt) setState(() {});
+    });
+
+    if (activeState == NostrConnectState.listening) {
+      unawaited(_waitForConnection(attempt));
+    }
+  }
+
+  Future<void> _startSession() async {
+    final attempt = ++_sessionAttempt;
+    await _stateSubscription?.cancel();
+    _stateSubscription = null;
+    _uiTimer?.cancel();
+    _uiTimer = null;
+    _elapsedTimer
+      ..stop()
+      ..reset();
+    _isWaiting = false;
+    _switchedToBunker = false;
+
+    setState(() {
+      _connectUrl = null;
       _sessionState = NostrConnectState.generating;
       _errorMessage = null;
     });
@@ -72,7 +146,7 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
       final authService = ref.read(authServiceProvider);
       final session = await authService.initiateNostrConnect();
 
-      if (!mounted) return;
+      if (!mounted || attempt != _sessionAttempt) return;
 
       setState(() {
         _connectUrl = session.connectUrl;
@@ -81,7 +155,7 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
 
       // Listen to state changes
       _stateSubscription = session.stateStream.listen((state) {
-        if (!mounted) return;
+        if (!mounted || attempt != _sessionAttempt) return;
         setState(() {
           _sessionState = state;
         });
@@ -94,14 +168,14 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
       });
 
       // Start waiting for the connection
-      _waitForConnection();
+      _waitForConnection(attempt);
     } catch (e) {
       Log.error(
         'Failed to start nostrconnect session: $e',
         name: 'NostrConnectScreen',
         category: LogCategory.auth,
       );
-      if (!mounted) return;
+      if (!mounted || attempt != _sessionAttempt) return;
       setState(() {
         _sessionState = NostrConnectState.error;
         _errorMessage = 'Failed to start session: $e';
@@ -109,18 +183,18 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
     }
   }
 
-  Future<void> _waitForConnection() async {
+  Future<void> _waitForConnection(int attempt) async {
     if (_isWaiting) return;
     _isWaiting = true;
 
     final authService = ref.read(authServiceProvider);
     final result = await authService.waitForNostrConnectResponse();
 
+    if (!mounted || attempt != _sessionAttempt) return;
+
     _isWaiting = false;
     _elapsedTimer.stop();
     _uiTimer?.cancel();
-
-    if (!mounted) return;
 
     // If the user switched to a bunker connection via the paste dialog,
     // ignore the nostrconnect session result to avoid interfering with
@@ -256,6 +330,7 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
     // Cancel the current nostrconnect session and prevent its completion
     // callback from interfering with the bunker auth flow.
     _switchedToBunker = true;
+    _sessionAttempt++;
     _authService.cancelNostrConnect();
     _stateSubscription?.cancel();
     _uiTimer?.cancel();

--- a/mobile/lib/screens/auth/nostr_connect_screen.dart
+++ b/mobile/lib/screens/auth/nostr_connect_screen.dart
@@ -63,6 +63,8 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
     // the active NIP-46 session so the replacement route can reattach.
     if (!_authService.isNostrConnectCallbackHandoffActive) {
       _authService.cancelNostrConnect();
+    } else {
+      _authService.preserveNostrConnectForCallbackHandoff();
     }
     super.dispose();
   }
@@ -81,6 +83,7 @@ class _NostrConnectScreenState extends ConsumerState<NostrConnectScreen> {
   }
 
   void _resumeActiveSession(String activeUrl, NostrConnectState activeState) {
+    _authService.claimNostrConnectCallbackHandoff();
     final attempt = ++_sessionAttempt;
     unawaited(_stateSubscription?.cancel());
     _stateSubscription = null;

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -337,6 +337,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   NostrConnectSession? _nostrConnectSession;
   Future<AuthResult>? _nostrConnectWaitFuture;
   Timer? _nostrConnectCallbackHandoffTimer;
+  Timer? _nostrConnectCallbackHandoffCancelTimer;
   bool _isNostrConnectCallbackHandoffActive = false;
 
   // Atomic signing identity — couples pubkey with signing mechanism
@@ -3481,6 +3482,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _isNostrConnectCallbackHandoffActive = false;
     _nostrConnectCallbackHandoffTimer?.cancel();
     _nostrConnectCallbackHandoffTimer = null;
+    _nostrConnectCallbackHandoffCancelTimer?.cancel();
+    _nostrConnectCallbackHandoffCancelTimer = null;
 
     if (_nostrConnectSession != null) {
       Log.info(
@@ -3511,35 +3514,73 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   bool get isNostrConnectCallbackHandoffActive =>
       _isNostrConnectCallbackHandoffActive;
 
+  /// Preserve the active session for the replacement NostrConnect screen.
+  ///
+  /// If no replacement screen claims the handoff quickly, cancel the session so
+  /// backing out during the callback route handoff cannot orphan relay sockets.
+  void preserveNostrConnectForCallbackHandoff() {
+    if (!_isNostrConnectCallbackHandoffActive ||
+        _nostrConnectSession?.state != NostrConnectState.listening) {
+      return;
+    }
+
+    _nostrConnectCallbackHandoffCancelTimer?.cancel();
+    _nostrConnectCallbackHandoffCancelTimer = Timer(
+      const Duration(seconds: 5),
+      () {
+        _nostrConnectCallbackHandoffCancelTimer = null;
+        if (_isNostrConnectCallbackHandoffActive &&
+            _nostrConnectSession?.state == NostrConnectState.listening) {
+          Log.info(
+            'NostrConnect callback handoff was not resumed - cancelling',
+            name: 'AuthService',
+            category: LogCategory.auth,
+          );
+          cancelNostrConnect();
+        }
+      },
+    );
+  }
+
+  /// Marks the callback handoff as claimed by a mounted NostrConnect screen.
+  ///
+  /// The short handoff flag is left to expire on its own so an old route that
+  /// disposes after the replacement screen mounts still preserves the session.
+  void claimNostrConnectCallbackHandoff() {
+    _nostrConnectCallbackHandoffCancelTimer?.cancel();
+    _nostrConnectCallbackHandoffCancelTimer = null;
+  }
+
   /// Called when a divine:// signer callback deep link is received.
   ///
   /// Ensures the nostrconnect session relay connections are alive so we
   /// don't miss the bunker's response event after being brought back
   /// from background.
   void onSignerCallbackReceived({String? relayUrl}) {
+    if (_nostrConnectSession?.state != NostrConnectState.listening) {
+      return;
+    }
+
     _isNostrConnectCallbackHandoffActive = true;
     _nostrConnectCallbackHandoffTimer?.cancel();
     _nostrConnectCallbackHandoffTimer = Timer(const Duration(seconds: 5), () {
       _isNostrConnectCallbackHandoffActive = false;
     });
 
-    if (_nostrConnectSession != null &&
-        _nostrConnectSession!.state == NostrConnectState.listening) {
-      if (relayUrl != null) {
-        Log.info(
-          'Signer callback supplied relay $relayUrl - connecting',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        unawaited(_nostrConnectSession!.addRelay(relayUrl));
-      }
+    if (relayUrl != null) {
       Log.info(
-        'Signer callback received - ensuring nostrconnect relays are connected',
+        'Signer callback supplied relay $relayUrl - connecting',
         name: 'AuthService',
         category: LogCategory.auth,
       );
-      _nostrConnectSession!.ensureConnected();
+      unawaited(_nostrConnectSession!.addRelay(relayUrl));
     }
+    Log.info(
+      'Signer callback received - ensuring nostrconnect relays are connected',
+      name: 'AuthService',
+      category: LogCategory.auth,
+    );
+    unawaited(_nostrConnectSession!.ensureConnected());
   }
 
   /// Sign in using OAuth 2.0 flow
@@ -5719,6 +5760,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
     _nostrConnectCallbackHandoffTimer?.cancel();
     _nostrConnectCallbackHandoffTimer = null;
+    _nostrConnectCallbackHandoffCancelTimer?.cancel();
+    _nostrConnectCallbackHandoffCancelTimer = null;
 
     // Securely dispose of key container
     _currentKeyContainer?.dispose();

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -335,6 +335,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
 
   // NIP-46 nostrconnect:// session state (for client-initiated connections)
   NostrConnectSession? _nostrConnectSession;
+  Future<AuthResult>? _nostrConnectWaitFuture;
+  Timer? _nostrConnectCallbackHandoffTimer;
+  bool _isNostrConnectCallbackHandoffActive = false;
 
   // Atomic signing identity — couples pubkey with signing mechanism
   NostrIdentity? _currentIdentity;
@@ -3337,13 +3340,31 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// authenticate, or [AuthResult.failure] on timeout/error.
   Future<AuthResult> waitForNostrConnectResponse({
     Duration timeout = const Duration(minutes: 2),
-  }) async {
+  }) {
     if (_nostrConnectSession == null) {
-      return AuthResult.failure(
-        'No active nostrconnect session. Call initiateNostrConnect first.',
+      return Future.value(
+        AuthResult.failure(
+          'No active nostrconnect session. Call initiateNostrConnect first.',
+        ),
       );
     }
 
+    final activeWait = _nostrConnectWaitFuture;
+    if (activeWait != null) return activeWait;
+
+    final waitFuture = _waitForNostrConnectResponse(timeout: timeout);
+    _nostrConnectWaitFuture = waitFuture;
+    waitFuture.whenComplete(() {
+      if (identical(_nostrConnectWaitFuture, waitFuture)) {
+        _nostrConnectWaitFuture = null;
+      }
+    });
+    return waitFuture;
+  }
+
+  Future<AuthResult> _waitForNostrConnectResponse({
+    required Duration timeout,
+  }) async {
     Log.info(
       'Waiting for nostrconnect response (timeout: ${timeout.inSeconds}s)...',
       name: 'AuthService',
@@ -3456,6 +3477,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   ///
   /// Safe to call even if no session is active.
   void cancelNostrConnect() {
+    _nostrConnectWaitFuture = null;
+    _isNostrConnectCallbackHandoffActive = false;
+    _nostrConnectCallbackHandoffTimer?.cancel();
+    _nostrConnectCallbackHandoffTimer = null;
+
     if (_nostrConnectSession != null) {
       Log.info(
         'Cancelling nostrconnect session',
@@ -3480,14 +3506,33 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   Stream<NostrConnectState>? get nostrConnectStateStream =>
       _nostrConnectSession?.stateStream;
 
+  /// True while Android/iOS custom-scheme routing is handing control back
+  /// from a NIP-46 signer app to Divine.
+  bool get isNostrConnectCallbackHandoffActive =>
+      _isNostrConnectCallbackHandoffActive;
+
   /// Called when a divine:// signer callback deep link is received.
   ///
   /// Ensures the nostrconnect session relay connections are alive so we
   /// don't miss the bunker's response event after being brought back
   /// from background.
-  void onSignerCallbackReceived() {
+  void onSignerCallbackReceived({String? relayUrl}) {
+    _isNostrConnectCallbackHandoffActive = true;
+    _nostrConnectCallbackHandoffTimer?.cancel();
+    _nostrConnectCallbackHandoffTimer = Timer(const Duration(seconds: 5), () {
+      _isNostrConnectCallbackHandoffActive = false;
+    });
+
     if (_nostrConnectSession != null &&
         _nostrConnectSession!.state == NostrConnectState.listening) {
+      if (relayUrl != null) {
+        Log.info(
+          'Signer callback supplied relay $relayUrl - connecting',
+          name: 'AuthService',
+          category: LogCategory.auth,
+        );
+        unawaited(_nostrConnectSession!.addRelay(relayUrl));
+      }
       Log.info(
         'Signer callback received - ensuring nostrconnect relays are connected',
         name: 'AuthService',
@@ -5671,6 +5716,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     // Close Amber signer if active
     _amberSigner?.close();
     _amberSigner = null;
+
+    _nostrConnectCallbackHandoffTimer?.cancel();
+    _nostrConnectCallbackHandoffTimer = null;
 
     // Securely dispose of key container
     _currentKeyContainer?.dispose();

--- a/mobile/lib/services/deep_link_service.dart
+++ b/mobile/lib/services/deep_link_service.dart
@@ -27,6 +27,7 @@ class DeepLink {
     this.hashtag,
     this.searchTerm,
     this.inviteCode,
+    this.signerCallbackRelay,
     this.index,
     this.autoOpenComments = false,
   });
@@ -42,6 +43,7 @@ class DeepLink {
   final String? hashtag;
   final String? searchTerm;
   final String? inviteCode;
+  final String? signerCallbackRelay;
   final int? index; // Optional video index for feed view
 
   /// When true the video detail screen should open the comments section
@@ -148,7 +150,12 @@ class DeepLinkService {
           name: 'DeepLinkService',
           category: LogCategory.auth,
         );
-        return const DeepLink(type: DeepLinkType.signerCallback);
+        return DeepLink(
+          type: DeepLinkType.signerCallback,
+          signerCallbackRelay: _validSignerCallbackRelay(
+            uri.queryParameters['relay'],
+          ),
+        );
       }
 
       if (_isInternalAppRoute(uri, url)) {
@@ -330,6 +337,14 @@ class DeepLinkService {
     }
 
     return null;
+  }
+
+  static String? _validSignerCallbackRelay(String? relay) {
+    if (relay == null || relay.isEmpty) return null;
+    final uri = Uri.tryParse(relay);
+    if (uri == null || uri.host.isEmpty) return null;
+    if (uri.scheme != 'wss' && uri.scheme != 'ws') return null;
+    return relay;
   }
 
   static String _describeUriForLogs(Uri uri) {

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -364,7 +364,7 @@ class NostrConnectSession {
     try {
       // Re-add the subscription filter so it is sent on connect
       await _addSubscription(relay);
-      final connected = await relay.connect();
+      final connected = await relay.connect().timeout(_relayConnectTimeout);
       if (connected) {
         log('[NostrConnectSession] Reconnected to $addr');
       } else {

--- a/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
+++ b/mobile/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart
@@ -21,6 +21,8 @@ import '../utils/string_util.dart';
 import 'nostr_remote_response.dart';
 import 'nostr_remote_signer_info.dart';
 
+const _relayConnectTimeout = Duration(seconds: 8);
+
 /// State of a nostrconnect:// session.
 enum NostrConnectState {
   /// Session not started.
@@ -200,6 +202,11 @@ class NostrConnectSession {
       );
     }
 
+    final activeWait = _connectionCompleter;
+    if (activeWait != null && !activeWait.isCompleted) {
+      return activeWait.future;
+    }
+
     _connectionCompleter = Completer<NostrConnectResult?>();
 
     // Start timeout timer
@@ -253,6 +260,31 @@ class NostrConnectSession {
     if (_relays.isEmpty) {
       log('[NostrConnectSession] All relays lost, reconnecting from scratch');
       await _connectToRelays();
+    }
+  }
+
+  /// Adds a signer-supplied relay to the active session.
+  ///
+  /// Some same-device signers return a callback relay after the user approves
+  /// the connection. Connect to it in addition to the original nostrconnect://
+  /// relays so the response event can arrive on the signer's chosen transport.
+  Future<void> addRelay(String relayUrl) async {
+    if (_isClosed || _state != NostrConnectState.listening) return;
+    if (relays.contains(relayUrl) ||
+        _relays.any((relay) => relay.relayStatus.addr == relayUrl)) {
+      return;
+    }
+
+    try {
+      final relay = await _connectToRelay(relayUrl);
+      if (_isClosed) {
+        relay.disconnect();
+        return;
+      }
+      _relays.add(relay);
+      log('[NostrConnectSession] Added callback relay $relayUrl');
+    } catch (e) {
+      log('[NostrConnectSession] Failed to add callback relay $relayUrl: $e');
     }
   }
 
@@ -316,7 +348,10 @@ class NostrConnectSession {
     // Add subscription for listening to responses
     await _addSubscription(relay);
 
-    await relay.connect();
+    final connected = await relay.connect().timeout(_relayConnectTimeout);
+    if (!connected) {
+      throw StateError('Relay connect returned false');
+    }
     log('[NostrConnectSession] Connected to $relayAddr');
 
     return relay;

--- a/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
+++ b/mobile/packages/nostr_sdk/test/unit/nostr_connect_session_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for NostrConnectSession class
 // ABOUTME: Tests state machine transitions and URL generation
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:nostr_sdk/nip46/nostr_remote_response.dart';
@@ -285,6 +286,104 @@ void main() {
 
       session.dispose();
     });
+
+    test('addRelay dedupes configured and connected relays', () async {
+      final primaryRelay = await _TestRelayServer.start();
+      final callbackRelay = await _TestRelayServer.start();
+      addTearDown(primaryRelay.close);
+      addTearDown(callbackRelay.close);
+
+      final session = NostrConnectSession(relays: [primaryRelay.url]);
+      addTearDown(session.dispose);
+
+      await session.start();
+      expect(primaryRelay.connectionCount, equals(1));
+
+      await session.addRelay(primaryRelay.url);
+      expect(
+        primaryRelay.connectionCount,
+        equals(1),
+        reason: 'configured relays should not be added a second time',
+      );
+
+      await session.addRelay(callbackRelay.url);
+      expect(callbackRelay.connectionCount, equals(1));
+
+      await session.addRelay(callbackRelay.url);
+      expect(
+        callbackRelay.connectionCount,
+        equals(1),
+        reason: 'already-connected callback relays should be deduped',
+      );
+    });
+
+    test('addRelay is a no-op unless the session is listening', () async {
+      final callbackRelay = await _TestRelayServer.start();
+      addTearDown(callbackRelay.close);
+
+      final idleSession = NostrConnectSession(relays: ['ws://127.0.0.1:9']);
+      addTearDown(idleSession.dispose);
+
+      await idleSession.addRelay(callbackRelay.url);
+      expect(callbackRelay.connectionCount, equals(0));
+
+      idleSession.cancel();
+      await idleSession.addRelay(callbackRelay.url);
+      expect(callbackRelay.connectionCount, equals(0));
+    });
+
+    test('addRelay excludes relays whose connect returns false', () async {
+      final primaryRelay = await _TestRelayServer.start();
+      final failedPort = await _unusedLoopbackPort();
+      final callbackUrl = 'ws://127.0.0.1:$failedPort';
+      addTearDown(primaryRelay.close);
+
+      final session = NostrConnectSession(relays: [primaryRelay.url]);
+      addTearDown(session.dispose);
+
+      await session.start();
+      await session.addRelay(callbackUrl);
+
+      final callbackRelay = await _TestRelayServer.start(port: failedPort);
+      addTearDown(callbackRelay.close);
+
+      await session.addRelay(callbackUrl);
+      expect(
+        callbackRelay.connectionCount,
+        equals(1),
+        reason: 'failed relay attempts must not be retained as connected',
+      );
+    });
+
+    test(
+      'addRelay excludes relays whose connect times out',
+      () async {
+        final primaryRelay = await _TestRelayServer.start();
+        final blackhole = await _BlackholeServer.start();
+        final callbackUrl = blackhole.url;
+        addTearDown(primaryRelay.close);
+        addTearDown(blackhole.close);
+
+        final session = NostrConnectSession(relays: [primaryRelay.url]);
+        addTearDown(session.dispose);
+
+        await session.start();
+        await session.addRelay(callbackUrl);
+
+        final failedPort = blackhole.port;
+        await blackhole.close();
+        final callbackRelay = await _TestRelayServer.start(port: failedPort);
+        addTearDown(callbackRelay.close);
+
+        await session.addRelay(callbackUrl);
+        expect(
+          callbackRelay.connectionCount,
+          equals(1),
+          reason: 'timed-out relay attempts must not be retained as connected',
+        );
+      },
+      timeout: const Timeout(Duration(seconds: 20)),
+    );
   });
 
   group('NostrConnectState enum', () {
@@ -453,11 +552,11 @@ void main() {
     test(
       'source file does not log the response.result or the expected secret',
       () {
-        final sourceFile = File('lib/nip46/nostr_connect_session.dart');
+        final sourceFile = _findNostrConnectSessionSource();
         expect(
           sourceFile.existsSync(),
           isTrue,
-          reason: 'Test must run from the nostr_sdk package root',
+          reason: 'Test must resolve the nostr_sdk package source',
         );
         final source = sourceFile.readAsStringSync();
         // The pre-fix code logged both `result=${response.result}` in the
@@ -470,4 +569,106 @@ void main() {
       },
     );
   });
+}
+
+File _findNostrConnectSessionSource() {
+  var directory = Directory.current;
+  while (true) {
+    final packageRootFile = File(
+      '${directory.path}/lib/nip46/nostr_connect_session.dart',
+    );
+    if (packageRootFile.existsSync()) return packageRootFile;
+
+    final mobileRootFile = File(
+      '${directory.path}/packages/nostr_sdk/lib/nip46/nostr_connect_session.dart',
+    );
+    if (mobileRootFile.existsSync()) return mobileRootFile;
+
+    final parent = directory.parent;
+    if (parent.path == directory.path) return packageRootFile;
+    directory = parent;
+  }
+}
+
+Future<int> _unusedLoopbackPort() async {
+  final socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final port = socket.port;
+  await socket.close();
+  return port;
+}
+
+class _TestRelayServer {
+  _TestRelayServer._(this._server) {
+    _requests = _server.listen(_handleRequest);
+  }
+
+  final HttpServer _server;
+  final _sockets = <WebSocket>[];
+  late final StreamSubscription<HttpRequest> _requests;
+  int connectionCount = 0;
+  bool _closed = false;
+
+  String get url => 'ws://127.0.0.1:${_server.port}';
+
+  static Future<_TestRelayServer> start({int? port}) async {
+    final server = await HttpServer.bind(
+      InternetAddress.loopbackIPv4,
+      port ?? 0,
+    );
+    return _TestRelayServer._(server);
+  }
+
+  Future<void> _handleRequest(HttpRequest request) async {
+    if (!WebSocketTransformer.isUpgradeRequest(request)) {
+      request.response.statusCode = HttpStatus.badRequest;
+      await request.response.close();
+      return;
+    }
+
+    final socket = await WebSocketTransformer.upgrade(request);
+    _sockets.add(socket);
+    connectionCount += 1;
+    socket.listen((_) {});
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    for (final socket in _sockets) {
+      await socket.close();
+    }
+    await _requests.cancel();
+    await _server.close(force: true);
+  }
+}
+
+class _BlackholeServer {
+  _BlackholeServer._(this._server) {
+    _requests = _server.listen((socket) {
+      _sockets.add(socket);
+    });
+  }
+
+  final ServerSocket _server;
+  final _sockets = <Socket>[];
+  late final StreamSubscription<Socket> _requests;
+  bool _closed = false;
+
+  int get port => _server.port;
+  String get url => 'ws://127.0.0.1:$port';
+
+  static Future<_BlackholeServer> start() async {
+    final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    return _BlackholeServer._(server);
+  }
+
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    for (final socket in _sockets) {
+      socket.destroy();
+    }
+    await _requests.cancel();
+    await _server.close();
+  }
 }

--- a/mobile/test/router/app_router_test.dart
+++ b/mobile/test/router/app_router_test.dart
@@ -17,6 +17,7 @@ import 'package:openvine/models/minor_account_review_status.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
+import 'package:openvine/screens/auth/nostr_connect_screen.dart';
 import 'package:openvine/screens/hashtag_screen_router.dart';
 import 'package:openvine/screens/inbox/conversation/conversation_page.dart';
 import 'package:openvine/screens/inbox/message_requests/request_preview_page.dart';
@@ -394,6 +395,34 @@ void main() {
         );
       },
     );
+  });
+
+  group('NIP-46 signer callbacks', () {
+    test('redirect active signer callback route back to nostr connect', () {
+      final authService = _MockAuthService();
+      when(() => authService.nostrConnectUrl).thenReturn(
+        'nostrconnect://4c4060f6d19c8cafad01952e625e9819386b7a620bc03bfc6491b797b36cde5a',
+      );
+      when(
+        () => authService.onSignerCallbackReceived(
+          relayUrl: any(named: 'relayUrl'),
+        ),
+      ).thenReturn(null);
+
+      final target = signerCallbackRedirectTarget(
+        Uri.parse(
+          'divine://nostrconnect?x-source=aegis&relay=wss://localrelay.link:28443',
+        ),
+        authService,
+      );
+
+      expect(target, equals(NostrConnectScreen.path));
+      verify(
+        () => authService.onSignerCallbackReceived(
+          relayUrl: 'wss://localrelay.link:28443',
+        ),
+      ).called(greaterThan(0));
+    });
   });
 
   group('DM route extras', () {

--- a/mobile/test/router/route_normalization_test.dart
+++ b/mobile/test/router/route_normalization_test.dart
@@ -36,6 +36,15 @@ void main() {
       );
     });
 
+    test('skips NIP-46 signer callbacks from native signer apps', () {
+      expect(
+        shouldSkipRouteNormalization(
+          'divine://nostrconnect?x-source=aegis&relay=wss://localrelay.link:28443',
+        ),
+        isTrue,
+      );
+    });
+
     test('does not skip unrelated hosts', () {
       expect(
         shouldSkipRouteNormalization('https://example.com/video/abc123'),

--- a/mobile/test/services/deep_link_service_test.dart
+++ b/mobile/test/services/deep_link_service_test.dart
@@ -223,6 +223,20 @@ void main() {
       });
     });
 
+    group('Signer Callback Parsing', () {
+      test('parses NIP-46 callback from native signer apps', () {
+        final result = DeepLinkService.parseDeepLink(
+          'divine://nostrconnect?x-source=aegis&relay=wss://localrelay.link:28443',
+        );
+
+        expect(result.type, equals(DeepLinkType.signerCallback));
+        expect(
+          result.signerCallbackRelay,
+          equals('wss://localrelay.link:28443'),
+        );
+      });
+    });
+
     group('Unknown URL Patterns', () {
       test('ignores internal app route paths', () {
         const url = '/profile/npub1abc123def456';


### PR DESCRIPTION
## Summary
- preserve active nostrconnect sessions across native signer callback routing
- parse signer callback relay URLs and add them to the active NIP-46 session
- bound relay connect attempts and make NIP-46 waits single-flight/idempotent
- add regression coverage for Aegis-style signer callbacks

Closes #5603

## Verification
- mise exec java@21.0.2 -- flutter test test/router/route_normalization_test.dart test/services/deep_link_service_test.dart test/screens/auth/nostr_connect_screen_test.dart test/router/app_router_test.dart
- mise exec java@21.0.2 -- flutter test test/unit/nostr_connect_session_test.dart (from mobile/packages/nostr_sdk)
- mise exec java@21.0.2 -- flutter analyze
- Android emulator smoke with Aegis callback: callback relay consumed, custom URI redirected to /nostr-connect, active session resumed