### PR TITLE
fix(video-editor): stop iOS ProVideoEditor callback crash on FlutterEngine teardown

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "6fc9e07232ce289cf6671e695e904758ea5ec841ea351d6807adb97941ac8b52"
+      sha256: cbb81a402882e4d57d4ce6a9966f7bb6b54434724c8c6df987c1cc00e9556883
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -307,7 +307,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^2.1.1
+  pro_video_editor: ^2.1.3
   pro_image_editor: ^12.8.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
## Description

Crashlytics (build 1.0.13) had an iOS fatal crash cluster where
`ProVideoEditorPlugin.postProgress` or another late native callback could fire
against a torn-down `FlutterEngine`:
`NSInternalInconsistencyException: Sending a message before the FlutterEngine
has been run`.

The fix lives in the **`pro_video_editor` package** (2.1.3). The Darwin plugin
now publishes the plugin instance so `detachFromEngine(for:)` is invoked on
FlutterEngine teardown, marks detach as terminal before cleanup, cancels active
render/audio/waveform tasks, clears every event/log sink, and routes late
asynchronous method-channel deliveries through a detach guard so captured
`FlutterResult` callbacks no-op after engine teardown.

This app-side PR only bumps the dependency `pro_video_editor 2.1.1 -> 2.1.3`
to pull that fix in. There is no Dart-side behavior change.

**Related Issue:** Closes #4400

## Out of Scope

The adjacent iOS texture-player teardown paths are already covered by #5369
(texture frame driver on background) and #5371 (dispose iOS players on engine
teardown). None of that is touched here.

## Verification

- `flutter pub get` resolves `pro_video_editor` 2.1.3 cleanly (lockfile updated).
- Native-only patch bump; no Dart public API changes.
- Source-verified the published 2.1.3 archive checksum against `pubspec.lock`.
- Source-verified the 2.1.3 Darwin plugin guards late render, stop-motion,
  audio, waveform, metadata, audio-track, and thumbnail result delivery after
  engine detach.
- Runtime verification from the PR commit: the iOS teardown crash reproduces on
  the pre-2.1.3 build and no longer reproduces on 2.1.3 when starting an editor
  render/export, leaving the editor or backgrounding while progress is active,
  then terminating/relaunching.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
