### PR TITLE
fix(age-verification): stop repeated video verification

### DIFF
--- a/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
@@ -44,6 +44,16 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
     emit(state.withVerifying(eventId, false));
   }
 
+  /// Marks the automatic age-verification retry as spent for [eventId].
+  ///
+  /// Returns `true` when this call consumed the attempt budget, or `false`
+  /// when an automatic retry was already attempted for the video.
+  bool consumeAutoRetryAttempt(String eventId) {
+    if (state.hasAutoRetryAttempted(eventId)) return false;
+    emit(state.withAutoRetryAttempted(eventId));
+    return true;
+  }
+
   /// Clears all tracked statuses (call on feed-mode change).
   void clear() {
     emit(state.cleared());

--- a/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_cubit.dart
@@ -12,12 +12,17 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_state
 class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
   /// Creates a cubit. [maxEntries] caps the internal LRU map; defaults
   /// to the [VideoPlaybackStatusState] default when null.
-  VideoPlaybackStatusCubit({int? maxEntries})
-    : super(
-        maxEntries == null
-            ? VideoPlaybackStatusState()
-            : VideoPlaybackStatusState(maxEntries: maxEntries),
-      );
+  VideoPlaybackStatusCubit({
+    int? maxEntries,
+    bool Function()? canAutoAuthorizeAgeRestrictedMedia,
+  }) : _canAutoAuthorizeAgeRestrictedMedia = canAutoAuthorizeAgeRestrictedMedia,
+       super(
+         maxEntries == null
+             ? VideoPlaybackStatusState()
+             : VideoPlaybackStatusState(maxEntries: maxEntries),
+       );
+
+  final bool Function()? _canAutoAuthorizeAgeRestrictedMedia;
 
   /// Reports [status] for the video with [eventId].
   ///
@@ -52,6 +57,23 @@ class VideoPlaybackStatusCubit extends Cubit<VideoPlaybackStatusState> {
     if (state.hasAutoRetryAttempted(eventId)) return false;
     emit(state.withAutoRetryAttempted(eventId));
     return true;
+  }
+
+  /// Consumes one automatic age-verification retry when the current playback
+  /// state and viewer policy allow it.
+  ///
+  /// This keeps the retry/fallback decision in the cubit rather than in the
+  /// error overlay. The caller still owns invoking the UI callback after this
+  /// method grants the attempt.
+  bool consumeAgeRestrictedAutoRetryIfEligible(
+    String eventId, {
+    required bool isAgeRestricted,
+    required bool hasVerifyAction,
+  }) {
+    if (!isAgeRestricted || !hasVerifyAction) return false;
+    if (state.isVerifying(eventId)) return false;
+    if (!(_canAutoAuthorizeAgeRestrictedMedia?.call() ?? false)) return false;
+    return consumeAutoRetryAttempt(eventId);
   }
 
   /// Clears all tracked statuses (call on feed-mode change).

--- a/mobile/lib/blocs/video_playback_status/video_playback_status_state.dart
+++ b/mobile/lib/blocs/video_playback_status/video_playback_status_state.dart
@@ -40,12 +40,16 @@ class VideoPlaybackStatusState extends Equatable {
     this.maxEntries = _defaultMaxEntries,
     LinkedHashMap<String, PlaybackStatus>? statuses,
     Set<String>? verifyingIds,
+    Set<String>? autoRetryAttemptedIds,
   }) : _statuses = statuses == null
            ? LinkedHashMap<String, PlaybackStatus>()
            : LinkedHashMap<String, PlaybackStatus>.from(statuses),
        _verifyingIds = verifyingIds == null
            ? <String>{}
-           : Set<String>.from(verifyingIds);
+           : Set<String>.from(verifyingIds),
+       _autoRetryAttemptedIds = autoRetryAttemptedIds == null
+           ? <String>{}
+           : Set<String>.from(autoRetryAttemptedIds);
 
   static const int _defaultMaxEntries = 100;
 
@@ -58,6 +62,11 @@ class VideoPlaybackStatusState extends Equatable {
   /// and small (usually 0-1 entries); not LRU-bounded.
   final Set<String> _verifyingIds;
 
+  /// Event IDs whose automatic age-verification retry has already been spent
+  /// for this feed session. Kept above the overlay so retry teardown/rebuild
+  /// cannot reset the attempt budget.
+  final Set<String> _autoRetryAttemptedIds;
+
   /// Returns the status for [eventId], or [PlaybackStatus.ready] when no
   /// status has been recorded.
   PlaybackStatus statusFor(String eventId) =>
@@ -66,6 +75,11 @@ class VideoPlaybackStatusState extends Equatable {
   /// Whether an age-verification retry is currently in flight for [eventId].
   /// Drives the "Verify age" button's loading state.
   bool isVerifying(String eventId) => _verifyingIds.contains(eventId);
+
+  /// Whether the automatic age-verification retry has already been attempted
+  /// for [eventId].
+  bool hasAutoRetryAttempted(String eventId) =>
+      _autoRetryAttemptedIds.contains(eventId);
 
   /// Returns a new state with [status] recorded for [eventId].
   ///
@@ -83,6 +97,7 @@ class VideoPlaybackStatusState extends Equatable {
       maxEntries: maxEntries,
       statuses: next,
       verifyingIds: _verifyingIds,
+      autoRetryAttemptedIds: _autoRetryAttemptedIds,
     );
   }
 
@@ -98,6 +113,18 @@ class VideoPlaybackStatusState extends Equatable {
       maxEntries: maxEntries,
       statuses: _statuses,
       verifyingIds: next,
+      autoRetryAttemptedIds: _autoRetryAttemptedIds,
+    );
+  }
+
+  /// Returns a new state with [eventId]'s automatic retry attempt marked.
+  VideoPlaybackStatusState withAutoRetryAttempted(String eventId) {
+    final next = Set<String>.from(_autoRetryAttemptedIds)..add(eventId);
+    return VideoPlaybackStatusState(
+      maxEntries: maxEntries,
+      statuses: _statuses,
+      verifyingIds: _verifyingIds,
+      autoRetryAttemptedIds: next,
     );
   }
 
