### PR TITLE
fix(video-player): bound Android feed ExoPlayer buffers to curb OOM (#3419)

### DIFF
--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -33,6 +33,7 @@ internal class DivineVideoPlayerInstance(
     private val context: Context,
     private val playerId: Int,
     private val playerFactory: ((Context) -> ExoPlayer)? = null,
+    private val bufferProfile: BufferProfile = BufferProfile.FULL,
     private val mainHandler: Handler = Handler(Looper.getMainLooper()),
     private val audioOverlayManagerFactory: (Context) -> AudioOverlayManager = { ctx ->
         AudioOverlayManager(ctx)
@@ -252,7 +253,21 @@ internal class DivineVideoPlayerInstance(
     }
 
     private fun ensurePlayer(): ExoPlayer {
-        return player ?: (playerFactory?.invoke(context) ?: ExoPlayer.Builder(context)
+        return player ?: (playerFactory?.invoke(context) ?: buildDefaultPlayer())
+            .also { newPlayer ->
+                player = newPlayer
+                newPlayer.setSeekParameters(SeekParameters.EXACT)
+                newPlayer.addListener(playerListener)
+                val surface = activeSurface
+                if (surface != null) {
+                    newPlayer.setVideoSurface(surface)
+                    needsSurface = false
+                }
+            }
+    }
+
+    private fun buildDefaultPlayer(): ExoPlayer {
+        val builder = ExoPlayer.Builder(context)
             .setMediaSourceFactory(
                 DefaultMediaSourceFactory(
                     VideoCache.dataSourceFactory(context) { uri: Uri ->
@@ -260,16 +275,13 @@ internal class DivineVideoPlayerInstance(
                     },
                 ),
             )
-            .build()).also { newPlayer ->
-            player = newPlayer
-            newPlayer.setSeekParameters(SeekParameters.EXACT)
-            newPlayer.addListener(playerListener)
-            val surface = activeSurface
-            if (surface != null) {
-                newPlayer.setVideoSurface(surface)
-                needsSurface = false
-            }
+        // The feed keeps several players live on memory-constrained devices,
+        // so cap their read-ahead to avoid ExoPlayer OOM (#3419). Editing
+        // surfaces keep the default unbounded buffering.
+        if (bufferProfile == BufferProfile.FEED) {
+            builder.setLoadControl(FeedLoadControl.build())
         }
+        return builder.build()
     }
 
     internal fun httpHeadersForRequest(url: String): Map<String, String> {

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerPlugin.kt
@@ -137,16 +137,21 @@ class DivineVideoPlayerPlugin : FlutterPlugin, MethodChannel.MethodCallHandler, 
                 // channel name, so the old instance must release them
                 // first to avoid nullifying the new handlers.
                 PlayerRegistry.remove(id)?.dispose()
+                val bufferProfile = BufferProfile.fromWireValue(
+                    call.argument<String>("bufferProfile"),
+                )
                 val instance = DivineVideoPlayerInstance(
                     binding.binaryMessenger,
                     binding.applicationContext,
                     id,
+                    bufferProfile = bufferProfile,
                 )
                 PlayerRegistry.put(id, instance)
 
                 val useTexture = call.argument<Boolean>("useTexture") ?: false
                 DivineVideoPlayerLog.info(
-                    "Player $id created (useTexture=$useTexture)",
+                    "Player $id created " +
+                        "(useTexture=$useTexture, bufferProfile=$bufferProfile)",
                     name = "DivineVideoPlayer.Lifecycle",
                 )
                 if (useTexture) {

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/FeedLoadControl.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/FeedLoadControl.kt
@@ -1,0 +1,57 @@
+package com.divinevideo.divine_video_player
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.LoadControl
+
+/**
+ * Buffering policy applied to a [DivineVideoPlayerInstance]'s ExoPlayer.
+ *
+ * Mirrors the Dart `VideoBufferProfile` enum sent over the platform channel.
+ */
+internal enum class BufferProfile {
+    /** Short-form feed: bounded buffers to protect memory on low-RAM devices. */
+    FEED,
+
+    /** Editing/preview: platform-default (unbounded) buffering. */
+    FULL;
+
+    companion object {
+        /** Maps the Dart wire value; anything unknown falls back to [FULL]. */
+        fun fromWireValue(value: String?): BufferProfile =
+            if (value == "feed") FEED else FULL
+    }
+}
+
+/**
+ * Tightly bounded [LoadControl] for the short-form video feed.
+ *
+ * Divine clips are at most ~6.3 s and the feed keeps up to three players
+ * (prev/current/next) live at once. ExoPlayer's default load control buffers
+ * up to 50 s ahead with an unbounded byte target, so several concurrent feed
+ * players can exhaust a small Java heap and crash with OutOfMemoryError from
+ * inside ExoPlayer's loader (issue #3419). These bounds cap each player's
+ * read-ahead; a whole clip fits well within [TARGET_BUFFER_BYTES].
+ */
+@UnstableApi
+internal object FeedLoadControl {
+    const val MIN_BUFFER_MS = 2_000
+    const val MAX_BUFFER_MS = 10_000
+    const val BUFFER_FOR_PLAYBACK_MS = 1_000
+    const val BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS = 2_000
+    const val TARGET_BUFFER_BYTES = 8 * 1024 * 1024
+
+    fun build(): LoadControl =
+        DefaultLoadControl.Builder()
+            .setBufferDurationsMs(
+                MIN_BUFFER_MS,
+                MAX_BUFFER_MS,
+                BUFFER_FOR_PLAYBACK_MS,
+                BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
+            )
+            // Enforce the byte ceiling as a hard memory cap rather than letting
+            // the time thresholds buffer past it.
+            .setTargetBufferBytes(TARGET_BUFFER_BYTES)
+            .setPrioritizeTimeOverSizeThresholds(false)
+            .build()
+}

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/FeedLoadControlTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/FeedLoadControlTest.kt
@@ -1,0 +1,62 @@
+package com.divinevideo.divine_video_player
+
+import androidx.media3.common.util.UnstableApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Guards the bounded feed buffering policy that protects low-RAM Android
+ * devices from ExoPlayer OOM during feed playback (#3419).
+ */
+@UnstableApi
+class FeedLoadControlTest {
+
+    @Test
+    fun `fromWireValue maps feed to FEED`() {
+        assertEquals(BufferProfile.FEED, BufferProfile.fromWireValue("feed"))
+    }
+
+    @Test
+    fun `fromWireValue maps full to FULL`() {
+        assertEquals(BufferProfile.FULL, BufferProfile.fromWireValue("full"))
+    }
+
+    @Test
+    fun `fromWireValue falls back to FULL for null`() {
+        assertEquals(BufferProfile.FULL, BufferProfile.fromWireValue(null))
+    }
+
+    @Test
+    fun `fromWireValue falls back to FULL for unknown values`() {
+        assertEquals(BufferProfile.FULL, BufferProfile.fromWireValue("nonsense"))
+    }
+
+    @Test
+    fun `build returns a usable LoadControl`() {
+        // DefaultLoadControl.Builder.build() asserts the duration ordering
+        // contract, so a non-null result also proves the constants are valid.
+        assertNotNull(FeedLoadControl.build())
+    }
+
+    @Test
+    fun `buffer durations satisfy the load-control ordering contract`() {
+        assertTrue(FeedLoadControl.MIN_BUFFER_MS <= FeedLoadControl.MAX_BUFFER_MS)
+        assertTrue(
+            FeedLoadControl.BUFFER_FOR_PLAYBACK_MS <= FeedLoadControl.MIN_BUFFER_MS,
+        )
+        assertTrue(
+            FeedLoadControl.BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS <=
+                FeedLoadControl.MIN_BUFFER_MS,
+        )
+    }
+
+    @Test
+    fun `target buffer bytes stay bounded`() {
+        assertTrue(FeedLoadControl.TARGET_BUFFER_BYTES > 0)
+        // A whole ~6.3s clip fits comfortably; keep the per-player heap cap
+        // small enough that several concurrent feed players stay safe.
+        assertTrue(FeedLoadControl.TARGET_BUFFER_BYTES <= 16 * 1024 * 1024)
+    }
+}

--- a/mobile/packages/divine_video_player/lib/divine_video_player.dart
+++ b/mobile/packages/divine_video_player/lib/divine_video_player.dart
@@ -3,5 +3,6 @@ export 'src/divine_video_player_controller.dart';
 export 'src/divine_video_player_widget.dart';
 export 'src/linux/divine_video_player_linux_plugin.dart';
 export 'src/player_error_code.dart';
+export 'src/video_buffer_profile.dart';
 export 'src/video_clip.dart';
 export 'src/video_player_state.dart';

--- a/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
+++ b/mobile/packages/divine_video_player/lib/src/divine_video_player_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:divine_video_player/src/audio_track.dart';
 import 'package:divine_video_player/src/linux/linux_video_player_backend.dart';
+import 'package:divine_video_player/src/video_buffer_profile.dart';
 import 'package:divine_video_player/src/video_clip.dart';
 import 'package:divine_video_player/src/video_player_state.dart';
 import 'package:divine_video_player/src/web/web_video_player_backend.dart';
@@ -46,9 +47,16 @@ class DivineVideoPlayerController {
   /// players coexist and a sibling decoder is released (the feed flicker).
   /// Use it for screens that render many players at once. No effect on
   /// iOS/macOS. Defaults to `false`.
+  ///
+  /// [bufferProfile] caps how much media each native player buffers into
+  /// memory. Defaults to [VideoBufferProfile.full] (platform defaults);
+  /// short-form many-player surfaces like the feed should pass
+  /// [VideoBufferProfile.feed] to bound per-player heap use. Only Android
+  /// acts on it today. See [VideoBufferProfile].
   DivineVideoPlayerController({
     this.useTexture = false,
     this.useLegacySurface = false,
+    this.bufferProfile = VideoBufferProfile.full,
   }) {
     _ensureNativeLogHandler();
   }
@@ -110,6 +118,10 @@ class DivineVideoPlayerController {
   /// Whether to use the legacy Android `SurfaceTextureEntry` backend
   /// instead of `SurfaceProducer`. See the constructor docs.
   final bool useLegacySurface;
+
+  /// How aggressively the native player buffers media into memory.
+  /// See the constructor docs and [VideoBufferProfile].
+  final VideoBufferProfile bufferProfile;
 
   static const _globalChannel = MethodChannel('divine_video_player');
 
@@ -360,6 +372,7 @@ class DivineVideoPlayerController {
           'id': _playerId,
           'useTexture': useTexture,
           'useLegacySurface': useLegacySurface,
+          'bufferProfile': bufferProfile.wireValue,
         },
       );
       if (useTexture && result != null) {

--- a/mobile/packages/divine_video_player/lib/src/video_buffer_profile.dart
+++ b/mobile/packages/divine_video_player/lib/src/video_buffer_profile.dart
@@ -1,0 +1,22 @@
+/// How aggressively a native player buffers media into memory.
+///
+/// Each native ExoPlayer keeps its read-ahead buffer on the Java heap, so on
+/// memory-constrained Android devices several concurrent players can exhaust
+/// the heap and crash with an `OutOfMemoryError` from inside ExoPlayer's load
+/// control. The profile lets short-form, many-player surfaces cap that buffer
+/// while long-form editing surfaces keep the generous platform defaults.
+///
+/// Only Android acts on this today; other platforms manage their own
+/// buffering and ignore it.
+enum VideoBufferProfile {
+  /// Short-form feed playback: several players coexist, clips are seconds
+  /// long, so each player uses a tightly bounded buffer to protect memory.
+  feed,
+
+  /// Editing/preview playback: a single player loads longer or scrubbable
+  /// content, so it keeps the platform's default (unbounded) buffering.
+  full;
+
+  /// Stable wire value sent across the platform channel.
+  String get wireValue => name;
+}

--- a/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
+++ b/mobile/packages/divine_video_player/test/src/divine_video_player_controller_test.dart
@@ -224,6 +224,36 @@ void main() {
         },
       );
 
+      test(
+        'passes default bufferProfile full through create',
+        () async {
+          await initController();
+
+          expect(globalCalls, hasLength(1));
+          expect(
+            globalCalls.first.arguments,
+            containsPair('bufferProfile', VideoBufferProfile.full.wireValue),
+          );
+        },
+      );
+
+      test(
+        'passes explicit bufferProfile feed through create',
+        () async {
+          controller = DivineVideoPlayerController(
+            bufferProfile: VideoBufferProfile.feed,
+          );
+
+          await initController();
+
+          expect(globalCalls, hasLength(1));
+          expect(
+            globalCalls.first.arguments,
+            containsPair('bufferProfile', VideoBufferProfile.feed.wireValue),
+          );
+        },
+      );
+
       test('throws StateError if called twice', () async {
         await initController();
 

--- a/mobile/packages/divine_video_player/test/src/video_buffer_profile_test.dart
+++ b/mobile/packages/divine_video_player/test/src/video_buffer_profile_test.dart
@@ -1,0 +1,21 @@
+import 'package:divine_video_player/divine_video_player.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(VideoBufferProfile, () {
+    group('wireValue', () {
+      // These literals are the cross-language contract with the native side:
+      // Kotlin's BufferProfile.fromWireValue hardcodes "feed", so a rename of
+      // the Dart enum value would silently fall back to FULL buffering on
+      // Android and re-introduce the feed OOM (#3419). Pin the strings here so
+      // such a rename breaks this test instead of slipping through.
+      test('maps feed to the stable "feed" wire string', () {
+        expect(VideoBufferProfile.feed.wireValue, equals('feed'));
+      });
+
+      test('maps full to the stable "full" wire string', () {
+        expect(VideoBufferProfile.full.wireValue, equals('full'));
+      });
+    });
+  });
+}

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1020,6 +1020,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     final controller = DivineVideoPlayerController(
       useTexture: true,
       useLegacySurface: true,
+      // Up to three feed players stay live at once; bound each one's native
+      // read-ahead buffer so short-form playback doesn't OOM on low-RAM
+      // Android devices (#3419).
+      bufferProfile: VideoBufferProfile.feed,
     );
     _controllers[index] = controller;
 


### PR DESCRIPTION
## Description

On low-RAM Android devices the feed crashes with `OutOfMemoryError` from
inside ExoPlayer's loader (`shouldContinueLoading`). Each native ExoPlayer
keeps its read-ahead buffer on the Java heap, and the default load control
buffers up to ~50s ahead with an unbounded byte target. The feed keeps up
to three players (prev/current/next) live at once, so the combined buffers
exhaust a small heap (the sample crash device caps at a 256&nbsp;MB growth
limit).

This threads a `VideoBufferProfile` (`feed` / `full`) from the Dart
`DivineVideoPlayerController` through the `create` channel call to the
native player:

- **`feed`** → a tightly bounded `DefaultLoadControl` (max 10s / 8&nbsp;MB
  target per player). Our clips are ≤ 6.3s, so a whole clip still fits
  comfortably within the byte cap.
- **`full`** (the default) → platform-default buffering, unchanged. Editing
  and preview surfaces keep this so users can still load longer, scrubbable
  content there.

Only the feed opts into `feed`; every other caller keeps the default, so
behavior is unchanged outside the feed. Android is the only platform that
acts on the profile today (the issue is `android-only`); other platforms
ignore the extra `create` arg.

**Related Issue:** Related to #3419

## Out of Scope

- Closing #3419 — its acceptance criterion is post-release Crashlytics
  confirmation that `f649daf8de6690f190b6bb2f9df879b3` stops receiving
  events. This PR is a code-level mitigation; leave the issue open until
  that is verified in production.
- Reducing concurrent player count further on low-memory devices — the
  June change `e1f9f343f` already releases backgrounded home-feed
  neighbours; this PR is the complementary per-player heap cap.

## Verification

- `flutter analyze` (`divine_video_player`, `infinite_video_feed`) — no issues
- `flutter test` (`divine_video_player`) — 72/72 pass, incl. new
  `bufferProfile` create-passthrough tests
- `gradle :divine_video_player:testDebugUnitTest` — BUILD SUCCESSFUL;
  new `FeedLoadControlTest` 7/7, `DivineVideoPlayerInstanceTest` 23/23,
  all others green
- `dart format --set-exit-if-changed` clean on all changed Dart files

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
