### PR TITLE
fix(feed): apply square-only filter to explore and grid feeds

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -139,6 +139,9 @@ VideoEventService videoEventService(Ref ref) {
   service.setContentFilterService(ref.watch(contentFilterServiceProvider));
   service.setModerationLabelService(moderationLabelService);
   service.setDivineHostFilterService(divineHostFilterService);
+  service.setFeedAspectRatioPreference(
+    ref.watch(feedAspectRatioPreferenceServiceProvider),
+  );
 
   // Attach the broken-video tracker (async init) so videos confirmed
   // unavailable (hard 404) stay filtered out of every list surface across

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -269,7 +269,7 @@ final class VideoEventServiceProvider
   }
 }
 
-String _$videoEventServiceHash() => r'9795e17f42ef25c2af8e036b10ca4e043babf179';
+String _$videoEventServiceHash() => r'9f1e17199b9f2499a4d68d14f199d9a2511c3322';
 
 /// Video event publisher for publishing video events to Nostr relays
 

--- a/mobile/lib/services/feed_aspect_ratio_preference_service.dart
+++ b/mobile/lib/services/feed_aspect_ratio_preference_service.dart
@@ -20,6 +20,17 @@ class FeedAspectRatioPreferenceService extends ChangeNotifier {
   final SharedPreferences _prefs;
   late FeedAspectRatioPreference _preference;
 
+  /// Whether each video is non-square, recovered from real dimensions resolved
+  /// at render time (a loaded thumbnail or decoded video frame). The backend
+  /// often omits `dim` metadata, so this is the only signal the square-only
+  /// filter has for those rows until the dimensions arrive (#3882).
+  final Map<String, bool> _renderedNonSquareById = {};
+
+  /// Bumps whenever a freshly rendered video is learned to be non-square while
+  /// the square-only preference is active, so feed lists can re-filter in place
+  /// without re-fetching.
+  final ValueNotifier<int> renderedDimensionsRevision = ValueNotifier<int>(0);
+
   FeedAspectRatioPreference get preference => _preference;
 
   Future<void> setPreference(FeedAspectRatioPreference preference) async {
@@ -29,13 +40,32 @@ class FeedAspectRatioPreferenceService extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Records real dimensions recovered while rendering [videoId] so a row whose
+  /// metadata omits dimensions can still be judged by [shouldHideVideo]. No-op
+  /// when the size is unusable or already known.
+  void recordRenderedDimensions(String videoId, int width, int height) {
+    if (width <= 0 || height <= 0) return;
+    final isNonSquare = width != height;
+    if (_renderedNonSquareById[videoId] == isNonSquare) return;
+    _renderedNonSquareById[videoId] = isNonSquare;
+    if (isNonSquare && _preference == FeedAspectRatioPreference.squareOnly) {
+      renderedDimensionsRevision.value++;
+    }
+  }
+
   bool shouldHideVideo(VideoEvent video) {
     if (_preference != FeedAspectRatioPreference.squareOnly) return false;
     final width = video.width;
     final height = video.height;
-    if (width == null || height == null || width <= 0 || height <= 0) {
-      return false;
+    if (width != null && height != null && width > 0 && height > 0) {
+      return width != height;
     }
-    return width != height;
+    return _renderedNonSquareById[video.id] ?? false;
+  }
+
+  @override
+  void dispose() {
+    renderedDimensionsRevision.dispose();
+    super.dispose();
   }
 }

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -41,6 +41,7 @@ import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/divine_host_filter_service.dart';
 import 'package:openvine/services/effective_content_labels.dart';
 import 'package:openvine/services/event_router.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
 import 'package:openvine/services/moderation_label_service.dart';
 import 'package:openvine/services/performance_monitoring_service.dart';
 import 'package:openvine/services/repost_resolver.dart';
@@ -241,6 +242,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   ContentFilterService? _contentFilterService;
   ModerationLabelService? _moderationLabelService;
   DivineHostFilterService? _divineHostFilterService;
+  FeedAspectRatioPreferenceService? _feedAspectRatioPreference;
   BrokenVideoTracker? _brokenVideoTracker;
   final SubscriptionManager _subscriptionManager;
 
@@ -468,6 +470,17 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     );
   }
 
