### PR TITLE
fix(video-editor): drop clips with deleted source files to prevent frozen preview

### DIFF
--- a/mobile/lib/models/divine_video_clip.dart
+++ b/mobile/lib/models/divine_video_clip.dart
@@ -2,6 +2,7 @@
 // ABOUTME: Supports ordering, thumbnails, crop metadata, and JSON serialization
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:divine_camera/divine_camera.dart'
     show CameraLensMetadata, DivineCameraLens;
@@ -146,6 +147,20 @@ class DivineVideoClip {
       playbackDuration.inMilliseconds / 1000.0;
   bool get isProcessing =>
       processingCompleter != null && !processingCompleter!.isCompleted;
+
+  /// Whether this clip's source video file currently exists on disk.
+  ///
+  /// A clip can outlive its media: when a clip is removed, [FileCleanupService]
+  /// deletes its source file as soon as no clip/draft row references it — but
+  /// the editor's undo history (and any draft that persisted that history) can
+  /// still resurrect the clip. Handing a clip whose file is gone to the native
+  /// preview player makes the whole composition fail with `COMPOSITION_ERROR`
+  /// and freezes the editor, so restore/undo paths use this to drop orphaned
+  /// clips. See `restoreDraft` and `VideoEditorCanvas._syncMainCapabilities`.
+  bool get hasResolvableVideoFile {
+    final path = video.file?.path;
+    return path != null && File(path).existsSync();
+  }
 
   /// Whether this clip was recorded with a front-facing camera.
   bool get isFrontCameraLens =>

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -814,9 +814,27 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       return false;
     }
 
+    // Drop clips whose source video file is gone. A draft can outlive its
+    // media: a clip removed mid-session has its file deleted by
+    // FileCleanupService, yet the draft's persisted undo history can still
+    // carry it. Restoring such a clip hands a dead path to the native player,
+    // which fails the whole composition (COMPOSITION_ERROR) and freezes the
+    // editor — so an orphaned clip must never re-enter the timeline.
+    final restorableClips = draft.clips
+        .where((clip) => clip.hasResolvableVideoFile)
+        .toList();
+    if (restorableClips.length != draft.clips.length) {
+      Log.warning(
+        '⚠️ Dropped ${draft.clips.length - restorableClips.length} clip(s) '
+        'with missing source files while restoring draft: $draftId',
+        name: 'VideoEditorNotifier',
+        category: LogCategory.video,
+      );
+    }
+
     // Regenerate missing thumbnails
     final clipsWithThumbnails = <DivineVideoClip>[];
