### PR TITLE
feat(profile): track original Funnelcake profile event timestamps

### DIFF
--- a/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
+++ b/mobile/packages/funnelcake_api_client/test/src/funnelcake_api_client_test.dart
@@ -3519,7 +3519,8 @@ void main() {
     "display_name": "Test User",
     "about": "A test profile",
     "picture": "https://example.com/avatar.jpg",
-    "nip05": "test@example.com"
+    "nip05": "test@example.com",
+    "profile_updated": "2023-11-14T22:13:20Z"
   }
 }
 ''';
@@ -3534,6 +3535,11 @@ void main() {
         expect(found.profile.pubkey, equals(testPubkey));
         expect(found.profile.name, equals('testuser'));
         expect(found.profile.displayName, equals('Test User'));
+        // The original Nostr Kind 0 timestamp is carried through (#3141).
+        expect(
+          found.profile.createdAt,
+          equals(DateTime.utc(2023, 11, 14, 22, 13, 20)),
+        );
       });
 
       test(

--- a/mobile/packages/models/lib/src/user_profile.dart
+++ b/mobile/packages/models/lib/src/user_profile.dart
@@ -119,6 +119,12 @@ class UserProfile {
   /// future NIP additions) cannot be recovered by this factory and
   /// must be re-seeded by `ProfileRepository.saveProfileEvent` from a
   /// relay query before publishing.
+  ///
+  /// `createdAt` uses the original Kind 0 event timestamp when Funnelcake
+  /// provides one (`UserProfileData.createdAt`), falling back to
+  /// `DateTime.now()` only when it is absent. The real timestamp lets the
+  /// repository run a newest-wins comparison against the local cache instead
+  /// of treating every Funnelcake profile as freshly minted.
   factory UserProfile.fromUserProfileFound(
     UserProfileFound result, {
     String? eventIdPrefix,
@@ -145,7 +151,7 @@ class UserProfile {
       nip05: p.nip05,
       lud16: p.lud16,
       rawData: rawData,
-      createdAt: DateTime.now(),
+      createdAt: p.createdAt ?? DateTime.now(),
       eventId: '${eventIdPrefix ?? 'rest'}-${p.pubkey}',
     );
   }

--- a/mobile/packages/models/lib/src/user_profile_data.dart
+++ b/mobile/packages/models/lib/src/user_profile_data.dart
@@ -44,6 +44,7 @@ class UserProfileData {
     this.website,
     this.nip05,
     this.lud16,
+    this.createdAt,
   });
 
   factory UserProfileData.fromJson(String pubkey, Map<String, dynamic> json) {
@@ -57,6 +58,10 @@ class UserProfileData {
       website: json['website'] as String?,
       nip05: json['nip05'] as String?,
       lud16: json['lud16'] as String?,
+      createdAt: switch (json['profile_updated']) {
+        final String value => DateTime.tryParse(value),
+        _ => null,
+      },
     );
   }
 
@@ -70,6 +75,16 @@ class UserProfileData {
   final String? nip05;
   final String? lud16;
 
+  /// The original Nostr Kind 0 event `created_at`, taken from Funnelcake's
+  /// `profile.profile_updated` field.
+  ///
+  /// Funnelcake derives this directly from the indexed Kind 0 event timestamp
+  /// (newest-wins), so it is a trustworthy original event time rather than a
+  /// service/cache write time. `null` when the API response omits it or the
+  /// value cannot be parsed. Used by `UserProfile.fromUserProfileFound` to
+  /// drive newest-wins cache merges instead of a synthetic `DateTime.now()`.
+  final DateTime? createdAt;
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -82,7 +97,8 @@ class UserProfileData {
         other.banner == banner &&
         other.website == website &&
         other.nip05 == nip05 &&
-        other.lud16 == lud16;
+        other.lud16 == lud16 &&
+        other.createdAt == createdAt;
   }
 
   @override
@@ -96,6 +112,7 @@ class UserProfileData {
     website,
     nip05,
     lud16,
+    createdAt,
   );
 
   @override

--- a/mobile/packages/models/test/src/user_profile_result_test.dart
+++ b/mobile/packages/models/test/src/user_profile_result_test.dart
@@ -37,6 +37,34 @@ void main() {
       expect(data.pubkey, equals(_pubkey));
       expect(data.name, isNull);
       expect(data.displayName, isNull);
+      expect(data.createdAt, isNull);
+    });
+
+    test('fromJson parses profile_updated into createdAt', () {
+      final data = UserProfileData.fromJson(_pubkey, const {
+        'name': 'alice',
+        'profile_updated': '2023-11-14T22:13:20Z',
+      });
+
+      expect(
+        data.createdAt,
+        equals(DateTime.utc(2023, 11, 14, 22, 13, 20)),
+      );
+    });
+
+    test('fromJson leaves createdAt null when profile_updated absent', () {
+      final data = UserProfileData.fromJson(_pubkey, const {'name': 'alice'});
+
+      expect(data.createdAt, isNull);
+    });
+
+    test('fromJson leaves createdAt null when profile_updated unparseable', () {
+      final data = UserProfileData.fromJson(_pubkey, const {
+        'name': 'alice',
+        'profile_updated': 'not-a-date',
+      });
+
+      expect(data.createdAt, isNull);
     });
 
     test('equality', () {
@@ -44,6 +72,19 @@ void main() {
       final b = UserProfileData.fromJson(_pubkey, const {'name': 'alice'});
 
       expect(a, equals(b));
+    });
+
+    test('equality distinguishes createdAt', () {
+      final a = UserProfileData.fromJson(_pubkey, const {
+        'name': 'alice',
+        'profile_updated': '2023-11-14T22:13:20Z',
+      });
+      final b = UserProfileData.fromJson(_pubkey, const {
+        'name': 'alice',
+        'profile_updated': '2024-01-01T00:00:00Z',
+      });
+
+      expect(a, isNot(equals(b)));
     });
   });
 

--- a/mobile/packages/models/test/src/user_profile_test.dart
+++ b/mobile/packages/models/test/src/user_profile_test.dart
@@ -286,6 +286,43 @@ void main() {
         expect(profile.rawData.containsKey('lud16'), isFalse);
         expect(profile.rawData.containsKey('website'), isFalse);
       });
+
+      test('uses the original Kind 0 timestamp when Funnelcake provides '
+          'one (#3141)', () {
+        final original = DateTime.utc(2023, 11, 14, 22, 13, 20);
+        final result = UserProfileFound(
+          profile: UserProfileData(
+            pubkey: testPubkey,
+            displayName: 'Alice',
+            createdAt: original,
+          ),
+        );
+
+        final profile = UserProfile.fromUserProfileFound(result);
+
+        expect(profile.createdAt, equals(original));
+      });
+
+      test('falls back to DateTime.now() when no timestamp is provided', () {
+        const result = UserProfileFound(
+          profile: UserProfileData(pubkey: testPubkey, displayName: 'Alice'),
+        );
+
+        final before = DateTime.now();
+        final profile = UserProfile.fromUserProfileFound(result);
+        final after = DateTime.now();
+
+        expect(
+          profile.createdAt.isBefore(before),
+          isFalse,
+          reason: 'synthetic timestamp should be >= before',
+        );
+        expect(
+          profile.createdAt.isAfter(after),
+          isFalse,
+          reason: 'synthetic timestamp should be <= after',
+        );
+      });
     });
 
     group('fromJson', () {

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -328,14 +328,18 @@ class ProfileRepository {
               // genuinely newer Funnelcake profile can upgrade an older
               // local one (#3141).
               final existing = await _userProfilesDao.getProfile(pubkey);
-              await _cacheProfileIfNewer(funnelcakeProfile);
-              // Return the newest of the two so the caller never sees a
-              // stale Funnelcake copy when the local cache is more recent.
-              if (existing != null &&
-                  existing.createdAt.isAfter(funnelcakeProfile.createdAt)) {
-                return existing;
-              }
-              return funnelcakeProfile;
+              final funnelcakeWon = await _cacheProfileIfNewer(
+                funnelcakeProfile,
+                cached: existing,
+                cachedResolved: true,
+              );
+              // Mirror the cache decision exactly: when the Funnelcake copy
+              // did not win (older-or-equal, so the cache kept `existing`),
+              // return `existing` too. Returning the Funnelcake copy here
+              // would hand the caller a profile that disagrees with the
+              // cache and may be missing fields the local one carries
+              // (lud06, eventId, custom rawData).
+              return funnelcakeWon ? funnelcakeProfile : existing;
             }
 
             // Defensive fallback: a found profile without a parseable
@@ -395,16 +399,33 @@ class ProfileRepository {
     return null;
   }
 
-  Future<void> _cacheProfileIfNewer(UserProfile profile) async {
-    final cachedProfile = await _userProfilesDao.getProfile(profile.pubkey);
+  /// Upserts [profile] into the local cache only when it is strictly newer
+  /// than the currently-cached profile for the same pubkey.
+  ///
+  /// Returns `true` when the cache was written ([profile] won), `false` when
+  /// an existing, newer-or-equal cache entry was kept.
+  ///
+  /// Pass [cached] together with `cachedResolved: true` when the caller has
+  /// already read the current cache entry, to skip a redundant DAO read. A
+  /// `null` [cached] with [cachedResolved] true means "confirmed no local
+  /// profile".
+  Future<bool> _cacheProfileIfNewer(
+    UserProfile profile, {
+    UserProfile? cached,
+    bool cachedResolved = false,
+  }) async {
+    final cachedProfile = cachedResolved
+        ? cached
+        : await _userProfilesDao.getProfile(profile.pubkey);
     if (cachedProfile != null &&
         !profile.createdAt.isAfter(cachedProfile.createdAt)) {
-      return;
+      return false;
     }
 
     _confirmedMissing.remove(profile.pubkey);
     _knownCached.add(profile.pubkey);
     await _userProfilesDao.upsertProfile(profile);
+    return true;
   }
 
   /// Queries connected relays and indexer relays in parallel for a

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -318,25 +318,39 @@ class ProfileRepository {
         switch (result) {
           case UserProfileFound():
             final funnelcakeProfile = UserProfile.fromUserProfileFound(result);
-            // Funnelcake profiles use DateTime.now() as a synthetic
-            // createdAt (the REST API does not expose the Nostr event
-            // timestamp), so _cacheProfileIfNewer cannot reliably guard
-            // against overwriting a freshly-saved bio. Only write to
-            // cache when no local profile exists yet; otherwise fall
+            await _cacheProfileStatsFromResult(pubkey, result);
+
+            if (result.profile.createdAt != null) {
+              // Funnelcake exposes the original Nostr Kind 0 `created_at`
+              // (the `profile.profile_updated` field), so a newest-wins
+              // merge against the local cache is safe — a stale Funnelcake
+              // copy can no longer clobber a freshly-saved bio, and a
+              // genuinely newer Funnelcake profile can upgrade an older
+              // local one (#3141).
+              final existing = await _userProfilesDao.getProfile(pubkey);
+              await _cacheProfileIfNewer(funnelcakeProfile);
+              // Return the newest of the two so the caller never sees a
+              // stale Funnelcake copy when the local cache is more recent.
+              if (existing != null &&
+                  existing.createdAt.isAfter(funnelcakeProfile.createdAt)) {
+                return existing;
+              }
+              return funnelcakeProfile;
+            }
+
+            // Defensive fallback: a found profile without a parseable
+            // timestamp. Keep the conservative behavior — only write to
+            // cache when no local profile exists yet, otherwise fall
             // through to the relay/indexer path so a newer Kind 0 on
             // relays can still upgrade the cache.
             final existing = await _userProfilesDao.getProfile(pubkey);
             if (existing == null) {
               _knownCached.add(pubkey);
               await _userProfilesDao.upsertProfile(funnelcakeProfile);
+              return funnelcakeProfile;
             }
-            await _cacheProfileStatsFromResult(pubkey, result);
-            if (existing != null) {
-              // Local profile exists — skip the early return and let
-              // the relay/indexer path run so a newer Kind 0 can win.
-              break;
-            }
-            return funnelcakeProfile;
+          // Local profile exists — let the relay/indexer path below run
+          // so a newer Kind 0 can still win.
           case UserProfileNotPublished():
             // User exists but has no Kind 0. Cache stats and skip relay
             // fallback — the profile genuinely does not exist yet.

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -893,6 +893,128 @@ void main() {
           expect(result!.about, equals('New bio'));
           expect(result.displayName, equals('New Name'));
         });
+
+        test('returns the richer local profile on a createdAt tie instead of '
+            'the leaner Funnelcake copy (#3141)', () async {
+          // Local cache and Funnelcake share the same Kind 0 timestamp.
+          // _cacheProfileIfNewer keeps the local copy (not strictly newer),
+          // so the return value must match the cache — the richer local
+          // profile, not the leaner Funnelcake one that may omit fields.
+          final localProfile = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Local Name',
+            about: 'Local bio',
+            rawData: const {'display_name': 'Local Name', 'about': 'Local bio'},
+            createdAt: DateTime.utc(2024, 3),
+            eventId: testEventId,
+          );
+
+          final freshDao = MockUserProfilesDao();
+          when(
+            () => freshDao.getProfile(any()),
+          ).thenAnswer((_) async => localProfile);
+          when(() => freshDao.upsertProfile(any())).thenAnswer((_) async {});
+
+          final repo = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: freshDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            profileStatsDao: mockProfileStatsDao,
+          );
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getUserProfile(testPubkey),
+          ).thenAnswer(
+            (_) async => UserProfileFound(
+              profile: UserProfileData.fromJson(testPubkey, const {
+                'display_name': 'Funnelcake Name',
+                'about': 'Funnelcake bio',
+                'profile_updated': '2024-03-01T00:00:00Z', // tie
+              }),
+            ),
+          );
+
+          final result = await repo.fetchFreshProfile(pubkey: testPubkey);
+
+          // Tie is not strictly newer — the cache is untouched.
+          verifyNever(() => freshDao.upsertProfile(any()));
+          // Resolved directly from the cache; no relay fallback.
+          verifyNever(() => mockNostrClient.fetchProfile(any()));
+          // The returned profile is the richer local copy, not Funnelcake's.
+          expect(result, isNotNull);
+          expect(result!.about, equals('Local bio'));
+          expect(result.displayName, equals('Local Name'));
+        });
+
+        test(
+          'keeps the local cache and falls through to relay when a found '
+          'Funnelcake profile carries no timestamp (defensive #3141)',
+          () async {
+            // Funnelcake returns a found profile but omits profile_updated, so
+            // UserProfileData.createdAt is null. With a local profile already
+            // cached, newest-wins cannot be applied, so the conservative path
+            // must run: do NOT overwrite the cache with the timestamp-less
+            // copy, and fall through to the relay/indexer path so a newer
+            // Kind 0 can still win.
+            final localProfile = UserProfile(
+              pubkey: testPubkey,
+              displayName: 'Local Name',
+              about: 'Local bio',
+              rawData: const {
+                'display_name': 'Local Name',
+                'about': 'Local bio',
+              },
+              createdAt: DateTime.utc(2024),
+              eventId: testEventId,
+            );
+
+            final freshDao = MockUserProfilesDao();
+            when(
+              () => freshDao.getProfile(any()),
+            ).thenAnswer((_) async => localProfile);
+            when(() => freshDao.upsertProfile(any())).thenAnswer((_) async {});
+
+            final repo = ProfileRepository(
+              nostrClient: mockNostrClient,
+              userProfilesDao: freshDao,
+              httpClient: mockHttpClient,
+              funnelcakeApiClient: mockFunnelcakeClient,
+              profileStatsDao: mockProfileStatsDao,
+            );
+
+            when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+            when(
+              () => mockFunnelcakeClient.getUserProfile(testPubkey),
+            ).thenAnswer(
+              (_) async => UserProfileFound(
+                profile: UserProfileData.fromJson(testPubkey, const {
+                  'display_name': 'Funnelcake Name',
+                  'about': 'Funnelcake bio',
+                  // No profile_updated → createdAt stays null.
+                }),
+              ),
+            );
+
+            // Relays find nothing newer — the local cache is the fallback.
+            when(
+              () => mockNostrClient.fetchProfile(testPubkey),
+            ).thenAnswer((_) async => null);
+
+            final result = await repo.fetchFreshProfile(pubkey: testPubkey);
+
+            // The timestamp-less Funnelcake copy must not overwrite the cache.
+            verifyNever(() => freshDao.upsertProfile(any()));
+
+            // The relay path must run so a newer Kind 0 can still win.
+            verify(() => mockNostrClient.fetchProfile(testPubkey)).called(1);
+
+            // Relays found nothing newer, so the local cache is returned.
+            expect(result, isNotNull);
+            expect(result!.about, equals('Local bio'));
+          },
+        );
       });
 
       group('indexer relay fallback', () {

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -755,25 +755,18 @@ void main() {
 
         test('does not overwrite a newer locally-cached bio with stale '
             'Funnelcake data (regression: bio appears not to save)', () async {
-          // Simulate: user just saved their bio. The local cache holds
-          // the freshly-published profile (createdAt = 1704153600, newer).
-          // Funnelcake returns a stale cached profile
-          // (createdAt = 1704067200, older). The bio must NOT be
-          // overwritten, the relay path must still run (so a newer Kind 0
-          // on relays can win), and the return value must be the locally
-          // cached profile when relays find nothing newer.
-          const newerTimestamp = 1704153600; // newer — just saved
-          const olderTimestamp = 1704067200; // older — stale Funnelcake cache
-
+          // Simulate: user just saved their bio. The local cache holds the
+          // freshly-published profile (newer). Funnelcake returns a stale
+          // profile carrying its original — older — Kind 0 timestamp
+          // (profile.profile_updated). Newest-wins must keep the local copy:
+          // no overwrite, and the newer local profile is returned (#3141,
+          // follow-up to #3104).
           final freshlySavedProfile = UserProfile(
             pubkey: testPubkey,
             displayName: 'Test User',
             about: 'My new bio',
             rawData: const {'display_name': 'Test User', 'about': 'My new bio'},
-            createdAt: DateTime.fromMillisecondsSinceEpoch(
-              newerTimestamp * 1000,
-              isUtc: true,
-            ),
+            createdAt: DateTime.utc(2024, 1, 2), // newer — just saved
             eventId: testEventId,
           );
 
@@ -801,15 +794,10 @@ void main() {
               profile: UserProfileData.fromJson(testPubkey, const {
                 'display_name': 'Test User',
                 'about': '', // stale — bio not yet indexed by Funnelcake
-                'created_at': olderTimestamp,
+                'profile_updated': '2024-01-01T00:00:00Z', // older
               }),
             ),
           );
-
-          // Relays find nothing newer — the local cache is the fallback.
-          when(
-            () => mockNostrClient.fetchProfile(testPubkey),
-          ).thenAnswer((_) async => null);
 
           final result = await repo.fetchFreshProfile(pubkey: testPubkey);
 
@@ -826,16 +814,84 @@ void main() {
             ),
           );
 
-          // The relay path must have been invoked so a newer Kind 0 can
-          // still win — a future refactor cannot safely turn the Funnelcake
-          // break into an early return while keeping this assertion green.
-          verify(() => mockNostrClient.fetchProfile(testPubkey)).called(1);
+          // Funnelcake now carries the original Kind 0 timestamp, so the
+          // relay fallback is no longer needed to protect a freshly-saved
+          // bio — newest-wins resolves it directly.
+          verifyNever(() => mockNostrClient.fetchProfile(any()));
 
-          // The return value must be the freshly-saved local profile,
-          // not null (the break path falls back to the cache when relays
-          // find nothing).
+          // The newer local profile is returned, not the stale Funnelcake
+          // copy.
           expect(result, isNotNull);
           expect(result!.about, equals('My new bio'));
+        });
+
+        test('updates an older locally-cached profile when Funnelcake has a '
+            'newer one (#3141)', () async {
+          // The local cache holds an older profile. Funnelcake returns a
+          // newer profile carrying a newer original Kind 0 timestamp.
+          // Newest-wins must upsert the Funnelcake copy and return it.
+          final olderLocalProfile = UserProfile(
+            pubkey: testPubkey,
+            displayName: 'Old Name',
+            about: 'Old bio',
+            rawData: const {'display_name': 'Old Name', 'about': 'Old bio'},
+            createdAt: DateTime.utc(2024), // older
+            eventId: testEventId,
+          );
+
+          UserProfile? stored = olderLocalProfile;
+          final freshDao = MockUserProfilesDao();
+          when(
+            () => freshDao.getProfile(any()),
+          ).thenAnswer((_) async => stored);
+          when(() => freshDao.upsertProfile(any())).thenAnswer((
+            invocation,
+          ) async {
+            stored = invocation.positionalArguments.first as UserProfile;
+          });
+
+          final repo = ProfileRepository(
+            nostrClient: mockNostrClient,
+            userProfilesDao: freshDao,
+            httpClient: mockHttpClient,
+            funnelcakeApiClient: mockFunnelcakeClient,
+            profileStatsDao: mockProfileStatsDao,
+          );
+
+          when(() => mockFunnelcakeClient.isAvailable).thenReturn(true);
+          when(
+            () => mockFunnelcakeClient.getUserProfile(testPubkey),
+          ).thenAnswer(
+            (_) async => UserProfileFound(
+              profile: UserProfileData.fromJson(testPubkey, const {
+                'display_name': 'New Name',
+                'about': 'New bio',
+                'profile_updated': '2024-02-01T00:00:00Z', // newer
+              }),
+            ),
+          );
+
+          final result = await repo.fetchFreshProfile(pubkey: testPubkey);
+
+          // The newer Funnelcake profile upgrades the cache.
+          verify(
+            () => freshDao.upsertProfile(
+              any(
+                that: isA<UserProfile>().having(
+                  (p) => p.about,
+                  'about',
+                  equals('New bio'),
+                ),
+              ),
+            ),
+          ).called(1);
+
+          // Resolved directly from Funnelcake; no relay fallback needed.
+          verifyNever(() => mockNostrClient.fetchProfile(any()));
+
+          expect(result, isNotNull);
+          expect(result!.about, equals('New bio'));
+          expect(result.displayName, equals('New Name'));
         });
       });
 


### PR DESCRIPTION
## Description

`ProfileRepository.fetchFreshProfile` previously treated Funnelcake profile data as having a synthetic timestamp (`UserProfile.fromUserProfileFound` always assigned `DateTime.now()`), so Funnelcake profiles were only cached when no local profile existed — avoiding stale overwrites but also blocking Funnelcake from updating an existing local profile with genuinely newer data.

**Confirmed (AC #1):** Funnelcake **does** expose the original Nostr Kind 0 `created_at`, as the `profile.profile_updated` field (RFC3339), on both `GET /api/users/:pubkey` and the bulk endpoint. Verified against `divine-funnelcake`: the field maps `p.created_at AS profile_updated` from `user_profiles_latest_data`, whose `created_at` comes directly from `events_local.created_at WHERE kind = 0`, deduped newest-wins via `ReplacingMergeTree(created_at)`. It is the original event timestamp, not a service/cache time.

### Changes
- **`UserProfileData`**: new nullable `createdAt`, parsed from `profile_updated` (`DateTime.tryParse`), included in `==`/`hashCode`. Both single and bulk profile parsing flow through this.
- **`UserProfile.fromUserProfileFound`**: uses `p.createdAt ?? DateTime.now()` instead of always `DateTime.now()`.
- **`ProfileRepository.fetchFreshProfile`** (`UserProfileFound` case): when a real timestamp is present, runs a newest-wins merge against the local cache and returns the newer of the two. Falls back to the previous conservative behavior (only cache when nothing local exists, otherwise relay/indexer path) only when the timestamp is absent.

### Tests
- Regression: stale Funnelcake profile does **not** overwrite a newer local profile (updated to use the real `profile_updated` field + newest-wins resolution).
- Regression: newer Funnelcake profile **upgrades** an older local profile.
- `UserProfileData` parsing/equality for `profile_updated`, `fromUserProfileFound` timestamp handling, and an end-to-end parse assertion in the Funnelcake client.

All targeted suites pass (models 129, funnelcake_api_client 291, profile_repository 191) and `flutter analyze` is clean.

Follow-up from #3104.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

Closes #3141