### PR TITLE
fix(auth): allow badges oauth navigation safely

### DIFF
--- a/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
+++ b/mobile/lib/screens/apps/nostr_app_sandbox_screen.dart
@@ -148,7 +148,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
   }
 
   bool _handleNavigationAttempt(Uri uri) {
-    if (_isAllowedOrigin(uri)) {
+    if (_isAllowedNavigationOrigin(uri)) {
       if (_blockedUri != null && mounted) {
         setState(() {
           _blockedUri = null;
@@ -165,8 +165,19 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
     return false;
   }
 
-  bool _isAllowedOrigin(Uri uri) {
-    return widget.app.allowedOrigins.any((allowedOrigin) {
+  bool _isAllowedNavigationOrigin(Uri uri) {
+    return _isAllowedOrigin(uri, [
+      ...widget.app.allowedOrigins,
+      ...widget.app.allowedNavigationOrigins,
+    ]);
+  }
+
+  bool _isAllowedBridgeOrigin(Uri uri) {
+    return _isAllowedOrigin(uri, widget.app.allowedOrigins);
+  }
+
+  bool _isAllowedOrigin(Uri uri, List<String> allowedOrigins) {
+    return allowedOrigins.any((allowedOrigin) {
       final parsedAllowed = Uri.tryParse(allowedOrigin);
       return parsedAllowed != null && parsedAllowed.origin == uri.origin;
     });
@@ -278,7 +289,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
   bool _shouldBootstrapNavigation(NavigationRequest request, Uri uri) {
     return defaultTargetPlatform == TargetPlatform.android &&
         request.isMainFrame &&
-        _isAllowedOrigin(uri);
+        _isAllowedBridgeOrigin(uri);
   }
 
   /// Activates platform-level frame attestation by replacing the pigeon-managed
@@ -430,7 +441,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
       }
 
       final resolvedUri = response.request?.url ?? uri;
-      if (!_isAllowedOrigin(resolvedUri)) {
+      if (!_isAllowedBridgeOrigin(resolvedUri)) {
         return null;
       }
 
@@ -450,7 +461,7 @@ class _NostrAppSandboxScreenState extends ConsumerState<NostrAppSandboxScreen> {
 
   Future<void> _injectBridge() async {
     final origin = _currentPageUri;
-    if (origin == null || !_isAllowedOrigin(origin)) {
+    if (origin == null || !_isAllowedBridgeOrigin(origin)) {
       return;
     }
 

--- a/mobile/packages/models/lib/src/nostr_app_directory_entry.dart
+++ b/mobile/packages/models/lib/src/nostr_app_directory_entry.dart
@@ -19,6 +19,7 @@ class NostrAppDirectoryEntry {
     required this.sortOrder,
     required this.createdAt,
     required this.updatedAt,
+    this.allowedNavigationOrigins = const [],
   });
 
   factory NostrAppDirectoryEntry.fromJson(Map<String, dynamic> json) {
@@ -31,6 +32,9 @@ class NostrAppDirectoryEntry {
       iconUrl: json['icon_url'] as String? ?? '',
       launchUrl: json['launch_url'] as String? ?? '',
       allowedOrigins: _readStringList(json['allowed_origins']),
+      allowedNavigationOrigins: _readStringList(
+        json['allowed_navigation_origins'],
+      ),
       allowedMethods: _readStringList(json['allowed_methods']),
       allowedSignEventKinds: _readIntList(json['allowed_sign_event_kinds']),
       promptRequiredFor: _readStringList(json['prompt_required_for']),
@@ -49,6 +53,7 @@ class NostrAppDirectoryEntry {
   final String iconUrl;
   final String launchUrl;
   final List<String> allowedOrigins;
+  final List<String> allowedNavigationOrigins;
   final List<String> allowedMethods;
   final List<int> allowedSignEventKinds;
   final List<String> promptRequiredFor;
@@ -70,6 +75,8 @@ class NostrAppDirectoryEntry {
       'icon_url': iconUrl,
       'launch_url': launchUrl,
       'allowed_origins': allowedOrigins,
+      if (allowedNavigationOrigins.isNotEmpty)
+        'allowed_navigation_origins': allowedNavigationOrigins,
       'allowed_methods': allowedMethods,
       'allowed_sign_event_kinds': allowedSignEventKinds,
       'prompt_required_for': promptRequiredFor,

--- a/mobile/packages/models/test/src/nostr_app_directory_entry_test.dart
+++ b/mobile/packages/models/test/src/nostr_app_directory_entry_test.dart
@@ -1,0 +1,58 @@
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('NostrAppDirectoryEntry', () {
+    test('defaults allowedNavigationOrigins to empty', () {
+      final entry = _buildEntry();
+
+      expect(entry.allowedNavigationOrigins, isEmpty);
+    });
+
+    test('round-trips allowedNavigationOrigins through JSON when present', () {
+      final entry = _buildEntry(
+        allowedNavigationOrigins: const ['https://login.divine.video'],
+      );
+
+      final json = entry.toJson();
+
+      expect(
+        json['allowed_navigation_origins'],
+        equals(['https://login.divine.video']),
+      );
+      expect(
+        NostrAppDirectoryEntry.fromJson(json).allowedNavigationOrigins,
+        equals(['https://login.divine.video']),
+      );
+    });
+
+    test('omits allowed_navigation_origins from JSON when empty', () {
+      final json = _buildEntry().toJson();
+
+      expect(json.containsKey('allowed_navigation_origins'), isFalse);
+    });
+  });
+}
+
+NostrAppDirectoryEntry _buildEntry({
+  List<String> allowedNavigationOrigins = const [],
+}) {
+  return NostrAppDirectoryEntry(
+    id: '1',
+    slug: 'test',
+    name: 'Test',
+    tagline: 'A test app',
+    description: 'Description',
+    iconUrl: 'https://example.com/icon.png',
+    launchUrl: 'https://example.com/app',
+    allowedOrigins: const ['https://example.com'],
+    allowedNavigationOrigins: allowedNavigationOrigins,
+    allowedMethods: const ['getPublicKey'],
+    allowedSignEventKinds: const [1],
+    promptRequiredFor: const ['signEvent'],
+    status: 'approved',
+    sortOrder: 0,
+    createdAt: DateTime.utc(2026),
+    updatedAt: DateTime.utc(2026),
+  );
+}

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/first_party_nostr_app_navigation.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/first_party_nostr_app_navigation.dart
@@ -1,0 +1,27 @@
+/// Client-pinned navigation origins for first-party Nostr apps.
+///
+/// These origins may be loaded in the sandbox without receiving NIP-07 bridge
+/// capability. The expected app origin prevents a remote directory entry from
+/// claiming a first-party slug and inheriting these navigation exceptions.
+class FirstPartyNostrAppNavigation {
+  /// Creates a first-party navigation exception config.
+  const FirstPartyNostrAppNavigation({
+    required this.expectedOrigin,
+    required this.allowedNavigationOrigins,
+  });
+
+  /// Origin that must match the app entry before applying exceptions.
+  final String expectedOrigin;
+
+  /// Extra origins the sandbox may navigate to without bridge capability.
+  final List<String> allowedNavigationOrigins;
+}
+
+/// First-party navigation exception configs keyed by app slug.
+const Map<String, FirstPartyNostrAppNavigation>
+firstPartyNostrAppNavigationBySlug = {
+  'badges': FirstPartyNostrAppNavigation(
+    expectedOrigin: 'https://badges.divine.video',
+    allowedNavigationOrigins: ['https://login.divine.video'],
+  ),
+};

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/models/nostr_app_directory_entry.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/models/nostr_app_directory_entry.dart
@@ -22,6 +22,7 @@ class NostrAppDirectoryEntry extends Equatable {
     required this.sortOrder,
     required this.createdAt,
     required this.updatedAt,
+    this.allowedNavigationOrigins = const [],
     this.autoLoginScript,
   });
 
@@ -38,6 +39,9 @@ class NostrAppDirectoryEntry extends Equatable {
       iconUrl: json['icon_url'] as String? ?? '',
       launchUrl: json['launch_url'] as String? ?? '',
       allowedOrigins: _readStringList(json['allowed_origins']),
+      allowedNavigationOrigins: _readStringList(
+        json['allowed_navigation_origins'],
+      ),
       allowedMethods: _readStringList(json['allowed_methods']),
       allowedSignEventKinds: _readIntList(json['allowed_sign_event_kinds']),
       promptRequiredFor: _readStringList(json['prompt_required_for']),
@@ -72,6 +76,10 @@ class NostrAppDirectoryEntry extends Equatable {
 
   /// Origins that may make NIP-07 requests.
   final List<String> allowedOrigins;
+
+  /// Additional origins the sandbox may navigate to without granting NIP-07
+  /// bridge capability.
+  final List<String> allowedNavigationOrigins;
 
   /// NIP-07 methods the app may call.
   final List<String> allowedMethods;
@@ -118,6 +126,32 @@ class NostrAppDirectoryEntry extends Equatable {
     return uri.origin;
   }
 
+  /// Returns a copy with selected fields replaced.
+  NostrAppDirectoryEntry copyWith({
+    List<String>? allowedNavigationOrigins,
+  }) {
+    return NostrAppDirectoryEntry(
+      id: id,
+      slug: slug,
+      name: name,
+      tagline: tagline,
+      description: description,
+      iconUrl: iconUrl,
+      launchUrl: launchUrl,
+      allowedOrigins: allowedOrigins,
+      allowedNavigationOrigins:
+          allowedNavigationOrigins ?? this.allowedNavigationOrigins,
+      allowedMethods: allowedMethods,
+      allowedSignEventKinds: allowedSignEventKinds,
+      promptRequiredFor: promptRequiredFor,
+      status: status,
+      sortOrder: sortOrder,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      autoLoginScript: autoLoginScript,
+    );
+  }
+
   @override
   List<Object?> get props => [
     id,
@@ -128,6 +162,7 @@ class NostrAppDirectoryEntry extends Equatable {
     iconUrl,
     launchUrl,
     allowedOrigins,
+    allowedNavigationOrigins,
     allowedMethods,
     allowedSignEventKinds,
     promptRequiredFor,
@@ -149,6 +184,8 @@ class NostrAppDirectoryEntry extends Equatable {
       'icon_url': iconUrl,
       'launch_url': launchUrl,
       'allowed_origins': allowedOrigins,
+      if (allowedNavigationOrigins.isNotEmpty)
+        'allowed_navigation_origins': allowedNavigationOrigins,
       'allowed_methods': allowedMethods,
       'allowed_sign_event_kinds': allowedSignEventKinds,
       'prompt_required_for': promptRequiredFor,

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/nostr_app_directory_service.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/nostr_app_directory_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:nostr_app_bridge_repository/src/first_party_nostr_app_navigation.dart';
 import 'package:nostr_app_bridge_repository/src/models/nostr_app_directory_entry.dart';
 import 'package:nostr_app_bridge_repository/src/preloaded_nostr_apps.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -26,10 +27,6 @@ class NostrAppDirectoryService {
 
   /// SharedPreferences key for the cached ETag.
   static const String eTagCacheKey = 'nostr_app_directory_etag';
-
-  static const Map<String, List<String>> _clientNavigationOriginsBySlug = {
-    'badges': ['https://login.divine.video'],
-  };
 
   final SharedPreferences _sharedPreferences;
   final http.Client _client;
@@ -189,21 +186,24 @@ class NostrAppDirectoryService {
   NostrAppDirectoryEntry _withClientNavigationOrigins(
     NostrAppDirectoryEntry app,
   ) {
-    final clientOrigins = _clientNavigationOriginsBySlug[app.slug];
-    if (clientOrigins == null || !_isExpectedFirstPartyApp(app)) {
+    final navigationConfig = firstPartyNostrAppNavigationBySlug[app.slug];
+    if (navigationConfig == null ||
+        !_hasExpectedFirstPartyOrigin(app, navigationConfig.expectedOrigin)) {
       return app;
     }
 
     final origins = <String>{
       ...app.allowedNavigationOrigins,
-      ...clientOrigins,
+      ...navigationConfig.allowedNavigationOrigins,
     }.toList(growable: false);
     return app.copyWith(allowedNavigationOrigins: origins);
   }
 
-  bool _isExpectedFirstPartyApp(NostrAppDirectoryEntry app) {
-    return app.slug == 'badges' &&
-        (app.primaryOrigin == 'https://badges.divine.video' ||
-            app.allowedOrigins.contains('https://badges.divine.video'));
+  bool _hasExpectedFirstPartyOrigin(
+    NostrAppDirectoryEntry app,
+    String expectedOrigin,
+  ) {
+    return app.primaryOrigin == expectedOrigin ||
+        app.allowedOrigins.contains(expectedOrigin);
   }
 }

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/nostr_app_directory_service.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/nostr_app_directory_service.dart
@@ -27,6 +27,10 @@ class NostrAppDirectoryService {
   /// SharedPreferences key for the cached ETag.
   static const String eTagCacheKey = 'nostr_app_directory_etag';
 
+  static const Map<String, List<String>> _clientNavigationOriginsBySlug = {
+    'badges': ['https://login.divine.video'],
+  };
+
   final SharedPreferences _sharedPreferences;
   final http.Client _client;
   final String _baseUrl;
@@ -172,7 +176,7 @@ class NostrAppDirectoryService {
 
     for (final app in remoteOrCachedApps) {
       if (app.isApproved) {
-        appsBySlug[app.slug] = app;
+        appsBySlug[app.slug] = _withClientNavigationOrigins(app);
       } else {
         appsBySlug.remove(app.slug);
       }
@@ -180,5 +184,26 @@ class NostrAppDirectoryService {
 
     final apps = appsBySlug.values.toList(growable: false)..sort(_compareApps);
     return List<NostrAppDirectoryEntry>.unmodifiable(apps);
+  }
+
+  NostrAppDirectoryEntry _withClientNavigationOrigins(
+    NostrAppDirectoryEntry app,
+  ) {
+    final clientOrigins = _clientNavigationOriginsBySlug[app.slug];
+    if (clientOrigins == null || !_isExpectedFirstPartyApp(app)) {
+      return app;
+    }
+
+    final origins = <String>{
+      ...app.allowedNavigationOrigins,
+      ...clientOrigins,
+    }.toList(growable: false);
+    return app.copyWith(allowedNavigationOrigins: origins);
+  }
+
+  bool _isExpectedFirstPartyApp(NostrAppDirectoryEntry app) {
+    return app.slug == 'badges' &&
+        (app.primaryOrigin == 'https://badges.divine.video' ||
+            app.allowedOrigins.contains('https://badges.divine.video'));
   }
 }

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/preloaded_nostr_apps.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/preloaded_nostr_apps.dart
@@ -1,3 +1,4 @@
+import 'package:nostr_app_bridge_repository/src/first_party_nostr_app_navigation.dart';
 import 'package:nostr_app_bridge_repository/src/models/nostr_app_directory_entry.dart';
 
 const List<String> _sharedAllowedMethods = [
@@ -23,10 +24,6 @@ const List<int> _sharedSignEventKinds = [
   1111,
   9734,
   30023,
-];
-
-const List<String> _badgesAllowedNavigationOrigins = [
-  'https://login.divine.video',
 ];
 
 /// Bundled starter catalog of vetted third-party Nostr apps.
@@ -203,7 +200,6 @@ final List<NostrAppDirectoryEntry> preloadedNostrApps = List.unmodifiable([
         'A Divine Nostr app for reviewing badge awards, pinning the '
         'ones you accept to your profile, and checking badge issue status.',
     launchUrl: 'https://badges.divine.video/me',
-    allowedNavigationOrigins: _badgesAllowedNavigationOrigins,
     allowedMethods: const [
       'getPublicKey',
       'getRelays',
@@ -285,12 +281,15 @@ NostrAppDirectoryEntry _buildPreloadedApp({
   required String description,
   required String launchUrl,
   required int sortOrder,
-  List<String> allowedNavigationOrigins = const [],
   List<String> allowedMethods = _sharedAllowedMethods,
   List<int> allowedSignEventKinds = _sharedSignEventKinds,
   List<String> promptRequiredFor = _sharedPromptRequiredFor,
 }) {
   final origin = Uri.parse(launchUrl).origin;
+  final navigationConfig = firstPartyNostrAppNavigationBySlug[slug];
+  final allowedNavigationOrigins = navigationConfig?.expectedOrigin == origin
+      ? navigationConfig!.allowedNavigationOrigins
+      : const <String>[];
 
   return NostrAppDirectoryEntry(
     id: id,

--- a/mobile/packages/nostr_app_bridge_repository/lib/src/preloaded_nostr_apps.dart
+++ b/mobile/packages/nostr_app_bridge_repository/lib/src/preloaded_nostr_apps.dart
@@ -25,6 +25,10 @@ const List<int> _sharedSignEventKinds = [
   30023,
 ];
 
+const List<String> _badgesAllowedNavigationOrigins = [
+  'https://login.divine.video',
+];
+
 /// Bundled starter catalog of vetted third-party Nostr apps.
 ///
 /// Provides a curated baseline before the remote directory is
@@ -199,6 +203,7 @@ final List<NostrAppDirectoryEntry> preloadedNostrApps = List.unmodifiable([
         'A Divine Nostr app for reviewing badge awards, pinning the '
         'ones you accept to your profile, and checking badge issue status.',
     launchUrl: 'https://badges.divine.video/me',
+    allowedNavigationOrigins: _badgesAllowedNavigationOrigins,
     allowedMethods: const [
       'getPublicKey',
       'getRelays',
@@ -280,6 +285,7 @@ NostrAppDirectoryEntry _buildPreloadedApp({
   required String description,
   required String launchUrl,
   required int sortOrder,
+  List<String> allowedNavigationOrigins = const [],
   List<String> allowedMethods = _sharedAllowedMethods,
   List<int> allowedSignEventKinds = _sharedSignEventKinds,
   List<String> promptRequiredFor = _sharedPromptRequiredFor,
@@ -295,6 +301,7 @@ NostrAppDirectoryEntry _buildPreloadedApp({
     iconUrl: '$origin/favicon.ico',
     launchUrl: launchUrl,
     allowedOrigins: [origin],
+    allowedNavigationOrigins: allowedNavigationOrigins,
     allowedMethods: allowedMethods,
     allowedSignEventKinds: allowedSignEventKinds,
     promptRequiredFor: promptRequiredFor,

--- a/mobile/packages/nostr_app_bridge_repository/test/nostr_app_bridge_policy_test.dart
+++ b/mobile/packages/nostr_app_bridge_repository/test/nostr_app_bridge_policy_test.dart
@@ -175,6 +175,14 @@ void main() {
         );
         expect(blockedDirectMessage.decision, BridgeDecision.deny);
         expect(blockedDirectMessage.reasonCode, 'blocked_event_kind');
+
+        final loginOrigin = policy.evaluate(
+          app: badges,
+          origin: Uri.parse('https://login.divine.video/api/oauth/authorize'),
+          method: 'getPublicKey',
+        );
+        expect(loginOrigin.decision, BridgeDecision.deny);
+        expect(loginOrigin.reasonCode, 'blocked_origin');
       },
     );
   });

--- a/mobile/packages/nostr_app_bridge_repository/test/nostr_app_directory_entry_test.dart
+++ b/mobile/packages/nostr_app_bridge_repository/test/nostr_app_directory_entry_test.dart
@@ -106,6 +106,50 @@ void main() {
       });
     });
 
+    group('allowedNavigationOrigins', () {
+      test('defaults to empty', () {
+        final entry = buildEntry();
+        expect(entry.allowedNavigationOrigins, isEmpty);
+      });
+
+      test('round-trips through JSON when present', () {
+        final entry = NostrAppDirectoryEntry(
+          id: '1',
+          slug: 'test',
+          name: 'Test',
+          tagline: 'A test app',
+          description: 'Description',
+          iconUrl: 'https://example.com/icon.png',
+          launchUrl: 'https://example.com/app',
+          allowedOrigins: const ['https://example.com'],
+          allowedNavigationOrigins: const ['https://login.divine.video'],
+          allowedMethods: const ['getPublicKey'],
+          allowedSignEventKinds: const [1],
+          promptRequiredFor: const ['signEvent'],
+          status: 'approved',
+          sortOrder: 0,
+          createdAt: DateTime.utc(2026),
+          updatedAt: DateTime.utc(2026),
+        );
+        final json = entry.toJson();
+        expect(
+          json['allowed_navigation_origins'],
+          equals(['https://login.divine.video']),
+        );
+
+        final restored = NostrAppDirectoryEntry.fromJson(json);
+        expect(restored.allowedNavigationOrigins, [
+          'https://login.divine.video',
+        ]);
+      });
+
+      test('omits allowed_navigation_origins from JSON when empty', () {
+        final entry = buildEntry();
+        final json = entry.toJson();
+        expect(json.containsKey('allowed_navigation_origins'), isFalse);
+      });
+    });
+
     group('Equatable', () {
       test('two entries with same fields are equal', () {
         final a = buildEntry();

--- a/mobile/packages/nostr_app_bridge_repository/test/nostr_app_directory_service_test.dart
+++ b/mobile/packages/nostr_app_bridge_repository/test/nostr_app_directory_service_test.dart
@@ -174,6 +174,9 @@ void main() {
         expect(badges.name, 'Divine Badges');
         expect(badges.launchUrl, 'https://badges.divine.video/me');
         expect(badges.allowedOrigins, ['https://badges.divine.video']);
+        expect(badges.allowedNavigationOrigins, [
+          'https://login.divine.video',
+        ]);
         expect(
           badges.allowedMethods,
           ['getPublicKey', 'getRelays', 'signEvent'],
@@ -184,6 +187,40 @@ void main() {
         );
         expect(badges.promptRequiredFor, ['signEvent']);
         expect(badges.autoLoginScript, contains('dbdg_session'));
+      },
+    );
+
+    test(
+      'fetchApprovedApps preserves Badges OAuth navigation origin when '
+      'remote directory data overrides the bundled entry',
+      () async {
+        when(
+          () => mockHttpClient.get(
+            Uri.parse('https://apps.divine.video/v1/apps'),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'items': [
+                _appJson(
+                  slug: 'badges',
+                  name: 'Divine Badges',
+                  updatedAt: '2026-05-03T10:00:00Z',
+                ),
+              ],
+            }),
+            200,
+          ),
+        );
+
+        final apps = await service.fetchApprovedApps();
+        final badges = apps.where((app) => app.slug == 'badges').single;
+
+        expect(badges.allowedOrigins, ['https://badges.divine.video']);
+        expect(badges.allowedNavigationOrigins, [
+          'https://login.divine.video',
+        ]);
       },
     );
 
@@ -447,6 +484,7 @@ String _launchUrlForSlug(String slug) => switch (slug) {
   'shopstr' => 'https://shopstr.store/',
   'nostrnests' => 'https://nostrnests.com/',
   'ditto' => 'https://ditto.pub/',
+  'badges' => 'https://badges.divine.video/me',
   _ => 'https://$slug.example.com',
 };
 

--- a/mobile/packages/nostr_app_bridge_repository/test/nostr_app_directory_service_test.dart
+++ b/mobile/packages/nostr_app_bridge_repository/test/nostr_app_directory_service_test.dart
@@ -225,6 +225,39 @@ void main() {
     );
 
     test(
+      'fetchApprovedApps does not add first-party navigation origins '
+      'when remote directory origin does not match',
+      () async {
+        when(
+          () => mockHttpClient.get(
+            Uri.parse('https://apps.divine.video/v1/apps'),
+            headers: any(named: 'headers'),
+          ),
+        ).thenAnswer(
+          (_) async => http.Response(
+            jsonEncode({
+              'items': [
+                _appJson(
+                  slug: 'badges',
+                  name: 'Badges Spoof',
+                  updatedAt: '2026-05-03T10:00:00Z',
+                  launchUrl: 'https://badges.example.com/me',
+                ),
+              ],
+            }),
+            200,
+          ),
+        );
+
+        final apps = await service.fetchApprovedApps();
+        final badges = apps.where((app) => app.slug == 'badges').single;
+
+        expect(badges.allowedOrigins, ['https://badges.example.com']);
+        expect(badges.allowedNavigationOrigins, isEmpty);
+      },
+    );
+
+    test(
       'fetchApprovedApps with useCacheOnly reads cached apps '
       'only',
       () async {
@@ -452,10 +485,11 @@ Map<String, dynamic> _appJson({
   required String slug,
   required String name,
   required String updatedAt,
+  String? launchUrl,
   int? sortOrder,
   String status = 'approved',
 }) {
-  final launchUrl = _launchUrlForSlug(slug);
+  final resolvedLaunchUrl = launchUrl ?? _launchUrlForSlug(slug);
   return {
     'id': slug == 'primal' ? 1 : 'app-$slug',
     'slug': slug,
@@ -463,8 +497,8 @@ Map<String, dynamic> _appJson({
     'tagline': '$name on Nostr',
     'description': 'A vetted Nostr app called $name.',
     'icon_url': 'https://cdn.divine.video/$slug.png',
-    'launch_url': launchUrl,
-    'allowed_origins': [Uri.parse(launchUrl).origin],
+    'launch_url': resolvedLaunchUrl,
+    'allowed_origins': [Uri.parse(resolvedLaunchUrl).origin],
     'allowed_methods': ['getPublicKey', 'signEvent'],
     'allowed_sign_event_kinds': [1, 7],
     'prompt_required_for': ['signEvent'],

--- a/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
+++ b/mobile/test/screens/apps/nostr_app_sandbox_screen_test.dart
@@ -237,6 +237,34 @@ void main() {
       );
     });
 
+    testWidgets(
+      'allows navigation-only origins without showing the safety block',
+      (tester) async {
+        void Function(Uri uri)? navigationHandler;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: NostrAppSandboxScreen(
+              app: _fixtureBadgesApp(),
+              sandboxBuilder: (_) => const SizedBox.shrink(),
+              onNavigationHandlerReady: (handler) =>
+                  navigationHandler = handler,
+            ),
+          ),
+        );
+
+        navigationHandler!(
+          Uri.parse('https://login.divine.video/api/oauth/authorize'),
+        );
+        await tester.pump();
+
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        expect(find.text(l10n.appsSandboxBlockedTitle), findsNothing);
+      },
+    );
+
     testWidgets('handles bridge messages and emits JavaScript responses', (
       tester,
     ) async {
@@ -874,6 +902,7 @@ NostrAppDirectoryEntry _fixtureBadgesApp() {
     iconUrl: 'https://badges.divine.video/favicon.ico',
     launchUrl: 'https://badges.divine.video/me',
     allowedOrigins: const ['https://badges.divine.video'],
+    allowedNavigationOrigins: const ['https://login.divine.video'],
     allowedMethods: const ['getPublicKey', 'signEvent'],
     allowedSignEventKinds: const [3, 8, 10002, 10008, 30008, 30009],
     promptRequiredFor: const ['signEvent'],


### PR DESCRIPTION
## Summary
- add navigation-only origins to Nostr app directory entries so sandbox redirects can be allowed without granting NIP-07 bridge capability
- allow Divine Badges to navigate to https://login.divine.video for OAuth while keeping bridge signing restricted to https://badges.divine.video
- preserve the client-pinned Badges OAuth navigation origin when remote or cached directory data overrides the bundled Badges entry
- cover the sandbox navigation path, directory JSON/merge behavior, and bridge-policy denial for the OAuth host

## Root cause
Badges opens inside the in-app Nostr app sandbox because it needs the host NIP-07 bridge for badge signing. Its OAuth login redirects from https://badges.divine.video to https://login.divine.video, but the sandbox used the bridge allowlist as its navigation allowlist. That blocked the login page with the "Blocked for safety" screen. Adding the login host to allowed_origins would have granted that host bridge access, so this PR separates navigation permission from bridge authority.

## Validation
- flutter analyze
- flutter test test/screens/apps/nostr_app_sandbox_screen_test.dart test/screens/badges/badges_screen_test.dart
- flutter test test/nostr_app_directory_entry_test.dart test/nostr_app_directory_service_test.dart test/nostr_app_bridge_policy_test.dart from mobile/packages/nostr_app_bridge_repository
- pre-push hook analyzer and changed-file tests passed

Closes #5422