### PR TITLE
refactor(camera): route recorder permission asks through the gate

### DIFF
--- a/mobile/integration_test/auth/user_journey_test.dart
+++ b/mobile/integration_test/auth/user_journey_test.dart
@@ -75,8 +75,8 @@ void main() {
         await tapSemantic(tester, 'camera_button');
         logPhase('Camera button tapped');
 
-        // The CameraPermissionGate shows a pre-permission bottom sheet
-        // with a "Continue" button before triggering the native OS dialog.
+        // The recorder's CameraPermissionGate renders a permission screen
+        // with a "Continue" button that triggers the native OS dialog.
         // We must tap "Continue" first, then handle the native dialogs.
         final continuePermission = find.text('Continue');
         final foundContinue = await waitForWidget(

--- a/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
+++ b/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
@@ -1,3 +1,4 @@
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -9,11 +10,23 @@ part 'camera_permission_state.dart';
 
 /// BLoC for managing camera and microphone permissions.
 ///
+/// Permission prompting is owned by the recorder gate
+/// (`CameraPermissionGate`): a [CameraPermissionRequest] is only dispatched
+/// from the gate's explicit "Continue" action, so the native media permission
+/// dialog always happens in response to a user gesture on the recorder
+/// screen. Callers that navigate to the recorder no longer prompt themselves.
+///
 /// Handles:
 /// - Checking current permission status
-/// - Requesting permissions via OS dialog
+/// - Requesting permissions via OS dialog (from the gate)
 /// - Caching status to avoid repeated OS calls
 /// - Refreshing status when app resumes from background
+///
+/// Both [CameraPermissionRequest] and [CameraPermissionRefresh] use the
+/// `droppable()` transformer so duplicate requests/refreshes dispatched while
+/// one is already in flight are ignored. This replaces the previous in-flight
+/// boolean/future fields with the idiomatic bloc concurrency primitive and
+/// keeps all coordination out of mutable instance state.
 class CameraPermissionBloc
     extends Bloc<CameraPermissionEvent, CameraPermissionState> {
   CameraPermissionBloc({
@@ -22,8 +35,8 @@ class CameraPermissionBloc
   }) : _permissionsService = permissionsService,
        _skipMacOSBypass = skipMacOSBypass ?? false,
        super(const CameraPermissionInitial()) {
-    on<CameraPermissionRequest>(_onRequest);
-    on<CameraPermissionRefresh>(_onRefresh);
+    on<CameraPermissionRequest>(_onRequest, transformer: droppable());
+    on<CameraPermissionRefresh>(_onRefresh, transformer: droppable());
     on<CameraPermissionOpenSettings>(_onOpenSettings);
   }
 
@@ -48,7 +61,10 @@ class CameraPermissionBloc
       final cameraStatus = await _permissionsService.requestCameraPermission();
 
       if (cameraStatus != PermissionStatus.granted) {
-        emit(const CameraPermissionDenied());
+        // Stay on the recorder gate with the resolved status so the gate can
+        // re-prompt (canRequest) or send the user to Settings
+        // (requiresSettings) instead of silently bouncing back to the feed.
+        emit(CameraPermissionLoaded(_cameraStatusFromPermission(cameraStatus)));
         return;
       }
 
@@ -56,7 +72,11 @@ class CameraPermissionBloc
           .requestMicrophonePermission();
 
       if (microphoneStatus != PermissionStatus.granted) {
-        emit(const CameraPermissionDenied());
+        emit(
+          CameraPermissionLoaded(
+            _cameraStatusFromPermission(microphoneStatus),
+          ),
+        );
         return;
       }
 
@@ -81,11 +101,9 @@ class CameraPermissionBloc
       category: LogCategory.video,
     );
 
-    // On desktop, permission_handler doesn't work reliably.
-    // macOS handles camera permissions at the system level when the app
-    // actually tries to access the camera, showing its own permission dialog.
-    // Linux has no camera support yet, so permissions are irrelevant.
-    // So we bypass the permission check and assume authorized.
+    // Linux has no camera support yet, so permissions are irrelevant and we
+    // assume authorized. macOS permission behavior is tracked separately in
+    // #4112; this refactor intentionally leaves the desktop bypass untouched.
     if (!kIsWeb &&
         (defaultTargetPlatform == TargetPlatform.macOS ||
             defaultTargetPlatform == TargetPlatform.linux) &&
@@ -124,6 +142,17 @@ class CameraPermissionBloc
   ) async {
     await _permissionsService.openAppSettings();
   }
+
+  /// Maps a raw [PermissionStatus] from a request to the gate-facing
+  /// [CameraPermissionStatus] so a denied/blocked request keeps the user on
+  /// the recorder gate with the correct prompt.
+  CameraPermissionStatus _cameraStatusFromPermission(PermissionStatus status) =>
+      switch (status) {
+        PermissionStatus.granted => CameraPermissionStatus.authorized,
+        PermissionStatus.requiresSettings =>
+          CameraPermissionStatus.requiresSettings,
+        PermissionStatus.canRequest => CameraPermissionStatus.canRequest,
+      };
 
   /// Check the status of camera, microphone, and gallery permissions.
   Future<CameraPermissionStatus> checkPermissions() async {

--- a/mobile/lib/blocs/camera_permission/camera_permission_state.dart
+++ b/mobile/lib/blocs/camera_permission/camera_permission_state.dart
@@ -40,13 +40,6 @@ class CameraPermissionLoaded extends CameraPermissionState {
   List<Object?> get props => [status];
 }
 
-class CameraPermissionDenied extends CameraPermissionState {
-  const CameraPermissionDenied();
-
-  @override
-  List<Object?> get props => [];
-}
-
 /// Error checking or requesting permissions.
 class CameraPermissionError extends CameraPermissionState {
   const CameraPermissionError();

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -2344,7 +2344,6 @@
     "saveOriginalPhotosAccessMessage": "ቪዲዮዎችን ለማስቀመጥ በቅንብሮች ውስጥ የፎቶዎች መዳረሻ ፍቀድ።",
     "saveOriginalOpenSettings": "ቅንብሮችን ይክፈቱ",
     "saveOriginalNotNow": "አሁን አይደለም",
-    "cameraPermissionNotNow": "አሁን አይደለም",
     "saveOriginalDownloadFailed": "ማውረድ አልተሳካም።",
     "saveOriginalDismiss": "አሰናብት",
     "saveOriginalDownloadingVideo": "ቪዲዮን በማውረድ ላይ",

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -2015,7 +2015,6 @@
     "saveOriginalPhotosAccessMessage": "لحفظ مقاطع الفيديو، اسمح بالوصول إلى الصور في الإعدادات.",
     "saveOriginalOpenSettings": "فتح الإعدادات",
     "saveOriginalNotNow": "ليس الآن",
-    "cameraPermissionNotNow": "ليس الآن",
     "saveOriginalDownloadFailed": "فشل التنزيل",
     "saveOriginalDismiss": "إخفاء",
     "saveOriginalDownloadingVideo": "جارٍ تنزيل الفيديو",

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -2222,7 +2222,6 @@
     "saveOriginalPhotosAccessMessage": "За да запазваш видеа, дай достъп до снимките в настройките.",
     "saveOriginalOpenSettings": "Отвори Настройки",
     "saveOriginalNotNow": "Не сега",
-    "cameraPermissionNotNow": "Не сега",
     "saveOriginalDownloadFailed": "Неуспешно изтегляне",
     "saveOriginalDismiss": "Отхвърляне",
     "saveOriginalDownloadingVideo": "Изтегляне на видео",

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -2023,7 +2023,6 @@
     "saveOriginalPhotosAccessMessage": "Um Videos zu speichern, erlaube den Fotozugriff in den Einstellungen.",
     "saveOriginalOpenSettings": "Einstellungen öffnen",
     "saveOriginalNotNow": "Nicht jetzt",
-    "cameraPermissionNotNow": "Nicht jetzt",
     "saveOriginalDownloadFailed": "Download fehlgeschlagen",
     "saveOriginalDismiss": "Schließen",
     "saveOriginalDownloadingVideo": "Video wird heruntergeladen",

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -2670,7 +2670,6 @@
   "saveOriginalPhotosAccessMessage": "To save videos, allow Photos access in Settings.",
   "saveOriginalOpenSettings": "Open Settings",
   "saveOriginalNotNow": "Not Now",
-  "cameraPermissionNotNow": "Not now",
   "saveOriginalDownloadFailed": "Download Failed",
   "saveOriginalDismiss": "Dismiss",
   "saveOriginalDownloadingVideo": "Downloading Video",

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -2027,7 +2027,6 @@
     "saveOriginalPhotosAccessMessage": "Para guardar videos, permití el acceso a Fotos en Ajustes.",
     "saveOriginalOpenSettings": "Abrir Ajustes",
     "saveOriginalNotNow": "Ahora no",
-    "cameraPermissionNotNow": "Ahora no",
     "saveOriginalDownloadFailed": "Falló la descarga",
     "saveOriginalDismiss": "Descartar",
     "saveOriginalDownloadingVideo": "Descargando video",

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -1283,7 +1283,6 @@
     "saveOriginalPhotosAccessMessage": "Para mag-save ng video, payagan ang access sa Photos sa Settings.",
     "saveOriginalOpenSettings": "Buksan ang Settings",
     "saveOriginalNotNow": "Hindi muna",
-    "cameraPermissionNotNow": "Hindi muna",
     "saveOriginalDownloadFailed": "Hindi Nag-download",
     "saveOriginalDismiss": "Isantabi",
     "saveOriginalDownloadingVideo": "Nagda-download ng Video",

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -2023,7 +2023,6 @@
     "saveOriginalPhotosAccessMessage": "Pour enregistrer les vidéos, autorise l'accès aux Photos dans les Réglages.",
     "saveOriginalOpenSettings": "Ouvrir les Réglages",
     "saveOriginalNotNow": "Pas maintenant",
-    "cameraPermissionNotNow": "Pas maintenant",
     "saveOriginalDownloadFailed": "Téléchargement échoué",
     "saveOriginalDismiss": "Ignorer",
     "saveOriginalDownloadingVideo": "Téléchargement de la vidéo",

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -2022,7 +2022,6 @@
     "saveOriginalPhotosAccessMessage": "Untuk menyimpan video, izinkan akses Foto di Pengaturan.",
     "saveOriginalOpenSettings": "Buka Pengaturan",
     "saveOriginalNotNow": "Nanti Saja",
-    "cameraPermissionNotNow": "Nanti Saja",
     "saveOriginalDownloadFailed": "Unduhan Gagal",
     "saveOriginalDismiss": "Tutup",
     "saveOriginalDownloadingVideo": "Mengunduh Video",

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -2023,7 +2023,6 @@
     "saveOriginalPhotosAccessMessage": "Per salvare i video, consenti l'accesso a Foto nelle Impostazioni.",
     "saveOriginalOpenSettings": "Apri impostazioni",
     "saveOriginalNotNow": "Non ora",
-    "cameraPermissionNotNow": "Non ora",
     "saveOriginalDownloadFailed": "Download fallito",
     "saveOriginalDismiss": "Ignora",
     "saveOriginalDownloadingVideo": "Download video",

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -2015,7 +2015,6 @@
     "saveOriginalPhotosAccessMessage": "動画を保存するには、設定で写真へのアクセスを許可してね。",
     "saveOriginalOpenSettings": "設定を開く",
     "saveOriginalNotNow": "今はいい",
-    "cameraPermissionNotNow": "今はいい",
     "saveOriginalDownloadFailed": "ダウンロードがうまくいかなかった",
     "saveOriginalDismiss": "閉じる",
     "saveOriginalDownloadingVideo": "動画をダウンロード中",

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -1339,7 +1339,6 @@
     "saveOriginalPhotosAccessMessage": "영상을 저장하려면 설정에서 사진 접근을 허용해 주세요.",
     "saveOriginalOpenSettings": "설정 열기",
     "saveOriginalNotNow": "나중에",
-    "cameraPermissionNotNow": "나중에",
     "saveOriginalDownloadFailed": "다운로드 실패",
     "saveOriginalDismiss": "닫기",
     "saveOriginalDownloadingVideo": "영상 다운로드 중",

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -2023,7 +2023,6 @@
     "saveOriginalPhotosAccessMessage": "Om video's op te slaan, geef je in Instellingen toegang tot Foto's.",
     "saveOriginalOpenSettings": "Instellingen openen",
     "saveOriginalNotNow": "Niet nu",
-    "cameraPermissionNotNow": "Niet nu",
     "saveOriginalDownloadFailed": "Download mislukt",
     "saveOriginalDismiss": "Sluiten",
     "saveOriginalDownloadingVideo": "Video downloaden",

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -2023,7 +2023,6 @@
     "saveOriginalPhotosAccessMessage": "Aby zapisać filmy, zezwól na dostęp do Zdjęć w Ustawieniach.",
     "saveOriginalOpenSettings": "Otwórz Ustawienia",
     "saveOriginalNotNow": "Nie teraz",
-    "cameraPermissionNotNow": "Nie teraz",
     "saveOriginalDownloadFailed": "Pobieranie nieudane",
     "saveOriginalDismiss": "Odrzuć",
     "saveOriginalDownloadingVideo": "Pobieranie filmu",

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -2023,7 +2023,6 @@
     "saveOriginalPhotosAccessMessage": "Para salvar vídeos, permita o acesso a Fotos nas Configurações.",
     "saveOriginalOpenSettings": "Abrir Configurações",
     "saveOriginalNotNow": "Agora não",
-    "cameraPermissionNotNow": "Agora não",
     "saveOriginalDownloadFailed": "Download falhou",
     "saveOriginalDismiss": "Dispensar",
     "saveOriginalDownloadingVideo": "Baixando vídeo",

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -2023,7 +2023,6 @@
     "saveOriginalPhotosAccessMessage": "Pentru a salva videoclipuri, permite accesul la Poze în Setări.",
     "saveOriginalOpenSettings": "Deschide setările",
     "saveOriginalNotNow": "Nu acum",
-    "cameraPermissionNotNow": "Nu acum",
     "saveOriginalDownloadFailed": "Descărcare eșuată",
     "saveOriginalDismiss": "Respinge",
     "saveOriginalDownloadingVideo": "Se descarcă videoclipul",

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -2023,7 +2023,6 @@
     "saveOriginalPhotosAccessMessage": "För att spara videor, tillåt fotoåtkomst i Inställningar.",
     "saveOriginalOpenSettings": "Öppna inställningar",
     "saveOriginalNotNow": "Inte nu",
-    "cameraPermissionNotNow": "Inte nu",
     "saveOriginalDownloadFailed": "Nedladdning misslyckades",
     "saveOriginalDismiss": "Avfärda",
     "saveOriginalDownloadingVideo": "Laddar ner video",

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -2022,7 +2022,6 @@
     "saveOriginalPhotosAccessMessage": "Videoları kaydetmek için Ayarlar'dan Fotoğraf erişimine izin ver.",
     "saveOriginalOpenSettings": "Ayarları Aç",
     "saveOriginalNotNow": "Şimdi Değil",
-    "cameraPermissionNotNow": "Şimdi Değil",
     "saveOriginalDownloadFailed": "İndirme Başarısız",
     "saveOriginalDismiss": "Kapat",
     "saveOriginalDownloadingVideo": "Video İndiriliyor",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -8468,12 +8468,6 @@ abstract class AppLocalizations {
   /// **'Not Now'**
   String get saveOriginalNotNow;
 
-  /// No description provided for @cameraPermissionNotNow.
-  ///
-  /// In en, this message translates to:
-  /// **'Not now'**
-  String get cameraPermissionNotNow;
-
   /// No description provided for @saveOriginalDownloadFailed.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -4735,9 +4735,6 @@ class AppLocalizationsAm extends AppLocalizations {
   String get saveOriginalNotNow => 'አሁን አይደለም';
 
   @override
-  String get cameraPermissionNotNow => 'አሁን አይደለም';
-
-  @override
   String get saveOriginalDownloadFailed => 'ማውረድ አልተሳካም።';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -4787,9 +4787,6 @@ class AppLocalizationsAr extends AppLocalizations {
   String get saveOriginalNotNow => 'ليس الآن';
 
   @override
-  String get cameraPermissionNotNow => 'ليس الآن';
-
-  @override
   String get saveOriginalDownloadFailed => 'فشل التنزيل';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -4885,9 +4885,6 @@ class AppLocalizationsBg extends AppLocalizations {
   String get saveOriginalNotNow => 'Не сега';
 
   @override
-  String get cameraPermissionNotNow => 'Не сега';
-
-  @override
   String get saveOriginalDownloadFailed => 'Неуспешно изтегляне';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -4894,9 +4894,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get saveOriginalNotNow => 'Nicht jetzt';
 
   @override
-  String get cameraPermissionNotNow => 'Nicht jetzt';
-
-  @override
   String get saveOriginalDownloadFailed => 'Download fehlgeschlagen';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -4836,9 +4836,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get saveOriginalNotNow => 'Not Now';
 
   @override
-  String get cameraPermissionNotNow => 'Not now';
-
-  @override
   String get saveOriginalDownloadFailed => 'Download Failed';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -4877,9 +4877,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get saveOriginalNotNow => 'Ahora no';
 
   @override
-  String get cameraPermissionNotNow => 'Ahora no';
-
-  @override
   String get saveOriginalDownloadFailed => 'Falló la descarga';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -4898,9 +4898,6 @@ class AppLocalizationsFil extends AppLocalizations {
   String get saveOriginalNotNow => 'Hindi muna';
 
   @override
-  String get cameraPermissionNotNow => 'Hindi muna';
-
-  @override
   String get saveOriginalDownloadFailed => 'Hindi Nag-download';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -4901,9 +4901,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get saveOriginalNotNow => 'Pas maintenant';
 
   @override
-  String get cameraPermissionNotNow => 'Pas maintenant';
-
-  @override
   String get saveOriginalDownloadFailed => 'Téléchargement échoué';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -4812,9 +4812,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get saveOriginalNotNow => 'Nanti Saja';
 
   @override
-  String get cameraPermissionNotNow => 'Nanti Saja';
-
-  @override
   String get saveOriginalDownloadFailed => 'Unduhan Gagal';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -4883,9 +4883,6 @@ class AppLocalizationsIt extends AppLocalizations {
   String get saveOriginalNotNow => 'Non ora';
 
   @override
-  String get cameraPermissionNotNow => 'Non ora';
-
-  @override
   String get saveOriginalDownloadFailed => 'Download fallito';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -4623,9 +4623,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get saveOriginalNotNow => '今はいい';
 
   @override
-  String get cameraPermissionNotNow => '今はいい';
-
-  @override
   String get saveOriginalDownloadFailed => 'ダウンロードがうまくいかなかった';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -4639,9 +4639,6 @@ class AppLocalizationsKo extends AppLocalizations {
   String get saveOriginalNotNow => '나중에';
 
   @override
-  String get cameraPermissionNotNow => '나중에';
-
-  @override
   String get saveOriginalDownloadFailed => '다운로드 실패';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -4855,9 +4855,6 @@ class AppLocalizationsNl extends AppLocalizations {
   String get saveOriginalNotNow => 'Niet nu';
 
   @override
-  String get cameraPermissionNotNow => 'Niet nu';
-
-  @override
   String get saveOriginalDownloadFailed => 'Download mislukt';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -4957,9 +4957,6 @@ class AppLocalizationsPl extends AppLocalizations {
   String get saveOriginalNotNow => 'Nie teraz';
 
   @override
-  String get cameraPermissionNotNow => 'Nie teraz';
-
-  @override
   String get saveOriginalDownloadFailed => 'Pobieranie nieudane';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -4865,9 +4865,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get saveOriginalNotNow => 'Agora não';
 
   @override
-  String get cameraPermissionNotNow => 'Agora não';
-
-  @override
   String get saveOriginalDownloadFailed => 'Download falhou';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -4972,9 +4972,6 @@ class AppLocalizationsRo extends AppLocalizations {
   String get saveOriginalNotNow => 'Nu acum';
 
   @override
-  String get cameraPermissionNotNow => 'Nu acum';
-
-  @override
   String get saveOriginalDownloadFailed => 'Descărcare eșuată';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -4834,9 +4834,6 @@ class AppLocalizationsSv extends AppLocalizations {
   String get saveOriginalNotNow => 'Inte nu';
 
   @override
-  String get cameraPermissionNotNow => 'Inte nu';
-
-  @override
   String get saveOriginalDownloadFailed => 'Nedladdning misslyckades';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -4818,9 +4818,6 @@ class AppLocalizationsTr extends AppLocalizations {
   String get saveOriginalNotNow => 'Şimdi Değil';
 
   @override
-  String get cameraPermissionNotNow => 'Şimdi Değil';
-
-  @override
   String get saveOriginalDownloadFailed => 'İndirme Başarısız';
 
   @override

--- a/mobile/lib/utils/camera_permission_check.dart
+++ b/mobile/lib/utils/camera_permission_check.dart
@@ -1,22 +1,26 @@
-// ABOUTME: Pre-navigation camera permission check with bottom sheet UI
-// ABOUTME: Shows permission sheet before navigating to VideoRecorderScreen
+// ABOUTME: Pre-navigation camera permission check for camera routes
+// ABOUTME: Routes requestable permissions to VideoRecorderScreen's gate
 
 import 'dart:async';
 
-import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
-import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/pause_aware_modals.dart';
 
 /// Extension for camera navigation with pre-flight permission check.
 extension CameraPermissionNavigation on BuildContext {
-  /// Checks camera/microphone permissions and shows a bottom sheet if
-  /// not authorized. Navigates to [VideoRecorderScreen] only when
-  /// permissions are granted.
+  /// Navigates to [VideoRecorderScreen] after the permission status has
+  /// settled.
+  ///
+  /// Permission prompts are owned by [VideoRecorderScreen]'s
+  /// `CameraPermissionGate`, so the native media permission request happens
+  /// from the recorder's explicit Continue action rather than from a
+  /// pre-navigation bottom sheet. This method only waits for the bloc to
+  /// resolve out of its initial state so the gate renders the correct screen
+  /// immediately on arrival.
   ///
   /// Returns `true` if navigation occurred.
   Future<bool> pushToCameraWithPermission() async {
@@ -27,88 +31,39 @@ extension CameraPermissionNavigation on BuildContext {
       return true;
     }
 
-    final status = await _resolvePermissionStatus(bloc);
+    await _awaitPermissionResolved(bloc);
     if (!mounted) return false;
 
-    // Couldn't determine status, already authorized, or requiresSettings
-    // → navigate directly (CameraPermissionGate handles the rest)
-    if (status == null ||
-        status == .authorized ||
-        status == .requiresSettings) {
-      await pushWithVideoPause(VideoRecorderScreen.path);
-      return true;
-    }
-
-    // canRequest → show bottom sheet
-    var permissionRequested = false;
-    await VineBottomSheetPrompt.show<void>(
-      context: this,
-      sticker: DivineStickerName.skeletonKey,
-      title: l10n.cameraPermissionAllowAccessTitle,
-      subtitle: l10n.cameraPermissionAllowAccessDescription,
-      primaryButtonText: l10n.cameraPermissionContinue,
-      onPrimaryPressed: () {
-        permissionRequested = true;
-        Navigator.of(this).pop();
-      },
-      secondaryButtonText: l10n.cameraPermissionNotNow,
-      onSecondaryPressed: () => Navigator.of(this).pop(),
-    );
-
-    if (!permissionRequested || !mounted) return false;
-
-    bloc.add(const CameraPermissionRequest());
-    final result = await bloc.stream
-        .firstWhere(
-          (s) =>
-              s is CameraPermissionLoaded ||
-              s is CameraPermissionDenied ||
-              s is CameraPermissionError,
-        )
-        .timeout(
-          const Duration(seconds: 30),
-          onTimeout: () => const CameraPermissionError(),
-        );
-    if (!mounted) return false;
-    if (result is CameraPermissionLoaded &&
-        result.status == CameraPermissionStatus.authorized) {
-      await pushWithVideoPause(VideoRecorderScreen.path);
-      return true;
-    }
-    return false;
+    // Navigate for every resolved status. The route gate renders the
+    // authorized camera, the canRequest prompt, the requiresSettings prompt,
+    // or the loading/error UI, and owns the native permission request.
+    await pushWithVideoPause(VideoRecorderScreen.path);
+    return true;
   }
 }
 
-/// Returns the current permission status, or `null` if it couldn't be
-/// determined (error / denied / unknown).
-Future<CameraPermissionStatus?> _resolvePermissionStatus(
-  CameraPermissionBloc bloc,
-) async {
+/// Waits until the permission bloc has settled out of its initial/loading
+/// state so the recorder gate renders the correct screen on arrival.
+///
+/// Triggers a refresh first when no check has run yet, and falls back after a
+/// timeout so navigation is never blocked on a stream that never emits.
+Future<void> _awaitPermissionResolved(CameraPermissionBloc bloc) async {
   final current = bloc.state;
-  if (current is CameraPermissionLoaded) return current.status;
+  if (current is CameraPermissionLoaded || current is CameraPermissionError) {
+    return;
+  }
 
-  // Already in a terminal state with no pending event — return
-  // immediately instead of waiting on a stream that will never emit.
-  if (current is CameraPermissionDenied) return null;
-  if (current is CameraPermissionError) return null;
-
-  // Not yet loaded — trigger refresh and wait for result.
+  // Not yet loaded — trigger refresh and wait for the result.
   if (current is CameraPermissionInitial) {
     bloc.add(const CameraPermissionRefresh());
   }
 
-  final state = await bloc.stream
+  await bloc.stream
       .firstWhere(
-        (s) =>
-            s is CameraPermissionLoaded ||
-            s is CameraPermissionError ||
-            s is CameraPermissionDenied,
+        (s) => s is CameraPermissionLoaded || s is CameraPermissionError,
       )
       .timeout(
         const Duration(seconds: 10),
         onTimeout: () => const CameraPermissionError(),
       );
-
-  if (state is CameraPermissionLoaded) return state.status;
-  return null;
 }

--- a/mobile/lib/widgets/camera_permission_gate.dart
+++ b/mobile/lib/widgets/camera_permission_gate.dart
@@ -17,11 +17,17 @@ import 'package:unified_logger/unified_logger.dart';
 
 /// A declarative gate widget that handles camera/microphone permissions.
 ///
+/// This gate owns permission prompting: a denied or blocked request keeps the
+/// user here on the matching prompt instead of bouncing back to the feed, so
+/// the native permission dialog only ever fires from the explicit Continue
+/// action below.
+///
 /// Renders appropriate UI based on permission state:
-/// - Loading: Shows camera placeholder with loading indicator
-/// - canRequest: Shows bottom sheet style UI with Continue/Not now buttons
-/// - requiresSettings: Shows bottom sheet style UI with Go to Settings/Not now
+/// - loading: Shows a loading indicator
+/// - canRequest: Shows the prompt with a Continue button that requests access
+/// - requiresSettings: Shows the prompt with a Go to Settings button
 /// - authorized: Renders the [child] (camera screen)
+/// - error: Shows an error screen with a Retry button
 ///
 /// Handles app lifecycle to refresh permissions when returning from background.
 class CameraPermissionGate extends StatefulWidget {
@@ -117,10 +123,6 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
           name: 'CameraPermissionGate',
           category: LogCategory.video,
         );
-        // When user denies native permission dialog, pop back to home
-        if (state is CameraPermissionDenied) {
-          _popBack();
-        }
       },
       builder: (context, state) {
         Log.debug(
@@ -153,7 +155,6 @@ class _CameraPermissionGateState extends State<CameraPermissionGate>
             },
             onClose: _popBack,
           ),
-          CameraPermissionDenied() => const _LoadingIndicator(),
           CameraPermissionLoaded(:final status) => switch (status) {
             CameraPermissionStatus.authorized => widget.child,
             CameraPermissionStatus.canRequest => _PermissionScreen(

--- a/mobile/test/blocs/camera_permission/camera_permission_bloc_test.dart
+++ b/mobile/test/blocs/camera_permission/camera_permission_bloc_test.dart
@@ -102,7 +102,7 @@ void main() {
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Denied] when camera permission denied',
+        'stays on Loaded(canRequest) when camera request stays requestable',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -115,11 +115,21 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        expect: () => [const CameraPermissionDenied()],
+        // Mapped status equals the seeded state, so no new state is emitted —
+        // the gate keeps showing the canRequest prompt for a retry.
+        expect: () => <CameraPermissionState>[],
+        verify: (_) {
+          verify(
+            () => mockPermissionsService.requestCameraPermission(),
+          ).called(1);
+          verifyNever(
+            () => mockPermissionsService.requestMicrophonePermission(),
+          );
+        },
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Denied] when microphone permission denied',
+        'stays on Loaded(canRequest) when microphone request stays requestable',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -135,7 +145,15 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        expect: () => [const CameraPermissionDenied()],
+        expect: () => <CameraPermissionState>[],
+        verify: (_) {
+          verify(
+            () => mockPermissionsService.requestCameraPermission(),
+          ).called(1);
+          verify(
+            () => mockPermissionsService.requestMicrophonePermission(),
+          ).called(1);
+        },
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
@@ -165,7 +183,7 @@ void main() {
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Denied] when camera permission requires settings',
+        'emits Loaded(requiresSettings) when camera permission is blocked',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -178,11 +196,18 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        expect: () => [const CameraPermissionDenied()],
+        expect: () => [
+          const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
+        ],
+        verify: (_) {
+          verifyNever(
+            () => mockPermissionsService.requestMicrophonePermission(),
+          );
+        },
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
-        'emits [Denied] when microphone permission requires settings',
+        'emits Loaded(requiresSettings) when microphone permission is blocked',
         setUp: () {
           when(
             () => mockPermissionsService.requestCameraPermission(),
@@ -198,7 +223,47 @@ void main() {
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
-        expect: () => [const CameraPermissionDenied()],
+        expect: () => [
+          const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
+        ],
+      );
+
+      blocTest<CameraPermissionBloc, CameraPermissionState>(
+        'drops a duplicate request dispatched while one is in flight',
+        setUp: () {
+          when(
+            () => mockPermissionsService.requestCameraPermission(),
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            return PermissionStatus.granted;
+          });
+          when(
+            () => mockPermissionsService.requestMicrophonePermission(),
+          ).thenAnswer((_) async => PermissionStatus.granted);
+          when(
+            () => mockPermissionsService.requestGalleryPermission(),
+          ).thenAnswer((_) async => PermissionStatus.granted);
+        },
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
+        seed: () =>
+            const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        act: (bloc) {
+          bloc
+            ..add(const CameraPermissionRequest())
+            ..add(const CameraPermissionRequest());
+        },
+        wait: const Duration(milliseconds: 20),
+        expect: () => [
+          const CameraPermissionLoaded(CameraPermissionStatus.authorized),
+        ],
+        verify: (_) {
+          verify(
+            () => mockPermissionsService.requestCameraPermission(),
+          ).called(1);
+        },
       );
 
       blocTest<CameraPermissionBloc, CameraPermissionState>(
@@ -289,6 +354,40 @@ void main() {
     });
 
     group('CameraPermissionRefresh', () {
+      blocTest<CameraPermissionBloc, CameraPermissionState>(
+        'drops a duplicate refresh while a permission check is in flight',
+        setUp: () {
+          when(() => mockPermissionsService.checkCameraStatus()).thenAnswer((
+            _,
+          ) async {
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            return PermissionStatus.canRequest;
+          });
+          when(
+            () => mockPermissionsService.checkMicrophoneStatus(),
+          ).thenAnswer((_) async => PermissionStatus.canRequest);
+        },
+        build: () => CameraPermissionBloc(
+          permissionsService: mockPermissionsService,
+          skipMacOSBypass: true,
+        ),
+        act: (bloc) {
+          bloc
+            ..add(const CameraPermissionRefresh())
+            ..add(const CameraPermissionRefresh());
+        },
+        wait: const Duration(milliseconds: 20),
+        expect: () => [
+          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+        ],
+        verify: (_) {
+          verify(() => mockPermissionsService.checkCameraStatus()).called(1);
+          verify(
+            () => mockPermissionsService.checkMicrophoneStatus(),
+          ).called(1);
+        },
+      );
+
       blocTest<CameraPermissionBloc, CameraPermissionState>(
         'emits [Loaded(canRequest)] when permissions can be requested',
         setUp: () {
@@ -549,13 +648,6 @@ void main() {
         );
       },
     );
-
-    test('CameraPermissionDenied instances are equal', () {
-      expect(
-        const CameraPermissionDenied(),
-        equals(const CameraPermissionDenied()),
-      );
-    });
 
     test('CameraPermissionError instances are equal', () {
       expect(

--- a/mobile/test/utils/camera_permission_check_test.dart
+++ b/mobile/test/utils/camera_permission_check_test.dart
@@ -1,12 +1,9 @@
 // ABOUTME: Tests for pushToCameraWithPermission extension on BuildContext
-// ABOUTME: Verifies pre-navigation permission check and bottom sheet flow
+// ABOUTME: Verifies pre-navigation permission checks route to the recorder gate
 
 import 'dart:async';
 
-import 'package:divine_ui/divine_ui.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,100 +14,6 @@ import 'package:openvine/screens/video_recorder_screen.dart';
 import 'package:openvine/utils/camera_permission_check.dart';
 
 import '../helpers/go_router.dart';
-
-// 1×1 transparent PNG for DivineSticker asset loading in tests.
-final _transparentPng = Uint8List.fromList(const <int>[
-  0x89,
-  0x50,
-  0x4e,
-  0x47,
-  0x0d,
-  0x0a,
-  0x1a,
-  0x0a,
-  0x00,
-  0x00,
-  0x00,
-  0x0d,
-  0x49,
-  0x48,
-  0x44,
-  0x52,
-  0x00,
-  0x00,
-  0x00,
-  0x01,
-  0x00,
-  0x00,
-  0x00,
-  0x01,
-  0x08,
-  0x06,
-  0x00,
-  0x00,
-  0x00,
-  0x1f,
-  0x15,
-  0xc4,
-  0x89,
-  0x00,
-  0x00,
-  0x00,
-  0x0a,
-  0x49,
-  0x44,
-  0x41,
-  0x54,
-  0x78,
-  0x9c,
-  0x63,
-  0x00,
-  0x01,
-  0x00,
-  0x00,
-  0x05,
-  0x00,
-  0x01,
-  0x0d,
-  0x0a,
-  0x2d,
-  0xb4,
-  0x00,
-  0x00,
-  0x00,
-  0x00,
-  0x49,
-  0x45,
-  0x4e,
-  0x44,
-  0xae,
-  0x42,
-  0x60,
-  0x82,
-]);
-
-class _TestAssetBundle extends CachingAssetBundle {
-  _TestAssetBundle() {
-    final manifest = <String, List<Map<String, Object>>>{
-      for (final sticker in DivineStickerName.values)
-        sticker.assetPath: [
-          <String, Object>{'asset': sticker.assetPath},
-        ],
-    };
-    _manifest = const StandardMessageCodec().encodeMessage(manifest)!;
-  }
-
-  late final ByteData _manifest;
-  final ByteData _imageData = ByteData.sublistView(_transparentPng);
-
-  @override
-  Future<ByteData> load(String key) {
-    if (key == 'AssetManifest.bin') {
-      return SynchronousFuture<ByteData>(_manifest);
-    }
-    return SynchronousFuture<ByteData>(_imageData);
-  }
-}
 
 class _FakeCameraPermissionBloc extends Fake implements CameraPermissionBloc {
   _FakeCameraPermissionBloc(CameraPermissionState initialState)
@@ -147,11 +50,9 @@ class _FakeCameraPermissionBloc extends Fake implements CameraPermissionBloc {
 
 void main() {
   late MockGoRouter mockGoRouter;
-  late _TestAssetBundle testBundle;
 
   setUp(() {
     mockGoRouter = MockGoRouter();
-    testBundle = _TestAssetBundle();
     when(
       () => mockGoRouter.push<Object?>(any(), extra: any(named: 'extra')),
     ).thenAnswer((_) async => null);
@@ -169,8 +70,6 @@ void main() {
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
             supportedLocales: AppLocalizations.supportedLocales,
-            builder: (context, child) =>
-                DefaultAssetBundle(bundle: testBundle, child: child!),
             home: Scaffold(
               body: Builder(
                 builder: (context) => ElevatedButton(
@@ -290,8 +189,8 @@ void main() {
         await tester.tap(find.text('Trigger'));
         await tester.pump();
 
-        // Stream never emits → 10s timeout fires → status is null
-        // → navigates directly.
+        // Stream never emits → 10s timeout fires → navigates anyway and lets
+        // the gate render the loading/error UI.
         await tester.pump(const Duration(seconds: 11));
         await tester.pumpAndSettle();
 
@@ -330,29 +229,6 @@ void main() {
     });
 
     group('returns immediately for terminal states', () {
-      testWidgets('navigates directly when state is $CameraPermissionDenied', (
-        tester,
-      ) async {
-        final bloc = _FakeCameraPermissionBloc(const CameraPermissionDenied());
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
-        );
-
-        await tester.tap(find.text('Trigger'));
-        await tester.pumpAndSettle();
-
-        verify(
-          () => mockGoRouter.push<Object?>(
-            VideoRecorderScreen.path,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
-        expect(result, isTrue);
-        // Must not have dispatched any events.
-        expect(bloc.addedEvents, isEmpty);
-      });
-
       testWidgets('navigates directly when state is $CameraPermissionError', (
         tester,
       ) async {
@@ -376,144 +252,34 @@ void main() {
       });
     });
 
-    group('shows bottom sheet when canRequest', () {
-      testWidgets('renders prompt with correct content', (tester) async {
-        final bloc = _FakeCameraPermissionBloc(
-          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        );
-        await tester.pumpWidget(buildSubject(bloc));
+    group('routes requestable permissions to the recorder gate', () {
+      testWidgets(
+        'navigates without dispatching $CameraPermissionRequest when canRequest',
+        (tester) async {
+          final bloc = _FakeCameraPermissionBloc(
+            const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
+          );
+          bool? result;
+          await tester.pumpWidget(
+            buildSubject(bloc, onResult: (r) => result = r),
+          );
 
-        await tester.tap(find.text('Trigger'));
-        await tester.pumpAndSettle();
+          await tester.tap(find.text('Trigger'));
+          await tester.pumpAndSettle();
 
-        expect(find.text('Allow camera & microphone access'), findsOneWidget);
-        expect(find.text('Continue'), findsOneWidget);
-        expect(find.text('Not now'), findsOneWidget);
-      });
-
-      testWidgets('navigates after user grants permission', (tester) async {
-        final bloc = _FakeCameraPermissionBloc(
-          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        );
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
-        );
-
-        await tester.tap(find.text('Trigger'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Continue'));
-        await tester.pumpAndSettle();
-
-        bloc.emitState(
-          const CameraPermissionLoaded(CameraPermissionStatus.authorized),
-        );
-        await tester.pumpAndSettle();
-
-        verify(
-          () => mockGoRouter.push<Object?>(
-            VideoRecorderScreen.path,
-            extra: any(named: 'extra'),
-          ),
-        ).called(1);
-        expect(result, isTrue);
-      });
-
-      testWidgets('adds $CameraPermissionRequest after user taps Continue', (
-        tester,
-      ) async {
-        final bloc = _FakeCameraPermissionBloc(
-          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        );
-        await tester.pumpWidget(buildSubject(bloc));
-
-        await tester.tap(find.text('Trigger'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Continue'));
-        await tester.pumpAndSettle();
-
-        expect(bloc.addedEvents, contains(isA<CameraPermissionRequest>()));
-
-        // Unblock the stream wait
-        bloc.emitState(const CameraPermissionDenied());
-        await tester.pumpAndSettle();
-      });
-
-      testWidgets('returns false when permission is denied', (tester) async {
-        final bloc = _FakeCameraPermissionBloc(
-          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        );
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
-        );
-
-        await tester.tap(find.text('Trigger'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Continue'));
-        await tester.pumpAndSettle();
-
-        bloc.emitState(const CameraPermissionDenied());
-        await tester.pumpAndSettle();
-
-        verifyNever(
-          () => mockGoRouter.push<Object?>(any(), extra: any(named: 'extra')),
-        );
-        expect(result, isFalse);
-      });
-
-      testWidgets('returns false when user taps Not now', (tester) async {
-        final bloc = _FakeCameraPermissionBloc(
-          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        );
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
-        );
-
-        await tester.tap(find.text('Trigger'));
-        await tester.pumpAndSettle();
-
-        await tester.tap(find.text('Not now'));
-        await tester.pumpAndSettle();
-
-        verifyNever(
-          () => mockGoRouter.push<Object?>(any(), extra: any(named: 'extra')),
-        );
-        expect(result, isFalse);
-      });
-
-      testWidgets('returns false when permission request times out', (
-        tester,
-      ) async {
-        final bloc = _FakeCameraPermissionBloc(
-          const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
-        );
-        bool? result;
-        await tester.pumpWidget(
-          buildSubject(bloc, onResult: (r) => result = r),
-        );
-
-        await tester.tap(find.text('Trigger'));
-        await tester.pumpAndSettle();
-
-        // Tap Continue to dispatch CameraPermissionRequest.
-        await tester.tap(find.text('Continue'));
-        await tester.pumpAndSettle();
-
-        // Simulate timeout by using fakeAsync elapsed time.
-        // The stream never emits, so the 30 s timeout fires.
-        await tester.pump(const Duration(seconds: 31));
-        await tester.pumpAndSettle();
-
-        verifyNever(
-          () => mockGoRouter.push<Object?>(any(), extra: any(named: 'extra')),
-        );
-        expect(result, isFalse);
-      });
+          verify(
+            () => mockGoRouter.push<Object?>(
+              VideoRecorderScreen.path,
+              extra: any(named: 'extra'),
+            ),
+          ).called(1);
+          expect(
+            bloc.addedEvents,
+            isNot(contains(isA<CameraPermissionRequest>())),
+          );
+          expect(result, isTrue);
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

Splits the **app-layer (recorder-owned) camera permission flow** out of #4029 into its own focused PR, independent of the video-replies feature. The macOS native permission/recording work stays scoped to #4112.

New ownership model: the recorder's `CameraPermissionGate` owns prompting. A denied or blocked request now keeps the user on the gate with the matching prompt (Continue / Go to Settings) instead of silently bouncing back to the feed, and the native dialog only ever fires from the gate's explicit Continue action.

- **`CameraPermissionBloc`**
  - A non-granted camera/microphone request now emits `Loaded(canRequest | requiresSettings)` (mapped via the new `_cameraStatusFromPermission`) instead of the removed `CameraPermissionDenied`.
  - Request/refresh are deduplicated with `droppable()` transformers, replacing the in-flight `bool`/`Future` fields — no mutable coordination state on the bloc (per `state_management.md`). This also removes the multi-reset `_refreshInFlight` lifecycle the issue called out.
  - Desktop (macOS/Linux) refresh bypass left **untouched** — macOS behavior belongs to #4112.
- **`camera_permission_check.dart`** — removed the pre-navigation bottom-sheet prompt; `pushToCameraWithPermission` now just waits for the bloc to settle and routes every status into the gate.
- **State contract made explicit** — deleted the now-dead `CameraPermissionDenied` state and audited/updated every caller (gate listener + builder switch, check util, tests).
- **L10n cleanup** — removed the now-unused `cameraPermissionNotNow` key from all locale ARBs and regenerated localization output.

**Related Issue:** Closes #4113

## Out of Scope

- macOS native camera permission + recording hardening, including removing the macOS refresh bypass (#4112).

## Verification

- `flutter gen-l10n`
- `mise exec -- dart format lib test integration_test` — 0 changed
- `flutter analyze lib test integration_test` — no issues
- `flutter test test/blocs/camera_permission/camera_permission_bloc_test.dart test/utils/camera_permission_check_test.dart test/screens/video_recorder_screen_test.dart` — 65 passed
- pre-push hook analyzer — no issues
- pre-push hook changed-file tests — 43 passed

## Type of Change

- [x] 🧹 Code refactor