### PR TITLE
perf(dm): debounce conversation-list recompute to coalesce write bursts

### DIFF
--- a/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation_list/conversation_list_bloc.dart
@@ -23,9 +23,11 @@ class ConversationListBloc
     required DmRepository dmRepository,
     required FollowRepository followRepository,
     ContentBlocklistRepository? contentBlocklistRepository,
+    Duration recomputeDebounce = _defaultRecomputeDebounce,
   }) : _dmRepository = dmRepository,
        _followRepository = followRepository,
        _blocklistRepository = contentBlocklistRepository,
+       _recomputeDebounce = recomputeDebounce,
        super(const ConversationListState()) {
     on<ConversationListStarted>(_onStarted, transformer: restartable());
     on<ConversationListLoadMore>(_onLoadMore, transformer: droppable());
@@ -41,6 +43,18 @@ class ConversationListBloc
   final DmRepository _dmRepository;
   final FollowRepository _followRepository;
   final ContentBlocklistRepository? _blocklistRepository;
+
+  /// Window over which bursty conversation writes are coalesced before the
+  /// list is re-composed. The combined stream re-runs `classifyPotentialRequests`
+  /// + `mergeAndSort` + two `filterBlockedConversations` passes in `onData` on
+  /// every conversations-table write; relay deliveries, the mark-read fan-out,
+  /// and the post-reinstall drain fire those in bursts. Debouncing collapses a
+  /// burst into a single recompute. The list is not latency-critical, so the
+  /// small delay is invisible and the settled result is identical. Overridable
+  /// in tests.
+  static const _defaultRecomputeDebounce = Duration(milliseconds: 200);
+
+  final Duration _recomputeDebounce;
 
   Future<void> _onStarted(
     ConversationListStarted event,
@@ -99,7 +113,7 @@ class ConversationListBloc
           isRestoring: isRestoring,
           userPubkey: userPubkey,
         ),
-      ),
+      ).debounceTime(_recomputeDebounce),
       onData: (data) {
         // Until credentials are set, the pubkey is empty and self cannot be
         // filtered out of a conversation's participants — classifying now would

--- a/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation_list/conversation_list_bloc_test.dart
@@ -6,6 +6,7 @@
 import 'dart:async';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
@@ -16,6 +17,9 @@ import 'package:openvine/blocs/dm/conversation_list/conversation_list_bloc.dart'
 class _MockDmRepository extends Mock implements DmRepository {}
 
 class _MockFollowRepository extends Mock implements FollowRepository {}
+
+class _MockContentBlocklistRepository extends Mock
+    implements ContentBlocklistRepository {}
 
 // Full 64-character hex Nostr IDs for test data.
 const _testConversationId1 =
@@ -124,6 +128,10 @@ void main() {
     ConversationListBloc createBloc() => ConversationListBloc(
       dmRepository: mockDmRepository,
       followRepository: mockFollowRepository,
+      // These tests assert state sequences/content, not coalescing timing, so
+      // disable the recompute debounce for deterministic, prompt emissions.
+      // The debounce itself is covered by a dedicated coalescing test.
+      recomputeDebounce: Duration.zero,
     );
 
     test('initial state is $ConversationListState with initial status', () {
@@ -135,6 +143,78 @@ void main() {
 
       bloc.close();
     });
+
+    test(
+      'coalesces a burst of conversation writes into a single recompute '
+      '(debounce)',
+      () async {
+        final acceptedController =
+            StreamController<List<DmConversation>>.broadcast();
+        addTearDown(acceptedController.close);
+        when(
+          () => mockDmRepository.watchAcceptedConversations(
+            limit: any(named: 'limit'),
+          ),
+        ).thenAnswer((_) => acceptedController.stream);
+        // combineLatest5 needs every source to emit at least once; potential
+        // emits a single empty value (the others use startWith in the bloc).
+        when(
+          () => mockDmRepository.watchPotentialRequests(),
+        ).thenAnswer((_) => Stream.value(const <DmConversation>[]));
+        when(
+          () => mockDmRepository.historyRecoveryStream,
+        ).thenAnswer((_) => const Stream<bool>.empty());
+        when(() => mockDmRepository.isRecoveringHistory).thenReturn(false);
+
+        // filterBlockedConversations runs once per `onData` pass (inbox +
+        // requests = 2 calls), so it doubles as a recompute counter.
+        var filterCalls = 0;
+        final blocklist = _MockContentBlocklistRepository();
+        when(
+          () => blocklist.filterBlockedConversations(
+            any(),
+            userPubkey: any(named: 'userPubkey'),
+          ),
+        ).thenAnswer((inv) {
+          filterCalls++;
+          return inv.positionalArguments.first as List<DmConversation>;
+        });
+
+        final bloc = ConversationListBloc(
+          dmRepository: mockDmRepository,
+          followRepository: mockFollowRepository,
+          contentBlocklistRepository: blocklist,
+          recomputeDebounce: const Duration(milliseconds: 100),
+        )..add(const ConversationListStarted());
+        addTearDown(bloc.close);
+
+        // Let _onStarted subscribe to the (broadcast) streams before the burst,
+        // otherwise events emitted pre-subscription are dropped.
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+
+        final convos = [
+          _createConversation(
+            id: _testConversationId1,
+            isRead: false,
+            currentUserHasSent: true,
+          ),
+        ];
+        // Five rapid accepted-list updates inside the debounce window.
+        for (var i = 0; i < 5; i++) {
+          acceptedController.add(convos);
+        }
+
+        // Still inside the window: the expensive pass has not run yet.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(filterCalls, equals(0));
+
+        // After the window settles: exactly one recompute (inbox + requests
+        // filtered once each) for the whole burst, not two per write.
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        expect(filterCalls, equals(2));
+        expect(bloc.state.status, equals(ConversationListStatus.loaded));
+      },
+    );
 
     group('ConversationListStarted', () {
       blocTest<ConversationListBloc, ConversationListState>(


### PR DESCRIPTION
Closes #5656

## What

`ConversationListBloc` re-runs `classifyPotentialRequests` + `mergeAndSort` + **two** `filterBlockedConversations` passes in `onData` on **every** conversations-table write. Those burst during relay deliveries, the mark-read fan-out, and the post-reinstall history drain, and this bloc keeps its own Drift subscriptions (independent of the badge cubit), so the open inbox pays the full O(N) transform per write. (#5395 moved only the SQL off the main isolate — not these Dart transforms.)

## How

The `combineLatest5` combiner was already cheap (it just packages a record), so `.debounceTime(200ms)` on the combined stream makes the expensive composition in `onData` run **once per settled burst** instead of once per write. `restartable()` still cancels superseded subscriptions, and the settled result is identical.

The window is an injectable constructor param (default 200ms; production wiring unchanged) for testability.

## Testing

- `flutter analyze` clean; `dart format` clean.
- `flutter test .../conversation_list_bloc_test.dart` → 53/53 pass.
- Existing sequence/content tests inject `Duration.zero` (they assert state content, not coalescing timing) → no timing churn.
- New test asserts a five-write burst → **one** recompute (counted via the blocklist-filter spy, called inbox+requests = 2× per pass).

## Risk

Low. List refresh is delayed by at most ~200ms after a write; not latency-critical, and the settled list is unchanged. Companion to the badge-cubit debounce (#5652) — same technique on the other DM-list consumer.

Part of a DM/app-wide performance series targeting steady-state battery drain.