### PR TITLE
perf(dm): skip redundant mark-read writes on outgoing-only conversation ticks

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_bloc.dart
@@ -76,10 +76,22 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
     await emit.forEach(
       ticks,
       onData: (tick) {
-        // Mark as read whenever new messages arrive while the user is
-        // viewing this conversation. This ensures incoming messages are
-        // immediately marked as read rather than only on initial open.
-        unawaited(_dmRepository.markConversationAsRead(_conversationId));
+        // Mark as read only when this conversation's persisted message list
+        // actually changed — a new (or edited/removed) message — not on ticks
+        // driven solely by the outgoing-queue stream or a bare re-emit.
+        //
+        // Every tick previously fired markConversationAsRead, and the DAO's
+        // conversations-table notification fans out to the badge cubit and the
+        // list bloc even when no row changed, so each outgoing-status
+        // transition (pending → sent → delivered) and re-emit forced a
+        // redundant recompute. A genuinely new incoming message always changes
+        // `messages`, so this never leaves an unread uncleared while the
+        // conversation is open. `combineLatest2` re-emits the same `messages`
+        // instance on an outgoing-only tick, so the `identical` fast-path keeps
+        // that common case O(1).
+        if (!_sameMessages(tick.messages, state.messages)) {
+          unawaited(_dmRepository.markConversationAsRead(_conversationId));
+        }
         return state.copyWith(
           status: ConversationStatus.loaded,
           messages: tick.messages,
@@ -93,6 +105,18 @@ class ConversationBloc extends Bloc<ConversationEvent, ConversationState> {
         return state.copyWith(status: ConversationStatus.error);
       },
     );
+  }
+
+  /// Whether two persisted-message lists carry the same messages in the same
+  /// order. `DmMessage` is `Equatable`, so element comparison is by value.
+  /// The `identical` fast-path keeps the common outgoing-only tick O(1).
+  static bool _sameMessages(List<DmMessage> a, List<DmMessage> b) {
+    if (identical(a, b)) return true;
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 
   Future<void> _onMessageDeleted(

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -231,6 +231,62 @@ void main() {
               .having((s) => s.messages.length, 'messages.length', equals(2)),
         ],
       );
+
+      blocTest<ConversationBloc, ConversationState>(
+        'does not re-mark read on an outgoing-queue-only tick, but does on a '
+        'genuinely new message',
+        setUp: () {
+          final messagesController = StreamController<List<DmMessage>>();
+          final outgoingController = StreamController<List<OutgoingDm>>();
+          when(
+            () => mockDmRepository.markConversationAsRead(conversationId),
+          ).thenAnswer((_) async {});
+          when(
+            () => mockDmRepository.watchMessages(conversationId),
+          ).thenAnswer((_) => messagesController.stream);
+          when(
+            () => mockDmRepository.watchOutgoing(any()),
+          ).thenAnswer((_) => outgoingController.stream);
+
+          Future<void>.delayed(Duration.zero).then((_) async {
+            // First message arrives: messages change -> marks read.
+            messagesController.add([testMessage]);
+            outgoingController.add(const <OutgoingDm>[]);
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            // Outgoing-queue status change only (e.g. pending -> delivered):
+            // combineLatest2 re-emits the SAME messages instance, so this tick
+            // must NOT re-mark the conversation read.
+            outgoingController.add([_outgoingDm(id: 'pending-rumor')]);
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            // A genuinely new incoming message: marks read again.
+            const secondMessage = DmMessage(
+              id: '7777777777777777777777777777777777777777777777777777777777777777',
+              conversationId: conversationId,
+              senderPubkey: recipientPubkey,
+              content: 'Reply message',
+              createdAt: 1700000100,
+              giftWrapId:
+                  '8888888888888888888888888888888888888888888888888888888888888888',
+            );
+            messagesController.add([testMessage, secondMessage]);
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            await messagesController.close();
+            await outgoingController.close();
+          });
+        },
+        build: buildBloc,
+        act: (bloc) => bloc.add(const ConversationStarted()),
+        wait: const Duration(milliseconds: 80),
+        verify: (bloc) {
+          // The outgoing-only tick was processed (its row reached state)...
+          expect(bloc.state.pendingOutgoing, hasLength(1));
+          // ...but mark-read fired only on open + the two message-list changes,
+          // NOT on the outgoing-only tick in between.
+          verify(
+            () => mockDmRepository.markConversationAsRead(conversationId),
+          ).called(3);
+        },
+      );
     });
 
     group('ConversationMessageSent', () {


### PR DESCRIPTION
Closes #5659

## What

`ConversationBloc` fired `markConversationAsRead` on **every** dual-stream tick. The tick fires on any `watchMessages` *or* `watchOutgoing` change, and the DAO's `customUpdate` emits the `{conversations}` table notification **regardless of affected rows** — so each outgoing-status transition (pending → sent → delivered) and bare re-emit triggered a conversations write whose notification fans out to the always-mounted badge cubit and the open list bloc for a full recompute.

(A SQL `WHERE` guard alone would not help — the Drift notification fires even when zero rows change.)

## How

Guard the per-tick mark-read on whether this conversation's persisted message list **actually changed**:

- `combineLatest2` re-emits the *same* `messages` instance on an outgoing-only tick, so the `identical()` fast-path makes the common case O(1);
- a content compare catches genuine changes and is robust to same-second messages and to Drift re-queries triggered by *other* conversations.

A new incoming message always changes `messages`, so a genuine unread is never left uncleared while the conversation is open. The on-open mark is unchanged.

This is more precise than a timestamp watermark (no same-second miss) and needs **no new state field** — it compares against the messages already in `state`.

## Testing

- `flutter analyze` clean; `dart format` clean.
- `flutter test .../conversation_bloc_test.dart` → 63/63 pass (62 existing + 1 new).
- New regression test asserts an outgoing-queue-only tick (status pending → delivered) does **not** re-mark read, while a genuinely new incoming message does — and verifies the outgoing tick actually reached state, so the skip is real.

## Risk

Medium-low. Read-state correctness is user-visible, so the guard keys on message-list changes (a new incoming always changes the list) and leaves the on-open mark intact. Halves conversations writes while a conversation is open during outgoing-status churn.

Part of a DM/app-wide performance series targeting steady-state battery drain.