### PR TITLE
perf(cache-sync): track running byte total and batch LRU eviction

### DIFF
--- a/mobile/packages/cache_sync/lib/src/cache_dao.dart
+++ b/mobile/packages/cache_sync/lib/src/cache_dao.dart
@@ -34,7 +34,7 @@ abstract interface class CacheDao {
 
   /// Returns the total size of all `payload` strings, in characters.
   ///
-  /// Uses `String.length` semantics (UTF-16 code units), suitable as an
+  /// Uses SQLite `LENGTH` semantics for text payloads, suitable as an
   /// approximation of storage bytes for JSON-heavy payloads.
   Future<int> totalPayloadBytes();
 

--- a/mobile/packages/cache_sync/lib/src/cache_dao_impl.dart
+++ b/mobile/packages/cache_sync/lib/src/cache_dao_impl.dart
@@ -89,7 +89,7 @@ class CacheDaoImpl implements CacheDao {
 
     if (limit == null) return;
 
-    final newTotal = preWriteTotal - replacedLength + payload.length;
+    final newTotal = preWriteTotal - replacedLength + _payloadSize(payload);
     _totalBytes = newTotal;
     if (newTotal > limit) {
       await evictOldest(newTotal - limit);
@@ -194,4 +194,7 @@ class CacheDaoImpl implements CacheDao {
     final row = await query.getSingleOrNull();
     return row?.read(_payloadLength) ?? 0;
   }
+
+  /// Matches SQLite `LENGTH(payload)` for JSON text payloads.
+  static int _payloadSize(String payload) => payload.runes.length;
 }

--- a/mobile/packages/cache_sync/lib/src/cache_dao_impl.dart
+++ b/mobile/packages/cache_sync/lib/src/cache_dao_impl.dart
@@ -8,9 +8,17 @@ import 'package:drift/drift.dart';
 /// TTL eviction is applied **on read**: an expired row is deleted and `null`
 /// is returned, so stale data never reaches the caller.
 ///
-/// When [maxSizeBytes] is set, LRU eviction runs **after every write**:
-/// the oldest entries (by `cachedAt`) are deleted until the total payload
-/// size is within the budget.
+/// When [maxSizeBytes] is set, LRU eviction runs **after every write**: the
+/// oldest entries (by `cachedAt`) are deleted until the total payload size is
+/// within the budget.
+///
+/// To keep that budget check cheap, the total payload size is held in a
+/// running counter ([_totalBytes]) instead of a full-table
+/// `SUM(LENGTH(payload))` scan on every write. The counter is seeded lazily
+/// from [totalPayloadBytes], maintained on write/delete/evict, invalidated on
+/// the bulk [deletePrefix] path, and periodically reconciled against the real
+/// sum to bound drift from a concurrent same-key write. It is maintained only
+/// when [maxSizeBytes] is set — an unbounded cache pays nothing.
 class CacheDaoImpl implements CacheDao {
   CacheDaoImpl(this._db, {this.maxSizeBytes});
 
@@ -18,6 +26,20 @@ class CacheDaoImpl implements CacheDao {
 
   /// Maximum total payload size in characters. `null` = unlimited.
   final int? maxSizeBytes;
+
+  /// Running total payload size in characters, or `null` when not yet computed
+  /// / invalidated (recomputed lazily via [_ensureTotalBytes]).
+  int? _totalBytes;
+
+  /// Writes since the running counter was last reconciled against the real
+  /// `SUM`. Drift to zero forces a fresh [totalPayloadBytes] read.
+  int _writesSinceReconcile = 0;
+
+  /// Recompute the running counter from the real sum after this many writes, so
+  /// any drift from an interleaved same-key write self-corrects.
+  static const int _reconcileEveryWrites = 256;
+
+  Expression<int> get _payloadLength => _db.cacheEntries.payload.length;
 
   @override
   Future<String?> read(String key) async {
@@ -43,6 +65,17 @@ class CacheDaoImpl implements CacheDao {
     Duration? ttl,
   }) async {
     final now = DateTime.now().toUtc();
+    final limit = maxSizeBytes;
+
+    // Seed the running counter from the PRE-write total and capture the
+    // replaced payload's length, both before the upsert mutates the table, so
+    // the counter stays exact across an overwrite (insertOnConflictUpdate
+    // replaces an existing row). Only needed when a budget is enforced.
+    final preWriteTotal = limit == null ? 0 : await _ensureTotalBytes();
+    final replacedLength = limit == null
+        ? 0
+        : await _existingPayloadLength(key);
+
     await _db
         .into(_db.cacheEntries)
         .insertOnConflictUpdate(
@@ -54,18 +87,33 @@ class CacheDaoImpl implements CacheDao {
           ),
         );
 
-    final limit = maxSizeBytes;
-    if (limit != null) {
-      final total = await totalPayloadBytes();
-      if (total > limit) await evictOldest(total - limit);
+    if (limit == null) return;
+
+    final newTotal = preWriteTotal - replacedLength + payload.length;
+    _totalBytes = newTotal;
+    if (newTotal > limit) {
+      await evictOldest(newTotal - limit);
+    }
+
+    if (++_writesSinceReconcile >= _reconcileEveryWrites) {
+      _writesSinceReconcile = 0;
+      _totalBytes = null;
     }
   }
 
   @override
   Future<void> delete(String key) async {
+    // Keep the running counter exact: subtract the deleted row's length. Skip
+    // the probe when no budget is enforced or the counter isn't initialised
+    // (the next write recomputes it).
+    final removedLength = (maxSizeBytes != null && _totalBytes != null)
+        ? await _existingPayloadLength(key)
+        : 0;
     await (_db.delete(
       _db.cacheEntries,
     )..where((t) => t.cacheKey.equals(key))).go();
+    final total = _totalBytes;
+    if (total != null) _totalBytes = total - removedLength;
   }
 
   @override
@@ -82,6 +130,9 @@ class CacheDaoImpl implements CacheDao {
       r"DELETE FROM cache_entries WHERE cache_key LIKE ?1 || '%' ESCAPE '\'",
       [escaped],
     );
+    // A bulk delete can't cheaply report the freed byte count, so invalidate
+    // the running counter and let the next write recompute it from the sum.
+    _totalBytes = null;
   }
 
   @override
@@ -100,18 +151,47 @@ class CacheDaoImpl implements CacheDao {
   Future<void> evictOldest(int bytesToFree) async {
     if (bytesToFree <= 0) return;
     await _db.transaction(() async {
-      var freed = 0;
-      final rows = await (_db.select(
-        _db.cacheEntries,
-      )..orderBy([(t) => OrderingTerm.asc(t.cachedAt)])).get();
+      // Select only the key and payload LENGTH (oldest first) instead of
+      // materialising every full payload into memory.
+      final query = _db.selectOnly(_db.cacheEntries)
+        ..addColumns([_db.cacheEntries.cacheKey, _payloadLength])
+        ..orderBy([OrderingTerm.asc(_db.cacheEntries.cachedAt)]);
+      final rows = await query.get();
 
+      var freed = 0;
+      final keysToDelete = <String>[];
       for (final row in rows) {
         if (freed >= bytesToFree) break;
-        freed += row.payload.length;
-        await (_db.delete(
-          _db.cacheEntries,
-        )..where((t) => t.cacheKey.equals(row.cacheKey))).go();
+        final key = row.read(_db.cacheEntries.cacheKey);
+        if (key == null) continue;
+        freed += row.read(_payloadLength) ?? 0;
+        keysToDelete.add(key);
       }
+      if (keysToDelete.isEmpty) return;
+
+      // One bounded DELETE instead of a per-row delete loop.
+      await (_db.delete(
+        _db.cacheEntries,
+      )..where((t) => t.cacheKey.isIn(keysToDelete))).go();
+
+      final total = _totalBytes;
+      if (total != null) _totalBytes = total - freed;
     });
+  }
+
+  /// Returns the running counter, computing it from the real sum on first use
+  /// (or after invalidation).
+  Future<int> _ensureTotalBytes() async {
+    return _totalBytes ??= await totalPayloadBytes();
+  }
+
+  /// Length of the payload currently stored under [key], or 0 when absent.
+  /// Indexed point lookup on the `cache_key` primary key.
+  Future<int> _existingPayloadLength(String key) async {
+    final query = _db.selectOnly(_db.cacheEntries)
+      ..addColumns([_payloadLength])
+      ..where(_db.cacheEntries.cacheKey.equals(key));
+    final row = await query.getSingleOrNull();
+    return row?.read(_payloadLength) ?? 0;
   }
 }

--- a/mobile/packages/cache_sync/test/cache_dao_test.dart
+++ b/mobile/packages/cache_sync/test/cache_dao_test.dart
@@ -259,6 +259,15 @@ void main() {
         expect(await dao.read('c'), equals('ccccc'));
       });
 
+      test('uses the database length metric for non-BMP payloads', () async {
+        await dao.write(key: 'emoji', payload: '😀' * 5);
+        await dao.write(key: 'plain', payload: 'xxxxx');
+
+        expect(await dao.read('emoji'), equals('😀' * 5));
+        expect(await dao.read('plain'), equals('xxxxx'));
+        expect(await dao.totalPayloadBytes(), equals(10));
+      });
+
       test(
         'deletePrefix keeps the budget accurate for a later write',
         () async {
@@ -276,9 +285,8 @@ void main() {
       );
 
       test('reconciles the running counter after 256 writes', () async {
-        // Lines 99–100 of cache_dao_impl.dart: after _reconcileEveryWrites (256)
-        // writes the branch resets _writesSinceReconcile and nullifies _totalBytes
-        // so the next write recomputes the counter from the real DB sum.
+        // The reconcile branch resets the counter after enough writes, so the
+        // next write recomputes the value from the real DB sum.
         for (var i = 0; i < 256; i++) {
           await dao.write(key: 'k', payload: 'x');
         }

--- a/mobile/packages/cache_sync/test/cache_dao_test.dart
+++ b/mobile/packages/cache_sync/test/cache_dao_test.dart
@@ -274,6 +274,20 @@ void main() {
           expect(await dao.read('user2:z'), equals('zzzzz'));
         },
       );
+
+      test('reconciles the running counter after 256 writes', () async {
+        // Lines 99–100 of cache_dao_impl.dart: after _reconcileEveryWrites (256)
+        // writes the branch resets _writesSinceReconcile and nullifies _totalBytes
+        // so the next write recomputes the counter from the real DB sum.
+        for (var i = 0; i < 256; i++) {
+          await dao.write(key: 'k', payload: 'x');
+        }
+        // This 257th write exercises the post-reconcile path where _totalBytes
+        // was nullified and must be recomputed via totalPayloadBytes().
+        await dao.write(key: 'k', payload: 'x');
+        expect(await dao.read('k'), equals('x'));
+        expect(await dao.totalPayloadBytes(), equals(1));
+      });
     });
   });
 }

--- a/mobile/packages/cache_sync/test/cache_dao_test.dart
+++ b/mobile/packages/cache_sync/test/cache_dao_test.dart
@@ -232,6 +232,48 @@ void main() {
         expect(await unlimitedDao.read('x'), isNotNull);
         expect(await unlimitedDao.read('y'), isNotNull);
       });