@@ -115,7 +142,13 @@ class VideoPlaybackStatusState extends Equatable {
     // `_statuses.keys.toList()` catches those insertion-order changes.
     // Removing either would silently suppress a whole class of state
     // updates — do not "simplify" this.
-    return [_statuses, _statuses.keys.toList(), maxEntries, _verifyingIds];
+    return [
+      _statuses,
+      _statuses.keys.toList(),
+      maxEntries,
+      _verifyingIds,
+      _autoRetryAttemptedIds,
+    ];
   }
 }
 

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -27,11 +27,8 @@ Future<void> retryAgeRestrictedPooledVideo({
   required PooledAgeRestrictedSha256Resolver resolveSha256,
   required FutureOr<bool> Function(Map<String, String>) retryPlayback,
 }) async {
-  // The pooled overlays (ModeratedContentOverlay / PooledVideoErrorOverlay)
-  // emit no tap-time log of their own, so this is the only record that the
-  // user actually pressed "Verify age" on the native feed path.
   Log.info(
-    '🔐 [AGE-GATE] User tapped Verify age (pooled) for video ${video.id}',
+    '🔐 [AGE-GATE] Starting age-restricted pooled retry for video ${video.id}',
     name: _logName,
     category: LogCategory.video,
   );

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -278,7 +278,13 @@ class PooledFullscreenVideoFeedScreen extends ConsumerWidget {
             feedTuningRepository: feedTuningRepository,
           )..add(const FullscreenFeedStarted()),
         ),
-        BlocProvider(create: (_) => VideoPlaybackStatusCubit()),
+        BlocProvider(
+          create: (_) => VideoPlaybackStatusCubit(
+            canAutoAuthorizeAgeRestrictedMedia: () => ref
+                .read(mediaAuthInterceptorProvider)
+                .shouldAutoAuthorizeAgeRestrictedMedia,
+          ),
+        ),
       ],
       child: FullscreenFeedContent(
         contextTitle: contextTitle,

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -94,7 +94,13 @@ class VideoFeedPage extends ConsumerWidget {
             ),
           )..add(VideoFeedStarted(mode: initialMode)),
         ),
