### PR TITLE
fix(video-editor): clean up draft-local audio files on draft deletion

### DIFF
--- a/mobile/lib/extensions/draft_local_audio_extensions.dart
+++ b/mobile/lib/extensions/draft_local_audio_extensions.dart
@@ -1,0 +1,50 @@
+import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+
+/// Extraction of draft-local audio file paths for draft-delete cleanup.
+extension DraftLocalAudioPaths on DivineVideoDraft {
+  /// Absolute file paths of draft-local audio referenced by this draft.
+  ///
+  /// Covers imported audio created by `LocalAudioImportService` (stored under
+  /// `draft_audio_imports/<draftId>`) and committed voice-over recordings, both
+  /// persisted as draft-local [AudioEvent]s. Sweeps every history entry's audio
+  /// metadata in [DivineVideoDraft.editorStateHistory] plus the legacy
+  /// [DivineVideoDraft.selectedSound], collecting [AudioEvent.localFilePath] for
+  /// each [AudioEvent.isLocalImport] track. Used by draft deletion to remove
+  /// audio files that would otherwise persist after the draft is gone.
+  Set<String> get localAudioFilePaths {
+    final paths = <String>{};
+
+    void addIfLocal(AudioEvent event) {
+      final path = event.localFilePath;
+      if (event.isLocalImport && path != null && path.isNotEmpty) {
+        paths.add(path);
+      }
+    }
+
+    final selected = selectedSound;
+    if (selected != null) addIfLocal(selected);
+
+    final history = editorStateHistory['history'];
+    if (history is! Iterable) return paths;
+
+    for (final item in history) {
+      if (item is! Map) continue;
+      final meta = item['meta'];
+      if (meta is! Map) continue;
+      final audio = meta[VideoEditorConstants.audioStateHistoryKey];
+      if (audio is! Iterable) continue;
+      for (final raw in audio) {
+        if (raw is! Map) continue;
+        try {
+          addIfLocal(AudioEvent.fromJson(Map<String, dynamic>.from(raw)));
+        } catch (_) {
+          // Skip malformed audio entries; cleanup must never throw.
+        }
+      }
+    }
+
+    return paths;
+  }
+}

