### PR TITLE
refactor(di): inject clean infra services via Riverpod providers

### DIFF
--- a/mobile/lib/blocs/explore_tabs/explore_tabs_cubit.dart
+++ b/mobile/lib/blocs/explore_tabs/explore_tabs_cubit.dart
@@ -20,13 +20,15 @@ part 'explore_tabs_state.dart';
 /// analytics and top-hashtag loading) so the presentation layer reaches them
 /// through the cubit rather than importing services directly.
 class ExploreTabsCubit extends Cubit<ExploreTabsState> {
-  /// Creates the cubit. [screenAnalytics] and [topHashtags] default to their
-  /// singletons; inject fakes in tests.
+  /// Creates the cubit. [screenAnalytics] and [topHashtags] default to
+  /// standalone instances; production injects the shared
+  /// `topHashtagsServiceProvider` instance (so the warmed cache is shared),
+  /// and tests inject fakes.
   ExploreTabsCubit({
     ScreenAnalyticsService? screenAnalytics,
     TopHashtagsLoader? topHashtags,
   }) : _screenAnalytics = screenAnalytics ?? ScreenAnalyticsService(),
-       _topHashtags = topHashtags ?? TopHashtagsService.instance,
+       _topHashtags = topHashtags ?? TopHashtagsService(),
        super(const ExploreTabsState());
 
   static const _screenName = 'explore_screen';

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -93,7 +93,6 @@ import 'package:openvine/services/notification_service.dart'
     show NotificationTapEvent;
 import 'package:openvine/services/notification_target_resolver.dart';
 import 'package:openvine/services/openvine_media_cache.dart';
-import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/pro_video_editor_log_forwarder.dart';
 import 'package:openvine/services/quick_actions_coordinator.dart';
 import 'package:openvine/services/secure_storage_options.dart';
@@ -780,7 +779,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
       await _runTimedStartupTask(
         phaseName: 'performance_monitoring',
         initializationStep: 'Initializing performance monitoring',
-        task: PerformanceMonitoringService.instance.initialize,
+        task: container.read(performanceMonitoringServiceProvider).initialize,
       );
     },
     optional: true,

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -63,6 +63,7 @@ import 'package:openvine/providers/deep_link_provider.dart';
 import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/foreground_idle_warmup_provider.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/router/router.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
@@ -84,7 +85,6 @@ import 'package:openvine/services/database_encryption_bootstrap.dart';
 import 'package:openvine/services/deep_link_service.dart';
 import 'package:openvine/services/firebase_initialization.dart';
 import 'package:openvine/services/locale_preference_service.dart';
-import 'package:openvine/services/logging_config_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/nip98_auth_service.dart' show HttpMethod;
 import 'package:openvine/services/notification_helpers.dart'
@@ -794,7 +794,7 @@ StartupCoordinator _createStartupCoordinator(ProviderContainer container) {
         phaseName: 'logging_config',
         initializationStep: 'Initializing logging configuration',
         task: () async {
-          await LoggingConfigService.instance.initialize();
+          await container.read(loggingConfigServiceProvider).initialize();
           LogMessageBatcher.instance.initialize();
         },
       );

--- a/mobile/lib/providers/repository_providers.dart
+++ b/mobile/lib/providers/repository_providers.dart
@@ -30,6 +30,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/relay_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/video_providers.dart';
@@ -39,7 +40,6 @@ import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/curated_list_service.dart';
 import 'package:openvine/services/immediate_completion_helper.dart';
 import 'package:openvine/services/pending_action_service.dart';
-import 'package:openvine/services/top_hashtags_service.dart';
 import 'package:openvine/utils/search_utils.dart';
 import 'package:people_lists_repository/people_lists_repository.dart';
 import 'package:profile_repository/profile_repository.dart';
