### PR TITLE
fix(video-editor): handle COMPOSITION_ERROR from native setClips on draft reopen

### DIFF
--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart' show kReleaseMode, listEquals;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart' hide Layer;
 import 'package:flutter/scheduler.dart' show Ticker;
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -126,21 +127,27 @@ class VideoEditorCanvas extends StatelessWidget {
     return (delta.isNegative ? -delta : delta) <= seekSettleTolerance;
   }
 
-  /// Runs a `setClips` [load], swallowing an unbuildable-composition failure.
+  /// Runs a `setClips` [load], swallowing the native unbuildable-composition
+  /// rejection.
   ///
   /// iOS rejects an unbuildable composition — zero render size, no playable
   /// video track, or a missing / partially-rendered draft clip file — with a
   /// `COMPOSITION_ERROR` `PlatformException`. That is an expected domain
   /// failure for stale draft clips on reopen, not a crash. Returns `true` when
-  /// the composition built and `false` when it was rejected, so callers can
-  /// stay on the thumbnail fallback instead of letting the rejection escape as
-  /// an unhandled async error and surface as a Crashlytics non-fatal (#3410).
+  /// the composition built and `false` when the native player rejected it, so
+  /// callers can stay on the thumbnail fallback instead of letting the
+  /// rejection escape as an unhandled async error and surface as a Crashlytics
+  /// non-fatal (#3410).
+  ///
+  /// Only [PlatformException] is swallowed; any other error (e.g. a
+  /// `StateError` from a broken invariant) is rethrown so it still reaches
+  /// Crashlytics rather than being silently hidden.
   @visibleForTesting
   static Future<bool> guardClipLoad(Future<void> Function() load) async {
     try {
       await load();
       return true;
-    } catch (e, s) {
+    } on PlatformException catch (e, s) {
       Log.error(
         'setClips failed: $e',
         name: 'VideoEditorCanvas',

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -126,6 +126,32 @@ class VideoEditorCanvas extends StatelessWidget {
     return (delta.isNegative ? -delta : delta) <= seekSettleTolerance;
   }
 
+  /// Runs a `setClips` [load], swallowing an unbuildable-composition failure.
+  ///
+  /// iOS rejects an unbuildable composition — zero render size, no playable
+  /// video track, or a missing / partially-rendered draft clip file — with a
+  /// `COMPOSITION_ERROR` `PlatformException`. That is an expected domain
+  /// failure for stale draft clips on reopen, not a crash. Returns `true` when
+  /// the composition built and `false` when it was rejected, so callers can
+  /// stay on the thumbnail fallback instead of letting the rejection escape as
+  /// an unhandled async error and surface as a Crashlytics non-fatal (#3410).
+  @visibleForTesting
+  static Future<bool> guardClipLoad(Future<void> Function() load) async {
+    try {
+      await load();
+      return true;
+    } catch (e, s) {
+      Log.error(
+        'setClips failed: $e',
+        name: 'VideoEditorCanvas',
+        category: LogCategory.video,
+        error: e,
+        stackTrace: s,
+      );
+      return false;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final isSubEditorOpen = context.select(
@@ -763,9 +789,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     // Pin so a reset report from loading the (seam-aware) composition doesn't
     // snap the playhead back while paused.
     _pendingSeekTarget = currentPosition;
-    _videoPlayer?.setClips([
-      ...buildSeamAwarePlayerClips(clips, _seamService),
-    ], startPosition: _timelineToPlayer(currentPosition));
+    unawaited(
+      _setClipsSafely(_videoPlayer, [
+        ...buildSeamAwarePlayerClips(clips, _seamService),
+      ], startPosition: _timelineToPlayer(currentPosition)),
+    );
     _ensureSeamsRendered(clips);
   }
 
@@ -826,6 +854,23 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         );
   }
 
+  /// Loads [clips] into [player], returning whether the composition built.
+  ///
+  /// Thin instance wrapper over [VideoEditorCanvas.guardClipLoad] so callers
+  /// don't repeat the null-player guard; see that method for the failure
+  /// contract.
+  Future<bool> _setClipsSafely(
+    DivineVideoPlayerController? player,
+    List<VideoClip> clips, {
+    Duration? startPosition,
+  }) {
+    return VideoEditorCanvas.guardClipLoad(
+      () =>
+          player?.setClips(clips, startPosition: startPosition) ??
+          Future<void>.value(),
+    );
+  }
+
   /// Initializes (or reinitializes) the native video player with [clipPaths].
   Future<void> _initializePlayer(
     List<String> clipPaths, {
@@ -853,7 +898,8 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
     await player.initialize();
     if (!mounted || !identical(_videoPlayer, player)) return;
-    await player.setClips(
+    final loaded = await _setClipsSafely(
+      player,
       [
         ...buildSeamAwarePlayerClips(clips, _seamService),
       ],
@@ -862,6 +908,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
           : null,
     );
     if (!mounted || !identical(_videoPlayer, player)) return;
+    // Composition failed to build (stale/corrupt draft clip): leave the canvas
+    // on its thumbnail fallback rather than marking a broken player ready.
+    if (!loaded) return;
 
     if (clips.isEmpty) return;
     _ensureSeamsRendered(clips);
@@ -1292,9 +1341,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         // Pin so a reset report from loading the seam-aware composition
         // doesn't snap the playhead back while paused.
         _pendingSeekTarget = currentPosition;
-        _videoPlayer?.setClips([
-          ...buildSeamAwarePlayerClips(clips, _seamService),
-        ], startPosition: _timelineToPlayer(currentPosition));
+        unawaited(
+          _setClipsSafely(_videoPlayer, [
+            ...buildSeamAwarePlayerClips(clips, _seamService),
+          ], startPosition: _timelineToPlayer(currentPosition)),
+        );
         _ensureSeamsRendered(clips);
       },
     );
@@ -1317,9 +1368,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         // Pin so a reset report from loading the seam-aware composition
         // doesn't snap the playhead back while paused.
         _pendingSeekTarget = currentPosition;
-        _videoPlayer?.setClips([
-          ...buildSeamAwarePlayerClips(clips, _seamService),
-        ], startPosition: _timelineToPlayer(currentPosition));
+        unawaited(
+          _setClipsSafely(_videoPlayer, [
+            ...buildSeamAwarePlayerClips(clips, _seamService),
+          ], startPosition: _timelineToPlayer(currentPosition)),
+        );
         _ensureSeamsRendered(clips);
       },
     );
@@ -1426,14 +1479,16 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             _seekEpoch++;
             _pendingSeekPosition = null;
             _isSeeking = false;
-            _videoPlayer?.setClips([
-              VideoClip(
-                uri: path,
-                end: clip.duration,
-                volume: clip.volume,
-                playbackSpeed: clip.playbackSpeed ?? 1.0,
-              ),
-            ]);
+            unawaited(
+              _setClipsSafely(_videoPlayer, [
+                VideoClip(
+                  uri: path,
+                  end: clip.duration,
+                  volume: clip.volume,
+                  playbackSpeed: clip.playbackSpeed ?? 1.0,
+                ),
+              ]),
+            );
           },
         ),
         BlocListener<ClipEditorBloc, ClipEditorState>(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -127,6 +127,8 @@ class VideoEditorCanvas extends StatelessWidget {
     return (delta.isNegative ? -delta : delta) <= seekSettleTolerance;
   }
 
+  static const _compositionErrorCode = 'COMPOSITION_ERROR';
+
   /// Runs a `setClips` [load], swallowing the native unbuildable-composition
   /// rejection.
   ///
@@ -134,22 +136,24 @@ class VideoEditorCanvas extends StatelessWidget {
   /// video track, or a missing / partially-rendered draft clip file — with a
   /// `COMPOSITION_ERROR` `PlatformException`. That is an expected domain
   /// failure for stale draft clips on reopen, not a crash. Returns `true` when
-  /// the composition built and `false` when the native player rejected it, so
-  /// callers can stay on the thumbnail fallback instead of letting the
-  /// rejection escape as an unhandled async error and surface as a Crashlytics
-  /// non-fatal (#3410).
+  /// the composition built and `false` when the native player rejected it with
+  /// that exact error, so callers can stay on the thumbnail fallback instead of
+  /// letting the rejection escape as an unhandled async error and surface as a
+  /// Crashlytics non-fatal (#3410).
   ///
-  /// Only [PlatformException] is swallowed; any other error (e.g. a
-  /// `StateError` from a broken invariant) is rethrown so it still reaches
-  /// Crashlytics rather than being silently hidden.
+  /// Only `COMPOSITION_ERROR` is swallowed; any other error (e.g. a
+  /// `PLAYER_ERROR`, `INVALID_ARGS`, or a `StateError` from a broken invariant)
+  /// is rethrown so it still reaches Crashlytics rather than being silently
+  /// hidden.
   @visibleForTesting
   static Future<bool> guardClipLoad(Future<void> Function() load) async {
     try {
       await load();
       return true;
     } on PlatformException catch (e, s) {
+      if (e.code != _compositionErrorCode) rethrow;
       Log.error(
-        'setClips failed: $e',
+        'setClips failed with $_compositionErrorCode: $e',
         name: 'VideoEditorCanvas',
         category: LogCategory.video,
         error: e,
@@ -450,9 +454,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     _isSeeking = true;
     final ownerEpoch = _seekEpoch;
     try {
-      await _videoPlayer?.setClips([
+      final loaded = await _setClipsSafely(_videoPlayer, [
         ...buildSeamAwarePlayerClips(clips, _seamService),
       ], startPosition: _timelineToPlayer(timelineStartPosition));
+      if (!loaded) return;
       // Only pin the restored position if no newer swap took over during the
       // await — matching the epoch-guarded [_isSeeking] release below. Without
       // this a stale swap would write its old composite position over the one a
@@ -462,14 +467,6 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         _pendingSeekTarget = timelineStartPosition;
         _proVideoController.setPlayTime(timelineStartPosition);
       }
-    } catch (e, s) {
-      Log.error(
-        'setClips failed on composition swap: $e',
-        name: 'VideoEditorCanvas',
-        category: LogCategory.video,
-        error: e,
-        stackTrace: s,
-      );
     } finally {
       if (_seekEpoch == ownerEpoch) _isSeeking = false;
     }
@@ -1630,22 +1627,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             final ownerEpoch = _seekEpoch;
 
             try {
-              await _videoPlayer?.setClips([
+              final loaded = await _setClipsSafely(_videoPlayer, [
                 ...buildSeamAwarePlayerClips(state.clips, _seamService),
               ], startPosition: _timelineToPlayer(currentPosition));
+              if (!loaded) return;
 
               if (!mounted) return;
               _lastReportedPosition = currentPosition;
               _pendingSeekTarget = currentPosition;
               _proVideoController.setPlayTime(currentPosition);
-            } catch (e, s) {
-              Log.error(
-                'setClips failed after reverse completion: $e',
-                name: 'VideoEditorCanvas',
-                category: LogCategory.video,
-                error: e,
-                stackTrace: s,
-              );
             } finally {
               if (_seekEpoch == ownerEpoch) {
                 _isSeeking = false;
@@ -1692,9 +1682,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             final ownerEpoch = _seekEpoch;
 
             try {
-              await _videoPlayer?.setClips([
+              final loaded = await _setClipsSafely(_videoPlayer, [
                 ...buildSeamAwarePlayerClips(state.clips, _seamService),
               ], startPosition: _timelineToPlayer(startPosition));
+              if (!loaded) return;
               if (mounted) {
                 VideoEditorCanvas.syncPositionAfterTrimRelease(
                   mainBloc: bloc,
@@ -1703,14 +1694,6 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
                   trimEndAlreadyDispatched: trimEndPosition != null,
                 );
               }
-            } catch (e, s) {
-              Log.error(
-                'setClips failed on trim release: $e',
-                name: 'VideoEditorCanvas',
-                category: LogCategory.video,
-                error: e,
-                stackTrace: s,
-              );
             } finally {
               _lastReportedPosition = startPosition;
               _pendingSeekTarget = startPosition;

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -341,6 +341,24 @@ void main() {
         throwsA(isA<ArgumentError>()),
       );
     });
+
+    test('rethrows non-composition platform errors', () {
+      expect(
+        VideoEditorCanvas.guardClipLoad(
+          () async => throw PlatformException(
+            code: 'PLAYER_ERROR',
+            message: 'Decoder failed while loading clips.',
+          ),
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (error) => error.code,
+            'code',
+            'PLAYER_ERROR',
+          ),
+        ),
+      );
+    });
   });
 
   group('interpolatePlayheadPosition', () {

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -330,12 +330,15 @@ void main() {
       },
     );
 
-    test('reports failure for any thrown error, not just platform ones', () {
+    test('rethrows a non-platform error so genuine bugs still surface', () {
+      // A programming-invariant violation (StateError/ArgumentError) is not a
+      // composition rejection — it must propagate so it reaches Crashlytics
+      // instead of being hidden behind a silent thumbnail fallback.
       expect(
         VideoEditorCanvas.guardClipLoad(
           () async => throw ArgumentError('clips must not be empty'),
         ),
-        completion(isFalse),
+        throwsA(isA<ArgumentError>()),
       );
     });
   });

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -301,6 +302,40 @@ void main() {
           isPlaying: false,
         ),
         isFalse,
+      );
+    });
+  });
+
+  group('VideoEditorCanvas.guardClipLoad', () {
+    test('returns true when the composition builds', () async {
+      final built = await VideoEditorCanvas.guardClipLoad(() async {});
+
+      expect(built, isTrue);
+    });
+
+    test(
+      'returns false and swallows a COMPOSITION_ERROR rejection (#3410)',
+      () async {
+        // The iOS player rejects an unbuildable composition for stale draft
+        // clips. The rejection must not escape as an unhandled async error and
+        // surface as a Crashlytics non-fatal.
+        Future<bool> guard() => VideoEditorCanvas.guardClipLoad(
+          () async => throw PlatformException(
+            code: 'COMPOSITION_ERROR',
+            message: 'Video composition has an invalid render size.',
+          ),
+        );
+
+        await expectLater(guard(), completion(isFalse));
+      },
+    );
+
+    test('reports failure for any thrown error, not just platform ones', () {
+      expect(
+        VideoEditorCanvas.guardClipLoad(
+          () async => throw ArgumentError('clips must not be empty'),
+        ),
+        completion(isFalse),
       );
     });
   });


### PR DESCRIPTION
## Description

The iOS player rejects an unbuildable AVComposition, such as a zero render size, no playable video track, or a missing / partially-rendered draft clip file, with a COMPOSITION_ERROR PlatformException instead of crashing the app. The native guard landed in #3402, but the editor canvas still had unguarded or inconsistently guarded setClips callsites that could let the rejection escape as an unhandled async error on stale draft reopen.

This PR routes editor setClips loads through a single guarded path:

- VideoEditorCanvas.guardClipLoad returns true on success and false only for native COMPOSITION_ERROR.
- _setClipsSafely keeps the null-player guard in one place.
- _initializePlayer leaves the canvas on the thumbnail fallback when a stale draft composition is rejected instead of marking a broken player ready.
- Fire-and-forget setClips calls are wrapped with unawaited(_setClipsSafely(...)) so async rejections are actually handled.
- The existing composition-swap, reverse-completion, and trim-release callsites now use the same guard instead of broad catch blocks, so ArgumentError, StateError, TypeError, PLAYER_ERROR, INVALID_ARGS, and other non-composition failures still surface as reportable bugs.

Fixes #5645.
Related to #3410 and #3402.

## Verification

- dart format lib/widgets/video_editor/main_editor/video_editor_canvas.dart test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
- mise exec -- dart format lib test integration_test
- flutter analyze lib/widgets/video_editor/main_editor/video_editor_canvas.dart test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
- flutter test test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
- git diff --check

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
