### PR TITLE
fix(dm): stop reaction removal from popping the conversation screen

### DIFF
--- a/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
+++ b/mobile/lib/screens/inbox/conversation/widgets/reactions_detail_sheet.dart
@@ -88,9 +88,16 @@ class _ReactionsDetailBody extends StatelessWidget {
               ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
 
         if (reactions.isEmpty) {
-          // The last reaction was just removed — close the sheet.
+          // The last reaction was just removed — close the sheet, but only
+          // when this sheet is still the topmost route. Removing your own
+          // (only) reaction already pops the sheet in `_onOwnTap`; without the
+          // `isCurrent` guard the post-frame pop below would fall through and
+          // dismiss the conversation screen too — a spurious back-navigation.
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            if (context.mounted) Navigator.of(context).maybePop();
+            if (!context.mounted) return;
+            if (ModalRoute.of(context)?.isCurrent ?? false) {
+              Navigator.of(context).maybePop();
+            }
           });
           return const SizedBox.shrink();
         }

--- a/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
+++ b/mobile/test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Covers reactor listing and own-row remove / retry dispatch through
 // ABOUTME: the cubit re-provided above the modal via contentWrapper.
 
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -167,6 +169,89 @@ void main() {
       // Sheet dismissed after removal.
       expect(find.text(l10n.dmReactionsSheetTitle), findsNothing);
     });
+
+    testWidgets(
+      'removing your only reaction closes the sheet without navigating back',
+      (tester) async {
+        // Reproduces the double-pop: tapping the own row pops the sheet in
+        // `_onOwnTap`, then the cubit emits an empty list (the optimistic
+        // removal) which made the empty-state auto-close pop a SECOND time —
+        // falling through to dismiss the conversation screen underneath.
+        final controller =
+            StreamController<ConversationReactionsState>.broadcast();
+        addTearDown(controller.close);
+
+        final initial = ConversationReactionsState(
+          reactionsByMessageId: {
+            messageId: [
+              makeReaction(id: 'own1', reactorPubkey: ownerPubkey, emoji: '🔥'),
+            ],
+          },
+        );
+        when(() => cubit.state).thenReturn(initial);
+        whenListen(cubit, controller.stream, initialState: initial);
+
+        await tester.pumpWidget(
+          testMaterialApp(
+            home: Builder(
+              builder: (homeContext) => Scaffold(
+                body: Center(
+                  child: ElevatedButton(
+                    onPressed: () => Navigator.of(homeContext).push(
+                      MaterialPageRoute<void>(
+                        builder: (pageContext) => Scaffold(
+                          body: Center(
+                            child: Column(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                const Text('conversation'),
+                                ElevatedButton(
+                                  onPressed: () => ReactionsDetailSheet.show(
+                                    context: pageContext,
+                                    cubit: cubit,
+                                    conversationId: conversationId,
+                                    messageId: messageId,
+                                    messageAuthorPubkey: otherPubkey,
+                                    ownerPubkey: ownerPubkey,
+                                  ),
+                                  child: const Text('open'),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    child: const Text('go'),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('go'));
+        await tester.pumpAndSettle();
+        expect(find.text('conversation'), findsOneWidget);
+
+        await tester.tap(find.text('open'));
+        await tester.pumpAndSettle();
+        expect(find.text(l10n.dmReactionsSheetTitle), findsOneWidget);
+
+        // Tap own remove → `_onOwnTap` pops the sheet + dispatches the toggle.
+        await tester.tap(find.text(l10n.dmReactionRemoveAction));
+        await tester.pump();
+
+        // The real cubit then emits the optimistic-removed (now empty) state.
+        controller.add(const ConversationReactionsState());
+        await tester.pumpAndSettle();
+
+        // Sheet is dismissed, but the conversation screen stays put — no
+        // spurious back-navigation.
+        expect(find.text(l10n.dmReactionsSheetTitle), findsNothing);
+        expect(find.text('conversation'), findsOneWidget);
+      },
+    );
 
     testWidgets('tapping own failed row dispatches a retry request', (
       tester,


### PR DESCRIPTION
## Description

Removing your reaction from a DM's **"who reacted"** sheet also navigated you back out of the conversation — a spurious back-navigation.

**Root cause — a double-pop.** When you tap your own row to remove a reaction, two independent code paths each close the sheet:

1. `_onOwnTap` dispatches the toggle and calls `Navigator.maybePop()` — the intentional "remove → close sheet" pop (fires first, synchronously).
2. The cubit then emits the optimistic-removed state. When that was your **only** reaction, `reactionsFor(messageId)` goes empty, so `_ReactionsDetailBody`'s empty-state branch scheduled a **second** post-frame `maybePop()`. By the time it ran, the sheet was already gone, so it popped the route underneath — the conversation screen.

(With other reactors present the list isn't empty, so the second pop never schedules — which is why it reproduced specifically when removing your only/last reaction, the common case.)

**Fix.** Guard the empty-state auto-close on `ModalRoute.of(context)?.isCurrent` so it only pops when the sheet is still the active route. When `_onOwnTap` already popped the sheet, it's no longer current and the redundant pop is skipped. The sheet still auto-closes when it empties by other means (e.g. another reactor's row disappearing via reconciliation), which remains the active-route case.

**Why tests missed it.** The existing sheet test uses a `MockBloc` whose `add` is a no-op, so the cubit never emits the post-removal empty state and the empty-state auto-close path was never exercised. Added a regression test that drives the empty emit through a controllable stream over a real route stack (home → conversation → sheet) and asserts the conversation screen is not popped. It fails on the unfixed code and passes with the fix.

**Related Issue:** Closes #5667.

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` — clean (also run by pre-commit/pre-push hooks).
- `flutter test test/screens/inbox/conversation/widgets/reactions_detail_sheet_test.dart test/screens/inbox/conversation/widgets/reactions_row_test.dart` — all green.
- Verified the new regression test **fails** against the pre-fix code (`+0 -1`) and **passes** with the fix.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
