### PR TITLE
refactor(analytics): inject ErrorAnalyticsTracker via Riverpod provider

### DIFF
--- a/mobile/lib/providers/analytics_providers.dart
+++ b/mobile/lib/providers/analytics_providers.dart
@@ -14,3 +14,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 final surfacePerformanceTrackerProvider = Provider<SurfacePerformanceTracker>(
   (ref) => SurfacePerformanceTracker(),
 );
+
+/// Provides the app's shared [ErrorAnalyticsTracker].
+///
+/// Replaces the former `ErrorAnalyticsTracker()` factory singleton. A single
+/// shared instance is kept alive so per-error counts accumulate in one place
+/// (read back by the bug-report diagnostics), and the tracker is mockable
+/// through a provider override in tests instead of reaching into static state.
+final errorAnalyticsTrackerProvider = Provider<ErrorAnalyticsTracker>(
+  (ref) => ErrorAnalyticsTracker(),
+);

--- a/mobile/lib/providers/social_providers.dart
+++ b/mobile/lib/providers/social_providers.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:collaborator_repository/collaborator_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/database_provider.dart';
@@ -509,5 +510,6 @@ BugReportService bugReportService(Ref ref) {
   return BugReportService(
     nip17MessageService: nip17Service,
     blossomUploadService: blossomService,
+    errorTracker: ref.watch(errorAnalyticsTrackerProvider),
   );
 }

--- a/mobile/lib/providers/social_providers.g.dart
+++ b/mobile/lib/providers/social_providers.g.dart
@@ -725,4 +725,4 @@ final class BugReportServiceProvider
   }
 }
 
-String _$bugReportServiceHash() => r'a243bf5fae16e223b148a829b14f9857af1c4592';
+String _$bugReportServiceHash() => r'1f3ab38afd37b54e5920062232fcccd22c347014';

