### PR TITLE
feat(profile): crop avatars and banners before upload

### DIFF
--- a/mobile/assets/icon/flip_horizontal.svg
+++ b/mobile/assets/icon/flip_horizontal.svg
@@ -1,0 +1,8 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="15" y="4" width="2" height="4" rx="1" fill="white"/>
+<rect x="15" y="11" width="2" height="4" rx="1" fill="white"/>
+<rect x="15" y="18" width="2" height="4" rx="1" fill="white"/>
+<rect x="15" y="25" width="2" height="3" rx="1" fill="white"/>
+<path d="M5 6L5 26L12 16L5 6Z" fill="white"/>
+<path d="M27 6L27 26L20 16L27 6Z" fill="white"/>
+</svg>

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -5,7 +5,6 @@
 // ABOUTME: avatar upload for the current edit session; Save remains the
 // ABOUTME: only publish point.
 
-import 'dart:io' show File;
 import 'dart:typed_data';
 import 'dart:ui' show Color;
 
@@ -123,20 +122,12 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
 
     BlossomUploadResult result;
     try {
-      if (event.bytes != null) {
-        result = await _blossomUploadService.uploadImageBytes(
-          bytes: event.bytes!,
-          filename: event.filename ?? 'avatar.jpg',
-          nostrPubkey: event.pubkey,
-          mimeType: event.mimeType,
-        );
-      } else {
-        result = await _blossomUploadService.uploadImage(
-          imageFile: event.file!,
-          nostrPubkey: event.pubkey,
-          mimeType: event.mimeType,
-        );
-      }
+      result = await _blossomUploadService.uploadImageBytes(
+        bytes: event.bytes,
+        filename: event.filename ?? 'avatar.jpg',
+        nostrPubkey: event.pubkey,
+        mimeType: event.mimeType,
+      );
     } on Object catch (error, stackTrace) {
       Log.error(
         'Avatar upload threw: $error',
@@ -296,20 +287,12 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
 
     BlossomUploadResult result;
     try {
-      if (event.bytes != null) {
-        result = await _blossomUploadService.uploadImageBytes(
-          bytes: event.bytes!,
-          filename: event.filename ?? 'banner.jpg',
-          nostrPubkey: event.pubkey,
-          mimeType: event.mimeType,
-        );
-      } else {
-        result = await _blossomUploadService.uploadImage(
-          imageFile: event.file!,
-          nostrPubkey: event.pubkey,
-          mimeType: event.mimeType,
-        );
-      }
+      result = await _blossomUploadService.uploadImageBytes(
+        bytes: event.bytes,
+        filename: event.filename ?? 'banner.jpg',
+        nostrPubkey: event.pubkey,
+        mimeType: event.mimeType,
+      );
     } on Object catch (error, stackTrace) {
       Log.error(
         'Banner upload threw: $error',

--- a/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_bloc.dart
@@ -124,7 +124,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     try {
       result = await _blossomUploadService.uploadImageBytes(
         bytes: event.bytes,
-        filename: event.filename ?? 'avatar.jpg',
+        filename: event.filename,
         nostrPubkey: event.pubkey,
         mimeType: event.mimeType,
       );
@@ -289,7 +289,7 @@ class ProfileEditorBloc extends Bloc<ProfileEditorEvent, ProfileEditorState> {
     try {
       result = await _blossomUploadService.uploadImageBytes(
         bytes: event.bytes,
-        filename: event.filename ?? 'banner.jpg',
+        filename: event.filename,
         nostrPubkey: event.pubkey,
         mimeType: event.mimeType,
       );

--- a/mobile/lib/blocs/profile_editor/profile_editor_event.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_event.dart
@@ -125,34 +125,28 @@ final class InitialPersistedPictureSet extends ProfileEditorEvent {
 
 /// Request to upload a new profile picture for the current edit session.
 ///
-/// Exactly one of [file] or [bytes] must be supplied. The bloc handles the
-/// upload via the injected `BlossomUploadService` and stages the resulting
-/// CDN URL on success. Save remains the only path that publishes a kind 0
-/// — this event does **not** trigger publish.
+/// [bytes] are the cropped JPEG produced by the crop editor — every pick
+/// (native and web) is cropped to bounded bytes before dispatch. The bloc
+/// handles the upload via the injected `BlossomUploadService` and stages the
+/// resulting CDN URL on success. Save remains the only path that publishes a
+/// kind 0 — this event does **not** trigger publish.
 final class ProfilePictureUploadRequested extends ProfileEditorEvent {
   const ProfilePictureUploadRequested({
     required this.pubkey,
-    this.file,
-    this.bytes,
+    required this.bytes,
     this.filename,
     this.mimeType = 'image/jpeg',
-  }) : assert(
-         (file == null) != (bytes == null),
-         'Exactly one of file or bytes must be supplied',
-       );
+  });
 
   /// User's public key in hex format. Required by the upload service for
   /// the BUD-01 auth event.
   final String pubkey;
 
-  /// Native file payload (iOS / Android / desktop).
-  final File? file;
+  /// In-memory cropped JPEG bytes to upload.
+  final Uint8List bytes;
 
-  /// In-memory bytes payload (web).
-  final Uint8List? bytes;
-
-  /// Filename for the bytes payload (web only). Used by the metadata
-  /// stripper to preserve / normalize the extension.
+  /// Filename for the bytes payload. Used by the metadata stripper to
+  /// preserve / normalize the extension.
   final String? filename;
 
   /// MIME type. Defaults to `image/jpeg`.
@@ -212,32 +206,27 @@ final class InitialPersistedBannerSet extends ProfileEditorEvent {
 
 /// Request to upload a new banner image for the current edit session.
 ///
-/// Exactly one of [file] or [bytes] must be supplied. The bloc handles the
-/// upload via the injected `BlossomUploadService` and stages the resulting
-/// CDN URL on success. Save remains the only path that publishes a kind 0
-/// — this event does **not** trigger publish.
+/// [bytes] are the cropped JPEG produced by the crop editor — every pick
+/// (native and web) is cropped to bounded bytes before dispatch. The bloc
+/// handles the upload via the injected `BlossomUploadService` and stages the
+/// resulting CDN URL on success. Save remains the only path that publishes a
+/// kind 0 — this event does **not** trigger publish.
 final class ProfileBannerUploadRequested extends ProfileEditorEvent {
   const ProfileBannerUploadRequested({
     required this.pubkey,
-    this.file,
-    this.bytes,
+    required this.bytes,
     this.filename,
     this.mimeType = 'image/jpeg',
-  }) : assert(
-         (file == null) != (bytes == null),
-         'Exactly one of file or bytes must be supplied',
-       );
+  });
 
   /// User's public key in hex format.
   final String pubkey;
 
-  /// Native file payload (iOS / Android / desktop).
-  final File? file;
+  /// In-memory cropped JPEG bytes to upload.
+  final Uint8List bytes;
 
-  /// In-memory bytes payload (web).
-  final Uint8List? bytes;
-
-  /// Filename for the bytes payload (web only).
+  /// Filename for the bytes payload. Used by the metadata stripper to
+  /// preserve / normalize the extension.
   final String? filename;
 
   /// MIME type. Defaults to `image/jpeg`.

--- a/mobile/lib/blocs/profile_editor/profile_editor_event.dart
+++ b/mobile/lib/blocs/profile_editor/profile_editor_event.dart
@@ -134,7 +134,7 @@ final class ProfilePictureUploadRequested extends ProfileEditorEvent {
   const ProfilePictureUploadRequested({
     required this.pubkey,
     required this.bytes,
-    this.filename,
+    required this.filename,
     this.mimeType = 'image/jpeg',
   });
 
@@ -147,7 +147,7 @@ final class ProfilePictureUploadRequested extends ProfileEditorEvent {
 
   /// Filename for the bytes payload. Used by the metadata stripper to
   /// preserve / normalize the extension.
-  final String? filename;
+  final String filename;
 
   /// MIME type. Defaults to `image/jpeg`.
   final String mimeType;
@@ -215,7 +215,7 @@ final class ProfileBannerUploadRequested extends ProfileEditorEvent {
   const ProfileBannerUploadRequested({
     required this.pubkey,
     required this.bytes,
-    this.filename,
+    required this.filename,
     this.mimeType = 'image/jpeg',
   });
 
@@ -227,7 +227,7 @@ final class ProfileBannerUploadRequested extends ProfileEditorEvent {
 
   /// Filename for the bytes payload. Used by the metadata stripper to
   /// preserve / normalize the extension.
-  final String? filename;
+  final String filename;
 
   /// MIME type. Defaults to `image/jpeg`.
   final String mimeType;

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4145,5 +4145,6 @@
     "imageCropEditorFlipLabel": "ግልብጥ",
     "imageCropEditorResetLabel": "ዳግም አስጀምር",
     "imageCropEditorCloseSemanticLabel": "መከርከምን ሰርዝ",
-    "imageCropEditorDoneSemanticLabel": "መከርከምን ተግብር"
+    "imageCropEditorDoneSemanticLabel": "መከርከምን ተግብር",
+    "imageCropEditorProcessing": "መከርከም በመተግበር ላይ…"
 }

--- a/mobile/lib/l10n/app_am.arb
+++ b/mobile/lib/l10n/app_am.arb
@@ -4140,5 +4140,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "የተመረጡ ቅንጥቦችን ሰርዝ",
     "videoEditorMergeProgressLabel": "ትንሽ ይቆዩ፣ ቅንጥቦችዎን እያዋሃድን ነው",
     "videoEditorMergeFailed": "ቅንጥቦችን ማዋሃድ አልተቻለም። እባክዎ እንደገና ይሞክሩ።",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "አሽከርክር",
+    "imageCropEditorFlipLabel": "ግልብጥ",
+    "imageCropEditorResetLabel": "ዳግም አስጀምር",
+    "imageCropEditorCloseSemanticLabel": "መከርከምን ሰርዝ",
+    "imageCropEditorDoneSemanticLabel": "መከርከምን ተግብር"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "حذف المقاطع المحددة",
     "videoEditorMergeProgressLabel": "لحظة من فضلك، نقوم بدمج مقاطعك",
     "videoEditorMergeFailed": "تعذّر دمج المقاطع. يُرجى المحاولة مرة أخرى.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "تدوير",
+    "imageCropEditorFlipLabel": "قلب",
+    "imageCropEditorResetLabel": "إعادة تعيين",
+    "imageCropEditorCloseSemanticLabel": "إلغاء الاقتصاص",
+    "imageCropEditorDoneSemanticLabel": "تطبيق الاقتصاص"
 }

--- a/mobile/lib/l10n/app_ar.arb
+++ b/mobile/lib/l10n/app_ar.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "قلب",
     "imageCropEditorResetLabel": "إعادة تعيين",
     "imageCropEditorCloseSemanticLabel": "إلغاء الاقتصاص",
-    "imageCropEditorDoneSemanticLabel": "تطبيق الاقتصاص"
+    "imageCropEditorDoneSemanticLabel": "تطبيق الاقتصاص",
+    "imageCropEditorProcessing": "جارٍ تطبيق الاقتصاص…"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4146,5 +4146,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Изтриване на избраните клипове",
     "videoEditorMergeProgressLabel": "Един момент, обединяваме клиповете ти",
     "videoEditorMergeFailed": "Клиповете не могат да бъдат обединени. Опитай отново.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Завъртане",
+    "imageCropEditorFlipLabel": "Обръщане",
+    "imageCropEditorResetLabel": "Нулиране",
+    "imageCropEditorCloseSemanticLabel": "Отказ от изрязването",
+    "imageCropEditorDoneSemanticLabel": "Прилагане на изрязването"
 }

--- a/mobile/lib/l10n/app_bg.arb
+++ b/mobile/lib/l10n/app_bg.arb
@@ -4151,5 +4151,6 @@
     "imageCropEditorFlipLabel": "Обръщане",
     "imageCropEditorResetLabel": "Нулиране",
     "imageCropEditorCloseSemanticLabel": "Отказ от изрязването",
-    "imageCropEditorDoneSemanticLabel": "Прилагане на изрязването"
+    "imageCropEditorDoneSemanticLabel": "Прилагане на изрязването",
+    "imageCropEditorProcessing": "Прилагане на изрязването…"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Ausgewählte Clips löschen",
     "videoEditorMergeProgressLabel": "Einen Moment, wir führen deine Clips zusammen",
     "videoEditorMergeFailed": "Clips konnten nicht zusammengeführt werden. Bitte versuche es erneut.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Drehen",
+    "imageCropEditorFlipLabel": "Spiegeln",
+    "imageCropEditorResetLabel": "Zurücksetzen",
+    "imageCropEditorCloseSemanticLabel": "Zuschneiden abbrechen",
+    "imageCropEditorDoneSemanticLabel": "Zuschnitt übernehmen"
 }

--- a/mobile/lib/l10n/app_de.arb
+++ b/mobile/lib/l10n/app_de.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Spiegeln",
     "imageCropEditorResetLabel": "Zurücksetzen",
     "imageCropEditorCloseSemanticLabel": "Zuschneiden abbrechen",
-    "imageCropEditorDoneSemanticLabel": "Zuschnitt übernehmen"
+    "imageCropEditorDoneSemanticLabel": "Zuschnitt übernehmen",
+    "imageCropEditorProcessing": "Zuschnitt wird angewendet…"
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5450,5 +5450,9 @@
     "imageCropEditorDoneSemanticLabel": "Apply crop",
     "@imageCropEditorDoneSemanticLabel": {
         "description": "Accessibility label for the done button in the image crop editor that confirms the crop and proceeds with the upload."
+    },
+    "imageCropEditorProcessing": "Applying crop…",
+    "@imageCropEditorProcessing": {
+        "description": "Loading message shown while the image crop editor generates the final cropped image after the user taps done."
     }
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -5430,5 +5430,25 @@
     "subtitleEditorSaveSuccess": "Subtitles updated",
     "subtitleEditorSaveError": "Couldn't save subtitles. Try again.",
     "subtitleEditorRetry": "Retry",
-    "subtitleEditorCueHint": "Caption text"
+    "subtitleEditorCueHint": "Caption text",
+    "imageCropEditorRotateLabel": "Rotate",
+    "@imageCropEditorRotateLabel": {
+        "description": "Bottom-bar action in the image crop editor that rotates the image 90 degrees."
+    },
+    "imageCropEditorFlipLabel": "Flip",
+    "@imageCropEditorFlipLabel": {
+        "description": "Bottom-bar action in the image crop editor that mirrors the image horizontally."
+    },
+    "imageCropEditorResetLabel": "Reset",
+    "@imageCropEditorResetLabel": {
+        "description": "Bottom-bar action in the image crop editor that reverts all crop, rotate and flip changes."
+    },
+    "imageCropEditorCloseSemanticLabel": "Cancel cropping",
+    "@imageCropEditorCloseSemanticLabel": {
+        "description": "Accessibility label for the close button in the image crop editor that discards changes and returns without uploading."
+    },
+    "imageCropEditorDoneSemanticLabel": "Apply crop",
+    "@imageCropEditorDoneSemanticLabel": {
+        "description": "Accessibility label for the done button in the image crop editor that confirms the crop and proceeds with the upload."
+    }
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Eliminar clips seleccionados",
     "videoEditorMergeProgressLabel": "Un momento, estamos combinando tus clips",
     "videoEditorMergeFailed": "No se pudieron combinar los clips. Inténtalo de nuevo.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Girar",
+    "imageCropEditorFlipLabel": "Voltear",
+    "imageCropEditorResetLabel": "Restablecer",
+    "imageCropEditorCloseSemanticLabel": "Cancelar recorte",
+    "imageCropEditorDoneSemanticLabel": "Aplicar recorte"
 }

--- a/mobile/lib/l10n/app_es.arb
+++ b/mobile/lib/l10n/app_es.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Voltear",
     "imageCropEditorResetLabel": "Restablecer",
     "imageCropEditorCloseSemanticLabel": "Cancelar recorte",
-    "imageCropEditorDoneSemanticLabel": "Aplicar recorte"
+    "imageCropEditorDoneSemanticLabel": "Aplicar recorte",
+    "imageCropEditorProcessing": "Aplicando recorte…"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2589,5 +2589,6 @@
     "imageCropEditorFlipLabel": "Baligtarin",
     "imageCropEditorResetLabel": "I-reset",
     "imageCropEditorCloseSemanticLabel": "Kanselahin ang pag-crop",
-    "imageCropEditorDoneSemanticLabel": "Ilapat ang pag-crop"
+    "imageCropEditorDoneSemanticLabel": "Ilapat ang pag-crop",
+    "imageCropEditorProcessing": "Inilalapat ang pag-crop…"
 }

--- a/mobile/lib/l10n/app_fil.arb
+++ b/mobile/lib/l10n/app_fil.arb
@@ -2584,5 +2584,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Tanggalin ang mga napiling clip",
     "videoEditorMergeProgressLabel": "Sandali lang, pinagsasama namin ang iyong mga clip",
     "videoEditorMergeFailed": "Hindi mapagsama ang mga clip. Pakisubukang muli.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Iikot",
+    "imageCropEditorFlipLabel": "Baligtarin",
+    "imageCropEditorResetLabel": "I-reset",
+    "imageCropEditorCloseSemanticLabel": "Kanselahin ang pag-crop",
+    "imageCropEditorDoneSemanticLabel": "Ilapat ang pag-crop"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Retourner",
     "imageCropEditorResetLabel": "Réinitialiser",
     "imageCropEditorCloseSemanticLabel": "Annuler le recadrage",
-    "imageCropEditorDoneSemanticLabel": "Appliquer le recadrage"
+    "imageCropEditorDoneSemanticLabel": "Appliquer le recadrage",
+    "imageCropEditorProcessing": "Application du recadrage…"
 }

--- a/mobile/lib/l10n/app_fr.arb
+++ b/mobile/lib/l10n/app_fr.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Supprimer les clips sélectionnés",
     "videoEditorMergeProgressLabel": "Un instant, nous fusionnons vos clips",
     "videoEditorMergeFailed": "Impossible de fusionner les clips. Veuillez réessayer.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Pivoter",
+    "imageCropEditorFlipLabel": "Retourner",
+    "imageCropEditorResetLabel": "Réinitialiser",
+    "imageCropEditorCloseSemanticLabel": "Annuler le recadrage",
+    "imageCropEditorDoneSemanticLabel": "Appliquer le recadrage"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Hapus klip yang dipilih",
     "videoEditorMergeProgressLabel": "Sebentar, kami sedang menggabungkan klipmu",
     "videoEditorMergeFailed": "Tidak dapat menggabungkan klip. Silakan coba lagi.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Putar",
+    "imageCropEditorFlipLabel": "Balik",
+    "imageCropEditorResetLabel": "Atur ulang",
+    "imageCropEditorCloseSemanticLabel": "Batalkan pemangkasan",
+    "imageCropEditorDoneSemanticLabel": "Terapkan pemangkasan"
 }

--- a/mobile/lib/l10n/app_id.arb
+++ b/mobile/lib/l10n/app_id.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Balik",
     "imageCropEditorResetLabel": "Atur ulang",
     "imageCropEditorCloseSemanticLabel": "Batalkan pemangkasan",
-    "imageCropEditorDoneSemanticLabel": "Terapkan pemangkasan"
+    "imageCropEditorDoneSemanticLabel": "Terapkan pemangkasan",
+    "imageCropEditorProcessing": "Menerapkan pemangkasan…"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Capovolgi",
     "imageCropEditorResetLabel": "Reimposta",
     "imageCropEditorCloseSemanticLabel": "Annulla ritaglio",
-    "imageCropEditorDoneSemanticLabel": "Applica ritaglio"
+    "imageCropEditorDoneSemanticLabel": "Applica ritaglio",
+    "imageCropEditorProcessing": "Applicazione del ritaglio…"
 }

--- a/mobile/lib/l10n/app_it.arb
+++ b/mobile/lib/l10n/app_it.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Elimina le clip selezionate",
     "videoEditorMergeProgressLabel": "Un momento, stiamo unendo le tue clip",
     "videoEditorMergeFailed": "Impossibile unire le clip. Riprova.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Ruota",
+    "imageCropEditorFlipLabel": "Capovolgi",
+    "imageCropEditorResetLabel": "Reimposta",
+    "imageCropEditorCloseSemanticLabel": "Annulla ritaglio",
+    "imageCropEditorDoneSemanticLabel": "Applica ritaglio"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "反転",
     "imageCropEditorResetLabel": "リセット",
     "imageCropEditorCloseSemanticLabel": "切り抜きをキャンセル",
-    "imageCropEditorDoneSemanticLabel": "切り抜きを適用"
+    "imageCropEditorDoneSemanticLabel": "切り抜きを適用",
+    "imageCropEditorProcessing": "切り抜きを適用中…"
 }

--- a/mobile/lib/l10n/app_ja.arb
+++ b/mobile/lib/l10n/app_ja.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "選択したクリップを削除",
     "videoEditorMergeProgressLabel": "少々お待ちください。クリップを結合しています",
     "videoEditorMergeFailed": "クリップを結合できませんでした。もう一度お試しください。",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "回転",
+    "imageCropEditorFlipLabel": "反転",
+    "imageCropEditorResetLabel": "リセット",
+    "imageCropEditorCloseSemanticLabel": "切り抜きをキャンセル",
+    "imageCropEditorDoneSemanticLabel": "切り抜きを適用"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3337,5 +3337,6 @@
     "imageCropEditorFlipLabel": "뒤집기",
     "imageCropEditorResetLabel": "초기화",
     "imageCropEditorCloseSemanticLabel": "자르기 취소",
-    "imageCropEditorDoneSemanticLabel": "자르기 적용"
+    "imageCropEditorDoneSemanticLabel": "자르기 적용",
+    "imageCropEditorProcessing": "자르기 적용 중…"
 }

