### PR TITLE
refactor(analytics): inject SurfacePerformanceTracker via Riverpod provider

### DIFF
--- a/mobile/lib/blocs/comments/comments_surface_performance_telemetry.dart
+++ b/mobile/lib/blocs/comments/comments_surface_performance_telemetry.dart
@@ -3,9 +3,6 @@
 import 'package:analytics/analytics.dart';
 
 class CommentsSurfacePerformanceTelemetry {
-  CommentsSurfacePerformanceTelemetry()
-    : this.withTracker(SurfacePerformanceTracker());
-
   CommentsSurfacePerformanceTelemetry.withTracker(this._tracker);
 
   final SurfacePerformanceTracker _tracker;

--- a/mobile/lib/providers/analytics_providers.dart
+++ b/mobile/lib/providers/analytics_providers.dart
@@ -1,0 +1,16 @@
+// ABOUTME: Riverpod providers for the analytics package's tracker services,
+// ABOUTME: migrated off the factory-singleton pattern to constructor injection (#4743).
+
+import 'package:analytics/analytics.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provides the app's shared [SurfacePerformanceTracker].
+///
+/// Replaces the former `SurfacePerformanceTracker()` factory singleton. A
+/// single shared instance is kept alive so surface-load sessions started by
+/// one consumer are visible to the resume-time reset in the app lifecycle
+/// handler, and the tracker is mockable through a provider override in tests
+/// instead of reaching into static state.
+final surfacePerformanceTrackerProvider = Provider<SurfacePerformanceTracker>(
+  (ref) => SurfacePerformanceTracker(),
+);

--- a/mobile/lib/screens/comments/comments_screen.dart
+++ b/mobile/lib/screens/comments/comments_screen.dart
@@ -18,6 +18,7 @@ import 'package:openvine/features/feature_flags/models/feature_flag.dart';
 import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/video_reply_context.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/providers/video_reply_context_provider.dart';
@@ -143,11 +144,13 @@ abstract final class CommentsScreen {
       isFeatureEnabledProvider(FeatureFlag.videoReplies),
     );
     final seedCommentCount = initialCommentCount ?? liveCommentCountSeed(video);
-    final surfaceTelemetry = CommentsSurfacePerformanceTelemetry()
-      ..start(
-        videoRepliesEnabled: showVideoReplies,
-        initialCount: seedCommentCount,
-      );
+    final surfaceTelemetry =
+        CommentsSurfacePerformanceTelemetry.withTracker(
+          container.read(surfacePerformanceTrackerProvider),
+        )..start(
+          videoRepliesEnabled: showVideoReplies,
+          initialCount: seedCommentCount,
+        );
 
     // The draggable scroll controller is created inside buildScrollBody but
     // is also needed by the title's "new comments" pill (which lives above

--- a/mobile/lib/widgets/app_lifecycle_handler.dart
+++ b/mobile/lib/widgets/app_lifecycle_handler.dart
@@ -9,6 +9,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/invite_status/invite_status_cubit.dart';
 import 'package:openvine/notifications/services/notification_refresh_coordinator.dart';
+import 'package:openvine/providers/analytics_providers.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
@@ -110,7 +111,7 @@ class _AppLifecycleHandlerState extends ConsumerState<AppLifecycleHandler>
         // 27+ hours) when providers re-fire on resume.
         FeedPerformanceTracker().resetAllSessions();
         ScreenAnalyticsService().resetAllSessions();
-        SurfacePerformanceTracker().resetAllSessions();
+        ref.read(surfacePerformanceTrackerProvider).resetAllSessions();
 
         // Notify foreground state provider - enables visibility detection
         ref.read(appForegroundProvider.notifier).setForeground(true);

--- a/mobile/packages/analytics/lib/src/surface_performance_tracker.dart
+++ b/mobile/packages/analytics/lib/src/surface_performance_tracker.dart
@@ -5,7 +5,6 @@ import 'package:analytics/src/analytics_event_sink.dart';
 import 'package:analytics/src/analytics_surface.dart';
 import 'package:analytics/src/firebase_analytics_event_sink.dart';
 import 'package:analytics/src/page_load_history.dart';
-import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:unified_logger/unified_logger.dart';
 
 /// Maximum age for a session before it is considered stale and discarded.
@@ -27,30 +26,12 @@ const Set<String> _safeSurfaceParamKeys = {
 
 /// Tracks perceived load performance for user-visible surfaces.
 class SurfacePerformanceTracker {
-  factory SurfacePerformanceTracker() =>
-      _instance ??= SurfacePerformanceTracker._();
-
-  SurfacePerformanceTracker._({
+  /// Creates a tracker. Defaults to the Firebase analytics sink in production;
+  /// pass a [sink] (e.g. [NoOpAnalyticsEventSink]) and [now] clock in tests.
+  SurfacePerformanceTracker({
     AnalyticsEventSink? sink,
     DateTime Function()? now,
   }) : _sink = sink ?? FirebaseAnalyticsEventSink(),
-       _now = now ?? DateTime.now;
-
-  static SurfacePerformanceTracker? _instance;
-
-  /// Resets the singleton so tests do not leak active sessions across files.
-  @visibleForTesting
-  static void resetInstance() {
-    _instance?._activeSessions.clear();
-    _instance = null;
-  }
-
-  /// Creates a testable instance that does not touch Firebase.
-  @visibleForTesting
-  SurfacePerformanceTracker.testInstance({
-    AnalyticsEventSink? sink,
-    DateTime Function()? now,
-  }) : _sink = sink ?? const NoOpAnalyticsEventSink(),
        _now = now ?? DateTime.now;
 
   AnalyticsEventSink _sink;

--- a/mobile/packages/analytics/test/surface_performance_tracker_test.dart
+++ b/mobile/packages/analytics/test/surface_performance_tracker_test.dart
@@ -34,18 +34,16 @@ void main() {
     }
 
     setUp(() {
-      SurfacePerformanceTracker.resetInstance();
       PageLoadHistory().clear();
       sink = RecordingAnalyticsEventSink();
       now = DateTime(2026, 6, 12, 12);
-      tracker = SurfacePerformanceTracker.testInstance(
+      tracker = SurfacePerformanceTracker(
         sink: sink,
         now: () => now,
       );
     });
 
     tearDown(() {
-      SurfacePerformanceTracker.resetInstance();
       PageLoadHistory().clear();
     });
 

--- a/mobile/test/screens/comments/comments_screen_test.dart
+++ b/mobile/test/screens/comments/comments_screen_test.dart
@@ -152,7 +152,6 @@ void main() {
 
     tearDown(() {
       scrollController.dispose();
-      SurfacePerformanceTracker.resetInstance();
     });
 
     Widget buildTestWidget({
@@ -224,7 +223,7 @@ void main() {
 
       setUp(() {
         sink = _RecordingAnalyticsEventSink();
-        tracker = SurfacePerformanceTracker.testInstance(sink: sink);
+        tracker = SurfacePerformanceTracker(sink: sink);
       });
 
       testWidgets(


### PR DESCRIPTION
## What

Converts `SurfacePerformanceTracker` from a factory singleton to constructor injection behind a shared `surfacePerformanceTrackerProvider` (keepAlive).

- Service: `factory()=>_instance` + `testInstance` + `resetInstance` → one public ctor `SurfacePerformanceTracker({sink, now})`.
- `CommentsSurfacePerformanceTelemetry` now requires an injected tracker (the `SurfacePerformanceTracker()`-creating default ctor is removed); `CommentsScreen.show` injects it via the `ProviderScope` container, and `AppLifecycleHandler` reads it via `ref`.
- A **single shared instance** is required so the comments-sheet surface-load session is reset by the app-lifecycle resume handler (preserves the prior singleton behaviour).

## Why

First slice of batch **B2b** (analytics module) for #4743. `SurfacePerformanceTracker` is the cleanest piece of the cluster — only 2 consumers and no overlap with the other open #4743 PRs.

`PageLoadHistory` injection into this tracker is intentionally deferred to PageLoadHistory's own conversion (it stays a singleton here); this PR only removes `SurfacePerformanceTracker`'s own singleton.

Part of #4743 (epic #4338 Wave 2). Not closing the issue.

## Sequencing notes (for reviewers)

The analytics module is a **sequential chain** sharing `lib/providers/analytics_providers.dart`:
- This PR **adds** `surfacePerformanceTrackerProvider` to that file. #5631 (ErrorAnalyticsTracker) **created** the same file with `errorAnalyticsTrackerProvider` — so the two have a trivial **add/add** merge (keep both providers). Whichever merges second needs that one-line resolution.
- The remaining B2b pieces (`ScreenAnalytics`, then `PageLoadHistory`) are deliberately **not** in this PR: ScreenAnalytics' explore-cubit construction collides with #5630 (B1)'s `ExploreScreen` change, and `PageLoadHistory` must convert last (after both its writers — ScreenAnalytics and this tracker — are provider-constructed). Those follow once B1 + the analytics PRs land.

## Testing

- `flutter analyze lib test packages/analytics` — clean; format + generated files verified.
- Green: `surface_performance_tracker_test` (updated to the public ctor + drops `resetInstance`), `comments_screen_test` (surface-load telemetry group), `app_lifecycle_provider_test`.