-    for (final clip in draft.clips) {
+    for (final clip in restorableClips) {
       final thumbnailPath = clip.thumbnailPath;
       final thumbnailExists =
           thumbnailPath != null && File(thumbnailPath).existsSync();

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -872,8 +872,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     DivineVideoClip? validFinalRenderedClip;
     final finalClip = draft.finalRenderedClip;
     if (finalClip != null) {
-      final videoPath = finalClip.video.file?.path;
-      if (videoPath != null && File(videoPath).existsSync()) {
+      if (finalClip.hasResolvableVideoFile) {
         validFinalRenderedClip = finalClip;
         Log.info(
           '✅ Restored final rendered clip',

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1052,8 +1052,17 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         ),
       );
 
+      // Drop clips whose source file no longer exists on disk before they
+      // reach the live timeline and the native player. Undo/redo can resurrect
+      // a clip that was removed earlier in the session — its media was already
+      // deleted by FileCleanupService, and handing that dead path to the
+      // player fails the whole composition (COMPOSITION_ERROR) and freezes the
+      // editor. Dropping it here also keeps the orphan out of the autosaved
+      // draft, so a later reopen can't reintroduce the freeze.
       final clips = List<DivineVideoClip>.from(
-        editor.stateManager.clipSnapshots(await _documentsPath),
+        editor.stateManager
+            .clipSnapshots(await _documentsPath)
+            .where((clip) => clip.hasResolvableVideoFile),
       );
       if (!mounted || clips.isEmpty || _isImportingHistory) return;
 

--- a/mobile/test/models/divine_video_clip_test.dart
+++ b/mobile/test/models/divine_video_clip_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' as editor;
+
+void main() {
+  DivineVideoClip clip(String videoPath) => DivineVideoClip(
+    id: 'c1',
+    video: editor.EditorVideo.file(File(videoPath)),
+    duration: const Duration(seconds: 5),
+    recordedAt: DateTime(2024),
+    targetAspectRatio: model.AspectRatio.square,
+    originalAspectRatio: 1,
+  );
+
+  group('DivineVideoClip.hasResolvableVideoFile', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('divine_video_clip_test');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    test('is true when the source video file exists on disk', () async {
+      final path = '${tempDir.path}/clip.mp4';
+      await File(path).writeAsBytes(const [0]);
+
+      expect(clip(path).hasResolvableVideoFile, isTrue);
+    });
+
+    test('is false when the source video file is missing', () {
+      expect(
+        clip('${tempDir.path}/deleted.mp4').hasResolvableVideoFile,
+        isFalse,
+      );
+    });
+  });
+}

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -3,6 +3,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
 
@@ -1299,6 +1300,9 @@ void main() {
     group('restoreDraft', () {
       late _MockDraftStorageService mockDraftStorage;
       late ProviderContainer container;
+      late Directory tempDir;
+      late String clipVideoPath;
+      late String clipThumbnailPath;
 
       setUp(() async {
         SharedPreferences.setMockInitialValues({});
@@ -1310,10 +1314,18 @@ void main() {
             draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
           ],
         );
+        // A restorable clip must point at media that actually exists on disk;
+        // restoreDraft drops clips whose source file is gone.
+        tempDir = await Directory.systemTemp.createTemp('restore_draft_test');
+        clipVideoPath = '${tempDir.path}/clip.mp4';
+        clipThumbnailPath = '${tempDir.path}/clip_thumb.jpg';
+        await File(clipVideoPath).writeAsBytes(const [0]);
+        await File(clipThumbnailPath).writeAsBytes(const [0]);
       });
 
-      tearDown(() {
+      tearDown(() async {
         container.dispose();
+        if (tempDir.existsSync()) await tempDir.delete(recursive: true);
       });
 
       test('returns false when draft is not found', () async {
@@ -1358,13 +1370,99 @@ void main() {
         ).called(1);
       });
 
+      test(
+        'drops clips whose source video file is missing on restore',
+        () async {
+          final draft = DivineVideoDraft.create(
+            id: 'draft-1',
+            clips: [
+              DivineVideoClip(
+                id: 'present',
+                video: EditorVideo.file(clipVideoPath),
+                thumbnailPath: clipThumbnailPath,
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+              // This clip's media was deleted by FileCleanupService after it
+              // was removed mid-session; the draft's undo history still carries
+              // it. Restoring it would freeze the editor (COMPOSITION_ERROR).
+              DivineVideoClip(
+                id: 'orphan',
+                video: EditorVideo.file('${tempDir.path}/deleted.mp4'),
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+          );
+          when(
+            () => mockDraftStorage.getDraftById('draft-1'),
+          ).thenAnswer((_) async => draft);
+
+          final result = await container
+              .read(videoEditorProvider.notifier)
+              .restoreDraft('draft-1');
+
+          expect(result, isTrue);
+          final clips = container.read(clipManagerProvider).clips;
+          expect(
+            clips.map((c) => c.id),
+            ['present'],
+            reason:
+                'the clip with a missing source file must be dropped, '
+                'leaving only the clip whose media still exists',
+          );
+        },
+      );
+
+      test(
+        'returns false when every clip has a missing source file',
+        () async {
+          final draft = DivineVideoDraft.create(
+            id: 'draft-1',
+            clips: [
+              DivineVideoClip(
+                id: 'orphan',
+                video: EditorVideo.file('${tempDir.path}/deleted.mp4'),
+                duration: const Duration(seconds: 3),
+                recordedAt: DateTime.now(),
+                targetAspectRatio: .vertical,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Title',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+          );
+          when(
+            () => mockDraftStorage.getDraftById('draft-1'),
+          ).thenAnswer((_) async => draft);
+
+          final result = await container
+              .read(videoEditorProvider.notifier)
+              .restoreDraft('draft-1');
+
+          expect(result, isFalse);
+          expect(container.read(clipManagerProvider).clips, isEmpty);
+        },
+      );
+
       test('restores the saved cover position onto state', () async {
         final draft = DivineVideoDraft.create(
           id: 'draft-1',
           clips: [
             DivineVideoClip(
               id: 'c1',
-              video: EditorVideo.file('/docs/clip.mp4'),
+              video: EditorVideo.file(clipVideoPath),
+              thumbnailPath: clipThumbnailPath,
               duration: const Duration(seconds: 3),
               recordedAt: DateTime.now(),
               targetAspectRatio: .vertical,
@@ -1399,7 +1497,8 @@ void main() {
           clips: [
             DivineVideoClip(
               id: 'c1',
-              video: EditorVideo.file('/docs/clip.mp4'),
+              video: EditorVideo.file(clipVideoPath),
+              thumbnailPath: clipThumbnailPath,
               duration: const Duration(seconds: 3),
               recordedAt: DateTime.now(),
               targetAspectRatio: .vertical,
@@ -1488,7 +1587,8 @@ void main() {
             clips: [
               DivineVideoClip(
                 id: 'c1',
-                video: EditorVideo.file('/docs/clip.mp4'),
+                video: EditorVideo.file(clipVideoPath),
+                thumbnailPath: clipThumbnailPath,
                 duration: const Duration(seconds: 3),
                 recordedAt: DateTime.now(),
                 targetAspectRatio: .vertical,


### PR DESCRIPTION
Closes #5636

## Description

A clip removed mid-session has its source file deleted by `FileCleanupService`
once no clip/draft row references it — but the editor's **undo history** (and any
draft that persisted that history) can still resurrect the clip. Handing a clip
whose file is gone to the native preview player fails the whole composition
(`COMPOSITION_ERROR: The operation could not be completed`) and freezes the
preview **permanently**: every subsequent `setClips`, including the one after a
transform, keeps failing on the same dead clip. (This is the "player freezes
after transforming a video" report — the transform itself renders fine; it just
re-triggers `setClips` on an already-broken composition.)

Surfaced in user logs as the sequence: clip removed → file deleted by cleanup →
**undo** restores the clip → `THUMBNAIL_ERROR: Video file not found` →
`COMPOSITION_ERROR` on every following `setClips`.

### Fix

Drop clips whose source video file no longer exists at the two points where a
clip can re-enter the live editor, so a dead path never reaches the native
player:

- **`VideoEditorCanvas._syncMainCapabilities`** — filters the undo/redo clip
  snapshot before it syncs into the timeline + player. This is the in-session
  undo path, and dropping the orphan here also keeps it out of the autosaved
  draft, so a later reopen can't reintroduce the freeze.
- **`VideoEditorNotifier.restoreDraft`** — drops clips with missing source files
  on reopen. This honours the method's existing doc comment (which claimed this
  behaviour but never implemented it) and self-heals drafts already corrupted by
  this bug.

Backed by a new, testable `DivineVideoClip.hasResolvableVideoFile` getter.
`buildSeamAwarePlayerClips` is intentionally left as a pure, file-agnostic
mapping function.

**Related Issue:** 

## Out of Scope

The eager file-cleanup-on-removal design is unchanged; this PR makes the restore
paths tolerant rather than reworking when source files are deleted.

## Verification

- `flutter analyze` on the 5 changed files — no issues
- `flutter test test/models/divine_video_clip_test.dart test/providers/video_editor_provider_test.dart` — 72 passed (incl. 2 new restore tests + new model getter tests)
- Neighbouring suites green: `clip_manager_provider_test`, `transition_seam_render_service_test`, `file_cleanup_service_test`, `divine_video_clip_transition_test`
- `dart format` — clean
- Rebased onto fresh `origin/main`; re-ran analyze + tests after rebase

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
