### PR TITLE
fix(macos): drive camera and microphone permissions through native AVFoundation

### DIFF
--- a/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
+++ b/mobile/lib/blocs/camera_permission/camera_permission_bloc.dart
@@ -31,9 +31,9 @@ class CameraPermissionBloc
     extends Bloc<CameraPermissionEvent, CameraPermissionState> {
   CameraPermissionBloc({
     required PermissionsService permissionsService,
-    @visibleForTesting bool? skipMacOSBypass,
+    @visibleForTesting bool? skipLinuxBypass,
   }) : _permissionsService = permissionsService,
-       _skipMacOSBypass = skipMacOSBypass ?? false,
+       _skipLinuxBypass = skipLinuxBypass ?? false,
        super(const CameraPermissionInitial()) {
     on<CameraPermissionRequest>(_onRequest, transformer: droppable());
     on<CameraPermissionRefresh>(_onRefresh, transformer: droppable());
@@ -41,7 +41,7 @@ class CameraPermissionBloc
   }
 
   final PermissionsService _permissionsService;
-  final bool _skipMacOSBypass;
+  final bool _skipLinuxBypass;
 
   Future<void> _onRequest(
     CameraPermissionRequest event,
@@ -73,9 +73,7 @@ class CameraPermissionBloc
 
       if (microphoneStatus != PermissionStatus.granted) {
         emit(
-          CameraPermissionLoaded(
-            _cameraStatusFromPermission(microphoneStatus),
-          ),
+          CameraPermissionLoaded(_cameraStatusFromPermission(microphoneStatus)),
         );
         return;
       }
@@ -102,15 +100,13 @@ class CameraPermissionBloc
     );
 
     // Linux has no camera support yet, so permissions are irrelevant and we
-    // assume authorized. macOS permission behavior is tracked separately in
-    // #4112; this refactor intentionally leaves the desktop bypass untouched.
+    // assume authorized. macOS now goes through the real permission check
+    // backed by the native AVFoundation channel (see PermissionsService).
     if (!kIsWeb &&
-        (defaultTargetPlatform == TargetPlatform.macOS ||
-            defaultTargetPlatform == TargetPlatform.linux) &&
-        !_skipMacOSBypass) {
+        defaultTargetPlatform == TargetPlatform.linux &&
+        !_skipLinuxBypass) {
       Log.info(
-        '🔐 Desktop detected - bypassing permission_handler, '
-        'assuming authorized',
+        '🔐 Linux detected - bypassing permission check, assuming authorized',
         name: 'CameraPermissionBloc',
         category: LogCategory.video,
       );

--- a/mobile/macos/NativeCameraPlugin.swift
+++ b/mobile/macos/NativeCameraPlugin.swift
@@ -112,10 +112,11 @@ public class NativeCameraPlugin: NSObject, FlutterPlugin {
 
     private func openSystemSettings(result: @escaping FlutterResult) {
         // The app only appears in the Privacy pane after it has requested
-        // camera access at least once.
+        // media access at least once.
+        let privacyPane = Self.settingsPrivacyPane()
         if let url = URL(
             string:
-                "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+                "x-apple.systempreferences:com.apple.preference.security?\(privacyPane)"
         ) {
             NSWorkspace.shared.open(url)
             result(true)
@@ -139,5 +140,19 @@ public class NativeCameraPlugin: NSObject, FlutterPlugin {
             )
             result(false)
         }
+    }
+
+    private static func settingsPrivacyPane() -> String {
+        let cameraStatus = AVCaptureDevice.authorizationStatus(for: .video)
+        if cameraStatus == .denied || cameraStatus == .restricted {
+            return "Privacy_Camera"
+        }
+
+        let microphoneStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+        if microphoneStatus == .denied || microphoneStatus == .restricted {
+            return "Privacy_Microphone"
+        }
+
+        return "Privacy_Camera"
     }
 }

--- a/mobile/macos/NativeCameraPlugin.swift
+++ b/mobile/macos/NativeCameraPlugin.swift
@@ -1,13 +1,26 @@
-// ABOUTME: Native macOS camera permission handling using AVFoundation
-// ABOUTME: Provides camera permission checks and system settings navigation
+// ABOUTME: Native macOS camera/microphone permission handling using AVFoundation
+// ABOUTME: Exposes explicit camera and microphone request/status methods to Dart
 
-import FlutterMacOS
 import AVFoundation
+import FlutterMacOS
 import Foundation
+import os
 
+/// Bridges macOS media permissions to Dart.
+///
+/// `permission_handler` does not drive the AVFoundation authorization dialog
+/// reliably on macOS, so the recorder permission flow routes camera and
+/// microphone checks/requests through this plugin instead. Each method returns
+/// a lowercase status string (`authorized`, `denied`, `restricted`,
+/// `notDetermined`, `unknown`) that the Dart side maps to its domain status.
 public class NativeCameraPlugin: NSObject, FlutterPlugin {
+    private static let logger = Logger(
+        subsystem: "com.nostrvine.nostrvineApp",
+        category: "NativeCamera"
+    )
+
     private var methodChannel: FlutterMethodChannel?
-    
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
             name: "openvine/native_camera",
@@ -17,123 +30,114 @@ public class NativeCameraPlugin: NSObject, FlutterPlugin {
         instance.methodChannel = channel
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
-    
-    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        print("🔵 [NativeCamera] Method called: \(call.method)")
-        print("🔵 [NativeCamera] Current thread: \(Thread.current)")
-        print("🔵 [NativeCamera] Is main thread: \(Thread.isMainThread)")
-        
+
+    public func handle(
+        _ call: FlutterMethodCall,
+        result: @escaping FlutterResult
+    ) {
+        Self.logger.debug("Method called: \(call.method, privacy: .public)")
+
         switch call.method {
-        case "requestPermission":
-            print("🔵 [NativeCamera] Handling requestPermission request")
-            requestPermission(result: result)
-        case "hasPermission":
-            print("🔵 [NativeCamera] Handling hasPermission request")
-            hasPermission(result: result)
+        case "requestCameraPermission":
+            requestPermission(for: .video, result: result)
+        case "requestMicrophonePermission":
+            requestPermission(for: .audio, result: result)
+        case "cameraPermissionStatus":
+            permissionStatus(for: .video, result: result)
+        case "microphonePermissionStatus":
+            permissionStatus(for: .audio, result: result)
         case "openSystemSettings":
-            print("🔵 [NativeCamera] Handling openSystemSettings request")
             openSystemSettings(result: result)
         default:
-            print("❌ [NativeCamera] Unknown method: \(call.method)")
+            Self.logger.error(
+                "Unknown method: \(call.method, privacy: .public)"
+            )
             result(FlutterMethodNotImplemented)
         }
     }
-    
-    private func requestPermission(result: @escaping FlutterResult) {
-        print("🔵 [NativeCamera] Requesting camera permission explicitly")
-        let currentStatus = AVCaptureDevice.authorizationStatus(for: .video)
-        print("🔵 [NativeCamera] Current status before request: \(currentStatus.rawValue)")
-        
+
+    private func requestPermission(
+        for mediaType: AVMediaType,
+        result: @escaping FlutterResult
+    ) {
+        let currentStatus = AVCaptureDevice.authorizationStatus(for: mediaType)
+
         switch currentStatus {
-        case .authorized:
-            print("✅ [NativeCamera] Permission already granted")
+        case .authorized, .denied, .restricted:
+            // Already resolved — report the current status so the gate can
+            // re-prompt or send the user to System Settings as appropriate.
             DispatchQueue.main.async {
-                result(true)
+                result(Self.statusString(currentStatus))
             }
-            
-        case .denied, .restricted:
-            print("❌ [NativeCamera] Permission previously denied or restricted")
-            print("💡 [NativeCamera] User must enable camera in System Settings")
-            
-            // Return error with instruction to open settings
-            DispatchQueue.main.async {
-                result(FlutterError(
-                    code: "PERMISSION_DENIED",
-                    message: "Camera permission denied. Please enable camera access in System Settings > Privacy & Security > Camera",
-                    details: ["openSettings": true, "status": currentStatus.rawValue]
-                ))
-            }
-            
         case .notDetermined:
-            print("🔵 [NativeCamera] Permission not determined, requesting...")
-            AVCaptureDevice.requestAccess(for: .video) { granted in
-                print("🔵 [NativeCamera] Permission request completed with result: \(granted)")
-                let newStatus = AVCaptureDevice.authorizationStatus(for: .video)
-                print("🔵 [NativeCamera] New status after request: \(newStatus.rawValue)")
-                
+            AVCaptureDevice.requestAccess(for: mediaType) { _ in
+                let newStatus = AVCaptureDevice.authorizationStatus(
+                    for: mediaType
+                )
                 DispatchQueue.main.async {
-                    result(granted)
+                    result(Self.statusString(newStatus))
                 }
             }
-            
         @unknown default:
-            print("⚠️ [NativeCamera] Unknown permission status")
             DispatchQueue.main.async {
-                result(FlutterError(
-                    code: "PERMISSION_UNKNOWN",
-                    message: "Unknown camera permission status",
-                    details: nil
-                ))
+                result(Self.statusString(currentStatus))
             }
         }
     }
-    
-    private func hasPermission(result: @escaping FlutterResult) {
-        let status = AVCaptureDevice.authorizationStatus(for: .video)
-        print("🔵 [NativeCamera] Checking permission status: \(status.rawValue)")
-        print("🔵 [NativeCamera] Status meanings: 0=notDetermined, 1=restricted, 2=denied, 3=authorized")
-        result(status == .authorized)
+
+    private func permissionStatus(
+        for mediaType: AVMediaType,
+        result: @escaping FlutterResult
+    ) {
+        let status = AVCaptureDevice.authorizationStatus(for: mediaType)
+        result(Self.statusString(status))
     }
-    
+
+    private static func statusString(
+        _ status: AVAuthorizationStatus
+    ) -> String {
+        switch status {
+        case .authorized:
+            return "authorized"
+        case .denied:
+            return "denied"
+        case .restricted:
+            return "restricted"
+        case .notDetermined:
+            return "notDetermined"
+        @unknown default:
+            return "unknown"
+        }
+    }
+
     private func openSystemSettings(result: @escaping FlutterResult) {
-        print("🔵 [NativeCamera] Opening System Settings for camera privacy")
-        
-        // On macOS 13+ (Ventura), we need to use a different approach
-        // The app only appears in Settings after it has requested camera access at least once
-        
-        // Try modern approach first (macOS 13+)
-        if #available(macOS 13.0, *) {
-            // Modern URL scheme for System Settings
-            if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera") {
-                NSWorkspace.shared.open(url)
-                print("✅ [NativeCamera] System Settings opened (macOS 13+)")
-                result(true)
-                return
-            }
-        }
-        
-        // Fallback to older approach (macOS 12 and below)
-        // Note: This opens System Preferences, not System Settings
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera") {
+        // The app only appears in the Privacy pane after it has requested
+        // camera access at least once.
+        if let url = URL(
+            string:
+                "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera"
+        ) {
             NSWorkspace.shared.open(url)
-            print("✅ [NativeCamera] System Preferences opened (macOS 12-)") 
             result(true)
-        } else {
-            print("❌ [NativeCamera] Failed to create settings URL")
-            
-            // Last resort: Just open the Privacy & Security pane
-            let task = Process()
-            task.launchPath = "/usr/bin/open"
-            task.arguments = ["-b", "com.apple.systempreferences", "/System/Library/PreferencePanes/Security.prefPane"]
-            
-            do {
-                try task.run()
-                print("✅ [NativeCamera] Opened Security pane via command line")
-                result(true)
-            } catch {
-                print("❌ [NativeCamera] Failed to open settings: \(error)")
-                result(false)
-            }
+            return
+        }
+
+        let task = Process()
+        task.launchPath = "/usr/bin/open"
+        task.arguments = [
+            "-b", "com.apple.systempreferences",
+            "/System/Library/PreferencePanes/Security.prefPane",
+        ]
+
+        do {
+            try task.run()
+            result(true)
+        } catch {
+            let message = error.localizedDescription
+            Self.logger.error(
+                "Failed to open System Settings: \(message, privacy: .public)"
+            )
+            result(false)
         }
     }
 }

--- a/mobile/macos/Runner/DebugProfile.entitlements
+++ b/mobile/macos/Runner/DebugProfile.entitlements
@@ -30,6 +30,8 @@
 	<true/>
 	<key>com.apple.security.cs.disable-executable-page-protection</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 	<key>com.apple.security.photos.library.add-only</key>
 	<true/>
 </dict>

--- a/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
+++ b/mobile/packages/divine_camera/macos/Classes/CameraController+Recording.swift
@@ -27,6 +27,11 @@ extension CameraController {
         videoOutputQueue.async { [weak self] in
             guard let self = self else { return }
 
+            // Guard against the first-sample-buffer race (#4112): refuse to
+            // start the writer until the capture delegate has delivered a
+            // preview frame. Dimensions below come from the device's active
+            // format (always available), not the latest buffer, so this guard
+            // is the only thing gating record-start on the first frame.
             guard self.hasReceivedPreviewFrame() else {
                 self.disableAutoFlash()
                 DispatchQueue.main.async {

--- a/mobile/packages/permissions_service/lib/src/permission_handler_permissions_service.dart
+++ b/mobile/packages/permissions_service/lib/src/permission_handler_permissions_service.dart
@@ -1,6 +1,7 @@
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform, kIsWeb;
+import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:permission_handler/permission_handler.dart' as ph;
 import 'package:permissions_service/src/models/models.dart';
@@ -26,8 +27,19 @@ class PermissionHandlerPermissionsService implements PermissionsService {
   /// {@macro permission_handler_permissions_service}
   const PermissionHandlerPermissionsService();
 
+  static const MethodChannel _nativeCameraChannel = MethodChannel(
+    'openvine/native_camera',
+  );
+
   @override
   Future<PermissionStatus> checkCameraStatus() async {
+    if (_usesMacOSNativeMediaPermissions) {
+      final status = await _nativeCameraChannel.invokeMethod<String>(
+        'cameraPermissionStatus',
+      );
+      return mapMacOSAuthorizationStatus(status);
+    }
+
     // coverage:ignore-start
     final status = await ph.Permission.camera.status;
     return mapPermissionStatus(status);
@@ -36,6 +48,13 @@ class PermissionHandlerPermissionsService implements PermissionsService {
 
   @override
   Future<PermissionStatus> requestCameraPermission() async {
+    if (_usesMacOSNativeMediaPermissions) {
+      final status = await _nativeCameraChannel.invokeMethod<String>(
+        'requestCameraPermission',
+      );
+      return mapMacOSAuthorizationStatus(status);
+    }
+
     // coverage:ignore-start
     final status = await ph.Permission.camera.request();
     return mapPermissionStatus(status);
@@ -44,6 +63,13 @@ class PermissionHandlerPermissionsService implements PermissionsService {
 
   @override
   Future<PermissionStatus> checkMicrophoneStatus() async {
+    if (_usesMacOSNativeMediaPermissions) {
+      final status = await _nativeCameraChannel.invokeMethod<String>(
+        'microphonePermissionStatus',
+      );
+      return mapMacOSAuthorizationStatus(status);
+    }
+
     // coverage:ignore-start
     final status = await ph.Permission.microphone.status;
     return mapPermissionStatus(status);
@@ -52,6 +78,13 @@ class PermissionHandlerPermissionsService implements PermissionsService {
 
   @override
   Future<PermissionStatus> requestMicrophonePermission() async {
+    if (_usesMacOSNativeMediaPermissions) {
+      final status = await _nativeCameraChannel.invokeMethod<String>(
+        'requestMicrophonePermission',
+      );
+      return mapMacOSAuthorizationStatus(status);
+    }
+
     // coverage:ignore-start
     final status = await ph.Permission.microphone.request();
     return mapPermissionStatus(status);
@@ -139,4 +172,22 @@ class PermissionHandlerPermissionsService implements PermissionsService {
 
     return PermissionStatus.canRequest;
   }
+
+  /// Maps a macOS AVFoundation authorization status string (as returned by
+  /// `NativeCameraPlugin`) to our domain [PermissionStatus].
+  ///
+  /// `denied`/`restricted` require a System Settings trip on macOS; an
+  /// unknown or `notDetermined` status is still requestable.
+  @visibleForTesting
+  @internal
+  PermissionStatus mapMacOSAuthorizationStatus(String? status) {
+    return switch (status) {
+      'authorized' => PermissionStatus.granted,
+      'denied' || 'restricted' => PermissionStatus.requiresSettings,
+      _ => PermissionStatus.canRequest,
+    };
+  }
+
+  bool get _usesMacOSNativeMediaPermissions =>
+      !kIsWeb && defaultTargetPlatform == TargetPlatform.macOS;
 }

--- a/mobile/packages/permissions_service/lib/src/permission_handler_permissions_service.dart
+++ b/mobile/packages/permissions_service/lib/src/permission_handler_permissions_service.dart
@@ -92,9 +92,18 @@ class PermissionHandlerPermissionsService implements PermissionsService {
   }
 
   @override
-  // coverage:ignore-start
-  Future<bool> openAppSettings() => ph.openAppSettings();
-  // coverage:ignore-end
+  Future<bool> openAppSettings() async {
+    if (_usesMacOSNativeMediaPermissions) {
+      final opened = await _nativeCameraChannel.invokeMethod<bool>(
+        'openSystemSettings',
+      );
+      return opened ?? false;
+    }
+
+    // coverage:ignore-start
+    return ph.openAppSettings();
+    // coverage:ignore-end
+  }
 
   @override
   Future<PermissionStatus> checkGalleryStatus() async {

--- a/mobile/packages/permissions_service/test/src/permissions_service_test.dart
+++ b/mobile/packages/permissions_service/test/src/permissions_service_test.dart
@@ -1,6 +1,8 @@
 // Not required for test files where we want to test non-const constructors
 // ignore_for_file: prefer_const_constructors
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:permission_handler/permission_handler.dart' as ph;
@@ -12,6 +14,8 @@ import 'package:permissions_service/permissions_service.dart';
 class MockPermissionsService extends Mock implements PermissionsService {}
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('PermissionStatus', () {
     test('has expected values', () {
       expect(PermissionStatus.values, hasLength(3));
@@ -30,15 +34,21 @@ void main() {
       service = PermissionHandlerPermissionsService();
     });
 
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            const MethodChannel('openvine/native_camera'),
+            null,
+          );
+    });
+
     test('can be instantiated', () {
       expect(PermissionHandlerPermissionsService(), isNotNull);
     });
 
     test('is a PermissionsService', () {
-      expect(
-        PermissionHandlerPermissionsService(),
-        isA<PermissionsService>(),
-      );
+      expect(PermissionHandlerPermissionsService(), isA<PermissionsService>());
     });
 
     group('mapPermissionStatus', () {
@@ -79,6 +89,115 @@ void main() {
         );
         expect(result, PermissionStatus.canRequest);
       });
+    });
+
+    group('mapMacOSAuthorizationStatus', () {
+      test('maps authorized to PermissionStatus.granted', () {
+        expect(
+          service.mapMacOSAuthorizationStatus('authorized'),
+          PermissionStatus.granted,
+        );
+      });
+
+      test('maps denied to PermissionStatus.requiresSettings', () {
+        expect(
+          service.mapMacOSAuthorizationStatus('denied'),
+          PermissionStatus.requiresSettings,
+        );
+      });
+
+      test('maps restricted to PermissionStatus.requiresSettings', () {
+        expect(
+          service.mapMacOSAuthorizationStatus('restricted'),
+          PermissionStatus.requiresSettings,
+        );
+      });
+
+      test('maps notDetermined to PermissionStatus.canRequest', () {
+        expect(
+          service.mapMacOSAuthorizationStatus('notDetermined'),
+          PermissionStatus.canRequest,
+        );
+      });
+
+      test('maps null/unknown to PermissionStatus.canRequest', () {
+        expect(
+          service.mapMacOSAuthorizationStatus(null),
+          PermissionStatus.canRequest,
+        );
+        expect(
+          service.mapMacOSAuthorizationStatus('unknown'),
+          PermissionStatus.canRequest,
+        );
+      });
+    });
+
+    group('macOS native permissions', () {
+      void mockNativeCamera(Future<Object?>? Function(MethodCall) handler) {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+              const MethodChannel('openvine/native_camera'),
+              handler,
+            );
+      }
+
+      test('checkCameraStatus routes through the native channel', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        mockNativeCamera((call) async {
+          expect(call.method, 'cameraPermissionStatus');
+          return 'denied';
+        });
+
+        expect(
+          await service.checkCameraStatus(),
+          PermissionStatus.requiresSettings,
+        );
+      });
+
+      test(
+        'requestCameraPermission routes through the native channel',
+        () async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+          mockNativeCamera((call) async {
+            expect(call.method, 'requestCameraPermission');
+            return 'authorized';
+          });
+
+          expect(
+            await service.requestCameraPermission(),
+            PermissionStatus.granted,
+          );
+        },
+      );
+
+      test('checkMicrophoneStatus routes through the native channel', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        mockNativeCamera((call) async {
+          expect(call.method, 'microphonePermissionStatus');
+          return 'restricted';
+        });
+
+        expect(
+          await service.checkMicrophoneStatus(),
+          PermissionStatus.requiresSettings,
+        );
+      });
+
+      test(
+        'requestMicrophonePermission routes through the native channel',
+        () async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+          mockNativeCamera((call) async {
+            expect(call.method, 'requestMicrophonePermission');
+            return 'authorized';
+          });
+
+          expect(
+            await service.requestMicrophonePermission(),
+            PermissionStatus.granted,
+          );
+        },
+      );
     });
   });
 

--- a/mobile/packages/permissions_service/test/src/permissions_service_test.dart
+++ b/mobile/packages/permissions_service/test/src/permissions_service_test.dart
@@ -198,6 +198,26 @@ void main() {
           );
         },
       );
+
+      test('openAppSettings routes through the native channel', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        mockNativeCamera((call) async {
+          expect(call.method, 'openSystemSettings');
+          return true;
+        });
+
+        expect(await service.openAppSettings(), isTrue);
+      });
+
+      test('openAppSettings handles null native channel results', () async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        mockNativeCamera((call) async {
+          expect(call.method, 'openSystemSettings');
+          return null;
+        });
+
+        expect(await service.openAppSettings(), isFalse);
+      });
     });
   });
 