--- a/mobile/lib/l10n/app_ko.arb
+++ b/mobile/lib/l10n/app_ko.arb
@@ -3332,5 +3332,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "선택한 클립 삭제",
     "videoEditorMergeProgressLabel": "잠시만요, 클립을 병합하고 있어요",
     "videoEditorMergeFailed": "클립을 병합할 수 없습니다. 다시 시도해 주세요.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "회전",
+    "imageCropEditorFlipLabel": "뒤집기",
+    "imageCropEditorResetLabel": "초기화",
+    "imageCropEditorCloseSemanticLabel": "자르기 취소",
+    "imageCropEditorDoneSemanticLabel": "자르기 적용"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Geselecteerde clips verwijderen",
     "videoEditorMergeProgressLabel": "Een moment, we voegen je clips samen",
     "videoEditorMergeFailed": "Kan clips niet samenvoegen. Probeer het opnieuw.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Draaien",
+    "imageCropEditorFlipLabel": "Spiegelen",
+    "imageCropEditorResetLabel": "Resetten",
+    "imageCropEditorCloseSemanticLabel": "Bijsnijden annuleren",
+    "imageCropEditorDoneSemanticLabel": "Bijsnijden toepassen"
 }

--- a/mobile/lib/l10n/app_nl.arb
+++ b/mobile/lib/l10n/app_nl.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Spiegelen",
     "imageCropEditorResetLabel": "Resetten",
     "imageCropEditorCloseSemanticLabel": "Bijsnijden annuleren",
