### PR TITLE
docs: scope code-style line-length rule to Dart only

### DIFF
--- a/.claude/rules/code_style.md
+++ b/.claude/rules/code_style.md
@@ -42,7 +42,19 @@ Before writing a new helper, utility, or formatter, search `mobile/packages/` fo
 ## Code Quality
 
 ### Line Length
-Lines should be 80 characters or fewer.
+Dart source lines should be 80 characters or fewer. This matches the
+`dart format` default and the `very_good_analysis` lint.
+
+The 80-character limit applies **only to Dart code**. Other file types are
+not bound by it and should follow their own formatter and conventions:
+
+- **Markdown** (PR / issue descriptions, docs, these rule files):
+  renderers soft-wrap automatically, so the limit does not apply. Do not
+  hard-wrap PR or issue descriptions mid-sentence — GitHub shows the
+  manual breaks as broken lines in its editor.
+- **Kotlin / Swift / Gradle / YAML / JSON / shell / etc.**: use that
+  language's standard formatter or conventions; do not impose Dart's
+  80-column rule.
 
 ### Functions
 - Keep functions short with a single purpose

--- a/.claude/rules/code_style.md
+++ b/.claude/rules/code_style.md
@@ -42,8 +42,10 @@ Before writing a new helper, utility, or formatter, search `mobile/packages/` fo
 ## Code Quality
 
 ### Line Length
-Dart source lines should be 80 characters or fewer. This matches the
-`dart format` default and the `very_good_analysis` lint.
+Dart source lines should use `dart format`'s default 80-character page
+width. In this repo, the `very_good_analysis`
+`lines_longer_than_80_chars` lint is disabled, so formatting checks enforce
+this rule, not `flutter analyze`.
 
 The 80-character limit applies **only to Dart code**. Other file types are
 not bound by it and should follow their own formatter and conventions:

--- a/docs/FLUTTER.md
+++ b/docs/FLUTTER.md
@@ -74,7 +74,9 @@ mobile platforms.
 * **Error Handling:** Anticipate and handle potential errors. Don't let your
   code fail silently.
 * **Styling:**
-    * Line length: Lines should be 80 characters or fewer.
+    * Line length: Dart source should use `dart format`'s default
+      80-character page width. Other file types should follow their own
+      formatter and conventions.
     * Use `PascalCase` for classes, `camelCase` for
       members/variables/functions/enums, and `snake_case` for files.
 * **Functions:**


### PR DESCRIPTION
Closes #5680

## Description

The line-length guidance in `.claude/rules/code_style.md` and
`docs/FLUTTER.md` was too broad. Taken literally, it could be applied to
non-Dart files too, for example by hard-wrapping Markdown prose in PR
descriptions, issues, and docs even though GitHub and Markdown renderers
already soft-wrap text.

This clarifies that Dart source should follow `dart format`'s default
80-character page width. It also calls out that this repo disables the
`very_good_analysis` `lines_longer_than_80_chars` lint, so formatting checks
enforce the Dart width here, not `flutter analyze`.

The same scoping is now reflected in `docs/FLUTTER.md` so the older duplicate
wording does not remain behind.

Docs-only change. No code, generated files, or tests are affected.

## Verification

- `git diff --check`
- Pre-push hook: no merge conflicts with `main`; no Dart files changed, so
  Dart checks skipped

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality
  to change)
- [ ] Code refactor
- [ ] Build configuration change
- [x] Documentation
- [ ] Chore

**Related Issue:** #5680
