### PR TITLE
perf(test): speed up mobile test startup

### DIFF
--- a/.github/workflows/mobile_ci.yaml
+++ b/.github/workflows/mobile_ci.yaml
@@ -5,14 +5,73 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect App CI Scope
+    runs-on: ubuntu-24.04
+    outputs:
+      app: ${{ steps.scope.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect whether app CI is required
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "app=true" >> "$GITHUB_OUTPUT"
+            echo "Non-PR event; running full app CI."
+            exit 0
+          fi
+
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/mobile-ci-changed-files.txt
+          echo "Changed files:"
+          cat /tmp/mobile-ci-changed-files.txt
+
+          app=false
+          while IFS= read -r path; do
+            case "$path" in
+              .github/workflows/*)
+                app=true
+                ;;
+              *.md|docs/*|brand-guidelines/*|mobile/docs/*)
+                # Docs-only changes do not need the full app test matrix.
+                ;;
+              mobile/lib/*|mobile/test/*|mobile/integration_test/*|mobile/scripts/*)
+                app=true
+                ;;
+              mobile/android/*|mobile/ios/*|mobile/macos/*|mobile/web/*|mobile/assets/*|mobile/fonts/*|mobile/overrides/*|mobile/l10n/*)
+                app=true
+                ;;
+              mobile/pubspec.yaml|mobile/pubspec.lock|mobile/dart_test.yaml|mobile/analysis_options.yaml|mobile/build.yaml|mobile/l10n.yaml)
+                app=true
+                ;;
+              mobile/*)
+                app=true
+                ;;
+            esac
+          done < /tmp/mobile-ci-changed-files.txt
+
+          echo "app=$app" >> "$GITHUB_OUTPUT"
+          if [ "$app" = "true" ]; then
+            echo "App CI required."
+          else
+            echo "Package-only/docs-only change; app CI jobs may be skipped."
+          fi
+
   generated-files:
     name: Generated Files
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.app == 'true' }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -124,6 +183,8 @@ jobs:
           fi
   format:
     name: Format
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.app == 'true' }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -142,6 +203,8 @@ jobs:
         run: dart format --output=none --set-exit-if-changed lib test integration_test
   analyze:
     name: Analyze
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.app == 'true' }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -160,6 +223,8 @@ jobs:
         run: flutter analyze lib test integration_test
   tests:
     name: Tests
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.app == 'true' }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -186,6 +251,8 @@ jobs:
         run: very_good test --optimization --concurrency=4 --exclude-tags integration --test-randomize-ordering-seed random
   vgv-tag-gate:
     name: VGV Tag Gate
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.app == 'true' }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -220,6 +287,7 @@ jobs:
     name: Mobile CI
     if: ${{ always() }}
     needs:
+      - changes
       - generated-files
       - format
       - analyze
@@ -234,18 +302,42 @@ jobs:
           ANALYZE_RESULT: ${{ needs.analyze.result }}
           TESTS_RESULT: ${{ needs.tests.result }}
           VGV_TAG_GATE_RESULT: ${{ needs.vgv-tag-gate.result }}
+          APP_CI_REQUIRED: ${{ needs.changes.outputs.app }}
         run: |
+          echo "app-ci-required: ${APP_CI_REQUIRED}"
           echo "generated-files: ${GENERATED_FILES_RESULT}"
           echo "format: ${FORMAT_RESULT}"
           echo "analyze: ${ANALYZE_RESULT}"
           echo "tests: ${TESTS_RESULT}"
           echo "vgv-tag-gate: ${VGV_TAG_GATE_RESULT}"
 
-          if [[ "${GENERATED_FILES_RESULT}" != "success" || \
-                "${FORMAT_RESULT}" != "success" || \
-                "${ANALYZE_RESULT}" != "success" || \
-                "${TESTS_RESULT}" != "success" || \
-                "${VGV_TAG_GATE_RESULT}" != "success" ]]; then
-            echo "One or more Mobile CI jobs failed."
+          results=(
+            "${GENERATED_FILES_RESULT}"
+            "${FORMAT_RESULT}"
+            "${ANALYZE_RESULT}"
+            "${TESTS_RESULT}"
+            "${VGV_TAG_GATE_RESULT}"
+          )
+
+          if [ "${APP_CI_REQUIRED}" = "false" ]; then
+            for result in "${results[@]}"; do
+              if [[ "${result}" != "success" && "${result}" != "skipped" ]]; then
+                echo "One or more Mobile CI jobs failed or were cancelled."
+                exit 1
+              fi
+            done
+            echo "App CI intentionally skipped for this PR."
+            exit 0
+          fi
+
+          for result in "${results[@]}"; do
+            if [ "${result}" != "success" ]; then
+              echo "One or more Mobile CI jobs failed."
+              exit 1
+            fi
+          done
+
+          if [ "${APP_CI_REQUIRED}" != "true" ]; then
+            echo "Could not determine Mobile CI scope."
             exit 1
           fi

--- a/mobile/docs/TEST_PERFORMANCE.md
+++ b/mobile/docs/TEST_PERFORMANCE.md
@@ -1,0 +1,36 @@
+# Test Performance
+
+The app test suite is large enough that fixed startup costs and hidden waits
+matter. Use `scripts/test_timing_baseline.sh` before and after test-speed
+changes so improvements are measured instead of guessed.
+
+## Baseline Commands
+
+Run from `mobile/`:
+
+```bash
+scripts/test_timing_baseline.sh --quick
+scripts/test_timing_baseline.sh --full
+```
+
+The script writes JSONL timing records to `/tmp` by default and stores command
+logs in a temporary directory. Set `DIVINE_TEST_TIMING_OUTPUT` or pass
+`--output` when a stable artifact path is needed.
+
+## Current Hotspots
+
+- `test/flutter_test_config.dart` must keep ordinary test startup light. Golden
+  setup is opt-in via `-D DIVINE_GOLDEN_TESTS=true`.
+- `scripts/golden.sh` is the supported entrypoint for golden verification and
+  update runs.
+- `Future.delayed` and broad `pumpAndSettle()` calls should be replaced with
+  explicit async coordination or bounded pumps when touching affected tests.
+- `skip_very_good_optimization` tags should only remain when a test cannot be
+  isolated safely under the VGV optimizer.
+
+## Acceptance Signals
+
+- App unit bucket wall time drops from the measured baseline.
+- `scripts/check_future_delayed_ceiling.sh` and the VGV tag gate keep passing.
+- Golden verification remains isolated to explicit golden paths.
+- CI path filtering skips full app tests only when the app suite is not affected.

--- a/mobile/scripts/baseline/future_delayed_tests.txt
+++ b/mobile/scripts/baseline/future_delayed_tests.txt
@@ -24,7 +24,6 @@ test/services/curated_list_service_collaboration_test.dart
 test/services/curated_list_service_crud_test.dart
 test/services/curated_list_service_playlist_test.dart
 test/services/curated_list_service_query_test.dart
-test/services/curated_list_service_stream_test.dart
 test/services/curated_list_service_video_management_test.dart
 test/services/performance_monitoring_service_test.dart
 test/services/reactive_pagination_test.dart
@@ -37,7 +36,6 @@ test/services/video_event_service_pagination_test.dart
 test/services/video_event_service_repost_test.dart
 test/services/video_event_service_with_event_router_test.dart
 test/startup/startup_diagnostics_test.dart
-test/unit/services/classic_vines_priority_test.dart
 test/unit/services/video_event_service_force_refresh_test.dart
 test/unit/services/video_event_service_infinite_scroll_test.dart
 test/unit/services/video_event_service_subscription_test.dart

--- a/mobile/scripts/golden.sh
+++ b/mobile/scripts/golden.sh
@@ -9,6 +9,9 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 cd "$PROJECT_ROOT"
 
+GOLDEN_TEST_PATH="test/goldens/"
+GOLDEN_DART_DEFINE="--dart-define=DIVINE_GOLDEN_TESTS=true"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -44,11 +47,12 @@ update_goldens() {
     echo -e "${BLUE}Updating golden images...${NC}"
 
     if [ -z "$test_file" ]; then
-        echo "Running all golden tests with --update-goldens flag..."
-        flutter test --update-goldens --tags=golden || flutter test --update-goldens
+        require_golden_tests
+        echo "Running golden tests with --update-goldens flag..."
+        flutter test --no-pub "$GOLDEN_DART_DEFINE" --update-goldens "$GOLDEN_TEST_PATH"
     else
         echo "Updating goldens for: $test_file"
-        flutter test --update-goldens "$test_file"
+        flutter test --no-pub "$GOLDEN_DART_DEFINE" --update-goldens "$test_file"
     fi
 
     echo -e "${GREEN}✓ Golden images updated successfully${NC}"
@@ -60,11 +64,12 @@ verify_goldens() {
     echo -e "${BLUE}Verifying golden tests...${NC}"
 
     if [ -z "$test_file" ]; then
-        echo "Running all golden tests..."
-        flutter test --tags=golden || flutter test test/goldens/
+        require_golden_tests
+        echo "Running golden tests..."
+        flutter test --no-pub "$GOLDEN_DART_DEFINE" "$GOLDEN_TEST_PATH"
     else
         echo "Verifying: $test_file"
-        flutter test "$test_file"
+        flutter test --no-pub "$GOLDEN_DART_DEFINE" "$test_file"
     fi
 
     if [ $? -eq 0 ]; then
@@ -102,7 +107,7 @@ diff_goldens() {
 list_golden_tests() {
     echo -e "${BLUE}Golden test files:${NC}"
 
-    find test -name "*golden*.dart" -o -name "*_golden_test.dart" | sort
+    find "$GOLDEN_TEST_PATH" -name "*_test.dart" | sort
 
     echo ""
     echo -e "${BLUE}Golden image files:${NC}"
@@ -141,8 +146,8 @@ generate_golden_test() {
 ci_mode() {
     echo -e "${BLUE}Running golden tests in CI mode...${NC}"
 
-    # Run tests without updating
-    flutter test --tags=golden || flutter test test/goldens/
+    require_golden_tests
+    flutter test --no-pub "$GOLDEN_DART_DEFINE" "$GOLDEN_TEST_PATH"
 
     # Check for any uncommitted golden changes
     if git diff --exit-code test/goldens/ > /dev/null 2>&1; then
@@ -150,6 +155,14 @@ ci_mode() {
     else
         echo -e "${RED}✗ Golden images have uncommitted changes${NC}"
         git diff --stat test/goldens/
+        exit 1
+    fi
+}
+
+require_golden_tests() {
+    if ! find "$GOLDEN_TEST_PATH" -name "*_test.dart" -type f | grep -q .; then
+        echo -e "${RED}✗ No golden test files found under $GOLDEN_TEST_PATH${NC}"
+        echo -e "${YELLOW}Pass a specific golden test file or add tests under $GOLDEN_TEST_PATH.${NC}"
         exit 1
     fi
 }

--- a/mobile/scripts/test_timing_baseline.sh
+++ b/mobile/scripts/test_timing_baseline.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# ABOUTME: Measures representative Flutter test buckets without writing repo files.
+# ABOUTME: Emits JSONL timing records to /tmp by default for before/after comparisons.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+DEFAULT_OUTPUT="/tmp/divine-test-timing-$(date +%Y%m%d-%H%M%S).jsonl"
+OUTPUT="${DIVINE_TEST_TIMING_OUTPUT:-$DEFAULT_OUTPUT}"
+MODE="quick"
+FAILED=0
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/test_timing_baseline.sh [--quick|--full] [--output path]
+
+Runs representative test buckets and writes JSONL records with duration,
+exit status, and log path. The default output path is /tmp so normal timing
+runs do not dirty the repository.
+
+Modes:
+  --quick  app unit, router, golden, and VGV opt-out count buckets
+  --full   quick buckets plus services, widgets, selected packages, and
+           the CI-equivalent VGV optimized command
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --quick)
+      MODE="quick"
+      shift
+      ;;
+    --full)
+      MODE="full"
+      shift
+      ;;
+    --output)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --output" >&2
+        exit 2
+      fi
+      OUTPUT="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$(dirname "$OUTPUT")"
+LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/divine-test-timing.XXXXXX")"
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+run_bucket() {
+  local name="$1"
+  shift
+  local log_file="$LOG_DIR/${name}.log"
+  local command="$*"
+  local start_epoch
+  local end_epoch
+  local duration
+  local status
+
+  echo "==> $name"
+  echo "    $command"
+  start_epoch="$(date +%s)"
+  "$@" >"$log_file" 2>&1
+  status=$?
+  end_epoch="$(date +%s)"
+  duration=$((end_epoch - start_epoch))
+
+  printf '{"bucket":"%s","status":%s,"duration_seconds":%s,"command":"%s","log":"%s"}\n' \
+    "$(json_escape "$name")" \
+    "$status" \
+    "$duration" \
+    "$(json_escape "$command")" \
+    "$(json_escape "$log_file")" >>"$OUTPUT"
+
+  if [ "$status" -eq 0 ]; then
+    echo "    PASS in ${duration}s"
+  else
+    FAILED=1
+    echo "    FAIL in ${duration}s (log: $log_file)"
+  fi
+}
+
+run_shell_bucket() {
+  local name="$1"
+  local command="$2"
+  run_bucket "$name" bash -lc "$command"
+}
+
+cd "$PROJECT_ROOT"
+: >"$OUTPUT"
+
+echo "Writing timing records to $OUTPUT"
+echo "Command logs are in $LOG_DIR"
+
+run_bucket app-unit flutter test test/unit --no-pub --reporter=compact
+run_bucket app-router flutter test test/router --no-pub --reporter=compact
+run_bucket app-goldens scripts/golden.sh verify
+run_shell_bucket vgv-opt-out-count \
+  "grep -rln \"skip_very_good_optimization\" test | wc -l | tr -d '[:space:]'"
+
+if [ "$MODE" = "full" ]; then
+  run_bucket app-services flutter test test/services --no-pub --reporter=compact
+  run_bucket app-widgets flutter test test/widgets --no-pub --reporter=compact
+  run_bucket package-models flutter test packages/models/test --no-pub --reporter=compact
+  run_bucket package-db-client flutter test packages/db_client/test --no-pub --reporter=compact
+  run_bucket vgv-optimized very_good test --optimization --concurrency=4 \
+    --exclude-tags integration --test-randomize-ordering-seed random
+fi
+
+echo "Done. Timing JSONL: $OUTPUT"
+exit "$FAILED"

--- a/mobile/test/flutter_test_config.dart
+++ b/mobile/test/flutter_test_config.dart
@@ -1,5 +1,5 @@
-// ABOUTME: Test configuration file that loads fonts and sets up golden tests
-// ABOUTME: This file is automatically executed before all tests in the test directory
+// ABOUTME: Test configuration file that sets up app-wide plugin mocks.
+// ABOUTME: Golden-only font and Alchemist setup is opt-in to keep unit tests fast.
 
 import 'dart:async';
 
@@ -8,17 +8,21 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:golden_toolkit/golden_toolkit.dart';
 import 'test_setup.dart';
 
+const _runGoldenSetup = bool.fromEnvironment('DIVINE_GOLDEN_TESTS');
+
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Set up test environment with plugin mocks (secure_storage, path_provider, etc.)
   setupTestEnvironment();
 
-  // Web / `flutter test --platform chrome`: skip golden font loading and Alchemist.
-  // Those paths can stall headless Chrome with almost no CPU while `loading …` is shown.
-  if (kIsWeb) {
+  // Web / `flutter test --platform chrome`: skip golden font loading and
+  // Alchemist. Those paths can stall headless Chrome with almost no CPU while
+  // `loading ...` is shown.
+  if (kIsWeb || !_runGoldenSetup) {
     return testMain();
   }
 
-  // Load app fonts for golden tests
+  // Golden runs opt in with:
+  //   flutter test -D DIVINE_GOLDEN_TESTS=true test/goldens/
   await loadAppFonts();
 
   // Configure Alchemist for better golden test output

--- a/mobile/test/router/nip05_settings_navigation_test.dart
+++ b/mobile/test/router/nip05_settings_navigation_test.dart
@@ -138,7 +138,13 @@ void main() {
       router.go(NostrSettingsScreen.path);
       await tester.pumpAndSettle();
 
-      await tester.tap(find.text(l10n.nostrSettingsNip05Address));
+      final nip05Tile = find.text(l10n.nostrSettingsNip05Address);
+      await tester.scrollUntilVisible(
+        nip05Tile,
+        250,
+        scrollable: find.byType(Scrollable),
+      );
+      await tester.tap(nip05Tile);
       await tester.pumpAndSettle();
 
       expect(find.text(l10n.nostrSettingsNip05Address), findsWidgets);
@@ -197,7 +203,13 @@ void main() {
         router.go(NostrSettingsScreen.path);
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text(l10n.nostrSettingsNip05Address));
+        final nip05Tile = find.text(l10n.nostrSettingsNip05Address);
+        await tester.scrollUntilVisible(
+          nip05Tile,
+          250,
+          scrollable: find.byType(Scrollable),
+        );
+        await tester.tap(nip05Tile);
         await tester.pumpAndSettle();
 
         expect(find.byType(Nip05SettingsView), findsOneWidget);

--- a/mobile/test/screens/apps/app_detail_screen_test.dart
+++ b/mobile/test/screens/apps/app_detail_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_app_bridge_repository/nostr_app_bridge_repository.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -18,6 +19,10 @@ class _MockNostrAppDirectoryService extends Mock
 
 void main() {
   group('AppDetailScreen', () {
+    setUpAll(() async {
+      await loadAppFonts();
+    });
+
     late _MockNostrAppDirectoryService mockDirectoryService;
 
     setUp(() {

--- a/mobile/test/screens/key_management_screen_test.dart
+++ b/mobile/test/screens/key_management_screen_test.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/screens/key_management_screen.dart';
 import 'package:openvine/services/auth_service.dart';
@@ -47,6 +48,10 @@ class _FakeKeyManagementAuthService extends Fake implements AuthService {
 
 void main() {
   group(KeyManagementScreen, () {
+    setUpAll(() async {
+      await loadAppFonts();
+    });
+
     const testNpub =
         'npub1abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz';
 

--- a/mobile/test/screens/sound_detail_screen_test.dart
+++ b/mobile/test/screens/sound_detail_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:nostr_client/nostr_client.dart';
@@ -129,6 +130,10 @@ Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
+  setUpAll(() async {
+    await loadAppFonts();
+  });
+
   group('SoundDetailScreen', () {
     late _MockAudioPlaybackService mockAudioService;
     late _MockNostrClient mockNostrClient;

--- a/mobile/test/screens/sounds_screen_test.dart
+++ b/mobile/test/screens/sounds_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
@@ -94,6 +95,10 @@ Widget createTestWidget({required Widget child, List<dynamic>? overrides}) {
 }
 
 void main() {
+  setUpAll(() async {
+    await loadAppFonts();
+  });
+
   group('SoundsScreen', () {
     group('Widget Structure', () {
       testWidgets('renders with correct title', (tester) async {

--- a/mobile/test/screens/welcome_screen_test.dart
+++ b/mobile/test/screens/welcome_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
@@ -66,7 +67,8 @@ void main() {
   late _MockAppDatabase mockDb;
   late _MockUserProfilesDao mockUserProfilesDao;
 
-  setUpAll(() {
+  setUpAll(() async {
+    await loadAppFonts();
     registerFallbackValue(AuthenticationSource.none);
   });
 

--- a/mobile/test/services/curated_list_service_stream_test.dart
+++ b/mobile/test/services/curated_list_service_stream_test.dart
@@ -122,7 +122,7 @@ void main() {
         );
 
         // Wait for the async generator to reach the await for loop
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit list events one at a time
         eventController.add(
@@ -133,7 +133,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         eventController.add(
           createListEvent(
@@ -143,7 +143,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         eventController.add(
           createListEvent(
@@ -153,7 +153,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Close the event controller first to complete the stream
         await eventController.close();
@@ -174,7 +174,7 @@ void main() {
         );
 
         // Wait for the async generator to reach the await for loop
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit a list WITH videos
         eventController.add(
@@ -185,14 +185,14 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit a list WITHOUT videos
         eventController.add(
           createEmptyListEvent(dTag: 'list_without_videos', name: 'Empty List'),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit another list WITH videos
         eventController.add(
@@ -203,7 +203,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Close the event controller first to complete the stream
         await eventController.close();
@@ -230,7 +230,7 @@ void main() {
             .listen((lists) => receivedLists.add(List.from(lists)));
 
         // Wait for the async generator to reach the await for loop
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit list1 - should be yielded
         eventController.add(
@@ -241,7 +241,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit list2 - should be SKIPPED (in excludeIds)
         eventController.add(
@@ -252,7 +252,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit list3 - should be yielded
         eventController.add(
@@ -263,7 +263,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Close the event controller first to complete the stream
         await eventController.close();
@@ -289,7 +289,7 @@ void main() {
         );
 
         // Wait for the async generator to reach the await for loop
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit older version of list1
         eventController.add(
@@ -301,7 +301,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit newer version of same list1
         eventController.add(
@@ -313,7 +313,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Close the event controller first to complete the stream
         await eventController.close();
@@ -346,7 +346,7 @@ void main() {
             .streamPublicListsFromRelays(limit: 200)
             .listen((_) {});
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Close the event controller first to complete the stream
         await eventController.close();
@@ -365,7 +365,7 @@ void main() {
         );
 
         // Wait for the async generator to reach the await for loop
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit list with 1 video
         eventController.add(
@@ -376,7 +376,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit list with 5 videos
         eventController.add(
@@ -387,7 +387,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Emit list with 3 videos
         eventController.add(
@@ -398,7 +398,7 @@ void main() {
           ),
         );
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // Close the event controller first to complete the stream
         await eventController.close();

--- a/mobile/test/unit/services/classic_vines_priority_test.dart
+++ b/mobile/test/unit/services/classic_vines_priority_test.dart
@@ -177,20 +177,20 @@ void main() {
       await videoEventService.subscribeToVideoFeed(
         subscriptionType: SubscriptionType.discovery,
       );
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Add events in random order
       eventStreamController.add(regularVideo);
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       eventStreamController.add(classicVine1);
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       eventStreamController.add(editorPick);
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       eventStreamController.add(classicVine2);
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Verify order: Classic vines should be first, despite being older
       expect(videoEventService.discoveryVideos.length, equals(4));
@@ -233,10 +233,10 @@ void main() {
         await videoEventService.subscribeToVideoFeed(
           subscriptionType: SubscriptionType.discovery,
         );
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         eventStreamController.add(classicVine);
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         // Add multiple new regular videos
         for (var i = 0; i < 5; i++) {
@@ -253,7 +253,7 @@ void main() {
           newVideo.id = 'new-$i';
 
           eventStreamController.add(newVideo);
-          await Future.delayed(const Duration(milliseconds: 10));
+          await pumpEventQueue();
         }
 
         // Classic vine should still be first despite being oldest
@@ -293,7 +293,7 @@ void main() {
         await videoEventService.subscribeToVideoFeed(
           subscriptionType: SubscriptionType.discovery,
         );
-        await Future.delayed(const Duration(milliseconds: 10));
+        await pumpEventQueue();
 
         // Add in random order
         eventStreamController.add(classicVines[2]);
@@ -302,7 +302,7 @@ void main() {
         eventStreamController.add(classicVines[1]);
         eventStreamController.add(classicVines[3]);
 
-        await Future.delayed(const Duration(milliseconds: 50));
+        await pumpEventQueue();
 
         // All should be classic vines
         expect(videoEventService.discoveryVideos.length, equals(5));
@@ -365,14 +365,14 @@ void main() {
       await videoEventService.subscribeToVideoFeed(
         subscriptionType: SubscriptionType.discovery,
       );
-      await Future.delayed(const Duration(milliseconds: 10));
+      await pumpEventQueue();
 
       // Add in reverse priority order
       eventStreamController.add(regularVideo);
       eventStreamController.add(editorPick);
       eventStreamController.add(classicVine);
 
-      await Future.delayed(const Duration(milliseconds: 30));
+      await pumpEventQueue();
 
       // Verify priority ordering
       expect(videoEventService.discoveryVideos.length, equals(3));


### PR DESCRIPTION
Closes #5670

## Summary
- Make golden font/Alchemist setup opt-in via `DIVINE_GOLDEN_TESTS` instead of loading it for every Flutter test
- Route golden verification through explicit golden paths and add a JSONL timing baseline script
- Replace fixed `Future.delayed` waits in targeted tests with event-queue pumping and fix the NIP-05 router test viewport assumption
- Add docs-only app-CI path filtering while keeping app CI required for package/app/workflow changes

## Measured result
- Before investigation baseline: `flutter test test/unit --no-pub --reporter=compact` took about 1:28.63
- Final warmed timing smoke: app-unit 19s, app-router 14s, app-goldens 5s

## Verification
- `mise exec -- dart format lib test integration_test`
- `flutter analyze`
- `actionlint .github/workflows/mobile_ci.yaml`
- `bash -n scripts/golden.sh scripts/test_timing_baseline.sh`
- `scripts/test_timing_baseline.sh --quick --output /tmp/divine-test-timing-final.jsonl`
- `flutter test test/router --no-pub --reporter=compact`
- `flutter test test/services/curated_list_service_stream_test.dart --no-pub --reporter=compact`
- `flutter test test/unit/services/classic_vines_priority_test.dart --no-pub --reporter=compact`
- `bash scripts/check_future_delayed_ceiling.sh`
- `scripts/golden.sh verify`
