### PR TITLE
perf(dm): adopt keycast nip17_unwrap_batch to drain remote-signer DM history in one call/page

### DIFF
--- a/mobile/lib/services/nostr_identity.dart
+++ b/mobile/lib/services/nostr_identity.dart
@@ -125,7 +125,7 @@ class LocalNostrIdentity extends NostrIdentity implements IsolateDecryptSigner {
 /// When a matching local private key is available, signs locally for speed.
 /// Otherwise delegates to the remote [KeycastRpc] signer.
 class KeycastNostrIdentity extends NostrIdentity
-    implements IsolateDecryptSigner {
+    implements IsolateDecryptSigner, GiftWrapBatchUnwrapper {
   /// Creates a Keycast identity.
   ///
   /// [rpcSigner] is the remote Keycast RPC signer.
@@ -199,6 +199,19 @@ class KeycastNostrIdentity extends NostrIdentity
     }
 
     return null;
+  }
+
+  @override
+  Future<List<GiftWrapUnwrapSlot>?> nip17UnwrapBatch(
+    List<Map<String, dynamic>> giftWraps,
+  ) {
+    // OAuth-only Keycast (no local key) drains DM history over RPC; the batch
+    // verb unwraps a whole chunk in one round trip. When a local key is present
+    // the drain decrypts in an isolate instead and never reaches this path.
+    if (_rpcSigner case final GiftWrapBatchUnwrapper unwrapper) {
+      return unwrapper.nip17UnwrapBatch(giftWraps);
+    }
+    return Future.value();
   }
 
   /// OAuth-only Keycast (no matching local key) signs over the network RPC,

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -25,6 +25,7 @@ import 'package:nostr_client/nostr_client.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
+import 'package:nostr_sdk/nip59/gift_wrap_batch_unwrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
@@ -117,6 +118,11 @@ abstract class DmHistoryDrainConfig {
   /// only *decryption* is parallelized — persistence stays serialized under the
   /// event lock. Local-key signers are unaffected (they use the batch isolate).
   static const int remoteDecryptConcurrency = 8;
+
+  /// Gift wraps unwrapped per server round trip on the remote-signer drain via
+  /// the Keycast `nip17_unwrap_batch` verb. Capped at the server's batch limit
+  /// (100), so a [pageSize] page is one chunk. See #5471.
+  static const int unwrapBatchSize = 100;
 }
 
 const _relayLoopbackHosts = <String>{
@@ -271,6 +277,12 @@ class DmRepository {
   String _userPubkey;
   NostrSigner? _signer;
   RumorDecryptor _rumorDecryptor;
+
+  /// Latches true once the active signer's keycast is found not to support the
+  /// `nip17_unwrap_batch` verb, so the drain stops probing it and uses the
+  /// per-wrap fallback pool for the rest of the session. Reset when the signer
+  /// changes. See #5471.
+  bool _batchUnwrapUnsupported = false;
   Nip04Decryptor? _nip04Decryptor;
   final DmDecryptIsolateSpawner _decryptIsolateSpawner;
   final DmVerifyIsolateSpawner _verifyIsolateSpawner;
@@ -448,6 +460,9 @@ class DmRepository {
 
     _userPubkey = userPubkey;
     _signer = signer;
+    // A new signer may be a keycast that supports (or lacks) the batch verb;
+    // re-probe it. See #5471.
+    _batchUnwrapUnsupported = false;
     _messageService = messageService;
     if (rumorDecryptor != null) _rumorDecryptor = rumorDecryptor;
     if (nip04Decryptor != null) _nip04Decryptor = nip04Decryptor;
@@ -523,6 +538,7 @@ class DmRepository {
     _postAuthMaintenance = null;
     _userPubkey = '';
     _signer = null;
+    _batchUnwrapUnsupported = false;
     _messageService = null;
     _disposed = false;
     _subscriptionId = 'dm_inbox';
@@ -1772,14 +1788,46 @@ class DmRepository {
     if (pending.isEmpty) return const {};
     if (_disposed) return const {};
 
-    // One signer handle shared across the pool: the public key is refreshed
-    // once up front and the workers only read it. Each decrypt is independent
-    // (pubkey + ciphertext in, plaintext out), so sharing is safe on a single
-    // isolate.
+    final decrypted = <String, Event>{};
+
+    // #5471: when the remote signer is Keycast, unwrap a whole chunk of gift
+    // wraps in ONE server round trip (`nip17_unwrap_batch`) instead of two
+    // `nip44Decrypt` RPCs per wrap. Wraps the batch cannot handle — an older
+    // keycast without the verb, a transient error, or a per-item failure — fall
+    // back to the per-wrap pool below, preserving the #5426 behaviour.
+    var fallback = pending;
+    if (signer case final GiftWrapBatchUnwrapper unwrapper
+        when !_batchUnwrapUnsupported) {
+      fallback = await _serverBatchUnwrapGiftWraps(
+        unwrapper,
+        pending,
+        decrypted,
+      );
+    }
+    if (fallback.isEmpty || _disposed) return decrypted;
+
+    // Per-wrap fallback pool (#5426): a bounded set of decrypts in flight, each
+    // two RPCs (gift wrap -> seal, seal -> rumor). Shares one signer handle
+    // with the public key refreshed once up front. Used for non-Keycast remote
+    // signers (Amber / NIP-46), an older keycast without the batch verb, or
+    // wraps a transient batch error skipped.
     final nostr = Nostr(signer, [], _dummyRelay);
     await nostr.refreshPublicKey();
+    await _workerPoolDecrypt(nostr, fallback, decrypted);
+    return decrypted;
+  }
 
-    final decrypted = <String, Event>{};
+  /// Per-wrap fallback decrypt pool: keeps
+  /// [DmHistoryDrainConfig.remoteDecryptConcurrency] gift-wrap decrypts in
+  /// flight, each via the per-wrap [_decryptRumor] path (two RPCs to a remote
+  /// signer). Successful rumors land in [decrypted]; failures are left out so
+  /// the caller routes them to the per-event path and the failed-decrypt retry
+  /// queue. See #5426 / #5202.
+  Future<void> _workerPoolDecrypt(
+    Nostr nostr,
+    List<Event> events,
+    Map<String, Event> decrypted,
+  ) async {
     var next = 0;
 
     Future<void> worker() async {
@@ -1788,9 +1836,9 @@ class DmRepository {
         // Read-then-increment with no await in between, so two workers never
         // claim the same index on a single isolate.
         final index = next;
-        if (index >= pending.length) return;
+        if (index >= events.length) return;
         next = index + 1;
-        final event = pending[index];
+        final event = events[index];
         try {
           final rumor = await _decryptRumor(nostr, event);
           if (rumor != null) decrypted[event.id] = rumor;
@@ -1814,11 +1862,115 @@ class DmRepository {
     }
 
     final workerCount =
-        pending.length < DmHistoryDrainConfig.remoteDecryptConcurrency
-        ? pending.length
+        events.length < DmHistoryDrainConfig.remoteDecryptConcurrency
+        ? events.length
         : DmHistoryDrainConfig.remoteDecryptConcurrency;
     await Future.wait([for (var i = 0; i < workerCount; i++) worker()]);
-    return decrypted;
+  }
+
+  /// #5471: unwraps [pending] gift wraps via the Keycast `nip17_unwrap_batch`
+  /// verb in chunks of [DmHistoryDrainConfig.unwrapBatchSize], one server round
+  /// trip per chunk. Successful slots are written into [decrypted]; per-item
+  /// error slots are left out so they fall through to the per-event path and
+  /// the failed-decrypt retry queue (the lenient per-wrap path recovers the
+  /// rare sender mismatch the strict server rejects). Returns the wraps still
+  /// need the per-wrap fallback pool: every wrap from the chunk where the verb
+  /// turned out to be unsupported onward, plus any chunk a transient error
+  /// (e.g. a timeout) skipped.
+  Future<List<Event>> _serverBatchUnwrapGiftWraps(
+    GiftWrapBatchUnwrapper unwrapper,
+    List<Event> pending,
+    Map<String, Event> decrypted,
+  ) async {
+    final fallback = <Event>[];
+    for (
+      var start = 0;
+      start < pending.length;
+      start += DmHistoryDrainConfig.unwrapBatchSize
+    ) {
+      if (_disposed) break;
+      final end = start + DmHistoryDrainConfig.unwrapBatchSize;
+      final chunk = pending.sublist(
+        start,
+        end < pending.length ? end : pending.length,
+      );
+
+      // The verb was found missing on an earlier chunk: don't keep probing it.
+      if (_batchUnwrapUnsupported) {
+        fallback.addAll(chunk);
+        continue;
+      }
+
+      List<GiftWrapUnwrapSlot>? slots;
+      try {
+        slots = await unwrapper.nip17UnwrapBatch([
+          for (final event in chunk) event.toJson(),
+        ]);
+      } on Object catch (e, stackTrace) {
+        // Transient failure (e.g. a TimeoutException): route this chunk to the
+        // per-wrap pool but keep trying the verb for later chunks.
+        Log.error(
+          'Batch gift-wrap unwrap chunk threw: $e',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        fallback.addAll(chunk);
+        await _yieldToEventLoop();
+        continue;
+      }
+
+      if (slots == null) {
+        // Older keycast without the verb: latch off and fall the rest back.
+        _batchUnwrapUnsupported = true;
+        fallback.addAll(chunk);
+        continue;
+      }
+
+      for (var i = 0; i < chunk.length; i++) {
+        final slot = i < slots.length ? slots[i] : null;
+        if (slot != null && slot.isSuccess) {
+          final rumor = _rumorFromSlot(slot);
+          if (rumor != null) decrypted[chunk[i].id] = rumor;
+        }
+        // Error or missing slots are intentionally omitted: the caller routes
+        // them to the per-event path, which records the failed decrypt for the
+        // retry queue and recovers a sender mismatch via the lenient per-wrap
+        // path. See #5202.
+      }
+
+      // Yield between chunks so a large backfill cannot starve frame
+      // rendering. See #5391.
+      await _yieldToEventLoop();
+    }
+    return fallback;
+  }
+
+  /// Builds the kind:14 rumor [Event] from a successful unwrap [slot],
+  /// attributing it to the server-authenticated [GiftWrapUnwrapSlot.sender] —
+  /// the same authority [GiftWrapUtil.getRumorEvent] applies locally. The
+  /// server already verified both the gift-wrap and seal signatures (#5471), so
+  /// the client does not re-verify. The event id is recomputed by the
+  /// constructor.
+  Event? _rumorFromSlot(GiftWrapUnwrapSlot slot) {
+    try {
+      final inner = Event.fromJson(slot.rumor!);
+      return Event(
+        slot.sender!,
+        inner.kind,
+        inner.tags,
+        inner.content,
+        createdAt: inner.createdAt,
+      );
+    } on Object catch (e, stackTrace) {
+      Log.error(
+        'Failed to build rumor from unwrap slot: $e',
+        category: LogCategory.system,
+        error: e,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
   }
 
   /// Cooperative-scheduling yield (NOT UI timing): a zero-duration delay is a

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1763,6 +1763,13 @@ class DmRepository {
   /// collapses the wall-clock to roughly 1/N; the Keycast server does not
   /// serialize per-token decrypts, so the concurrency is real.
   ///
+  /// When the remote signer is Keycast (a [GiftWrapBatchUnwrapper]), the page
+  /// is FIRST run through [_serverBatchUnwrapGiftWraps] — one
+  /// `nip17_unwrap_batch` round trip per chunk that unwraps both NIP-59 layers
+  /// server-side (#5471). Only the wraps that path leaves behind — an older
+  /// keycast without the verb, a transient chunk error, or a per-item failure —
+  /// fall back to the bounded worker pool described above.
+  ///
   /// Returns a `{giftWrapId: rumor}` map of the SUCCESSFUL decrypts only, with
   /// the same contract as [_batchDecryptGiftWraps]: wraps that are already
   /// persisted, undecryptable, or fail are absent and fall through to the
@@ -1873,9 +1880,9 @@ class DmRepository {
   /// trip per chunk. Successful slots are written into [decrypted]; per-item
   /// error slots are left out so they fall through to the per-event path and
   /// the failed-decrypt retry queue (the lenient per-wrap path recovers the
-  /// rare sender mismatch the strict server rejects). Returns the wraps still
-  /// need the per-wrap fallback pool: every wrap from the chunk where the verb
-  /// turned out to be unsupported onward, plus any chunk a transient error
+  /// rare sender mismatch the strict server rejects). Returns the wraps that
+  /// still need the per-wrap fallback pool: every wrap from the chunk where the
+  /// verb turned out to be unsupported onward, plus any chunk a transient error
   /// (e.g. a timeout) skipped.
   Future<List<Event>> _serverBatchUnwrapGiftWraps(
     GiftWrapBatchUnwrapper unwrapper,
@@ -1947,20 +1954,39 @@ class DmRepository {
   }
 
   /// Builds the kind:14 rumor [Event] from a successful unwrap [slot],
-  /// attributing it to the server-authenticated [GiftWrapUnwrapSlot.sender] —
-  /// the same authority [GiftWrapUtil.getRumorEvent] applies locally. The
-  /// server already verified both the gift-wrap and seal signatures (#5471), so
-  /// the client does not re-verify. The event id is recomputed by the
-  /// constructor.
+  /// attributing it to the server-authenticated [GiftWrapUnwrapSlot.sender].
+  /// The server already verified both the gift-wrap and seal signatures and
+  /// rejects a rumor whose author disagrees with the seal signer (#5471), so
+  /// the client neither re-verifies nor re-checks the sender.
+  ///
+  /// Reads ONLY the fields it keeps — `kind`, `tags`, `content`, `created_at` —
+  /// straight from [GiftWrapUnwrapSlot.rumor], NOT via [Event.fromJson] (which
+  /// mandates `id` and `pubkey`). A NIP-59 rumor is unsigned, so its `id` is
+  /// derivable and a sender may legitimately omit it; keycast forwards the
+  /// rumor verbatim, so depending on those discarded fields would make such a
+  /// slot throw → fall silently to the per-wrap pool, quietly degrading the
+  /// batch verb to a no-op on prod while CI (which always injects `id`/`pubkey`)
+  /// stayed green.
+  ///
+  /// The id is recomputed by the constructor from [GiftWrapUnwrapSlot.sender] —
+  /// always the canonical NIP-01 id for the authenticated sender, the same
+  /// recompute [GiftWrapUtil.getRumorEvent] performs on its sender-mismatch
+  /// branch. For a well-formed sender (every diVine client embeds the canonical
+  /// id) it equals the claimed id, so there is no observable divergence; for a
+  /// non-canonical claimed id the recompute is the more correct, interoperable
+  /// choice (the DB primary key is the rumor id).
   Event? _rumorFromSlot(GiftWrapUnwrapSlot slot) {
     try {
-      final inner = Event.fromJson(slot.rumor!);
+      final rumor = slot.rumor!;
+      final tags = (rumor['tags'] as List<dynamic>)
+          .map((tag) => (tag as List<dynamic>).map((e) => e as String).toList())
+          .toList();
       return Event(
         slot.sender!,
-        inner.kind,
-        inner.tags,
-        inner.content,
-        createdAt: inner.createdAt,
+        rumor['kind'] as int,
+        tags,
+        rumor['content'] as String,
+        createdAt: rumor['created_at'] as int,
       );
     } on Object catch (e, stackTrace) {
       Log.error(

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -1964,6 +1964,133 @@ void main() {
             verifyInserted(3);
           },
         );
+
+        test(
+          'persists a rumor that omits the derivable id and pubkey '
+          'instead of degrading to the per-wrap path',
+          () async {
+            // #5471 review: a NIP-59 rumor is unsigned, so the sender may omit
+            // the derivable id (and keycast forwards it verbatim). The batch
+            // path must read only the fields it keeps (kind/tags/content/
+            // created_at) so such a slot still yields a usable rumor instead of
+            // throwing in Event.fromJson and silently falling to the per-wrap
+            // pool — which would quietly degrade the verb to a no-op on prod.
+            final wraps = buildWraps(2);
+            serveOnePage(wraps);
+
+            var decryptorCalls = 0;
+            final signer = _BatchUnwrapSigner(
+              (batch) async => [
+                for (var i = 0; i < batch.length; i++)
+                  GiftWrapUnwrapSlot.success(
+                    rumor: {
+                      'created_at': 1700000000 - i,
+                      'kind': EventKind.privateDirectMessage,
+                      'tags': [
+                        ['p', _validPubkeyA],
+                      ],
+                      'content': 'no-id-$i',
+                      // No 'id', no 'pubkey': both discarded by the unwrap.
+                    },
+                    sender: hex64(i, 'd'),
+                  ),
+              ],
+            );
+
+            final repository = batchRepository(
+              signer: signer,
+              rumorDecryptor: (_, _) async {
+                decryptorCalls++;
+                return null;
+              },
+            );
+
+            await repository.backfillHistoryIfNeeded();
+
+            expect(signer.batchCalls, 1);
+            expect(
+              decryptorCalls,
+              0,
+              reason:
+                  'a rumor lacking id/pubkey must still unwrap via the batch '
+                  'path, not fall back to the per-wrap decryptor',
+            );
+            verifyInserted(2);
+          },
+        );
+
+        test(
+          'recomputes the canonical rumor id rather than trusting the '
+          'claimed id',
+          () async {
+            // #5471 review: the batch path attributes the rumor to the
+            // server-authenticated sender and recomputes the id, so the
+            // persisted primary key is the canonical NIP-01 id, not whatever
+            // (possibly non-canonical) id the sender claimed.
+            final wraps = buildWraps(1);
+            serveOnePage(wraps);
+
+            final signer = _BatchUnwrapSigner(
+              (_) async => [
+                GiftWrapUnwrapSlot.success(
+                  rumor: rumorJsonFor(0),
+                  sender: hex64(0, 'd'),
+                ),
+              ],
+            );
+
+            final repository = batchRepository(
+              signer: signer,
+              rumorDecryptor: (_, _) async => null,
+            );
+
+            await repository.backfillHistoryIfNeeded();
+
+            final captured = verify(
+              () => mockDirectMessagesDao.insertMessage(
+                id: captureAny(named: 'id'),
+                conversationId: any(named: 'conversationId'),
+                senderPubkey: any(named: 'senderPubkey'),
+                content: any(named: 'content'),
+                createdAt: any(named: 'createdAt'),
+                giftWrapId: any(named: 'giftWrapId'),
+                messageKind: any(named: 'messageKind'),
+                replyToId: any(named: 'replyToId'),
+                subject: any(named: 'subject'),
+                fileType: any(named: 'fileType'),
+                encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+                decryptionKey: any(named: 'decryptionKey'),
+                decryptionNonce: any(named: 'decryptionNonce'),
+                fileHash: any(named: 'fileHash'),
+                originalFileHash: any(named: 'originalFileHash'),
+                fileSize: any(named: 'fileSize'),
+                dimensions: any(named: 'dimensions'),
+                blurhash: any(named: 'blurhash'),
+                thumbnailUrl: any(named: 'thumbnailUrl'),
+                ownerPubkey: any(named: 'ownerPubkey'),
+                tagsJson: any(named: 'tagsJson'),
+              ),
+            ).captured;
+
+            final claimedId = rumorJsonFor(0)['id'] as String;
+            final canonicalId = Event(
+              hex64(0, 'd'),
+              EventKind.privateDirectMessage,
+              [
+                ['p', _validPubkeyA],
+              ],
+              'msg-0',
+              createdAt: 1700000000,
+            ).id;
+
+            expect(captured.single, canonicalId);
+            expect(
+              captured.single,
+              isNot(claimedId),
+              reason: 'the claimed (non-canonical) id must be discarded',
+            );
+          },
+        );
       });
 
       test('successful gift-wrap persist advances sync boundaries', () async {

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -17,6 +17,7 @@ import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/filter.dart' as nostr_filter;
 import 'package:nostr_sdk/nip44/nip44_v2.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_batch_unwrap.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/relay/publish_outcome.dart';
 import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
@@ -188,6 +189,36 @@ class _MockDmReactionsRepository extends Mock
     implements DmReactionsRepository {}
 
 class _MockNostrSigner extends Mock implements NostrSigner {}
+
+/// A remote signer that supports the #5471 server-side batch unwrap verb.
+///
+/// [nip17UnwrapBatch] delegates to [_onBatch]; the rest of the [NostrSigner]
+/// surface is stubbed via [noSuchMethod] except [getPublicKey], which the
+/// per-wrap fallback pool's `refreshPublicKey()` needs.
+class _BatchUnwrapSigner implements NostrSigner, GiftWrapBatchUnwrapper {
+  _BatchUnwrapSigner(this._onBatch);
+
+  final Future<List<GiftWrapUnwrapSlot>?> Function(
+    List<Map<String, dynamic>> giftWraps,
+  )
+  _onBatch;
+
+  int batchCalls = 0;
+
+  @override
+  Future<List<GiftWrapUnwrapSlot>?> nip17UnwrapBatch(
+    List<Map<String, dynamic>> giftWraps,
+  ) {
+    batchCalls++;
+    return _onBatch(giftWraps);
+  }
+
+  @override
+  Future<String?> getPublicKey() async => _validPubkeyA;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 class _FakeEvent extends Fake implements Event {}
 
@@ -1714,6 +1745,226 @@ void main() {
           ).called(wrapCount);
         },
       );
+
+      group('remote-signer batch unwrap (#5471)', () {
+        String hex64(int seed, String tag) =>
+            (tag * 64).substring(0, 62) +
+            seed.toRadixString(16).padLeft(2, '0');
+
+        List<Event> buildWraps(int count) => [
+          for (var i = 0; i < count; i++)
+            Event.fromJson({
+              'id': hex64(i, 'a'),
+              'pubkey': hex64(i, 'b'),
+              'created_at': 1700000000 - i,
+              'kind': EventKind.giftWrap,
+              'tags': [
+                ['p', _validPubkeyA],
+              ],
+              'content': 'wrap-$i',
+              'sig': '',
+            }),
+        ];
+
+        // The seal `sender` equals the rumor pubkey, mirroring the strict
+        // server which only returns success when they agree.
+        Map<String, dynamic> rumorJsonFor(int i) => {
+          'id': hex64(i, 'c'),
+          'pubkey': hex64(i, 'd'),
+          'created_at': 1700000000 - i,
+          'kind': EventKind.privateDirectMessage,
+          'tags': [
+            ['p', _validPubkeyA],
+          ],
+          'content': 'msg-$i',
+          'sig': '',
+        };
+
+        void serveOnePage(List<Event> wraps) {
+          var served = false;
+          when(
+            () => mockNostrClient.queryEvents(
+              any(),
+              subscriptionId: any(named: 'subscriptionId'),
+              useCache: any(named: 'useCache'),
+            ),
+          ).thenAnswer((inv) async {
+            final filters =
+                inv.positionalArguments.first as List<nostr_filter.Filter>;
+            final filter = filters.single;
+            if (filter.authors != null && (filter.p?.isEmpty ?? true)) {
+              return const <Event>[];
+            }
+            if (served) return const <Event>[];
+            served = true;
+            return wraps;
+          });
+        }
+
+        void verifyInserted(int times) {
+          verify(
+            () => mockDirectMessagesDao.insertMessage(
+              id: any(named: 'id'),
+              conversationId: any(named: 'conversationId'),
+              senderPubkey: any(named: 'senderPubkey'),
+              content: any(named: 'content'),
+              createdAt: any(named: 'createdAt'),
+              giftWrapId: any(named: 'giftWrapId'),
+              messageKind: any(named: 'messageKind'),
+              replyToId: any(named: 'replyToId'),
+              subject: any(named: 'subject'),
+              fileType: any(named: 'fileType'),
+              encryptionAlgorithm: any(named: 'encryptionAlgorithm'),
+              decryptionKey: any(named: 'decryptionKey'),
+              decryptionNonce: any(named: 'decryptionNonce'),
+              fileHash: any(named: 'fileHash'),
+              originalFileHash: any(named: 'originalFileHash'),
+              fileSize: any(named: 'fileSize'),
+              dimensions: any(named: 'dimensions'),
+              blurhash: any(named: 'blurhash'),
+              thumbnailUrl: any(named: 'thumbnailUrl'),
+              ownerPubkey: any(named: 'ownerPubkey'),
+              tagsJson: any(named: 'tagsJson'),
+            ),
+          ).called(times);
+        }
+
+        DmRepository batchRepository({
+          required NostrSigner signer,
+          required RumorDecryptor rumorDecryptor,
+        }) {
+          final syncState = _FakeDmSyncState()
+            ..oldestOverride = 1700000000
+            ..drainVersionOverride = DmSyncState.currentDrainVersion;
+          return createRepository(
+            signer: signer,
+            syncState: syncState,
+            rumorDecryptor: rumorDecryptor,
+          );
+        }
+
+        setUp(() {
+          when(
+            () => mockDirectMessagesDao.hasGiftWrap(any()),
+          ).thenAnswer((_) async => false);
+          stubDaoInserts();
+        });
+
+        test(
+          'drains a page via the batch verb without the per-wrap decryptor',
+          () async {
+            final wraps = buildWraps(4);
+            serveOnePage(wraps);
+
+            var decryptorCalls = 0;
+            final signer = _BatchUnwrapSigner(
+              (batch) async => [
+                for (var i = 0; i < batch.length; i++)
+                  GiftWrapUnwrapSlot.success(
+                    rumor: rumorJsonFor(i),
+                    sender: hex64(i, 'd'),
+                  ),
+              ],
+            );
+
+            final repository = batchRepository(
+              signer: signer,
+              rumorDecryptor: (_, _) async {
+                decryptorCalls++;
+                return null;
+              },
+            );
+
+            await repository.backfillHistoryIfNeeded();
+
+            expect(signer.batchCalls, 1);
+            expect(
+              decryptorCalls,
+              0,
+              reason: 'batch-handled wraps must not hit the per-wrap path',
+            );
+            verifyInserted(4);
+          },
+        );
+
+        test(
+          'falls back to the per-wrap pool when the verb is unsupported',
+          () async {
+            final wraps = buildWraps(4);
+            serveOnePage(wraps);
+
+            var decryptorCalls = 0;
+            final signer = _BatchUnwrapSigner((_) async => null);
+
+            final repository = batchRepository(
+              signer: signer,
+              rumorDecryptor: (_, wrap) async {
+                decryptorCalls++;
+                final i = wraps.indexWhere((w) => w.id == wrap.id);
+                return Event.fromJson(rumorJsonFor(i));
+              },
+            );
+
+            await repository.backfillHistoryIfNeeded();
+
+            expect(
+              signer.batchCalls,
+              1,
+              reason: 'probes the verb once, then latches it off',
+            );
+            expect(
+              decryptorCalls,
+              4,
+              reason: 'every wrap falls back to the per-wrap path',
+            );
+            verifyInserted(4);
+          },
+        );
+
+        test(
+          'routes a per-item error slot to the per-wrap recovery path',
+          () async {
+            final wraps = buildWraps(3);
+            serveOnePage(wraps);
+
+            var decryptorCalls = 0;
+            // Index 0 fails (e.g. sender_mismatch); 1 and 2 succeed.
+            final signer = _BatchUnwrapSigner(
+              (_) async => [
+                const GiftWrapUnwrapSlot.failure('sender_mismatch'),
+                GiftWrapUnwrapSlot.success(
+                  rumor: rumorJsonFor(1),
+                  sender: hex64(1, 'd'),
+                ),
+                GiftWrapUnwrapSlot.success(
+                  rumor: rumorJsonFor(2),
+                  sender: hex64(2, 'd'),
+                ),
+              ],
+            );
+
+            final repository = batchRepository(
+              signer: signer,
+              rumorDecryptor: (_, wrap) async {
+                decryptorCalls++;
+                final i = wraps.indexWhere((w) => w.id == wrap.id);
+                return Event.fromJson(rumorJsonFor(i));
+              },
+            );
+
+            await repository.backfillHistoryIfNeeded();
+
+            expect(signer.batchCalls, 1);
+            expect(
+              decryptorCalls,
+              1,
+              reason:
+                  'only the error-slot wrap falls through to the per-wrap path',
+            );
+            verifyInserted(3);
+          },
+        );
+      });
 
       test('successful gift-wrap persist advances sync boundaries', () async {
         const rumorCreatedAt = 1700000500;

--- a/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
+++ b/mobile/packages/keycast_flutter/lib/src/rpc/keycast_rpc.dart
@@ -17,7 +17,7 @@ import 'package:unified_logger/unified_logger.dart';
 /// is not possible.
 typedef TokenRefreshCallback = Future<String?> Function();
 
-class KeycastRpc implements NostrSigner {
+class KeycastRpc implements NostrSigner, GiftWrapBatchUnwrapper {
   /// Default timeout applied to every RPC HTTP request.
   ///
   /// Without a bound, a dead socket (e.g. Android Doze killing the
@@ -216,6 +216,52 @@ class KeycastRpc implements NostrSigner {
       // Network/parse error: degrade gracefully.
       return null;
     }
+  }
+
+  /// Server-side NIP-59 gift-wrap unwrap for the remote-signer DM history
+  /// drain (`nip17_unwrap_batch`).
+  ///
+  /// Sends a chunk of kind:1059 gift wraps and gets back ordered, index-aligned
+  /// slots — each the decrypted kind:14 rumor plus the authenticated sender, or
+  /// a per-item error code. This replaces two `nip44Decrypt` round trips per
+  /// wrap (gift wrap → seal, seal → rumor) with a single round trip per chunk;
+  /// the server verifies both signatures and decrypts both layers.
+  ///
+  /// Returns `null` (rather than throwing) when the backend does not expose the
+  /// verb yet — method-not-found surfaces as an [RpcException] — so callers fall
+  /// back to the per-wrap decrypt path. A [TimeoutException] is deliberately
+  /// allowed to propagate so a slow page is retried by the caller rather than
+  /// being mistaken for an empty result.
+  @override
+  Future<List<GiftWrapUnwrapSlot>?> nip17UnwrapBatch(
+    List<Map<String, dynamic>> giftWraps,
+  ) async {
+    try {
+      return await _call(
+        'nip17_unwrap_batch',
+        giftWraps,
+        (result) => [
+          for (final slot in result as List)
+            _parseUnwrapSlot(slot as Map<String, dynamic>),
+        ],
+      );
+    } on RpcException {
+      // Older keycast without the verb, or a server-level error: degrade so the
+      // caller uses the per-wrap fallback. Note: no `catch (_)` here — a
+      // TimeoutException must propagate, not be swallowed into a null result.
+      return null;
+    }
+  }
+
+  static GiftWrapUnwrapSlot _parseUnwrapSlot(Map<String, dynamic> slot) {
+    final error = slot['error'];
+    if (error != null) return GiftWrapUnwrapSlot.failure(error.toString());
+    final rumor = slot['rumor'];
+    final sender = slot['sender'];
+    if (rumor is Map<String, dynamic> && sender is String) {
+      return GiftWrapUnwrapSlot.success(rumor: rumor, sender: sender);
+    }
+    return const GiftWrapUnwrapSlot.failure('invalid_slot');
   }
 
   @override

--- a/mobile/packages/keycast_flutter/test/rpc_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/rpc_client_test.dart
@@ -515,5 +515,107 @@ void main() {
         expect(result, isNull);
       });
     });
+
+    group('nip17UnwrapBatch', () {
+      Map<String, dynamic> giftWrap(String id) => {
+        'id': id,
+        'pubkey': 'a' * 64,
+        'created_at': 1700000000,
+        'kind': 1059,
+        'tags': <List<String>>[],
+        'content': 'ciphertext-$id',
+        'sig': 'b' * 128,
+      };
+
+      test('posts the verb with the gift-wrap list and parses ordered '
+          'slots', () async {
+        final wraps = [giftWrap('11'), giftWrap('22')];
+        final rumor = {
+          'id': 'c' * 64,
+          'pubkey': 'd' * 64,
+          'created_at': 1700000001,
+          'kind': 14,
+          'tags': <List<String>>[],
+          'content': 'hello',
+        };
+
+        mockClient = MockClient((request) async {
+          expect(request.headers['Authorization'], 'Bearer test_token');
+          final body = jsonDecode(request.body);
+          expect(body['method'], 'nip17_unwrap_batch');
+          expect(body['params'], wraps);
+          return http.Response(
+            jsonEncode({
+              'result': [
+                {'rumor': rumor, 'sender': 'd' * 64},
+                {'error': 'sender_mismatch'},
+              ],
+            }),
+            200,
+          );
+        });
+
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+
+        final slots = await rpc.nip17UnwrapBatch(wraps);
+        expect(slots, hasLength(2));
+        expect(slots![0].isSuccess, isTrue);
+        expect(slots[0].sender, 'd' * 64);
+        expect(slots[0].rumor, rumor);
+        expect(slots[1].isSuccess, isFalse);
+        expect(slots[1].error, 'sender_mismatch');
+      });
+
+      test('returns null when the backend lacks the verb', () async {
+        mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({'error': 'Unsupported method: nip17_unwrap_batch'}),
+            200,
+          );
+        });
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+        expect(await rpc.nip17UnwrapBatch([giftWrap('1')]), isNull);
+      });
+
+      test('returns null on an HTTP error response', () async {
+        mockClient = MockClient((request) async {
+          return http.Response('boom', 400);
+        });
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+        );
+        expect(await rpc.nip17UnwrapBatch([giftWrap('1')]), isNull);
+      });
+
+      test('propagates TimeoutException rather than swallowing it to '
+          'null', () async {
+        // A timed-out page must be retryable by the caller, never mistaken
+        // for "no messages" — so unlike signCanonicalPayload, the batch verb
+        // does not catch TimeoutException.
+        mockClient = MockClient(
+          (request) => Completer<http.Response>().future,
+        );
+        final rpc = KeycastRpc(
+          nostrApi: 'https://login.divine.video/api/nostr',
+          accessToken: 'test_token',
+          httpClient: mockClient,
+          requestTimeout: const Duration(milliseconds: 50),
+        );
+        await expectLater(
+          rpc.nip17UnwrapBatch([giftWrap('1')]),
+          throwsA(isA<TimeoutException>()),
+        );
+      });
+    });
   });
 }

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_batch_unwrap.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_batch_unwrap.dart
@@ -1,0 +1,56 @@
+// ABOUTME: Capability for unwrapping NIP-59 gift wraps server-side in one batch.
+// ABOUTME: Lets a remote signer (e.g. Keycast) unwrap a page in one round trip.
+
+/// One index-aligned result slot from a server-side NIP-17 gift-wrap unwrap
+/// batch.
+///
+/// On success it carries the decrypted kind:14 [rumor] (unsigned event JSON)
+/// and the server-authenticated [sender] (the seal signer's pubkey, hex). On a
+/// per-item failure it carries an [error] code instead — one bad gift wrap
+/// never fails the whole batch.
+class GiftWrapUnwrapSlot {
+  /// A slot whose gift wrap unwrapped successfully.
+  const GiftWrapUnwrapSlot.success({
+    required Map<String, dynamic> this.rumor,
+    required String this.sender,
+  }) : error = null;
+
+  /// A slot whose gift wrap failed to unwrap, carrying the server's [error]
+  /// code (e.g. `sender_mismatch`, `decrypt_failed`, `invalid_event`). The code
+  /// set is open: treat any unknown code as a failure rather than pinning to a
+  /// fixed list.
+  const GiftWrapUnwrapSlot.failure(String this.error)
+    : rumor = null,
+      sender = null;
+
+  /// The decrypted kind:14 rumor as JSON, or `null` on failure.
+  final Map<String, dynamic>? rumor;
+
+  /// The authenticated sender (seal signer pubkey, hex), or `null` on failure.
+  final String? sender;
+
+  /// The per-item error code, or `null` on success.
+  final String? error;
+
+  /// Whether this slot unwrapped successfully.
+  bool get isSuccess => error == null && rumor != null && sender != null;
+}
+
+/// A signer that can unwrap NIP-59 gift wraps server-side in a single batched
+/// round trip per chunk, rather than two `nip44Decrypt` round trips per wrap.
+///
+/// Signers that cannot do this simply do not implement the interface; callers
+/// detect support with `signer is GiftWrapBatchUnwrapper` and fall back to the
+/// per-wrap decrypt path when it is absent.
+abstract interface class GiftWrapBatchUnwrapper {
+  /// Unwraps [giftWraps] — a list of kind:1059 gift-wrap events as JSON — into
+  /// ordered, index-aligned [GiftWrapUnwrapSlot]s.
+  ///
+  /// Returns `null` when the server does not support the verb (e.g. an older
+  /// backend), so the caller can fall back to the per-wrap path. May throw
+  /// [TimeoutException] when the request times out — callers should treat that
+  /// as a transient failure to retry, never as "no messages".
+  Future<List<GiftWrapUnwrapSlot>?> nip17UnwrapBatch(
+    List<Map<String, dynamic>> giftWraps,
+  );
+}

--- a/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
+++ b/mobile/packages/nostr_sdk/lib/nostr_sdk.dart
@@ -35,6 +35,7 @@ export 'nip51/follow_set.dart';
 // Platform-specific (conditionally exported)
 export 'nip55/android_nostr_signer.dart';
 export 'nip58/badge_definition.dart';
+export 'nip59/gift_wrap_batch_unwrap.dart';
 export 'nip59/gift_wrap_util.dart';
 export 'nip65/nip65.dart';
 export 'nip65/relay_list_metadata.dart';

--- a/mobile/packages/nostr_sdk/test/nip59/gift_wrap_batch_unwrap_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip59/gift_wrap_batch_unwrap_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_batch_unwrap.dart';
+
+void main() {
+  group(GiftWrapUnwrapSlot, () {
+    test('success carries the rumor and authenticated sender', () {
+      const sender =
+          '0000000000000000000000000000000000000000000000000000000000000001';
+      final rumor = {'kind': 14, 'content': 'hi'};
+
+      final slot = GiftWrapUnwrapSlot.success(rumor: rumor, sender: sender);
+
+      expect(slot.isSuccess, isTrue);
+      expect(slot.rumor, same(rumor));
+      expect(slot.sender, sender);
+      expect(slot.error, isNull);
+    });
+
+    test('failure carries the error code and is not a success', () {
+      const slot = GiftWrapUnwrapSlot.failure('sender_mismatch');
+
+      expect(slot.isSuccess, isFalse);
+      expect(slot.error, 'sender_mismatch');
+      expect(slot.rumor, isNull);
+      expect(slot.sender, isNull);
+    });
+  });
+}

--- a/mobile/test/services/nostr_identity_test.dart
+++ b/mobile/test/services/nostr_identity_test.dart
@@ -26,6 +26,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(Event(testPublicKey, 0, [], ''));
     registerFallbackValue(Uint8List(0));
+    registerFallbackValue(<Map<String, dynamic>>[]);
   });
 
   group(LocalNostrIdentity, () {
@@ -260,6 +261,41 @@ void main() {
         expect(result, isNull);
       },
     );
+
+    test(
+      'nip17UnwrapBatch returns null when rpcSigner is a generic NostrSigner',
+      () async {
+        // A generic NostrSigner is not a GiftWrapBatchUnwrapper, so the
+        // identity short-circuits to null and the DM drain falls back to the
+        // per-wrap path. See #5471.
+        final identity = KeycastNostrIdentity(
+          pubkey: testPublicKey,
+          rpcSigner: mockRpc,
+        );
+
+        expect(await identity.nip17UnwrapBatch(const []), isNull);
+      },
+    );
+
+    test('nip17UnwrapBatch delegates to KeycastRpc', () async {
+      final mockKeycastRpc = _MockKeycastRpc();
+      final slots = [const GiftWrapUnwrapSlot.failure('decrypt_failed')];
+      when(
+        () => mockKeycastRpc.nip17UnwrapBatch(any()),
+      ).thenAnswer((_) async => slots);
+
+      final identity = KeycastNostrIdentity(
+        pubkey: testPublicKey,
+        rpcSigner: mockKeycastRpc,
+      );
+
+      final result = await identity.nip17UnwrapBatch([
+        {'id': 'wrap'},
+      ]);
+
+      expect(result, same(slots));
+      verify(() => mockKeycastRpc.nip17UnwrapBatch(any())).called(1);
+    });
 
     test(
       'signCanonicalPayload prefers local signer when available',


### PR DESCRIPTION
## Description

The remote-signer DM history drain decrypted each NIP-17 message with **two sequential `nip44_decrypt` RPCs** (gift wrap kind:1059 → seal kind:13, seal → rumor kind:14). Keycast's new server-side `nip17_unwrap_batch` verb (divinevideo/keycast#256) unwraps **both layers server-side** and returns the rumor plus the authenticated sender, so a page drains in **one round trip per ≤100-wrap chunk** instead of two RPCs per message — compounding the client-side parallelism shipped in #5426.

- **nostr_sdk** — new `GiftWrapBatchUnwrapper` capability + `GiftWrapUnwrapSlot` result type.
- **keycast_flutter** — `KeycastRpc.nip17UnwrapBatch`, mirroring `signCanonicalPayload`'s graceful degradation (returns `null` on method-not-found so the caller falls back), but **letting `TimeoutException` propagate** so a slow page is retried rather than mistaken for "no messages".
- **nostr_identity** — `KeycastNostrIdentity` exposes the capability, delegating to its RPC signer.
- **dm_repository** — chunks each drain page through the verb, attributes every rumor to the **server-authenticated sender** (no client-side re-verify — the server verifies both the gift-wrap and seal signatures), and falls back to the per-wrap pool (#5426) when the verb is absent or a chunk errors. Per-item error slots route to the existing failed-decrypt retry queue, where the lenient per-wrap path recovers the rare `sender_mismatch`.
- The local-key isolate decrypt path is **unchanged**.

**Behaviour today:** the verb is live on staging/poc but **not production yet** (prod keycast is pinned to a commit predating #256). The graceful fallback means this PR is a no-op on prod until keycast prod is deployed past #256 — at which point the speedup activates with no further client change. That backend deploy is an ops follow-up, tracked separately.

**Related Issue:** Closes #5471

## Out of Scope

- Deploying `nip17_unwrap_batch` to **production** keycast (ops: cut a keycast `v*` tag or a manual production deploy past #256).
- The live first-open `limit:50` subscription still decrypts incrementally (separate, per #5426).
- Local-key isolate batching (already optimal).

## Verification

- `flutter analyze lib test integration_test` — No issues found.
- `flutter test` in `packages/dm_repository` — 414 pass, including 3 new batch tests and the unchanged #5426 / #5391 / #5424 regressions.
- `flutter test` in `packages/keycast_flutter` — passes, including new `nip17UnwrapBatch` tests (ordered/partial-failure parsing, method-not-found → null, **TimeoutException propagation**).
- `flutter test test/services/nostr_identity_test.dart` — 45 pass (+2 delegation tests).
- `flutter test` in `packages/nostr_sdk` — new `GiftWrapUnwrapSlot` unit test passes.
- Keycast contract verified end-to-end against a locally-built keycast (#256) + Postgres: `nip17_unwrap_batch` integration tests (happy-path/partial-failure, size-cap, suspended-user) all green.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)