### PR TITLE
perf(dm): batch the per-page gift-wrap dedup probe into two IN queries

### DIFF
--- a/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/direct_messages_dao.dart
@@ -183,6 +183,26 @@ class DirectMessagesDao extends DatabaseAccessor<AppDatabase>
     return result != null;
   }
 
+  /// Which of [giftWrapIds] already have a persisted message row. Batched
+  /// counterpart to [hasGiftWrap]: one `IN` query instead of N single-id
+  /// lookups, used by the history-drain dedup probe to avoid a per-wrap DB
+  /// round trip. Like [hasGiftWrap], it is NOT scoped by `ownerPubkey`
+  /// (gift-wrap IDs are globally unique). Returns an empty set for an empty
+  /// input.
+  Future<Set<String>> giftWrapIdsPresent(Set<String> giftWrapIds) async {
+    if (giftWrapIds.isEmpty) return const <String>{};
+    final query = selectOnly(directMessages)
+      ..addColumns([directMessages.giftWrapId])
+      ..where(directMessages.giftWrapId.isIn(giftWrapIds));
+    final rows = await query.get();
+    final present = <String>{};
+    for (final row in rows) {
+      final id = row.read(directMessages.giftWrapId);
+      if (id != null) present.add(id);
+    }
+    return present;
+  }
+
   /// Check if a message with the same sender and content already exists in a
   /// conversation within a ±5 second window. Used for cross-protocol dedup
   /// when both a NIP-17 and NIP-04 copy of the same message arrive.

--- a/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
+++ b/mobile/packages/db_client/lib/src/database/daos/processed_gift_wraps_dao.dart
@@ -25,6 +25,24 @@ class ProcessedGiftWrapsDao extends DatabaseAccessor<AppDatabase>
     return (await query.get()).isNotEmpty;
   }
 
+  /// Which of [giftWrapIds] are already recorded in the ledger. Batched
+  /// counterpart to [hasGiftWrap]: one `IN` query instead of N single-id
+  /// lookups, used by the history-drain dedup probe to avoid a per-wrap DB
+  /// round trip. Returns an empty set for an empty input.
+  Future<Set<String>> giftWrapIdsPresent(Set<String> giftWrapIds) async {
+    if (giftWrapIds.isEmpty) return const <String>{};
+    final query = selectOnly(processedGiftWraps)
+      ..addColumns([processedGiftWraps.giftWrapId])
+      ..where(processedGiftWraps.giftWrapId.isIn(giftWrapIds));
+    final rows = await query.get();
+    final present = <String>{};
+    for (final row in rows) {
+      final id = row.read(processedGiftWraps.giftWrapId);
+      if (id != null) present.add(id);
+    }
+    return present;
+  }
+
   /// Records [giftWrapId] as terminally processed (idempotent — a re-delivered
   /// wrap or a concurrent writer never throws). [ownerPubkey] is informational
   /// only — not part of the dedup key, and not used to scope deletes (cleanup

--- a/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/direct_messages_dao_test.dart
@@ -448,6 +448,38 @@ void main() {
       });
     });
 
