### PR TITLE
perf(share): make share-to-DM feel instant (offload, optimistic send, batched + shimmer contacts)

### DIFF
--- a/mobile/integration_test/perf/share_dm_send_isolate_benchmark_test.dart
+++ b/mobile/integration_test/perf/share_dm_send_isolate_benchmark_test.dart
@@ -1,0 +1,121 @@
+// ABOUTME: #5391 — proves the NIP-17 send-path gift-wrap build no longer
+// ABOUTME: freezes the UI (main) isolate for local-key signers. Measures the
+// ABOUTME: max event-loop stall while building the recipient + self gift wraps
+// ABOUTME: the OLD way (GiftWrapUtil.getGiftWrapEvent on the main isolate) vs
+// ABOUTME: the NEW way (buildGiftWrapBatch via compute()). On-device only.
+
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/foundation.dart' show compute, debugPrint;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:nostr_sdk/client_utils/keys.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/event_kind.dart';
+import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
+import 'package:nostr_sdk/nostr.dart';
+import 'package:nostr_sdk/relay/relay.dart';
+import 'package:nostr_sdk/signer/local_nostr_signer.dart';
+
+// Signing-only Nostr instance never opens relays, so the generator is never
+// invoked (mirrors NIP17MessageService's own dummy generator).
+Relay _dummyRelay(String url) => throw UnimplementedError();
+
+/// Runs [work] while a 1ms periodic timer samples the event loop, returning the
+/// largest gap (ms) between consecutive ticks — i.e. the longest the main
+/// isolate was blocked from servicing the loop. A small gap means the UI thread
+/// stayed responsive; a large gap is a visible freeze.
+Future<double> _maxEventLoopStallMs(Future<void> Function() work) async {
+  final sw = Stopwatch()..start();
+  var last = sw.elapsedMicroseconds;
+  var maxGap = 0;
+  final timer = Timer.periodic(const Duration(milliseconds: 1), (_) {
+    final now = sw.elapsedMicroseconds;
+    final gap = now - last;
+    if (gap > maxGap) maxGap = gap;
+    last = now;
+  });
+  // Let the timer reach a steady cadence, then reset the baseline so the
+  // measured window covers only [work].
+  await Future<void>.delayed(const Duration(milliseconds: 20));
+  last = sw.elapsedMicroseconds;
+  maxGap = 0;
+  await work();
+  timer.cancel();
+  return maxGap / 1000.0;
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  test('#5391 send-path gift-wrap build no longer stalls the UI isolate', () async {
+    final senderPrivateKey = generatePrivateKey();
+    final senderPubkey = getPublicKey(senderPrivateKey);
+    final recipientPubkey = getPublicKey(generatePrivateKey());
+
+    final senderNostr = Nostr(
+      LocalNostrSigner(senderPrivateKey),
+      const [],
+      _dummyRelay,
+    );
+    await senderNostr.refreshPublicKey();
+
+    final rumor = Event(
+      senderPubkey,
+      EventKind.privateDirectMessage,
+      const <List<String>>[],
+      'benchmark message',
+    );
+    final rumorJson = rumor.toJson();
+
+    BuildGiftWrapRequest requestFor(String receiver) => BuildGiftWrapRequest(
+      privateKeyHex: senderPrivateKey,
+      rumorJson: rumorJson,
+      receiverPublicKeys: [receiver],
+    );
+
+    final view = PlatformDispatcher.instance.views.first;
+    final refreshHz = view.display.refreshRate;
+    final frameBudgetMs = refreshHz > 0 ? 1000.0 / refreshHz : 16.67;
+
+    // Warm up both paths (JIT + first-isolate spawn) so the measured windows
+    // reflect steady-state cost rather than one-off initialization.
+    await GiftWrapUtil.getGiftWrapEvent(senderNostr, rumor, recipientPubkey);
+    await compute(buildGiftWrapBatch, requestFor(recipientPubkey));
+
+    // OLD: build recipient + self wrap on the main isolate (today's path).
+    final oldStallMs = await _maxEventLoopStallMs(() async {
+      await GiftWrapUtil.getGiftWrapEvent(senderNostr, rumor, recipientPubkey);
+      await GiftWrapUtil.getGiftWrapEvent(senderNostr, rumor, senderPubkey);
+    });
+
+    // NEW: build each wrap off the main isolate via compute() — two sequential
+    // hops, matching the shipped send path.
+    final newStallMs = await _maxEventLoopStallMs(() async {
+      await compute(buildGiftWrapBatch, requestFor(recipientPubkey));
+      await compute(buildGiftWrapBatch, requestFor(senderPubkey));
+    });
+
+    debugPrint(
+      '[#5391] frameBudget=${frameBudgetMs.toStringAsFixed(2)}ms '
+      'OLD main-isolate stall=${oldStallMs.toStringAsFixed(1)}ms '
+      'NEW main-isolate stall=${newStallMs.toStringAsFixed(1)}ms',
+    );
+
+    // The OLD path blocks the UI isolate well past a single frame — the freeze.
+    expect(
+      oldStallMs,
+      greaterThan(frameBudgetMs),
+      reason: 'on-main-isolate build should blow the frame budget',
+    );
+    // The offloaded path keeps the UI isolate responsive: its stall is a small
+    // fraction of the old one.
+    expect(
+      newStallMs,
+      lessThan(oldStallMs * 0.5),
+      reason: 'compute() offload should remove most of the stall',
+    );
+  });
+}

--- a/mobile/integration_test/perf/share_dm_send_isolate_benchmark_test.dart
+++ b/mobile/integration_test/perf/share_dm_send_isolate_benchmark_test.dart
@@ -70,20 +70,21 @@ void main() {
     );
     final rumorJson = rumor.toJson();
 
-    BuildGiftWrapRequest requestFor(String receiver) => BuildGiftWrapRequest(
-      privateKeyHex: senderPrivateKey,
-      rumorJson: rumorJson,
-      receiverPublicKeys: [receiver],
-    );
-
     final view = PlatformDispatcher.instance.views.first;
     final refreshHz = view.display.refreshRate;
     final frameBudgetMs = refreshHz > 0 ? 1000.0 / refreshHz : 16.67;
 
+    // The shipped send path: one combined batch for recipient + self wrap.
+    final combinedRequest = BuildGiftWrapRequest(
+      privateKeyHex: senderPrivateKey,
+      rumorJson: rumorJson,
+      receiverPublicKeys: [recipientPubkey, senderPubkey],
+    );
+
     // Warm up both paths (JIT + first-isolate spawn) so the measured windows
     // reflect steady-state cost rather than one-off initialization.
     await GiftWrapUtil.getGiftWrapEvent(senderNostr, rumor, recipientPubkey);
-    await compute(buildGiftWrapBatch, requestFor(recipientPubkey));
+    await compute(buildGiftWrapBatch, combinedRequest);
 
     // OLD: build recipient + self wrap on the main isolate (today's path).
     final oldStallMs = await _maxEventLoopStallMs(() async {
@@ -91,11 +92,9 @@ void main() {
       await GiftWrapUtil.getGiftWrapEvent(senderNostr, rumor, senderPubkey);
     });
 
-    // NEW: build each wrap off the main isolate via compute() — two sequential
-    // hops, matching the shipped send path.
+    // NEW: build both wraps off the main isolate in one combined compute() hop.
     final newStallMs = await _maxEventLoopStallMs(() async {
-      await compute(buildGiftWrapBatch, requestFor(recipientPubkey));
-      await compute(buildGiftWrapBatch, requestFor(senderPubkey));
+      await compute(buildGiftWrapBatch, combinedRequest);
     });
 
     debugPrint(
@@ -110,12 +109,15 @@ void main() {
       greaterThan(frameBudgetMs),
       reason: 'on-main-isolate build should blow the frame budget',
     );
-    // The offloaded path keeps the UI isolate responsive: its stall is a small
-    // fraction of the old one.
+    // The offloaded path keeps the UI isolate under one frame budget — an
+    // absolute bound that is device-speed-independent, unlike a relative
+    // fraction of the old-path stall. This is precisely what "the freeze is
+    // gone" means to the user: the UI stays responsive across every frame.
     expect(
       newStallMs,
-      lessThan(oldStallMs * 0.5),
-      reason: 'compute() offload should remove most of the stall',
+      lessThan(frameBudgetMs),
+      reason:
+          'compute() offload should keep the UI isolate under one frame budget',
     );
   });
 }

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -116,7 +116,11 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       // One batched read (cache + bulk REST + relays, in the repository)
       // instead of a per-pubkey DB/network storm fired on sheet open. The
       // repository owns the source-selection strategy. Recents already carry
-      // their display data, so only the remaining follows need profiles.
+      // their display data snapshotted at last-send time, so only the
+      // remaining follows need profiles. Staleness is session-bounded:
+      // VideoSharingService._recentlySharedWith is in-memory only and resets
+      // to empty on app restart, so a stale avatar or name is visible at most
+      // within the same session until the user shares with that contact again.
       // Skip the call entirely when there are no follows to fetch. See #5391.
       final profiles = remainingFollows.isEmpty
           ? const <String, UserProfile>{}

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -109,37 +109,24 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
           .where((pk) => !recentPubkeys.contains(pk))
           .toList();
 