--- a/mobile/lib/services/bug_report_service.dart
+++ b/mobile/lib/services/bug_report_service.dart
@@ -31,12 +31,15 @@ class BugReportService {
   BugReportService({
     NIP17MessageService? nip17MessageService,
     BlossomUploadService? blossomUploadService,
+    ErrorAnalyticsTracker? errorTracker,
   }) : _nip17MessageService = nip17MessageService,
-       _blossomUploadService = blossomUploadService;
+       _blossomUploadService = blossomUploadService,
+       _errorTracker = errorTracker ?? ErrorAnalyticsTracker();
 
   static const _uuid = Uuid();
   final NIP17MessageService? _nip17MessageService;
   final BlossomUploadService? _blossomUploadService;
+  final ErrorAnalyticsTracker _errorTracker;
 
   /// Collect comprehensive diagnostics for bug report
   Future<BugReportData> collectDiagnostics({
@@ -130,8 +133,8 @@ class BugReportService {
         limit: BugReportConfig.maxLogEntries,
       );
 
-      // Get error counts from ErrorAnalyticsTracker
-      final errorCounts = ErrorAnalyticsTracker().getAllErrorCounts();
+      // Get error counts from the injected ErrorAnalyticsTracker
+      final errorCounts = _errorTracker.getAllErrorCounts();
 
       // Create bug report data
       final reportData = BugReportData(

--- a/mobile/lib/widgets/new_videos_tab.dart
+++ b/mobile/lib/widgets/new_videos_tab.dart
@@ -10,6 +10,7 @@ import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/feed_repository_provider.dart';
 import 'package:openvine/providers/new_videos_feed_provider.dart';
 import 'package:openvine/screens/feed/pooled_fullscreen_video_feed_screen.dart';
@@ -54,7 +55,8 @@ class _NewVideosTabState extends ConsumerState<NewVideosTab> {
     super.initState();
     _screenAnalytics = widget.screenAnalytics ?? ScreenAnalyticsService();
     _feedTracker = widget.feedTracker ?? FeedPerformanceTracker();
-    _errorTracker = widget.errorTracker ?? ErrorAnalyticsTracker();
+    _errorTracker =
+        widget.errorTracker ?? ref.read(errorAnalyticsTrackerProvider);
   }
 
   @override

--- a/mobile/lib/widgets/popular_videos_tab.dart
+++ b/mobile/lib/widgets/popular_videos_tab.dart
@@ -12,6 +12,7 @@ import 'package:funnelcake_api_client/funnelcake_api_client.dart';
 import 'package:go_router/go_router.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/feed_repository_provider.dart';
 import 'package:openvine/providers/popular_videos_feed_provider.dart';
 import 'package:openvine/providers/service_providers.dart';
@@ -60,7 +61,8 @@ class _PopularVideosTabState extends ConsumerState<PopularVideosTab> {
     super.initState();
     _screenAnalytics = widget.screenAnalytics ?? ScreenAnalyticsService();
     _feedTracker = widget.feedTracker ?? FeedPerformanceTracker();
-    _errorTracker = widget.errorTracker ?? ErrorAnalyticsTracker();
+    _errorTracker =
+        widget.errorTracker ?? ref.read(errorAnalyticsTrackerProvider);
   }
 
   @override

--- a/mobile/packages/analytics/lib/src/error_analytics_tracker.dart
+++ b/mobile/packages/analytics/lib/src/error_analytics_tracker.dart
@@ -4,20 +4,14 @@
 import 'package:analytics/src/analytics_event_sink.dart';
 import 'package:analytics/src/firebase_analytics_event_sink.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:unified_logger/unified_logger.dart';
 
 /// Service for tracking errors and exceptions across the app
 class ErrorAnalyticsTracker {
-  static final ErrorAnalyticsTracker _instance =
-      ErrorAnalyticsTracker._internal();
-  factory ErrorAnalyticsTracker() => _instance;
-  ErrorAnalyticsTracker._internal() : _analytics = FirebaseAnalyticsEventSink();
-
-  /// Creates a testable instance that does not touch Firebase Analytics.
-  @visibleForTesting
-  ErrorAnalyticsTracker.testInstance({AnalyticsEventSink? sink})
-    : _analytics = sink ?? const NoOpAnalyticsEventSink();
+  /// Creates a tracker. Defaults to the Firebase analytics sink in production;
+  /// pass a [sink] (e.g. [NoOpAnalyticsEventSink]) in tests.
+  ErrorAnalyticsTracker({AnalyticsEventSink? sink})
+    : _analytics = sink ?? FirebaseAnalyticsEventSink();
 
   final AnalyticsEventSink _analytics;
 

--- a/mobile/packages/analytics/test/error_analytics_tracker_test.dart
+++ b/mobile/packages/analytics/test/error_analytics_tracker_test.dart
@@ -30,7 +30,7 @@ void main() {
 
     setUp(() {
       sink = _RecordingAnalyticsEventSink();
-      tracker = ErrorAnalyticsTracker.testInstance(sink: sink);
+      tracker = ErrorAnalyticsTracker(sink: sink);
     });
 
     test('trackError logs app_error and counts repeated occurrences', () {

--- a/mobile/test/unit/services/bug_report_service_test.dart
+++ b/mobile/test/unit/services/bug_report_service_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:io' show Platform;
 
+import 'package:analytics/analytics.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' show BugReportData;
@@ -79,6 +80,24 @@ void main() {
       expect(data.recentLogs, isA<List>());
       expect(data.errorCounts, isA<Map<String, int>>());
       expect(data.timestamp, isA<DateTime>());
+    });
+
+    test('should collect error counts from injected tracker', () async {
+      final errorTracker =
+          ErrorAnalyticsTracker(
+            sink: const NoOpAnalyticsEventSink(),
+          )..trackError(
+            errorType: 'feed_load_failed',
+            errorMessage: 'Feed failed to load',
+            location: 'NewVideosTab',
+          );
+      final service = BugReportService(errorTracker: errorTracker);
+
+      final data = await service.collectDiagnostics(
+        userDescription: 'Feed failed',
+      );
+
+      expect(data.errorCounts, {'NewVideosTab:feed_load_failed': 1});
     });
 
     test(


### PR DESCRIPTION
## What

Converts `ErrorAnalyticsTracker` from a factory singleton to constructor injection behind the shared `errorAnalyticsTrackerProvider`, so it is mockable through normal DI instead of static state.

- Service: `factory ErrorAnalyticsTracker() => _instance` + `testInstance` -> public `ErrorAnalyticsTracker({AnalyticsEventSink? sink})`, defaulting to Firebase.
- `lib/providers/analytics_providers.dart` now holds both analytics tracker providers: `surfacePerformanceTrackerProvider` and `errorAnalyticsTrackerProvider`.
- `popular_videos_tab` and `new_videos_tab` read the shared tracker provider when no widget override is supplied.
- `BugReportService` accepts an injected tracker, and `social_providers` wires it to the same shared provider instance.
- Added regression coverage proving bug-report diagnostics read error counts from the injected tracker.

The shared instance matters because the video tabs record errors into `ErrorAnalyticsTracker`, and `BugReportService` later reads `getAllErrorCounts()` for diagnostics.

## Why

This is the ErrorAnalyticsTracker batch for the singleton-to-DI migration. It removes package-level static state from this tracker without taking on the remaining analytics services in the broader migration.

Closes #5641.
Part of #4743.
Part of epic #4338 Wave 2.

## Sequencing notes

- Rebases cleanly on current `main` after resolving the `analytics_providers.dart` add/add conflict with the already-merged `SurfacePerformanceTracker` provider.
- Independent of the remaining analytics tracker migration work in #4743.
- Keeps this PR focused on ErrorAnalyticsTracker and its direct consumers.

## Testing

- `flutter analyze lib test packages/analytics`
- `flutter test test/unit/services/bug_report_service_test.dart test/unit/services/bug_report_service_upload_logs_test.dart test/services/bug_report_worker_api_test.dart test/widgets/new_videos_tab_test.dart`
- `flutter test test/error_analytics_tracker_test.dart` from `mobile/packages/analytics`
- Pre-push checks: merge-conflict check, analyzer, generated-file verification, and changed-file tests