+    group('giftWrapIdsPresent', () {
+      test('returns only the subset of ids that have a message row', () async {
+        await dao.insertMessage(
+          id: 'msg_present',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_alice',
+          content: 'Hello!',
+          createdAt: 1700000000,
+          giftWrapId: 'gw_present',
+        );
+
+        final present = await dao.giftWrapIdsPresent({
+          'gw_present',
+          'gw_absent',
+        });
+        expect(present, equals({'gw_present'}));
+      });
+
+      test('returns an empty set for empty input', () async {
+        await dao.insertMessage(
+          id: 'msg_x',
+          conversationId: conversationId1,
+          senderPubkey: 'pubkey_alice',
+          content: 'Hi',
+          createdAt: 1700000000,
+          giftWrapId: 'gw_x',
+        );
+
+        expect(await dao.giftWrapIdsPresent(const <String>{}), isEmpty);
+      });
+    });
+
     group('deleteConversationMessages', () {
       test('deletes all messages in a conversation', () async {
         await dao.insertMessage(

--- a/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
+++ b/mobile/packages/db_client/test/src/database/daos/processed_gift_wraps_dao_test.dart
@@ -75,6 +75,18 @@ void main() {
       expect(await dao.hasGiftWrap(wrap1), isTrue);
     });
 
+    test('giftWrapIdsPresent returns only the recorded subset', () async {
+      await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+      expect(await dao.giftWrapIdsPresent({wrap1, wrap2}), equals({wrap1}));
+    });
+
+    test('giftWrapIdsPresent returns an empty set for empty input', () async {
+      await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
+
+      expect(await dao.giftWrapIdsPresent(const <String>{}), isEmpty);
+    });
+
     test('clearAll removes every row', () async {
       await dao.record(giftWrapId: wrap1, ownerPubkey: ownerA);
       await dao.record(giftWrapId: wrap2, ownerPubkey: ownerB);

--- a/mobile/packages/dm_repository/lib/src/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/src/dm_repository.dart
@@ -1413,6 +1413,24 @@ class DmRepository {
     return ledger.hasGiftWrap(giftWrapId);
   }
 
+  /// Batched form of [_alreadyProcessed] for the history-drain dedup probe.
+  /// Resolves which of [giftWrapIds] are already persisted or in the dedup
+  /// ledger with TWO `IN` queries instead of 2×N sequential single-id lookups,
+  /// collapsing a full page's probe from ~200 bg-isolate round trips to 2. The
+  /// in-transaction `hasGiftWrap` re-check in the persist path still guards
+  /// TOCTOU races, so this is purely a fast-path filter. #5452.
+  Future<Set<String>> _alreadyProcessedBatch(Set<String> giftWrapIds) async {
+    if (giftWrapIds.isEmpty) return const <String>{};
+    final present = <String>{
+      ...await _directMessagesDao.giftWrapIdsPresent(giftWrapIds),
+    };
+    final ledger = _processedGiftWrapsDao;
+    if (ledger != null) {
+      present.addAll(await ledger.giftWrapIdsPresent(giftWrapIds));
+    }
+    return present;
+  }
+
   /// Records a terminally-processed gift wrap in the dedup ledger so it is not
   /// re-decrypted on a later launch. No-op when the ledger DAO is absent (older
   /// test fixtures). Recorded AFTER the outcome write so a crash in between
@@ -1703,13 +1721,19 @@ class DmRepository {
     }
 
     // Only wraps not already persisted, to avoid re-decrypting on resume
-    // drains. The in-transaction hasGiftWrap re-check still protects races.
-    final pending = <Event>[];
-    for (final event in events) {
-      if (event.kind != EventKind.giftWrap) continue;
-      if (await _alreadyProcessed(event.id)) continue;
-      pending.add(event);
-    }
+    // drains. One batched dedup probe per page instead of 2 queries per wrap;
+    // the in-transaction hasGiftWrap re-check still protects races. #5452.
+    final giftWraps = [
+      for (final event in events)
+        if (event.kind == EventKind.giftWrap) event,
+    ];
+    final processed = await _alreadyProcessedBatch({
+      for (final event in giftWraps) event.id,
+    });
+    final pending = [
+      for (final event in giftWraps)
+        if (!processed.contains(event.id)) event,
+    ];
     if (pending.isEmpty) return const {};
 
     final decrypted = <String, Event>{};
@@ -1784,14 +1808,20 @@ class DmRepository {
     if (signer == null) return const {};
 
     // Probe the dedup index before paying any network decrypt, so a resume
-    // drain over already-persisted history costs DB reads, not RPCs. The
+    // drain over already-persisted history costs DB reads, not RPCs. One
+    // batched probe per page instead of 2 queries per wrap; the
     // in-transaction hasGiftWrap re-check in the caller still guards races.
-    final pending = <Event>[];
-    for (final event in events) {
-      if (event.kind != EventKind.giftWrap) continue;
-      if (await _alreadyProcessed(event.id)) continue;
-      pending.add(event);
-    }
+    final giftWraps = [
+      for (final event in events)
+        if (event.kind == EventKind.giftWrap) event,
+    ];
+    final processed = await _alreadyProcessedBatch({
+      for (final event in giftWraps) event.id,
+    });
+    final pending = [
+      for (final event in giftWraps)
+        if (!processed.contains(event.id)) event,
+    ];
     if (pending.isEmpty) return const {};
     if (_disposed) return const {};
 

--- a/mobile/packages/dm_repository/test/src/dm_repository_test.dart
+++ b/mobile/packages/dm_repository/test/src/dm_repository_test.dart
@@ -429,6 +429,13 @@ void main() {
         ),
       ).thenAnswer((_) async => []);
 
+      // Default for the batched drain dedup probe (#13): nothing already
+      // persisted. The drain group overrides this with a stateful version so
+      // its inclusive-`until` boundary re-request is deduped.
+      when(
+        () => mockDirectMessagesDao.giftWrapIdsPresent(any()),
+      ).thenAnswer((_) async => const <String>{});
+
       // Default for resolveDmInboxRelays(), which sendMessage now calls on
       // every send: recipient has no kind-10050 list, so the gift wrap
       // falls back to the default relay pool (existing behavior).
@@ -4660,6 +4667,15 @@ void main() {
           (inv) async =>
               persistedGiftWrapIds.contains(inv.positionalArguments[0]),
         );
+        // Batched dedup probe (#13) mirrors the same stateful set as
+        // hasGiftWrap, so the inclusive-`until` boundary re-request is deduped
+        // before decryption instead of re-decrypted.
+        when(
+          () => mockDirectMessagesDao.giftWrapIdsPresent(any()),
+        ).thenAnswer(
+          (inv) async => (inv.positionalArguments[0] as Set<String>)
+              .intersection(persistedGiftWrapIds),
+        );
         when(
           () => mockDirectMessagesDao.hasMatchingMessage(
             conversationId: any(named: 'conversationId'),
@@ -5099,6 +5115,42 @@ void main() {
             syncState.recorded.map((r) => r.createdAt),
             containsAll(<int>[1700000500, 1700000600]),
           );
+        },
+      );
+
+      test(
+        'probes the page dedup index with ONE batch query carrying the whole '
+        'page, not a per-wrap probe (#13)',
+        () async {
+          final wrap1 = await _buildGiftWrap(
+            rumor: rumorFor('probe 1', createdAt: 1700000500),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000000,
+          );
+          final wrap2 = await _buildGiftWrap(
+            rumor: rumorFor('probe 2', createdAt: 1700000600),
+            senderPrivateKey: senderPriv,
+            recipientPubkey: recipientPub,
+            outerCreatedAt: 1700000001,
+          );
+          stubDrainPage([wrap1, wrap2]);
+
+          final repository = createRepository(
+            userPubkey: recipientPub,
+            signer: _IsolateLocalSigner(recipientPriv),
+            syncState: drainPending(),
+          );
+
+          await repository.backfillHistoryIfNeeded();
+
+          // The first dedup probe carries BOTH wrap ids in one query — proving
+          // the page is probed in a single batch, not one hasGiftWrap per wrap.
+          final probed = verify(
+            () => mockDirectMessagesDao.giftWrapIdsPresent(captureAny()),
+          ).captured;
+          expect(probed, isNotEmpty);
+          expect(probed.first, equals({wrap1.id, wrap2.id}));
         },
       );
 


### PR DESCRIPTION
Closes #5661

## What

Both history-drain decrypt passes (`_batchDecryptGiftWraps` and `_parallelDecryptGiftWraps`) filtered a page's wraps by calling `_alreadyProcessed(id)` **per wrap** — two sequential single-id queries (`direct_messages` + the processed-wraps ledger). For a 100-wrap page that's up to **~200 sequential background-isolate round trips** before any decrypt; on a fully-synced resume drain (up to `maxPages`) the probe dominates.

## How

Add batched `DirectMessagesDao.giftWrapIdsPresent(Set)` and `ProcessedGiftWrapsDao.giftWrapIdsPresent(Set)` (one `IN` query each) and a repository `_alreadyProcessedBatch` helper that unions them. Each pass now computes the page's gift-wrap ids once and runs **two** batch queries — collapsing ~200 round trips per page to 2.

- Page size is 100, well under SQLite's `IN`-list variable limit (999/32766).
- The in-transaction `hasGiftWrap` re-check still guards the TOCTOU race, so dedup correctness and race protection are unchanged — this is purely a fast-path filter.

## Testing

- `flutter analyze` clean; `dart format` clean.
- New DAO unit tests for both `giftWrapIdsPresent` methods (subset semantics + empty input).
- `dm_repository` suite: 417/417 pass. The drain harness stubs the batch probe with the **same stateful set** as `hasGiftWrap`, so the inclusive-`until` boundary dedup still holds.
- New drain test asserts the first probe carries the **whole page in one query**, not a per-wrap probe.

## Risk

Low — read-only dedup fast-path; race protection (in-transaction re-check) unchanged. Touches `db_client` (additive DAO methods) and `dm_repository` (decrypt-pass probe).

Part of a DM/app-wide performance series targeting steady-state battery drain. The transaction-batching (#6) and per-page `recordSeen` (#14) parts of the drain are intentionally split into a separate PR given they touch the data-integrity transaction.