--- a/mobile/test/blocs/camera_permission/camera_permission_bloc_test.dart
+++ b/mobile/test/blocs/camera_permission/camera_permission_bloc_test.dart
@@ -1,4 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/camera_permission/camera_permission_bloc.dart';
@@ -12,6 +13,10 @@ void main() {
 
     setUp(() {
       mockPermissionsService = _MockPermissionsService();
+    });
+
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
     });
 
     group('initial state', () {
@@ -28,7 +33,7 @@ void main() {
         'does nothing when state is CameraPermissionInitial',
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
         expect: () => <CameraPermissionState>[],
@@ -38,7 +43,7 @@ void main() {
         'does nothing when state is CameraPermissionLoading',
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () => const CameraPermissionLoading(),
         act: (bloc) => bloc.add(const CameraPermissionRequest()),
@@ -49,7 +54,7 @@ void main() {
         'does nothing when status is authorized',
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.authorized),
@@ -64,7 +69,7 @@ void main() {
         'does nothing when status is requiresSettings',
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () => const CameraPermissionLoaded(
           CameraPermissionStatus.requiresSettings,
@@ -91,7 +96,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -110,7 +115,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -140,7 +145,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -172,7 +177,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -191,7 +196,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -218,7 +223,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -246,7 +251,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -282,7 +287,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -301,7 +306,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -321,7 +326,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -344,7 +349,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         seed: () =>
             const CameraPermissionLoaded(CameraPermissionStatus.canRequest),
@@ -354,6 +359,48 @@ void main() {
     });
 
     group('CameraPermissionRefresh', () {
+      blocTest<CameraPermissionBloc, CameraPermissionState>(
+        'checks permissions on macOS instead of bypassing to authorized',
+        setUp: () {
+          debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+          when(
+            () => mockPermissionsService.checkCameraStatus(),
+          ).thenAnswer((_) async => PermissionStatus.requiresSettings);
+          when(
+            () => mockPermissionsService.checkMicrophoneStatus(),
+          ).thenAnswer((_) async => PermissionStatus.granted);
+        },
+        build: () =>
+            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        act: (bloc) => bloc.add(const CameraPermissionRefresh()),
+        expect: () => [
+          const CameraPermissionLoaded(CameraPermissionStatus.requiresSettings),
+        ],
+        verify: (_) {
+          verify(() => mockPermissionsService.checkCameraStatus()).called(1);
+          verify(
+            () => mockPermissionsService.checkMicrophoneStatus(),
+          ).called(1);
+        },
+      );
+
+      blocTest<CameraPermissionBloc, CameraPermissionState>(
+        'bypasses to authorized on Linux without checking permissions',
+        setUp: () {
+          debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+        },
+        build: () =>
+            CameraPermissionBloc(permissionsService: mockPermissionsService),
+        act: (bloc) => bloc.add(const CameraPermissionRefresh()),
+        expect: () => [
+          const CameraPermissionLoaded(CameraPermissionStatus.authorized),
+        ],
+        verify: (_) {
+          verifyNever(() => mockPermissionsService.checkCameraStatus());
+          verifyNever(() => mockPermissionsService.checkMicrophoneStatus());
+        },
+      );
+
       blocTest<CameraPermissionBloc, CameraPermissionState>(
         'drops a duplicate refresh while a permission check is in flight',
         setUp: () {
@@ -369,7 +416,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         act: (bloc) {
           bloc
@@ -403,7 +450,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         act: (bloc) => bloc.add(const CameraPermissionRefresh()),
         expect: () => [
@@ -426,7 +473,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         act: (bloc) => bloc.add(const CameraPermissionRefresh()),
         expect: () => [
@@ -449,7 +496,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         act: (bloc) => bloc.add(const CameraPermissionRefresh()),
         expect: () => [
@@ -474,7 +521,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         act: (bloc) => bloc.add(const CameraPermissionRefresh()),
         expect: () => [const CameraPermissionError()],
@@ -491,7 +538,7 @@ void main() {
         },
         build: () => CameraPermissionBloc(
           permissionsService: mockPermissionsService,
-          skipMacOSBypass: true,
+          skipLinuxBypass: true,
         ),
         act: (bloc) => bloc.add(const CameraPermissionOpenSettings()),
         expect: () => <CameraPermissionState>[],
@@ -517,7 +564,7 @@ void main() {
 
           final bloc = CameraPermissionBloc(
             permissionsService: mockPermissionsService,
-            skipMacOSBypass: true,
+            skipLinuxBypass: true,
           );
           final result = await bloc.checkPermissions();
 
@@ -559,7 +606,7 @@ void main() {
 
           final bloc = CameraPermissionBloc(
             permissionsService: mockPermissionsService,
-            skipMacOSBypass: true,
+            skipLinuxBypass: true,
           );
           final result = await bloc.checkPermissions();
 
@@ -603,7 +650,7 @@ void main() {
 
           final bloc = CameraPermissionBloc(
             permissionsService: mockPermissionsService,
-            skipMacOSBypass: true,
+            skipLinuxBypass: true,
           );
           final result = await bloc.checkPermissions();
 


### PR DESCRIPTION
## Description

This PR carves the macOS native camera/microphone permission work out of
the merged-and-narrowed #4029 and adapts it to current `main`, plus a small
related macOS debug-launch fix discovered while verifying it (see *Bundled
fix* below).

`permission_handler` does not reliably trigger the macOS camera/microphone
authorization dialog, so the recorder permission gate previously bypassed the
check entirely and assumed *authorized* on macOS. PR #5644 (the recorder
permission gate) intentionally left that bypass in place and deferred the fix
to this issue.

- **`NativeCameraPlugin.swift`** — explicit `requestCameraPermission`,
  `requestMicrophonePermission`, `cameraPermissionStatus`,
  `microphonePermissionStatus`, and `openSystemSettings` methods. Permission
  methods return a lowercase AVFoundation status string. Settings routing opens
  the Camera or Microphone privacy pane based on the denied/restricted media
  permission. Drops the ambiguous `requestPermission`/`hasPermission` pair
  (no Dart callers) and replaces the emoji `print` spam with `os.Logger`.
- **`permission_handler_permissions_service.dart`** — on macOS, routes camera
  and microphone check/request through the native channel and maps the status
  string via `mapMacOSAuthorizationStatus`. macOS settings recovery also uses
  the native channel instead of `permission_handler`. All other platforms are
  unchanged.
- **`camera_permission_bloc.dart`** — the desktop bypass is now **Linux-only**
  (no camera support there); macOS runs the real permission check. The
  test-only `skipMacOSBypass` flag is renamed `skipLinuxBypass` to match.

### First-sample-buffer race

The recording-rewrite race the carve-out worried about is **already prevented
on `main`**: `startRecording` bails via `hasReceivedPreviewFrame()` and derives
dimensions from the device's active format rather than the latest sample buffer
(which was the original race source). Re-applying the old recording change would
have reintroduced it, so this PR only documents the guard at its call site
rather than touching the recording path.

### Bundled fix — macOS debug launch (library validation)

While verifying the permission flow on macOS, a clean debug build crashed at
launch with `dyld: Library not loaded: @rpath/Divine.debug.dylib … different
Team IDs`. The macOS debug build is ad-hoc signed with Hardened Runtime, and
the app's SwiftPM-built Dart module (`Divine.debug.dylib`) is a separate
ad-hoc Mach-O — library validation treats two independent ad-hoc signatures as
different Team IDs and refuses to load the dylib. Added
`com.apple.security.cs.disable-library-validation` to
`Runner/DebugProfile.entitlements` (Debug-only; Profile/Release stay
team-signed with full library validation). Kept in this PR as a small,
directly-related fix since the macOS permission flow can't be launched/tested
without it.

## Out of Scope

- The carve-out's macOS recording-output change (writing to a temp dir instead
  of `~/Documents`) and the unrelated mode-selector refactor — both superseded
  by independent hardening already on `main`.

## Verification

- `mise exec -- dart format lib test integration_test` → formatted, 0 changed
- `flutter analyze lib test integration_test` → No issues found
- `flutter analyze lib test` (permissions_service package) → No issues found
- `flutter test` (permissions_service package) → 24/24 pass
- `flutter test test/blocs/camera_permission/camera_permission_bloc_test.dart` → 37/37 pass
- `flutter build macos --debug` → built `Divine.app`
- pre-push hook green: no merge conflicts, analyzer clean, changed-file tests pass
- **Manual macOS QA passed** ✅ — fresh install camera permission ask, microphone
  permission ask, record after first grant, and record again after relaunch all
  work as expected.
- **macOS debug launch verified** ✅ — clean `flutter build macos --debug` +
  launch no longer hits the dyld team-ID crash; `disable-library-validation` is
  baked into the Debug binary and the app starts past the dylib load phase.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change

**Related Issue:** Closes #4112
