### PR TITLE
feat(profile): route kind 0 publish through publishEventAwaitOk for relay-confirmed saves

### DIFF
--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -996,45 +996,16 @@ class NostrClient {
     return null;
   }
 
-  /// Sends a user profile (Kind 0 metadata event).
-  ///
-  /// Delegates to [publishEvent], which handles relay connectivity checks,
-  /// retry, caching, and statistics. Kind 0 is replaceable, so it is cached
-  /// only on successful publish (not optimistically).
-  ///
-  /// Returns a [PublishResult] that callers can switch exhaustively over:
-  /// - [PublishSuccess] — the event was broadcast to at least one relay.
-  /// - [PublishNoRelays] — no relays were connected even after retry.
-  /// - [PublishFailed] — the relay pool was reachable but the send
-  ///   returned null (e.g. a serialisation error).
-  Future<PublishResult> sendProfile({
-    required Map<String, dynamic> profileContent,
-  }) {
-    final event = Event(
-      publicKey,
-      EventKind.metadata,
-      [],
-      jsonEncode(profileContent),
-    );
-
-    return publishEvent(event);
-  }
-
   /// Sends a user profile (Kind 0 metadata event), waiting for relay
   /// confirmation before reporting success.
   ///
-  /// Unlike [sendProfile] — which delegates to [publishEvent] and reports
-  /// success as soon as the relay pool accepts the WebSocket frame — this
-  /// routes through [publishEventAwaitOk] and only reports [PublishSuccess]
-  /// once at least one relay has returned `OK true` (NIP-20). A Kind 0 that
-  /// is accepted at the socket layer but then rejected by every relay
-  /// (rate limit, PoW, auth required) is reported as [PublishFailed] here,
-  /// where [sendProfile] would have reported success. Kind 0 is replaceable,
+  /// Routes through [publishEventAwaitOk] and only reports [PublishSuccess]
+  /// once at least one relay has returned `OK true` (NIP-20). A Kind 0 that is
+  /// accepted at the socket layer but then rejected by every relay (rate limit,
+  /// PoW, auth required) is reported as [PublishFailed]. Kind 0 is replaceable,
   /// so [publishEventAwaitOk] caches it only after confirmation.
   ///
-  /// The underlying [PublishOutcome] is mapped onto the same [PublishResult]
-  /// variants [sendProfile] returns, so both can be switched over
-  /// identically:
+  /// The underlying [PublishOutcome] is mapped onto [PublishResult]:
   /// - [PublishSuccess] — at least one relay confirmed the event.
   /// - [PublishNoRelays] — no relay was connected even after retry, so the
   ///   publish never left the device. Preserves the dedicated no-relays

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1020,6 +1020,53 @@ class NostrClient {
     return publishEvent(event);
   }
 
+  /// Sends a user profile (Kind 0 metadata event), waiting for relay
+  /// confirmation before reporting success.
+  ///
+  /// Unlike [sendProfile] — which delegates to [publishEvent] and reports
+  /// success as soon as the relay pool accepts the WebSocket frame — this
+  /// routes through [publishEventAwaitOk] and only reports [PublishSuccess]
+  /// once at least one relay has returned `OK true` (NIP-20). A Kind 0 that
+  /// is accepted at the socket layer but then rejected by every relay
+  /// (rate limit, PoW, auth required) is reported as [PublishFailed] here,
+  /// where [sendProfile] would have reported success. Kind 0 is replaceable,
+  /// so [publishEventAwaitOk] caches it only after confirmation.
+  ///
+  /// The underlying [PublishOutcome] is mapped onto the same [PublishResult]
+  /// variants [sendProfile] returns, so both can be switched over
+  /// identically:
+  /// - [PublishSuccess] — at least one relay confirmed the event.
+  /// - [PublishNoRelays] — no relay was reached even after retry, so the
+  ///   publish never left the device. Preserves the dedicated no-relays
+  ///   signal callers branch on.
+  /// - [PublishFailed] — relays were reached but every one rejected the
+  ///   event or failed to respond before the confirmation timeout.
+  Future<PublishResult> sendProfileAwaitOk({
+    required Map<String, dynamic> profileContent,
+  }) async {
+    final event = Event(
+      publicKey,
+      EventKind.metadata,
+      [],
+      jsonEncode(profileContent),
+    );
+
+    final outcome = await publishEventAwaitOk(event);
+
+    if (outcome.confirmed) {
+      return PublishSuccess(event: event);
+    }
+
+    // An outcome with no acceptances, rejections, or timeouts means the
+    // publish never reached a relay — keep that distinct from a relay-level
+    // rejection/timeout so the no-relays branch stays user-actionable.
+    if (outcome.rejectedBy.isEmpty && outcome.noResponseFrom.isEmpty) {
+      return const PublishNoRelays();
+    }
+
+    return const PublishFailed();
+  }
+
   /// Sends a repost
   ///
   /// Successfully sent events are cached locally with 1-day expiry.