-      // Batch-fetch uncached profiles
-      final allPubkeys = [...recentPubkeys, ...remainingFollows];
-      final cachedChecks = await Future.wait(
-        allPubkeys.map((pk) => _profileRepository.getCachedProfile(pubkey: pk)),
+      // One batched read (cache + bulk REST + relays, in the repository)
+      // instead of a per-pubkey DB/network storm fired on sheet open. The
+      // repository owns the source-selection strategy. Recents already carry
+      // their display data, so only the remaining follows need profiles.
+      // See #5391.
+      final profiles = await _profileRepository.fetchBatchProfiles(
+        pubkeys: remainingFollows,
       );
-      final uncached = <String>[];
-      for (var i = 0; i < allPubkeys.length; i++) {
-        if (cachedChecks[i] == null) uncached.add(allPubkeys[i]);
-      }
-      if (uncached.isNotEmpty) {
-        await Future.wait(
-          uncached.map(
-            (pk) => _profileRepository.fetchFreshProfile(pubkey: pk),
-          ),
-        );
-      }
 
-      final contacts = <ShareableUser>[...recentUsers];
-
-      for (final pubkey in remainingFollows) {
-        final profile = await _profileRepository.getCachedProfile(
-          pubkey: pubkey,
-        );
-        contacts.add(
+      final contacts = <ShareableUser>[
+        ...recentUsers,
+        for (final pubkey in remainingFollows)
           ShareableUser(
             pubkey: pubkey,
-            displayName: profile?.bestDisplayName,
-            picture: profile?.picture,
+            displayName: profiles[pubkey]?.bestDisplayName,
+            picture: profiles[pubkey]?.picture,
           ),
-        );
-      }
+      ];
 
       emit(
         state.copyWith(

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -117,10 +117,12 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
       // instead of a per-pubkey DB/network storm fired on sheet open. The
       // repository owns the source-selection strategy. Recents already carry
       // their display data, so only the remaining follows need profiles.
-      // See #5391.
-      final profiles = await _profileRepository.fetchBatchProfiles(
-        pubkeys: remainingFollows,
-      );
+      // Skip the call entirely when there are no follows to fetch. See #5391.
+      final profiles = remainingFollows.isEmpty
+          ? const <String, UserProfile>{}
+          : await _profileRepository.fetchBatchProfiles(
+              pubkeys: remainingFollows,
+            );
 
       final contacts = <ShareableUser>[
         ...recentUsers,

--- a/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
+++ b/mobile/lib/blocs/share_sheet/share_sheet_bloc.dart
@@ -55,7 +55,11 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     on<ShareSheetContactsLoadRequested>(_onContactsLoadRequested);
     on<ShareSheetQuickSendRequested>(
       _onQuickSendRequested,
-      transformer: droppable(),
+      // Concurrent (not droppable): each tap gives instant optimistic feedback
+      // and its send runs in the background, so tapping several people in a row
+      // confirms each immediately instead of dropping taps during an in-flight
+      // send. See #5391.
+      transformer: concurrent(),
     );
     on<ShareSheetRecipientSelected>(_onRecipientSelected);
     on<ShareSheetRecipientCleared>(_onRecipientCleared);
@@ -193,14 +197,20 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
     Emitter<ShareSheetState> emit,
   ) async {
     final user = event.recipient;
-    if (state.isSending || state.sentPubkeys.contains(user.pubkey)) return;
+    if (state.sentPubkeys.contains(user.pubkey)) return;
 
-    // Clear any selected recipient so More Actions stays visible
+    final recipientName = user.displayName ?? 'user';
+
+    // Optimistic: confirm instantly (checkmark + toast) and clear any selected
+    // recipient so More Actions stays visible. The actual NIP-17 send (crypto +
+    // relay publish) runs in the background below — the rumor is enqueued
+    // durably before publishing, so the send survives a crash and is retried.
+    // This is what removes the felt wait-for-network lag. See #5391.
     emit(
       state.copyWith(
-        isSending: true,
+        sentPubkeys: {...state.sentPubkeys, user.pubkey},
         clearRecipient: true,
-        clearActionResult: true,
+        actionResult: ShareSheetSendSuccess(recipientName),
       ),
     );
 
@@ -209,24 +219,16 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         video: _video,
         recipientPubkey: user.pubkey,
       );
-
-      final recipientName = user.displayName ?? 'user';
-      if (result.success) {
-        emit(
-          state.copyWith(
-            isSending: false,
-            sentPubkeys: {...state.sentPubkeys, user.pubkey},
-            actionResult: ShareSheetSendSuccess(recipientName),
-          ),
-        );
-      } else {
-        emit(
-          state.copyWith(
-            isSending: false,
-            actionResult: ShareSheetSendFailure(),
-          ),
-        );
-      }
+      // Success was already shown optimistically; nothing more to emit. If the
+      // sheet was dismissed mid-send, the bloc is closed — don't emit.
+      if (result.success || isClosed) return;
+      // Roll back the optimistic checkmark and surface the failure.
+      emit(
+        state.copyWith(
+          sentPubkeys: {...state.sentPubkeys}..remove(user.pubkey),
+          actionResult: ShareSheetSendFailure(),
+        ),
+      );
     } catch (e, stackTrace) {
       _addUnexpectedError(
         e,
@@ -238,8 +240,12 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
         name: 'ShareSheetBloc',
         category: LogCategory.ui,
       );
+      if (isClosed) return;
       emit(
-        state.copyWith(isSending: false, actionResult: ShareSheetSendFailure()),
+        state.copyWith(
+          sentPubkeys: {...state.sentPubkeys}..remove(user.pubkey),
+          actionResult: ShareSheetSendFailure(),
+        ),
       );
     }
   }
@@ -254,6 +260,9 @@ class ShareSheetBloc extends Bloc<ShareSheetEvent, ShareSheetState> {
   ) async {
     if (state.selectedRecipient == null || state.isSending) return;
 
+    // Send-with-message is a deliberate compose-then-send: it keeps the
+    // awaited flow with a visible "sending" spinner (isSending) and surfaces
+    // failures in-sheet. Only the no-feedback quick-send tap is optimistic.
     emit(state.copyWith(isSending: true, clearActionResult: true));
 
     try {

--- a/mobile/lib/services/video_sharing_service.dart
+++ b/mobile/lib/services/video_sharing_service.dart
@@ -151,7 +151,11 @@ class VideoSharingService {
 
     if (result.success) {
       _shareHistory[recipientPubkey] = DateTime.now();
-      await _updateRecentlySharedWith(recipientPubkey);
+      // Fire-and-forget: this only refreshes the in-memory recents list for
+      // the next share-sheet open. Awaiting it kept the success toast waiting
+      // on a 5s-timeout profile fetch for no user-visible benefit. It
+      // self-catches its own errors. See #5391.
+      unawaited(_updateRecentlySharedWith(recipientPubkey));
 
       final participants = [dmRepo.userPubkey, recipientPubkey]..sort();
       final conversationId = DmRepository.computeConversationId(participants);

--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -38,6 +38,7 @@ import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:openvine/widgets/watermark_download_progress_sheet.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:skeletonizer/skeletonizer.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 part 'share_sheet_header.dart';
@@ -215,12 +216,16 @@ class _UnifiedShareSheetState extends ConsumerState<_UnifiedShareSheet> {
           ),
         );
       case ShareSheetSendFailure():
-        messenger.showSnackBar(
-          DivineSnackbarContainer.snackBar(
-            context.l10n.shareFailedToSend,
-            error: true,
-          ),
-        );
+        // Replace the optimistic "shared with" toast with the failure so the
+        // two don't stack when a quick-send is rolled back.
+        messenger
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            DivineSnackbarContainer.snackBar(
+              context.l10n.shareFailedToSend,
+              error: true,
+            ),
+          );
       case ShareSheetSaveResult(
         :final succeeded,
         :final removed,

--- a/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_with_section.dart
@@ -1,5 +1,13 @@
 part of 'share_action_button.dart';
 
+/// Placeholder rows shown (skeletonized) while the real contacts load, so the
+/// shimmer has the same avatar + name shape it dissolves into — instead of a
+/// spinner that pops. See #5391.
+final List<ShareableUser> _skeletonContacts = List.generate(
+  6,
+  (_) => const ShareableUser(pubkey: '', displayName: 'Username'),
+);
+
 // ---------------------------------------------------------------------------
 // "Share with" horizontal contact row
 // ---------------------------------------------------------------------------
@@ -28,6 +36,10 @@ class _ShareWithSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // While loading, render placeholder rows so the shimmer matches the real
+    // avatar + name layout it will dissolve into.
+    final displayContacts = contactsLoaded ? contacts : _skeletonContacts;
+
     return Padding(
       padding: const EdgeInsets.only(top: 12, bottom: 8),
       child: Column(
@@ -48,33 +60,48 @@ class _ShareWithSection extends StatelessWidget {
           ),
           SizedBox(
             height: _rowHeight,
-            child: ListView.builder(
-              scrollDirection: Axis.horizontal,
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              // +1 for Find People; when loading, +1 more for the spinner
-              itemCount: contactsLoaded
-                  ? contacts.length + 1
-                  : 2, // Find People + spinner
-              itemBuilder: (context, index) {
-                if (index == 0) {
-                  return _FindPeopleItem(onTap: onFindPeople);
-                }
+            // Skeleton contacts shimmer, then dissolve into the real list when
+            // it loads (enableSwitchAnimation), instead of a spinner that pops.
+            child: IdentitySkeletonizer(
+              isLoading: !contactsLoaded,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+                // +1 for the always-present "Find people" entry.
+                itemCount: displayContacts.length + 1,
+                itemBuilder: (context, index) {
+                  if (index == 0) {
+                    // Keep "Find people" solid + tappable during the shimmer.
+                    return Skeleton.keep(
+                      child: _FindPeopleItem(onTap: onFindPeople),
+                    );
+                  }
 
-                if (!contactsLoaded) {
-                  return const _ContactsLoadingItem();
-                }
+                  final contact = displayContacts[index - 1];
+                  if (!contactsLoaded) {
+                    // Placeholder bone — not interactive, excluded from a11y.
+                    return ExcludeSemantics(
+                      child: _ContactItem(
+                        user: contact,
+                        isSelected: false,
+                        isSent: false,
+                        onTap: () {},
+                      ),
+                    );
+                  }
 
-                final contact = contacts[index - 1];
-                final isSelected = selectedRecipient?.pubkey == contact.pubkey;
-                final isSent = sentPubkeys.contains(contact.pubkey);
+                  final isSelected =
+                      selectedRecipient?.pubkey == contact.pubkey;
+                  final isSent = sentPubkeys.contains(contact.pubkey);
 
-                return _ContactItem(
-                  user: contact,
-                  isSelected: isSelected,
-                  isSent: isSent,
-                  onTap: () => onContactTapped(contact),
-                );
-              },
+                  return _ContactItem(
+                    user: contact,
+                    isSelected: isSelected,
+                    isSent: isSent,
+                    onTap: () => onContactTapped(contact),
+                  );
+                },
+              ),
             ),
           ),
         ],
@@ -129,28 +156,6 @@ class _FindPeopleItem extends StatelessWidget {
                 overflow: TextOverflow.ellipsis,
               ),
             ],
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Shown in the contacts row while contacts are still loading.
-class _ContactsLoadingItem extends StatelessWidget {
-  const _ContactsLoadingItem();
-
-  @override
-  Widget build(BuildContext context) {
-    return const SizedBox(
-      width: _ShareWithSection._itemWidth,
-      child: Center(
-        child: SizedBox(
-          width: 24,
-          height: 24,
-          child: CircularProgressIndicator(
-            strokeWidth: 2,
-            color: VineTheme.vineGreen,
           ),
         ),
       ),

--- a/mobile/packages/dm_repository/lib/dm_repository.dart
+++ b/mobile/packages/dm_repository/lib/dm_repository.dart
@@ -7,4 +7,6 @@ export 'src/dm_repository.dart';
 export 'src/dm_repository_reportable_sites.dart';
 export 'src/dm_sync_state.dart';
 export 'src/dm_verify_isolate.dart';
-export 'src/nip17_message_service.dart' hide GiftWrapBuilder;
+export 'src/gift_wrap_build_worker.dart';
+export 'src/nip17_message_service.dart'
+    hide GiftWrapBuilder, IsolateGiftWrapBatchBuilder;

--- a/mobile/packages/dm_repository/lib/src/gift_wrap_build_worker.dart
+++ b/mobile/packages/dm_repository/lib/src/gift_wrap_build_worker.dart
@@ -1,0 +1,90 @@
+// ABOUTME: Top-level function for off-main-isolate NIP-17 gift-wrap BUILD
+// ABOUTME: (seal + wrap + sign). Used by NIP17MessageService when the active
+// ABOUTME: signer is a local key signer that can safely expose raw private key
+// ABOUTME: bytes. Remote signers (Amber, Keycast RPC, NIP-46) keep building on
+// ABOUTME: the main isolate because they cannot cross an isolate boundary.
+// ABOUTME: Send-side twin of dm_decryption_worker.dart. See #5391.
+
+import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
+
+/// Input payload for [buildGiftWrapBatch].
+///
+/// All fields are sendable across a Dart isolate boundary: [rumorJson] is a
+/// plain JSON map (the output of `Event.toJson`), [privateKeyHex] is a raw hex
+/// string extracted from the caller's secure key container under a scoped
+/// callback, and [receiverPublicKeys] is a list of hex pubkeys.
+class BuildGiftWrapRequest {
+  /// Creates a batch gift-wrap build request.
+  const BuildGiftWrapRequest({
+    required this.privateKeyHex,
+    required this.rumorJson,
+    required this.receiverPublicKeys,
+  });
+
+  /// Hex-encoded sender private key used for NIP-44 ECDH and Schnorr signing.
+  final String privateKeyHex;
+
+  /// The unsigned kind-14 rumor as `Event.toJson`; its id is preserved.
+  final Map<String, dynamic> rumorJson;
+
+  /// Recipient public keys (hex) to wrap [rumorJson] for, one wrap each.
+  final List<String> receiverPublicKeys;
+}
+
+/// Per-receiver build result. Either holds the signed gift wrap as JSON (the
+/// shape produced by `Event.toJson`) or an error description.
+///
+/// The batch helper NEVER throws — every failure becomes a
+/// [BuiltGiftWrapResult.failure] entry so one bad receiver cannot tank the
+/// whole batch.
+class BuiltGiftWrapResult {
+  const BuiltGiftWrapResult._({this.giftWrap, this.error});
+
+  /// Creates a successful result containing the signed [giftWrap].
+  const BuiltGiftWrapResult.success(Map<String, dynamic> giftWrap)
+    : this._(giftWrap: giftWrap);
+
+  /// Creates a failure result with the given [error] description.
+  const BuiltGiftWrapResult.failure(String error) : this._(error: error);
+
+  /// Signed kind-1059 gift wrap as JSON (null on failure).
+  final Map<String, dynamic>? giftWrap;
+
+  /// Human-readable failure reason (null on success).
+  final String? error;
+
+  /// Whether this entry represents a successfully built gift wrap.
+  bool get isSuccess => giftWrap != null;
+}
+
+/// Builds NIP-17 gift wraps (kind 1059) for each receiver in
+/// [BuildGiftWrapRequest.receiverPublicKeys], running the full seal + wrap +
+/// sign with pure functions so it is safe to invoke inside [compute()].
+///
+/// Results are returned in the same order as the receiver list. A null wrap
+/// from the builder or any thrown error becomes a [BuiltGiftWrapResult.failure]
+/// entry — this function never throws.
+Future<List<BuiltGiftWrapResult>> buildGiftWrapBatch(
+  BuildGiftWrapRequest request,
+) async {
+  final results = <BuiltGiftWrapResult>[];
+  for (final receiver in request.receiverPublicKeys) {
+    try {
+      final wrap = await buildGiftWrapFromHex(
+        senderPrivateKeyHex: request.privateKeyHex,
+        rumorJson: request.rumorJson,
+        receiverPublicKey: receiver,
+      );
+      if (wrap == null) {
+        results.add(
+          const BuiltGiftWrapResult.failure('gift wrap build returned null'),
+        );
+      } else {
+        results.add(BuiltGiftWrapResult.success(wrap.toJson()));
+      }
+    } on Object catch (e) {
+      results.add(BuiltGiftWrapResult.failure('build failed: $e'));
+    }
+  }
+  return results;
+}

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -3,6 +3,8 @@
 // ABOUTME: (kind 14 rumor → kind 13 seal → kind 1059 gift wrap)
 // ABOUTME: Works with any NostrSigner (local keys, Keycast RPC, Amber, etc.)
 
+import 'package:dm_repository/src/gift_wrap_build_worker.dart';
+import 'package:flutter/foundation.dart' show compute;
 import 'package:meta/meta.dart';
 import 'package:models/models.dart' show NIP17SendResult;
 import 'package:nostr_client/nostr_client.dart';
@@ -11,6 +13,7 @@ import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
 import 'package:nostr_sdk/nostr.dart';
 import 'package:nostr_sdk/relay/relay.dart';
+import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -30,6 +33,15 @@ typedef GiftWrapBuilder =
       String recipientPubkey,
     );
 
+/// Builds NIP-17 gift wraps off the main isolate for local-key signers.
+///
+/// Defaults to running [buildGiftWrapBatch] in a [compute] isolate; injectable
+/// for tests so the offload branch can be exercised inline without spawning a
+/// real isolate.
+@internal
+typedef IsolateGiftWrapBatchBuilder =
+    Future<List<BuiltGiftWrapResult>> Function(BuildGiftWrapRequest request);
+
 /// Service for sending encrypted private messages using NIP-17 gift wrapping.
 ///
 /// Accepts any [NostrSigner] implementation, supporting both local key
@@ -41,18 +53,79 @@ class NIP17MessageService {
     required String senderPublicKey,
     required NostrClient nostrService,
     @visibleForTesting GiftWrapBuilder? giftWrapBuilder,
+    @visibleForTesting IsolateGiftWrapBatchBuilder? isolateGiftWrapBatchBuilder,
   }) : _signer = signer,
        _senderPublicKey = senderPublicKey,
        _nostrService = nostrService,
-       _giftWrapBuilder = giftWrapBuilder ?? GiftWrapUtil.getGiftWrapEvent;
+       _giftWrapBuilder = giftWrapBuilder ?? GiftWrapUtil.getGiftWrapEvent,
+       _isolateGiftWrapBatchBuilder =
+           isolateGiftWrapBatchBuilder ?? _computeGiftWrapBatch;
 
   final NostrSigner _signer;
   final String _senderPublicKey;
   final NostrClient _nostrService;
   final GiftWrapBuilder _giftWrapBuilder;
+  final IsolateGiftWrapBatchBuilder _isolateGiftWrapBatchBuilder;
+
+  /// Default off-main-isolate builder: runs [buildGiftWrapBatch] in a
+  /// [compute] isolate. Kept as a static tear-off so the constructor's
+  /// default does not capture instance state.
+  static Future<List<BuiltGiftWrapResult>> _computeGiftWrapBatch(
+    BuildGiftWrapRequest request,
+  ) => compute(buildGiftWrapBatch, request);
 
   /// Access to the underlying NostrService for relay management
   NostrClient get nostrService => _nostrService;
+
+  /// Builds a single NIP-17 gift wrap for [receiverPublicKey] from
+  /// [rumorEvent].
+  ///
+  /// Routes through a [compute] isolate when the signer can safely expose its
+  /// private key bytes (local-key signers), keeping the CPU-bound pure-Dart
+  /// secp256k1 work off the UI isolate. Remote signers (Amber, Keycast RPC,
+  /// NIP-46) cannot cross a `SendPort`, so they fall back to the
+  /// on-main-isolate [_giftWrapBuilder] — already async RPC/IPC, not a block.
+  ///
+  /// Any failure of the isolate path (thrown error, null/failed result) falls
+  /// back to the main-isolate builder, mirroring the receive-side decrypt
+  /// offload in DmRepository. See #5391.
+  Future<Event?> _buildWrap({
+    required Nostr nostr,
+    required Event rumorEvent,
+    required String receiverPublicKey,
+  }) async {
+    final signer = _signer;
+    if (signer is IsolateDecryptSigner && signer.canDecryptInIsolate) {
+      try {
+        final hex = signer.withPrivateKeyHex((k) => k);
+        final results = await _isolateGiftWrapBatchBuilder(
+          BuildGiftWrapRequest(
+            privateKeyHex: hex,
+            rumorJson: rumorEvent.toJson(),
+            receiverPublicKeys: [receiverPublicKey],
+          ),
+        );
+        final result = results.single;
+        if (result.isSuccess) {
+          return Event.fromJson(result.giftWrap!);
+        }
+        Log.debug(
+          'Isolate gift-wrap build returned failure for rumor '
+          '${rumorEvent.id}: ${result.error}; falling back to main isolate',
+          category: LogCategory.system,
+        );
+      } on Object catch (e, stackTrace) {
+        Log.error(
+          'Isolate gift-wrap build threw for rumor ${rumorEvent.id}: $e',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+        // Fall through to the main-isolate builder below.
+      }
+    }
+    return _giftWrapBuilder(nostr, rumorEvent, receiverPublicKey);
+  }
 
   /// Build the unsigned NIP-17 rumor event for a 1:1 send.
   ///
@@ -119,10 +192,10 @@ class NIP17MessageService {
       );
 
       // Create gift wrap for the recipient
-      final giftWrapEvent = await _giftWrapBuilder(
-        nostr,
-        rumorEvent,
-        recipientPubkey,
+      final giftWrapEvent = await _buildWrap(
+        nostr: nostr,
+        rumorEvent: rumorEvent,
+        receiverPublicKey: recipientPubkey,
       );
 
       if (giftWrapEvent == null) {
@@ -258,10 +331,10 @@ class NIP17MessageService {
     required Event rumorEvent,
   }) async {
     try {
-      final selfWrapEvent = await _giftWrapBuilder(
-        nostr,
-        rumorEvent,
-        _senderPublicKey,
+      final selfWrapEvent = await _buildWrap(
+        nostr: nostr,
+        rumorEvent: rumorEvent,
+        receiverPublicKey: _senderPublicKey,
       );
       if (selfWrapEvent == null) {
         Log.warning(
@@ -312,10 +385,10 @@ class NIP17MessageService {
       final nostr = Nostr(_signer, [], _dummyRelayGenerator);
       await nostr.refreshPublicKey();
       final rumor = Event(_senderPublicKey, eventKind, tags, content);
-      final selfWrapEvent = await _giftWrapBuilder(
-        nostr,
-        rumor,
-        _senderPublicKey,
+      final selfWrapEvent = await _buildWrap(
+        nostr: nostr,
+        rumorEvent: rumor,
+        receiverPublicKey: _senderPublicKey,
       );
       if (selfWrapEvent == null) return false;
       final published = (targetRelays != null && targetRelays.isNotEmpty)

--- a/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
+++ b/mobile/packages/dm_repository/lib/src/nip17_message_service.dart
@@ -127,6 +127,90 @@ class NIP17MessageService {
     return _giftWrapBuilder(nostr, rumorEvent, receiverPublicKey);
   }
 
+  /// Builds the recipient and self-addressed gift wraps in a single isolate
+  /// hop for local-key signers (one [compute] spawn covers both receivers,
+  /// halving the spawn cost vs two separate [_buildWrap] calls).
+  ///
+  /// Returns `(recipientWrap, selfWrap?)`. For remote signers — or if the
+  /// batch isolate call fails — only the recipient wrap is built here and
+  /// `selfWrap` is `null`; [_publishSelfWrap] then builds the self-wrap
+  /// lazily after the recipient publish confirms delivery (avoids an extra
+  /// signing round-trip on publish failure).
+  ///
+  /// Security: `withPrivateKeyHex((k) => k)` copies the raw private-key hex
+  /// out of its scoped callback so it can be serialised across the [compute]
+  /// isolate boundary. This matches the receive-side pattern in
+  /// `DmRepository._decryptRumor`. The key is already in the main-isolate
+  /// heap; the threat model for this copy is identical to the attacker who
+  /// can already read the heap. The isolate is short-lived and the key does
+  /// not persist beyond the call.
+  Future<(Event?, Event?)> _buildBothWraps({
+    required Nostr nostr,
+    required Event rumorEvent,
+    required String recipientPubkey,
+  }) async {
+    final signer = _signer;
+    if (signer is IsolateDecryptSigner && signer.canDecryptInIsolate) {
+      try {
+        final hex = signer.withPrivateKeyHex((k) => k);
+        final results = await _isolateGiftWrapBatchBuilder(
+          BuildGiftWrapRequest(
+            privateKeyHex: hex,
+            rumorJson: rumorEvent.toJson(),
+            receiverPublicKeys: [recipientPubkey, _senderPublicKey],
+          ),
+        );
+        if (results.length == 2) {
+          final r = results[0];
+          final s = results[1];
+          if (!r.isSuccess) {
+            Log.debug(
+              'Batch gift-wrap: recipient slot failed (${r.error}); '
+              'falling back to main-isolate builder',
+              category: LogCategory.system,
+            );
+          }
+          if (!s.isSuccess) {
+            Log.debug(
+              'Batch gift-wrap: self-wrap slot failed (${s.error}); '
+              '_publishSelfWrap will rebuild on the main isolate',
+              category: LogCategory.system,
+            );
+          }
+          return (
+            r.isSuccess ? Event.fromJson(r.giftWrap!) : null,
+            s.isSuccess ? Event.fromJson(s.giftWrap!) : null,
+          );
+        }
+        Log.debug(
+          'Batch gift-wrap returned unexpected result count '
+          '(${results.length}); falling back to main-isolate builder',
+          category: LogCategory.system,
+        );
+      } on Object catch (e, stackTrace) {
+        Log.error(
+          'Batch gift-wrap build threw for rumor ${rumorEvent.id}: $e; '
+          'falling back to main-isolate builder',
+          category: LogCategory.system,
+          error: e,
+          stackTrace: stackTrace,
+        );
+      }
+    }
+    // Remote signer or batch failed: build only the recipient wrap. The
+    // self-wrap is built lazily by _publishSelfWrap after the recipient
+    // publish confirms delivery — avoids an extra signing round-trip for
+    // remote signers when the recipient publish fails.
+    return (
+      await _buildWrap(
+        nostr: nostr,
+        rumorEvent: rumorEvent,
+        receiverPublicKey: recipientPubkey,
+      ),
+      null,
+    );
+  }
+
   /// Build the unsigned NIP-17 rumor event for a 1:1 send.
   ///
   /// Pure construction — does not touch relays or the signer. Exposed
@@ -191,11 +275,14 @@ class NIP17MessageService {
         category: LogCategory.system,
       );
 
-      // Create gift wrap for the recipient
-      final giftWrapEvent = await _buildWrap(
+      // Build recipient and self-addressed gift wraps. For local-key signers
+      // both are built in one isolate hop (half the spawn cost vs two separate
+      // calls); for remote signers the self-wrap is deferred to
+      // _publishSelfWrap after the recipient publish confirms delivery.
+      final (giftWrapEvent, prebuiltSelfWrap) = await _buildBothWraps(
         nostr: nostr,
         rumorEvent: rumorEvent,
-        receiverPublicKey: recipientPubkey,
+        recipientPubkey: recipientPubkey,
       );
 
       if (giftWrapEvent == null) {
@@ -242,6 +329,7 @@ class NIP17MessageService {
       final selfWrapPublished = await _publishSelfWrap(
         nostr: nostr,
         rumorEvent: rumorEvent,
+        prebuiltSelfWrap: prebuiltSelfWrap,
       );
 
       Log.info(
@@ -322,6 +410,11 @@ class NIP17MessageService {
   /// [rumorEvent]. Returns `true` when the wrap reached at least one
   /// relay.
   ///
+  /// When [prebuiltSelfWrap] is non-null (supplied by [_buildBothWraps] on
+  /// the local-key-signer path), the build step is skipped and the prebuilt
+  /// event is published directly. Otherwise the wrap is built via
+  /// [_buildWrap] on the main isolate.
+  ///
   /// Catches every error — used by both the happy-path send (where the
   /// recipient has already received the message and an exception must
   /// not crash the result) and the recovery path (where an exception
@@ -329,13 +422,16 @@ class NIP17MessageService {
   Future<bool> _publishSelfWrap({
     required Nostr nostr,
     required Event rumorEvent,
+    Event? prebuiltSelfWrap,
   }) async {
     try {
-      final selfWrapEvent = await _buildWrap(
-        nostr: nostr,
-        rumorEvent: rumorEvent,
-        receiverPublicKey: _senderPublicKey,
-      );
+      final selfWrapEvent =
+          prebuiltSelfWrap ??
+          await _buildWrap(
+            nostr: nostr,
+            rumorEvent: rumorEvent,
+            receiverPublicKey: _senderPublicKey,
+          );
       if (selfWrapEvent == null) {
         Log.warning(
           'Self-wrap creation returned null — the sender will not see '

--- a/mobile/packages/dm_repository/test/src/gift_wrap_build_worker_test.dart
+++ b/mobile/packages/dm_repository/test/src/gift_wrap_build_worker_test.dart
@@ -1,0 +1,119 @@
+// ABOUTME: Tests for buildGiftWrapBatch — the off-main-isolate NIP-17 gift-wrap
+// ABOUTME: build worker. Covers per-receiver ordering, round-trip decrypt, the
+// ABOUTME: never-throws contract, and a real compute() isolate run.
+
+import 'package:dm_repository/dm_repository.dart';
+import 'package:flutter/foundation.dart' show compute;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+void main() {
+  Relay dummyRelay(String url) => RelayBase(url, RelayStatus(url));
+
+  late String senderPrivateKey;
+  late String senderPubkey;
+  late String recipientPrivateKey;
+  late String recipientPubkey;
+
+  setUp(() {
+    senderPrivateKey = generatePrivateKey();
+    senderPubkey = getPublicKey(senderPrivateKey);
+    recipientPrivateKey = generatePrivateKey();
+    recipientPubkey = getPublicKey(recipientPrivateKey);
+  });
+
+  Map<String, dynamic> rumorJson({String content = 'hi'}) => Event(
+    senderPubkey,
+    EventKind.privateDirectMessage,
+    const <List<String>>[],
+    content,
+  ).toJson();
+
+  Future<Event?> decryptFor(
+    String recipientPriv,
+    Map<String, dynamic> wrapJson,
+  ) {
+    final nostr = Nostr(LocalNostrSigner(recipientPriv), const [], dummyRelay);
+    return GiftWrapUtil.getRumorEvent(nostr, Event.fromJson(wrapJson));
+  }
+
+  group('buildGiftWrapBatch', () {
+    test(
+      'returns one result per receiver, in order, and both round-trip',
+      () async {
+        final results = await buildGiftWrapBatch(
+          BuildGiftWrapRequest(
+            privateKeyHex: senderPrivateKey,
+            rumorJson: rumorJson(content: 'batched'),
+            receiverPublicKeys: [recipientPubkey, senderPubkey],
+          ),
+        );
+
+        expect(results, hasLength(2));
+        expect(results.every((r) => r.isSuccess), isTrue);
+
+        // results[0] = recipient wrap, results[1] = self wrap; order preserved.
+        final toRecipient = await decryptFor(
+          recipientPrivateKey,
+          results[0].giftWrap!,
+        );
+        expect(toRecipient, isNotNull);
+        expect(toRecipient!.content, equals('batched'));
+        expect(toRecipient.pubkey, equals(senderPubkey));
+
+        final toSelf = await decryptFor(senderPrivateKey, results[1].giftWrap!);
+        expect(toSelf, isNotNull);
+        expect(toSelf!.content, equals('batched'));
+      },
+    );
+
+    test(
+      'never throws on a malformed receiver — emits a failure entry',
+      () async {
+        final results = await buildGiftWrapBatch(
+          BuildGiftWrapRequest(
+            privateKeyHex: senderPrivateKey,
+            rumorJson: rumorJson(),
+            receiverPublicKeys: ['not-a-valid-pubkey', recipientPubkey],
+          ),
+        );
+
+        expect(results, hasLength(2));
+        expect(results[0].isSuccess, isFalse);
+        expect(results[0].error, isNotNull);
+        // A valid receiver still succeeds despite the bad one.
+        expect(results[1].isSuccess, isTrue);
+      },
+    );
+
+    test('empty receiver list yields an empty result list', () async {
+      final results = await buildGiftWrapBatch(
+        BuildGiftWrapRequest(
+          privateKeyHex: senderPrivateKey,
+          rumorJson: rumorJson(),
+          receiverPublicKeys: const [],
+        ),
+      );
+      expect(results, isEmpty);
+    });
+
+    test('runs inside a real compute() isolate and round-trips', () async {
+      final results = await compute(
+        buildGiftWrapBatch,
+        BuildGiftWrapRequest(
+          privateKeyHex: senderPrivateKey,
+          rumorJson: rumorJson(content: 'from isolate'),
+          receiverPublicKeys: [recipientPubkey],
+        ),
+      );
+      expect(results, hasLength(1));
+      expect(results.single.isSuccess, isTrue);
+      final decrypted = await decryptFor(
+        recipientPrivateKey,
+        results.single.giftWrap!,
+      );
+      expect(decrypted, isNotNull);
+      expect(decrypted!.content, equals('from isolate'));
+    });
+  });
+}

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -1179,6 +1179,131 @@ void main() {
           expect(isolateSeamCalls, equals(0));
         },
       );
+
+      test(
+        'batch builder throws falls back to single-receiver isolate path '
+        'for recipient and self-wrap',
+        () async {
+          var batchCalls = 0;
+          final service = NIP17MessageService(
+            signer: _LocalIsolateSigner(localPrivateKey),
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            isolateGiftWrapBatchBuilder: (request) {
+              batchCalls++;
+              if (request.receiverPublicKeys.length == 2) {
+                throw Exception('batch boom');
+              }
+              // Single-receiver call from _buildWrap fallback — succeed.
+              return buildGiftWrapBatch(request);
+            },
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'batch-throw fallback',
+          );
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isTrue);
+          // 1 batch (throws) + 1 single-receiver for recipient + 1 for self.
+          expect(batchCalls, equals(3));
+        },
+      );
+
+      test(
+        'batch builder reports self-wrap slot failure triggers _buildWrap '
+        'for the self-wrap lazily',
+        () async {
+          final service = NIP17MessageService(
+            signer: _LocalIsolateSigner(localPrivateKey),
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            isolateGiftWrapBatchBuilder: (request) async {
+              final all = await buildGiftWrapBatch(request);
+              if (request.receiverPublicKeys.length == 2) {
+                // Recipient succeeds; self-wrap slot reports failure.
+                return [
+                  all[0],
+                  const BuiltGiftWrapResult.failure('self-wrap slot failed'),
+                ];
+              }
+              return all;
+            },
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'self-wrap-slot-failure',
+          );
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isTrue);
+          expect(result.selfWrapPublished, isTrue);
+        },
+      );
+
+      test(
+        'batch builder reports recipient slot failure causes sendRumor to '
+        'return failure',
+        () async {
+          final service = NIP17MessageService(
+            signer: _LocalIsolateSigner(localPrivateKey),
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            isolateGiftWrapBatchBuilder: (request) async {
+              final all = await buildGiftWrapBatch(request);
+              if (request.receiverPublicKeys.length == 2) {
+                // Recipient slot fails; self-wrap slot succeeds.
+                return [
+                  const BuiltGiftWrapResult.failure('recipient slot failed'),
+                  all[1],
+                ];
+              }
+              return all;
+            },
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'recipient-slot-failure',
+          );
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isFalse);
+          verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+
+      test(
+        'uses compute() isolate by default when no isolateGiftWrapBatchBuilder '
+        'is injected (covers the _computeGiftWrapBatch static method)',
+        () async {
+          // No isolateGiftWrapBatchBuilder injection — exercises the default
+          // _computeGiftWrapBatch static tear-off that calls compute().
+          final realIsolateService = NIP17MessageService(
+            signer: _LocalIsolateSigner(localPrivateKey),
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+          );
+
+          final result = await realIsolateService.sendPrivateMessage(
+            recipientPubkey: _recipientPubkey,
+            content: 'real compute isolate test',
+          );
+
+          expect(result.success, isTrue);
+        },
+      );
     });
   });
 }

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -1133,8 +1133,8 @@ void main() {
           );
 
           expect(result.success, isTrue);
-          // One hop for the recipient wrap, one for the self wrap (sequential).
-          expect(isolateSeamCalls, equals(2));
+          // One combined batch hop builds both the recipient and self wraps.
+          expect(isolateSeamCalls, equals(1));
           expect(mainBuilderCalls, equals(0));
         },
       );

--- a/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
+++ b/mobile/packages/dm_repository/test/src/nip17_message_service_test.dart
@@ -10,6 +10,7 @@ import 'package:nostr_sdk/client_utils/keys.dart';
 import 'package:nostr_sdk/event.dart';
 import 'package:nostr_sdk/event_kind.dart';
 import 'package:nostr_sdk/nip59/gift_wrap_util.dart';
+import 'package:nostr_sdk/signer/isolate_decrypt_signer.dart';
 import 'package:nostr_sdk/signer/local_nostr_signer.dart';
 import 'package:nostr_sdk/signer/nostr_signer.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -19,6 +20,52 @@ class _MockNostrClient extends Mock implements NostrClient {}
 class _MockNostrSigner extends Mock implements NostrSigner {}
 
 class _FakeEvent extends Fake implements Event {}
+
+/// A local-key signer that advertises the isolate-offload capability,
+/// delegating all crypto to a real [LocalNostrSigner]. Used to exercise the
+/// `_buildWrap` isolate branch in [NIP17MessageService]. See #5391.
+class _LocalIsolateSigner implements IsolateDecryptSigner {
+  _LocalIsolateSigner(this._privateKeyHex)
+    : _delegate = LocalNostrSigner(_privateKeyHex);
+
+  final String _privateKeyHex;
+  final LocalNostrSigner _delegate;
+
+  @override
+  bool get canDecryptInIsolate => true;
+
+  @override
+  T withPrivateKeyHex<T>(T Function(String hex) operation) =>
+      operation(_privateKeyHex);
+
+  @override
+  Future<String?> getPublicKey() => _delegate.getPublicKey();
+
+  @override
+  Future<Event?> signEvent(Event event) => _delegate.signEvent(event);
+
+  @override
+  Future<Map<dynamic, dynamic>?> getRelays() => _delegate.getRelays();
+
+  @override
+  Future<String?> encrypt(String pubkey, String plaintext) =>
+      _delegate.encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> decrypt(String pubkey, String ciphertext) =>
+      _delegate.decrypt(pubkey, ciphertext);
+
+  @override
+  Future<String?> nip44Encrypt(String pubkey, String plaintext) =>
+      _delegate.nip44Encrypt(pubkey, plaintext);
+
+  @override
+  Future<String?> nip44Decrypt(String pubkey, String ciphertext) =>
+      _delegate.nip44Decrypt(pubkey, ciphertext);
+
+  @override
+  void close() => _delegate.close();
+}
 
 // Valid 64-character hex keys for testing.
 const _testPrivateKey =
@@ -1037,6 +1084,99 @@ void main() {
           expect(result.success, isFalse);
           expect(result.error, isNotNull);
           verifyNever(() => mockNostrClient.publishEvent(any()));
+        },
+      );
+    });
+
+    group('gift-wrap build offload (#5391)', () {
+      late String localPrivateKey;
+      late String localPubkey;
+
+      setUp(() {
+        localPrivateKey = generatePrivateKey();
+        localPubkey = getPublicKey(localPrivateKey);
+        when(() => mockNostrClient.publishEvent(any())).thenAnswer(
+          (inv) async =>
+              PublishSuccess(event: inv.positionalArguments[0] as Event),
+        );
+      });
+
+      test(
+        'local-key signer builds wraps via the isolate seam, not the main '
+        'builder',
+        () async {
+          var mainBuilderCalls = 0;
+          var isolateSeamCalls = 0;
+
+          final service = NIP17MessageService(
+            signer: _LocalIsolateSigner(localPrivateKey),
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (nostr, rumor, recipient) async {
+              mainBuilderCalls++;
+              return null;
+            },
+            isolateGiftWrapBatchBuilder: (request) {
+              isolateSeamCalls++;
+              // Build inline (no real isolate) — exercises the same worker.
+              return buildGiftWrapBatch(request);
+            },
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'via isolate',
+          );
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isTrue);
+          // One hop for the recipient wrap, one for the self wrap (sequential).
+          expect(isolateSeamCalls, equals(2));
+          expect(mainBuilderCalls, equals(0));
+        },
+      );
+
+      test(
+        'remote signer builds wraps on the main isolate, never the isolate '
+        'seam',
+        () async {
+          var mainBuilderCalls = 0;
+          var isolateSeamCalls = 0;
+
+          final remoteSigner = _MockNostrSigner();
+          when(remoteSigner.getPublicKey).thenAnswer((_) async => localPubkey);
+
+          final service = NIP17MessageService(
+            signer: remoteSigner,
+            senderPublicKey: localPubkey,
+            nostrService: mockNostrClient,
+            giftWrapBuilder: (nostr, rumor, recipient) async {
+              mainBuilderCalls++;
+              return Event(localPubkey, EventKind.giftWrap, [
+                ['p', recipient],
+              ], 'ciphertext');
+            },
+            isolateGiftWrapBatchBuilder: (request) async {
+              isolateSeamCalls++;
+              return const <BuiltGiftWrapResult>[];
+            },
+          );
+
+          final rumor = service.buildRumor(
+            recipientPubkey: _recipientPubkey,
+            content: 'via main isolate',
+          );
+          final result = await service.sendRumor(
+            rumorEvent: rumor,
+            recipientPubkey: _recipientPubkey,
+          );
+
+          expect(result.success, isTrue);
+          expect(mainBuilderCalls, equals(2));
+          expect(isolateSeamCalls, equals(0));
         },
       );
     });

--- a/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
+++ b/mobile/packages/nostr_sdk/lib/nip59/gift_wrap_util.dart
@@ -186,3 +186,71 @@ class GiftWrapUtil {
     return giftWrapEvent;
   }
 }
+
+/// Isolate-safe NIP-59 gift-wrap build over a raw private key hex.
+///
+/// Functionally identical to [GiftWrapUtil.getGiftWrapEvent] for a local-key
+/// sender, but takes the sender's private key hex directly instead of a
+/// [Nostr]/signer object, so it can run inside a `compute()` isolate — a remote
+/// signer's RPC/IPC handle cannot cross a `SendPort`, but a hex string can.
+/// This is the send-side counterpart of the receive-side decrypt offload.
+///
+/// The seal's pubkey is DERIVED from [senderPrivateKeyHex] rather than passed
+/// in: it must correspond to the signing key, or both the recipient's NIP-44
+/// ECDH (which keys on the seal pubkey) and the seal's Schnorr verification
+/// fail. [rumorJson] is the unsigned kind-14 rumor as [Event.toJson]; its `sig`
+/// is stripped before sealing and its id is preserved (receiver-side gift-wrap
+/// dedup keys on it).
+///
+/// Returns the signed kind-1059 gift wrap. Pure (no I/O, no signer object),
+/// so it is safe to run inside an isolate — the same crypto primitives already
+/// run inside the receive-side decrypt isolate.
+Future<Event?> buildGiftWrapFromHex({
+  required String senderPrivateKeyHex,
+  required Map<String, dynamic> rumorJson,
+  required String receiverPublicKey,
+}) async {
+  final baseCreatedAt = rumorJson['created_at'] as int;
+  final sealCreatedAt = GiftWrapUtil._randomizedPastTimestamp(baseCreatedAt);
+  final giftEventCreatedAt = GiftWrapUtil._randomizedPastTimestamp(
+    baseCreatedAt,
+  );
+
+  final rumorEventMap = Map<String, dynamic>.from(rumorJson)..remove('sig');
+
+  final senderPublicKey = getPublicKey(senderPrivateKeyHex);
+  final sealKey = NIP44V2.shareSecret(senderPrivateKeyHex, receiverPublicKey);
+  final sealEventContent = await NIP44V2.encrypt(
+    jsonEncode(rumorEventMap),
+    sealKey,
+  );
+
+  final sealEvent = Event(
+    senderPublicKey,
+    EventKind.sealEventKind,
+    [],
+    sealEventContent,
+    createdAt: sealCreatedAt,
+  );
+  sealEvent.sign(senderPrivateKeyHex);
+
+  final randomPrivateKey = generatePrivateKey();
+  final randomPubkey = getPublicKey(randomPrivateKey);
+  final randomKey = NIP44V2.shareSecret(randomPrivateKey, receiverPublicKey);
+  final giftWrapEventContent = await NIP44V2.encrypt(
+    jsonEncode(sealEvent.toJson()),
+    randomKey,
+  );
+  final giftWrapEvent = Event(
+    randomPubkey,
+    EventKind.giftWrap,
+    [
+      ['p', receiverPublicKey],
+    ],
+    giftWrapEventContent,
+    createdAt: giftEventCreatedAt,
+  );
+  giftWrapEvent.sign(randomPrivateKey);
+
+  return giftWrapEvent;
+}

--- a/mobile/packages/nostr_sdk/test/nip59/build_gift_wrap_from_hex_test.dart
+++ b/mobile/packages/nostr_sdk/test/nip59/build_gift_wrap_from_hex_test.dart
@@ -1,0 +1,133 @@
+// ABOUTME: Tests for buildGiftWrapFromHex — the isolate-safe send-side NIP-17
+// ABOUTME: gift-wrap builder. Covers round-trip decrypt, wrap structure,
+// ABOUTME: timestamp backdating, per-call CSPRNG, and the self-addressed wrap.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_sdk/nostr_sdk.dart';
+
+void main() {
+  Relay dummyRelay(String url) => RelayBase(url, RelayStatus(url));
+
+  late String senderPrivateKey;
+  late String senderPubkey;
+  late String recipientPrivateKey;
+  late String recipientPubkey;
+
+  setUp(() {
+    senderPrivateKey = generatePrivateKey();
+    senderPubkey = getPublicKey(senderPrivateKey);
+    recipientPrivateKey = generatePrivateKey();
+    recipientPubkey = getPublicKey(recipientPrivateKey);
+  });
+
+  Event buildRumor({String content = 'secret message'}) => Event(
+    senderPubkey,
+    EventKind.privateDirectMessage,
+    const <List<String>>[],
+    content,
+  );
+
+  group('buildGiftWrapFromHex', () {
+    test('round-trips back to the identical rumor for the recipient', () async {
+      final rumor = buildRumor();
+      final wrap = await buildGiftWrapFromHex(
+        senderPrivateKeyHex: senderPrivateKey,
+        rumorJson: rumor.toJson(),
+        receiverPublicKey: recipientPubkey,
+      );
+      expect(wrap, isNotNull);
+
+      final recipientNostr = Nostr(
+        LocalNostrSigner(recipientPrivateKey),
+        const [],
+        dummyRelay,
+      );
+      final decrypted = await GiftWrapUtil.getRumorEvent(recipientNostr, wrap!);
+
+      expect(decrypted, isNotNull);
+      expect(decrypted!.content, equals('secret message'));
+      expect(decrypted.pubkey, equals(senderPubkey));
+      expect(decrypted.kind, equals(EventKind.privateDirectMessage));
+      // Rumor id is preserved — receiver-side gift-wrap dedup keys on it.
+      expect(decrypted.id, equals(rumor.id));
+    });
+
+    test(
+      'produces a well-formed kind-1059 wrap with an ephemeral key',
+      () async {
+        final rumor = buildRumor();
+        final wrap = (await buildGiftWrapFromHex(
+          senderPrivateKeyHex: senderPrivateKey,
+          rumorJson: rumor.toJson(),
+          receiverPublicKey: recipientPubkey,
+        ))!;
+
+        expect(wrap.kind, equals(EventKind.giftWrap));
+        // id recomputes and the ephemeral signature verifies.
+        expect(verifyGiftWrapPart(wrap), isTrue);
+        // Outer pubkey is a throwaway ephemeral key, never the sender's.
+        expect(wrap.pubkey, isNot(equals(senderPubkey)));
+        final pTags = wrap.tags
+            .where((t) => t.isNotEmpty && t[0] == 'p')
+            .toList();
+        expect(pTags, hasLength(1));
+        expect(pTags.first[1], equals(recipientPubkey));
+      },
+    );
+
+    test(
+      'backdates the gift-wrap timestamp within 2 days and never to the future',
+      () async {
+        final rumor = buildRumor();
+        final base = rumor.createdAt;
+        final wrap = (await buildGiftWrapFromHex(
+          senderPrivateKeyHex: senderPrivateKey,
+          rumorJson: rumor.toJson(),
+          receiverPublicKey: recipientPubkey,
+        ))!;
+
+        const twoDays = 60 * 60 * 24 * 2;
+        expect(wrap.createdAt, lessThanOrEqualTo(base));
+        expect(wrap.createdAt, greaterThanOrEqualTo(base - twoDays));
+      },
+    );
+
+    test(
+      'uses a fresh CSPRNG per call (distinct ephemeral keys and wrap ids)',
+      () async {
+        final rumor = buildRumor();
+        final a = (await buildGiftWrapFromHex(
+          senderPrivateKeyHex: senderPrivateKey,
+          rumorJson: rumor.toJson(),
+          receiverPublicKey: recipientPubkey,
+        ))!;
+        final b = (await buildGiftWrapFromHex(
+          senderPrivateKeyHex: senderPrivateKey,
+          rumorJson: rumor.toJson(),
+          receiverPublicKey: recipientPubkey,
+        ))!;
+        expect(a.pubkey, isNot(equals(b.pubkey)));
+        expect(a.id, isNot(equals(b.id)));
+      },
+    );
+
+    test('self-addressed wrap round-trips for the sender', () async {
+      final rumor = buildRumor(content: 'note to self');
+      final wrap = (await buildGiftWrapFromHex(
+        senderPrivateKeyHex: senderPrivateKey,
+        rumorJson: rumor.toJson(),
+        receiverPublicKey: senderPubkey,
+      ))!;
+
+      final senderNostr = Nostr(
+        LocalNostrSigner(senderPrivateKey),
+        const [],
+        dummyRelay,
+      );
+      final decrypted = await GiftWrapUtil.getRumorEvent(senderNostr, wrap);
+      expect(decrypted, isNotNull);
+      expect(decrypted!.content, equals('note to self'));
+      expect(decrypted.pubkey, equals(senderPubkey));
+    });
+  });
+}

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -110,6 +110,11 @@ void main() {
       // Default stubs
       when(() => mockSharingService.recentlySharedWith).thenReturn([]);
       when(() => mockFollowRepository.followingPubkeys).thenReturn([]);
+      when(
+        () => mockProfileRepository.fetchBatchProfiles(
+          pubkeys: any(named: 'pubkeys'),
+        ),
+      ).thenAnswer((_) async => <String, UserProfile>{});
     });
 
     ShareSheetBloc createBloc({
@@ -146,6 +151,11 @@ void main() {
     // -----------------------------------------------------------------------
 
     group('ShareSheetContactsLoadRequested', () {
+      const profiledFollow =
+          'cccc456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+      const unprofiledFollow =
+          'dddd456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
       blocTest<ShareSheetBloc, ShareSheetState>(
         'emits [loading, ready] with empty contacts when no follows or recents',
         build: createBloc,
@@ -165,16 +175,6 @@ void main() {
           when(() => mockFollowRepository.followingPubkeys).thenReturn([
             'bbbb456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
           ]);
-          when(
-            () => mockProfileRepository.getCachedProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          ).thenAnswer((_) async => null);
-          when(
-            () => mockProfileRepository.fetchFreshProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          ).thenAnswer((_) async => null);
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),
@@ -213,16 +213,6 @@ void main() {
           when(
             () => mockSharingService.recentlySharedWith,
           ).thenReturn([testRecipient]);
-          when(
-            () => mockProfileRepository.getCachedProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          ).thenAnswer((_) async => null);
-          when(
-            () => mockProfileRepository.fetchFreshProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          ).thenAnswer((_) async => null);
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),
@@ -235,35 +225,27 @@ void main() {
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'fetches uncached profiles when getCachedProfile returns null',
+        'loads follow profiles via one fetchBatchProfiles call, no per-pubkey '
+        'storm',
         setUp: () {
-          const cachedPubkey =
-              'cccc456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
-          const uncachedPubkey =
-              'dddd456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
-
           when(() => mockSharingService.recentlySharedWith).thenReturn([]);
           when(
             () => mockFollowRepository.followingPubkeys,
-          ).thenReturn([cachedPubkey, uncachedPubkey]);
+          ).thenReturn([profiledFollow, unprofiledFollow]);
           when(
-            () => mockProfileRepository.getCachedProfile(pubkey: cachedPubkey),
-          ).thenAnswer(
-            (_) async => UserProfile(
-              pubkey: cachedPubkey,
-              createdAt: DateTime.now(),
-              eventId: 'event-$cachedPubkey',
-              rawData: const {},
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: any(named: 'pubkeys'),
             ),
+          ).thenAnswer(
+            (_) async => {
+              profiledFollow: UserProfile(
+                pubkey: profiledFollow,
+                createdAt: DateTime.now(),
+                eventId: 'event-$profiledFollow',
+                rawData: const {'name': 'Bob'},
+              ),
+            },
           );
-          when(
-            () =>
-                mockProfileRepository.getCachedProfile(pubkey: uncachedPubkey),
-          ).thenAnswer((_) async => null);
-          when(
-            () =>
-                mockProfileRepository.fetchFreshProfile(pubkey: uncachedPubkey),
-          ).thenAnswer((_) async => null);
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),
@@ -274,16 +256,23 @@ void main() {
               .having((s) => s.contacts.length, 'contacts.length', 2),
         ],
         verify: (_) {
-          verify(
-            () => mockProfileRepository.fetchFreshProfile(
-              pubkey:
-                  'dddd456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+          // Exactly one batched read covering both follows, in order — the
+          // per-pubkey getCachedProfile/fetchFreshProfile storm is gone.
+          final captured = verify(
+            () => mockProfileRepository.fetchBatchProfiles(
+              pubkeys: captureAny(named: 'pubkeys'),
             ),
-          ).called(1);
+          ).captured;
+          expect(captured, hasLength(1));
+          expect(captured.single, [profiledFollow, unprofiledFollow]);
+          verifyNever(
+            () => mockProfileRepository.getCachedProfile(
+              pubkey: any(named: 'pubkey'),
+            ),
+          );
           verifyNever(
             () => mockProfileRepository.fetchFreshProfile(
-              pubkey:
-                  'cccc456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+              pubkey: any(named: 'pubkey'),
             ),
           );
         },
@@ -307,16 +296,6 @@ void main() {
             duplicatePubkey,
             'bbbb456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
           ]);
-          when(
-            () => mockProfileRepository.getCachedProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          ).thenAnswer((_) async => null);
-          when(
-            () => mockProfileRepository.fetchFreshProfile(
-              pubkey: any(named: 'pubkey'),
-            ),
-          ).thenAnswer((_) async => null);
         },
         build: createBloc,
         act: (bloc) => bloc.add(const ShareSheetContactsLoadRequested()),

--- a/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
+++ b/mobile/test/blocs/share_sheet/share_sheet_bloc_test.dart
@@ -370,8 +370,14 @@ void main() {
     // -----------------------------------------------------------------------
 
     group('ShareSheetQuickSendRequested', () {
+      const otherRecipient = ShareableUser(
+        pubkey:
+            'ffff456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        displayName: 'Bob',
+      );
+
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'emits [sending, success] and marks pubkey as sent on success',
+        'optimistically marks sent and emits success immediately, no wait',
         setUp: () {
           when(
             () => mockSharingService.shareVideoWithUser(
@@ -384,12 +390,12 @@ void main() {
         build: createBloc,
         act: (bloc) =>
             bloc.add(const ShareSheetQuickSendRequested(testRecipient)),
+        // A single optimistic emit: marked sent + success toast, no isSending
+        // step. The background send succeeds, so nothing more is emitted.
         expect: () => [
           isA<ShareSheetState>()
-              .having((s) => s.isSending, 'isSending', isTrue)
-              .having((s) => s.selectedRecipient, 'selectedRecipient', isNull),
-          isA<ShareSheetState>()
               .having((s) => s.isSending, 'isSending', isFalse)
+              .having((s) => s.selectedRecipient, 'selectedRecipient', isNull)
               .having(
                 (s) => s.sentPubkeys.contains(testRecipient.pubkey),
                 'sentPubkeys contains recipient',
@@ -406,7 +412,7 @@ void main() {
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'emits failure when share returns error',
+        'rolls back the optimistic mark and emits failure when send fails',
         setUp: () {
           when(
             () => mockSharingService.shareVideoWithUser(
@@ -420,13 +426,25 @@ void main() {
         act: (bloc) =>
             bloc.add(const ShareSheetQuickSendRequested(testRecipient)),
         expect: () => [
-          isA<ShareSheetState>().having(
-            (s) => s.isSending,
-            'isSending',
-            isTrue,
-          ),
+          // Optimistic success first…
           isA<ShareSheetState>()
-              .having((s) => s.isSending, 'isSending', isFalse)
+              .having(
+                (s) => s.sentPubkeys.contains(testRecipient.pubkey),
+                'optimistically sent',
+                isTrue,
+              )
+              .having(
+                (s) => s.actionResult,
+                'actionResult',
+                isA<ShareSheetSendSuccess>(),
+              ),
+          // …then rolled back with a failure once the background send fails.
+          isA<ShareSheetState>()
+              .having(
+                (s) => s.sentPubkeys.contains(testRecipient.pubkey),
+                'rolled back',
+                isFalse,
+              )
               .having(
                 (s) => s.actionResult,
                 'actionResult',
@@ -436,15 +454,26 @@ void main() {
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(
-        'ignores event when already sending',
-        seed: () => const ShareSheetState(
-          status: ShareSheetStatus.ready,
-          isSending: true,
-        ),
+        'confirms multiple recipients tapped in a row (concurrent)',
+        setUp: () {
+          when(
+            () => mockSharingService.shareVideoWithUser(
+              video: any(named: 'video'),
+              recipientPubkey: any(named: 'recipientPubkey'),
+            ),
+          ).thenAnswer((_) async => ShareResult.createSuccess('msg-event-id'));
+        },
+        seed: () => const ShareSheetState(status: ShareSheetStatus.ready),
         build: createBloc,
-        act: (bloc) =>
-            bloc.add(const ShareSheetQuickSendRequested(testRecipient)),
-        expect: () => <ShareSheetState>[],
+        act: (bloc) => bloc
+          ..add(const ShareSheetQuickSendRequested(testRecipient))
+          ..add(const ShareSheetQuickSendRequested(otherRecipient)),
+        verify: (bloc) {
+          expect(
+            bloc.state.sentPubkeys,
+            containsAll([testRecipient.pubkey, otherRecipient.pubkey]),
+          );
+        },
       );
 
       blocTest<ShareSheetBloc, ShareSheetState>(

--- a/mobile/test/services/video_sharing_service_test.dart
+++ b/mobile/test/services/video_sharing_service_test.dart
@@ -2,6 +2,8 @@
 // ABOUTME: Covers NIP-17 share path, NIP-04 fallback, getShareableUsers,
 // ABOUTME: searchUsersToShareWith, shareVideoWithUser, and sharing utilities.
 
+import 'dart:async';
+
 import 'package:dm_repository/dm_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -103,6 +105,9 @@ void main() {
         video: testVideo,
         recipientPubkey: _recipientPubkey,
       );
+      // The recents update is now fire-and-forget (see #5391); drain the
+      // event loop so the background insert completes before asserting.
+      await Future<void>.delayed(Duration.zero);
 
       final result = await service.getShareableUsers();
 
@@ -153,6 +158,10 @@ void main() {
           recipientPubkey: hexI,
         );
       }
+
+      // The recents update is now fire-and-forget (see #5391); drain the
+      // event loop so all background inserts complete before asserting.
+      await Future<void>.delayed(Duration.zero);
 
       // Act - request with limit 3
       final result = await service.getShareableUsers(limit: 3);
@@ -421,6 +430,55 @@ void main() {
         ),
       );
     });
+
+    test(
+      'returns success without waiting on the recents profile fetch (#5391)',
+      () async {
+        when(() => mockAuthService.isAuthenticated).thenReturn(true);
+        when(
+          () => mockDmRepository.sendSharedVideo(
+            recipientPubkey: any(named: 'recipientPubkey'),
+            baseContent: any(named: 'baseContent'),
+            videoKind: any(named: 'videoKind'),
+            videoAuthorPubkey: any(named: 'videoAuthorPubkey'),
+            videoDTag: any(named: 'videoDTag'),
+            videoEventId: any(named: 'videoEventId'),
+            relayHint: any(named: 'relayHint'),
+          ),
+        ).thenAnswer(
+          (_) async => NIP17SendResult.success(
+            rumorEventId: 'nip17-rumor-id',
+            messageEventId: 'nip17-msg-id',
+            recipientPubkey: _recipientPubkey,
+          ),
+        );
+        // The post-send recents refresh must be fire-and-forget: a hung
+        // profile fetch must NOT delay the success result (the toast).
+        final neverCompletes = Completer<UserProfile?>();
+        when(
+          () => mockProfileRepository.fetchFreshProfile(
+            pubkey: any(named: 'pubkey'),
+          ),
+        ).thenAnswer((_) => neverCompletes.future);
+
+        final now = DateTime.now();
+        final result = await nip17Service
+            .shareVideoWithUser(
+              video: VideoEvent(
+                id: _testVideoId,
+                pubkey: _testPubkey,
+                createdAt: now.millisecondsSinceEpoch ~/ 1000,
+                timestamp: now,
+                content: 'Test',
+              ),
+              recipientPubkey: _recipientPubkey,
+            )
+            .timeout(const Duration(seconds: 2));
+
+        expect(result.success, isTrue);
+        expect(result.messageEventId, equals('nip17-msg-id'));
+      },
+    );
 
     test('returns failure when NIP-17 send fails', () async {
       when(() => mockAuthService.isAuthenticated).thenReturn(true);


### PR DESCRIPTION
## Description

Sharing a video to a DM felt laggy in two places: opening the share sheet, and
tapping a person to send. This makes both feel immediate, on every device,
without weakening delivery reliability.

**On-device profiling drove the design.** The felt lag when tapping a person
was the ~2.4–3.3 s wait for the *network* send (DM-inbox-relay lookup + relay
publishes), **not** the crypto. So the fix that removes the felt wait is the
optimistic UI; the isolate offload keeps the UI thread smooth (it matters most
on slower/older/Android hardware where pure-Dart secp256k1 is far slower).

What changed (one branch, 6 commits):

1. **`perf(dm)` — gift-wrap crypto off the main isolate** for local-key
   signers, mirroring the receive-path `compute()` offload and gated on
   `IsolateDecryptSigner.canDecryptInIsolate`. Remote signers (Keycast RPC /
   Amber / NIP-46) cannot cross a `SendPort`, so they keep the unchanged
   main-isolate path (already async I/O). Sequential ordering preserved; any
   isolate-path failure falls back to the main builder. Lives in the shared
   `sendRumor`, so all 1:1 sends inherit it.
2. **`perf(share)` — batched contacts load.** One
   `ProfileRepository.fetchBatchProfiles` instead of a per-pubkey DB + network
   storm fired during the sheet-open animation.
3. **`perf(share)` — fire-and-forget the post-send recents refresh** so the
   "sent" confirmation no longer waits on a 5 s-timeout profile fetch.
4. **`test(dm)` — unit coverage** for the offload + batch, plus an on-device
   main-isolate-stall benchmark.
5. **`perf(share)` — optimistic quick-send.** Tapping a contact confirms
   instantly (checkmark + toast); the send runs in the background. It rolls
   back with an error if it fails while the sheet is open, and is `concurrent`
   so tapping several people each confirms immediately. Send-with-message keeps
   its awaited "sending" spinner (it already showed feedback).
6. **`perf(share)` — shimmer the contacts row** that dissolves into the real
   list (`IdentitySkeletonizer`) instead of a spinner that pops.

**Reliability is unchanged.** Every send is enqueued in the durable
`outgoing_dms` queue before publishing, and `OutgoingDmRetryService`
re-publishes failed/interrupted sends on app foreground (the rumor id is
stable, so the receiver dedups any replay).

**Related Issue:** Relates to #5391

## Out of Scope

- A persistent "failed to send" marker in the conversation for the rare case
  where an optimistic send fails *after* the sheet is closed and the durable
  retries exhaust.
- Making the actual relay round-trip faster — this PR removes the felt wait,
  not the network time itself.
- A long-lived send isolate to amortize the per-send `compute()` spawn (the
  spawn cost is paid as background work now, so it's invisible to the user).

## Verification

- `flutter analyze lib test integration_test` — clean.
- `dart analyze packages/nostr_sdk packages/dm_repository` — clean.
- `dart format --set-exit-if-changed` on all changed files — clean.
- Tests: `dm_repository` full suite (423), `nostr_sdk` nip59 (17),
  `share_sheet_bloc` (41), share UI widget tests (38), `video_sharing_service`
  (25). All green after rebasing on `origin/main`.
- **On-device (iPhone, debug):** the committed benchmark integration test
  asserts the worst-case main-isolate stall during the gift-wrap build collapses
  (12.2 ms → 1.3 ms; 8.33 ms frame budget). Manual share confirmed the sheet
  opens smoothly, contacts shimmer then dissolve in, and tapping a person is
  instant; logs confirmed the offload path fired and the background send
  completed end-to-end.

_Screen recording to be added._

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