+  /// Set the feed aspect-ratio ("square only") preference used by
+  /// [filterVideoList] to drop non-square videos from feed lists.
+  void setFeedAspectRatioPreference(FeedAspectRatioPreferenceService service) {
+    _feedAspectRatioPreference = service;
+    Log.debug(
+      'Feed aspect-ratio preference attached to VideoEventService',
+      name: 'VideoEventService',
+      category: LogCategory.video,
+    );
+  }
+
   /// Set the broken-video tracker used to filter videos confirmed unavailable
   /// (hard 404). Marked entries are persisted by the tracker, so this keeps
   /// videos that 404'd in the fullscreen player out of every list surface
@@ -630,11 +643,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   List<VideoEvent> filterVideoList(List<VideoEvent> videos) {
     final service = _contentFilterService;
     final tracker = _brokenVideoTracker;
+    final aspectRatio = _feedAspectRatioPreference;
     final baseVideos = videos
         .where(
           (video) =>
               !shouldHideVideo(video) &&
-              !(tracker?.isVideoBroken(video.id) ?? false),
+              !(tracker?.isVideoBroken(video.id) ?? false) &&
+              !(aspectRatio?.shouldHideVideo(video) ?? false),
         )
         .toList();
     if (service == null) {

--- a/mobile/lib/widgets/composable_video_grid.dart
+++ b/mobile/lib/widgets/composable_video_grid.dart
@@ -14,7 +14,10 @@ import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/mixins/scroll_pagination_mixin.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
+import 'package:openvine/services/broken_video_tracker.dart'
+    show BrokenVideoTracker;
 import 'package:openvine/services/content_deletion_service.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
 import 'package:openvine/utils/delete_failure_localization.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/feed_refresh_control.dart';
@@ -114,6 +117,25 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
   Widget build(BuildContext context) {
     // Watch broken video tracker asynchronously
     final brokenTrackerAsync = ref.watch(brokenVideoTrackerProvider);
+    final aspectRatio = ref.watch(feedAspectRatioPreferenceServiceProvider);
+
+    // Re-filter in place when a thumbnail resolves a video's real dimensions
+    // (the backend omits them), so "square only" can drop now-known portrait
+    // videos without re-fetching the feed (#3882).
+    return ListenableBuilder(
+      listenable: aspectRatio.renderedDimensionsRevision,
+      builder: (context, _) =>
+          _buildWithTracker(context, brokenTrackerAsync, aspectRatio),
+    );
+  }
+
+  Widget _buildWithTracker(
+    BuildContext context,
+    AsyncValue<BrokenVideoTracker> brokenTrackerAsync,
+    FeedAspectRatioPreferenceService aspectRatio,
+  ) {
+    List<VideoEvent> withoutHidden(List<VideoEvent> videos) =>
+        videos.where((video) => !aspectRatio.shouldHideVideo(video)).toList();
 
     return brokenTrackerAsync.when(
       loading: () => const Center(
@@ -121,13 +143,15 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
       ),
       error: (error, stack) {
         // Fallback: show all videos if tracker fails
-        return _buildGrid(context, widget.videos);
+        return _buildGrid(context, withoutHidden(widget.videos));
       },
       data: (tracker) {
-        // Filter out broken videos
-        final filteredVideos = widget.videos
-            .where((video) => !tracker.isVideoBroken(video.id))
-            .toList();
+        // Filter out broken and non-square (square-only) videos
+        final filteredVideos = withoutHidden(
+          widget.videos
+              .where((video) => !tracker.isVideoBroken(video.id))
+              .toList(),
+        );
 
         return _buildGrid(context, filteredVideos);
       },
@@ -168,6 +192,9 @@ class _ComposableVideoGridState extends ConsumerState<ComposableVideoGrid>
         displayedVideos: videosToShow,
         onLongPress: () => _showVideoContextMenu(context, video),
         isInSubscribedList: isInSubscribedList,
+        onRenderedDimensions: (width, height) => ref
+            .read(feedAspectRatioPreferenceServiceProvider)
+            .recordRenderedDimensions(video.id, width, height),
       );
     }
 
@@ -509,6 +536,7 @@ class _VideoItem extends StatelessWidget {
     required this.index,
     required this.displayedVideos,
     this.isInSubscribedList = false,
+    this.onRenderedDimensions,
   });
 
   final VideoEvent video;
@@ -518,6 +546,7 @@ class _VideoItem extends StatelessWidget {
   final int index;
   final List<VideoEvent> displayedVideos;
   final bool isInSubscribedList;
+  final void Function(int width, int height)? onRenderedDimensions;
 
   @override
   Widget build(BuildContext context) {
@@ -532,7 +561,10 @@ class _VideoItem extends StatelessWidget {
           borderRadius: BorderRadius.circular(4),
           child: Stack(
             children: [
-              _VideoThumbnail(video: video),
+              _VideoThumbnail(
+                video: video,
+                onRenderedDimensions: onRenderedDimensions,
+              ),
               Positioned(
                 left: 0,
                 right: 0,
@@ -647,15 +679,19 @@ class _VideoInfoSection extends StatelessWidget {
 }
 
 class _VideoThumbnail extends StatelessWidget {
-  const _VideoThumbnail({required this.video});
+  const _VideoThumbnail({required this.video, this.onRenderedDimensions});
 
   final VideoEvent video;
+  final void Function(int width, int height)? onRenderedDimensions;
 
   @override
   Widget build(BuildContext context) {
     return ColoredBox(
       color: VineTheme.cardBackground,
-      child: VideoThumbnailWidget(video: video),
+      child: VideoThumbnailWidget(
+        video: video,
+        onRenderedDimensions: onRenderedDimensions,
+      ),
     );
   }
 }

--- a/mobile/lib/widgets/video_thumbnail_widget.dart
+++ b/mobile/lib/widgets/video_thumbnail_widget.dart
@@ -21,6 +21,7 @@ class VideoThumbnailWidget extends StatefulWidget {
     this.fit = BoxFit.cover,
     this.showPlayIcon = false,
     this.borderRadius,
+    this.onRenderedDimensions,
   });
   final VideoEvent video;
   final double? width;
@@ -28,6 +29,11 @@ class VideoThumbnailWidget extends StatefulWidget {
   final BoxFit fit;
   final bool showPlayIcon;
   final BorderRadius? borderRadius;
+
+  /// Called with the real pixel dimensions recovered from the loaded thumbnail
+  /// when the video's own metadata omits them. Lets the feed re-apply the
+  /// aspect-ratio filter on backend rows that ship without a `dim` tag (#3882).
+  final void Function(int width, int height)? onRenderedDimensions;
 
   @override
   State<VideoThumbnailWidget> createState() => _VideoThumbnailWidgetState();
@@ -81,6 +87,10 @@ class _VideoThumbnailWidgetState extends State<VideoThumbnailWidget> {
         height <= 0) {
       return;
     }
+
+    // Feed the real thumbnail dimensions back so the feed can re-apply the
+    // aspect-ratio filter on a backend row without `dim` metadata (#3882).
+    widget.onRenderedDimensions?.call(width, height);
 
     final aspectRatio = width / height;
     if (_resolvedAspectRatio == aspectRatio) return;

--- a/mobile/test/services/feed_aspect_ratio_preference_service_test.dart
+++ b/mobile/test/services/feed_aspect_ratio_preference_service_test.dart
@@ -27,6 +27,17 @@ void main() {
       );
     }
 
+    VideoEvent videoWithoutDimensions({required String id}) {
+      return VideoEvent(
+        id: id,
+        pubkey: 'pubkey',
+        createdAt: 1,
+        content: '',
+        timestamp: DateTime.fromMillisecondsSinceEpoch(1000),
+        videoUrl: 'https://example.com/$id.mp4',
+      );
+    }
+
     test('defaults to showing square and portrait videos', () {
       final service = FeedAspectRatioPreferenceService(prefs);
 
@@ -58,6 +69,78 @@ void main() {
       await service.setPreference(FeedAspectRatioPreference.squareOnly);
 
       expect(service.shouldHideVideo(video(dimensions: '')), isFalse);
+    });
+
+    test('square-only hides a video learned non-square from rendered '
+        'dimensions', () async {
+      final service = FeedAspectRatioPreferenceService(prefs);
+      await service.setPreference(FeedAspectRatioPreference.squareOnly);
+      final target = videoWithoutDimensions(id: 'v1');
+
+      expect(service.shouldHideVideo(target), isFalse);
+
+      service.recordRenderedDimensions('v1', 720, 1280);
+
+      expect(service.shouldHideVideo(target), isTrue);
+    });
+
+    test('square-only keeps a video learned square from rendered '
+        'dimensions', () async {
+      final service = FeedAspectRatioPreferenceService(prefs);
+      await service.setPreference(FeedAspectRatioPreference.squareOnly);
+      final target = videoWithoutDimensions(id: 'v1');
+
+      service.recordRenderedDimensions('v1', 640, 640);
+
+      expect(service.shouldHideVideo(target), isFalse);
+    });
+
+    test(
+      'metadata dimensions take precedence over rendered dimensions',
+      () async {
+        final service = FeedAspectRatioPreferenceService(prefs);
+        await service.setPreference(FeedAspectRatioPreference.squareOnly);
+
+        // Rendered says portrait, but the event metadata says square.
+        service.recordRenderedDimensions('event-id', 720, 1280);
+
+        expect(service.shouldHideVideo(video(dimensions: '640x640')), isFalse);
+      },
+    );
+
+    test('rendered dimensions are ignored under square-and-portrait', () {
+      final service = FeedAspectRatioPreferenceService(prefs);
+      final target = videoWithoutDimensions(id: 'v1');
+
+      service.recordRenderedDimensions('v1', 720, 1280);
+
+      expect(service.shouldHideVideo(target), isFalse);
+    });
+
+    test('revision bumps only when a new non-square video is learned '
+        'under square-only', () async {
+      final service = FeedAspectRatioPreferenceService(prefs);
+      await service.setPreference(FeedAspectRatioPreference.squareOnly);
+
+      expect(service.renderedDimensionsRevision.value, 0);
+
+      service.recordRenderedDimensions('square', 640, 640);
+      expect(service.renderedDimensionsRevision.value, 0);
+
+      service.recordRenderedDimensions('portrait', 720, 1280);
+      expect(service.renderedDimensionsRevision.value, 1);
+
+      // Re-recording the same result does not bump again.
+      service.recordRenderedDimensions('portrait', 720, 1280);
+      expect(service.renderedDimensionsRevision.value, 1);
+    });
+
+    test('revision does not bump under square-and-portrait', () {
+      final service = FeedAspectRatioPreferenceService(prefs);
+
+      service.recordRenderedDimensions('portrait', 720, 1280);
+
+      expect(service.renderedDimensionsRevision.value, 0);
     });
   });
 }

--- a/mobile/test/services/video_event_service_aspect_ratio_filter_test.dart
+++ b/mobile/test/services/video_event_service_aspect_ratio_filter_test.dart
@@ -1,0 +1,168 @@
+// ABOUTME: Tests that VideoEventService.filterVideoList drops non-square videos
+// ABOUTME: when the "square only" feed aspect-ratio preference is attached.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/models.dart';
+import 'package:nostr_client/nostr_client.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:nostr_sdk/filter.dart';
+import 'package:openvine/services/feed_aspect_ratio_preference_service.dart';
+import 'package:openvine/services/subscription_manager.dart';
+import 'package:openvine/services/video_event_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockNostrClient extends Mock implements NostrClient {}
+
+class _MockSubscriptionManager extends Mock implements SubscriptionManager {}
+
+VideoEvent _videoEvent({required String id, String? dimensions}) {
+  final event =
+      Event(
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          34236,
+          [
+            ['d', 'd-$id'],
+            ['url', 'https://example.com/$id.mp4'],
+            if (dimensions != null) ['dim', dimensions],
+          ],
+          'test video',
+          createdAt: 1000,
+        )
+        ..id = id
+        ..sig = 'sig-$id';
+  return VideoEvent.fromNostrEvent(event);
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(<Filter>[]);
+  });
+
+  group('VideoEventService aspect-ratio filtering', () {
+    late VideoEventService service;
+    late _MockNostrClient nostrClient;
+    late _MockSubscriptionManager subscriptionManager;
+    late SharedPreferences prefs;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
+      nostrClient = _MockNostrClient();
+      subscriptionManager = _MockSubscriptionManager();
+      when(() => nostrClient.isInitialized).thenReturn(true);
+      when(() => nostrClient.connectedRelayCount).thenReturn(1);
+      when(() => nostrClient.publicKey).thenReturn(
+        'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      );
+      when(
+        () => nostrClient.subscribe(any()),
+      ).thenAnswer((_) => const Stream<Event>.empty());
+
+      service = VideoEventService(
+        nostrClient,
+        subscriptionManager: subscriptionManager,
+      );
+    });
+
+    tearDown(() {
+      service.dispose();
+    });
+
+    test(
+      'filterVideoList drops non-square videos when square-only is attached',
+      () async {
+        final preference = FeedAspectRatioPreferenceService(prefs);
+        await preference.setPreference(FeedAspectRatioPreference.squareOnly);
+        service.setFeedAspectRatioPreference(preference);
+
+        final videos = [
+          _videoEvent(id: 'square', dimensions: '640x640'),
+          _videoEvent(id: 'portrait', dimensions: '720x1280'),
+          _videoEvent(id: 'landscape', dimensions: '1280x720'),
+        ];
+
+        final filtered = service.filterVideoList(videos);
+
+        expect(filtered.map((v) => v.id), equals(['square']));
+      },
+    );
+
+    test(
+      'filterVideoList keeps dimensionless videos even when square-only',
+      () async {
+        final preference = FeedAspectRatioPreferenceService(prefs);
+        await preference.setPreference(FeedAspectRatioPreference.squareOnly);
+        service.setFeedAspectRatioPreference(preference);
+
+        final videos = [
+          _videoEvent(id: 'square', dimensions: '640x640'),
+          _videoEvent(id: 'unknown'),
+        ];
+
+        final filtered = service.filterVideoList(videos);
+
+        expect(filtered.map((v) => v.id), equals(['square', 'unknown']));
+      },
+    );
+
+    test(
+      'filterVideoList keeps all videos when no preference is attached',
+      () {
+        final videos = [
+          _videoEvent(id: 'square', dimensions: '640x640'),
+          _videoEvent(id: 'portrait', dimensions: '720x1280'),
+        ];
+
+        final filtered = service.filterVideoList(videos);
+
+        expect(filtered.map((v) => v.id), equals(['square', 'portrait']));
+      },
+    );
+
+    test(
+      'filterVideoList keeps all videos under square-and-portrait preference',
+      () async {
+        final preference = FeedAspectRatioPreferenceService(prefs);
+        await preference.setPreference(
+          FeedAspectRatioPreference.squareAndPortrait,
+        );
+        service.setFeedAspectRatioPreference(preference);
+
+        final videos = [
+          _videoEvent(id: 'square', dimensions: '640x640'),
+          _videoEvent(id: 'portrait', dimensions: '720x1280'),
+        ];
+
+        final filtered = service.filterVideoList(videos);
+
+        expect(filtered.map((v) => v.id), equals(['square', 'portrait']));
+      },
+    );
+
+    test(
+      'filterVideoList reflects a live preference change after attach',
+      () async {
+        final preference = FeedAspectRatioPreferenceService(prefs);
+        service.setFeedAspectRatioPreference(preference);
+
+        final videos = [
+          _videoEvent(id: 'square', dimensions: '640x640'),
+          _videoEvent(id: 'portrait', dimensions: '720x1280'),
+        ];
+        expect(
+          service.filterVideoList(videos).map((v) => v.id),
+          equals(['square', 'portrait']),
+        );
+
+        await preference.setPreference(FeedAspectRatioPreference.squareOnly);
+        expect(
+          service.filterVideoList(videos).map((v) => v.id),
+          equals(['square']),
+        );
+      },
+    );
+  });
+}

--- a/mobile/test/widgets/composable_video_grid_test.dart
+++ b/mobile/test/widgets/composable_video_grid_test.dart
@@ -28,16 +28,21 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/broken_video_tracker.dart' as broken_tracker;
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:openvine/widgets/composable_video_grid.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   group('ComposableVideoGrid', () {
     late List<VideoEvent> testVideos;
     late broken_tracker.BrokenVideoTracker mockTracker;
+    late SharedPreferences prefs;
 
-    setUp(() {
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      prefs = await SharedPreferences.getInstance();
       final now = DateTime.now();
       final nowTimestamp = now.millisecondsSinceEpoch ~/ 1000;
       testVideos = [
@@ -91,6 +96,7 @@ void main() {
         ProviderScope(
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -123,6 +129,7 @@ void main() {
         ProviderScope(
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -151,6 +158,7 @@ void main() {
         ProviderScope(
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -180,6 +188,7 @@ void main() {
         ProviderScope(
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -221,6 +230,7 @@ void main() {
         ProviderScope(
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -260,6 +270,7 @@ void main() {
         ProviderScope(
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -294,6 +305,7 @@ void main() {
         ProviderScope(
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -326,6 +338,7 @@ void main() {
         ProviderScope(
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -361,6 +374,7 @@ void main() {
           overrides: [
             brokenVideoTrackerProvider.overrideWith((ref) async => mockTracker),
             subscribedListVideoCacheProvider.overrideWithValue(null),
+            sharedPreferencesProvider.overrideWithValue(prefs),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,


### PR DESCRIPTION
## Description

The "Square only" video-shape preference only ever filtered the main home feed, and even there it stayed blind because the backend omits video dimensions. This makes the preference actually filter the explore and grid feeds — including now, before the backend ships dimensions.

**1. Filter grids by the real aspect ratio resolved at render time.** The backend omits `dim` metadata, so the filter has nothing to judge — yet the grid already renders the true aspect ratio, because the loaded thumbnail's real pixel size is known. `VideoThumbnailWidget` now reports that size via an `onRenderedDimensions` callback when metadata is absent; `ComposableVideoGrid` feeds it to `FeedAspectRatioPreferenceService`, which caches the non-square verdict and exposes it through `shouldHideVideo`. The grid listens to a lightweight revision notifier and re-filters in place as thumbnails resolve, so portrait videos drop out of square-only grids without a re-fetch. This makes explore (Popular, For You, New, Classic) and profile grids work *today*.

**2. Wire the filter into the shared feed chokepoint.** The aspect-ratio preference was only attached to `VideosRepository`'s content filter (home feed only). It's now also applied in `VideoEventService.filterVideoList` — the shared list filter every grid/feed surface uses — so once a video has dimensions (rendered, relay-sourced, or backend), every surface hides it consistently. Detail/by-id surfaces use `shouldHideVideo` directly and stay unfiltered, so a directly-opened portrait video still plays.

**Related Issue:** Closes #3882

## Out of Scope / Companion work

- **The clean root-cause fix is the backend returning dimensions** (divine-funnelcake#359). The mobile side already auto-consumes them (`VideoStats.toVideoEvent` maps `dimensions`), so once it ships, every feed — including the main home/fullscreen feed — filters at load with no thumbnail-resolve dependency and no flash. The render-time path in (1) is the no-backend fallback for grids and goes inert when metadata is present.
- The main home/fullscreen feed is intentionally left to the backend fix: the render-time path only covers grids (thumbnails), and the fullscreen player can only resolve dimensions once a video decodes — too late to drop it from the list without a jarring mid-scroll skip. Until #359 ships, the fullscreen feed still shows portrait videos.

## Verification

- `flutter test test/services/feed_aspect_ratio_preference_service_test.dart` — covers rendered-dimension learning, metadata precedence, square-and-portrait no-op, and the revision-notifier semantics.
- `flutter test test/services/video_event_service_aspect_ratio_filter_test.dart` — `filterVideoList` drops portrait/landscape, keeps square/dimensionless, no-op without a preference, live preference change.
- `flutter test test/widgets/composable_video_grid_test.dart` / `test/widgets/video_thumbnail_widget_test.dart` — green (grid scopes updated with `sharedPreferencesProvider`).
- `flutter analyze` on touched files — no issues; generated `video_providers.g.dart` regenerated.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore