### PR TITLE
fix(video-editor): guard editor capability sync and audio preview against unmount

### DIFF
--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -14,6 +14,7 @@ import 'package:openvine/blocs/sound_waveform/sound_waveform_bloc.dart';
 import 'package:openvine/blocs/video_editor/audio_timing/audio_timing_cubit.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/utils/mounted_post_frame.dart';
 import 'package:openvine/widgets/stereo_waveform_painter.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/video_editor_audio_chip.dart';
 import 'package:openvine/widgets/video_editor/video_editor_toolbar.dart';
@@ -113,9 +114,7 @@ class _VideoAudioEditorTimingScreenState
     );
 
     // Delay initialization until after first frame
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-
+    addPostFrameCallbackIfMounted(() {
       // Sync fling controller with initial offset after cubit initializes
       _audioTimingCubit.initialize().then((_) {
         if (mounted) {

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -33,6 +33,7 @@ import 'package:openvine/screens/video_editor/voice_over_take_commit.dart';
 import 'package:openvine/screens/video_editor/voice_over_take_placement.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/await_push_transition.dart';
+import 'package:openvine/utils/mounted_post_frame.dart';
 import 'package:openvine/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
@@ -164,9 +165,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
       _clipEditorBloc.add(ClipEditorInitialized(initialClips));
     }
 
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (!mounted) return;
-
+    addPostFrameCallbackIfMounted(() async {
       Log.debug(
         '🎬 Initializing video editor provider',
         name: 'VideoEditorScreen',

--- a/mobile/lib/utils/mounted_post_frame.dart
+++ b/mobile/lib/utils/mounted_post_frame.dart
@@ -1,0 +1,27 @@
+// ABOUTME: State extension that schedules a post-frame callback guarded by the
+// ABOUTME: widget's mounted flag, so async/post-frame UI work never outlives it.
+
+import 'package:flutter/widgets.dart';
+
+/// Lifecycle-safe [addPostFrameCallback] for a [State].
+extension MountedPostFrame on State {
+  /// Runs [callback] after the next frame, but only if this [State] is still
+  /// mounted when that frame lands.
+  ///
+  /// A post-frame callback scheduled from a [State] still fires after the
+  /// widget has been disposed. If the callback then reads `context` or touches
+  /// a provider it crashes ("looking up a deactivated widget's ancestor" /
+  /// `State.context` used after unmount) — a class of non-fatal Crashlytics
+  /// reports for editor UI whose post-frame work raced the screen teardown.
+  /// Routing that work through this guard drops it when the widget is gone.
+  ///
+  /// [callback] may be `async`; like a raw post-frame callback its future is
+  /// fire-and-forget, so any work after an `await` inside it must re-check
+  /// [mounted] before touching `context` again.
+  void addPostFrameCallbackIfMounted(VoidCallback callback) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      callback();
+    });
+  }
+}

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -549,9 +549,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   void _scheduleVolumeHistoryWrite() {
     if (_isVolumeSavePending) return;
     _isVolumeSavePending = true;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    addPostFrameCallbackIfMounted(() {
       _isVolumeSavePending = false;
-      if (!mounted) return;
       VideoEditorScope.of(context).editor?.setVolumeState(
         clips: context.read<ClipEditorBloc>().state.clips,
         audioTracks: context.read<TimelineOverlayBloc>().state.audioTracks,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -31,6 +31,7 @@ import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:openvine/services/haptic_service.dart';
 import 'package:openvine/services/video_editor/transition_seam_render_service.dart';
 import 'package:openvine/utils/await_push_transition.dart';
+import 'package:openvine/utils/mounted_post_frame.dart';
 import 'package:openvine/utils/path_resolver.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_feed_preview_overlay.dart';
@@ -1031,7 +1032,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     final editor = scope.editor;
     if (editor == null) return;
 
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
+    // The frame can land after the editor is torn down; the guard bails before
+    // touching context or providers so we never read State.context post-unmount.
+    addPostFrameCallbackIfMounted(() async {
       bloc.add(
         VideoEditorMainCapabilitiesChanged(
           canUndo: editor.canUndo,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -14,6 +14,7 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:openvine/utils/mounted_post_frame.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/controls/video_editor_transition_sheet.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/timeline_trim_handles.dart';
 
@@ -329,8 +330,8 @@ class _VideoEditorTimelineClipStripState
 
     // Trigger the width shrink in the next frame so AnimatedContainer can
     // interpolate from the full clip width to _reorderSize.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted && _isReordering) {
+    addPostFrameCallbackIfMounted(() {
+      if (_isReordering) {
         setState(() => _dragClipWidth = _reorderSize);
       }
     });

--- a/mobile/test/utils/mounted_post_frame_test.dart
+++ b/mobile/test/utils/mounted_post_frame_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/utils/mounted_post_frame.dart';
+
+void main() {
+  group('addPostFrameCallbackIfMounted', () {
+    testWidgets('runs the callback (reading context) while still mounted', (
+      tester,
+    ) async {
+      var didRun = false;
+      TextDirection? contextLookup;
+      final key = GlobalKey<_ProbeState>();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: _Probe(
+            key: key,
+            onRun: (context) {
+              didRun = true;
+              // An inherited-widget lookup — the kind of context access that
+              // throws when run after the State is unmounted.
+              contextLookup = Directionality.of(context);
+            },
+          ),
+        ),
+      );
+
+      key.currentState!.scheduleGuardedWork();
+      // Drive the frame that flushes the pending post-frame callback while the
+      // probe is still mounted.
+      tester.binding.scheduleFrame();
+      await tester.pump();
+
+      expect(didRun, isTrue);
+      expect(contextLookup, TextDirection.ltr);
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets(
+      'skips the callback when the widget is disposed before the frame',
+      (tester) async {
+        var didRun = false;
+        final key = GlobalKey<_ProbeState>();
+
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: _Probe(
+              key: key,
+              onRun: (context) {
+                didRun = true;
+                // Throws ("looking up a deactivated widget's ancestor") if the
+                // guard ever lets this run against an unmounted State.
+                Directionality.of(context);
+              },
+            ),
+          ),
+        );
+
+        key.currentState!.scheduleGuardedWork();
+        // Replace the tree before the scheduled callback runs: this frame both
+        // disposes the probe and flushes the pending post-frame callback, which
+        // now fires against an unmounted State and must be dropped by the guard.
+        await tester.pumpWidget(const SizedBox.shrink());
+
+        expect(didRun, isFalse);
+        expect(tester.takeException(), isNull);
+      },
+    );
+  });
+}
+
+class _Probe extends StatefulWidget {
+  const _Probe({required this.onRun, super.key});
+
+  final void Function(BuildContext context) onRun;
+
+  @override
+  State<_Probe> createState() => _ProbeState();
+}
+
+class _ProbeState extends State<_Probe> {
+  void scheduleGuardedWork() {
+    addPostFrameCallbackIfMounted(() => widget.onRun(context));
+  }
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}

--- a/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
+++ b/mobile/test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart
@@ -288,6 +288,71 @@ void main() {
       });
     });
 
+    group('Lifecycle', () {
+      testWidgets(
+        'does not setState after the sheet is disposed mid-preview',
+        (tester) async {
+          final audioService = _MockAudioPlaybackService();
+          final playCompleter = Completer<void>();
+          final sound = _createTestAudioEvent(title: 'Pending Preview');
+          Future<void> immediate(Invocation _) => Future<void>.value();
+          Future<Duration> loadDuration(Invocation _) =>
+              Future.value(const Duration(seconds: 5));
+          Future<void> blockOnPlay(Invocation _) => playCompleter.future;
+
+          when(() => audioService.isPlaying).thenReturn(false);
+          when(
+            () => audioService.playingStream,
+          ).thenAnswer((_) => const Stream<bool>.empty());
+          when(
+            () => audioService.durationStream,
+          ).thenAnswer((_) => const Stream<Duration?>.empty());
+          when(
+            () => audioService.positionStream,
+          ).thenAnswer((_) => const Stream<Duration>.empty());
+          when(() => audioService.duration).thenReturn(null);
+          when(
+            () => audioService.seek(Duration.zero),
+          ).thenAnswer(immediate);
+          when(audioService.stop).thenAnswer(immediate);
+          when(
+            () => audioService.loadAudio(sound.url!),
+          ).thenAnswer(loadDuration);
+          // Blocks for the whole "playback" so the preview future is still
+          // pending when the sheet is torn down.
+          when(audioService.play).thenAnswer(blockOnPlay);
+          when(audioService.pause).thenAnswer(immediate);
+          when(audioService.dispose).thenAnswer(immediate);
+
+          await tester.pumpWidget(
+            buildWidget(
+              trendingSoundsAsync: AsyncValue.data([sound]),
+              audioService: audioService,
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          final l10n = lookupAppLocalizations(const Locale('en'));
+          await tester.tap(find.text(l10n.videoEditorAudioCategoryCommunity));
+          await tester.pumpAndSettle();
+
+          // Start the preview; the handler now sits awaiting play().
+          await tester.tap(find.text('Pending Preview'));
+          await tester.pumpAndSettle();
+
+          // Tear the sheet down while play() is still pending.
+          await tester.pumpWidget(const SizedBox.shrink());
+
+          // Resolve the preview after disposal: the finally path awaits
+          // pause() then a mounted-guarded setState that must be skipped.
+          playCompleter.complete();
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+        },
+      );
+    });
+
     group('Empty state', () {
       testWidgets('renders empty state when no bundled sounds available', (
         tester,


### PR DESCRIPTION
## Description

Fixes the two Crashlytics 1.0.13 lifecycle crashes from video-editor UI work that outlives the screen/sheet.

**1. `_VideoEditorState._syncMainCapabilities` (issue 31cf5709…)** — its `addPostFrameCallback` reads `context`/providers, but the frame can land after the editor is torn down. The existing `mounted` check sat *after* the first awaited work, so the synchronous `context.read` calls at the top of the callback ran unguarded → `State.context used after unmount`.

Routed the post-frame work through a new `State.addPostFrameCallbackIfMounted` extension ([mounted_post_frame.dart](mobile/lib/utils/mounted_post_frame.dart)) that bails before invoking the body when the `State` is no longer mounted. This is the testable seam for the guard — the full editor can't be pumped in a focused test without the native video player (`DivineVideoPlayerController` is constructed directly in `_initializePlayer`), so the guard itself is unit-tested with a minimal real widget that reproduces the exact crash.

**2. `AudioSelectionBottomSheet._togglePlayPause` (issue bf9cb8b8…)** — `setState` from the play/pause `finally` path after the preview future resolves. This is **already guarded in code** (`if (mounted) setState(...)`); added a focused regression test that disposes the sheet while the preview future is still pending, so the guard can't silently regress. Both new tests were verified to fail without their respective guards (`This widget has been unmounted…` / `setState() called after dispose()`).

**Related Issue:** Closes #4396

## Out of Scope

- `_syncDrawCapabilities` (the other post-frame callback in the same file) only touches a captured bloc, not `context`, and was not implicated in the crash reports — left unchanged.

## Verification

- `flutter analyze lib test` — no issues
- `flutter test test/utils/mounted_post_frame_test.dart test/widgets/video_editor/audio_editor/audio_selection_bottom_sheet_test.dart test/widgets/video_editor/main_editor/video_editor_canvas_test.dart` — 37 passing
- Negative-control check: removed each guard, confirmed the new tests fail with the exact reported crash, restored.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)