+
+      test('overwriting with a smaller payload frees budget (counter '
+          'tracks the replaced length, no spurious eviction)', () async {
+        await dao.write(key: 'a', payload: 'aaaaaaaa'); // 8
+        await dao.write(key: 'b', payload: 'bb'); // 2 — total 10
+        // Shrink 'a' to 1 char: a correct counter drops the total to 3, so the
+        // next write fits. A counter that ignored the replaced 8 chars would
+        // think the store is full and evict.
+        await dao.write(key: 'a', payload: 'a'); // total 3
+        await dao.write(key: 'c', payload: 'ccccccc'); // 7 — total 10
+
+        expect(await dao.read('a'), equals('a'));
+        expect(await dao.read('b'), equals('bb'));
+        expect(await dao.read('c'), equals('ccccccc'));
+      });
+
+      test('delete frees budget so a later write does not evict', () async {
+        await dao.write(key: 'a', payload: 'aaaaa'); // 5
+        await dao.write(key: 'b', payload: 'bbbbb'); // 5 — total 10
+        await dao.delete('a'); // total 5
+        await dao.write(key: 'c', payload: 'ccccc'); // 5 — total 10, no evict
+
+        expect(await dao.read('a'), isNull);
+        expect(await dao.read('b'), equals('bbbbb'));
+        expect(await dao.read('c'), equals('ccccc'));
+      });
+
+      test(
+        'deletePrefix keeps the budget accurate for a later write',
+        () async {
+          await dao.write(key: 'user1:x', payload: 'xxxxx'); // 5
+          await dao.write(key: 'user2:y', payload: 'yyyyy'); // 5 — total 10
+          await dao.deletePrefix('user1:'); // removes user1:x → real total 5
+          // The counter was invalidated and is recomputed from the sum, so this
+          // write fits. A stale counter (still 10) would evict user2:y.
+          await dao.write(key: 'user2:z', payload: 'zzzzz'); // 5 — total 10
+
+          expect(await dao.read('user1:x'), isNull);
+          expect(await dao.read('user2:y'), equals('yyyyy'));
+          expect(await dao.read('user2:z'), equals('zzzzz'));
+        },
+      );
     });
   });
 }