--- a/mobile/lib/extensions/draft_local_audio_extensions.dart
+++ b/mobile/lib/extensions/draft_local_audio_extensions.dart
@@ -17,8 +17,10 @@ extension DraftLocalAudioPaths on DivineVideoDraft {
     final paths = <String>{};
 
     void addIfLocal(AudioEvent event) {
+      // localFilePath is non-null only for a local import with a non-empty
+      // url, so the null check alone covers the import and emptiness guards.
       final path = event.localFilePath;
-      if (event.isLocalImport && path != null && path.isNotEmpty) {
+      if (path != null) {
         paths.add(path);
       }
     }

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:db_client/db_client.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/draft_local_audio_extensions.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
@@ -520,6 +521,61 @@ class DraftStorageService {
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
     );
+
+    // Delete draft-local audio (imported audio + voice-over recordings) held
+    // in the editor metadata, keeping any file a surviving draft still
+    // references (e.g. a draft shared with its publish copy).
+    final audioPaths = draft.localAudioFilePaths;
+    if (audioPaths.isNotEmpty) {
+      await FileCleanupService.deleteDraftAudioFiles(
+        audioPaths,
+        draftsDao: _draftsDao,
+        clipsDao: _clipsDao,
+        referencedAudioFilenames: await _referencedLocalAudioFilenames(
+          excludeDraftId: id,
+        ),
+      );
+    }
+  }
+
+  /// Basenames of draft-local audio files referenced by any draft other than
+  /// [excludeDraftId], across all accounts.
+  ///
+  /// The same local audio file can be shared by a draft and its publish copy —
+  /// `copyWith` carries [DivineVideoDraft.editorStateHistory] and
+  /// [DivineVideoDraft.selectedSound] — so this guard keeps shared audio until
+  /// the last referencing draft is deleted. Scans the draft `data` blobs
+  /// directly (audio paths live there, not in an indexed column) and never
+  /// throws: a corrupt blob is logged and skipped.
+  Future<Set<String>> _referencedLocalAudioFilenames({
+    String? excludeDraftId,
+  }) async {
+    final rows = await _draftsDao.getAllDrafts();
+    final documentsPath = await getDocumentsPath();
+    final filenames = <String>{};
+
+    for (final row in rows) {
+      if (row.id == excludeDraftId) continue;
+      final DivineVideoDraft draft;
+      try {
+        draft = DivineVideoDraft.fromJson(
+          json.decode(row.data) as Map<String, dynamic>,
+          documentsPath,
+        );
+      } catch (e) {
+        Log.error(
+          '🧹 Skipping draft ${row.id} during audio reference scan: $e',
+          name: 'DraftStorageService',
+          category: LogCategory.video,
+        );
+        continue;
+      }
+      for (final path in draft.localAudioFilePaths) {
+        filenames.add(p.basename(path));
+      }
+    }
+
+    return filenames;
   }
 
   /// Clear all drafts from storage and delete associated files
@@ -538,6 +594,9 @@ class DraftStorageService {
     final allCustomThumbnailPaths = drafts
         .map((draft) => draft.customThumbnailPath)
         .toList();
+    final allAudioPaths = drafts
+        .expand((draft) => draft.localAudioFilePaths)
+        .toSet();
 
     // Clear DB first (clips cascade via FK), then delete files
     await _draftsDao.clearAll();
@@ -555,6 +614,12 @@ class DraftStorageService {
     );
     await FileCleanupService.deleteFilesIfUnreferenced(
       allCustomThumbnailPaths,
+      draftsDao: _draftsDao,
+      clipsDao: _clipsDao,
+    );
+    // No drafts survive a clear-all, so nothing can still reference the audio.
+    await FileCleanupService.deleteDraftAudioFiles(
+      allAudioPaths,
       draftsDao: _draftsDao,
       clipsDao: _clipsDao,
     );

--- a/mobile/lib/services/file_cleanup_service.dart
+++ b/mobile/lib/services/file_cleanup_service.dart
@@ -82,6 +82,45 @@ class FileCleanupService {
     }
   }
 
+  /// Deletes draft-local audio files in [audioFilePaths], skipping any still
+  /// referenced elsewhere.
+  ///
+  /// Imported audio and voice-over recordings live in a draft's editor
+  /// metadata rather than an indexed file column, so a surviving draft that
+  /// shares the same file (e.g. a draft and its publish copy) cannot be
+  /// detected by the indexed-column check. The caller therefore supplies
+  /// [referencedAudioFilenames] — the basenames of local audio still
+  /// referenced by other drafts — and a file is kept when its basename is in
+  /// that set. The indexed clip/draft reference check still runs as a
+  /// defensive backstop.
+  ///
+  /// Throws:
+  ///
+  /// * No exceptions – errors are logged and silently handled.
+  static Future<void> deleteDraftAudioFiles(
+    Iterable<String> audioFilePaths, {
+    required DraftsDao draftsDao,
+    required ClipsDao clipsDao,
+    Set<String> referencedAudioFilenames = const {},
+  }) async {
+    for (final path in audioFilePaths) {
+      if (path.isEmpty) continue;
+      if (referencedAudioFilenames.contains(p.basename(path))) {
+        Log.info(
+          '🔗 Audio still referenced by another draft, skipping delete: $path',
+          name: 'FileCleanupService',
+          category: LogCategory.video,
+        );
+        continue;
+      }
+      await deleteFileIfUnreferenced(
+        path,
+        draftsDao: draftsDao,
+        clipsDao: clipsDao,
+      );
+    }
+  }
+
   /// Deletes files for a RecordingClip if not referenced
   static Future<void> deleteRecordingClipFiles(
     DivineVideoClip clip, {

--- a/mobile/test/extensions/draft_local_audio_extensions_test.dart
+++ b/mobile/test/extensions/draft_local_audio_extensions_test.dart
@@ -1,0 +1,170 @@
+// ABOUTME: Tests for DraftLocalAudioPaths.localAudioFilePaths extraction
+// ABOUTME: Validates imported audio + voice-over paths are collected for cleanup
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' show AudioEvent;
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/extensions/draft_local_audio_extensions.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/models/divine_video_draft.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+const _testPubkey =
+    'abc123def456789012345678901234567890123456789012345678901234abcd';
+
+DivineVideoClip _createTestClip() => DivineVideoClip(
+  id: 'clip_1',
+  video: EditorVideo.file('/tmp/test.mp4'),
+  duration: const Duration(seconds: 6),
+  recordedAt: DateTime(2025),
+  originalAspectRatio: 9 / 16,
+  targetAspectRatio: .vertical,
+);
+
+DivineVideoDraft _draft({
+  Map<String, dynamic> editorStateHistory = const {},
+  AudioEvent? selectedSound,
+}) => DivineVideoDraft(
+  id: 'draft_1',
+  clips: [_createTestClip()],
+  title: '',
+  description: '',
+  hashtags: const {},
+  selectedApproach: 'camera',
+  createdAt: DateTime(2025),
+  lastModified: DateTime(2025),
+  publishStatus: PublishStatus.draft,
+  publishAttempts: 0,
+  editorStateHistory: editorStateHistory,
+  selectedSound: selectedSound,
+);
+
+AudioEvent _localImport(String id, String path) => AudioEvent.fromLocalImport(
+  id: id,
+  filePath: path,
+  createdAt: 1700000000,
+  title: 'Imported',
+  mimeType: 'audio/mp4',
+);
+
+Map<String, dynamic> _historyWithAudio(List<AudioEvent> tracks) => {
+  'position': 0,
+  'history': [
+    {
+      'meta': {
+        VideoEditorConstants.audioStateHistoryKey: tracks
+            .map((t) => t.toJson())
+            .toList(),
+      },
+    },
+  ],
+};
+
+void main() {
+  group('DraftLocalAudioPaths', () {
+    test('returns empty when no audio metadata exists', () {
+      expect(_draft().localAudioFilePaths, isEmpty);
+    });
+
+    test('collects imported-audio path from editor history', () {
+      const path = '/docs/draft_audio_imports/draft_1/imported.m4a';
+      final draft = _draft(
+        editorStateHistory: _historyWithAudio([
+          _localImport('local_import_1', path),
+        ]),
+      );
+
+      expect(draft.localAudioFilePaths, {path});
+    });
+
+    test('collects voice-over recording path from editor history', () {
+      const path = '/docs/voice_over_recordings/voice_over_1.m4a';
+      final draft = _draft(
+        editorStateHistory: _historyWithAudio([
+          _localImport('local_import_voice_over_1', path),
+        ]),
+      );
+
+      expect(draft.localAudioFilePaths, {path});
+    });
+
+    test('collects local audio held in legacy selectedSound', () {
+      const path = '/docs/draft_audio_imports/draft_1/selected.m4a';
+      final draft = _draft(selectedSound: _localImport('local_import_2', path));
+
+      expect(draft.localAudioFilePaths, {path});
+    });
+
+    test('ignores non-local audio (bundled, network, original sound)', () {
+      final draft = _draft(
+        editorStateHistory: _historyWithAudio([
+          const AudioEvent(
+            id: 'bundled_chime',
+            pubkey: AudioEvent.bundledMarker,
+            createdAt: 0,
+            url: 'asset://sounds/chime.mp3',
+          ),
+          const AudioEvent(
+            id: 'remote-sound-id',
+            pubkey: _testPubkey,
+            createdAt: 1700000000,
+            url: 'https://cdn.example.com/audio.mp3',
+          ),
+        ]),
+        selectedSound: const AudioEvent(
+          id: 'video_remote',
+          pubkey: _testPubkey,
+          createdAt: 1700000000,
+          url: 'https://cdn.example.com/original.mp4',
+        ),
+      );
+
+      expect(draft.localAudioFilePaths, isEmpty);
+    });
+
+    test('deduplicates a path repeated across history entries', () {
+      const path = '/docs/voice_over_recordings/voice_over_1.m4a';
+      final track = _localImport('local_import_voice_over_1', path);
+      final draft = _draft(
+        editorStateHistory: {
+          'position': 1,
+          'history': [
+            {
+              'meta': {
+                VideoEditorConstants.audioStateHistoryKey: [track.toJson()],
+              },
+            },
+            {
+              'meta': {
+                VideoEditorConstants.audioStateHistoryKey: [track.toJson()],
+              },
+            },
+          ],
+        },
+      );
+
+      expect(draft.localAudioFilePaths, {path});
+    });
+
+    test('does not throw on malformed history shapes', () {
+      final draft = _draft(
+        editorStateHistory: const {
+          'history': [
+            'not-a-map',
+            {'meta': 'not-a-map'},
+            {
+              'meta': {VideoEditorConstants.audioStateHistoryKey: 'not-a-list'},
+            },
+            {
+              'meta': {
+                VideoEditorConstants.audioStateHistoryKey: ['not-a-map'],
+              },
+            },
+          ],
+        },
+      );
+
+      expect(draft.localAudioFilePaths, isEmpty);
+    });
+  });
+}

--- a/mobile/test/extensions/draft_local_audio_extensions_test.dart
+++ b/mobile/test/extensions/draft_local_audio_extensions_test.dart
@@ -166,5 +166,27 @@ void main() {
 
       expect(draft.localAudioFilePaths, isEmpty);
     });
+
+    test('skips audio entries that parse as a map but throw in fromJson', () {
+      // These clear the `raw is! Map` guard and reach AudioEvent.fromJson,
+      // where the non-nullable id/pubkey/createdAt casts throw — exercising
+      // the try/catch "cleanup must never throw" branch.
+      final draft = _draft(
+        editorStateHistory: const {
+          'history': [
+            {
+              'meta': {
+                VideoEditorConstants.audioStateHistoryKey: [
+                  <String, dynamic>{},
+                  {'id': 123},
+                ],
+              },
+            },
+          ],
+        },
+      );
+
+      expect(draft.localAudioFilePaths, isEmpty);
+    });
   });
 }

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -7,7 +7,8 @@ import 'dart:io';
 import 'package:db_client/db_client.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:models/models.dart' show AspectRatio;