-        BlocProvider(create: (_) => VideoPlaybackStatusCubit()),
+        BlocProvider(
+          create: (_) => VideoPlaybackStatusCubit(
+            canAutoAuthorizeAgeRestrictedMedia: () => ref
+                .read(mediaAuthInterceptorProvider)
+                .shouldAutoAuthorizeAgeRestrictedMedia,
+          ),
+        ),
       ],
       child: VideoFeedView(initialIndex: initialIndex),
     );

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -22,10 +22,18 @@ class MediaAuthInterceptor {
   final ContentFilterService _contentFilterService;
   final MediaViewerAuthService _mediaViewerAuthService;
 
-  bool get canAutoAuthorizeAdultMedia =>
+  /// Whether an age-restricted media surface can retry with viewer auth without
+  /// asking the user to verify again.
+  ///
+  /// `hide` remains a hard block. Verified users with `warn` or `show`
+  /// preferences can reuse their existing verification for playback auth.
+  bool get shouldAutoAuthorizeAgeRestrictedMedia =>
+      _mediaViewerAuthService.canCreateHeaders &&
       _ageVerificationService.isAdultContentVerified &&
-      _contentFilterService.adultPlaybackPreference ==
-          ContentFilterPreference.show;
+      _contentFilterService.adultPlaybackPreference !=
+          ContentFilterPreference.hide;
+
+  bool get canAutoAuthorizeAdultMedia => shouldAutoAuthorizeAgeRestrictedMedia;
 
   /// Creates viewer-auth headers only when the user's existing adult-content
   /// preferences allow automatic playback.
@@ -101,11 +109,13 @@ class MediaAuthInterceptor {
         return const ViewerAuthUnavailable();
       }
 
-      // Auto-create auth headers only when the user is already verified and
-      // every adult category is configured to show.
-      if (canAutoAuthorizeAdultMedia) {
+      // Once the viewer has completed adult-content age verification, keep that
+      // verification durable for playback. `hide` remains a hard block above;
+      // `warn` means the category can be surfaced with a warning elsewhere, not
+      // that the user must re-verify for every media request.
+      if (isAdultContentVerified) {
         Log.debug(
-          '✅ Auto-showing adult content (user preference: always show)',
+          '✅ Auto-authorizing age-restricted media for verified user',
           name: 'MediaAuthInterceptor',
           category: LogCategory.system,
         );
@@ -150,6 +160,8 @@ class MediaAuthInterceptor {
         name: 'MediaAuthInterceptor',
         category: LogCategory.system,
       );
+
+      await _contentFilterService.unlockAdultCategories();
 
       // Create auth header after verification
       return await _mediaViewerAuthService.createAuthHeaders(

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -11,7 +11,6 @@ import 'package:infinite_video_feed/infinite_video_feed.dart'
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -74,19 +73,14 @@ class _PooledVideoErrorOverlayState
       return;
     }
 
-    final mediaAuthInterceptor = ref.read(mediaAuthInterceptorProvider);
-    if (!mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia) {
-      return;
-    }
-
-    final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
-    if (playbackStatusCubit.state.hasAutoRetryAttempted(widget.video.id)) {
-      return;
-    }
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      if (!playbackStatusCubit.consumeAutoRetryAttempt(widget.video.id)) {
+      final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
+      if (!playbackStatusCubit.consumeAgeRestrictedAutoRetryIfEligible(
+        widget.video.id,
+        isAgeRestricted: showVerifyAge,
+        hasVerifyAction: widget.onVerifyAge != null,
+      )) {
         return;
       }
       widget.onVerifyAge?.call();

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -9,6 +9,7 @@ import 'package:infinite_video_feed/infinite_video_feed.dart'
     show VideoErrorType;
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 
@@ -22,7 +23,7 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 ///   Verify Age
 /// - [VideoErrorType.notFound]: Error icon + "Video not found" + Retry
 /// - [VideoErrorType.generic]: Error icon + "Video playback error" + Retry
-class PooledVideoErrorOverlay extends ConsumerWidget {
+class PooledVideoErrorOverlay extends ConsumerStatefulWidget {
   const PooledVideoErrorOverlay({
     required this.video,
     required this.onRetry,
@@ -54,25 +55,63 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
   /// viewport.
   final bool isSquare;
 
+  @override
+  ConsumerState<PooledVideoErrorOverlay> createState() =>
+      _PooledVideoErrorOverlayState();
+}
+
+class _PooledVideoErrorOverlayState
+    extends ConsumerState<PooledVideoErrorOverlay> {
+  bool _autoRetryAttempted = false;
+
+  @override
+  void didUpdateWidget(PooledVideoErrorOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.video.id != widget.video.id ||
+        oldWidget.errorType != widget.errorType) {
+      _autoRetryAttempted = false;
+    }
+  }
+
   BoxFit _resolveBoxFit() {
-    if (!shouldPortraitExpand) return BoxFit.contain;
-    return isSquare ? BoxFit.contain : BoxFit.cover;
+    if (!widget.shouldPortraitExpand) return BoxFit.contain;
+    return widget.isSquare ? BoxFit.contain : BoxFit.cover;
+  }
+
+  void _maybeAutoRetryAgeRestricted({required bool showVerifyAge}) {
+    if (!showVerifyAge ||
+        widget.isVerifying ||
+        _autoRetryAttempted ||
+        widget.onVerifyAge == null) {
+      return;
+    }
+
+    final mediaAuthInterceptor = ref.read(mediaAuthInterceptorProvider);
+    if (!mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia) {
+      return;
+    }
+
+    _autoRetryAttempted = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      widget.onVerifyAge?.call();
+    });
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final type = errorType ?? VideoErrorType.generic;
+  Widget build(BuildContext context) {
+    final type = widget.errorType ?? VideoErrorType.generic;
     final shouldEnrichNotFoundWithModeration = type == VideoErrorType.notFound;
     final isDivineUrl = VideoModerationStatusService.shouldCheckModeration(
-      video.videoUrl,
+      widget.video.videoUrl,
     );
 
     // For divine URLs, check moderation status to enrich 404/notFound
     // errors with moderation context.
     final sha256 = isDivineUrl && shouldEnrichNotFoundWithModeration
         ? VideoModerationStatusService.resolveSha256(
-            explicitSha256: video.sha256,
-            videoUrl: video.videoUrl,
+            explicitSha256: widget.video.sha256,
+            videoUrl: widget.video.videoUrl,
           )
         : null;
 
@@ -124,18 +163,21 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
         : isModerationRestricted
         ? context.l10n.videoErrorContentRestrictedBody
         : null;
-    final showVerifyAge = isAgeRestricted && onVerifyAge != null;
+    final showVerifyAge = isAgeRestricted && widget.onVerifyAge != null;
     final showRetry = !isModerationRestricted && !showVerifyAge;
+    _maybeAutoRetryAgeRestricted(showVerifyAge: showVerifyAge);
 
     return Stack(
       fit: StackFit.expand,
       children: [
         ColoredBox(
           color: VineTheme.backgroundColor,
-          child: video.thumbnailUrl != null && video.thumbnailUrl!.isNotEmpty
+          child:
+              widget.video.thumbnailUrl != null &&
+                  widget.video.thumbnailUrl!.isNotEmpty
               ? SizedBox.expand(
                   child: VineCachedImage(
-                    imageUrl: video.thumbnailUrl!,
+                    imageUrl: widget.video.thumbnailUrl!,
                     fit: _resolveBoxFit(),
                     fadeInDuration: Duration.zero,
                     fadeOutDuration: Duration.zero,
@@ -173,15 +215,15 @@ class PooledVideoErrorOverlay extends ConsumerWidget {
                     size: DivineButtonSize.small,
                     // Disabled while a retry is in flight so a second tap
                     // can't kick off a duplicate verification.
-                    onPressed: isVerifying ? null : onVerifyAge,
-                    isLoading: isVerifying,
+                    onPressed: widget.isVerifying ? null : widget.onVerifyAge,
+                    isLoading: widget.isVerifying,
                   ),
                 if (showRetry)
                   DivineButton(
                     label: context.l10n.videoErrorRetry,
                     type: DivineButtonType.tertiary,
                     size: DivineButtonSize.small,
-                    onPressed: onRetry,
+                    onPressed: widget.onRetry,
                   ),
               ],
             ),

--- a/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/pooled_video_error_overlay.dart
@@ -4,10 +4,12 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart'
     show VideoErrorType;
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
@@ -62,27 +64,13 @@ class PooledVideoErrorOverlay extends ConsumerStatefulWidget {
 
 class _PooledVideoErrorOverlayState
     extends ConsumerState<PooledVideoErrorOverlay> {
-  bool _autoRetryAttempted = false;
-
-  @override
-  void didUpdateWidget(PooledVideoErrorOverlay oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.video.id != widget.video.id ||
-        oldWidget.errorType != widget.errorType) {
-      _autoRetryAttempted = false;
-    }
-  }
-
   BoxFit _resolveBoxFit() {
     if (!widget.shouldPortraitExpand) return BoxFit.contain;
     return widget.isSquare ? BoxFit.contain : BoxFit.cover;
   }
 
   void _maybeAutoRetryAgeRestricted({required bool showVerifyAge}) {
-    if (!showVerifyAge ||
-        widget.isVerifying ||
-        _autoRetryAttempted ||
-        widget.onVerifyAge == null) {
+    if (!showVerifyAge || widget.isVerifying || widget.onVerifyAge == null) {
       return;
     }
 
@@ -91,9 +79,16 @@ class _PooledVideoErrorOverlayState
       return;
     }
 
-    _autoRetryAttempted = true;
+    final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
+    if (playbackStatusCubit.state.hasAutoRetryAttempted(widget.video.id)) {
+      return;
+    }
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      if (!playbackStatusCubit.consumeAutoRetryAttempt(widget.video.id)) {
+        return;
+      }
       widget.onVerifyAge?.call();
     });
   }

--- a/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
+++ b/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
@@ -175,6 +175,90 @@ void main() {
 
         expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
       });
+
+      test(
+        'auto retry eligibility requires age restriction and verify action',
+        () {
+          final cubit = VideoPlaybackStatusCubit(
+            canAutoAuthorizeAgeRestrictedMedia: () => true,
+          );
+
+          expect(
+            cubit.consumeAgeRestrictedAutoRetryIfEligible(
+              id1,
+              isAgeRestricted: false,
+              hasVerifyAction: true,
+            ),
+            isFalse,
+          );
+          expect(
+            cubit.consumeAgeRestrictedAutoRetryIfEligible(
+              id1,
+              isAgeRestricted: true,
+              hasVerifyAction: false,
+            ),
+            isFalse,
+          );
+          expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
+        },
+      );
+
+      test('auto retry eligibility requires an auto-authorized viewer', () {
+        final cubit = VideoPlaybackStatusCubit(
+          canAutoAuthorizeAgeRestrictedMedia: () => false,
+        );
+
+        expect(
+          cubit.consumeAgeRestrictedAutoRetryIfEligible(
+            id1,
+            isAgeRestricted: true,
+            hasVerifyAction: true,
+          ),
+          isFalse,
+        );
+        expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
+      });
+
+      test('auto retry eligibility is blocked while verifying', () {
+        final cubit = VideoPlaybackStatusCubit(
+          canAutoAuthorizeAgeRestrictedMedia: () => true,
+        );
+        cubit.markVerifying(id1);
+
+        expect(
+          cubit.consumeAgeRestrictedAutoRetryIfEligible(
+            id1,
+            isAgeRestricted: true,
+            hasVerifyAction: true,
+          ),
+          isFalse,
+        );
+        expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
+      });
+
+      test('auto retry eligibility spends the per-video budget once', () {
+        final cubit = VideoPlaybackStatusCubit(
+          canAutoAuthorizeAgeRestrictedMedia: () => true,
+        );
+
+        expect(
+          cubit.consumeAgeRestrictedAutoRetryIfEligible(
+            id1,
+            isAgeRestricted: true,
+            hasVerifyAction: true,
+          ),
+          isTrue,
+        );
+        expect(cubit.state.hasAutoRetryAttempted(id1), isTrue);
+        expect(
+          cubit.consumeAgeRestrictedAutoRetryIfEligible(
+            id1,
+            isAgeRestricted: true,
+            hasVerifyAction: true,
+          ),
+          isFalse,
+        );
+      });
     });
 
     group('playbackStatusFromError', () {

--- a/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
+++ b/mobile/test/blocs/video_playback_status/video_playback_status_cubit_test.dart
@@ -148,6 +148,35 @@ void main() {
       });
     });
 
+    group('auto age-restricted retry attempts', () {
+      test('consumeAutoRetryAttempt spends the per-video budget once', () {
+        final cubit = VideoPlaybackStatusCubit();
+
+        expect(cubit.consumeAutoRetryAttempt(id1), isTrue);
+        expect(cubit.state.hasAutoRetryAttempted(id1), isTrue);
+        expect(cubit.state.hasAutoRetryAttempted(id2), isFalse);
+
+        expect(cubit.consumeAutoRetryAttempt(id1), isFalse);
+      });
+
+      test('reporting a status preserves the spent auto-retry budget', () {
+        final cubit = VideoPlaybackStatusCubit();
+        cubit.consumeAutoRetryAttempt(id1);
+        cubit.report(id1, PlaybackStatus.ready);
+
+        expect(cubit.state.hasAutoRetryAttempted(id1), isTrue);
+        expect(cubit.state.statusFor(id1), PlaybackStatus.ready);
+      });
+
+      test('clear() drops spent auto-retry budgets', () {
+        final cubit = VideoPlaybackStatusCubit();
+        cubit.consumeAutoRetryAttempt(id1);
+        cubit.clear();
+
+        expect(cubit.state.hasAutoRetryAttempted(id1), isFalse);
+      });
+    });
+
     group('playbackStatusFromError', () {
       test('maps each VideoErrorType to the expected PlaybackStatus', () {
         expect(

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -69,6 +69,9 @@ void main() {
         );
 
         when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
+        when(
           () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
             url: any(named: 'url'),
@@ -86,6 +89,7 @@ void main() {
           realContentFilterService.adultPlaybackPreference,
           ContentFilterPreference.warn,
         );
+        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isTrue);
 
         final result = await interceptor.handleUnauthorizedMedia(
           context: mockContext,
@@ -97,6 +101,9 @@ void main() {
         expect(
           result.headersOrNull,
           equals({'Authorization': 'Nostr unlockedToken'}),
+        );
+        verifyNever(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         );
         verify(
           () => mockMediaViewerAuthService.createAuthHeaders(
@@ -115,6 +122,11 @@ void main() {
         when(
           () => mockAgeVerificationService.isAdultContentVerified,
         ).thenReturn(true);
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
+
+        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isFalse);
 
         final result = await interceptor.handleUnauthorizedMedia(
           context: mockContext,
@@ -150,6 +162,9 @@ void main() {
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).thenAnswer((_) async => true);
         when(
+          () => mockContentFilterService.unlockAdultCategories(),
+        ).thenAnswer((_) async {});
+        when(
           () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
             url: any(named: 'url'),
@@ -175,6 +190,9 @@ void main() {
         verify(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).called(1);
+        verify(
+          () => mockContentFilterService.unlockAdultCategories(),
+        ).called(1);
       },
     );
 
@@ -187,6 +205,9 @@ void main() {
         ).thenReturn(ContentFilterPreference.show);
         when(
           () => mockAgeVerificationService.isAdultContentVerified,
+        ).thenReturn(true);
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
         ).thenReturn(true);
         when(
           () => mockMediaViewerAuthService.createAuthHeaders(
@@ -207,6 +228,7 @@ void main() {
         );
 
         // Assert - auto auth header created, no dialog shown
+        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isTrue);
         expect(result, isA<ViewerAuthAuthorized>());
         expect(
           result.headersOrNull,
@@ -231,6 +253,9 @@ void main() {
         ).thenReturn(ContentFilterPreference.show);
         when(
           () => mockAgeVerificationService.isAdultContentVerified,
+        ).thenReturn(true);
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
         ).thenReturn(true);
         when(
           () => mockMediaViewerAuthService.createAuthHeaders(
@@ -265,7 +290,7 @@ void main() {
     );
 
     test(
-      'createAutoAuthHeadersForAdultMedia does not prompt when preference is warn',
+      'createAutoAuthHeadersForAdultMedia creates auth without prompting when preference is warn',
       () async {
         when(
           () => mockContentFilterService.adultPlaybackPreference,
@@ -273,39 +298,51 @@ void main() {
         when(
           () => mockAgeVerificationService.isAdultContentVerified,
         ).thenReturn(true);
-
-        final result = await interceptor.createAutoAuthHeadersForAdultMedia(
-          sha256Hash: 'abc123',
-        );
-
-        expect(result, isA<ViewerAuthUnavailable>());
-        verifyNever(
-          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-        );
-        verifyNever(
+        when(
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
+        when(
           () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
             url: any(named: 'url'),
             serverUrl: any(named: 'serverUrl'),
           ),
+        ).thenAnswer(
+          (_) async => const ViewerAuthAuthorized({
+            'Authorization': 'Nostr warnToken',
+          }),
         );
+
+        final result = await interceptor.createAutoAuthHeadersForAdultMedia(
+          sha256Hash: 'abc123',
+        );
+
+        expect(result, isA<ViewerAuthAuthorized>());
+        expect(result.headersOrNull, {'Authorization': 'Nostr warnToken'});
+        verifyNever(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        );
+        verify(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: 'abc123',
+          ),
+        ).called(1);
       },
     );
 
     test(
-      'handleUnauthorizedMedia shows dialog when askEachTime and verified',
+      'handleUnauthorizedMedia auto-creates auth when warn and verified',
       () async {
-        // Arrange - askEachTime preference, already verified for age
+        // Arrange - warn preference, already verified for age
         when(
           () => mockContentFilterService.adultPlaybackPreference,
         ).thenReturn(ContentFilterPreference.warn);
         when(
           () => mockAgeVerificationService.isAdultContentVerified,
         ).thenReturn(true);
-        when(() => mockContext.mounted).thenReturn(true);
         when(
-          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-        ).thenAnswer((_) async => true);
+          () => mockMediaViewerAuthService.canCreateHeaders,
+        ).thenReturn(true);
         when(
           () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
@@ -325,15 +362,16 @@ void main() {
           category: 'nudity',
         );
 
-        // Assert - dialog was shown, auth header created after confirmation
+        // Assert - auth header created without re-verification
+        expect(interceptor.shouldAutoAuthorizeAgeRestrictedMedia, isTrue);
         expect(result, isA<ViewerAuthAuthorized>());
         expect(
           result.headersOrNull,
           equals({'Authorization': 'Nostr dialogToken'}),
         );
-        verify(
+        verifyNever(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
-        ).called(1);
+        );
         verify(
           () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: 'abc123',
@@ -345,13 +383,13 @@ void main() {
     test(
       'handleUnauthorizedMedia returns null when askEachTime and user declines',
       () async {
-        // Arrange - askEachTime preference, user declines in dialog
+        // Arrange - askEachTime preference, unverified user declines in dialog
         when(
           () => mockContentFilterService.adultPlaybackPreference,
         ).thenReturn(ContentFilterPreference.warn);
         when(
           () => mockAgeVerificationService.isAdultContentVerified,
-        ).thenReturn(true);
+        ).thenReturn(false);
         when(() => mockContext.mounted).thenReturn(true);
         when(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),

--- a/mobile/test/services/media_auth_interceptor_test.dart
+++ b/mobile/test/services/media_auth_interceptor_test.dart
@@ -136,11 +136,14 @@ void main() {
         // Arrange - warn preference uses the click-through verification path
         when(
           () => mockAgeVerificationService.isAdultContentVerified,
-        ).thenReturn(true);
+        ).thenReturn(false);
         when(() => mockContext.mounted).thenReturn(true);
         when(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
         ).thenAnswer((_) async => true);
+        when(
+          () => mockContentFilterService.unlockAdultCategories(),
+        ).thenAnswer((_) async {});
         when(
           () => mockMediaViewerAuthService.createAuthHeaders(
             sha256Hash: any(named: 'sha256Hash'),
@@ -168,6 +171,9 @@ void main() {
         );
         verify(
           () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        ).called(1);
+        verify(
+          () => mockContentFilterService.unlockAdultCategories(),
         ).called(1);
         verify(
           () => mockMediaViewerAuthService.createAuthHeaders(

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -9,12 +9,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart'
     show VideoErrorType;
-import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
-import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
 
@@ -23,15 +20,12 @@ import '../builders/test_video_event_builder.dart';
 Finder _findDivineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
-class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
-
 void main() {
   group(PooledVideoErrorOverlay, () {
     late VideoEvent divineVideo;
     late VideoEvent thirdPartyVideo;
     late bool retryPressed;
     late bool verifyAgePressed;
-    late MediaAuthInterceptor mediaAuthInterceptor;
     late AppLocalizations l10n;
 
     // Valid 64-char hex sha256 for moderation status resolution.
@@ -49,10 +43,6 @@ void main() {
       );
       retryPressed = false;
       verifyAgePressed = false;
-      mediaAuthInterceptor = _MockMediaAuthInterceptor();
-      when(
-        () => mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
-      ).thenReturn(false);
       l10n = lookupAppLocalizations(const Locale('en'));
     });
 
@@ -61,7 +51,6 @@ void main() {
       VideoEvent? video,
       VoidCallback? onVerifyAge,
       bool isVerifying = false,
-      MediaAuthInterceptor? authInterceptor,
       VideoPlaybackStatusCubit? playbackStatusCubit,
     }) {
       final overlay = PooledVideoErrorOverlay(
@@ -73,9 +62,6 @@ void main() {
       );
       return ProviderScope(
         overrides: [
-          mediaAuthInterceptorProvider.overrideWithValue(
-            authInterceptor ?? mediaAuthInterceptor,
-          ),
           videoModerationStatusProvider.overrideWith(
             (ref, sha256) async => null,
           ),
@@ -103,7 +89,6 @@ void main() {
       required VideoModerationStatus moderationStatus,
       VideoEvent? video,
       VoidCallback? onVerifyAge,
-      MediaAuthInterceptor? authInterceptor,
       VideoPlaybackStatusCubit? playbackStatusCubit,
     }) {
       final overlay = PooledVideoErrorOverlay(
@@ -114,9 +99,6 @@ void main() {
       );
       return ProviderScope(
         overrides: [
-          mediaAuthInterceptorProvider.overrideWithValue(
-            authInterceptor ?? mediaAuthInterceptor,
-          ),
           videoModerationStatusProvider.overrideWith(
             (ref, sha256) async => moderationStatus,
           ),
@@ -207,28 +189,29 @@ void main() {
       testWidgets('auto-runs Verify age for already-authorized viewers', (
         tester,
       ) async {
-        when(
-          () => mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
-        ).thenReturn(true);
+        final playbackStatusCubit = VideoPlaybackStatusCubit(
+          canAutoAuthorizeAgeRestrictedMedia: () => true,
+        );
 
         await tester.pumpWidget(
           buildWidget(
             errorType: VideoErrorType.ageRestricted,
             onVerifyAge: () => verifyAgePressed = true,
+            playbackStatusCubit: playbackStatusCubit,
           ),
         );
         await tester.pump();
 
         expect(verifyAgePressed, isTrue);
+        await playbackStatusCubit.close();
       });
 
       testWidgets(
         'auto-runs Verify age only once across overlay teardown and rebuild',
         (tester) async {
-          when(
-            () => mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
-          ).thenReturn(true);
-          final playbackStatusCubit = VideoPlaybackStatusCubit();
+          final playbackStatusCubit = VideoPlaybackStatusCubit(
+            canAutoAuthorizeAgeRestrictedMedia: () => true,
+          );
           var verifyAgeCalls = 0;
 
           await tester.pumpWidget(
@@ -368,9 +351,9 @@ void main() {
       testWidgets(
         'auto-runs verify action for moderation age restriction when already authorized',
         (tester) async {
-          when(
-            () => mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
-          ).thenReturn(true);
+          final playbackStatusCubit = VideoPlaybackStatusCubit(
+            canAutoAuthorizeAgeRestrictedMedia: () => true,
+          );
 
           await tester.pumpWidget(
             buildWidgetWithModeration(
@@ -384,11 +367,13 @@ void main() {
                 aiGenerated: false,
               ),
               onVerifyAge: () => verifyAgePressed = true,
+              playbackStatusCubit: playbackStatusCubit,
             ),
           );
           await tester.pumpAndSettle();
 
           expect(verifyAgePressed, isTrue);
+          await playbackStatusCubit.close();
         },
       );
 

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -8,8 +8,11 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart'
     show VideoErrorType;
+import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/widgets/video_feed_item/pooled_video_error_overlay.dart';
 
@@ -18,12 +21,15 @@ import '../builders/test_video_event_builder.dart';
 Finder _findDivineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
+class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
+
 void main() {
   group(PooledVideoErrorOverlay, () {
     late VideoEvent divineVideo;
     late VideoEvent thirdPartyVideo;
     late bool retryPressed;
     late bool verifyAgePressed;
+    late MediaAuthInterceptor mediaAuthInterceptor;
     late AppLocalizations l10n;
 
     // Valid 64-char hex sha256 for moderation status resolution.
@@ -41,6 +47,10 @@ void main() {
       );
       retryPressed = false;
       verifyAgePressed = false;
+      mediaAuthInterceptor = _MockMediaAuthInterceptor();
+      when(
+        () => mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
+      ).thenReturn(false);
       l10n = lookupAppLocalizations(const Locale('en'));
     });
 
@@ -49,9 +59,13 @@ void main() {
       VideoEvent? video,
       VoidCallback? onVerifyAge,
       bool isVerifying = false,
+      MediaAuthInterceptor? authInterceptor,
     }) {
       return ProviderScope(
         overrides: [
+          mediaAuthInterceptorProvider.overrideWithValue(
+            authInterceptor ?? mediaAuthInterceptor,
+          ),
           videoModerationStatusProvider.overrideWith(
             (ref, sha256) async => null,
           ),
@@ -77,9 +91,13 @@ void main() {
       required VideoModerationStatus moderationStatus,
       VideoEvent? video,
       VoidCallback? onVerifyAge,
+      MediaAuthInterceptor? authInterceptor,
     }) {
       return ProviderScope(
         overrides: [
+          mediaAuthInterceptorProvider.overrideWithValue(
+            authInterceptor ?? mediaAuthInterceptor,
+          ),
           videoModerationStatusProvider.overrideWith(
             (ref, sha256) async => moderationStatus,
           ),
@@ -163,6 +181,38 @@ void main() {
           expect(verifyAgePressed, isFalse);
         },
       );
+
+      testWidgets('auto-runs Verify age for already-authorized viewers', (
+        tester,
+      ) async {
+        when(
+          () => mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
+        ).thenReturn(true);
+
+        await tester.pumpWidget(
+          buildWidget(
+            errorType: VideoErrorType.ageRestricted,
+            onVerifyAge: () => verifyAgePressed = true,
+          ),
+        );
+        await tester.pump();
+
+        expect(verifyAgePressed, isTrue);
+      });
+
+      testWidgets('does not auto-run Verify age when adult content is hidden', (
+        tester,
+      ) async {
+        await tester.pumpWidget(
+          buildWidget(
+            errorType: VideoErrorType.ageRestricted,
+            onVerifyAge: () => verifyAgePressed = true,
+          ),
+        );
+        await tester.pump();
+
+        expect(verifyAgePressed, isFalse);
+      });
     });
 
     group('notFound', () {
@@ -249,6 +299,33 @@ void main() {
           expect(find.text(l10n.videoErrorRetry), findsNothing);
 
           await tester.tap(find.text(l10n.videoErrorVerifyAgeButton));
+
+          expect(verifyAgePressed, isTrue);
+        },
+      );
+
+      testWidgets(
+        'auto-runs verify action for moderation age restriction when already authorized',
+        (tester) async {
+          when(
+            () => mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
+          ).thenReturn(true);
+
+          await tester.pumpWidget(
+            buildWidgetWithModeration(
+              errorType: VideoErrorType.notFound,
+              moderationStatus: const VideoModerationStatus(
+                moderated: true,
+                blocked: false,
+                quarantined: false,
+                ageRestricted: true,
+                needsReview: false,
+                aiGenerated: false,
+              ),
+              onVerifyAge: () => verifyAgePressed = true,
+            ),
+          );
+          await tester.pumpAndSettle();
 
           expect(verifyAgePressed, isTrue);
         },

--- a/mobile/test/widgets/pooled_video_error_overlay_test.dart
+++ b/mobile/test/widgets/pooled_video_error_overlay_test.dart
@@ -4,12 +4,14 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:infinite_video_feed/infinite_video_feed.dart'
     show VideoErrorType;
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/media_auth_interceptor.dart';
@@ -60,7 +62,15 @@ void main() {
       VoidCallback? onVerifyAge,
       bool isVerifying = false,
       MediaAuthInterceptor? authInterceptor,
+      VideoPlaybackStatusCubit? playbackStatusCubit,
     }) {
+      final overlay = PooledVideoErrorOverlay(
+        video: video ?? divineVideo,
+        onRetry: () => retryPressed = true,
+        onVerifyAge: onVerifyAge,
+        errorType: errorType,
+        isVerifying: isVerifying,
+      );
       return ProviderScope(
         overrides: [
           mediaAuthInterceptorProvider.overrideWithValue(
@@ -74,13 +84,15 @@ void main() {
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
-            body: PooledVideoErrorOverlay(
-              video: video ?? divineVideo,
-              onRetry: () => retryPressed = true,
-              onVerifyAge: onVerifyAge,
-              errorType: errorType,
-              isVerifying: isVerifying,
-            ),
+            body: playbackStatusCubit == null
+                ? BlocProvider(
+                    create: (_) => VideoPlaybackStatusCubit(),
+                    child: overlay,
+                  )
+                : BlocProvider<VideoPlaybackStatusCubit>.value(
+                    value: playbackStatusCubit,
+                    child: overlay,
+                  ),
           ),
         ),
       );
@@ -92,7 +104,14 @@ void main() {
       VideoEvent? video,
       VoidCallback? onVerifyAge,
       MediaAuthInterceptor? authInterceptor,
+      VideoPlaybackStatusCubit? playbackStatusCubit,
     }) {
+      final overlay = PooledVideoErrorOverlay(
+        video: video ?? divineVideo,
+        onRetry: () => retryPressed = true,
+        onVerifyAge: onVerifyAge,
+        errorType: errorType,
+      );
       return ProviderScope(
         overrides: [
           mediaAuthInterceptorProvider.overrideWithValue(
@@ -106,12 +125,15 @@ void main() {
           localizationsDelegates: AppLocalizations.localizationsDelegates,
           supportedLocales: AppLocalizations.supportedLocales,
           home: Scaffold(
-            body: PooledVideoErrorOverlay(
-              video: video ?? divineVideo,
-              onRetry: () => retryPressed = true,
-              onVerifyAge: onVerifyAge,
-              errorType: errorType,
-            ),
+            body: playbackStatusCubit == null
+                ? BlocProvider(
+                    create: (_) => VideoPlaybackStatusCubit(),
+                    child: overlay,
+                  )
+                : BlocProvider<VideoPlaybackStatusCubit>.value(
+                    value: playbackStatusCubit,
+                    child: overlay,
+                  ),
           ),
         ),
       );
@@ -199,6 +221,45 @@ void main() {
 
         expect(verifyAgePressed, isTrue);
       });
+
+      testWidgets(
+        'auto-runs Verify age only once across overlay teardown and rebuild',
+        (tester) async {
+          when(
+            () => mediaAuthInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
+          ).thenReturn(true);
+          final playbackStatusCubit = VideoPlaybackStatusCubit();
+          var verifyAgeCalls = 0;
+
+          await tester.pumpWidget(
+            buildWidget(
+              errorType: VideoErrorType.ageRestricted,
+              onVerifyAge: () => verifyAgeCalls++,
+              playbackStatusCubit: playbackStatusCubit,
+            ),
+          );
+          await tester.pump();
+
+          expect(verifyAgeCalls, 1);
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await tester.pumpWidget(
+            buildWidget(
+              errorType: VideoErrorType.ageRestricted,
+              onVerifyAge: () => verifyAgeCalls++,
+              playbackStatusCubit: playbackStatusCubit,
+            ),
+          );
+          await tester.pump();
+
+          expect(verifyAgeCalls, 1);
+
+          await tester.pumpWidget(const SizedBox.shrink());
+          await tester.pump();
+          await playbackStatusCubit.close();
+        },
+      );
 
       testWidgets('does not auto-run Verify age when adult content is hidden', (
         tester,

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -140,6 +140,13 @@ extension _PlaybackCubitStub on _MockVideoPlaybackStatusCubit {
           ? baseState
           : baseState.withStatus(videoId, status),
     );
+    when(
+      () => consumeAgeRestrictedAutoRetryIfEligible(
+        any(),
+        isAgeRestricted: any(named: 'isAgeRestricted'),
+        hasVerifyAction: any(named: 'hasVerifyAction'),
+      ),
+    ).thenReturn(false);
     whenListen(this, const Stream<VideoPlaybackStatusState>.empty());
   }
 }

--- a/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
@@ -61,11 +61,14 @@ void main() {
       required VideoPlaybackStatusCubit cubit,
       MediaAuthInterceptor? interceptor,
     }) {
+      final authInterceptor = interceptor ?? _MockMediaAuthInterceptor();
+      when(
+        () => authInterceptor.shouldAutoAuthorizeAgeRestrictedMedia,
+      ).thenReturn(false);
       return tester.pumpWidget(
         ProviderScope(
           overrides: [
-            if (interceptor != null)
-              mediaAuthInterceptorProvider.overrideWithValue(interceptor),
+            mediaAuthInterceptorProvider.overrideWithValue(authInterceptor),
           ],
           child: BlocProvider<VideoPlaybackStatusCubit>.value(
             value: cubit,
@@ -92,9 +95,7 @@ void main() {
 
     testWidgets(
       'shows the Verify age spinner when the cubit reports verifying',
-      (
-        tester,
-      ) async {
+      (tester) async {
         final cubit = VideoPlaybackStatusCubit();
         addTearDown(cubit.close);
 


### PR DESCRIPTION
## Summary

Closes #5566.

This fixes repeated age-verification prompts on age-restricted video playback. The persisted age-verification flag was already durable; the repeated prompt came from the per-video playback gate only retrying viewer-auth media after a manual "Verify age" action.

## Root Cause

- Verified users with `warn` adult playback preference still hit the age-restricted overlay on each new restricted video, because the retry path only ran from the overlay button.
- In-feed verification set `adult_content_verified` but did not unlock adult categories, leaving that path inconsistent with the settings toggle.
- The pooled retry helper logged every retry as a user tap, which became misleading once verified users can be retried automatically.

## Changes

- Treat verified + non-`hide` adult playback preference as eligible for automatic viewer-auth retry.
- Keep `hide` as a hard block so adult content is not shown when the user has explicitly hidden it.
- Unlock adult categories after a successful in-feed adult-content verification so the feed and settings flows land in the same state.
- Auto-run the existing pooled age-restricted retry once for already-authorized viewers, including moderation-enriched age-restricted 404s.
- Clarify the pooled retry log line so it covers both manual and automatic retry paths.
- Added regression coverage for verified `warn`, verified `hide`, first-time in-feed verification, and pooled overlay auto-retry behavior.

## Validation

- `dart format` via commit hook
- `flutter analyze`
- `flutter test test/services/media_auth_interceptor_test.dart test/services/media_auth_interceptor_preference_test.dart test/screens/feed/pooled_age_restricted_retry_test.dart test/widgets/pooled_video_error_overlay_test.dart test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart`
- `flutter test --concurrency=1` full mobile suite: 11114 passed, 350 skipped
- Pre-push hook analyzer and changed-file tests passed