-    "imageCropEditorDoneSemanticLabel": "Bijsnijden toepassen"
+    "imageCropEditorDoneSemanticLabel": "Bijsnijden toepassen",
+    "imageCropEditorProcessing": "Bijsnijden toepassen…"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Odbij",
     "imageCropEditorResetLabel": "Resetuj",
     "imageCropEditorCloseSemanticLabel": "Anuluj kadrowanie",
-    "imageCropEditorDoneSemanticLabel": "Zastosuj kadrowanie"
+    "imageCropEditorDoneSemanticLabel": "Zastosuj kadrowanie",
+    "imageCropEditorProcessing": "Stosowanie kadrowania…"
 }

--- a/mobile/lib/l10n/app_pl.arb
+++ b/mobile/lib/l10n/app_pl.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Usuń zaznaczone klipy",
     "videoEditorMergeProgressLabel": "Chwila, scalamy Twoje klipy",
     "videoEditorMergeFailed": "Nie udało się scalić klipów. Spróbuj ponownie.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Obróć",
+    "imageCropEditorFlipLabel": "Odbij",
+    "imageCropEditorResetLabel": "Resetuj",
+    "imageCropEditorCloseSemanticLabel": "Anuluj kadrowanie",
+    "imageCropEditorDoneSemanticLabel": "Zastosuj kadrowanie"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Inverter",
     "imageCropEditorResetLabel": "Redefinir",
     "imageCropEditorCloseSemanticLabel": "Cancelar recorte",
-    "imageCropEditorDoneSemanticLabel": "Aplicar recorte"
+    "imageCropEditorDoneSemanticLabel": "Aplicar recorte",
+    "imageCropEditorProcessing": "Aplicando recorte…"
 }

--- a/mobile/lib/l10n/app_pt.arb
+++ b/mobile/lib/l10n/app_pt.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Excluir clipes selecionados",
     "videoEditorMergeProgressLabel": "Um momento, estamos mesclando seus clipes",
     "videoEditorMergeFailed": "Não foi possível mesclar os clipes. Tente novamente.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Girar",
+    "imageCropEditorFlipLabel": "Inverter",
+    "imageCropEditorResetLabel": "Redefinir",
+    "imageCropEditorCloseSemanticLabel": "Cancelar recorte",
+    "imageCropEditorDoneSemanticLabel": "Aplicar recorte"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Șterge clipurile selectate",
     "videoEditorMergeProgressLabel": "Un moment, îți îmbinăm clipurile",
     "videoEditorMergeFailed": "Clipurile nu au putut fi îmbinate. Încearcă din nou.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Rotește",
+    "imageCropEditorFlipLabel": "Întoarce",
+    "imageCropEditorResetLabel": "Resetează",
+    "imageCropEditorCloseSemanticLabel": "Anulează decuparea",
+    "imageCropEditorDoneSemanticLabel": "Aplică decuparea"
 }

--- a/mobile/lib/l10n/app_ro.arb
+++ b/mobile/lib/l10n/app_ro.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Întoarce",
     "imageCropEditorResetLabel": "Resetează",
     "imageCropEditorCloseSemanticLabel": "Anulează decuparea",
-    "imageCropEditorDoneSemanticLabel": "Aplică decuparea"
+    "imageCropEditorDoneSemanticLabel": "Aplică decuparea",
+    "imageCropEditorProcessing": "Se aplică decuparea…"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Ta bort markerade klipp",
     "videoEditorMergeProgressLabel": "Ett ögonblick, vi slår samman dina klipp",
     "videoEditorMergeFailed": "Det gick inte att slå samman klippen. Försök igen.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Rotera",
+    "imageCropEditorFlipLabel": "Vänd",
+    "imageCropEditorResetLabel": "Återställ",
+    "imageCropEditorCloseSemanticLabel": "Avbryt beskärning",
+    "imageCropEditorDoneSemanticLabel": "Använd beskärning"
 }

--- a/mobile/lib/l10n/app_sv.arb
+++ b/mobile/lib/l10n/app_sv.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Vänd",
     "imageCropEditorResetLabel": "Återställ",
     "imageCropEditorCloseSemanticLabel": "Avbryt beskärning",
-    "imageCropEditorDoneSemanticLabel": "Använd beskärning"
+    "imageCropEditorDoneSemanticLabel": "Använd beskärning",
+    "imageCropEditorProcessing": "Tillämpar beskärning…"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4015,5 +4015,10 @@
     "videoEditorDeleteSelectedClipsSemanticLabel": "Seçili klipleri sil",
     "videoEditorMergeProgressLabel": "Bir saniye, kliplerini birleştiriyoruz",
     "videoEditorMergeFailed": "Klipler birleştirilemedi. Lütfen tekrar dene.",
-  "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device."
+    "deleteAccountLocalDataDeletionFailed": "Account deleted and signed out, but some local data could not be removed from this device.",
+    "imageCropEditorRotateLabel": "Döndür",
+    "imageCropEditorFlipLabel": "Çevir",
+    "imageCropEditorResetLabel": "Sıfırla",
+    "imageCropEditorCloseSemanticLabel": "Kırpmayı iptal et",
+    "imageCropEditorDoneSemanticLabel": "Kırpmayı uygula"
 }

--- a/mobile/lib/l10n/app_tr.arb
+++ b/mobile/lib/l10n/app_tr.arb
@@ -4020,5 +4020,6 @@
     "imageCropEditorFlipLabel": "Çevir",
     "imageCropEditorResetLabel": "Sıfırla",
     "imageCropEditorCloseSemanticLabel": "Kırpmayı iptal et",
-    "imageCropEditorDoneSemanticLabel": "Kırpmayı uygula"
+    "imageCropEditorDoneSemanticLabel": "Kırpmayı uygula",
+    "imageCropEditorProcessing": "Kırpma uygulanıyor…"
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -16271,6 +16271,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Caption text'**
   String get subtitleEditorCueHint;
+
+  /// Bottom-bar action in the image crop editor that rotates the image 90 degrees.
+  ///
+  /// In en, this message translates to:
+  /// **'Rotate'**
+  String get imageCropEditorRotateLabel;
+
+  /// Bottom-bar action in the image crop editor that mirrors the image horizontally.
+  ///
+  /// In en, this message translates to:
+  /// **'Flip'**
+  String get imageCropEditorFlipLabel;
+
+  /// Bottom-bar action in the image crop editor that reverts all crop, rotate and flip changes.
+  ///
+  /// In en, this message translates to:
+  /// **'Reset'**
+  String get imageCropEditorResetLabel;
+
+  /// Accessibility label for the close button in the image crop editor that discards changes and returns without uploading.
+  ///
+  /// In en, this message translates to:
+  /// **'Cancel cropping'**
+  String get imageCropEditorCloseSemanticLabel;
+
+  /// Accessibility label for the done button in the image crop editor that confirms the crop and proceeds with the upload.
+  ///
+  /// In en, this message translates to:
+  /// **'Apply crop'**
+  String get imageCropEditorDoneSemanticLabel;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -16301,6 +16301,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Apply crop'**
   String get imageCropEditorDoneSemanticLabel;
+
+  /// Loading message shown while the image crop editor generates the final cropped image after the user taps done.
+  ///
+  /// In en, this message translates to:
+  /// **'Applying crop…'**
+  String get imageCropEditorProcessing;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9211,4 +9211,19 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'አሽከርክር';
+
+  @override
+  String get imageCropEditorFlipLabel => 'ግልብጥ';
+
+  @override
+  String get imageCropEditorResetLabel => 'ዳግም አስጀምር';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'መከርከምን ሰርዝ';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'መከርከምን ተግብር';
 }

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -9226,4 +9226,7 @@ class AppLocalizationsAm extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'መከርከምን ተግብር';
+
+  @override
+  String get imageCropEditorProcessing => 'መከርከም በመተግበር ላይ…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9304,4 +9304,19 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'تدوير';
+
+  @override
+  String get imageCropEditorFlipLabel => 'قلب';
+
+  @override
+  String get imageCropEditorResetLabel => 'إعادة تعيين';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'إلغاء الاقتصاص';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'تطبيق الاقتصاص';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -9319,4 +9319,7 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'تطبيق الاقتصاص';
+
+  @override
+  String get imageCropEditorProcessing => 'جارٍ تطبيق الاقتصاص…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9491,4 +9491,7 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Прилагане на изрязването';
+
+  @override
+  String get imageCropEditorProcessing => 'Прилагане на изрязването…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -9476,4 +9476,19 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Завъртане';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Обръщане';
+
+  @override
+  String get imageCropEditorResetLabel => 'Нулиране';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Отказ от изрязването';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Прилагане на изрязването';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9488,4 +9488,19 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Drehen';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Spiegeln';
+
+  @override
+  String get imageCropEditorResetLabel => 'Zurücksetzen';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Zuschneiden abbrechen';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Zuschnitt übernehmen';
 }

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -9503,4 +9503,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Zuschnitt übernehmen';
+
+  @override
+  String get imageCropEditorProcessing => 'Zuschnitt wird angewendet…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9387,4 +9387,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Apply crop';
+
+  @override
+  String get imageCropEditorProcessing => 'Applying crop…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -9372,4 +9372,19 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Rotate';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Flip';
+
+  @override
+  String get imageCropEditorResetLabel => 'Reset';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Cancel cropping';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Apply crop';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9485,4 +9485,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Aplicar recorte';
+
+  @override
+  String get imageCropEditorProcessing => 'Aplicando recorte…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -9470,4 +9470,19 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Girar';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Voltear';
+
+  @override
+  String get imageCropEditorResetLabel => 'Restablecer';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Cancelar recorte';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Aplicar recorte';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9501,4 +9501,7 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Ilapat ang pag-crop';
+
+  @override
+  String get imageCropEditorProcessing => 'Inilalapat ang pag-crop…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -9486,4 +9486,19 @@ class AppLocalizationsFil extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Iikot';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Baligtarin';
+
+  @override
+  String get imageCropEditorResetLabel => 'I-reset';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Kanselahin ang pag-crop';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Ilapat ang pag-crop';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9527,4 +9527,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Appliquer le recadrage';
+
+  @override
+  String get imageCropEditorProcessing => 'Application du recadrage…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -9512,4 +9512,19 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Pivoter';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Retourner';
+
+  @override
+  String get imageCropEditorResetLabel => 'Réinitialiser';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Annuler le recadrage';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Appliquer le recadrage';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9378,4 +9378,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Terapkan pemangkasan';
+
+  @override
+  String get imageCropEditorProcessing => 'Menerapkan pemangkasan…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -9363,4 +9363,19 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Putar';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Balik';
+
+  @override
+  String get imageCropEditorResetLabel => 'Atur ulang';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Batalkan pemangkasan';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Terapkan pemangkasan';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9483,4 +9483,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Applica ritaglio';
+
+  @override
+  String get imageCropEditorProcessing => 'Applicazione del ritaglio…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -9468,4 +9468,19 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Ruota';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Capovolgi';
+
+  @override
+  String get imageCropEditorResetLabel => 'Reimposta';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Annulla ritaglio';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Applica ritaglio';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9058,4 +9058,19 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => '回転';
+
+  @override
+  String get imageCropEditorFlipLabel => '反転';
+
+  @override
+  String get imageCropEditorResetLabel => 'リセット';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => '切り抜きをキャンセル';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => '切り抜きを適用';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -9073,4 +9073,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => '切り抜きを適用';
+
+  @override
+  String get imageCropEditorProcessing => '切り抜きを適用中…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9082,4 +9082,19 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => '회전';
+
+  @override
+  String get imageCropEditorFlipLabel => '뒤집기';
+
+  @override
+  String get imageCropEditorResetLabel => '초기화';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => '자르기 취소';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => '자르기 적용';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -9097,4 +9097,7 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => '자르기 적용';
+
+  @override
+  String get imageCropEditorProcessing => '자르기 적용 중…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9427,4 +9427,19 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Draaien';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Spiegelen';
+
+  @override
+  String get imageCropEditorResetLabel => 'Resetten';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Bijsnijden annuleren';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Bijsnijden toepassen';
 }

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -9442,4 +9442,7 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Bijsnijden toepassen';
+
+  @override
+  String get imageCropEditorProcessing => 'Bijsnijden toepassen…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9546,4 +9546,19 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Obróć';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Odbij';
+
+  @override
+  String get imageCropEditorResetLabel => 'Resetuj';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Anuluj kadrowanie';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Zastosuj kadrowanie';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -9561,4 +9561,7 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Zastosuj kadrowanie';
+
+  @override
+  String get imageCropEditorProcessing => 'Stosowanie kadrowania…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9456,4 +9456,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Aplicar recorte';
+
+  @override
+  String get imageCropEditorProcessing => 'Aplicando recorte…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -9441,4 +9441,19 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Girar';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Inverter';
+
+  @override
+  String get imageCropEditorResetLabel => 'Redefinir';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Cancelar recorte';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Aplicar recorte';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9575,4 +9575,19 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Rotește';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Întoarce';
+
+  @override
+  String get imageCropEditorResetLabel => 'Resetează';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Anulează decuparea';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Aplică decuparea';
 }

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -9590,4 +9590,7 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Aplică decuparea';
+
+  @override
+  String get imageCropEditorProcessing => 'Se aplică decuparea…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9408,4 +9408,7 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Använd beskärning';
+
+  @override
+  String get imageCropEditorProcessing => 'Tillämpar beskärning…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -9393,4 +9393,19 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Rotera';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Vänd';
+
+  @override
+  String get imageCropEditorResetLabel => 'Återställ';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Avbryt beskärning';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Använd beskärning';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9375,4 +9375,7 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get imageCropEditorDoneSemanticLabel => 'Kırpmayı uygula';
+
+  @override
+  String get imageCropEditorProcessing => 'Kırpma uygulanıyor…';
 }

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -9360,4 +9360,19 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get subtitleEditorCueHint => 'Caption text';
+
+  @override
+  String get imageCropEditorRotateLabel => 'Döndür';
+
+  @override
+  String get imageCropEditorFlipLabel => 'Çevir';
+
+  @override
+  String get imageCropEditorResetLabel => 'Sıfırla';
+
+  @override
+  String get imageCropEditorCloseSemanticLabel => 'Kırpmayı iptal et';
+
+  @override
+  String get imageCropEditorDoneSemanticLabel => 'Kırpmayı uygula';
 }