+import 'package:models/models.dart' show AspectRatio, AudioEvent;
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/services/draft_storage_service.dart';
@@ -1223,6 +1224,157 @@ void main() {
           cover.existsSync(),
           isFalse,
           reason: 'clearing all drafts should not leak custom cover files',
+        );
+      });
+    });
+
+    group('draft-local audio file hygiene', () {
+      late Directory docsDir;
+
+      setUp(() {
+        docsDir = Directory(documentsPath)..createSync(recursive: true);
+      });
+
+      tearDown(() {
+        if (docsDir.existsSync()) docsDir.deleteSync(recursive: true);
+      });
+
+      File writeAudio(String relativePath) {
+        final file = File(p.join(documentsPath, relativePath));
+        file.parent.createSync(recursive: true);
+        file.writeAsBytesSync(const [0, 1, 2, 3]);
+        return file;
+      }
+
+      Map<String, dynamic> historyWithLocalAudio(String audioPath, String id) {
+        final track = AudioEvent.fromLocalImport(
+          id: id,
+          filePath: audioPath,
+          createdAt: 1700000000,
+          title: 'Local audio',
+          mimeType: 'audio/mp4',
+        );
+        return {
+          'position': 0,
+          'history': [
+            {
+              'meta': {
+                VideoEditorConstants.audioStateHistoryKey: [track.toJson()],
+              },
+            },
+          ],
+        };
+      }
+
+      DivineVideoDraft draftWithAudio({
+        required String id,
+        required String audioPath,
+        required String audioId,
+      }) => DivineVideoDraft.create(
+        id: id,
+        clips: [
+          DivineVideoClip(
+            id: 'clip_$id',
+            video: EditorVideo.file('/path/to/video.mp4'),
+            duration: const Duration(seconds: 6),
+            recordedAt: DateTime(2025),
+            targetAspectRatio: AspectRatio.square,
+            originalAspectRatio: 9 / 16,
+          ),
+        ],
+        title: 'Audio draft',
+        description: '',
+        hashtags: const {},
+        selectedApproach: 'video',
+        editorStateHistory: historyWithLocalAudio(audioPath, audioId),
+      );
+
+      test('deletes imported audio when the draft is deleted', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_audio', 'imported.m4a'),
+        );
+        final draft = draftWithAudio(
+          id: 'draft_audio',
+          audioPath: audio.path,
+          audioId: 'local_import_1',
+        );
+        await service.saveDraft(draft);
+
+        await service.deleteDraft(draft.id);
+
+        expect(
+          audio.existsSync(),
+          isFalse,
+          reason: 'deleting a draft must remove its imported audio file',
+        );
+      });
+
+      test('deletes a committed voice-over recording when the draft is '
+          'deleted', () async {
+        final audio = writeAudio(
+          p.join('voice_over_recordings', 'voice_over_1.m4a'),
+        );
+        final draft = draftWithAudio(
+          id: 'draft_voice',
+          audioPath: audio.path,
+          audioId: 'local_import_voice_over_1',
+        );
+        await service.saveDraft(draft);
+
+        await service.deleteDraft(draft.id);
+
+        expect(
+          audio.existsSync(),
+          isFalse,
+          reason: 'deleting a draft must remove its voice-over recording',
+        );
+      });
+
+      test('keeps audio referenced by another draft (publish copy) when one '
+          'draft is deleted', () async {
+        final audio = writeAudio(
+          p.join('voice_over_recordings', 'shared_voice_over.m4a'),
+        );
+        final draft = draftWithAudio(
+          id: 'draft_source',
+          audioPath: audio.path,
+          audioId: 'local_import_voice_over_2',
+        );
+        // The publish flow copies editorStateHistory onto a new draft id, so
+        // both drafts reference the same local audio file.
+        final publishCopy = draft.copyWith(id: 'draft_publish_copy');
+
+        await service.saveDraft(draft);
+        await service.saveDraft(publishCopy);
+
+        await service.deleteDraft(draft.id);
+
+        expect(
+          audio.existsSync(),
+          isTrue,
+          reason:
+              'audio shared with a surviving draft must not be deleted until '
+              'the last referencing draft is gone',
+        );
+      });
+
+      test('deletes audio files when all drafts are cleared', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_clear', 'imported.m4a'),
+        );
+        final draft = draftWithAudio(
+          id: 'draft_clear',
+          audioPath: audio.path,
+          audioId: 'local_import_3',
+        );
+        await service.saveDraft(draft);
+
+        await service.clearAllDrafts();
+
+        expect(
+          audio.existsSync(),
+          isFalse,
+          reason: 'clearing all drafts should not leak local audio files',
         );
       });
     });

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -1358,6 +1358,42 @@ void main() {
         );
       });
 