--- a/mobile/packages/cache_sync/test/fake_cache_dao.dart
+++ b/mobile/packages/cache_sync/test/fake_cache_dao.dart
@@ -50,7 +50,7 @@ class FakeCacheDao implements CacheDao {
 
   @override
   Future<int> totalPayloadBytes() async =>
-      _store.values.fold<int>(0, (sum, e) => sum + e.payload.length);
+      _store.values.fold<int>(0, (sum, e) => sum + e.payload.runes.length);
 
   @override
   Future<void> evictOldest(int bytesToFree) async {
@@ -60,7 +60,7 @@ class FakeCacheDao implements CacheDao {
       ..sort((a, b) => a.value.cachedAt.compareTo(b.value.cachedAt));
     for (final entry in sorted) {
       if (freed >= bytesToFree) break;
-      freed += entry.value.payload.length;
+      freed += entry.value.payload.runes.length;
       _store.remove(entry.key);
     }
   }


### PR DESCRIPTION
## What

`CacheDaoImpl` recomputed a full-table `SUM(LENGTH(payload))` **after every write** (to check the size budget), and when evicting it **materialised every full payload row into memory** and deleted one row at a time. On a write-heavy cache that's an O(N) scan per write plus a memory spike per eviction.

## How

- **Running counter** for the total payload size: seeded lazily from the real sum, kept exact across `write` (accounting for the length the `insertOnConflictUpdate` overwrite replaces) and `delete`, invalidated on the bulk `deletePrefix` path, and reconciled against the real sum every 256 writes to bound drift from a concurrent same-key write. Only maintained when a budget is set — an unbounded cache pays nothing.
- **Batched eviction**: `evictOldest` now selects just the key + payload `LENGTH` (oldest first) and issues **one** `DELETE ... WHERE cache_key IN (...)` instead of loading payloads and deleting per row.

The public `CacheDao` interface is unchanged (the test fake still conforms).

## Testing

- `flutter analyze` clean; `dart format` clean.
- `cache_sync` suite: 81/81 pass (78 existing + 3 new).
- New tests exercise the counter across an **overwrite-shrink**, a **delete**, and a **`deletePrefix` invalidation** — each framed so mis-accounting would force an *incorrect* eviction (so they fail loudly if the counter drifts).

## Risk

Low — contained to one package; the interface and eviction outcome are unchanged, and the existing size-based-LRU tests are the regression net for counter correctness.

Part of a DM/app-wide performance series targeting steady-state CPU/battery.