--- a/mobile/packages/nostr_client/lib/src/nostr_client.dart
+++ b/mobile/packages/nostr_client/lib/src/nostr_client.dart
@@ -1036,14 +1036,31 @@ class NostrClient {
   /// variants [sendProfile] returns, so both can be switched over
   /// identically:
   /// - [PublishSuccess] — at least one relay confirmed the event.
-  /// - [PublishNoRelays] — no relay was reached even after retry, so the
+  /// - [PublishNoRelays] — no relay was connected even after retry, so the
   ///   publish never left the device. Preserves the dedicated no-relays
   ///   signal callers branch on.
-  /// - [PublishFailed] — relays were reached but every one rejected the
-  ///   event or failed to respond before the confirmation timeout.
+  /// - [PublishFailed] — relays were connected but the event was not confirmed:
+  ///   every relay rejected it, none responded before the confirmation
+  ///   timeout, or the send failed before reaching them (e.g. the signer
+  ///   returned null).
   Future<PublishResult> sendProfileAwaitOk({
     required Map<String, dynamic> profileContent,
   }) async {
+    // Resolve the no-relays case up front. [publishEventAwaitOk] returns an
+    // all-empty [PublishOutcome] both when no relay was ever connected AND
+    // when the relay pool was connected but the send failed before any `OK`
+    // could arrive (e.g. the signer returned null) — the two are
+    // indistinguishable from its result. Only the former is [PublishNoRelays],
+    // so detect it here, mirroring [publishEvent]'s connectivity check. Any
+    // non-confirmed outcome afterwards means relays were reached but did not
+    // persist the event, which is [PublishFailed].
+    if (_relayManager.connectedRelays.isEmpty) {
+      await retryDisconnectedRelays();
+      if (_relayManager.connectedRelays.isEmpty) {
+        return const PublishNoRelays();
+      }
+    }
+
     final event = Event(
       publicKey,
       EventKind.metadata,
@@ -1055,13 +1072,6 @@ class NostrClient {
 
     if (outcome.confirmed) {
       return PublishSuccess(event: event);
-    }
-
-    // An outcome with no acceptances, rejections, or timeouts means the
-    // publish never reached a relay — keep that distinct from a relay-level
-    // rejection/timeout so the no-relays branch stays user-actionable.
-    if (outcome.rejectedBy.isEmpty && outcome.noResponseFrom.isEmpty) {
-      return const PublishNoRelays();
     }
 
     return const PublishFailed();

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1935,6 +1935,117 @@ void main() {
       });
     });
 
+    group('sendProfileAwaitOk', () {
+      PublishOutcome accepted() => const PublishOutcome(
+        eventId: 'kind0',
+        acceptedBy: ['wss://relay.test'],
+        rejectedBy: {},
+        noResponseFrom: [],
+      );
+
+      PublishOutcome rejected() => const PublishOutcome(
+        eventId: 'kind0',
+        acceptedBy: [],
+        rejectedBy: {'wss://relay.test': 'rate-limited: slow down'},
+        noResponseFrom: [],
+      );
+
+      PublishOutcome timedOut() => const PublishOutcome(
+        eventId: 'kind0',
+        acceptedBy: [],
+        rejectedBy: {},
+        noResponseFrom: ['wss://relay.test'],
+      );
+
+      void stubAwaitOk(PublishOutcome outcome) {
+        when(
+          () => mockNostr.sendEventAwaitOk(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).thenAnswer((_) async => outcome);
+      }
+
+      test('returns PublishSuccess with the Kind 0 event when a relay '
+          'confirms', () async {
+        final profileContent = {'display_name': 'Alice', 'about': 'Hello'};
+        stubAwaitOk(accepted());
+
+        final result = await client.sendProfileAwaitOk(
+          profileContent: profileContent,
+        );
+
+        expect(result, isA<PublishSuccess>());
+        final event = (result as PublishSuccess).event;
+        expect(event.kind, equals(EventKind.metadata));
+        expect(event.content, equals(jsonEncode(profileContent)));
+      });
+
+      test('returns PublishSuccess when at least one relay confirms even if '
+          'another rejects', () async {
+        stubAwaitOk(
+          const PublishOutcome(
+            eventId: 'kind0',
+            acceptedBy: ['wss://relay.ok'],
+            rejectedBy: {'wss://relay.bad': 'blocked: policy'},
+            noResponseFrom: [],
+          ),
+        );
+
+        final result = await client.sendProfileAwaitOk(
+          profileContent: {'display_name': 'Alice'},
+        );
+
+        expect(result, isA<PublishSuccess>());
+      });
+
+      test('returns PublishFailed when every relay rejects the event '
+          '(accepted at socket, OK false)', () async {
+        stubAwaitOk(rejected());
+
+        final result = await client.sendProfileAwaitOk(
+          profileContent: {'display_name': 'Alice'},
+        );
+
+        expect(result, isA<PublishFailed>());
+      });
+
+      test(
+        'returns PublishFailed when no relay responds before timeout',
+        () async {
+          stubAwaitOk(timedOut());
+
+          final result = await client.sendProfileAwaitOk(
+            profileContent: {'display_name': 'Alice'},
+          );
+
+          expect(result, isA<PublishFailed>());
+        },
+      );
+
+      test('returns PublishNoRelays when no relay is reachable, without '
+          'attempting a send', () async {
+        when(() => mockRelayManager.connectedRelays).thenReturn([]);
+        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {});
+
+        final result = await client.sendProfileAwaitOk(
+          profileContent: {'display_name': 'Alice'},
+        );
+
+        expect(result, isA<PublishNoRelays>());
+        verifyNever(
+          () => mockNostr.sendEventAwaitOk(
+            any(),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        );
+      });
+    });
+
     group('sendRepost', () {
       test('sends repost successfully', () async {
         const eventId = 'event-to-repost';

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -1834,107 +1834,6 @@ void main() {
       });
     });
 
-    group('sendProfile', () {
-      test('returns PublishSuccess with Kind 0 event on success', () async {
-        final profileContent = {'display_name': 'Alice', 'about': 'Hello'};
-        final sentEvent = _createTestEvent(kind: EventKind.metadata);
-
-        when(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-          ),
-        ).thenAnswer((_) async => sentEvent);
-
-        final result = await client.sendProfile(profileContent: profileContent);
-
-        expect(result, isA<PublishSuccess>());
-        expect((result as PublishSuccess).event, equals(sentEvent));
-        verify(
-          () => mockNostr.sendEvent(
-            any(
-              that: isA<Event>()
-                  .having((e) => e.kind, 'kind', EventKind.metadata)
-                  .having(
-                    (e) => e.content,
-                    'content',
-                    jsonEncode(profileContent),
-                  ),
-            ),
-          ),
-        ).called(1);
-      });
-
-      test(
-        'returns PublishNoRelays when no relays connected and retry fails',
-        () async {
-          when(() => mockRelayManager.connectedRelays).thenReturn([]);
-          when(
-            mockRelayManager.retryDisconnectedRelays,
-          ).thenAnswer((_) async {});
-
-          final result = await client.sendProfile(
-            profileContent: {'display_name': 'Alice'},
-          );
-
-          expect(result, isA<PublishNoRelays>());
-          verify(mockRelayManager.retryDisconnectedRelays).called(1);
-          verifyNever(
-            () => mockNostr.sendEvent(
-              any(),
-              tempRelays: any(named: 'tempRelays'),
-              targetRelays: any(named: 'targetRelays'),
-            ),
-          );
-        },
-      );
-
-      test('retries disconnected relays and returns PublishSuccess', () async {
-        final sentEvent = _createTestEvent(kind: EventKind.metadata);
-        final connectedRelays = ['wss://relay1.example.com'];
-
-        when(() => mockRelayManager.connectedRelays).thenReturn([]);
-        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {
-          when(
-            () => mockRelayManager.connectedRelays,
-          ).thenReturn(connectedRelays);
-        });
-        when(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-          ),
-        ).thenAnswer((_) async => sentEvent);
-
-        final result = await client.sendProfile(
-          profileContent: {'display_name': 'Alice'},
-        );
-
-        expect(result, isA<PublishSuccess>());
-        expect((result as PublishSuccess).event, equals(sentEvent));
-        verify(mockRelayManager.retryDisconnectedRelays).called(1);
-        verify(() => mockNostr.sendEvent(any())).called(1);
-      });
-
-      test('returns PublishFailed when sendEvent returns null', () async {
-        when(
-          () => mockNostr.sendEvent(
-            any(),
-            tempRelays: any(named: 'tempRelays'),
-            targetRelays: any(named: 'targetRelays'),
-          ),
-        ).thenAnswer((_) async => null);
-
-        final result = await client.sendProfile(
-          profileContent: {'display_name': 'Alice'},
-        );
-
-        expect(result, isA<PublishFailed>());
-      });
-    });
-
     group('sendProfileAwaitOk', () {
       PublishOutcome accepted() => const PublishOutcome(
         eventId: 'kind0',
@@ -1999,6 +1898,41 @@ void main() {
         );
 
         expect(result, isA<PublishSuccess>());
+      });
+
+      test('retries disconnected relays and returns PublishSuccess when '
+          'a relay confirms', () async {
+        var connectedRelays = <String>[];
+        when(
+          () => mockRelayManager.connectedRelays,
+        ).thenAnswer((_) => connectedRelays);
+        when(mockRelayManager.retryDisconnectedRelays).thenAnswer((_) async {
+          connectedRelays = ['wss://relay.test'];
+        });
+        stubAwaitOk(accepted());
+
+        final result = await client.sendProfileAwaitOk(
+          profileContent: {'display_name': 'Alice'},
+        );
+
+        expect(result, isA<PublishSuccess>());
+        verify(mockRelayManager.retryDisconnectedRelays).called(1);
+        verify(
+          () => mockNostr.sendEventAwaitOk(
+            any(
+              that: isA<Event>()
+                  .having((e) => e.kind, 'kind', EventKind.metadata)
+                  .having(
+                    (e) => e.content,
+                    'content',
+                    jsonEncode({'display_name': 'Alice'}),
+                  ),
+            ),
+            tempRelays: any(named: 'tempRelays'),
+            targetRelays: any(named: 'targetRelays'),
+            timeout: any(named: 'timeout'),
+          ),
+        ).called(1);
       });
 
       test('returns PublishFailed when every relay rejects the event '

--- a/mobile/packages/nostr_client/test/src/nostr_client_test.dart
+++ b/mobile/packages/nostr_client/test/src/nostr_client_test.dart
@@ -2025,6 +2025,32 @@ void main() {
         },
       );
 
+      test(
+        'returns PublishFailed when relays are connected but the send fails '
+        'before any OK (SDK returns null, e.g. signer failure)',
+        () async {
+          // connectedRelays defaults to non-empty in setUp, so the no-relays
+          // connectivity check passes. The all-empty outcome here comes from
+          // the null-send fallback inside publishEventAwaitOk (signing failure
+          // with relays connected), which must surface as PublishFailed — not
+          // PublishNoRelays.
+          when(
+            () => mockNostr.sendEventAwaitOk(
+              any(),
+              tempRelays: any(named: 'tempRelays'),
+              targetRelays: any(named: 'targetRelays'),
+              timeout: any(named: 'timeout'),
+            ),
+          ).thenAnswer((_) async => null);
+
+          final result = await client.sendProfileAwaitOk(
+            profileContent: {'display_name': 'Alice'},
+          );
+
+          expect(result, isA<PublishFailed>());
+        },
+      );
+
       test('returns PublishNoRelays when no relay is reachable, without '
           'attempting a send', () async {
         when(() => mockRelayManager.connectedRelays).thenReturn([]);

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -551,7 +551,8 @@ class ProfileRepository {
   ///
   /// Throws [NoRelaysConnectedException] when no relays are connected.
   /// Throws [ProfilePublishFailedException] when relays were reached but none
-  /// confirmed the event (rejection or timeout).
+  /// confirmed the event (rejection, timeout, or a send failure such as the
+  /// signer returning null).
   Future<UserProfile> saveProfileEvent({
     required String displayName,
     String? about,

--- a/mobile/packages/profile_repository/lib/src/profile_repository.dart
+++ b/mobile/packages/profile_repository/lib/src/profile_repository.dart
@@ -543,11 +543,15 @@ class ProfileRepository {
   /// [clearNip05] as `true` to explicitly remove the NIP-05 from the profile
   /// (overriding any value in `currentProfile.rawData`).
   ///
-  /// After successful publish, the profile is cached locally for immediate
-  /// subsequent reads.
+  /// Publishes through [NostrClient.sendProfileAwaitOk], so success means at
+  /// least one relay confirmed the Kind 0 with an `OK true` (NIP-20) — a save
+  /// that is accepted at the socket layer but then rejected by every relay
+  /// surfaces as a failure rather than a false success. After a confirmed
+  /// publish, the profile is cached locally for immediate subsequent reads.
   ///
   /// Throws [NoRelaysConnectedException] when no relays are connected.
-  /// Throws [ProfilePublishFailedException] for other send failures.
+  /// Throws [ProfilePublishFailedException] when relays were reached but none
+  /// confirmed the event (rejection or timeout).
   Future<UserProfile> saveProfileEvent({
     required String displayName,
     String? about,
@@ -614,7 +618,9 @@ class ProfileRepository {
     // custom client fields, future NIPs — flows through from the seed
     // untouched. Adding new editable fields here MUST keep that invariant.
 
-    final result = await _nostrClient.sendProfile(profileContent: newContent);
+    final result = await _nostrClient.sendProfileAwaitOk(
+      profileContent: newContent,
+    );
 
     // Switch exhaustively over the typed result — no post-failure
     // connectedRelays snapshot needed.
@@ -626,7 +632,7 @@ class ProfileRepository {
 
       case PublishNoRelays():
         Log.error(
-          'sendProfile: no connected relays after retry',
+          'sendProfileAwaitOk: no connected relays after retry',
           name: 'ProfileRepository.saveProfileEvent',
           category: LogCategory.relay,
         );
@@ -636,7 +642,7 @@ class ProfileRepository {
 
       case PublishFailed():
         Log.error(
-          'sendProfile: relay rejected the event or send failed',
+          'sendProfileAwaitOk: relay rejected the event or no relay confirmed',
           name: 'ProfileRepository.saveProfileEvent',
           category: LogCategory.relay,
         );

--- a/mobile/packages/profile_repository/test/src/profile_repository_test.dart
+++ b/mobile/packages/profile_repository/test/src/profile_repository_test.dart
@@ -102,7 +102,7 @@ void main() {
       ).thenAnswer((_) async => <Event>[]);
 
       when(
-        () => mockNostrClient.sendProfile(
+        () => mockNostrClient.sendProfileAwaitOk(
           profileContent: any(named: 'profileContent'),
         ),
       ).thenAnswer((_) async => PublishSuccess(event: mockProfileEvent));
@@ -1439,7 +1439,7 @@ void main() {
         expect(profile.picture, equals('https://example.com/new.png'));
 
         verify(
-          () => mockNostrClient.sendProfile(
+          () => mockNostrClient.sendProfileAwaitOk(
             profileContent: {
               'display_name': 'New Name',
               'about': 'New bio',
@@ -1458,7 +1458,7 @@ void main() {
         );
 
         verify(
-          () => mockNostrClient.sendProfile(
+          () => mockNostrClient.sendProfileAwaitOk(
             profileContent: {
               'display_name': 'Test',
               'nip05': '_@alice.divine.video',
@@ -1474,7 +1474,7 @@ void main() {
         );
 
         verify(
-          () => mockNostrClient.sendProfile(
+          () => mockNostrClient.sendProfileAwaitOk(
             profileContent: {
               'display_name': 'Test',
               'nip05': '_@alice.divine.video',
@@ -1494,7 +1494,7 @@ void main() {
         );
 
         verify(
-          () => mockNostrClient.sendProfile(
+          () => mockNostrClient.sendProfileAwaitOk(
             profileContent: {
               'display_name': 'Test',
               'nip05': 'alice@example.com',
@@ -1515,7 +1515,7 @@ void main() {
         );
 
         verify(
-          () => mockNostrClient.sendProfile(
+          () => mockNostrClient.sendProfileAwaitOk(
             profileContent: {
               'display_name': 'Test',
               'nip05': 'alice@example.com',
@@ -1530,7 +1530,7 @@ void main() {
           await profileRepository.saveProfileEvent(displayName: 'Only Name');
 
           verify(
-            () => mockNostrClient.sendProfile(
+            () => mockNostrClient.sendProfileAwaitOk(
               profileContent: {'display_name': 'Only Name'},
             ),
           ).called(1);
@@ -1542,7 +1542,7 @@ void main() {
 
         final captured =
             verify(
-                  () => mockNostrClient.sendProfile(
+                  () => mockNostrClient.sendProfileAwaitOk(
                     profileContent: captureAny(named: 'profileContent'),
                   ),
                 ).captured.single
@@ -1561,7 +1561,7 @@ void main() {
         );
 
         verify(
-          () => mockNostrClient.sendProfile(
+          () => mockNostrClient.sendProfileAwaitOk(
             profileContent: {'display_name': 'Test User', 'banner': '0x33ccbf'},
           ),
         ).called(1);
@@ -1575,7 +1575,7 @@ void main() {
 
         final captured =
             verify(
-                  () => mockNostrClient.sendProfile(
+                  () => mockNostrClient.sendProfileAwaitOk(
                     profileContent: captureAny(named: 'profileContent'),
                   ),
                 ).captured.single
@@ -1597,7 +1597,7 @@ void main() {
 
         final captured =
             verify(
-                  () => mockNostrClient.sendProfile(
+                  () => mockNostrClient.sendProfileAwaitOk(
                     profileContent: captureAny(named: 'profileContent'),
                   ),
                 ).captured.single
@@ -1606,10 +1606,11 @@ void main() {
       });
 
       test(
-        'throws ProfilePublishFailedException when sendProfile fails',
+        'throws ProfilePublishFailedException when no relay confirms '
+        '(rejection or timeout)',
         () async {
           when(
-            () => mockNostrClient.sendProfile(
+            () => mockNostrClient.sendProfileAwaitOk(
               profileContent: any(named: 'profileContent'),
             ),
           ).thenAnswer((_) async => const PublishFailed());
@@ -1626,7 +1627,7 @@ void main() {
         'throws NoRelaysConnectedException when no relays are connected',
         () async {
           when(
-            () => mockNostrClient.sendProfile(
+            () => mockNostrClient.sendProfileAwaitOk(
               profileContent: any(named: 'profileContent'),
             ),
           ).thenAnswer((_) async => const PublishNoRelays());
@@ -1654,7 +1655,7 @@ void main() {
           );
 
           verify(
-            () => mockNostrClient.sendProfile(
+            () => mockNostrClient.sendProfileAwaitOk(
               profileContent: {
                 'display_name': 'New Name',
                 'website': 'https://old.com',
@@ -1680,7 +1681,7 @@ void main() {
           );
 
           verify(
-            () => mockNostrClient.sendProfile(
+            () => mockNostrClient.sendProfileAwaitOk(
               profileContent: {
                 'display_name': 'New Name',
                 'nip05': '_@newuser.divine.video',
@@ -1712,7 +1713,7 @@ void main() {
             );
 
             verify(
-              () => mockNostrClient.sendProfile(
+              () => mockNostrClient.sendProfileAwaitOk(
                 profileContent: {'display_name': 'New Name'},
               ),
             ).called(1);
@@ -1733,7 +1734,7 @@ void main() {
             );
 
             verify(
-              () => mockNostrClient.sendProfile(
+              () => mockNostrClient.sendProfileAwaitOk(
                 profileContent: {
                   'display_name': 'New Name',
                   'nip05': 'alice@example.com',
@@ -1758,7 +1759,7 @@ void main() {
           );
 
           verify(
-            () => mockNostrClient.sendProfile(
+            () => mockNostrClient.sendProfileAwaitOk(
               profileContent: {'display_name': 'New Name', 'about': 'Bio'},
             ),
           ).called(1);
@@ -1795,7 +1796,7 @@ void main() {
           );
 
           verify(
-            () => mockNostrClient.sendProfile(
+            () => mockNostrClient.sendProfileAwaitOk(
               profileContent: {
                 'display_name': 'New Name',
                 'nip05': '_@ike.divine.video',
@@ -1825,7 +1826,7 @@ void main() {
           );
 
           verify(
-            () => mockNostrClient.sendProfile(
+            () => mockNostrClient.sendProfileAwaitOk(
               profileContent: {'display_name': 'New Name'},
             ),
           ).called(1);
@@ -1854,7 +1855,7 @@ void main() {
             );
 
             verify(
-              () => mockNostrClient.sendProfile(
+              () => mockNostrClient.sendProfileAwaitOk(
                 profileContent: {
                   'display_name': 'New Name',
                   'nip05': 'new@example.com',
@@ -1925,7 +1926,7 @@ void main() {
 
             final captured =
                 verify(
-                      () => mockNostrClient.sendProfile(
+                      () => mockNostrClient.sendProfileAwaitOk(
                         profileContent: captureAny(named: 'profileContent'),
                       ),
                     ).captured.single
@@ -1971,7 +1972,7 @@ void main() {
             );
 
             verify(
-              () => mockNostrClient.sendProfile(
+              () => mockNostrClient.sendProfileAwaitOk(
                 profileContent: {
                   'display_name': 'New Name',
                   'lud16': 'alice@strike.me',


### PR DESCRIPTION
## Description

`NostrClient.sendProfile` reported success as soon as the relay pool accepted the WebSocket frame, before any relay confirmed with a NIP-20 `OK true`. A kind 0 profile save could therefore report success even when every relay then returned `OK false` (rate limit, PoW required, auth required): the user saw the edit succeed in-app, but it never persisted.

This routes kind 0 profile publishes through `publishEventAwaitOk` and maps its `PublishOutcome` back onto the existing `PublishResult` variants, so `ProfileRepository` keeps its exhaustive `switch` while opting into the stronger confirmation path:

- at least one relay returns `OK true` -> `PublishSuccess`
- no relay reached even after retry -> `PublishNoRelays` (preserves the dedicated no-relays signal from #3469)
- relays reached but all reject, time out, or signing/send fails -> `PublishFailed` -> `ProfilePublishFailedException` -> `ProfileEditorStatus.failure`

The old fire-and-forget `sendProfile` path is removed so profile publishing has one confirmed code path and no dead public API.

**Design note (why the mapping lives in `sendProfileAwaitOk`, not the repository):** keeping the return type `PublishResult` means the repository keeps its clean sealed-class switch and still receives the sent `Event` for `UserProfile.fromNostrEvent`. The rejection-vs-timeout distinction is a transport detail; both mean "not persisted", so it is collapsed to `PublishFailed` at the client boundary that owns it, and tested there.

**Related Issue:** Closes #3541

## Verification

- `flutter analyze packages/nostr_client packages/profile_repository` - no issues
- `flutter test packages/nostr_client/test/src/nostr_client_test.dart` - 146 pass
- `flutter test packages/profile_repository/test/src/profile_repository_test.dart --plain-name "saveProfileEvent"` - 22 pass
- `flutter test test/blocs/profile_editor/profile_editor_bloc_test.dart` - 93 pass
- pre-push hook - analyzer + changed-file tests pass

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
