### PR TITLE
fix(profile): animate avatar lightbox with a Hero route and proportional radius

### DIFF
--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -352,19 +352,10 @@ class _ProfileAvatarWithColor extends StatelessWidget {
             ),
             child: Hero(
               tag: _avatarHeroTag(userIdHex),
-              flightShuttleBuilder: (_, _, _, _, _) {
-                return LayoutBuilder(
-                  builder: (context, constraints) {
-                    final boxSize = constraints.biggest.shortestSide;
-                    return UserAvatar(
-                      imageUrl: imageUrl,
-                      placeholderSeed: userIdHex,
-                      size: boxSize,
-                      cornerRadius: boxSize * _avatarHeroCornerRatio,
-                    );
-                  },
-                );
-              },
+              flightShuttleBuilder: (_, _, _, _, _) => _AvatarHeroFlightShuttle(
+                imageUrl: imageUrl,
+                userIdHex: userIdHex,
+              ),
               child: avatarWidget,
             ),
           )
@@ -479,6 +470,28 @@ class _ProfileActionLabel extends StatelessWidget {
 // ---------------------------------------------------------------------------
 // Avatar lightbox
 // ---------------------------------------------------------------------------
+
+class _AvatarHeroFlightShuttle extends StatelessWidget {
+  const _AvatarHeroFlightShuttle({required this.userIdHex, this.imageUrl});
+
+  final String? imageUrl;
+  final String userIdHex;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final boxSize = constraints.biggest.shortestSide;
+        return UserAvatar(
+          imageUrl: imageUrl,
+          placeholderSeed: userIdHex,
+          size: boxSize,
+          cornerRadius: boxSize * _avatarHeroCornerRatio,
+        );
+      },
+    );
+  }
+}
 
 void _showAvatarLightbox(
   BuildContext context, {

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -1,5 +1,15 @@
 part of 'profile_header_widget.dart';
 
+const _heroAnimationTag = 'profile_hero_tag';
+
+/// Corner-radius-to-size ratio shared by the 144px header avatar (56px radius)
+/// and the 288px lightbox avatar (112px radius). The Hero flight reproduces
+/// this ratio at every interpolated size so the corner stays proportional.
+/// The default flight shuttle instead paints the destination's fixed 112px
+/// radius onto the shrinking flight box, which clamps to a full circle while
+/// the box is smaller than 224px and makes the avatar briefly round mid-flight.
+const double _avatarHeroCornerRatio = 112 / 288;
+
 class _AboutText extends StatefulWidget {
   const _AboutText({required this.about});
 
@@ -331,7 +341,23 @@ class _ProfileAvatarWithColor extends StatelessWidget {
               imageUrl: imageUrl,
               userIdHex: userIdHex,
             ),
-            child: avatarWidget,
+            child: Hero(
+              tag: _heroAnimationTag,
+              flightShuttleBuilder: (_, _, _, _, _) {
+                return LayoutBuilder(
+                  builder: (context, constraints) {
+                    final boxSize = constraints.biggest.shortestSide;
+                    return UserAvatar(
+                      imageUrl: imageUrl,
+                      placeholderSeed: userIdHex,
+                      size: boxSize,
+                      cornerRadius: boxSize * _avatarHeroCornerRatio,
+                    );
+                  },
+                );
+              },
+              child: avatarWidget,
+            ),
           )
         : avatarWidget;
 
@@ -450,13 +476,20 @@ void _showAvatarLightbox(
   required String userIdHex,
   String? imageUrl,
 }) {
-  showGeneralDialog<void>(
-    context: context,
-    barrierColor: VineTheme.transparent,
-    barrierDismissible: true,
-    barrierLabel: context.l10n.profileAvatarLightboxBarrierLabel,
-    pageBuilder: (context, _, _) =>
-        _AvatarLightbox(imageUrl: imageUrl, userIdHex: userIdHex),
+  // A PageRoute (not a PopupRoute like showGeneralDialog) is required for the
+  // Hero flight between the avatar and the lightbox to animate — the
+  // HeroController only drives transitions between PageRoutes.
+  Navigator.of(context).push<void>(
+    PageRouteBuilder<void>(
+      opaque: false,
+      barrierColor: VineTheme.transparent,
+      barrierDismissible: true,
+      barrierLabel: context.l10n.profileAvatarLightboxBarrierLabel,
+      pageBuilder: (context, _, _) =>
+          _AvatarLightbox(imageUrl: imageUrl, userIdHex: userIdHex),
+      transitionsBuilder: (context, animation, _, child) =>
+          FadeTransition(opacity: animation, child: child),
+    ),
   );
 }
 
@@ -486,11 +519,14 @@ class _AvatarLightbox extends StatelessWidget {
               child: Stack(
                 children: [
                   Center(
-                    child: UserAvatar(
-                      imageUrl: imageUrl,
-                      placeholderSeed: userIdHex,
-                      size: 288,
-                      cornerRadius: 112,
+                    child: Hero(
+                      tag: _heroAnimationTag,
+                      child: UserAvatar(
+                        imageUrl: imageUrl,
+                        placeholderSeed: userIdHex,
+                        size: 288,
+                        cornerRadius: 112,
+                      ),
                     ),
                   ),
                   Positioned(

--- a/mobile/lib/widgets/profile/profile_header_media.dart
+++ b/mobile/lib/widgets/profile/profile_header_media.dart
@@ -1,14 +1,23 @@
 part of 'profile_header_widget.dart';
 
-const _heroAnimationTag = 'profile_hero_tag';
+/// Hero tag for the avatar ↔ lightbox shared-element flight, scoped to the
+/// user. A global tag would let two profile headers with the same tag in one
+/// navigator (e.g. other-profile → other-profile, both on the root navigator)
+/// morph one user's avatar into another's during the page transition.
+String _avatarHeroTag(String userIdHex) => 'profile_avatar_hero_$userIdHex';
 
-/// Corner-radius-to-size ratio shared by the 144px header avatar (56px radius)
-/// and the 288px lightbox avatar (112px radius). The Hero flight reproduces
-/// this ratio at every interpolated size so the corner stays proportional.
-/// The default flight shuttle instead paints the destination's fixed 112px
-/// radius onto the shrinking flight box, which clamps to a full circle while
-/// the box is smaller than 224px and makes the avatar briefly round mid-flight.
-const double _avatarHeroCornerRatio = 112 / 288;
+/// Size and corner radius of the full-screen lightbox avatar.
+const double _lightboxAvatarSize = 288;
+const double _lightboxAvatarCornerRadius = 112;
+
+/// Corner-radius-to-size ratio of the lightbox avatar, also matched by the
+/// 144px header avatar (56px radius). The Hero flight reproduces this ratio at
+/// every interpolated size so the corner stays proportional. The default
+/// flight shuttle instead paints the destination's fixed 112px radius onto the
+/// shrinking flight box, which clamps to a full circle while the box is smaller
+/// than 224px and makes the avatar briefly round mid-flight.
+const double _avatarHeroCornerRatio =
+    _lightboxAvatarCornerRadius / _lightboxAvatarSize;
 
 class _AboutText extends StatefulWidget {
   const _AboutText({required this.about});
@@ -342,7 +351,7 @@ class _ProfileAvatarWithColor extends StatelessWidget {
               userIdHex: userIdHex,
             ),
             child: Hero(
-              tag: _heroAnimationTag,
+              tag: _avatarHeroTag(userIdHex),
               flightShuttleBuilder: (_, _, _, _, _) {
                 return LayoutBuilder(
                   builder: (context, constraints) {
@@ -476,10 +485,15 @@ void _showAvatarLightbox(
   required String userIdHex,
   String? imageUrl,
 }) {
-  // A PageRoute (not a PopupRoute like showGeneralDialog) is required for the
-  // Hero flight between the avatar and the lightbox to animate — the
-  // HeroController only drives transitions between PageRoutes.
-  Navigator.of(context).push<void>(
+  // Push on the root navigator so the full-screen blurred backdrop covers the
+  // bottom navigation bar: on the own-profile tab the nearest navigator is the
+  // StatefulShellRoute branch, confined to the Scaffold body. (The previous
+  // showGeneralDialog used useRootNavigator: true for the same reason.) The
+  // Hero flight still runs across the boundary because Flutter collects heroes
+  // from the current PageRoute of nested navigators, so the header avatar
+  // (branch) and the lightbox (root) are matched. A PageRoute — not a
+  // PopupRoute like showGeneralDialog — is required for the HeroController.
+  Navigator.of(context, rootNavigator: true).push<void>(
     PageRouteBuilder<void>(
       opaque: false,
       barrierColor: VineTheme.transparent,
@@ -520,12 +534,12 @@ class _AvatarLightbox extends StatelessWidget {
                 children: [
                   Center(
                     child: Hero(
-                      tag: _heroAnimationTag,
+                      tag: _avatarHeroTag(userIdHex),
                       child: UserAvatar(
                         imageUrl: imageUrl,
                         placeholderSeed: userIdHex,
-                        size: 288,
-                        cornerRadius: 112,
+                        size: _lightboxAvatarSize,
+                        cornerRadius: _lightboxAvatarCornerRadius,
                       ),
                     ),
                   ),

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -580,6 +580,105 @@ void main() {
     });
 
     testWidgets(
+      'avatar Hero flight scales the shuttle from the header size so the '
+      'corner radius stays proportional instead of clamping to a circle '
+      'mid-flight',
+      (tester) async {
+        final testProfile = createTestProfile(
+          displayName: 'Test User',
+          picture: 'https://example.com/avatar.jpg',
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Open the lightbox — this starts the Hero flight.
+        await tester.tap(find.byType(UserAvatar));
+        await tester.pump(); // push the route, start the flight at t=0
+        await tester.pump(const Duration(milliseconds: 150)); // mid-flight
+
+        // During the flight both the header (144px) and lightbox (288px)
+        // Heroes render size-preserving placeholders, so the only UserAvatar
+        // in the tree is the flight shuttle. The fix drives the shuttle's size
+        // and corner radius from the live flight box, so mid-flight the size
+        // sits strictly between the two ends. The old default shuttle painted
+        // the fixed 288px/112px destination avatar, whose 112px radius clamped
+        // to a full circle while the flight box was below 224px.
+        final shuttles = tester
+            .widgetList<UserAvatar>(find.byType(UserAvatar))
+            .where((a) => a.size > 144 && a.size < 288)
+            .toList();
+        expect(
+          shuttles,
+          hasLength(1),
+          reason: 'mid-flight the only avatar is the scaling Hero shuttle',
+        );
+
+        final shuttle = shuttles.single;
+        expect(shuttle.cornerRadius, isNotNull);
+        // Radius never exceeds half the box → never renders as a full circle.
+        expect(shuttle.cornerRadius! * 2, lessThan(shuttle.size));
+        // Radius tracks the 112/288 ratio shared by both ends of the flight.
+        expect(
+          shuttle.cornerRadius,
+          closeTo(shuttle.size * (112 / 288), 0.001),
+        );
+
+        // Let the flight finish so teardown is clean.
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets('tapping the opened avatar lightbox pops the route', (
+      tester,
+    ) async {
+      final testProfile = createTestProfile(
+        displayName: 'Test User',
+        picture: 'https://example.com/avatar.jpg',
+      );
+
+      await tester.pumpWidget(
+        buildTestWidget(
+          userIdHex: testUserHex,
+          isOwnProfile: true,
+          profile: testProfile,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(UserAvatar));
+      await tester.pumpAndSettle();
+
+      // Lightbox is open: the 288px avatar is present.
+      expect(
+        tester
+            .widgetList<UserAvatar>(find.byType(UserAvatar))
+            .where((a) => a.size == 288),
+        hasLength(1),
+      );
+
+      // Tapping the lightbox dismisses it via Navigator.pop.
+      await tester.tap(
+        find.byWidgetPredicate((w) => w is UserAvatar && w.size == 288),
+      );
+      await tester.pumpAndSettle();
+
+      // Route popped: only the 144px header avatar remains.
+      expect(
+        tester
+            .widgetList<UserAvatar>(find.byType(UserAvatar))
+            .where((a) => a.size == 288),
+        isEmpty,
+      );
+    });
+
+    testWidgets(
       'uses parent-supplied profile for other users while fallback provider is unresolved',
       (tester) async {
         final suppliedProfile = createTestProfile(

--- a/mobile/test/widgets/profile/profile_header_widget_test.dart
+++ b/mobile/test/widgets/profile/profile_header_widget_test.dart
@@ -580,6 +580,46 @@ void main() {
     });
 
     testWidgets(
+      'header avatar default corner radius matches the Hero flight ratio',
+      (tester) async {
+        final testProfile = createTestProfile(
+          displayName: 'Test User',
+          picture: 'https://example.com/avatar.jpg',
+        );
+
+        await tester.pumpWidget(
+          buildTestWidget(
+            userIdHex: testUserHex,
+            isOwnProfile: true,
+            profile: testProfile,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        final headerAvatar = tester.widget<UserAvatar>(
+          find.byType(UserAvatar),
+        );
+        expect(headerAvatar.cornerRadius, isNull);
+
+        final avatarClip = tester.widget<ClipRRect>(
+          find.descendant(
+            of: find.byType(UserAvatar),
+            matching: find.byType(ClipRRect),
+          ),
+        );
+        final borderRadius = avatarClip.borderRadius as BorderRadius;
+
+        // Mirrors the lightbox constants in profile_header_media.dart:
+        // _lightboxAvatarCornerRadius / _lightboxAvatarSize == 112 / 288.
+        // If the header size or UserAvatar's default radius formula changes,
+        // this catches the resulting jump at the start of the Hero flight.
+        final expectedRadius = headerAvatar.size * (112 / 288);
+        expect(borderRadius.topLeft.x, closeTo(expectedRadius, 0.001));
+        expect(borderRadius.topLeft.y, closeTo(expectedRadius, 0.001));
+      },
+    );
+
+    testWidgets(
       'avatar Hero flight scales the shuttle from the header size so the '
       'corner radius stays proportional instead of clamping to a circle '
       'mid-flight',


### PR DESCRIPTION
Closes #5678

## Description

Tapping the profile avatar opens a full-screen lightbox. Two issues with the animation:

1. **No Hero flight.** The lightbox was shown with `showGeneralDialog`, which creates a `PopupRoute`. Flutter's `HeroController` only animates Hero transitions between `PageRoute`s, so the shared-element flight never ran — the avatar just cross-faded with the dialog.
2. **Corner-radius flicker.** Even once a Hero flight is in play, Flutter's default flight shuttle paints the destination's **fixed** 112px radius onto the shrinking flight box. While the box is below 224px, `112 > box/2`, so the `ClipRRect` clamps it to a full circle — the avatar briefly turns round and then "un-clamps" back to a rounded square as the box grows.

Fixes:

- **Hero-capable route + full-screen coverage.** Open the lightbox via `Navigator.push` (not `showGeneralDialog`, a `PopupRoute` the `HeroController` ignores) with a transparent, non-opaque `PageRouteBuilder`. The push targets the **root navigator**: on the own-profile tab the nearest navigator is the `StatefulShellRoute` branch, confined to the `Scaffold` body, so a route there would leave the bottom navigation bar uncovered — matching the previous `showGeneralDialog(useRootNavigator: true)`. The Hero flight still runs across the shell boundary because Flutter collects heroes from the current `PageRoute` of nested navigators. A light `FadeTransition` fades the blurred backdrop only (the avatar flies in the overlay, so it is not faded).
- **Proportional corner radius.** A `flightShuttleBuilder` reads the live flight-box size via `LayoutBuilder` and keeps the corner radius proportional to it (`_avatarHeroCornerRatio`, the `112/288` ratio shared by the 144px header avatar at 56px radius and the 288px lightbox avatar at 112px). The corner stays consistent across the whole flight, both opening and closing (Flutter's `toHero ?? fromHero` shuttle fallback reuses the builder on the way back).
- **Per-user Hero tag.** The tag is scoped to the user (`profile_avatar_hero_<hex>`) so an other-profile → other-profile navigation (both on the root navigator, both rendering the same header) can't morph one user's avatar into another's via a shared global tag.
- **No magic numbers.** `_lightboxAvatarSize` / `_lightboxAvatarCornerRadius` are extracted as named constants, and `_avatarHeroCornerRatio` is derived from them — one source of truth for the lightbox size, the lightbox corner, and the flight-shuttle corner.

## Out of Scope

None.

## Verification

- `flutter analyze lib/widgets/profile/profile_header_media.dart test/widgets/profile/profile_header_widget_test.dart` → No issues found.
- `flutter test test/widgets/profile/profile_header_widget_test.dart` → 54 passed, including two new tests:
  - the Hero flight scales the shuttle to an intermediate size mid-flight and keeps `cornerRadius == size * 112/288` (never `> size/2`, i.e. never a circle) — this fails on both the old `showGeneralDialog` path and the default shuttle, so it guards the actual fix;
  - tapping the opened lightbox pops the route.
- ✅ Verified on device (own-profile tab): the avatar Hero flight runs on both open and close, the corner stays proportional (no mid-flight circle), and the blurred backdrop covers the bottom navigation bar.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

**Related Issue:**
