### PR TITLE
fix(camera): bind native diagnostics sink to UI activity lifecycle

### DIFF
--- a/mobile/packages/divine_camera/README.md
+++ b/mobile/packages/divine_camera/README.md
@@ -40,13 +40,18 @@ Ownership is bound to the UI lifecycle as closely as each platform allows:
 - **iOS** — `FlutterPlugin` has no Activity-attachment lifecycle, so the sink is
   re-asserted at every UI-bound entry point: each method call, plus the
   native-only callbacks that fire without one — the volume/Bluetooth and
-  suppression-timer callbacks (`VolumeKeyHandler`) and the audio-session
-  interruption observer plus the sample-buffer delegate's first-frame /
-  writer-start breadcrumbs (`CameraController`). Those native sources only ever
-  exist on the UI engine.
-- **macOS** — no remote-record / volume-key path and no audio-session
-  interruption observer, so there are no UI-only native camera events. Every
-  diagnostic is emitted inside a method call that already re-asserts the sink.
+  suppression-timer callbacks (`VolumeKeyHandler`) and, in `CameraController`,
+  the audio-session interruption observer, the sample-buffer delegate's
+  first-frame / writer-start breadcrumbs, the frame watchdog and init-timeout
+  timers, and the max-duration auto-stop's recording-finalization breadcrumbs
+  (including the #4779 "WITHOUT audio track" warning). Those native sources only
+  ever exist on the UI engine.
+- **macOS** — no native-only reclaim is needed, but not because every diagnostic
+  is method-driven (the init-timeout and max-duration auto-stop timers do emit
+  outside a method call). The reason is that desktop has no background
+  `FlutterEngine` (no FCM isolate) that could register the plugin and steal the
+  sink, so a single engine owns it from `register()` and re-asserting on each
+  method call is enough.
 
 Teardown is always ownership-guarded: a plugin instance only clears the sink
 when it still points at that instance, so one engine cannot silence another's

--- a/mobile/packages/divine_camera/README.md
+++ b/mobile/packages/divine_camera/README.md
@@ -13,3 +13,39 @@ Test locally:
 cd mobile/packages/divine_camera
 flutter test
 ```
+
+Android native unit tests (run in CI, see `.github/workflows/divine_camera.yaml`):
+
+```bash
+cd mobile/android
+gradle :divine_camera:testDebugUnitTest
+```
+
+## Native diagnostics sink ownership
+
+Curated native diagnostics are forwarded to Dart's `UnifiedLogger` through a
+process-wide sink (`DivineCameraLog.sink`). Because the app also runs a
+background Flutter engine (Firebase Messaging) that can register this plugin,
+that singleton must always be owned by the **UI engine**, or native-only events
+(e.g. a volume-key callback, an audio-session interruption) could be routed to
+the wrong isolate or dropped.
+
+Ownership is bound to the UI lifecycle as closely as each platform allows:
+
+- **Android** — ownership is tied to the `ActivityAware` lifecycle. The sink is
+  claimed in `onAttachedToActivity` / `onReattachedToActivityForConfigChanges`
+  and released (ownership-guarded) in `onDetachedFromActivity`. A background
+  engine attaches to the engine but never to an Activity, so it can never own
+  the sink — not even transiently. `onMethodCall` re-claims as defense-in-depth.
+- **iOS** — `FlutterPlugin` has no Activity-attachment lifecycle, so the sink is
+  re-asserted at every UI-bound entry point: each method call, plus the
+  native-only callbacks that fire without one — volume/Bluetooth events
+  (`VolumeKeyHandler`) and the audio-session interruption observer
+  (`CameraController`). Those native sources only ever exist on the UI engine.
+- **macOS** — no remote-record / volume-key path and no audio-session
+  interruption observer, so there are no UI-only native camera events. Every
+  diagnostic is emitted inside a method call that already re-asserts the sink.
+
+Teardown is always ownership-guarded: a plugin instance only clears the sink
+when it still points at that instance, so one engine cannot silence another's
+diagnostics.

--- a/mobile/packages/divine_camera/README.md
+++ b/mobile/packages/divine_camera/README.md
@@ -39,9 +39,11 @@ Ownership is bound to the UI lifecycle as closely as each platform allows:
   the sink — not even transiently. `onMethodCall` re-claims as defense-in-depth.
 - **iOS** — `FlutterPlugin` has no Activity-attachment lifecycle, so the sink is
   re-asserted at every UI-bound entry point: each method call, plus the
-  native-only callbacks that fire without one — volume/Bluetooth events
-  (`VolumeKeyHandler`) and the audio-session interruption observer
-  (`CameraController`). Those native sources only ever exist on the UI engine.
+  native-only callbacks that fire without one — the volume/Bluetooth and
+  suppression-timer callbacks (`VolumeKeyHandler`) and the audio-session
+  interruption observer plus the sample-buffer delegate's first-frame /
+  writer-start breadcrumbs (`CameraController`). Those native sources only ever
+  exist on the UI engine.
 - **macOS** — no remote-record / volume-key path and no audio-session
   interruption observer, so there are no UI-only native camera events. Every
   diagnostic is emitted inside a method call that already re-asserts the sink.

--- a/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
+++ b/mobile/packages/divine_camera/android/src/main/kotlin/co/openvine/divine_camera/DivineCameraPlugin.kt
@@ -35,9 +35,17 @@ class DivineCameraPlugin :
     // Per-instance forwarder that pushes native diagnostics over THIS engine's
     // channel. `DivineCameraLog.sink` is a process-wide singleton, so a second
     // FlutterEngine (e.g. the FCM background isolate that also runs
-    // GeneratedPluginRegistrant) would otherwise overwrite it and route camera
-    // logs to the wrong isolate. We re-assert this in onMethodCall — camera
-    // calls only ever reach the UI engine — so the sink always points back here.
+    // GeneratedPluginRegistrant) could otherwise overwrite it and route camera
+    // logs to the wrong isolate.
+    //
+    // Ownership is bound to the UI activity lifecycle: we claim the sink in
+    // onAttachedToActivity / onReattachedToActivityForConfigChanges and release
+    // it (ownership-guarded) in onDetachedFromActivity. A background engine
+    // attaches to the engine but never to an Activity, so it can never own the
+    // sink — not even in the narrow window before the next UI camera method
+    // call, which is the gap a purely native event (e.g. a volume-key callback)
+    // could otherwise fall into. onMethodCall re-claims as defense-in-depth,
+    // since camera calls only ever reach the UI engine.
     private val logSink: (String, String, String) -> Unit = { level, message, name ->
         mainHandler.post {
             channel.invokeMethod(
@@ -47,12 +55,29 @@ class DivineCameraPlugin :
         }
     }
 
+    // Claim the process-wide diagnostics sink for THIS engine. Only the UI
+    // engine reaches these call sites (activity attachment + camera method
+    // calls), so a background engine can never become the owner.
+    private fun claimLogSink() {
+        DivineCameraLog.sink = logSink
+    }
+
+    // Relinquish the shared sink only if it still points at this instance, so
+    // one engine's teardown can't silence another engine's diagnostics.
+    private fun releaseLogSinkIfOwned() {
+        if (DivineCameraLog.sink === logSink) {
+            DivineCameraLog.sink = null
+        }
+    }
+
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "divine_camera")
         channel.setMethodCallHandler(this)
         context = flutterPluginBinding.applicationContext
         textureRegistry = flutterPluginBinding.textureRegistry
-        DivineCameraLog.sink = logSink
+        // Intentionally NOT claiming DivineCameraLog.sink here. Engine
+        // attachment happens for background engines too; the sink is claimed on
+        // activity attachment so only the UI engine can own it.
     }
 
     // Session-lifecycle operations worth leaving a breadcrumb for. High-
@@ -76,7 +101,9 @@ class DivineCameraPlugin :
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         // Re-claim the shared sink in case another FlutterEngine overwrote it.
-        DivineCameraLog.sink = logSink
+        // Camera calls only ever reach the UI engine, so this keeps the sink
+        // pointing back here as defense-in-depth alongside activity binding.
+        claimLogSink()
         logLifecycleCall(call)
         val oneShotResult = OneShotMethodResult(result)
         when (call.method) {
@@ -490,11 +517,7 @@ class DivineCameraPlugin :
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
-        // Only relinquish the shared sink if it still points at this instance,
-        // so a background-engine teardown can't silence the UI engine's logs.
-        if (DivineCameraLog.sink === logSink) {
-            DivineCameraLog.sink = null
-        }
+        releaseLogSinkIfOwned()
         volumeKeyHandler?.release()
         volumeKeyHandler = null
         cameraController?.release()
@@ -503,18 +526,29 @@ class DivineCameraPlugin :
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activity = binding.activity
+        // The UI engine is the one that attaches to an Activity, so this is
+        // where diagnostics-sink ownership belongs.
+        claimLogSink()
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
         activity = null
+        // Keep the sink: the engine and its method channel survive a config
+        // change, and the same UI engine re-attaches via
+        // onReattachedToActivityForConfigChanges.
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
         activity = binding.activity
+        claimLogSink()
     }
 
     override fun onDetachedFromActivity() {
         activity = null
+        // Activity is gone (not a config change), so the UI engine no longer
+        // owns the diagnostics sink. Ownership-guarded so a background engine's
+        // sink — if one had somehow been installed — isn't cleared here.
+        releaseLogSinkIfOwned()
     }
 }
 

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
@@ -178,8 +178,14 @@ internal class DivineCameraLogSinkOwnershipTest {
     fun attachingToActivity_claimsSink() {
         val plugin = DivineCameraPlugin()
         plugin.onAttachedToEngine(engineBinding())
+        // Guard the actual transition the fix introduces: engine attachment
+        // alone must NOT claim the sink (the old behavior claimed it here, so
+        // this assertion is what makes the test discriminate the fix).
+        assertNull(DivineCameraLog.sink)
+
         plugin.onAttachedToActivity(activityBinding())
 
+        // Only Activity attachment installs the sink.
         assertNotNull(DivineCameraLog.sink)
     }
 

--- a/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
+++ b/mobile/packages/divine_camera/android/src/test/kotlin/co/openvine/divine_camera/DivineCameraPluginTest.kt
@@ -1,11 +1,20 @@
 package co.openvine.divine_camera
 
+import android.app.Activity
+import android.content.Context
 import android.hardware.camera2.CameraMetadata
 import androidx.camera.video.Quality
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.view.TextureRegistry
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -13,7 +22,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /*
@@ -114,6 +125,139 @@ internal class DivineCameraPluginTest {
         override fun notImplemented() {
             notImplementedCount += 1
         }
+    }
+}
+
+/**
+ * Verifies that the process-wide [DivineCameraLog.sink] is owned by the UI
+ * engine and bound to the Activity attachment lifecycle, so a background
+ * FlutterEngine (e.g. the FCM isolate that runs GeneratedPluginRegistrant)
+ * can never own camera diagnostics — not even transiently for a native-only
+ * event such as a volume-key callback. Regression coverage for #5128.
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class DivineCameraLogSinkOwnershipTest {
+    @Before
+    fun resetBefore() {
+        DivineCameraLog.sink = null
+    }
+
+    @After
+    fun resetAfter() {
+        DivineCameraLog.sink = null
+    }
+
+    private fun engineBinding(): FlutterPlugin.FlutterPluginBinding {
+        val binding = Mockito.mock(FlutterPlugin.FlutterPluginBinding::class.java)
+        Mockito.`when`(binding.binaryMessenger)
+            .thenReturn(Mockito.mock(BinaryMessenger::class.java))
+        Mockito.`when`(binding.applicationContext)
+            .thenReturn(Mockito.mock(Context::class.java))
+        Mockito.`when`(binding.textureRegistry)
+            .thenReturn(Mockito.mock(TextureRegistry::class.java))
+        return binding
+    }
+
+    private fun activityBinding(): ActivityPluginBinding {
+        val binding = Mockito.mock(ActivityPluginBinding::class.java)
+        Mockito.`when`(binding.activity).thenReturn(Mockito.mock(Activity::class.java))
+        return binding
+    }
+
+    @Test
+    fun attachingToEngine_doesNotClaimSink() {
+        val plugin = DivineCameraPlugin()
+        plugin.onAttachedToEngine(engineBinding())
+
+        // Engine attachment alone (the only lifecycle a background engine
+        // reaches) must not install the sink.
+        assertNull(DivineCameraLog.sink)
+    }
+
+    @Test
+    fun attachingToActivity_claimsSink() {
+        val plugin = DivineCameraPlugin()
+        plugin.onAttachedToEngine(engineBinding())
+        plugin.onAttachedToActivity(activityBinding())
+
+        assertNotNull(DivineCameraLog.sink)
+    }
+
+    @Test
+    fun backgroundEngineAttach_cannotStealUiOwnership() {
+        val ui = DivineCameraPlugin()
+        ui.onAttachedToEngine(engineBinding())
+        ui.onAttachedToActivity(activityBinding())
+        val uiSink = DivineCameraLog.sink
+        assertNotNull(uiSink)
+
+        // A second engine that only ever attaches to the engine (never an
+        // Activity) must not overwrite the UI engine's sink.
+        val background = DivineCameraPlugin()
+        background.onAttachedToEngine(engineBinding())
+
+        assertSame(uiSink, DivineCameraLog.sink)
+    }
+
+    @Test
+    fun detachFromActivity_relinquishesOwnedSink() {
+        val ui = DivineCameraPlugin()
+        ui.onAttachedToEngine(engineBinding())
+        ui.onAttachedToActivity(activityBinding())
+        assertNotNull(DivineCameraLog.sink)
+
+        ui.onDetachedFromActivity()
+
+        assertNull(DivineCameraLog.sink)
+    }
+
+    @Test
+    fun detachFromActivity_doesNotClearAnotherOwnersSink() {
+        val ui = DivineCameraPlugin()
+        ui.onAttachedToEngine(engineBinding())
+        ui.onAttachedToActivity(activityBinding())
+        val uiSink = DivineCameraLog.sink
+        assertNotNull(uiSink)
+
+        // A different instance that never owned the sink must not be able to
+        // clear it on teardown.
+        val other = DivineCameraPlugin()
+        other.onAttachedToEngine(engineBinding())
+        other.onDetachedFromActivity()
+
+        assertSame(uiSink, DivineCameraLog.sink)
+    }
+
+    @Test
+    fun configChangeDetach_keepsSink() {
+        val ui = DivineCameraPlugin()
+        ui.onAttachedToEngine(engineBinding())
+        ui.onAttachedToActivity(activityBinding())
+        val uiSink = DivineCameraLog.sink
+        assertNotNull(uiSink)
+
+        ui.onDetachedFromActivityForConfigChanges()
+
+        // The engine and its channel survive a config change, so the sink
+        // stays installed across it.
+        assertSame(uiSink, DivineCameraLog.sink)
+    }
+
+    @Test
+    fun reattachAfterConfigChange_reclaimsSink() {
+        val ui = DivineCameraPlugin()
+        ui.onAttachedToEngine(engineBinding())
+        ui.onAttachedToActivity(activityBinding())
+        val uiSink = DivineCameraLog.sink
+        assertNotNull(uiSink)
+
+        ui.onDetachedFromActivityForConfigChanges()
+        // Simulate the sink being lost while detached, then prove reattach
+        // restores UI ownership.
+        DivineCameraLog.sink = null
+        ui.onReattachedToActivityForConfigChanges(activityBinding())
+
+        assertSame(uiSink, DivineCameraLog.sink)
     }
 }
 

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -70,6 +70,14 @@ class CameraController: NSObject {
     }
     
     private var textureRegistry: FlutterTextureRegistry
+
+    /// Re-asserts the owning (UI) engine's diagnostics sink before emitting
+    /// native-only diagnostics (the audio-session interruption observer fires
+    /// without a method call). iOS has no Activity-attachment lifecycle to bind
+    /// sink ownership to, so this keeps a background engine that registered the
+    /// plugin from stealing these UI-only events. See #5128.
+    private let reclaimLogSink: (() -> Void)?
+
     private var textureId: Int64 = -1
     private var pixelBufferRef: CVPixelBuffer?
     private var latestSampleBuffer: CMSampleBuffer?
@@ -190,8 +198,12 @@ class CameraController: NSObject {
     private let sessionQueue = DispatchQueue(label: "com.divine_camera.session")
     private let videoOutputQueue = DispatchQueue(label: "com.divine_camera.videoOutput")
     
-    init(textureRegistry: FlutterTextureRegistry) {
+    init(
+        textureRegistry: FlutterTextureRegistry,
+        reclaimLogSink: (() -> Void)? = nil
+    ) {
         self.textureRegistry = textureRegistry
+        self.reclaimLogSink = reclaimLogSink
         super.init()
         checkCameraAvailability()
         registerAudioSessionInterruptionObserver()
@@ -369,6 +381,10 @@ class CameraController: NSObject {
             let typeValue = info[AVAudioSessionInterruptionTypeKey] as? UInt,
             let type = AVAudioSession.InterruptionType(rawValue: typeValue)
         else { return }
+
+        // Native-only event: reclaim the UI engine's diagnostics sink before
+        // any logging below.
+        reclaimLogSink?()
 
         switch type {
         case .began:

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -72,10 +72,11 @@ class CameraController: NSObject {
     private var textureRegistry: FlutterTextureRegistry
 
     /// Re-asserts the owning (UI) engine's diagnostics sink before emitting
-    /// native-only diagnostics (the audio-session interruption observer fires
-    /// without a method call). iOS has no Activity-attachment lifecycle to bind
-    /// sink ownership to, so this keeps a background engine that registered the
-    /// plugin from stealing these UI-only events. See #5128.
+    /// native-only diagnostics that fire without a method call — the
+    /// audio-session interruption observer and the sample-buffer delegate's
+    /// first-frame / writer-start breadcrumbs. iOS has no Activity-attachment
+    /// lifecycle to bind sink ownership to, so this keeps a background engine
+    /// that registered the plugin from stealing these UI-only events. See #5128.
     private let reclaimLogSink: (() -> Void)?
 
     private var textureId: Int64 = -1
@@ -2586,6 +2587,9 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
                 if !isWriterSessionStarted && writer.status == .writing {
                     writer.startSession(atSourceTime: timestamp)
                     isWriterSessionStarted = true
+                    // Native-only event (sample-buffer delegate, no method
+                    // call): reclaim the UI engine's diagnostics sink first.
+                    reclaimLogSink?()
                     DivineCameraLog.shared.debug("DivineCamera: Writer session started at \(timestamp.seconds)")
                 }
 
@@ -2640,6 +2644,9 @@ extension CameraController: AVCaptureVideoDataOutputSampleBufferDelegate {
         pixelBufferLock.unlock()
 
         if isFirstFrame {
+            // Native-only event (sample-buffer delegate, no method call):
+            // reclaim the UI engine's diagnostics sink first.
+            reclaimLogSink?()
             DivineCameraLog.shared.debug("DivineCamera: First frame received! Pixel buffer dimensions: \(CVPixelBufferGetWidth(pixelBuffer))x\(CVPixelBufferGetHeight(pixelBuffer))")
 
             // Complete initialization now that we know frames are flowing

--- a/mobile/packages/divine_camera/ios/Classes/CameraController.swift
+++ b/mobile/packages/divine_camera/ios/Classes/CameraController.swift
@@ -73,10 +73,12 @@ class CameraController: NSObject {
 
     /// Re-asserts the owning (UI) engine's diagnostics sink before emitting
     /// native-only diagnostics that fire without a method call — the
-    /// audio-session interruption observer and the sample-buffer delegate's
-    /// first-frame / writer-start breadcrumbs. iOS has no Activity-attachment
-    /// lifecycle to bind sink ownership to, so this keeps a background engine
-    /// that registered the plugin from stealing these UI-only events. See #5128.
+    /// audio-session interruption observer, the sample-buffer delegate's
+    /// first-frame / writer-start breadcrumbs, the frame watchdog and
+    /// init-timeout timers, and the max-duration auto-stop's recording-
+    /// finalization breadcrumbs. iOS has no Activity-attachment lifecycle to
+    /// bind sink ownership to, so this keeps a background engine that
+    /// registered the plugin from stealing these UI-only events. See #5128.
     private let reclaimLogSink: (() -> Void)?
 
     private var textureId: Int64 = -1
@@ -863,7 +865,11 @@ class CameraController: NSObject {
         // until it's restarted. This watchdog detects this condition and restarts the session.
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
             guard let self = self else { return }
-            
+
+            // Native-only event (watchdog timer, no method call): reclaim the
+            // UI engine's diagnostics sink before the watchdog breadcrumbs.
+            self.reclaimLogSink?()
+
             self.pixelBufferLock.lock()
             let hasReceivedFrames = self.pixelBufferRef != nil
             self.pixelBufferLock.unlock()
@@ -909,6 +915,10 @@ class CameraController: NSObject {
         // Set a timeout in case frames don't arrive (fallback to complete anyway)
         DispatchQueue.main.async { [weak self] in
             self?.initializationTimeoutTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: false) { [weak self] _ in
+                // Native-only entry (init-timeout timer, no method call): the
+                // first-frame caller reclaims at captureOutput, but the
+                // once-only guard means that never runs on the timeout path.
+                self?.reclaimLogSink?()
                 self?.completeInitializationIfNeeded(timedOut: true)
             }
         }
@@ -2219,7 +2229,14 @@ class CameraController: NSObject {
     /// Automatically stops recording when max duration is reached.
     private func autoStopRecording() {
         guard isRecording else { return }
-        
+
+        // Native-only entry (max-duration timer, no method call): reclaim the
+        // UI engine's diagnostics sink so the downstream recording-finalization
+        // breadcrumbs — including the #4779 "WITHOUT audio track" warning — are
+        // forwarded to the UI isolate. The sink is a process-wide singleton, so
+        // reclaiming here holds through the async finishWriting completion.
+        reclaimLogSink?()
+
         maxDurationTimer?.invalidate()
         maxDurationTimer = nil
         

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraLog.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraLog.swift
@@ -20,9 +20,29 @@ final class DivineCameraLog {
 
     private init() {}
 
+    private let sinkLock = NSLock()
+    private var _sink: ((String, String, String) -> Void)?
+
     /// Forwards `(level, message, name)` to Dart. `level` is one of
     /// `debug`, `info`, `warning`, `error`. Set by the plugin; `nil` until then.
-    var sink: ((String, String, String) -> Void)?
+    ///
+    /// Lock-guarded: the UI engine reclaims ownership from non-main queues
+    /// (e.g. `CameraController.captureOutput` on `videoOutputQueue`) while
+    /// `handle`/`emit` touch it on other queues. The lock serializes the
+    /// non-atomic closure store/load so a write is never torn against a read.
+    /// See #5128.
+    var sink: ((String, String, String) -> Void)? {
+        get {
+            sinkLock.lock()
+            defer { sinkLock.unlock() }
+            return _sink
+        }
+        set {
+            sinkLock.lock()
+            defer { sinkLock.unlock() }
+            _sink = newValue
+        }
+    }
 
     func debug(_ message: String, name: String = "DivineCamera") {
         emit("debug", message, name)
@@ -43,6 +63,9 @@ final class DivineCameraLog {
     private func emit(_ level: String, _ message: String, _ name: String) {
         // Keep the console fallback so on-device debugging is unchanged.
         print("[\(name)] \(message)")
+        // Snapshot under the lock, then invoke outside it so the forwarding
+        // closure can log without re-entering the lock.
+        let sink = self.sink
         sink?(level, message, name)
     }
 }

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -142,8 +142,9 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     /// to bind sink ownership to, so we cannot scope ownership to the UI engine
     /// at registration time. Instead the sink is re-asserted at every UI-bound
     /// entry point: each method call (`handle`), and — for events that fire
-    /// without a method call — the native volume/Bluetooth callbacks
-    /// (`VolumeKeyHandler`) and the audio-session interruption observer
+    /// without a method call — the native volume/Bluetooth and suppression-timer
+    /// callbacks (`VolumeKeyHandler`) and the audio-session interruption observer
+    /// plus the sample-buffer delegate's first-frame / writer-start breadcrumbs
     /// (`CameraController`). Those native sources only ever exist on the UI
     /// engine, so a background engine can't own these UI-only events. See #5128.
     private lazy var logSink: (String, String, String) -> Void = {

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -136,8 +136,16 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     /// Per-instance forwarder pushing native diagnostics over THIS engine's
     /// channel. `DivineCameraLog.shared.sink` is a process-wide singleton, so a
     /// second FlutterEngine that registers the plugin would otherwise overwrite
-    /// it and route camera logs to the wrong isolate. We re-assert it in
-    /// `handle` — camera calls only ever reach the UI engine.
+    /// it and route camera logs to the wrong isolate.
+    ///
+    /// Unlike Android, iOS `FlutterPlugin` has no Activity-attachment lifecycle
+    /// to bind sink ownership to, so we cannot scope ownership to the UI engine
+    /// at registration time. Instead the sink is re-asserted at every UI-bound
+    /// entry point: each method call (`handle`), and — for events that fire
+    /// without a method call — the native volume/Bluetooth callbacks
+    /// (`VolumeKeyHandler`) and the audio-session interruption observer
+    /// (`CameraController`). Those native sources only ever exist on the UI
+    /// engine, so a background engine can't own these UI-only events. See #5128.
     private lazy var logSink: (String, String, String) -> Void = {
         [weak self] level, message, name in
         DispatchQueue.main.async {
@@ -268,8 +276,11 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
         }
         
         cameraController?.release()
-        cameraController = CameraController(textureRegistry: registry)
-        
+        cameraController = CameraController(
+            textureRegistry: registry,
+            reclaimLogSink: { [weak self] in self?.installLogSink() }
+        )
+
         cameraController?.initialize(lens: lens, videoQuality: videoQuality, enableScreenFlash: enableScreenFlash, mirrorFrontCameraOutput: mirrorFrontCameraOutput, enableAutoLensSwitch: enableAutoLensSwitch) { [weak self] state, error in
             DispatchQueue.main.async {
                 if let error = error {
@@ -301,7 +312,9 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     private func setRemoteRecordControlEnabled(enabled: Bool, result: @escaping FlutterResult) {
         if enabled {
             if volumeKeyHandler == nil {
-                volumeKeyHandler = VolumeKeyHandler { [weak self] triggerType in
+                volumeKeyHandler = VolumeKeyHandler(
+                    reclaimLogSink: { [weak self] in self?.installLogSink() }
+                ) { [weak self] triggerType in
                     // Send trigger event to Flutter on main thread
                     DispatchQueue.main.async {
                         self?.methodChannel?.invokeMethod("onRemoteRecordTrigger", arguments: triggerType)

--- a/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/ios/Classes/DivineCameraPlugin.swift
@@ -143,10 +143,13 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     /// at registration time. Instead the sink is re-asserted at every UI-bound
     /// entry point: each method call (`handle`), and — for events that fire
     /// without a method call — the native volume/Bluetooth and suppression-timer
-    /// callbacks (`VolumeKeyHandler`) and the audio-session interruption observer
-    /// plus the sample-buffer delegate's first-frame / writer-start breadcrumbs
-    /// (`CameraController`). Those native sources only ever exist on the UI
-    /// engine, so a background engine can't own these UI-only events. See #5128.
+    /// callbacks (`VolumeKeyHandler`) and, in `CameraController`, the audio-
+    /// session interruption observer, the sample-buffer delegate's first-frame /
+    /// writer-start breadcrumbs, the frame watchdog and init-timeout timers, and
+    /// the max-duration auto-stop's recording-finalization breadcrumbs (the
+    /// #4779 "WITHOUT audio track" warning). Those native sources only ever
+    /// exist on the UI engine, so a background engine can't own these UI-only
+    /// events. See #5128.
     private lazy var logSink: (String, String, String) -> Void = {
         [weak self] level, message, name in
         DispatchQueue.main.async {

--- a/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
+++ b/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
@@ -76,6 +76,9 @@ class VolumeKeyHandler: NSObject {
         isSuppressed = true
         DispatchQueue.main.asyncAfter(deadline: .now() + activationCooldownSeconds) { [weak self] in
             self?.isSuppressed = false
+            // Native-only event (timer callback, no method call): reclaim the
+            // UI engine's diagnostics sink first.
+            self?.reclaimLogSink?()
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Initial suppression ended")
         }
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Enabled (suppressed for \(activationCooldownSeconds)s)")
@@ -119,6 +122,9 @@ class VolumeKeyHandler: NSObject {
         DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Suppressed for \(duration)s")
         DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak self] in
             self?.isSuppressed = false
+            // Native-only event (timer callback, no method call): reclaim the
+            // UI engine's diagnostics sink first.
+            self?.reclaimLogSink?()
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Suppression ended")
         }
     }

--- a/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
+++ b/mobile/packages/divine_camera/ios/Classes/VolumeKeyHandler.swift
@@ -34,8 +34,16 @@ class VolumeKeyHandler: NSObject {
     
     // Temporary suppression during camera switch / audio route changes
     private var isSuppressed = false
-    
-    init(onTrigger: @escaping (String) -> Void) {
+
+    // Re-asserts the owning (UI) engine's diagnostics sink before emitting any
+    // native-only diagnostic. iOS has no Activity-attachment lifecycle to bind
+    // sink ownership to (unlike Android), so volume/Bluetooth callbacks — which
+    // fire without a method call — reclaim the sink here so a background engine
+    // that registered the plugin can't steal these UI-only events. See #5128.
+    private let reclaimLogSink: (() -> Void)?
+
+    init(reclaimLogSink: (() -> Void)? = nil, onTrigger: @escaping (String) -> Void) {
+        self.reclaimLogSink = reclaimLogSink
         self.onTrigger = onTrigger
         super.init()
     }
@@ -128,20 +136,23 @@ class VolumeKeyHandler: NSObject {
         
         // Play/Pause toggle (most common on Bluetooth headphones)
         commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
+            self?.reclaimLogSink?()
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth toggle play/pause")
             self?.handleBluetoothTrigger()
             return .success
         }
-        
+
         // Play command
         commandCenter.playCommand.addTarget { [weak self] _ in
+            self?.reclaimLogSink?()
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth play")
             self?.handleBluetoothTrigger()
             return .success
         }
-        
+
         // Pause command
         commandCenter.pauseCommand.addTarget { [weak self] _ in
+            self?.reclaimLogSink?()
             DivineCameraLog.shared.debug("DivineCameraVolumeKeyHandler: Bluetooth pause")
             self?.handleBluetoothTrigger()
             return .success
@@ -283,7 +294,11 @@ class VolumeKeyHandler: NSObject {
               let oldValue = change?[.oldKey] as? Float else {
             return
         }
-        
+
+        // Native-only event: reclaim the UI engine's diagnostics sink before
+        // any logging below.
+        reclaimLogSink?()
+
         // Only trigger if volume keys are enabled, not suppressed,
         // and this is an external change.
         // The isSuppressed check prevents audio route changes during camera

--- a/mobile/packages/divine_camera/macos/Classes/DivineCameraLog.swift
+++ b/mobile/packages/divine_camera/macos/Classes/DivineCameraLog.swift
@@ -19,9 +19,28 @@ final class DivineCameraLog {
 
     private init() {}
 
+    private let sinkLock = NSLock()
+    private var _sink: ((String, String, String) -> Void)?
+
     /// Forwards `(level, message, name)` to Dart. `level` is one of
     /// `debug`, `info`, `warning`, `error`. Set by the plugin; `nil` until then.
-    var sink: ((String, String, String) -> Void)?
+    ///
+    /// Lock-guarded: `handle`/`register` store the sink on main while `emit`
+    /// reads it from native-only timer callbacks on other queues. The lock
+    /// serializes the non-atomic closure store/load so a write is never torn
+    /// against a read. See #5128.
+    var sink: ((String, String, String) -> Void)? {
+        get {
+            sinkLock.lock()
+            defer { sinkLock.unlock() }
+            return _sink
+        }
+        set {
+            sinkLock.lock()
+            defer { sinkLock.unlock() }
+            _sink = newValue
+        }
+    }
 
     func debug(_ message: String, name: String = "DivineCamera") {
         emit("debug", message, name)
@@ -42,6 +61,9 @@ final class DivineCameraLog {
     private func emit(_ level: String, _ message: String, _ name: String) {
         // Keep the console fallback so on-device debugging is unchanged.
         print("[\(name)] \(message)")
+        // Snapshot under the lock, then invoke outside it so the forwarding
+        // closure can log without re-entering the lock.
+        let sink = self.sink
         sink?(level, message, name)
     }
 }

--- a/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
@@ -65,17 +65,19 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     }
 
     /// Per-instance forwarder pushing native diagnostics over THIS engine's
-    /// channel. `DivineCameraLog.shared.sink` is a process-wide singleton, so a
-    /// second FlutterEngine that registers the plugin would otherwise overwrite
-    /// it and route camera logs to the wrong isolate. We re-assert it in
-    /// `handle` — camera calls only ever reach the UI engine.
+    /// channel. `DivineCameraLog.shared.sink` is a process-wide singleton. We
+    /// re-assert it in `handle` — camera calls only ever reach the UI engine.
     ///
-    /// macOS has no UI-only native camera events to reclaim around: it exposes
-    /// no remote-record / volume-key path and registers no audio-session
-    /// interruption observer, so every diagnostic is emitted inside a method
-    /// call that already re-asserts the sink. (Android binds ownership to the
-    /// Activity lifecycle; iOS additionally reclaims in its native volume and
-    /// interruption callbacks.) See #5128.
+    /// macOS does emit some diagnostics from native-only timer callbacks (the
+    /// init-timeout and max-duration auto-stop timers fire without a method
+    /// call), so it is not structurally exempt the way "every diagnostic is
+    /// method-driven" would imply. The reason no native-only reclaim is needed
+    /// here is that desktop has no background `FlutterEngine` (no FCM isolate)
+    /// that could register the plugin and steal the sink — effectively one
+    /// engine owns it from `register()`, so re-asserting on each method call is
+    /// sufficient. (Android binds ownership to the Activity lifecycle; iOS
+    /// reclaims in its native callbacks because the background-engine steal
+    /// scenario does apply on mobile.) See #5128.
     private lazy var logSink: (String, String, String) -> Void = {
         [weak self] level, message, name in
         DispatchQueue.main.async {

--- a/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
+++ b/mobile/packages/divine_camera/macos/Classes/DivineCameraPlugin.swift
@@ -69,6 +69,13 @@ public class DivineCameraPlugin: NSObject, FlutterPlugin {
     /// second FlutterEngine that registers the plugin would otherwise overwrite
     /// it and route camera logs to the wrong isolate. We re-assert it in
     /// `handle` — camera calls only ever reach the UI engine.
+    ///
+    /// macOS has no UI-only native camera events to reclaim around: it exposes
+    /// no remote-record / volume-key path and registers no audio-session
+    /// interruption observer, so every diagnostic is emitted inside a method
+    /// call that already re-asserts the sink. (Android binds ownership to the
+    /// Activity lifecycle; iOS additionally reclaims in its native volume and
+    /// interruption callbacks.) See #5128.
     private lazy var logSink: (String, String, String) -> Void = {
         [weak self] level, message, name in
         DispatchQueue.main.async {


### PR DESCRIPTION
## Description

`DivineCameraLog.sink` is a process-global singleton, so a background `FlutterEngine` (the FCM isolate that runs `GeneratedPluginRegistrant`) can overwrite it. PR #5110 re-asserted the UI engine's sink at the top of each camera method call, but a purely **native** event — for example a volume-key callback — could still fire in the narrow window after a background register and before the next UI method call, routing that diagnostic to the wrong isolate or dropping it.

This binds sink ownership to the UI lifecycle as closely as each platform allows, so background engine registration can no longer steal UI-only native camera diagnostics.

**Android (the actual fix):** ownership moves from engine attachment to the `ActivityAware` lifecycle. The sink is claimed in `onAttachedToActivity` / `onReattachedToActivityForConfigChanges` and released (ownership-guarded) in `onDetachedFromActivity`. A background engine attaches to the engine but *never* to an Activity, so it can never own the sink — this closes the window entirely rather than just narrowing it. `onMethodCall` still re-claims as defense-in-depth, and teardown stays ownership-guarded so one engine cannot clear another's sink.

**iOS:** `FlutterPlugin` has no Activity-attachment lifecycle to bind to, so the UI sink is re-asserted at the native-only entry points that fire *without* a method call — the volume/Bluetooth and suppression-timer callbacks in `VolumeKeyHandler`, and the audio-session interruption observer plus the sample-buffer delegate's first-frame / writer-start breadcrumbs in `CameraController`. Those native sources only ever exist on the UI engine (they require an active camera/remote-control session), so a background engine cannot own these events. The reclaim closure is threaded in via constructor injection.

**macOS:** there is no remote-record / volume-key path and no audio-session interruption observer, so there are no UI-only native camera events — every diagnostic is emitted inside a method call that already re-asserts the sink. Documented as method-reclaim only.

A README section documents the per-platform ownership model, and inline comments explain why engine attachment intentionally does *not* claim the sink on Android.

## Out of Scope

- Changing the diagnostics mechanism itself (the `onNativeLog` bridge from PR #5110 is unchanged).
- iOS/macOS cannot bind to an Activity lifecycle the way Android does; the per-native-event reclaim is the closest equivalent the platform supports.

## Verification

- `gradle :divine_camera:testDebugUnitTest` (the same target CI runs) — full Kotlin suite passes, including 7 new `DivineCameraLogSinkOwnershipTest` cases covering claim-on-activity, no-claim-on-engine, background-cannot-steal, guarded teardown, config-change persistence, and reattach reclaim.
- `flutter analyze lib test` from `mobile/packages/divine_camera` — no issues.
- `flutter test` from `mobile/packages/divine_camera` — 347 tests pass.
- **Manual smoke test on physical iOS and Android devices** — camera preview, video recording, volume-key / Bluetooth remote-record triggers, camera flip mid-recording, and audio interruption all behave correctly; native camera diagnostics still reach the unified log. This is the verification that actually exercises the iOS Swift paths: CI does not build or test the iOS plugin code (no iOS build/test step in `divine_camera.yaml`), so the device run is what backs the iOS reclaim changes.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation

Closes #5128