--- a/mobile/lib/providers/image_crop_launcher_provider.dart
+++ b/mobile/lib/providers/image_crop_launcher_provider.dart
@@ -6,7 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 
 /// Signature of the function that launches the crop editor and resolves to the
-/// cropped PNG bytes (or `null` when cancelled).
+/// cropped JPEG bytes (or `null` when cancelled).
 typedef ImageCropLauncher =
     Future<Uint8List?> Function(
       BuildContext context, {

--- a/mobile/lib/providers/image_crop_launcher_provider.dart
+++ b/mobile/lib/providers/image_crop_launcher_provider.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
+
+/// Signature of the function that launches the crop editor and resolves to the
+/// cropped PNG bytes (or `null` when cancelled).
+typedef ImageCropLauncher =
+    Future<Uint8List?> Function(
+      BuildContext context, {
+      required ImageCropKind kind,
+      File? file,
+      Uint8List? bytes,
+    });
+
+/// Injectable seam for [showImageCropEditor].
+///
+/// Picker widgets read the launcher from here instead of calling
+/// [showImageCropEditor] directly, so widget tests can override it with a fake
+/// that returns canned bytes / `null` without pumping the real editor (which
+/// needs a decodable image).
+final imageCropLauncherProvider = Provider<ImageCropLauncher>(
+  (ref) => showImageCropEditor,
+);

--- a/mobile/lib/screens/image_crop_editor/image_crop_editor.dart
+++ b/mobile/lib/screens/image_crop_editor/image_crop_editor.dart
@@ -1,0 +1,3 @@
+export 'image_crop_editor_screen.dart';
+export 'widgets/image_crop_editor_bottom_bar.dart';
+export 'widgets/image_crop_editor_toolbar.dart';

--- a/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
+++ b/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
@@ -1,0 +1,165 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/screens/image_crop_editor/widgets/image_crop_editor_bottom_bar.dart';
+import 'package:openvine/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
+import 'package:pro_image_editor/pro_image_editor.dart';
+
+/// What is being cropped. Determines the locked aspect ratio, the bounded
+/// output size of the re-encoded result, and the filename handed to the
+/// upload service.
+enum ImageCropKind {
+  /// Square 1:1 avatar, output capped at 1024x1024.
+  avatar(
+    aspectRatio: 1,
+    maxOutputSize: Size(1024, 1024),
+    filename: 'avatar.png',
+    mimeType: 'image/png',
+  ),
+
+  /// 3:1 banner, output capped at 1500x500.
+  banner(
+    aspectRatio: 3,
+    maxOutputSize: Size(1500, 500),
+    filename: 'banner.png',
+    mimeType: 'image/png',
+  );
+
+  const ImageCropKind({
+    required this.aspectRatio,
+    required this.maxOutputSize,
+    required this.filename,
+    required this.mimeType,
+  });
+
+  /// Locked width-to-height ratio of the crop frame.
+  final double aspectRatio;
+
+  /// Bounding box the re-encoded image is scaled to fit within.
+  final Size maxOutputSize;
+
+  /// Filename passed alongside the cropped bytes to the upload service. The
+  /// extension matches the editor's PNG output format.
+  final String filename;
+
+  /// MIME type of the cropped bytes, matching the editor's output format.
+  final String mimeType;
+}
+
+/// Pushes the Vine-styled crop editor and resolves to the cropped PNG bytes,
+/// or `null` if the user cancelled.
+///
+/// Exactly one of [file] / [bytes] must be supplied — [file] for native picks
+/// (real filesystem path), [bytes] for web picks (blob already read into
+/// memory).
+Future<Uint8List?> showImageCropEditor(
+  BuildContext context, {
+  required ImageCropKind kind,
+  File? file,
+  Uint8List? bytes,
+}) {
+  return Navigator.of(context).push<Uint8List>(
+    MaterialPageRoute<Uint8List>(
+      fullscreenDialog: true,
+      builder: (_) => ImageCropEditorScreen(
+        kind: kind,
+        file: file,
+        bytes: bytes,
+      ),
+    ),
+  );
+}
+
+/// Full-screen crop / rotate / flip editor wrapping `pro_image_editor`'s
+/// standalone [CropRotateEditor] with Vine chrome.
+///
+/// The editor re-encodes the result to [ImageCropKind.maxOutputSize] as a
+/// fresh PNG (`enableUseOriginalBytes: false`), which bounds the upload
+/// dimensions and drops the original EXIF as a side effect. Returns the bytes
+/// via `Navigator.pop`.
+class ImageCropEditorScreen extends StatefulWidget {
+  const ImageCropEditorScreen({
+    required this.kind,
+    this.file,
+    this.bytes,
+    super.key,
+  }) : assert(
+         (file == null) != (bytes == null),
+         'Exactly one of file or bytes must be supplied',
+       );
+
+  final ImageCropKind kind;
+  final File? file;
+  final Uint8List? bytes;
+
+  @override
+  State<ImageCropEditorScreen> createState() => _ImageCropEditorScreenState();
+}
+
+class _ImageCropEditorScreenState extends State<ImageCropEditorScreen> {
+  /// Captured cropped bytes. `done()` fills this via [onImageEditingComplete]
+  /// before [onCloseEditor] pops; the close button pops with it still null.
+  Uint8List? _result;
+
+  @override
+  Widget build(BuildContext context) {
+    final kind = widget.kind;
+    return CropRotateEditor.autoSource(
+      file: widget.file,
+      byteArray: widget.bytes,
+      initConfigs: CropRotateEditorInitConfigs(
+        theme: Theme.of(context),
+        convertToUint8List: true,
+        callbacks: ProImageEditorCallbacks(
+          onImageEditingComplete: (bytes) async => _result = bytes,
+          onCloseEditor: (_) {
+            if (mounted) Navigator.of(context).pop(_result);
+          },
+        ),
+        configs: ProImageEditorConfigs(
+          progressIndicatorConfigs: const ProgressIndicatorConfigs(
+            widgets: ProgressIndicatorWidgets(
+              circularProgressIndicator: BrandedLoadingIndicator(size: 64),
+            ),
+          ),
+          imageGeneration: ImageGenerationConfigs(
+            maxOutputSize: kind.maxOutputSize,
+            enableUseOriginalBytes: false,
+            outputFormat: .png,
+          ),
+          cropRotateEditor: CropRotateEditorConfigs(
+            initAspectRatio: kind.aspectRatio,
+            exportOvalMask: false,
+            enableFlipAnimation: false,
+            enableKeepAspectRatioOnRotate: kind == .banner,
+            rotateDirection: .right,
+            style: const CropRotateEditorStyle(
+              background: VineTheme.surfaceBackground,
+              cropCornerColor: VineTheme.primary,
+            ),
+            widgets: CropRotateEditorWidgets(
+              appBar: (editorState, rebuildStream) => ReactiveAppbar(
+                stream: rebuildStream,
+                builder: (_) => ImageCropEditorToolbar(
+                  onClose: editorState.close,
+                  onDone: editorState.done,
+                ),
+              ),
+              bottomBar: (editorState, rebuildStream) => ReactiveWidget(
+                stream: rebuildStream,
+                builder: (_) => ImageCropEditorBottomBar(
+                  onRotate: editorState.rotate,
+                  onFlip: editorState.flip,
+                  onReset: editorState.reset,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
+++ b/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/screens/image_crop_editor/widgets/image_crop_editor_bottom_bar.dart';
 import 'package:openvine/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -129,6 +130,9 @@ class _ImageCropEditorScreenState extends State<ImageCropEditorScreen> {
           },
         ),
         configs: ProImageEditorConfigs(
+          i18n: I18n(
+            doneLoadingMsg: context.l10n.imageCropEditorProcessing,
+          ),
           progressIndicatorConfigs: const ProgressIndicatorConfigs(
             widgets: ProgressIndicatorWidgets(
               circularProgressIndicator: BrandedLoadingIndicator(size: 64),

--- a/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
+++ b/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
@@ -17,16 +17,16 @@ enum ImageCropKind {
   avatar(
     aspectRatio: 1,
     maxOutputSize: Size(1024, 1024),
-    filename: 'avatar.png',
-    mimeType: 'image/png',
+    filename: 'avatar.jpg',
+    mimeType: 'image/jpeg',
   ),
 
   /// 3:1 banner, output capped at 1500x500.
   banner(
     aspectRatio: 3,
     maxOutputSize: Size(1500, 500),
-    filename: 'banner.png',
-    mimeType: 'image/png',
+    filename: 'banner.jpg',
+    mimeType: 'image/jpeg',
   );
 
   const ImageCropKind({
@@ -43,14 +43,14 @@ enum ImageCropKind {
   final Size maxOutputSize;
 
   /// Filename passed alongside the cropped bytes to the upload service. The
-  /// extension matches the editor's PNG output format.
+  /// extension matches the editor's JPEG output format.
   final String filename;
 
   /// MIME type of the cropped bytes, matching the editor's output format.
   final String mimeType;
 }
 
-/// Pushes the Vine-styled crop editor and resolves to the cropped PNG bytes,
+/// Pushes the Vine-styled crop editor and resolves to the cropped JPEG bytes,
 /// or `null` if the user cancelled.
 ///
 /// Exactly one of [file] / [bytes] must be supplied — [file] for native picks
@@ -78,7 +78,7 @@ Future<Uint8List?> showImageCropEditor(
 /// standalone [CropRotateEditor] with Vine chrome.
 ///
 /// The editor re-encodes the result to [ImageCropKind.maxOutputSize] as a
-/// fresh PNG (`enableUseOriginalBytes: false`), which bounds the upload
+/// fresh JPEG (`enableUseOriginalBytes: false`), which bounds the upload
 /// dimensions and drops the original EXIF as a side effect. Returns the bytes
 /// via `Navigator.pop`.
 class ImageCropEditorScreen extends StatefulWidget {
@@ -137,7 +137,6 @@ class _ImageCropEditorScreenState extends State<ImageCropEditorScreen> {
           imageGeneration: ImageGenerationConfigs(
             maxOutputSize: kind.maxOutputSize,
             enableUseOriginalBytes: false,
-            outputFormat: .png,
           ),
           cropRotateEditor: CropRotateEditorConfigs(
             initAspectRatio: kind.aspectRatio,

--- a/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
+++ b/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
@@ -92,10 +92,10 @@ Future<Uint8List?> showImageCropEditor(
 /// Full-screen crop / rotate / flip editor wrapping `pro_image_editor`'s
 /// standalone [CropRotateEditor] with Vine chrome.
 ///
-/// The editor re-encodes the result to [ImageCropKind.maxOutputSize] as a
-/// fresh JPEG (`enableUseOriginalBytes: false`), which bounds the upload
-/// dimensions and drops the original EXIF as a side effect. Returns the bytes
-/// via `Navigator.pop`.
+/// The crop is captured as a fresh JPEG bounded by
+/// [ImageCropKind.maxOutputSize] — an upper bound that only ever downscales,
+/// never upscales. The canvas re-capture drops the original EXIF as a side
+/// effect. Returns the bytes via `Navigator.pop`.
 class ImageCropEditorScreen extends StatefulWidget {
   const ImageCropEditorScreen({
     required this.kind,
@@ -164,6 +164,9 @@ class _ImageCropEditorScreenState extends State<ImageCropEditorScreen> {
           ),
           imageGeneration: ImageGenerationConfigs(
             maxOutputSize: kind.maxOutputSize,
+            // Forward-compat: inert in the standalone capture path today, but
+            // set so the upcoming sub-editor wiring (which does read it) stays
+            // consistent.
             enableUseOriginalBytes: false,
             jpegQuality: _cropOutputJpegQuality,
           ),

--- a/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
+++ b/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
@@ -51,6 +51,20 @@ enum ImageCropKind {
   final String mimeType;
 }
 
+/// JPEG quality for the re-encoded crop output. Matches the picker's
+/// `imageQuality: 85` so the bounded re-encode doesn't inflate an
+/// already-compressed source back toward a 100%-quality file.
+const int _cropOutputJpegQuality = 85;
+
+/// Maps the editor's emitted bytes to the value to pop with.
+///
+/// `pro_image_editor` hands back an **empty** list (not `null`) when its
+/// screenshot capture fails after all retries. Treat that as a failed crop —
+/// return `null` so the caller's cancel path runs instead of uploading a
+/// zero-byte image.
+@visibleForTesting
+Uint8List? croppedBytesOrNull(Uint8List bytes) => bytes.isEmpty ? null : bytes;
+
 /// Pushes the Vine-styled crop editor and resolves to the cropped JPEG bytes,
 /// or `null` if the user cancelled.
 ///
@@ -117,10 +131,20 @@ class _ImageCropEditorScreenState extends State<ImageCropEditorScreen> {
         convertToUint8List: true,
         callbacks: ProImageEditorCallbacks(
           onImageEditingComplete: (bytes) async {
-            _result = bytes;
+            final result = croppedBytesOrNull(bytes);
+            if (result == null) {
+              Log.error(
+                'Crop produced empty bytes for ${kind.name}; '
+                'treating as cancel',
+                name: 'ImageCropEditor',
+                category: LogCategory.ui,
+              );
+              return;
+            }
+            _result = result;
             Log.info(
-              'Cropped ${kind.name}: ${bytes.lengthInBytes} bytes '
-              '(${(bytes.lengthInBytes / 1024).toStringAsFixed(1)} KB)',
+              'Cropped ${kind.name}: ${result.lengthInBytes} bytes '
+              '(${(result.lengthInBytes / 1024).toStringAsFixed(1)} KB)',
               name: 'ImageCropEditor',
               category: LogCategory.ui,
             );
@@ -141,6 +165,7 @@ class _ImageCropEditorScreenState extends State<ImageCropEditorScreen> {
           imageGeneration: ImageGenerationConfigs(
             maxOutputSize: kind.maxOutputSize,
             enableUseOriginalBytes: false,
+            jpegQuality: _cropOutputJpegQuality,
           ),
           cropRotateEditor: CropRotateEditorConfigs(
             initAspectRatio: kind.aspectRatio,

--- a/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
+++ b/mobile/lib/screens/image_crop_editor/image_crop_editor_screen.dart
@@ -7,6 +7,7 @@ import 'package:openvine/screens/image_crop_editor/widgets/image_crop_editor_bot
 import 'package:openvine/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:pro_image_editor/pro_image_editor.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 /// What is being cropped. Determines the locked aspect ratio, the bounded
 /// output size of the re-encoded result, and the filename handed to the
@@ -114,7 +115,15 @@ class _ImageCropEditorScreenState extends State<ImageCropEditorScreen> {
         theme: Theme.of(context),
         convertToUint8List: true,
         callbacks: ProImageEditorCallbacks(
-          onImageEditingComplete: (bytes) async => _result = bytes,
+          onImageEditingComplete: (bytes) async {
+            _result = bytes;
+            Log.info(
+              'Cropped ${kind.name}: ${bytes.lengthInBytes} bytes '
+              '(${(bytes.lengthInBytes / 1024).toStringAsFixed(1)} KB)',
+              name: 'ImageCropEditor',
+              category: LogCategory.ui,
+            );
+          },
           onCloseEditor: (_) {
             if (mounted) Navigator.of(context).pop(_result);
           },

--- a/mobile/lib/screens/image_crop_editor/widgets/image_crop_editor_bottom_bar.dart
+++ b/mobile/lib/screens/image_crop_editor/widgets/image_crop_editor_bottom_bar.dart
@@ -1,0 +1,102 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Bottom action bar for the image crop editor.
+///
+/// Exposes the crop-frame tools as Vine-styled icon + label buttons. Takes
+/// plain callbacks so it stays decoupled from `pro_image_editor`'s editor
+/// state and is testable in isolation.
+class ImageCropEditorBottomBar extends StatelessWidget {
+  const ImageCropEditorBottomBar({
+    required this.onRotate,
+    required this.onFlip,
+    required this.onReset,
+    super.key,
+  });
+
+  /// Rotates the image 90 degrees.
+  final VoidCallback onRotate;
+
+  /// Mirrors the image horizontally.
+  final VoidCallback onFlip;
+
+  /// Reverts all crop, rotate and flip changes.
+  final VoidCallback onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return ColoredBox(
+      color: VineTheme.surfaceBackground,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              _CropAction(
+                icon: DivineIconName.arrowClockwise,
+                label: l10n.imageCropEditorRotateLabel,
+                onTap: onRotate,
+              ),
+              _CropAction(
+                icon: DivineIconName.flipHorizontal,
+                label: l10n.imageCropEditorFlipLabel,
+                onTap: onFlip,
+              ),
+              _CropAction(
+                icon: DivineIconName.arrowCounterClockwise,
+                label: l10n.imageCropEditorResetLabel,
+                onTap: onReset,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CropAction extends StatelessWidget {
+  const _CropAction({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final DivineIconName icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      button: true,
+      label: label,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(minWidth: 64, minHeight: 56),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              spacing: 4,
+              children: [
+                DivineIcon(icon: icon, color: VineTheme.lightText),
+                Text(
+                  label,
+                  style: VineTheme.labelSmallFont(color: VineTheme.lightText),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart
+++ b/mobile/lib/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart
@@ -1,0 +1,62 @@
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:openvine/l10n/l10n.dart';
+
+/// Top bar for the image crop editor.
+///
+/// Mirrors the video editor's chrome
+/// ([VideoEditorToolbar]): a ghost close (x) button on the left and a done
+/// (check) button on the right, on the dark Vine surface. Implements
+/// [PreferredSizeWidget] so it can be handed to `pro_image_editor`'s
+/// `ReactiveAppbar` app-bar slot.
+class ImageCropEditorToolbar extends StatelessWidget
+    implements PreferredSizeWidget {
+  const ImageCropEditorToolbar({
+    required this.onClose,
+    this.onDone,
+    super.key,
+  });
+
+  /// Called when the close button is pressed. Discards the crop and returns
+  /// without uploading.
+  final VoidCallback onClose;
+
+  /// Called when the done button is pressed. When null the button renders in
+  /// its disabled state.
+  final VoidCallback? onDone;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    return AppBar(
+      automaticallyImplyLeading: false,
+      backgroundColor: VineTheme.transparent,
+      surfaceTintColor: VineTheme.transparent,
+      leadingWidth: 72,
+      leading: Padding(
+        padding: const EdgeInsets.only(left: 16),
+        child: DivineIconButton(
+          icon: DivineIconName.x,
+          type: DivineIconButtonType.ghostSecondary,
+          size: DivineIconButtonSize.small,
+          semanticLabel: l10n.imageCropEditorCloseSemanticLabel,
+          onPressed: onClose,
+        ),
+      ),
+      actions: [
+        Padding(
+          padding: const EdgeInsets.only(right: 16),
+          child: DivineIconButton(
+            icon: DivineIconName.check,
+            size: DivineIconButtonSize.small,
+            semanticLabel: l10n.imageCropEditorDoneSemanticLabel,
+            onPressed: onDone,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/screens/profile_setup/widgets/banner_editing_block.dart
+++ b/mobile/lib/screens/profile_setup/widgets/banner_editing_block.dart
@@ -275,6 +275,7 @@ class _BannerActionRow extends StatelessWidget {
     }
 
     if (cropped == null) return;
+    if (!context.mounted) return;
 
     editorBloc.add(
       ProfileBannerUploadRequested(

--- a/mobile/lib/screens/profile_setup/widgets/banner_editing_block.dart
+++ b/mobile/lib/screens/profile_setup/widgets/banner_editing_block.dart
@@ -10,6 +10,8 @@ import 'package:image_picker/image_picker.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/image_crop_launcher_provider.dart';
+import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 import 'package:openvine/widgets/vine_cached_image.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -253,23 +255,35 @@ class _BannerActionRow extends StatelessWidget {
     }
     if (picked == null) return;
 
+    final cropLauncher = container.read(imageCropLauncherProvider);
+    Uint8List? cropped;
     if (kIsWeb) {
       final bytes = await picked.readAsBytes();
-      editorBloc.add(
-        ProfileBannerUploadRequested(
-          pubkey: pk,
-          bytes: bytes,
-          filename: picked.name,
-        ),
+      if (!context.mounted) return;
+      cropped = await cropLauncher(
+        context,
+        kind: ImageCropKind.banner,
+        bytes: bytes,
       );
     } else {
-      editorBloc.add(
-        ProfileBannerUploadRequested(
-          pubkey: pk,
-          file: File(picked.path),
-        ),
+      if (!context.mounted) return;
+      cropped = await cropLauncher(
+        context,
+        kind: ImageCropKind.banner,
+        file: File(picked.path),
       );
     }
+
+    if (cropped == null) return;
+
+    editorBloc.add(
+      ProfileBannerUploadRequested(
+        pubkey: pk,
+        bytes: cropped,
+        filename: ImageCropKind.banner.filename,
+        mimeType: ImageCropKind.banner.mimeType,
+      ),
+    );
   }
 }
 

--- a/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
@@ -184,7 +184,7 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
   /// Native picks yield an [XFile] with a real filesystem path (wrapped in a
   /// `dart:io File`); web picks yield blob bytes read eagerly before the URL
   /// is revoked. Either way the image is handed to the Vine crop editor, and
-  /// the resulting cropped PNG bytes are uploaded via
+  /// the resulting cropped JPEG bytes are uploaded via
   /// `BlossomUploadService.uploadImageBytes`. The crop re-encode bounds the
   /// output dimensions and drops the original EXIF.
   Future<void> _pickImage(ImageSource source) async {

--- a/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
+++ b/mobile/lib/screens/profile_setup/widgets/profile_avatar_section.dart
@@ -10,6 +10,8 @@ import 'package:image_picker/image_picker.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/image_crop_launcher_provider.dart';
+import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_image_picker.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 import 'package:unified_logger/unified_logger.dart';
@@ -25,7 +27,6 @@ class ProfileAvatarSection extends ConsumerStatefulWidget {
 }
 
 class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
-  File? _selectedImage;
   Uint8List? _selectedImageBytes;
   final TextEditingController _pictureController = TextEditingController();
   final ImagePicker _picker = ImagePicker();
@@ -163,7 +164,6 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
     //   4. Placeholder.
     if (editorState.pendingAvatarStatus == PendingAvatarStatus.uploading) {
       if (_selectedImageBytes != null) return MemoryImage(_selectedImageBytes!);
-      if (_selectedImage != null) return FileImage(_selectedImage!);
     }
 
     final pending = editorState.pendingPictureUrl;
@@ -179,17 +179,14 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
     return null;
   }
 
-  /// Platform-aware image selection.
+  /// Platform-aware image selection with an interactive crop step.
   ///
-  /// Native (mobile + desktop): selects an [XFile] with a real filesystem
-  /// path, wraps it in `dart:io File`, and routes through
-  /// `BlossomUploadService.uploadImage` so the platform-channel EXIF
-  /// stripper runs.
-  ///
-  /// Web: `image_picker` returns an [XFile] whose `.path` is a blob URL
-  /// that `dart:io` cannot resolve, so we read the bytes directly and
-  /// route through `BlossomUploadService.uploadImageBytes`, which strips
-  /// EXIF in pure Dart and uploads from memory.
+  /// Native picks yield an [XFile] with a real filesystem path (wrapped in a
+  /// `dart:io File`); web picks yield blob bytes read eagerly before the URL
+  /// is revoked. Either way the image is handed to the Vine crop editor, and
+  /// the resulting cropped PNG bytes are uploaded via
+  /// `BlossomUploadService.uploadImageBytes`. The crop re-encode bounds the
+  /// output dimensions and drops the original EXIF.
   Future<void> _pickImage(ImageSource source) async {
     try {
       Log.info(
@@ -224,35 +221,49 @@ class _ProfileAvatarSectionState extends ConsumerState<ProfileAvatarSection> {
         return;
       }
 
+      final cropLauncher = ref.read(imageCropLauncherProvider);
+      Uint8List? cropped;
       if (kIsWeb) {
         // Resolve the blob synchronously here — once we navigate away from
         // the picker the URL can be revoked.
         final bytes = await picked.readAsBytes();
         if (!mounted) return;
-        setState(() {
-          _selectedImage = null;
-          _selectedImageBytes = bytes;
-          _pictureController.clear();
-        });
-        context.read<ProfileEditorBloc>().add(
-          ProfilePictureUploadRequested(
-            pubkey: pubkey,
-            bytes: bytes,
-            filename: picked.name,
-          ),
+        cropped = await cropLauncher(
+          context,
+          kind: ImageCropKind.avatar,
+          bytes: bytes,
         );
       } else {
         if (!mounted) return;
-        final file = File(picked.path);
-        setState(() {
-          _selectedImage = file;
-          _selectedImageBytes = null;
-          _pictureController.clear();
-        });
-        context.read<ProfileEditorBloc>().add(
-          ProfilePictureUploadRequested(pubkey: pubkey, file: file),
+        cropped = await cropLauncher(
+          context,
+          kind: ImageCropKind.avatar,
+          file: File(picked.path),
         );
       }
+
+      if (cropped == null) {
+        Log.info(
+          '❌ Avatar crop cancelled',
+          name: 'ProfileSetupScreen',
+          category: LogCategory.ui,
+        );
+        return;
+      }
+      if (!mounted) return;
+
+      setState(() {
+        _selectedImageBytes = cropped;
+        _pictureController.clear();
+      });
+      context.read<ProfileEditorBloc>().add(
+        ProfilePictureUploadRequested(
+          pubkey: pubkey,
+          bytes: cropped,
+          filename: ImageCropKind.avatar.filename,
+          mimeType: ImageCropKind.avatar.mimeType,
+        ),
+      );
     } catch (e) {
       Log.error(
         'Error picking image: $e',

--- a/mobile/packages/divine_ui/lib/src/icon/divine_icon.dart
+++ b/mobile/packages/divine_ui/lib/src/icon/divine_icon.dart
@@ -92,6 +92,7 @@ enum DivineIconName {
   filmSlate('FilmSlate'),
   fingerprint('fingerprint'),
   flag('flag'),
+  flipHorizontal('flip_horizontal'),
   follow('Icon-Follow'),
   folderOpen('folder_open'),
   funnelSimple('funnel_simple'),

--- a/mobile/packages/divine_ui/test/src/icon/divine_icon_test.dart
+++ b/mobile/packages/divine_ui/test/src/icon/divine_icon_test.dart
@@ -44,6 +44,14 @@ void main() {
       );
     });
 
+    test('flipHorizontal maps to the mirror glyph', () {
+      expect(DivineIconName.flipHorizontal.fileName, 'flip_horizontal');
+      expect(
+        DivineIconName.flipHorizontal.assetPath,
+        'assets/icon/flip_horizontal.svg',
+      );
+    });
+
     test('all enum values have non-empty file names', () {
       for (final icon in DivineIconName.values) {
         expect(

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -2494,7 +2494,11 @@ void main() {
           pendingPictureUrl: testStagedUrl,
         ),
         act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.jpg',
+          ),
         ),
         expect: () => [
           // Optimistic transition to uploading retains the prior staged URL
@@ -2554,7 +2558,11 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.jpg',
+          ),
         ),
         skip: 1, // skip the "uploading" emission, only assert final state
         expect: () => [
@@ -2587,7 +2595,11 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.jpg',
+          ),
         ),
         skip: 1,
         expect: () => [
@@ -2620,7 +2632,11 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.jpg',
+          ),
         ),
         skip: 1,
         expect: () => [
@@ -2653,7 +2669,11 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.jpg',
+          ),
         ),
         skip: 1,
         expect: () => [
@@ -2686,7 +2706,11 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.jpg',
+          ),
         ),
         skip: 1,
         expect: () => [
@@ -2713,7 +2737,11 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.jpg',
+          ),
         ),
         skip: 1,
         expect: () => [
@@ -2899,7 +2927,11 @@ void main() {
         },
         build: createBloc,
         act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, bytes: testBytes),
+          ProfilePictureUploadRequested(
+            pubkey: testPubkey,
+            bytes: testBytes,
+            filename: 'avatar.jpg',
+          ),
         ),
         verify: (_) {
           // The load-bearing invariant from reviewer bullet 6: upload alone

--- a/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
+++ b/mobile/test/blocs/profile_editor/profile_editor_bloc_test.dart
@@ -2471,55 +2471,6 @@ void main() {
       );
 
       blocTest<ProfileEditorBloc, ProfileEditorState>(
-        'ProfilePictureUploadRequested with file stages on success',
-        setUp: () {
-          when(
-            () => mockBlossomUploadService.uploadImage(
-              imageFile: any(named: 'imageFile'),
-              nostrPubkey: any(named: 'nostrPubkey'),
-              mimeType: any(named: 'mimeType'),
-            ),
-          ).thenAnswer(
-            (_) async => const BlossomUploadResult(
-              success: true,
-              url: testStagedUrl,
-              fallbackUrl: testStagedUrl,
-            ),
-          );
-        },
-        build: createBloc,
-        act: (bloc) => bloc.add(
-          ProfilePictureUploadRequested(pubkey: testPubkey, file: _FakeFile()),
-        ),
-        expect: () => [
-          isA<ProfileEditorState>().having(
-            (s) => s.pendingAvatarStatus,
-            'pendingAvatarStatus',
-            PendingAvatarStatus.uploading,
-          ),
-          isA<ProfileEditorState>()
-              .having(
-                (s) => s.pendingAvatarStatus,
-                'pendingAvatarStatus',
-                PendingAvatarStatus.staged,
-              )
-              .having(
-                (s) => s.pendingPictureUrl,
-                'pendingPictureUrl',
-                testStagedUrl,
-              ),
-        ],
-        verify: (_) {
-          verify(
-            () => mockBlossomUploadService.uploadImage(
-              imageFile: any(named: 'imageFile'),
-              nostrPubkey: testPubkey,
-            ),
-          ).called(1);
-        },
-      );
-
-      blocTest<ProfileEditorBloc, ProfileEditorState>(
         'upload failure leaves pendingPictureUrl untouched and emits failed',
         setUp: () {
           when(

--- a/mobile/test/providers/image_crop_launcher_provider_test.dart
+++ b/mobile/test/providers/image_crop_launcher_provider_test.dart
@@ -1,0 +1,21 @@
+// ABOUTME: Tests the imageCropLauncherProvider DI seam default.
+// ABOUTME: Ensures it resolves to the real showImageCropEditor by default.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/providers/image_crop_launcher_provider.dart';
+import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
+
+void main() {
+  group('imageCropLauncherProvider', () {
+    test('defaults to showImageCropEditor', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        container.read(imageCropLauncherProvider),
+        same(showImageCropEditor),
+      );
+    });
+  });
+}

--- a/mobile/test/screens/image_crop_editor/image_crop_editor_screen_test.dart
+++ b/mobile/test/screens/image_crop_editor/image_crop_editor_screen_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests the ImageCropKind config contract used by the crop editor.
 // ABOUTME: Locks the per-kind aspect ratio, output cap, filename and mime type.
 
+import 'dart:typed_data';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
@@ -19,6 +21,17 @@ void main() {
       expect(ImageCropKind.banner.maxOutputSize, const Size(1500, 500));
       expect(ImageCropKind.banner.filename, 'banner.jpg');
       expect(ImageCropKind.banner.mimeType, 'image/jpeg');
+    });
+  });
+
+  group('croppedBytesOrNull', () {
+    test('returns null for empty bytes (failed capture)', () {
+      expect(croppedBytesOrNull(Uint8List(0)), isNull);
+    });
+
+    test('returns the bytes unchanged when non-empty', () {
+      final bytes = Uint8List.fromList([1, 2, 3]);
+      expect(croppedBytesOrNull(bytes), same(bytes));
     });
   });
 }

--- a/mobile/test/screens/image_crop_editor/image_crop_editor_screen_test.dart
+++ b/mobile/test/screens/image_crop_editor/image_crop_editor_screen_test.dart
@@ -7,18 +7,18 @@ import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 
 void main() {
   group(ImageCropKind, () {
-    test('avatar locks a 1:1 frame capped at 1024 as png', () {
+    test('avatar locks a 1:1 frame capped at 1024 as jpeg', () {
       expect(ImageCropKind.avatar.aspectRatio, 1);
       expect(ImageCropKind.avatar.maxOutputSize, const Size(1024, 1024));
-      expect(ImageCropKind.avatar.filename, 'avatar.png');
-      expect(ImageCropKind.avatar.mimeType, 'image/png');
+      expect(ImageCropKind.avatar.filename, 'avatar.jpg');
+      expect(ImageCropKind.avatar.mimeType, 'image/jpeg');
     });
 
-    test('banner locks a 3:1 frame capped at 1500x500 as png', () {
+    test('banner locks a 3:1 frame capped at 1500x500 as jpeg', () {
       expect(ImageCropKind.banner.aspectRatio, 3);
       expect(ImageCropKind.banner.maxOutputSize, const Size(1500, 500));
-      expect(ImageCropKind.banner.filename, 'banner.png');
-      expect(ImageCropKind.banner.mimeType, 'image/png');
+      expect(ImageCropKind.banner.filename, 'banner.jpg');
+      expect(ImageCropKind.banner.mimeType, 'image/jpeg');
     });
   });
 }

--- a/mobile/test/screens/image_crop_editor/image_crop_editor_screen_test.dart
+++ b/mobile/test/screens/image_crop_editor/image_crop_editor_screen_test.dart
@@ -1,0 +1,24 @@
+// ABOUTME: Tests the ImageCropKind config contract used by the crop editor.
+// ABOUTME: Locks the per-kind aspect ratio, output cap, filename and mime type.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
+
+void main() {
+  group(ImageCropKind, () {
+    test('avatar locks a 1:1 frame capped at 1024 as png', () {
+      expect(ImageCropKind.avatar.aspectRatio, 1);
+      expect(ImageCropKind.avatar.maxOutputSize, const Size(1024, 1024));
+      expect(ImageCropKind.avatar.filename, 'avatar.png');
+      expect(ImageCropKind.avatar.mimeType, 'image/png');
+    });
+
+    test('banner locks a 3:1 frame capped at 1500x500 as png', () {
+      expect(ImageCropKind.banner.aspectRatio, 3);
+      expect(ImageCropKind.banner.maxOutputSize, const Size(1500, 500));
+      expect(ImageCropKind.banner.filename, 'banner.png');
+      expect(ImageCropKind.banner.mimeType, 'image/png');
+    });
+  });
+}

--- a/mobile/test/screens/image_crop_editor/widgets/image_crop_editor_bottom_bar_test.dart
+++ b/mobile/test/screens/image_crop_editor/widgets/image_crop_editor_bottom_bar_test.dart
@@ -1,0 +1,81 @@
+// ABOUTME: Widget tests for the image crop editor's bottom action bar.
+// ABOUTME: Covers the rotate/flip/reset actions, labels, and callbacks.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/image_crop_editor/widgets/image_crop_editor_bottom_bar.dart';
+
+void main() {
+  group(ImageCropEditorBottomBar, () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    Future<void> pump(
+      WidgetTester tester, {
+      VoidCallback? onRotate,
+      VoidCallback? onFlip,
+      VoidCallback? onReset,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Scaffold(
+            body: ImageCropEditorBottomBar(
+              onRotate: onRotate ?? () {},
+              onFlip: onFlip ?? () {},
+              onReset: onReset ?? () {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders the rotate, flip and reset actions', (tester) async {
+      await pump(tester);
+
+      expect(find.text(l10n.imageCropEditorRotateLabel), findsOneWidget);
+      expect(find.text(l10n.imageCropEditorFlipLabel), findsOneWidget);
+      expect(find.text(l10n.imageCropEditorResetLabel), findsOneWidget);
+      expect(find.byType(DivineIcon), findsNWidgets(3));
+    });
+
+    testWidgets('invokes onRotate when the rotate action is tapped', (
+      tester,
+    ) async {
+      var rotated = false;
+      await pump(tester, onRotate: () => rotated = true);
+
+      await tester.tap(find.text(l10n.imageCropEditorRotateLabel));
+      await tester.pump();
+
+      expect(rotated, isTrue);
+    });
+
+    testWidgets('invokes onFlip when the flip action is tapped', (
+      tester,
+    ) async {
+      var flipped = false;
+      await pump(tester, onFlip: () => flipped = true);
+
+      await tester.tap(find.text(l10n.imageCropEditorFlipLabel));
+      await tester.pump();
+
+      expect(flipped, isTrue);
+    });
+
+    testWidgets('invokes onReset when the reset action is tapped', (
+      tester,
+    ) async {
+      var reset = false;
+      await pump(tester, onReset: () => reset = true);
+
+      await tester.tap(find.text(l10n.imageCropEditorResetLabel));
+      await tester.pump();
+
+      expect(reset, isTrue);
+    });
+  });
+}

--- a/mobile/test/screens/image_crop_editor/widgets/image_crop_editor_toolbar_test.dart
+++ b/mobile/test/screens/image_crop_editor/widgets/image_crop_editor_toolbar_test.dart
@@ -1,0 +1,88 @@
+// ABOUTME: Widget tests for the image crop editor's top toolbar chrome.
+// ABOUTME: Covers close/done buttons, callbacks, and the disabled-done state.
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/screens/image_crop_editor/widgets/image_crop_editor_toolbar.dart';
+
+void main() {
+  group(ImageCropEditorToolbar, () {
+    final l10n = lookupAppLocalizations(const Locale('en'));
+
+    Finder buttonWithIcon(DivineIconName icon) => find.byWidgetPredicate(
+      (widget) => widget is DivineIconButton && widget.icon == icon,
+    );
+
+    Future<void> pump(
+      WidgetTester tester, {
+      required VoidCallback onClose,
+      VoidCallback? onDone,
+    }) {
+      return tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          theme: VineTheme.theme,
+          home: Scaffold(
+            appBar: ImageCropEditorToolbar(onClose: onClose, onDone: onDone),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders close and done buttons', (tester) async {
+      await pump(tester, onClose: () {}, onDone: () {});
+
+      expect(buttonWithIcon(DivineIconName.x), findsOneWidget);
+      expect(buttonWithIcon(DivineIconName.check), findsOneWidget);
+    });
+
+    testWidgets('invokes onClose when the close button is tapped', (
+      tester,
+    ) async {
+      var closed = false;
+      await pump(tester, onClose: () => closed = true, onDone: () {});
+
+      await tester.tap(buttonWithIcon(DivineIconName.x));
+      await tester.pump();
+
+      expect(closed, isTrue);
+    });
+
+    testWidgets('invokes onDone when the done button is tapped', (
+      tester,
+    ) async {
+      var done = false;
+      await pump(tester, onClose: () {}, onDone: () => done = true);
+
+      await tester.tap(buttonWithIcon(DivineIconName.check));
+      await tester.pump();
+
+      expect(done, isTrue);
+    });
+
+    testWidgets('disables the done button when onDone is null', (tester) async {
+      await pump(tester, onClose: () {});
+
+      final doneButton = tester.widget<DivineIconButton>(
+        buttonWithIcon(DivineIconName.check),
+      );
+      expect(doneButton.onPressed, isNull);
+    });
+
+    testWidgets('labels the buttons for screen readers', (tester) async {
+      await pump(tester, onClose: () {}, onDone: () {});
+
+      expect(
+        find.bySemanticsLabel(l10n.imageCropEditorCloseSemanticLabel),
+        findsOneWidget,
+      );
+      expect(
+        find.bySemanticsLabel(l10n.imageCropEditorDoneSemanticLabel),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/mobile/test/screens/profile_setup/banner_editing_block_test.dart
+++ b/mobile/test/screens/profile_setup/banner_editing_block_test.dart
@@ -1,0 +1,146 @@
+// ABOUTME: Widget tests for BannerEditingBlock in the profile-setup form.
+// ABOUTME: Covers the pick → crop → dispatch path via imageCropLauncherProvider.
+
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:bloc_test/bloc_test.dart';
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/image_crop_launcher_provider.dart';
+import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
+import 'package:openvine/screens/profile_setup/widgets/banner_editing_block.dart';
+
+import '../../helpers/test_provider_overrides.dart';
+
+class _MockProfileEditorBloc
+    extends MockBloc<ProfileEditorEvent, ProfileEditorState>
+    implements ProfileEditorBloc {}
+
+/// Fake crop launcher that records its invocation and returns a canned result
+/// without pumping the real editor (which needs a decodable image).
+class _FakeCropLauncher {
+  _FakeCropLauncher(this.result);
+
+  final Uint8List? result;
+  int callCount = 0;
+  ImageCropKind? lastKind;
+
+  Future<Uint8List?> launch(
+    BuildContext context, {
+    required ImageCropKind kind,
+    File? file,
+    Uint8List? bytes,
+  }) async {
+    callCount++;
+    lastKind = kind;
+    return result;
+  }
+}
+
+void main() {
+  group(BannerEditingBlock, () {
+    const testPubkeyHex =
+        'a1b2c3d4e5f6789012345678901234567890abcdef1234567890123456789012';
+
+    late MockAuthService mockAuthService;
+    late _MockProfileEditorBloc bloc;
+
+    setUp(() {
+      mockAuthService = createMockAuthService();
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(testPubkeyHex);
+      bloc = _MockProfileEditorBloc();
+      when(() => bloc.state).thenReturn(const ProfileEditorState());
+    });
+
+    Future<void> pump(
+      WidgetTester tester, {
+      ImageCropLauncher? cropLauncher,
+    }) {
+      return tester.pumpWidget(
+        testProviderScope(
+          additionalOverrides: [
+            authServiceProvider.overrideWithValue(mockAuthService),
+            if (cropLauncher != null)
+              imageCropLauncherProvider.overrideWithValue(cropLauncher),
+          ],
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            theme: VineTheme.theme,
+            home: Scaffold(
+              body: BlocProvider<ProfileEditorBloc>.value(
+                value: bloc,
+                child: const BannerEditingBlock(),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    Finder uploadButton() => find.widgetWithText(
+      OutlinedButton,
+      lookupAppLocalizations(
+        const Locale('en'),
+      ).profileSetupBannerUploadButton,
+    );
+
+    testWidgets(
+      'dispatches ProfileBannerUploadRequested with the cropped bytes',
+      (tester) async {
+        final croppedBytes = Uint8List.fromList([1, 2, 3, 4]);
+        final launcher = _FakeCropLauncher(croppedBytes);
+        await pump(tester, cropLauncher: launcher.launch);
+
+        await tester.tap(uploadButton());
+        await tester.pumpAndSettle();
+
+        expect(launcher.callCount, 1);
+        expect(launcher.lastKind, ImageCropKind.banner);
+
+        final captured = verify(() => bloc.add(captureAny())).captured;
+        expect(captured, hasLength(1));
+        final event = captured.single;
+        expect(event, isA<ProfileBannerUploadRequested>());
+        final upload = event as ProfileBannerUploadRequested;
+        expect(upload.pubkey, testPubkeyHex);
+        expect(upload.bytes, equals(croppedBytes));
+        expect(upload.file, isNull);
+        expect(upload.filename, ImageCropKind.banner.filename);
+        expect(upload.mimeType, ImageCropKind.banner.mimeType);
+      },
+    );
+
+    testWidgets('does not dispatch when the crop is cancelled', (tester) async {
+      final launcher = _FakeCropLauncher(null);
+      await pump(tester, cropLauncher: launcher.launch);
+
+      await tester.tap(uploadButton());
+      await tester.pumpAndSettle();
+
+      expect(launcher.callCount, 1);
+      verifyNever(() => bloc.add(any()));
+    });
+
+    testWidgets('skips crop and dispatch when no public key is available', (
+      tester,
+    ) async {
+      when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
+      final launcher = _FakeCropLauncher(Uint8List.fromList([1, 2, 3]));
+      await pump(tester, cropLauncher: launcher.launch);
+
+      await tester.tap(uploadButton());
+      await tester.pumpAndSettle();
+
+      expect(launcher.callCount, 0);
+      verifyNever(() => bloc.add(any()));
+    });
+  });
+}

--- a/mobile/test/screens/profile_setup/banner_editing_block_test.dart
+++ b/mobile/test/screens/profile_setup/banner_editing_block_test.dart
@@ -112,7 +112,6 @@ void main() {
         final upload = event as ProfileBannerUploadRequested;
         expect(upload.pubkey, testPubkeyHex);
         expect(upload.bytes, equals(croppedBytes));
-        expect(upload.file, isNull);
         expect(upload.filename, ImageCropKind.banner.filename);
         expect(upload.mimeType, ImageCropKind.banner.mimeType);
       },

--- a/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
+++ b/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
@@ -1,8 +1,12 @@
 // ABOUTME: Widget tests for ProfileAvatarSection in the profile-setup form.
-// ABOUTME: Covers avatar rendering and the upload progress indicator.
+// ABOUTME: Covers avatar rendering, the upload progress indicator, and the
+// ABOUTME: pick → crop → dispatch path via the imageCropLauncherProvider seam.
+
+import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -10,6 +14,8 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/profile_editor/profile_editor_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/image_crop_launcher_provider.dart';
+import 'package:openvine/screens/image_crop_editor/image_crop_editor.dart';
 import 'package:openvine/screens/profile_setup/widgets/profile_avatar_section.dart';
 import 'package:openvine/widgets/user_avatar.dart';
 
@@ -18,6 +24,27 @@ import '../../helpers/test_provider_overrides.dart';
 class _MockProfileEditorBloc
     extends MockBloc<ProfileEditorEvent, ProfileEditorState>
     implements ProfileEditorBloc {}
+
+/// Fake crop launcher that records its invocation and returns a canned result
+/// without pumping the real editor (which needs a decodable image).
+class _FakeCropLauncher {
+  _FakeCropLauncher(this.result);
+
+  final Uint8List? result;
+  int callCount = 0;
+  ImageCropKind? lastKind;
+
+  Future<Uint8List?> launch(
+    BuildContext context, {
+    required ImageCropKind kind,
+    File? file,
+    Uint8List? bytes,
+  }) async {
+    callCount++;
+    lastKind = kind;
+    return result;
+  }
+}
 
 void main() {
   group(ProfileAvatarSection, () {
@@ -41,11 +68,14 @@ void main() {
     Future<void> pump(
       WidgetTester tester, {
       TextEditingController? controller,
+      ImageCropLauncher? cropLauncher,
     }) {
       return tester.pumpWidget(
         testProviderScope(
           additionalOverrides: [
             authServiceProvider.overrideWithValue(mockAuthService),
+            if (cropLauncher != null)
+              imageCropLauncherProvider.overrideWithValue(cropLauncher),
           ],
           child: MaterialApp(
             localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -103,5 +133,86 @@ void main() {
         );
       },
     );
+
+    group('pick → crop → dispatch', () {
+      // Gallery picks route through file_selector on desktop and image_picker
+      // on mobile; force a mobile platform so the mocked image_picker channel
+      // is exercised. With camera present the source-button order is
+      // [camera, gallery, link], so gallery is the second button.
+      Finder galleryButton() => find
+          .descendant(
+            of: find.byType(ProfileAvatarSection),
+            matching: find.byType(GestureDetector),
+          )
+          .at(1);
+
+      testWidgets(
+        'dispatches ProfilePictureUploadRequested with the cropped bytes',
+        (tester) async {
+          debugDefaultTargetPlatformOverride = TargetPlatform.android;
+          try {
+            final croppedBytes = Uint8List.fromList([1, 2, 3, 4]);
+            final launcher = _FakeCropLauncher(croppedBytes);
+            await pump(tester, cropLauncher: launcher.launch);
+
+            await tester.tap(galleryButton());
+            await tester.pumpAndSettle();
+
+            expect(launcher.callCount, 1);
+            expect(launcher.lastKind, ImageCropKind.avatar);
+
+            final captured = verify(() => bloc.add(captureAny())).captured;
+            expect(captured, hasLength(1));
+            final event = captured.single;
+            expect(event, isA<ProfilePictureUploadRequested>());
+            final upload = event as ProfilePictureUploadRequested;
+            expect(upload.pubkey, testPubkeyHex);
+            expect(upload.bytes, equals(croppedBytes));
+            expect(upload.file, isNull);
+            expect(upload.filename, ImageCropKind.avatar.filename);
+            expect(upload.mimeType, ImageCropKind.avatar.mimeType);
+          } finally {
+            debugDefaultTargetPlatformOverride = null;
+          }
+        },
+      );
+
+      testWidgets('does not dispatch when the crop is cancelled', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          final launcher = _FakeCropLauncher(null);
+          await pump(tester, cropLauncher: launcher.launch);
+
+          await tester.tap(galleryButton());
+          await tester.pumpAndSettle();
+
+          expect(launcher.callCount, 1);
+          verifyNever(() => bloc.add(any()));
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+
+      testWidgets('skips crop and dispatch when no public key is available', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        try {
+          when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
+          final launcher = _FakeCropLauncher(Uint8List.fromList([1, 2, 3]));
+          await pump(tester, cropLauncher: launcher.launch);
+
+          await tester.tap(galleryButton());
+          await tester.pumpAndSettle();
+
+          expect(launcher.callCount, 0);
+          verifyNever(() => bloc.add(any()));
+        } finally {
+          debugDefaultTargetPlatformOverride = null;
+        }
+      });
+    });
   });
 }

--- a/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
+++ b/mobile/test/screens/profile_setup/profile_avatar_section_test.dart
@@ -168,7 +168,6 @@ void main() {
             final upload = event as ProfilePictureUploadRequested;
             expect(upload.pubkey, testPubkeyHex);
             expect(upload.bytes, equals(croppedBytes));
-            expect(upload.file, isNull);
             expect(upload.filename, ImageCropKind.avatar.filename);
             expect(upload.mimeType, ImageCropKind.avatar.mimeType);
           } finally {


### PR DESCRIPTION
## Description

Routes avatar (camera + gallery) and banner (gallery) picks through a new full-screen crop editor before upload, built on `pro_image_editor`'s standalone `CropRotateEditor` and wrapped in Vine chrome: a close/done app bar and a rotate / flip / reset bottom bar matching the video editor. The crop frame is locked per kind — 1:1 (square) for avatars, 3:1 for banners — and the result is re-encoded to a bounded output size (avatar 1024×1024, banner 1500×500) as a fresh JPEG (`jpegQuality: 85`), which cuts a typical avatar from ~900 KB to ~110 KB.

Rather than the silent byte guard #4272 originally proposed, this gives users an interactive crop step whose bounded re-encode caps the output dimensions (the dimension half of #4272 for these two picker sites) and drops the original EXIF as a side effect; the server-side 413 mapping stays as the existing fallback.

A few non-obvious choices worth calling out: avatars export as a square 1:1 image (not an oval mask) so every Nostr client can apply its own rounding, which `UserAvatar` already does — an oval-masked image would show transparent corners on clients that render a square avatar. After crop, both native and web dispatch the existing bytes upload path (`uploadImageBytes`), since the crop re-encode supersedes the native platform-channel EXIF stripper. The crop launcher sits behind a Riverpod provider (`imageCropLauncherProvider`) so the picker widgets stay testable without pumping the heavy editor pipeline.

Also adds a `flipHorizontal` icon to `divine_ui` (asset + enum + test) and new `imageCropEditor*` l10n keys translated into all 17 non-English locales.

<img width="322" alt="image" src="https://github.com/user-attachments/assets/ccb9ef2a-7929-4d62-8fd0-0f3806c05466" />

**Related Issue:** Closes #4272

## #4272 audit of the other picker sites

#4272 asks to audit every in-app `image_picker` → `BlossomUploadService` site, listing video thumbnail flows and bug-report image attach alongside avatar/banner. The audit's conclusion is that only avatar and banner need the crop treatment:

- **Video thumbnails are not gallery picks.** The cover is a timestamp-selected frame of the user's *own* video (`VideoEditorNotifier.updateCover`), rendered by the editor and bounded by the video resolution — there is no oversized-gallery-upload path, so there is nothing to guard.
- **Bug-report image attachments are intentionally left unlimited.** A bug screenshot must keep its detail — downscaling or re-cropping it would destroy the evidence being reported. The pick is already soft-bounded by `maxWidth: 1920` + `imageQuality: 80`, and the server-side 413 → `fileTooLarge` mapping remains the backstop. (Happy to revisit if review prefers an explicit byte cap there.)

## Out of Scope

- A standalone byte-cap validator — superseded by the bounded crop re-encode for avatar/banner.
- Aspect-ratio selection UI — ratios are locked per kind.

## Verification

- `flutter analyze lib test` — no issues.
- New widget tests for the toolbar and bottom bar (close / done / rotate / flip / reset callbacks, labels, semantics), the `ImageCropKind` config contract, and the launcher provider default.
- divine_ui suite (598), profile_setup section + screen tests, and the new crop-editor tests all green.
- `flutter gen-l10n` confirms the new keys are translated in every locale.
- Manual device verification of the live pick → crop → upload flow confirmed (avatar 1024² ≈ 110 KB JPEG).

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