+      test('still deletes the target audio when a sibling draft has a corrupt '
+          'data blob', () async {
+        final audio = writeAudio(
+          p.join('draft_audio_imports', 'draft_target', 'imported.m4a'),
+        );
+        final draft = draftWithAudio(
+          id: 'draft_target',
+          audioPath: audio.path,
+          audioId: 'local_import_4',
+        );
+        await service.saveDraft(draft);
+
+        // A sibling row whose data blob can't be parsed back into a draft.
+        // The reference scan runs after the target row is already deleted, so
+        // an unguarded throw here would leak the deleted draft's audio file.
+        await database.draftsDao.upsertDraft(
+          id: 'draft_corrupt_sibling',
+          title: 'corrupt',
+          description: '',
+          publishStatus: 'draft',
+          createdAt: DateTime(2025),
+          lastModified: DateTime(2025),
+          data: 'not-json',
+          renderedFilePath: null,
+          renderedThumbnailPath: null,
+        );
+
+        await service.deleteDraft(draft.id);
+
+        expect(
+          audio.existsSync(),
+          isFalse,
+          reason: 'a corrupt sibling draft must not block audio cleanup',
+        );
+      });
+
       test('deletes audio files when all drafts are cleared', () async {
         final audio = writeAudio(
           p.join('draft_audio_imports', 'draft_clear', 'imported.m4a'),

--- a/mobile/test/services/file_cleanup_service_test.dart
+++ b/mobile/test/services/file_cleanup_service_test.dart
@@ -92,6 +92,34 @@ void main() {
         },
       );
 
+      test(
+        'keeps audio still referenced by the indexed clip/draft backstop',
+        () async {
+          // No referencedAudioFilenames entry, so the cross-draft guard does not
+          // short-circuit and the defensive indexed reference check runs.
+          when(
+            () => clipsDao.isFileReferenced(any()),
+          ).thenAnswer((_) async => true);
+          when(
+            () => draftsDao.isDraftFileReferenced(any()),
+          ).thenAnswer((_) async => false);
+          final audio = writeAudio('indexed_ref.m4a');
+
+          await FileCleanupService.deleteDraftAudioFiles(
+            [audio.path],
+            draftsDao: draftsDao,
+            clipsDao: clipsDao,
+          );
+
+          expect(
+            audio.existsSync(),
+            isTrue,
+            reason:
+                'the indexed reference check must still keep referenced audio',
+          );
+        },
+      );
+
       test('skips empty paths without querying references', () async {
         await FileCleanupService.deleteDraftAudioFiles(
           [''],

--- a/mobile/test/services/file_cleanup_service_test.dart
+++ b/mobile/test/services/file_cleanup_service_test.dart
@@ -1,10 +1,13 @@
 // ABOUTME: Tests for FileCleanupService file-existence guard behavior.
 // ABOUTME: Keeps cleanup from touching shared database state when no file exists.
 
+import 'dart:io';
+
 import 'package:db_client/db_client.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/services/file_cleanup_service.dart';
+import 'package:path/path.dart' as p;
 
 class _MockDraftsDao extends Mock implements DraftsDao {}
 
@@ -29,6 +32,76 @@ void main() {
 
       verifyNever(() => clipsDao.isFileReferenced(any()));
       verifyNever(() => draftsDao.isDraftFileReferenced(any()));
+    });
+
+    group('deleteDraftAudioFiles', () {
+      late Directory tempDir;
+
+      setUp(() {
+        tempDir = Directory.systemTemp.createTempSync('divine_audio_cleanup');
+      });
+
+      tearDown(() {
+        if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+      });
+
+      File writeAudio(String name) {
+        final file = File(p.join(tempDir.path, name))
+          ..writeAsBytesSync(const [0, 1, 2, 3]);
+        return file;
+      }
+
+      test('deletes a local audio file that nothing references', () async {
+        when(
+          () => clipsDao.isFileReferenced(any()),
+        ).thenAnswer((_) async => false);
+        when(
+          () => draftsDao.isDraftFileReferenced(any()),
+        ).thenAnswer((_) async => false);
+        final audio = writeAudio('voice_over_1.m4a');
+
+        await FileCleanupService.deleteDraftAudioFiles(
+          [audio.path],
+          draftsDao: draftsDao,
+          clipsDao: clipsDao,
+        );
+
+        expect(audio.existsSync(), isFalse);
+      });
+
+      test(
+        'keeps audio whose basename is referenced by another draft',
+        () async {
+          final audio = writeAudio('shared.m4a');
+
+          await FileCleanupService.deleteDraftAudioFiles(
+            [audio.path],
+            draftsDao: draftsDao,
+            clipsDao: clipsDao,
+            referencedAudioFilenames: {'shared.m4a'},
+          );
+
+          expect(
+            audio.existsSync(),
+            isTrue,
+            reason: 'a basename in referencedAudioFilenames must be kept',
+          );
+          // The cross-draft guard short-circuits before the indexed lookups.
+          verifyNever(() => clipsDao.isFileReferenced(any()));
+          verifyNever(() => draftsDao.isDraftFileReferenced(any()));
+        },
+      );
+
+      test('skips empty paths without querying references', () async {
+        await FileCleanupService.deleteDraftAudioFiles(
+          [''],
+          draftsDao: draftsDao,
+          clipsDao: clipsDao,
+        );
+
+        verifyNever(() => clipsDao.isFileReferenced(any()));
+        verifyNever(() => draftsDao.isDraftFileReferenced(any()));
+      });
     });
   });
 }


### PR DESCRIPTION
## Description

Draft-local audio files were never swept when a draft was deleted, so imported audio (`LocalAudioImportService`, under `draft_audio_imports/<draftId>`) and committed voice-over recordings (under `voice_over_recordings/`) accumulated on disk after deletion. `DraftStorageService.deleteDraft` already cleaned clip files, the final rendered clip, and the custom cover, but not local audio referenced from the editor metadata.

This wires draft-local audio cleanup into both deletion paths:

- New `DivineVideoDraft.localAudioFilePaths` extension collects `AudioEvent.localFilePath` for every `isLocalImport` track across all `editorStateHistory` history entries' `meta` audio, plus the legacy `selectedSound`.
- New `FileCleanupService.deleteDraftAudioFiles(...)` deletes those files while honoring a caller-supplied cross-draft reference set. Local audio lives in the draft JSON blob, not in an indexed file column, so the existing indexed-column guard can't see it; the indexed check still runs as a defensive backstop.
- `DraftStorageService.deleteDraft` and `clearAllDrafts` now call it. A `_referencedLocalAudioFilenames` scan keeps any file a surviving draft still references — notably a draft and its publish copy, since `copyWith` carries the same `editorStateHistory`/`selectedSound`. The shared file is freed only when the last referencing draft is gone (verified against the real `background_publish_bloc` flow, which deletes the publish copy first, then the source).

**Related Issue:** Closes #5593

## Out of Scope

- Drafts removed via paths that bypass `DraftStorageService` (e.g. the corrupted-row cleanup in `getAllDrafts`, or DAO-level `deleteOlderThan`/`deleteAllForUser`) — these already skip clip/cover cleanup too, so audio is consistent with existing behavior.
- The pre-existing use of absolute audio paths in editor metadata (a latent iOS container-path concern) is untouched; cleanup reads the same path the rest of the editor uses.

## Verification

- `flutter analyze lib test` — clean
- `flutter test test/extensions/draft_local_audio_extensions_test.dart` (7 tests)
- `flutter test test/services/draft_storage_service_test.dart` (41 tests, incl. 4 new audio-hygiene cases: imported delete, voice-over delete, shared-file guard, clear-all)
- `flutter test test/services/file_cleanup_service_test.dart` (new `deleteDraftAudioFiles` cases)
- `flutter test .../background_publish_bloc_test.dart .../voice_over_cubit_test.dart` — green

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)