### PR TITLE
perf(dm): short-circuit statusFor when there are no in-flight queue rows

### DIFF
--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -145,6 +145,12 @@ class ConversationState extends Equatable {
   /// (the repository transactionally couples queue-row deletion with
   /// persisted-row insertion).
   DmDeliveryStatus statusFor(String id) {
+    // Hot path: with no in-flight queue rows every bubble is delivered, so
+    // short-circuit before building `_outgoingByRumorId`. Mirrors the
+    // `displayedMessages` guard and avoids allocating an empty lookup map per
+    // sent bubble on every emit (statusFor is called per bubble via a
+    // BlocSelector).
+    if (pendingOutgoing.isEmpty) return DmDeliveryStatus.delivered;
     final q = _outgoingByRumorId[id];
     if (q == null) return DmDeliveryStatus.delivered;
     if (q.recipientWrapStatus == OutgoingWrapStatus.failed) {

--- a/mobile/lib/blocs/dm/conversation/conversation_state.dart
+++ b/mobile/lib/blocs/dm/conversation/conversation_state.dart
@@ -135,7 +135,7 @@ class ConversationState extends Equatable {
   ///   until the user explicitly cancels.
   final List<OutgoingDm> pendingOutgoing;
 
-  /// Lookup of queue rows by rumor id for O(1) status resolution.
+  /// Lookup of queue rows by rumor id once the map is built.
   Map<String, OutgoingDm> get _outgoingByRumorId => {
     for (final row in pendingOutgoing) row.id: row,
   };

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -1563,6 +1563,19 @@ void main() {
         );
       });
 
+      test(
+        'returns delivered for an id absent from a non-empty queue '
+        '(past the empty-queue short-circuit)',
+        () {
+          final row = _outgoingDm(id: 'rumor-present');
+          final state = ConversationState(pendingOutgoing: [row]);
+          expect(
+            state.statusFor('rumor-absent'),
+            equals(DmDeliveryStatus.delivered),
+          );
+        },
+      );
+
       test('returns pending while recipient wrap is pending', () {
         final row = _outgoingDm(id: 'rumor-pending');
         final state = ConversationState(pendingOutgoing: [row]);


### PR DESCRIPTION
Closes #5664

## What

`ConversationState.statusFor` rebuilt the `_outgoingByRumorId` map on **every** call, and it is called **per bubble** via a `BlocSelector`. In the hot path (no in-flight sends) `pendingOutgoing` is empty, so each sent bubble paid an empty-map allocation on every emit.

## How

Short-circuit to `DmDeliveryStatus.delivered` when `pendingOutgoing` is empty, mirroring the existing `displayedMessages` guard. Behaviour is unchanged: an empty queue already resolved every bubble to `delivered`.

The `const` constructor is preserved. A precomputed final field would force dropping `const` on `ConversationState`, a net loss for the common path; the short-circuit captures the hot-path win without it.

The adjacent `_outgoingByRumorId` documentation now avoids implying that the full non-empty `statusFor` path is O(1), because the lookup map is still built on demand.

## Testing

- `flutter analyze` clean.
- `mise exec -- dart format lib test integration_test` clean, 0 files changed.
- `flutter test test/blocs/dm/conversation/conversation_bloc_test.dart` passed, 64/64.
- Pre-push hook analyzer and changed-file tests passed.
- GitHub Actions checks are green, including Analyze, Format, Generated Files, Tests, Web Preview, semantic PR, mergeability, and CLA.
- New boundary test: an id absent from a **non-empty** queue still returns `delivered`, exercising the path past the short-circuit.

## Risk

Very low: behavior-preserving micro-optimization on the conversation render path.

Part of a DM/app-wide performance series targeting steady-state CPU/battery.