### PR TITLE
fix(content-warnings): respect age-restricted playback settings

### DIFF
--- a/mobile/lib/blocs/feed_loading_moderation/feed_loading_moderation_cubit.dart
+++ b/mobile/lib/blocs/feed_loading_moderation/feed_loading_moderation_cubit.dart
@@ -1,6 +1,5 @@
 // ABOUTME: Drives the moderation-check gate during video loading.
-// ABOUTME: Emits restricted when the moderation API confirms the video is
-// ABOUTME: blocked, quarantined, or age-restricted.
+// ABOUTME: Emits blocked/quarantined and age-restricted results separately.
 
 import 'dart:async';
 
@@ -11,9 +10,10 @@ import 'package:openvine/services/video_moderation_status_service.dart';
 /// Performs a moderation check during the video loading phase.
 ///
 /// Fetches the moderation status for the video's sha256. If the content is
-/// moderation-restricted (blocked, quarantined, or age-restricted), emits
-/// [FeedLoadingModerationStatus.restricted]; otherwise the state remains
-/// [FeedLoadingModerationStatus.loading] for the lifetime of the cubit.
+/// blocked/quarantined, emits [FeedLoadingModerationStatus.restricted]. If the
+/// content is age-restricted, emits [FeedLoadingModerationStatus.ageRestricted].
+/// Otherwise the state remains [FeedLoadingModerationStatus.loading] for the
+/// lifetime of the cubit.
 ///
 /// Call [start] immediately after the cubit is constructed.
 class FeedLoadingModerationCubit extends Cubit<FeedLoadingModerationState> {
@@ -57,8 +57,11 @@ class FeedLoadingModerationCubit extends Cubit<FeedLoadingModerationState> {
     try {
       final status = await _service.fetchStatus(sha256);
       if (isClosed) return;
-      if (status?.isUnavailableDueToModeration ?? false) {
+      if (status == null) return;
+      if (status.blocked || status.quarantined) {
         emit(state.copyWith(status: FeedLoadingModerationStatus.restricted));
+      } else if (status.ageRestricted) {
+        emit(state.copyWith(status: FeedLoadingModerationStatus.ageRestricted));
       }
     } catch (e, stackTrace) {
       addError(e, stackTrace);

--- a/mobile/lib/blocs/feed_loading_moderation/feed_loading_moderation_state.dart
+++ b/mobile/lib/blocs/feed_loading_moderation/feed_loading_moderation_state.dart
@@ -1,5 +1,5 @@
-// ABOUTME: State for FeedLoadingModerationCubit — whether a video was flagged
-// ABOUTME: as moderation-restricted during the feed loading phase.
+// ABOUTME: State for FeedLoadingModerationCubit — moderation result for a
+// ABOUTME: video that is still loading.
 
 import 'package:equatable/equatable.dart';
 
@@ -8,8 +8,11 @@ enum FeedLoadingModerationStatus {
   /// The check has not yet completed (or is not applicable for this video).
   loading,
 
-  /// The moderation service confirmed this video is restricted.
+  /// The moderation service confirmed this video is blocked or quarantined.
   restricted,
+
+  /// The moderation service confirmed this video requires adult access.
+  ageRestricted,
 }
 
 /// State for [FeedLoadingModerationCubit].
@@ -20,8 +23,12 @@ class FeedLoadingModerationState extends Equatable {
 
   final FeedLoadingModerationStatus status;
 
-  /// Whether the video was flagged as moderation-restricted.
+  /// Whether the video was flagged as blocked/quarantined by moderation.
   bool get isRestricted => status == FeedLoadingModerationStatus.restricted;
+
+  /// Whether the video is available to adult-verified viewers only.
+  bool get isAgeRestricted =>
+      status == FeedLoadingModerationStatus.ageRestricted;
 
   /// Returns a copy with the given fields replaced.
   FeedLoadingModerationState copyWith({FeedLoadingModerationStatus? status}) {

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -10,6 +10,7 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_state
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 const _logName = 'PooledAgeRestrictedRetry';
@@ -41,8 +42,8 @@ Future<void> retryAgeRestrictedPooledVideo({
   }
   playbackStatusCubit.markVerifying(video.id);
   try {
-    final videoUrl = video.videoUrl;
-    if (videoUrl == null || videoUrl.isEmpty) {
+    final retryInput = _resolveRetryInput(video);
+    if (retryInput == null) {
       Log.warning(
         'Skipping age-restricted retry: missing videoUrl for event '
         '${video.id}',
@@ -58,8 +59,7 @@ Future<void> retryAgeRestrictedPooledVideo({
     // to every resolved source. Without a sha256 the auth path falls back to
     // URL-bound NIP-98, which would only authenticate the bare event URL and
     // re-401 on the optimized/HLS variants — refuse the retry instead.
-    final sha256Hash = _resolveSha256(video);
-    if (sha256Hash == null) {
+    if (retryInput.sha256 == null) {
       Log.warning(
         'Skipping age-restricted retry: cannot resolve sha256 for event '
         '${video.id}',
@@ -74,9 +74,9 @@ Future<void> retryAgeRestrictedPooledVideo({
         .read(mediaAuthInterceptorProvider)
         .handleUnauthorizedMedia(
           context: context,
-          sha256Hash: sha256Hash,
-          url: videoUrl,
-          serverUrl: _extractServerUrl(videoUrl),
+          sha256Hash: retryInput.sha256,
+          url: retryInput.videoUrl,
+          serverUrl: retryInput.serverUrl,
           category: 'video',
         );
     if (!context.mounted) return;
@@ -115,6 +115,50 @@ Future<void> retryAgeRestrictedPooledVideo({
   }
 }
 
+/// Silently retries pooled age-restricted playback when the viewer's existing
+/// preferences already allow adult media to play without prompting.
+Future<void> autoRetryAgeRestrictedPooledVideo({
+  required BuildContext context,
+  required WidgetRef ref,
+  required VideoEvent video,
+  required int index,
+  required FutureOr<bool> Function(Map<String, String>) retryPlayback,
+}) async {
+  final mediaAuthInterceptor = ref.read(mediaAuthInterceptorProvider);
+  if (!mediaAuthInterceptor.canAutoAuthorizeAdultMedia) return;
+
+  final retryInput = _resolveRetryInput(video);
+  if (retryInput == null || retryInput.sha256 == null) return;
+
+  final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
+  if (playbackStatusCubit.state.isVerifying(video.id)) return;
+
+  playbackStatusCubit.markVerifying(video.id);
+  try {
+    final authResult = await mediaAuthInterceptor
+        .createAutoAuthHeadersForAdultMedia(
+          sha256Hash: retryInput.sha256,
+          url: retryInput.videoUrl,
+          serverUrl: retryInput.serverUrl,
+        );
+    if (!context.mounted) return;
+
+    switch (authResult) {
+      case ViewerAuthAuthorized(:final headers):
+        final playbackSucceeded = await retryPlayback(headers);
+        if (!context.mounted || !playbackSucceeded) return;
+        playbackStatusCubit.report(video.id, PlaybackStatus.ready);
+      case ViewerAuthSignerUnreachable():
+      case ViewerAuthUnavailable():
+        break;
+    }
+  } finally {
+    if (!playbackStatusCubit.isClosed) {
+      playbackStatusCubit.clearVerifying(video.id);
+    }
+  }
+}
+
 /// Surfaces a localized failure so a tapped "Verify age" button is never a
 /// silent no-op when verification can't complete.
 void _showVerifyAgeFailed(BuildContext context) {
@@ -136,35 +180,20 @@ void _showSignerUnreachable(BuildContext context) {
   );
 }
 
-String? _resolveSha256(VideoEvent video) {
-  final sha256 = video.sha256;
-  if (sha256 != null && sha256.isNotEmpty) {
-    return sha256;
-  }
-
+_PooledRetryInput? _resolveRetryInput(VideoEvent video) {
   final videoUrl = video.videoUrl;
   if (videoUrl == null || videoUrl.isEmpty) {
     return null;
   }
 
-  return _extractSha256FromUrl(videoUrl);
-}
-
-String? _extractSha256FromUrl(String url) {
-  try {
-    final uri = Uri.parse(url);
-    for (final segment in uri.pathSegments.reversed) {
-      final cleanSegment = segment.split('.').first;
-      if (cleanSegment.length == 64 &&
-          RegExp(r'^[a-fA-F0-9]+$').hasMatch(cleanSegment)) {
-        return cleanSegment.toLowerCase();
-      }
-    }
-  } catch (_) {
-    return null;
-  }
-
-  return null;
+  return _PooledRetryInput(
+    videoUrl: videoUrl,
+    sha256: VideoModerationStatusService.resolveSha256(
+      explicitSha256: video.sha256,
+      videoUrl: videoUrl,
+    ),
+    serverUrl: _extractServerUrl(videoUrl),
+  );
 }
 
 String? _extractServerUrl(String videoUrl) {
@@ -175,4 +204,16 @@ String? _extractServerUrl(String videoUrl) {
   } catch (_) {
     return null;
   }
+}
+
+class _PooledRetryInput {
+  const _PooledRetryInput({
+    required this.videoUrl,
+    required this.sha256,
+    required this.serverUrl,
+  });
+
+  final String videoUrl;
+  final String? sha256;
+  final String? serverUrl;
 }

--- a/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
+++ b/mobile/lib/screens/feed/pooled_age_restricted_retry.dart
@@ -10,10 +10,12 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_state
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 const _logName = 'PooledAgeRestrictedRetry';
+
+typedef PooledAgeRestrictedSha256Resolver =
+    String? Function({String? explicitSha256, String? videoUrl});
 
 /// Verifies access to an age-restricted pooled video, then retries playback
 /// with viewer auth headers on the active pooled controller item.
@@ -22,6 +24,7 @@ Future<void> retryAgeRestrictedPooledVideo({
   required WidgetRef ref,
   required VideoEvent video,
   required int index,
+  required PooledAgeRestrictedSha256Resolver resolveSha256,
   required FutureOr<bool> Function(Map<String, String>) retryPlayback,
 }) async {
   // The pooled overlays (ModeratedContentOverlay / PooledVideoErrorOverlay)
@@ -42,7 +45,7 @@ Future<void> retryAgeRestrictedPooledVideo({
   }
   playbackStatusCubit.markVerifying(video.id);
   try {
-    final retryInput = _resolveRetryInput(video);
+    final retryInput = _resolveRetryInput(video, resolveSha256);
     if (retryInput == null) {
       Log.warning(
         'Skipping age-restricted retry: missing videoUrl for event '
@@ -122,12 +125,13 @@ Future<void> autoRetryAgeRestrictedPooledVideo({
   required WidgetRef ref,
   required VideoEvent video,
   required int index,
+  required PooledAgeRestrictedSha256Resolver resolveSha256,
   required FutureOr<bool> Function(Map<String, String>) retryPlayback,
 }) async {
   final mediaAuthInterceptor = ref.read(mediaAuthInterceptorProvider);
   if (!mediaAuthInterceptor.canAutoAuthorizeAdultMedia) return;
 
-  final retryInput = _resolveRetryInput(video);
+  final retryInput = _resolveRetryInput(video, resolveSha256);
   if (retryInput == null || retryInput.sha256 == null) return;
 
   final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
@@ -180,7 +184,10 @@ void _showSignerUnreachable(BuildContext context) {
   );
 }
 
-_PooledRetryInput? _resolveRetryInput(VideoEvent video) {
+_PooledRetryInput? _resolveRetryInput(
+  VideoEvent video,
+  PooledAgeRestrictedSha256Resolver resolveSha256,
+) {
   final videoUrl = video.videoUrl;
   if (videoUrl == null || videoUrl.isEmpty) {
     return null;
@@ -188,7 +195,7 @@ _PooledRetryInput? _resolveRetryInput(VideoEvent video) {
 
   return _PooledRetryInput(
     videoUrl: videoUrl,
-    sha256: VideoModerationStatusService.resolveSha256(
+    sha256: resolveSha256(
       explicitSha256: video.sha256,
       videoUrl: videoUrl,
     ),

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -22,6 +22,11 @@ class MediaAuthInterceptor {
   final ContentFilterService _contentFilterService;
   final MediaViewerAuthService _mediaViewerAuthService;
 
+  bool get canAutoAuthorizeAdultMedia =>
+      _ageVerificationService.isAdultContentVerified &&
+      _contentFilterService.adultPlaybackPreference ==
+          ContentFilterPreference.show;
+
   /// Creates viewer-auth headers only when the user's existing adult-content
   /// preferences allow automatic playback.
   ///
@@ -34,11 +39,7 @@ class MediaAuthInterceptor {
     String? serverUrl,
   }) async {
     try {
-      final isAdultContentVerified =
-          _ageVerificationService.isAdultContentVerified;
-      final playbackPreference = _contentFilterService.adultPlaybackPreference;
-      if (!isAdultContentVerified ||
-          playbackPreference != ContentFilterPreference.show) {
+      if (!canAutoAuthorizeAdultMedia) {
         return const ViewerAuthUnavailable();
       }
 
@@ -102,8 +103,7 @@ class MediaAuthInterceptor {
 
       // Auto-create auth headers only when the user is already verified and
       // every adult category is configured to show.
-      if (isAdultContentVerified &&
-          playbackPreference == ContentFilterPreference.show) {
+      if (canAutoAuthorizeAdultMedia) {
         Log.debug(
           '✅ Auto-showing adult content (user preference: always show)',
           name: 'MediaAuthInterceptor',

--- a/mobile/lib/services/media_auth_interceptor.dart
+++ b/mobile/lib/services/media_auth_interceptor.dart
@@ -22,6 +22,46 @@ class MediaAuthInterceptor {
   final ContentFilterService _contentFilterService;
   final MediaViewerAuthService _mediaViewerAuthService;
 
+  /// Creates viewer-auth headers only when the user's existing adult-content
+  /// preferences allow automatic playback.
+  ///
+  /// Unlike [handleUnauthorizedMedia], this never shows an age-verification
+  /// dialog. Callers use it for background retries where a surprise prompt would
+  /// be worse than leaving the explicit Verify age button on screen.
+  Future<ViewerAuthResult> createAutoAuthHeadersForAdultMedia({
+    String? sha256Hash,
+    String? url,
+    String? serverUrl,
+  }) async {
+    try {
+      final isAdultContentVerified =
+          _ageVerificationService.isAdultContentVerified;
+      final playbackPreference = _contentFilterService.adultPlaybackPreference;
+      if (!isAdultContentVerified ||
+          playbackPreference != ContentFilterPreference.show) {
+        return const ViewerAuthUnavailable();
+      }
+
+      Log.debug(
+        '✅ Auto-authorizing adult media playback',
+        name: 'MediaAuthInterceptor',
+        category: LogCategory.system,
+      );
+      return await _mediaViewerAuthService.createAuthHeaders(
+        sha256Hash: sha256Hash,
+        url: url,
+        serverUrl: serverUrl,
+      );
+    } catch (e) {
+      Log.error(
+        'Failed to auto-authorize adult media: $e',
+        name: 'MediaAuthInterceptor',
+        category: LogCategory.system,
+      );
+      return const ViewerAuthUnavailable();
+    }
+  }
+
   /// Handle 401 unauthorized response from Blossom media server.
   ///
   /// Returns [ViewerAuthAuthorized] with request headers when the viewer can

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -17,7 +17,6 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_state
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -959,7 +958,7 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
           previous.status != current.status && current.isAgeRestricted,
       listener: (context, state) {
         unawaited(
-          _autoRetryAgeRestrictedPooledVideo(
+          autoRetryAgeRestrictedPooledVideo(
             context: context,
             ref: ref,
             video: video,
@@ -1020,61 +1019,5 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
             },
           ),
     );
-  }
-}
-
-Future<void> _autoRetryAgeRestrictedPooledVideo({
-  required BuildContext context,
-  required WidgetRef ref,
-  required VideoEvent video,
-  required int index,
-  required FutureOr<bool> Function(Map<String, String>) retryPlayback,
-}) async {
-  final videoUrl = video.videoUrl;
-  if (videoUrl == null || videoUrl.isEmpty) return;
-
-  final sha256 = VideoModerationStatusService.resolveSha256(
-    explicitSha256: video.sha256,
-    videoUrl: videoUrl,
-  );
-  if (sha256 == null) return;
-
-  final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
-  if (playbackStatusCubit.state.isVerifying(video.id)) return;
-
-  playbackStatusCubit.markVerifying(video.id);
-  try {
-    final authResult = await ref
-        .read(mediaAuthInterceptorProvider)
-        .createAutoAuthHeadersForAdultMedia(
-          sha256Hash: sha256,
-          url: videoUrl,
-          serverUrl: _extractServerUrl(videoUrl),
-        );
-    if (!context.mounted) return;
-
-    switch (authResult) {
-      case ViewerAuthAuthorized(:final headers):
-        final playbackSucceeded = await retryPlayback(headers);
-        if (!context.mounted || !playbackSucceeded) return;
-        playbackStatusCubit.report(video.id, PlaybackStatus.ready);
-      case ViewerAuthSignerUnreachable():
-      case ViewerAuthUnavailable():
-        break;
-    }
-  } finally {
-    if (!playbackStatusCubit.isClosed) {
-      playbackStatusCubit.clearVerifying(video.id);
-    }
-  }
-}
-
-String? _extractServerUrl(String videoUrl) {
-  try {
-    final uri = Uri.parse(videoUrl);
-    final portSuffix = uri.hasPort ? ':${uri.port}' : '';
-    return '${uri.scheme}://${uri.host}$portSuffix';
-  } catch (_) {
-    return null;
   }
 }

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -10,12 +10,14 @@ import 'package:infinite_video_feed/infinite_video_feed.dart';
 import 'package:models/models.dart';
 import 'package:openvine/blocs/codec_heavy_surface/codec_heavy_surface_cubit.dart';
 import 'package:openvine/blocs/feed_loading_moderation/feed_loading_moderation_cubit.dart';
+import 'package:openvine/blocs/feed_loading_moderation/feed_loading_moderation_state.dart';
 import 'package:openvine/blocs/video_interactions/video_interactions_bloc.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit.dart';
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/router/app_router.dart';
@@ -935,7 +937,7 @@ class _FeedLoadingOrRestrictedOverlay extends ConsumerWidget {
   }
 }
 
-class _FeedLoadingOrRestrictedOverlayView extends StatelessWidget {
+class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
   const _FeedLoadingOrRestrictedOverlayView({
     required this.video,
     required this.index,
@@ -951,36 +953,128 @@ class _FeedLoadingOrRestrictedOverlayView extends StatelessWidget {
   final bool shouldPortraitExpand;
 
   @override
-  Widget build(BuildContext context) {
-    final isRestricted = context.select(
-      (FeedLoadingModerationCubit c) => c.state.isRestricted,
-    );
+  Widget build(BuildContext context, WidgetRef ref) {
+    return BlocListener<FeedLoadingModerationCubit, FeedLoadingModerationState>(
+      listenWhen: (previous, current) =>
+          previous.status != current.status && current.isAgeRestricted,
+      listener: (context, state) {
+        unawaited(
+          _autoRetryAgeRestrictedPooledVideo(
+            context: context,
+            ref: ref,
+            video: video,
+            index: index,
+            retryPlayback: (httpHeaders) =>
+                context
+                    .findAncestorStateOfType<InfiniteVideoFeedState>()
+                    ?.retryAt(index, httpHeaders: httpHeaders) ??
+                Future.value(false),
+          ),
+        );
+      },
+      child:
+          BlocBuilder<FeedLoadingModerationCubit, FeedLoadingModerationState>(
+            builder: (context, state) {
+              if (state.isRestricted) {
+                return VerifyingAwareVideoErrorOverlay(
+                  video: video,
+                  index: index,
+                  // Retry is hidden for moderation-restricted content.
+                  onRetry: () {},
+                  retryPlayback: (httpHeaders) =>
+                      context
+                          .findAncestorStateOfType<InfiniteVideoFeedState>()
+                          ?.retryAt(index, httpHeaders: httpHeaders) ??
+                      Future.value(false),
+                  errorType: VideoErrorType.forbidden,
+                  shouldPortraitExpand: shouldPortraitExpand,
+                  isSquare: isSquare,
+                );
+              }
 
-    if (isRestricted) {
-      return VerifyingAwareVideoErrorOverlay(
-        video: video,
-        index: index,
-        // Retry is hidden for moderation-restricted content.
-        onRetry: () {},
-        retryPlayback: (httpHeaders) =>
-            context.findAncestorStateOfType<InfiniteVideoFeedState>()?.retryAt(
-              index,
-              httpHeaders: httpHeaders,
-            ) ??
-            Future.value(false),
-        errorType: VideoErrorType.notFound,
-        shouldPortraitExpand: shouldPortraitExpand,
-        isSquare: isSquare,
-      );
+              if (state.isAgeRestricted) {
+                return VerifyingAwareVideoErrorOverlay(
+                  video: video,
+                  index: index,
+                  // Retry is hidden while age-gated playback uses Verify age.
+                  onRetry: () {},
+                  retryPlayback: (httpHeaders) =>
+                      context
+                          .findAncestorStateOfType<InfiniteVideoFeedState>()
+                          ?.retryAt(index, httpHeaders: httpHeaders) ??
+                      Future.value(false),
+                  errorType: VideoErrorType.ageRestricted,
+                  shouldPortraitExpand: shouldPortraitExpand,
+                  isSquare: isSquare,
+                );
+              }
+
+              return VideoLoadingPlaceholder(
+                videoId: video.id,
+                index: index,
+                feedMode: feedMode,
+                thumbnailUrl: video.thumbnailUrl,
+                isSquare: isSquare,
+                shouldPortraitExpand: shouldPortraitExpand,
+              );
+            },
+          ),
+    );
+  }
+}
+
+Future<void> _autoRetryAgeRestrictedPooledVideo({
+  required BuildContext context,
+  required WidgetRef ref,
+  required VideoEvent video,
+  required int index,
+  required FutureOr<bool> Function(Map<String, String>) retryPlayback,
+}) async {
+  final videoUrl = video.videoUrl;
+  if (videoUrl == null || videoUrl.isEmpty) return;
+
+  final sha256 = VideoModerationStatusService.resolveSha256(
+    explicitSha256: video.sha256,
+    videoUrl: videoUrl,
+  );
+  if (sha256 == null) return;
+
+  final playbackStatusCubit = context.read<VideoPlaybackStatusCubit>();
+  if (playbackStatusCubit.state.isVerifying(video.id)) return;
+
+  playbackStatusCubit.markVerifying(video.id);
+  try {
+    final authResult = await ref
+        .read(mediaAuthInterceptorProvider)
+        .createAutoAuthHeadersForAdultMedia(
+          sha256Hash: sha256,
+          url: videoUrl,
+          serverUrl: _extractServerUrl(videoUrl),
+        );
+    if (!context.mounted) return;
+
+    switch (authResult) {
+      case ViewerAuthAuthorized(:final headers):
+        final playbackSucceeded = await retryPlayback(headers);
+        if (!context.mounted || !playbackSucceeded) return;
+        playbackStatusCubit.report(video.id, PlaybackStatus.ready);
+      case ViewerAuthSignerUnreachable():
+      case ViewerAuthUnavailable():
+        break;
     }
+  } finally {
+    if (!playbackStatusCubit.isClosed) {
+      playbackStatusCubit.clearVerifying(video.id);
+    }
+  }
+}
 
-    return VideoLoadingPlaceholder(
-      videoId: video.id,
-      index: index,
-      feedMode: feedMode,
-      thumbnailUrl: video.thumbnailUrl,
-      isSquare: isSquare,
-      shouldPortraitExpand: shouldPortraitExpand,
-    );
+String? _extractServerUrl(String videoUrl) {
+  try {
+    final uri = Uri.parse(videoUrl);
+    final portSuffix = uri.hasPort ? ':${uri.port}' : '';
+    return '${uri.scheme}://${uri.host}$portSuffix';
+  } catch (_) {
+    return null;
   }
 }

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -369,6 +369,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
           return VerifyingAwareVideoErrorOverlay(
             video: video,
             index: index,
+            resolveSha256: VideoModerationStatusService.resolveSha256,
             onRetry: onRetry,
             retryPlayback: (httpHeaders) =>
                 _retryPooledVideoAt(index, httpHeaders),
@@ -535,6 +536,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
       ref: ref,
       video: widget.video,
       index: widget.index,
+      resolveSha256: VideoModerationStatusService.resolveSha256,
       retryPlayback: (httpHeaders) =>
           _feedState?.retryAt(widget.index, httpHeaders: httpHeaders) ??
           Future.value(false),
@@ -963,6 +965,7 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
             ref: ref,
             video: video,
             index: index,
+            resolveSha256: VideoModerationStatusService.resolveSha256,
             retryPlayback: (httpHeaders) =>
                 context
                     .findAncestorStateOfType<InfiniteVideoFeedState>()
@@ -978,6 +981,7 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
                 return VerifyingAwareVideoErrorOverlay(
                   video: video,
                   index: index,
+                  resolveSha256: VideoModerationStatusService.resolveSha256,
                   // Retry is hidden for moderation-restricted content.
                   onRetry: () {},
                   retryPlayback: (httpHeaders) =>
@@ -995,6 +999,7 @@ class _FeedLoadingOrRestrictedOverlayView extends ConsumerWidget {
                 return VerifyingAwareVideoErrorOverlay(
                   video: video,
                   index: index,
+                  resolveSha256: VideoModerationStatusService.resolveSha256,
                   // Retry is hidden while age-gated playback uses Verify age.
                   onRetry: () {},
                   retryPlayback: (httpHeaders) =>

--- a/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
+++ b/mobile/lib/widgets/video_feed_item/verifying_aware_video_error_overlay.dart
@@ -25,6 +25,7 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
   const VerifyingAwareVideoErrorOverlay({
     required this.video,
     required this.index,
+    required this.resolveSha256,
     required this.onRetry,
     required this.retryPlayback,
     required this.errorType,
@@ -35,6 +36,8 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
 
   final VideoEvent video;
   final int index;
+
+  final PooledAgeRestrictedSha256Resolver resolveSha256;
 
   /// Called when the user taps Retry. Hidden for moderation-restricted content.
   final VoidCallback onRetry;
@@ -62,6 +65,7 @@ class VerifyingAwareVideoErrorOverlay extends ConsumerWidget {
           ref: ref,
           video: video,
           index: index,
+          resolveSha256: resolveSha256,
           retryPlayback: retryPlayback,
         ),
         errorType: errorType,

--- a/mobile/test/blocs/feed_loading_moderation/feed_loading_moderation_cubit_test.dart
+++ b/mobile/test/blocs/feed_loading_moderation/feed_loading_moderation_cubit_test.dart
@@ -114,10 +114,42 @@ void main() {
         },
       );
 
-      test('emits restricted when service returns age-restricted status', () {
-        const ageRestricted = VideoModerationStatus(
+      test(
+        'emits ageRestricted when service returns age-restricted status',
+        () {
+          const ageRestricted = VideoModerationStatus(
+            moderated: true,
+            blocked: false,
+            quarantined: false,
+            ageRestricted: true,
+            needsReview: false,
+            aiGenerated: false,
+          );
+          when(
+            () => mockService.fetchStatus(sha256),
+          ).thenAnswer((_) async => ageRestricted);
+
+          fakeAsync((fake) {
+            final cubit = buildCubit(videoUrl: divineUrl);
+            cubit.start();
+            fake.elapse(const Duration(seconds: 2));
+            fake.flushMicrotasks();
+            expect(cubit.state.isRestricted, isFalse);
+            expect(cubit.state.isAgeRestricted, isTrue);
+            expect(
+              cubit.state.status,
+              FeedLoadingModerationStatus.ageRestricted,
+            );
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test('blocked status wins over age-restricted status', () {
+        const blockedAndAgeRestricted = VideoModerationStatus(
           moderated: true,
-          blocked: false,
+          blocked: true,
           quarantined: false,
           ageRestricted: true,
           needsReview: false,
@@ -125,14 +157,15 @@ void main() {
         );
         when(
           () => mockService.fetchStatus(sha256),
-        ).thenAnswer((_) async => ageRestricted);
+        ).thenAnswer((_) async => blockedAndAgeRestricted);
 
         fakeAsync((fake) {
           final cubit = buildCubit(videoUrl: divineUrl);
           cubit.start();
-          fake.elapse(const Duration(seconds: 2));
           fake.flushMicrotasks();
           expect(cubit.state.isRestricted, isTrue);
+          expect(cubit.state.isAgeRestricted, isFalse);
+          expect(cubit.state.status, FeedLoadingModerationStatus.restricted);
           cubit.close();
           fake.flushMicrotasks();
         });

--- a/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
+++ b/mobile/test/screens/feed/pooled_age_restricted_retry_test.dart
@@ -491,6 +491,7 @@ class _RetryHarness extends StatelessWidget {
                     ref: ref,
                     video: video ?? _video,
                     index: 0,
+                    resolveSha256: _resolveSha256,
                     retryPlayback: retryPlayback,
                   ),
                   child: const Text('Verify'),
@@ -513,3 +514,10 @@ final _video = VideoEvent(
   videoUrl: _videoUrl,
   sha256: _sha256,
 );
+
+String? _resolveSha256({String? explicitSha256, String? videoUrl}) {
+  if (explicitSha256 != null && explicitSha256.isNotEmpty) {
+    return explicitSha256;
+  }
+  return null;
+}

--- a/mobile/test/services/media_auth_interceptor_preference_test.dart
+++ b/mobile/test/services/media_auth_interceptor_preference_test.dart
@@ -224,6 +224,75 @@ void main() {
     );
 
     test(
+      'createAutoAuthHeadersForAdultMedia creates auth when alwaysShow and verified',
+      () async {
+        when(
+          () => mockContentFilterService.adultPlaybackPreference,
+        ).thenReturn(ContentFilterPreference.show);
+        when(
+          () => mockAgeVerificationService.isAdultContentVerified,
+        ).thenReturn(true);
+        when(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              const ViewerAuthAuthorized({'Authorization': 'Nostr autoToken'}),
+        );
+
+        final result = await interceptor.createAutoAuthHeadersForAdultMedia(
+          sha256Hash: 'abc123',
+          url: 'https://media.divine.video/abc123',
+          serverUrl: 'https://media.divine.video',
+        );
+
+        expect(result, isA<ViewerAuthAuthorized>());
+        expect(result.headersOrNull, {'Authorization': 'Nostr autoToken'});
+        verifyNever(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        );
+        verify(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: 'abc123',
+            url: 'https://media.divine.video/abc123',
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(1);
+      },
+    );
+
+    test(
+      'createAutoAuthHeadersForAdultMedia does not prompt when preference is warn',
+      () async {
+        when(
+          () => mockContentFilterService.adultPlaybackPreference,
+        ).thenReturn(ContentFilterPreference.warn);
+        when(
+          () => mockAgeVerificationService.isAdultContentVerified,
+        ).thenReturn(true);
+
+        final result = await interceptor.createAutoAuthHeadersForAdultMedia(
+          sha256Hash: 'abc123',
+        );
+
+        expect(result, isA<ViewerAuthUnavailable>());
+        verifyNever(
+          () => mockAgeVerificationService.verifyAdultContentAccess(any()),
+        );
+        verifyNever(
+          () => mockMediaViewerAuthService.createAuthHeaders(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
+      },
+    );
+
+    test(
       'handleUnauthorizedMedia shows dialog when askEachTime and verified',
       () async {
         // Arrange - askEachTime preference, already verified for age

--- a/mobile/test/services/video_moderation_status_service_test.dart
+++ b/mobile/test/services/video_moderation_status_service_test.dart
@@ -83,6 +83,20 @@ void main() {
       );
     });
 
+    test('extracts the blob hash before later variant path hashes', () {
+      const blobHash =
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+      const variantHash =
+          'fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210';
+
+      expect(
+        VideoModerationStatusService.extractSha256FromVideoUrl(
+          'https://media.divine.video/$blobHash/$variantHash/720p.mp4',
+        ),
+        blobHash,
+      );
+    });
+
     test('checks moderation only for known hosts', () {
       expect(
         VideoModerationStatusService.shouldCheckModeration(

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -19,6 +19,7 @@ import 'package:openvine/blocs/video_playback_status/video_playback_status_cubit
 import 'package:openvine/blocs/video_playback_status/video_playback_status_state.dart';
 import 'package:openvine/blocs/video_volume/video_volume_cubit.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/models/viewer_auth_result.dart';
 import 'package:openvine/providers/app_foreground_provider.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/subtitle_providers.dart';
@@ -26,6 +27,7 @@ import 'package:openvine/router/app_router.dart';
 import 'package:openvine/screens/feed/feed_auto_advance_cubit.dart';
 import 'package:openvine/services/analytics_service.dart';
 import 'package:openvine/services/connection_status_service.dart';
+import 'package:openvine/services/media_auth_interceptor.dart';
 import 'package:openvine/services/seen_videos_service.dart';
 import 'package:openvine/services/video_moderation_status_service.dart';
 import 'package:openvine/services/view_event_publisher.dart'
@@ -65,6 +67,8 @@ class _MockConnectionStatusService extends Mock
 
 class _MockVideoModerationStatusService extends Mock
     implements VideoModerationStatusService {}
+
+class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
 
 class _MockLikesRepository extends Mock implements LikesRepository {}
 
@@ -106,14 +110,20 @@ const _testVideoId =
 const _testPubkey =
     'd4e5f6789012345678901234567890abcdef123456789012345678901234a1b2c3';
 
-VideoEvent _makeVideo({String? id, List<String> warnLabels = const []}) {
+VideoEvent _makeVideo({
+  String? id,
+  String? videoUrl,
+  String? sha256,
+  List<String> warnLabels = const [],
+}) {
   return VideoEvent(
     id: id ?? _testVideoId,
     pubkey: _testPubkey,
     createdAt: 1704067200,
     content: 'Test video',
     timestamp: DateTime.fromMillisecondsSinceEpoch(1704067200 * 1000),
-    videoUrl: 'https://example.com/video.mp4',
+    videoUrl: videoUrl ?? 'https://example.com/video.mp4',
+    sha256: sha256,
     warnLabels: warnLabels,
   );
 }
@@ -187,6 +197,7 @@ extension _RepostsRepoStub on _MockRepostsRepository {
 // ignore: strict_raw_type
 List _buildOverrides({
   VideoModerationStatusService? moderationService,
+  MediaAuthInterceptor? mediaAuthInterceptor,
   LikesRepository? likesRepository,
   CommentsRepository? commentsRepository,
   RepostsRepository? repostsRepository,
@@ -201,6 +212,8 @@ List _buildOverrides({
     videoModerationStatusServiceProvider.overrideWithValue(
       moderationService ?? _MockVideoModerationStatusService(),
     ),
+    if (mediaAuthInterceptor != null)
+      mediaAuthInterceptorProvider.overrideWithValue(mediaAuthInterceptor),
     subtitleVisibilityProvider.overrideWithValue(false),
     likesRepositoryProvider.overrideWithValue(
       likesRepository ?? (_MockLikesRepository()..stubAll()),
@@ -224,6 +237,7 @@ Future<void> _pumpFeedVideos(
   _MockFeedAutoAdvanceCubit? feedAutoAdvanceCubit,
   _MockVideoVolumeCubit? videoVolumeCubit,
   VideoModerationStatusService? moderationService,
+  MediaAuthInterceptor? mediaAuthInterceptor,
   _MockLikesRepository? likesRepository,
   _MockCommentsRepository? commentsRepository,
   _MockRepostsRepository? repostsRepository,
@@ -247,6 +261,7 @@ Future<void> _pumpFeedVideos(
   final container = ProviderContainer(
     overrides: _buildOverrides(
       moderationService: moderationService,
+      mediaAuthInterceptor: mediaAuthInterceptor,
       likesRepository: likesRepository,
       commentsRepository: commentsRepository,
       repostsRepository: repostsRepository,
@@ -380,6 +395,57 @@ void main() {
 
         expect(find.byType(PooledVideoErrorOverlay), findsOneWidget);
         expect(find.byType(VideoLoadingPlaceholder), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'auto-authorizes age-restricted loading media when preferences allow show',
+      (tester) async {
+        const sha256 =
+            '8ad13ea11bed00b086a4c93d1bbc43f85953cf05f7715bfb16200663b6e3c0ac';
+        final video = _makeVideo(
+          videoUrl: 'https://media.divine.video/$sha256',
+          sha256: sha256,
+        );
+        final moderationService = _MockVideoModerationStatusService();
+        when(() => moderationService.fetchStatus(sha256)).thenAnswer(
+          (_) async => const VideoModerationStatus(
+            moderated: true,
+            blocked: false,
+            quarantined: false,
+            ageRestricted: true,
+            needsReview: false,
+            aiGenerated: false,
+          ),
+        );
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        when(
+          () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        ).thenAnswer(
+          (_) async => const ViewerAuthAuthorized({
+            'Authorization': 'Nostr auto-token',
+          }),
+        );
+
+        await _pumpFeedVideos(
+          tester,
+          videos: [video],
+          moderationService: moderationService,
+          mediaAuthInterceptor: mediaAuthInterceptor,
+        );
+        await tester.pump();
+
+        verify(
+          () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
+            sha256Hash: sha256,
+            url: 'https://media.divine.video/$sha256',
+            serverUrl: 'https://media.divine.video',
+          ),
+        ).called(1);
       },
     );
   });

--- a/mobile/test/widgets/video_feed_item/feed_videos_test.dart
+++ b/mobile/test/widgets/video_feed_item/feed_videos_test.dart
@@ -420,6 +420,9 @@ void main() {
         );
         final mediaAuthInterceptor = _MockMediaAuthInterceptor();
         when(
+          () => mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+        ).thenReturn(true);
+        when(
           () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
             sha256Hash: any(named: 'sha256Hash'),
             url: any(named: 'url'),
@@ -446,6 +449,54 @@ void main() {
             serverUrl: 'https://media.divine.video',
           ),
         ).called(1);
+      },
+    );
+
+    testWidgets(
+      'does not mark verifying for age-restricted loading media when '
+      'preferences do not allow auto-show',
+      (tester) async {
+        const sha256 =
+            '8ad13ea11bed00b086a4c93d1bbc43f85953cf05f7715bfb16200663b6e3c0ac';
+        final video = _makeVideo(
+          videoUrl: 'https://media.divine.video/$sha256',
+          sha256: sha256,
+        );
+        final moderationService = _MockVideoModerationStatusService();
+        when(() => moderationService.fetchStatus(sha256)).thenAnswer(
+          (_) async => const VideoModerationStatus(
+            moderated: true,
+            blocked: false,
+            quarantined: false,
+            ageRestricted: true,
+            needsReview: false,
+            aiGenerated: false,
+          ),
+        );
+        final mediaAuthInterceptor = _MockMediaAuthInterceptor();
+        when(
+          () => mediaAuthInterceptor.canAutoAuthorizeAdultMedia,
+        ).thenReturn(false);
+        final playbackStatusCubit = _MockVideoPlaybackStatusCubit()
+          ..stub(PlaybackStatus.ready, video.id);
+
+        await _pumpFeedVideos(
+          tester,
+          videos: [video],
+          moderationService: moderationService,
+          mediaAuthInterceptor: mediaAuthInterceptor,
+          videoPlaybackStatusCubit: playbackStatusCubit,
+        );
+        await tester.pump();
+
+        verifyNever(() => playbackStatusCubit.markVerifying(video.id));
+        verifyNever(
+          () => mediaAuthInterceptor.createAutoAuthHeadersForAdultMedia(
+            sha256Hash: any(named: 'sha256Hash'),
+            url: any(named: 'url'),
+            serverUrl: any(named: 'serverUrl'),
+          ),
+        );
       },
     );
   });

--- a/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
+++ b/mobile/test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart
@@ -20,6 +20,13 @@ import 'package:openvine/widgets/video_feed_item/verifying_aware_video_error_ove
 
 class _MockMediaAuthInterceptor extends Mock implements MediaAuthInterceptor {}
 
+String? _resolveSha256({String? explicitSha256, String? videoUrl}) {
+  if (explicitSha256 != null && explicitSha256.isNotEmpty) {
+    return explicitSha256;
+  }
+  return null;
+}
+
 class _FakeBuildContext extends Fake implements BuildContext {}
 
 const _videoId =
@@ -69,6 +76,7 @@ void main() {
                 body: VerifyingAwareVideoErrorOverlay(
                   video: _video,
                   index: 0,
+                  resolveSha256: _resolveSha256,
                   onRetry: () {},
                   retryPlayback: (_) => true,
                   errorType: VideoErrorType.ageRestricted,


### PR DESCRIPTION
## Summary

Closes #4480.

This fixes mobile playback for Divine-hosted media that moderation marks `age_restricted` but not blocked/quarantined. The reported KingBach clip resolves to sha256 `8ad13ea11bed00b086a4c93d1bbc43f85953cf05f7715bfb16200663b6e3c0ac`; the media endpoint returns 401 without viewer auth and the moderation API returns `age_restricted`, `blocked: false`, `quarantined: false`.

## Root Cause

The feed loading moderation gate treated `age_restricted` the same as blocked/quarantined content. That sent adult-gated videos through the unrecoverable "Content restricted" path instead of the existing age-restricted viewer-auth flow, so verified users with "show adult content" enabled still got stuck.

## Changes

- Split feed-loading moderation state into blocked/quarantined vs age-restricted outcomes.
- Added a non-prompting adult-media auto-auth helper that only signs viewer auth when the user is already adult-verified and has selected the show preference.
- Retried age-restricted loading media through the pooled player with viewer-auth headers while keeping blocked/quarantined media on the restricted overlay.
- Blocked/quarantined feed-loading failures now use `VideoErrorType.forbidden` instead of `notFound`, so they keep the same restricted-overlay treatment while using the semantic forbidden error type.
- Added regression coverage for moderation priority, auto-auth preference handling, and the feed overlay age-restricted retry path.

## Verification

- `flutter analyze`
- `flutter test test/blocs/feed_loading_moderation/feed_loading_moderation_cubit_test.dart test/services/media_auth_interceptor_preference_test.dart test/widgets/pooled_video_error_overlay_test.dart test/widgets/video_feed_item/feed_videos_test.dart test/widgets/video_feed_item/verifying_aware_video_error_overlay_test.dart`
- `flutter test`
- Pre-push hook: analyzer plus changed-file tests passed.