@@ -230,10 +230,11 @@ List<CuratedList> subscribedListsForHomeBridge(CuratedListService service) =>
 HashtagRepository hashtagRepository(Ref ref) {
   final funnelcakeClient = ref.watch(funnelcakeApiClientProvider);
   final hashtagService = ref.watch(hashtagServiceProvider);
+  final topHashtags = ref.watch(topHashtagsServiceProvider);
 
   // Ensure static hashtags are loaded before any local search callback runs.
   // loadTopHashtags is idempotent and no-ops if already loaded.
-  TopHashtagsService.instance.loadTopHashtags();
+  topHashtags.loadTopHashtags();
 
   return HashtagRepository(
     funnelcakeApiClient: funnelcakeClient,
@@ -251,7 +252,7 @@ HashtagRepository hashtagRepository(Ref ref) {
       addMatches(hashtagService.searchHashtags(query));
       if (results.length < limit) {
         addMatches(
-          TopHashtagsService.instance.searchHashtags(query, limit: limit),
+          topHashtags.searchHashtags(query, limit: limit),
         );
       }
 

--- a/mobile/lib/providers/repository_providers.g.dart
+++ b/mobile/lib/providers/repository_providers.g.dart
@@ -266,7 +266,7 @@ final class HashtagRepositoryProvider
   }
 }
 
-String _$hashtagRepositoryHash() => r'fe5341fcbbd62c6418fd00154f9ea24112476251';
+String _$hashtagRepositoryHash() => r'9bb8a737619e6dbf039bd8d0dd218c94a6ca17e6';
 
 /// Provider for CategoriesRepository instance.
 ///

--- a/mobile/lib/providers/service_providers.dart
+++ b/mobile/lib/providers/service_providers.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/services/logging_config_service.dart';
+import 'package:openvine/services/top_hashtags_service.dart';
 
 /// Provides the app's [LoggingConfigService].
 ///
@@ -11,4 +12,14 @@ import 'package:openvine/services/logging_config_service.dart';
 /// static state. Kept alive for the app's lifetime (logging config is global).
 final loggingConfigServiceProvider = Provider<LoggingConfigService>(
   (ref) => LoggingConfigService(),
+);
+
+/// Provides the app's shared [TopHashtagsService].
+///
+/// Replaces the former `TopHashtagsService.instance` singleton. A single
+/// shared instance is kept alive so the in-memory hashtag list loaded by one
+/// consumer (e.g. the explore cubit warming the cache) is visible to the
+/// others (the hashtag repository and the popular-videos tab).
+final topHashtagsServiceProvider = Provider<TopHashtagsService>(
+  (ref) => TopHashtagsService(),
 );

--- a/mobile/lib/providers/service_providers.dart
+++ b/mobile/lib/providers/service_providers.dart
@@ -3,6 +3,7 @@
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/services/logging_config_service.dart';
+import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/top_hashtags_service.dart';
 
 /// Provides the app's [LoggingConfigService].
@@ -23,3 +24,13 @@ final loggingConfigServiceProvider = Provider<LoggingConfigService>(
 final topHashtagsServiceProvider = Provider<TopHashtagsService>(
   (ref) => TopHashtagsService(),
 );
+
+/// Provides the app's [PerformanceMonitoringService] (a [PerformanceTraceMonitor]).
+///
+/// Replaces the former `PerformanceMonitoringService.instance` singleton. A
+/// single shared instance is kept alive; consumers that only need the trace
+/// API depend on it through the [PerformanceTraceMonitor] interface.
+final performanceMonitoringServiceProvider =
+    Provider<PerformanceMonitoringService>(
+      (ref) => PerformanceMonitoringService(),
+    );

--- a/mobile/lib/providers/service_providers.dart
+++ b/mobile/lib/providers/service_providers.dart
@@ -25,11 +25,13 @@ final topHashtagsServiceProvider = Provider<TopHashtagsService>(
   (ref) => TopHashtagsService(),
 );
 
-/// Provides the app's [PerformanceMonitoringService] (a [PerformanceTraceMonitor]).
+/// Provides the app's [PerformanceMonitoringService].
 ///
 /// Replaces the former `PerformanceMonitoringService.instance` singleton. A
-/// single shared instance is kept alive; consumers that only need the trace
-/// API depend on it through the [PerformanceTraceMonitor] interface.
+/// single shared instance is kept alive. Typed to the concrete class (not
+/// [PerformanceTraceMonitor]) because app startup calls the concrete-only
+/// [PerformanceMonitoringService.initialize]; consumers that only need the
+/// trace API accept a [PerformanceTraceMonitor] in their constructor.
 final performanceMonitoringServiceProvider =
     Provider<PerformanceMonitoringService>(
       (ref) => PerformanceMonitoringService(),

--- a/mobile/lib/providers/service_providers.dart
+++ b/mobile/lib/providers/service_providers.dart
@@ -1,0 +1,14 @@
+// ABOUTME: Riverpod providers for infrastructure services migrated off the
+// ABOUTME: lazy-static singleton pattern to constructor injection (#4743).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/services/logging_config_service.dart';
+
+/// Provides the app's [LoggingConfigService].
+///
+/// Replaces the former `LoggingConfigService.instance` singleton so the
+/// service can be overridden with a fake in tests instead of reaching into
+/// static state. Kept alive for the app's lifetime (logging config is global).
+final loggingConfigServiceProvider = Provider<LoggingConfigService>(
+  (ref) => LoggingConfigService(),
+);

--- a/mobile/lib/providers/upload_media_providers.dart
+++ b/mobile/lib/providers/upload_media_providers.dart
@@ -10,6 +10,7 @@ import 'package:openvine/providers/environment_provider.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/overlay_visibility_provider.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shell_obscured_provider.dart';
 import 'package:openvine/services/api_service.dart';
 import 'package:openvine/services/auth_service.dart' hide UserProfile;
@@ -49,24 +50,22 @@ class _BlossomAuthAdapter implements BlossomAuthProvider {
   }
 }
 
-/// Adapts [PerformanceMonitoringService] to the package-level
+/// Adapts a [PerformanceTraceMonitor] to the package-level
 /// [BlossomPerformanceMonitor] interface.
 class _FirebasePerformanceAdapter implements BlossomPerformanceMonitor {
-  @override
-  Future<void> startTrace(String traceName) =>
-      PerformanceMonitoringService.instance.startTrace(traceName);
+  _FirebasePerformanceAdapter(this._monitor);
+
+  final PerformanceTraceMonitor _monitor;
 
   @override
-  Future<void> stopTrace(String traceName) =>
-      PerformanceMonitoringService.instance.stopTrace(traceName);
+  Future<void> startTrace(String traceName) => _monitor.startTrace(traceName);
+
+  @override
+  Future<void> stopTrace(String traceName) => _monitor.stopTrace(traceName);
 
   @override
   void setMetric(String traceName, String metricName, int value) =>
-      PerformanceMonitoringService.instance.setMetric(
-        traceName,
-        metricName,
-        value,
-      );
+      _monitor.setMetric(traceName, metricName, value);
 }
 
 /// Blossom BUD-01 authentication service for age-restricted content
@@ -126,7 +125,9 @@ BlossomUploadService blossomUploadService(Ref ref) {
   final env = ref.read(currentEnvironmentProvider);
   return BlossomUploadService(
     authProvider: _BlossomAuthAdapter(authService),
-    performanceMonitor: _FirebasePerformanceAdapter(),
+    performanceMonitor: _FirebasePerformanceAdapter(
+      ref.watch(performanceMonitoringServiceProvider),
+    ),
     defaultServerUrl: env.blossomUrl,
     // Backpressure: while a feed video is actively playing in the foreground,
     // pause briefly between chunks so the upload doesn't starve playback on a

--- a/mobile/lib/providers/upload_media_providers.g.dart
+++ b/mobile/lib/providers/upload_media_providers.g.dart
@@ -165,7 +165,7 @@ final class BlossomUploadServiceProvider
 }
 
 String _$blossomUploadServiceHash() =>
-    r'fd5823c218bc0ddc19d02aaad4d6b32f209863f6';
+    r'6df7595f06a8a9c53f83ca2c135de7f3af06e247';
 
 /// Upload manager uses only Blossom upload service
 

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -19,6 +19,7 @@ import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/relay_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/saved_sounds_provider.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
@@ -118,6 +119,7 @@ VideoEventService videoEventService(Ref ref) {
     profileRepository: profileRepository,
     eventRouter: eventRouter,
     videoFilterBuilder: videoFilterBuilder,
+    performanceMonitor: ref.watch(performanceMonitoringServiceProvider),
   );
   var persistedDeletions = const <ContentDeletion>[];
   try {

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -322,7 +322,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'4d5d25bfab30bb44b73e1aa5e6b4f47e6de7b12d';
+String _$videoEventServiceHash() => r'9795e17f42ef25c2af8e036b10ca4e043babf179';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/screens/explore/explore_screen.dart
+++ b/mobile/lib/screens/explore/explore_screen.dart
@@ -3,12 +3,14 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/explore_tabs/explore_tabs_cubit.dart';
 import 'package:openvine/providers/route_feed_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/screens/explore/explore_view.dart';
 
 /// Explore screen: a thin tabs Page over [ExploreTabsCubit] + [ExploreView].
-class ExploreScreen extends StatelessWidget {
+class ExploreScreen extends ConsumerWidget {
   /// Creates the explore screen, optionally selecting [initialTabName].
   const ExploreScreen({super.key, this.initialTabName});
 
@@ -66,9 +68,10 @@ class ExploreScreen extends StatelessWidget {
   final String? initialTabName;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return BlocProvider(
-      create: (_) => ExploreTabsCubit(),
+      create: (_) =>
+          ExploreTabsCubit(topHashtags: ref.read(topHashtagsServiceProvider)),
       child: ExploreView(initialTabName: initialTabName),
     );
   }

--- a/mobile/lib/screens/explore/explore_screen.dart
+++ b/mobile/lib/screens/explore/explore_screen.dart
@@ -70,6 +70,8 @@ class ExploreScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return BlocProvider(
+      // topHashtagsServiceProvider is a stable keepAlive Provider that is never
+      // invalidated, so ref.read is safe here (see state_management.md §1).
       create: (_) =>
           ExploreTabsCubit(topHashtags: ref.read(topHashtagsServiceProvider)),
       child: ExploreView(initialTabName: initialTabName),

--- a/mobile/lib/services/logging_config_service.dart
+++ b/mobile/lib/services/logging_config_service.dart
@@ -7,14 +7,8 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// Service for managing logging configuration
 class LoggingConfigService {
-  LoggingConfigService._();
+  LoggingConfigService();
   static const String _logLevelKey = 'log_level_preference';
-  static LoggingConfigService? _instance;
-
-  static LoggingConfigService get instance {
-    _instance ??= LoggingConfigService._();
-    return _instance!;
-  }
 
   /// Initialize logging configuration from stored preferences
   Future<void> initialize() async {

--- a/mobile/lib/services/performance_monitoring_service.dart
+++ b/mobile/lib/services/performance_monitoring_service.dart
@@ -17,13 +17,31 @@ abstract class PerformanceTraceMonitor {
   void putAttribute(String traceName, String attribute, String value);
 }
 
+/// No-op [PerformanceTraceMonitor] used as the default when no real monitor is
+/// injected (e.g. in tests). Mirrors the prior behaviour of the uninitialised
+/// singleton, whose methods early-returned without touching Firebase.
+class NoOpPerformanceTraceMonitor implements PerformanceTraceMonitor {
+  const NoOpPerformanceTraceMonitor();
+
+  @override
+  Future<void> startTrace(String traceName) async {}
+
+  @override
+  Future<void> stopTrace(String traceName) async {}
+
+  @override
+  void incrementMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void setMetric(String traceName, String metricName, int value) {}
+
+  @override
+  void putAttribute(String traceName, String attribute, String value) {}
+}
+
 /// Performance monitoring service for tracking app performance
 class PerformanceMonitoringService implements PerformanceTraceMonitor {
-  static PerformanceMonitoringService? _instance;
-  static PerformanceMonitoringService get instance =>
-      _instance ??= PerformanceMonitoringService._();
-
-  PerformanceMonitoringService._();
+  PerformanceMonitoringService();
 
   late final FirebasePerformance _performance;
   bool _initialized = false;

--- a/mobile/lib/services/top_hashtags_service.dart
+++ b/mobile/lib/services/top_hashtags_service.dart
@@ -6,8 +6,6 @@ import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart';
 import 'package:unified_logger/unified_logger.dart';
 
-typedef _AssetStringLoader = Future<String> Function(String key);
-
 /// Minimal seam for loading hashtag suggestions.
 abstract interface class TopHashtagsLoader {
   /// Loads the top hashtag data used by explore surfaces.
@@ -38,16 +36,12 @@ class HashtagData {
 }
 
 class TopHashtagsService implements TopHashtagsLoader {
-  TopHashtagsService._({_AssetStringLoader? loadAssetString})
-    : _loadAssetString = loadAssetString ?? rootBundle.loadString;
+  TopHashtagsService() : _loadAssetString = rootBundle.loadString;
 
   @visibleForTesting
   TopHashtagsService.forTesting({
     required Future<String> Function(String key) loadAssetString,
-  }) : this._(loadAssetString: loadAssetString);
-
-  static final TopHashtagsService _instance = TopHashtagsService._();
-  static TopHashtagsService get instance => _instance;
+  }) : _loadAssetString = loadAssetString;
 
   /// Default fallback hashtags shown when loading fails or is slow.
   /// These mirror the top current suggestions from the bundled JSON asset.
@@ -76,7 +70,7 @@ class TopHashtagsService implements TopHashtagsLoader {
 
   List<HashtagData>? _topHashtags;
   bool _isLoaded = false;
-  final _AssetStringLoader _loadAssetString;
+  final Future<String> Function(String key) _loadAssetString;
 
   /// Get top hashtags (returns empty list if not loaded)
   List<HashtagData> get topHashtags => _topHashtags ?? [];

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -140,7 +140,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
        _connectionService = connectionService ?? ConnectionStatusService(),
        _ownsConnectionService = connectionService == null,
        _performanceMonitor =
-           performanceMonitor ?? PerformanceMonitoringService.instance {
+           performanceMonitor ?? const NoOpPerformanceTraceMonitor() {
     _initializePaginationStates();
     _initializeRepostResolver();
   }

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -14,8 +14,8 @@ import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/feed_repository_provider.dart';
 import 'package:openvine/providers/popular_videos_feed_provider.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
-import 'package:openvine/services/top_hashtags_service.dart';
 import 'package:openvine/services/view_event_publisher.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
@@ -220,7 +220,8 @@ class _PopularVideosTrendingContentState
     final popularVideosFeedNotifier = ref.read(
       popularVideosFeedProvider.notifier,
     );
-    final hashtags = TopHashtagsService.instance.getTopHashtags(limit: 20);
+    final topHashtags = ref.read(topHashtagsServiceProvider);
+    final hashtags = topHashtags.getTopHashtags(limit: 20);
 
     measureHeaderHeight();
 
@@ -290,7 +291,7 @@ class _PopularVideosTrendingContentState
           child: TrendingHashtagsSection(
             key: headerKey,
             hashtags: hashtags,
-            isLoading: !TopHashtagsService.instance.isLoaded,
+            isLoading: !topHashtags.isLoaded,
             leading: const _PopularFeedVariantToggle(),
           ),
         ),

--- a/mobile/lib/widgets/video_metrics_tracker.dart
+++ b/mobile/lib/widgets/video_metrics_tracker.dart
@@ -8,9 +8,9 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/service_providers.dart';
 import 'package:openvine/services/analytics_service.dart';
 import 'package:openvine/services/auth_service.dart';
-import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/seen_videos_service.dart';
 import 'package:openvine/services/view_event_publisher.dart'
     show ViewTrafficSource;
@@ -130,7 +130,7 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
     if (!_hasStartedPlaybackTrace) {
       _hasStartedPlaybackTrace = true;
       final traceName = 'video_playback_${widget.video.id}';
-      PerformanceMonitoringService.instance.startTrace(traceName);
+      ref.read(performanceMonitoringServiceProvider).startTrace(traceName);
     }
 
     _addControllerListeners();
@@ -177,7 +177,7 @@ class _VideoMetricsTrackerState extends ConsumerState<VideoMetricsTracker> {
     if (!_hasCompletedPlaybackTrace && controller.value.isPlaying) {
       _hasCompletedPlaybackTrace = true;
       final traceName = 'video_playback_${widget.video.id}';
-      PerformanceMonitoringService.instance.stopTrace(traceName);
+      ref.read(performanceMonitoringServiceProvider).stopTrace(traceName);
       Log.debug(
         '⏱️ Video playback started for ${widget.video.id}',
         name: 'VideoMetricsTracker',

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -40,7 +40,6 @@ share_service
 social_event_service_base
 social_service # decision: OD-2 keep-vs-delete (#4337)
 subscription_manager
-top_hashtags_service
 upload_manager # defer: #4339 oversized-file split
 video_cache_service
 video_event_service # defer: #4338 Track D demolition

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -24,7 +24,6 @@ identity_manager_service
 immediate_completion_helper # noise: helper
 js_stub # noise: web/io shim
 js_util_stub # noise: web/io shim
-logging_config_service # defer: #4338 C2 singleton-to-DI
 native_proofmode_service
 nip05_verification_service
 nip07_interop # noise: web/io conditional-import

--- a/mobile/test/screens/explore_screen_pure_test.dart
+++ b/mobile/test/screens/explore_screen_pure_test.dart
@@ -38,10 +38,10 @@ void main() {
       });
 
       test('ExploreScreen should have constructor', () {
-        // ExploreScreen is a thin Page (StatelessWidget) that provides
-        // ExploreTabsCubit to its ConsumerStatefulWidget view.
+        // ExploreScreen is a thin Page (ConsumerWidget) that reads the shared
+        // topHashtagsServiceProvider and provides ExploreTabsCubit to its view.
         const screen = ExploreScreen();
-        expect(screen, isA<StatelessWidget>());
+        expect(screen, isA<ConsumerWidget>());
       });
     });
 

--- a/mobile/test/services/logging_config_service_test.dart
+++ b/mobile/test/services/logging_config_service_test.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Tests for LoggingConfigService log-level persistence and restore.
+// ABOUTME: Verifies the DI-constructed service drives UnifiedLogger + SharedPreferences.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/logging_config_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+void main() {
+  group(LoggingConfigService, () {
+    late LogLevel originalLevel;
+
+    setUp(() {
+      originalLevel = UnifiedLogger.currentLevel;
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    tearDown(() => UnifiedLogger.setLogLevel(originalLevel));
+
+    test('setLogLevel updates the active log level', () async {
+      await LoggingConfigService().setLogLevel(LogLevel.verbose);
+
+      expect(UnifiedLogger.currentLevel, equals(LogLevel.verbose));
+      expect(LoggingConfigService().currentLevel, equals(LogLevel.verbose));
+      expect(LoggingConfigService().isVerboseEnabled, isTrue);
+    });
+
+    test('initialize restores a previously persisted level', () async {
+      // Persist a level, then simulate a fresh process default.
+      await LoggingConfigService().setLogLevel(LogLevel.verbose);
+      UnifiedLogger.setLogLevel(LogLevel.info);
+
+      await LoggingConfigService().initialize();
+
+      expect(UnifiedLogger.currentLevel, equals(LogLevel.verbose));
+    });
+
+    test('initialize is a no-op when no level was persisted', () async {
+      UnifiedLogger.setLogLevel(LogLevel.info);
+
+      await LoggingConfigService().initialize();
+
+      expect(UnifiedLogger.currentLevel, equals(LogLevel.info));
+    });
+  });
+}

--- a/mobile/test/services/performance_monitoring_service_test.dart
+++ b/mobile/test/services/performance_monitoring_service_test.dart
@@ -9,13 +9,7 @@ void main() {
     late PerformanceMonitoringService service;
 
     setUp(() {
-      service = PerformanceMonitoringService.instance;
-    });
-
-    test('should be a singleton', () {
-      final instance1 = PerformanceMonitoringService.instance;
-      final instance2 = PerformanceMonitoringService.instance;
-      expect(instance1, same(instance2));
+      service = PerformanceMonitoringService();
     });
 
     test('should initialize without error', () async {

--- a/mobile/test/services/top_hashtags_service_test.dart
+++ b/mobile/test/services/top_hashtags_service_test.dart
@@ -1,0 +1,60 @@
+// ABOUTME: Tests for TopHashtagsService JSON loading, search, and fallbacks.
+// ABOUTME: Uses the forTesting ctor to inject a fake asset loader (no DI statics).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/top_hashtags_service.dart';
+
+const _fakeJson = '''
+{"hashtags":[
+  {"rank":1,"hashtag":"funny","count":100,"percentage":10.0},
+  {"rank":2,"hashtag":"fun","count":90,"percentage":9.0},
+  {"rank":3,"hashtag":"music","count":80,"percentage":8.0}
+]}''';
+
+void main() {
+  group(TopHashtagsService, () {
+    TopHashtagsService build({String json = _fakeJson}) =>
+        TopHashtagsService.forTesting(loadAssetString: (_) async => json);
+
+    test('getTopHashtags returns bundled defaults before loading', () {
+      final service = build();
+
+      expect(service.isLoaded, isFalse);
+      expect(
+        service.getTopHashtags(limit: 3),
+        equals(TopHashtagsService.defaultHashtags.take(3)),
+      );
+    });
+
+    test('loadTopHashtags parses the asset and marks loaded', () async {
+      final service = build();
+
+      await service.loadTopHashtags();
+
+      expect(service.isLoaded, isTrue);
+      expect(service.getTopHashtags(limit: 2), equals(['funny', 'fun']));
+    });
+
+    test('searchHashtags ranks exact before prefix matches', () async {
+      final service = build();
+      await service.loadTopHashtags();
+
+      expect(service.searchHashtags('fun'), equals(['fun', 'funny']));
+    });
+
+    test('loadTopHashtags is idempotent', () async {
+      var calls = 0;
+      final service = TopHashtagsService.forTesting(
+        loadAssetString: (_) async {
+          calls++;
+          return _fakeJson;
+        },
+      );
+
+      await service.loadTopHashtags();
+      await service.loadTopHashtags();
+
+      expect(calls, equals(1));
+    });
+  });
+}

--- a/mobile/test/startup/app_startup_test.dart
+++ b/mobile/test/startup/app_startup_test.dart
@@ -29,7 +29,7 @@ void main() {
       CrashReportingService.instance.log('Test message');
 
       // Initialize logging config
-      await LoggingConfigService.instance.initialize();
+      await LoggingConfigService().initialize();
 
       final duration = DateTime.now().difference(startTime).inMilliseconds;
       expect(duration, greaterThanOrEqualTo(0));


### PR DESCRIPTION
## What

Converts three lazy-static singleton services to constructor injection behind Riverpod providers, so they're mockable through normal DI in tests instead of reaching into static state. One service per commit:

- **`LoggingConfigService`** → `loggingConfigServiceProvider`. The single deferred-startup call site reads the provider from the startup container.
- **`TopHashtagsService`** → shared `topHashtagsServiceProvider` (keepAlive). `ExploreScreen` becomes a `ConsumerWidget` and injects the shared instance into `ExploreTabsCubit` so the on-mount cache-warming stays visible to the hashtag repository and the popular-videos tab.
- **`PerformanceMonitoringService`** → `performanceMonitoringServiceProvider`. Consumers read the provider (deferred init, the Blossom upload perf adapter, `VideoMetricsTracker`). `VideoEventService`'s optional `performanceMonitor` now defaults to a new `const NoOpPerformanceTraceMonitor` — behaviour-identical to the prior uninitialised singleton, whose methods early-returned — and `video_providers` passes the real instance so production monitoring is preserved.

All three use plain keepAlive `Provider`s (no codegen); the two `@riverpod` consumer files (`video_providers`, `upload_media_providers`, `repository_providers`) have regenerated hashes only.

## Why

Batch **B1** (clean infra services) of the singleton → DI conversion for #4743. These three were the lowest-risk conversions and establish the provider + test-override template the later batches follow.

This also **un-defers** `logging_config_service` and `top_hashtags_service` from `untested_services.txt` (the rows were explicitly deferred on this issue) and adds direct unit tests for both.

Part of #4743 (epic #4338 Wave 2). Not closing the issue — one of ~10 batches. Independent of #5629 (B0); no file overlap.

## Testing

- `flutter analyze lib test` — clean; `dart format` clean; generated files verified.
- New: `logging_config_service_test.dart`, `top_hashtags_service_test.dart`.
- Updated: `performance_monitoring_service_test.dart` (drops the "should be a singleton" test that asserted the removed anti-pattern), `explore_screen_pure_test.dart` (asserts `ConsumerWidget`).
- Green: explore screen + router suite, `app_startup_test`, upload media providers, VideoEventService perf-monitor tests, `video_metrics_tracker` tests, the `untested_services_floor` ratchet.