### PR TITLE
perf(dm): debounce DM unread-count cubit to coalesce write bursts

### DIFF
--- a/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
+++ b/mobile/lib/blocs/dm/unread_count/dm_unread_count_cubit.dart
@@ -49,7 +49,9 @@ class DmUnreadCountCubit extends Cubit<int> {
     required DmRepository dmRepository,
     required FollowRepository followRepository,
     ContentBlocklistRepository? contentBlocklistRepository,
-  }) : super(0) {
+    Duration recomputeDebounce = _defaultRecomputeDebounce,
+  }) : _recomputeDebounce = recomputeDebounce,
+       super(0) {
     setRepositories(
       dmRepository: dmRepository,
       followRepository: followRepository,
@@ -57,6 +59,17 @@ class DmUnreadCountCubit extends Cubit<int> {
     );
   }
 
+  /// Window over which bursty conversation writes are coalesced into a single
+  /// recompute. This cubit is always mounted (app-shell scope) and re-runs the
+  /// full follow-aware, blocklist-filtered list composition on every
+  /// conversations-table write; a relay delivery, the mark-read fan-out, or the
+  /// post-reinstall history drain can fire dozens of writes in a burst.
+  /// Collapsing each burst into one classify+sort+filter pass removes redundant
+  /// main-isolate CPU. The count is not latency-critical, so the small delay is
+  /// invisible and the coalesced result is identical. Overridable in tests.
+  static const _defaultRecomputeDebounce = Duration(milliseconds: 200);
+
+  final Duration _recomputeDebounce;
   DmRepository? _dmRepository;
   FollowRepository? _followRepository;
   ContentBlocklistRepository? _blocklistRepository;
@@ -103,6 +116,13 @@ class DmUnreadCountCubit extends Cubit<int> {
               .map<Object?>((_) => null)
               .startWith(null);
 
+    // The combiner stays cheap — it only packages the inputs into a record so
+    // the debounce sees one value per source tick. The expensive recompute
+    // (`_countUnread`: classify + mergeAndSort + filter) runs AFTER the debounce
+    // in `map`, so a burst of writes triggers a single pass, not one per write.
+    // Following/blocklist ticks carry no value into the record — they only need
+    // to trigger a recompute, and `_countUnread` reads the live follow/block
+    // state, so the debounced `map` picks up their latest values.
     _subscription =
         Rx.combineLatest5<
               List<DmConversation>,
@@ -110,7 +130,7 @@ class DmUnreadCountCubit extends Cubit<int> {
               List<String>,
               Object?,
               String,
-              int
+              (List<DmConversation>, List<DmConversation>, String)
             >(
               dmRepository.watchAcceptedConversations(),
               dmRepository.watchPotentialRequests(),
@@ -121,10 +141,18 @@ class DmUnreadCountCubit extends Cubit<int> {
               // _countUnread classifies with the empty pubkey and undercounts
               // followed-but-unreplied 1:1s. Re-fires once the identity lands.
               dmRepository.userPubkeyStream.startWith(dmRepository.userPubkey),
-              (accepted, potentialRequests, _, _, userPubkey) => _countUnread(
-                accepted: accepted,
-                potentialRequests: potentialRequests,
-                userPubkey: userPubkey,
+              (accepted, potentialRequests, _, _, userPubkey) => (
+                accepted,
+                potentialRequests,
+                userPubkey,
+              ),
+            )
+            .debounceTime(_recomputeDebounce)
+            .map(
+              (inputs) => _countUnread(
+                accepted: inputs.$1,
+                potentialRequests: inputs.$2,
+                userPubkey: inputs.$3,
               ),
             )
             .listen(

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_auth_transition_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_auth_transition_test.dart
@@ -102,6 +102,9 @@ class _BadgeProbe extends ConsumerWidget {
       create: (_) => DmUnreadCountCubit(
         dmRepository: ref.read(_dmSelector),
         followRepository: ref.read(_followSelector),
+        // These tests assert repository-forwarding behaviour, not debounce
+        // timing, so disable the coalescing delay for prompt settling.
+        recomputeDebounce: Duration.zero,
       ),
       child: _DmRepositorySync(
         child: _MountProbe(

--- a/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
+++ b/mobile/test/blocs/dm/unread_count/dm_unread_count_cubit_test.dart
@@ -110,6 +110,10 @@ void main() {
         dmRepository: dmRepository,
         followRepository: followRepository,
         contentBlocklistRepository: contentBlocklistRepository,
+        // Behaviour tests assert the final settled count, not coalescing
+        // timing — disable the debounce so a single `_settle()` is enough.
+        // The debounce itself is covered by the dedicated coalescing test.
+        recomputeDebounce: Duration.zero,
       );
     }
 
@@ -422,6 +426,57 @@ void main() {
         acceptedController.add(const []);
         await _settle();
         expect(cubit.state, equals(2));
+      },
+    );
+
+    test(
+      'coalesces a burst of conversation writes into a single recompute '
+      '(debounce)',
+      () async {
+        var filterCalls = 0;
+        final blocklist = _MockContentBlocklistRepository();
+        final stateController = StreamController<ContentPolicyState>();
+        addTearDown(stateController.close);
+        when(
+          () => blocklist.stateStream,
+        ).thenAnswer((_) => stateController.stream);
+        // filterBlockedConversations runs once per `_countUnread` pass, so it
+        // doubles as a recompute counter.
+        when(
+          () => blocklist.filterBlockedConversations(
+            any(),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((inv) {
+          filterCalls++;
+          return inv.positionalArguments.first as List<DmConversation>;
+        });
+
+        // Real (non-zero) debounce window so the burst is genuinely coalesced.
+        final cubit = DmUnreadCountCubit(
+          dmRepository: dmRepository,
+          followRepository: followRepository,
+          contentBlocklistRepository: blocklist,
+          recomputeDebounce: const Duration(milliseconds: 100),
+        );
+        addTearDown(cubit.close);
+
+        potentialController.add(const []);
+        // Five rapid accepted-list updates inside the debounce window.
+        for (var i = 0; i < 5; i++) {
+          acceptedController.add([
+            _convo('c$i', peer: _bob, isRead: false, currentUserHasSent: true),
+          ]);
+        }
+
+        // Still inside the window: the expensive pass has not run yet.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(filterCalls, equals(0));
+
+        // After the window settles: exactly one recompute for the whole burst.
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        expect(filterCalls, equals(1));
+        expect(cubit.state, equals(1));
       },
     );
 


### PR DESCRIPTION
Closes #5653

## What

`DmUnreadCountCubit` is created once at app-shell scope (`main.dart`) and consumed by the always-mounted bottom-nav badge, so it lives the whole session. Its `Rx.combineLatest5` ran the full `classifyPotentialRequests` + `mergeAndSort` + `filterBlockedConversations` + count on **every** conversations-table write — and those bursts hard during relay deliveries, the mark-read fan-out, and the post-reinstall history drain. That's redundant main-isolate CPU while the app is simply open (a steady-state battery cost, not a cold-start one-shot).

## How

The expensive recompute lived **inside** the `combineLatest5` combiner, so a plain `.debounceTime()` on the output would still recompute per write. Instead:

- the combiner now packages a cheap record `(accepted, potentialRequests, userPubkey)`,
- `.debounceTime(200ms)` coalesces the burst,
- `.map(_countUnread)` runs the classify/sort/filter **once per settled burst**.

Correctness is preserved: following/blocklist ticks still *trigger* a recompute (they carry no value into the record), and `_countUnread` reads live follow/block state, so the debounced `map` always picks up their latest values. The final count is identical — only redundant intermediate recomputes are dropped.

The 200ms window is an injectable constructor param (default 200ms; production wiring unchanged) for testability.

## Testing

- `flutter analyze` clean; `dart format` clean.
- `flutter test test/blocs/dm/unread_count/` → 17/17 pass.
- New test asserts a five-write burst collapses to **exactly one** recompute (counted via the blocklist-filter spy).
- Existing behaviour tests inject `Duration.zero` (assert final settled count, not coalescing timing) so they need no timing churn.

## Risk

Low. The badge update is delayed by at most ~200ms after a write; the count is not latency-critical and the final value is unchanged. No other real construction sites are affected (all other references are mocks).

Part of a DM/app-wide performance series targeting steady-state battery drain.