### PR TITLE
fix(video): play and visualize imported audio in lip-sync recorder

### DIFF
--- a/mobile/lib/blocs/sound_waveform/sound_waveform_bloc.dart
+++ b/mobile/lib/blocs/sound_waveform/sound_waveform_bloc.dart
@@ -1,11 +1,13 @@
 // ABOUTME: BLoC for extracting audio waveform data from sounds.
 // ABOUTME: Uses ProVideoEditor to extract amplitude samples for visualization.
 
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/models.dart' show AudioEvent, AudioSourceKind;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
@@ -31,9 +33,11 @@ class SoundWaveformBloc extends Bloc<SoundWaveformEvent, SoundWaveformState> {
     emit(const SoundWaveformLoading());
 
     try {
-      final video = event.isAsset
-          ? EditorVideo.asset(event.path)
-          : EditorVideo.network(event.path);
+      final video = switch (event.kind) {
+        AudioSourceKind.asset => EditorVideo.asset(event.path),
+        AudioSourceKind.file => EditorVideo.file(File(event.path)),
+        AudioSourceKind.network => EditorVideo.network(event.path),
+      };
 
       final configs = WaveformConfigs(video: video);
 

--- a/mobile/lib/blocs/sound_waveform/sound_waveform_event.dart
+++ b/mobile/lib/blocs/sound_waveform/sound_waveform_event.dart
@@ -8,25 +8,38 @@ sealed class SoundWaveformEvent extends Equatable {
   List<Object?> get props => [];
 }
 
-/// Extract waveform data from a sound URL or asset path.
+/// Extract waveform data from a sound source.
 class SoundWaveformExtract extends SoundWaveformEvent {
   const SoundWaveformExtract({
     required this.path,
     required this.soundId,
-    this.isAsset = false,
+    this.kind = AudioSourceKind.network,
   });
 
-  /// The URL or asset path of the sound to extract waveform from.
+  /// Build an extract event for [sound], or `null` when it has no usable
+  /// source. Resolves the correct [AudioSourceKind] (bundled asset, imported
+  /// file, or network URL) so callers don't re-derive it.
+  static SoundWaveformExtract? forSound(AudioEvent sound) {
+    final source = sound.resolvedSource;
+    if (source == null) return null;
+    return SoundWaveformExtract(
+      path: source.path,
+      soundId: sound.id,
+      kind: source.kind,
+    );
+  }
+
+  /// The asset path, file path, or URL of the sound to extract from.
   final String path;
 
   /// The sound ID for logging purposes.
   final String soundId;
 
-  /// Whether this is an asset path (true) or network URL (false).
-  final bool isAsset;
+  /// The kind of source [path] points to.
+  final AudioSourceKind kind;
 
   @override
-  List<Object?> get props => [path, soundId, isAsset];
+  List<Object?> get props => [path, soundId, kind];
 }
 
 /// Clear the current waveform data.

--- a/mobile/lib/blocs/video_editor/audio_timing/audio_timing_cubit.dart
+++ b/mobile/lib/blocs/video_editor/audio_timing/audio_timing_cubit.dart
@@ -2,10 +2,11 @@
 // ABOUTME: Handles audio playback, clipping, and offset normalization.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:models/models.dart' show AudioEvent;
+import 'package:models/models.dart' show AudioEvent, AudioSourceKind;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:sound_service/sound_service.dart';
@@ -161,14 +162,17 @@ class AudioTimingCubit extends Cubit<AudioTimingState> {
   /// Returns 0 if the audio source is unavailable or metadata extraction
   /// fails.
   Future<double> _resolveAudioDurationSecs() async {
-    final EditorVideo source;
-    if (_sound.isBundled && _sound.assetPath != null) {
-      source = EditorVideo.asset(_sound.assetPath!);
-    } else if (_sound.url != null && _sound.url!.isNotEmpty) {
-      source = EditorVideo.network(_sound.url!);
-    } else {
-      return 0;
-    }
+    final resolved = _sound.resolvedSource;
+    if (resolved == null) return 0;
+
+    // Imported audio stores an on-disk path; probing it as a network URL
+    // throws "No host specified in URI" (issue #5579). resolvedSource picks
+    // the right loader so this mirrors the recorder and waveform paths.
+    final source = switch (resolved.kind) {
+      AudioSourceKind.asset => EditorVideo.asset(resolved.path),
+      AudioSourceKind.file => EditorVideo.file(File(resolved.path)),
+      AudioSourceKind.network => EditorVideo.network(resolved.path),
+    };
 
     try {
       final metadata = await _proVideoEditor.getMetadata(source);

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -19,7 +19,7 @@ import 'package:divine_video_player/divine_video_player.dart'
 import 'package:equatable/equatable.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:models/models.dart' as model show AspectRatio;
+import 'package:models/models.dart' as model show AspectRatio, AudioSourceKind;
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
@@ -1598,7 +1598,8 @@ class VideoRecorderBloc
 
   Future<void> _prepareSoundForPlayback() async {
     final selectedSound = _readVideoEditorState().selectedSound;
-    if (selectedSound == null || selectedSound.url == null) {
+    final source = selectedSound?.resolvedSource;
+    if (selectedSound == null || source == null) {
       await _audioPlaybackService?.dispose();
       _audioPlaybackService = null;
       return;
@@ -1608,7 +1609,13 @@ class VideoRecorderBloc
       _audioPlaybackService ??= _audioPlaybackServiceFactory();
 
       await _audioPlaybackService!.configureForRecording();
-      await _audioPlaybackService!.loadAudio(selectedSound.url!);
+      // Imported audio is an on-disk file; loading it via loadAudio would
+      // parse the path as a URL and fail with iOS "unsupported URL".
+      if (source.kind == model.AudioSourceKind.file) {
+        await _audioPlaybackService!.loadAudioFromFile(source.path);
+      } else {
+        await _audioPlaybackService!.loadAudio(selectedSound.url!);
+      }
 
       final clipManager = _readClipManager();
       final startPosition =

--- a/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
+++ b/mobile/lib/screens/video_editor/video_audio_editor_timing_screen.dart
@@ -178,20 +178,9 @@ class _VideoAudioEditorTimingScreenState
   }
 
   void _extractWaveform() {
-    final sound = widget.sound;
-
-    if (sound.isBundled && sound.assetPath != null) {
-      _waveformBloc.add(
-        SoundWaveformExtract(
-          path: sound.assetPath!,
-          soundId: sound.id,
-          isAsset: true,
-        ),
-      );
-    } else if (sound.url != null) {
-      _waveformBloc.add(
-        SoundWaveformExtract(path: sound.url!, soundId: sound.id),
-      );
+    final event = SoundWaveformExtract.forSound(widget.sound);
+    if (event != null) {
+      _waveformBloc.add(event);
     }
   }
 

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -350,29 +350,9 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
       return;
     }
 
-    // Handle bundled sounds (from app assets)
-    if (sound.isBundled) {
-      final assetPath = sound.assetPath;
-      Log.info(
-        '🎵 Bundled sound assetPath: $assetPath',
-        name: 'VideoRecorderScreen',
-        category: LogCategory.video,
-      );
-      if (assetPath != null) {
-        bloc.add(
-          SoundWaveformExtract(
-            path: assetPath,
-            soundId: sound.id,
-            isAsset: true,
-          ),
-        );
-      }
-      return;
-    }
-
-    // Handle network sounds
-    if (sound.url != null) {
-      bloc.add(SoundWaveformExtract(path: sound.url!, soundId: sound.id));
+    final event = SoundWaveformExtract.forSound(sound);
+    if (event != null) {
+      bloc.add(event);
     }
   }
 

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -10,6 +10,21 @@ import 'package:nostr_sdk/event.dart';
 /// Kind number for audio file metadata events (NIP-94)
 const int audioEventKind = 1063;
 
+/// The kind of underlying media source backing an [AudioEvent].
+///
+/// Used to pick the correct loading strategy: a bundled [asset], an
+/// on-disk [file] (imported audio), or a remote [network] URL.
+enum AudioSourceKind {
+  /// Bundled app asset (`asset://…`).
+  asset,
+
+  /// Local file on disk (imported audio).
+  file,
+
+  /// Remote `http`/`https` URL.
+  network,
+}
+
 /// Represents an audio file metadata event (Kind 1063)
 /// for the audio reuse feature.
 ///
@@ -268,6 +283,33 @@ class AudioEvent {
       return url!.substring(prefix.length);
     }
     return null;
+  }
+
+  /// Classifies the playable source for this audio and returns the matching
+  /// path, or `null` when no usable source exists.
+  ///
+  /// Imported audio stores its on-disk path in [url]; it must be loaded as a
+  /// file rather than parsed as a network URL (which fails with "No host
+  /// specified in URI" / iOS "unsupported URL"). Bundled sounds expose a bare
+  /// asset path. Centralising this mapping keeps call sites from re-deriving
+  /// it and mis-handling local imports.
+  ({AudioSourceKind kind, String path})? get resolvedSource {
+    if (isBundled) {
+      final path = assetPath;
+      return path == null || path.isEmpty
+          ? null
+          : (kind: AudioSourceKind.asset, path: path);
+    }
+    if (isLocalImport) {
+      final path = localFilePath;
+      return path == null || path.isEmpty
+          ? null
+          : (kind: AudioSourceKind.file, path: path);
+    }
+    final path = url;
+    return path == null || path.isEmpty
+        ? null
+        : (kind: AudioSourceKind.network, path: path);
   }
 
   /// The Nostr event ID (64-character hex string).

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -292,8 +292,13 @@ class AudioEvent {
   /// Imported audio stores its on-disk path in [url]; it must be loaded as a
   /// file rather than parsed as a network URL (which fails with "No host
   /// specified in URI" / iOS "unsupported URL"). Bundled sounds expose a bare
-  /// asset path. Centralising this mapping keeps call sites from re-deriving
-  /// it and mis-handling local imports.
+  /// asset path. Bare absolute paths (`/var/mobile/...`) and `file://` URIs —
+  /// e.g. clip-extracted J-cut audio whose [url] is a raw on-disk path — are
+  /// also classified as files, matching the `#4395` file-vs-network guard used
+  /// at the duration/render/waveform call sites so this getter is a true
+  /// superset they can migrate onto without reintroducing that bug. Everything
+  /// else (`http(s)`, plus unhandled schemes like `content://`/`blob:`) is
+  /// network.
   ({AudioSourceKind kind, String path})? get resolvedSource {
     if (isBundled) {
       final path = assetPath;
@@ -307,10 +312,21 @@ class AudioEvent {
           ? null
           : (kind: AudioSourceKind.file, path: path);
     }
-    final path = url;
-    return path == null || path.isEmpty
-        ? null
-        : (kind: AudioSourceKind.network, path: path);
+    final rawUrl = url;
+    if (rawUrl == null || rawUrl.isEmpty) return null;
+    final parsed = Uri.tryParse(rawUrl);
+    final isLocalFile =
+        parsed == null ||
+        parsed.scheme.isEmpty ||
+        parsed.scheme == 'file' ||
+        rawUrl.startsWith('/');
+    if (isLocalFile) {
+      final filePath = parsed != null && parsed.scheme == 'file'
+          ? parsed.toFilePath()
+          : rawUrl;
+      return (kind: AudioSourceKind.file, path: filePath);
+    }
+    return (kind: AudioSourceKind.network, path: rawUrl);
   }
 
   /// The Nostr event ID (64-character hex string).

--- a/mobile/packages/models/lib/src/audio_event.dart
+++ b/mobile/packages/models/lib/src/audio_event.dart
@@ -15,7 +15,8 @@ const int audioEventKind = 1063;
 /// Used to pick the correct loading strategy: a bundled [asset], an
 /// on-disk [file] (imported audio), or a remote [network] URL.
 enum AudioSourceKind {
-  /// Bundled app asset (`asset://…`).
+  /// Bundled app asset. The resolved path is the bare asset path, with the
+  /// `asset://` scheme stripped.
   asset,
 
   /// Local file on disk (imported audio).

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -468,6 +468,42 @@ void main() {
         );
       });
 
+      test('classifies a bare absolute path as a file source', () {
+        // Clip-extracted J-cut audio: not a `local_import_` id, `url` is a
+        // raw on-disk path (clip_editor_bloc writes `result.audioFilePath`).
+        const event = AudioEvent(
+          id: 'local_extracted_1700000000000',
+          pubkey: '',
+          createdAt: 0,
+          url: '/var/mobile/clip_audio/extracted.m4a',
+        );
+
+        expect(
+          event.resolvedSource,
+          equals((
+            kind: AudioSourceKind.file,
+            path: '/var/mobile/clip_audio/extracted.m4a',
+          )),
+        );
+      });
+
+      test('classifies a file:// URI as a file source', () {
+        const event = AudioEvent(
+          id: 'local_extracted_1700000000000',
+          pubkey: '',
+          createdAt: 0,
+          url: 'file:///var/mobile/clip_audio/extracted.m4a',
+        );
+
+        expect(
+          event.resolvedSource,
+          equals((
+            kind: AudioSourceKind.file,
+            path: '/var/mobile/clip_audio/extracted.m4a',
+          )),
+        );
+      });
+
       test('returns null when no source url is present', () {
         const event = AudioEvent(id: 'empty', pubkey: 'abc', createdAt: 0);
 

--- a/mobile/packages/models/test/src/audio_event_test.dart
+++ b/mobile/packages/models/test/src/audio_event_test.dart
@@ -413,6 +413,68 @@ void main() {
       });
     });
 
+    group('resolvedSource', () {
+      test('classifies imported audio as a file source', () {
+        final event = AudioEvent.fromLocalImport(
+          id: 'local_import_1700000000000',
+          filePath: '/var/mobile/draft_audio/import.mp3',
+          createdAt: 1700000000,
+          title: 'import',
+          mimeType: 'audio/mpeg',
+        );
+
+        expect(
+          event.resolvedSource,
+          equals((
+            kind: AudioSourceKind.file,
+            path: '/var/mobile/draft_audio/import.mp3',
+          )),
+        );
+      });
+
+      test('classifies bundled sounds as an asset source', () {
+        final event = AudioEvent.fromBundledSound(
+          VineSound(
+            id: 'bruh',
+            title: 'Bruh',
+            assetPath: 'assets/sounds/bruh.mp3',
+            duration: const Duration(seconds: 1),
+          ),
+        );
+
+        expect(
+          event.resolvedSource,
+          equals((
+            kind: AudioSourceKind.asset,
+            path: 'assets/sounds/bruh.mp3',
+          )),
+        );
+      });
+
+      test('classifies remote sounds as a network source', () {
+        const event = AudioEvent(
+          id: 'remote',
+          pubkey: 'abc',
+          createdAt: 0,
+          url: 'https://example.com/audio.mp3',
+        );
+
+        expect(
+          event.resolvedSource,
+          equals((
+            kind: AudioSourceKind.network,
+            path: 'https://example.com/audio.mp3',
+          )),
+        );
+      });
+
+      test('returns null when no source url is present', () {
+        const event = AudioEvent(id: 'empty', pubkey: 'abc', createdAt: 0);
+
+        expect(event.resolvedSource, isNull);
+      });
+    });
+
     group('external provider metadata', () {
       test('round trips external source and license metadata through JSON', () {
         const audioEvent = AudioEvent(

--- a/mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart
+++ b/mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
 import 'package:openvine/blocs/sound_waveform/sound_waveform_bloc.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
@@ -149,11 +150,80 @@ void main() {
           const SoundWaveformExtract(
             path: 'assets/sounds/test.mp3',
             soundId: 'bundled-sound-id',
-            isAsset: true,
+            kind: AudioSourceKind.asset,
           ),
         ),
         expect: () => [isA<SoundWaveformLoading>(), isA<SoundWaveformLoaded>()],
       );
+
+      blocTest<SoundWaveformBloc, SoundWaveformState>(
+        'handles local file path extraction',
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const SoundWaveformExtract(
+            path: '/var/mobile/Containers/Data/draft_audio/import.mp3',
+            soundId: 'local_import_1',
+            kind: AudioSourceKind.file,
+          ),
+        ),
+        expect: () => [isA<SoundWaveformLoading>(), isA<SoundWaveformLoaded>()],
+      );
+    });
+
+    group('$SoundWaveformExtract.forSound', () {
+      test('returns a file-kind event for imported audio', () {
+        final sound = AudioEvent.fromLocalImport(
+          id: '${AudioEvent.localImportMarker}_1',
+          filePath: '/var/mobile/Containers/Data/draft_audio/import.mp3',
+          createdAt: 0,
+          title: 'Imported',
+          mimeType: 'audio/mpeg',
+        );
+
+        final event = SoundWaveformExtract.forSound(sound);
+
+        expect(event, isNotNull);
+        expect(event!.kind, AudioSourceKind.file);
+        expect(event.path, sound.localFilePath);
+      });
+
+      test('returns an asset-kind event for bundled sounds', () {
+        final sound = AudioEvent.fromBundledSound(
+          VineSound(
+            id: 'wednesday',
+            title: 'Wednesday',
+            assetPath: 'assets/sounds/wednesday.mp3',
+            duration: const Duration(seconds: 6),
+          ),
+        );
+
+        final event = SoundWaveformExtract.forSound(sound);
+
+        expect(event, isNotNull);
+        expect(event!.kind, AudioSourceKind.asset);
+        expect(event.path, sound.assetPath);
+      });
+
+      test('returns a network-kind event for remote sounds', () {
+        const sound = AudioEvent(
+          id: 'remote',
+          pubkey: 'abc',
+          createdAt: 0,
+          url: 'https://example.com/audio.mp3',
+        );
+
+        final event = SoundWaveformExtract.forSound(sound);
+
+        expect(event, isNotNull);
+        expect(event!.kind, AudioSourceKind.network);
+        expect(event.path, 'https://example.com/audio.mp3');
+      });
+
+      test('returns null when the sound has no usable source', () {
+        const sound = AudioEvent(id: 'no-source', pubkey: 'abc', createdAt: 0);
+
+        expect(SoundWaveformExtract.forSound(sound), isNull);
+      });
     });
 
     group(SoundWaveformClear, () {
@@ -214,12 +284,12 @@ void main() {
       expect(event1, isNot(equals(event2)));
     });
 
-    test('$SoundWaveformExtract isAsset prop affects equality', () {
+    test('$SoundWaveformExtract kind prop affects equality', () {
       const event1 = SoundWaveformExtract(path: 'test.mp3', soundId: 'sound-1');
       const event2 = SoundWaveformExtract(
         path: 'test.mp3',
         soundId: 'sound-1',
-        isAsset: true,
+        kind: AudioSourceKind.asset,
       );
       expect(event1, isNot(equals(event2)));
     });

--- a/mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart
+++ b/mobile/test/blocs/sound_waveform/sound_waveform_bloc_test.dart
@@ -15,6 +15,11 @@ class _MockProVideoEditor extends ProVideoEditor {
   late Float32List leftChannel;
   Float32List? rightChannel;
 
+  /// The source the bloc built from the extract event's [AudioSourceKind].
+  /// Captured so tests can assert the file-vs-network mapping rather than
+  /// just the resulting state.
+  EditorVideo? lastWaveformSource;
+
   _MockProVideoEditor() {
     // Default waveform data
     leftChannel = Float32List.fromList([0.1, 0.5, 0.9, 0.3, 0.7]);
@@ -31,6 +36,7 @@ class _MockProVideoEditor extends ProVideoEditor {
     WaveformConfigs configs, {
     NativeLogLevel? nativeLogLevel,
   }) async {
+    lastWaveformSource = configs.video;
     if (shouldThrowError) {
       throw Exception('Waveform extraction failed');
     }
@@ -143,8 +149,12 @@ void main() {
         errors: () => [isA<Exception>()],
       );
 
+      // The mapping at sound_waveform_bloc.dart:36-40 turns each
+      // AudioSourceKind into the matching EditorVideo source. These tests
+      // assert the built source (not just the resulting state) so a regression
+      // that maps file → network (issue #5579) fails loudly.
       blocTest<SoundWaveformBloc, SoundWaveformState>(
-        'handles asset path extraction',
+        'builds an asset source for asset-kind extraction',
         build: buildBloc,
         act: (bloc) => bloc.add(
           const SoundWaveformExtract(
@@ -154,10 +164,17 @@ void main() {
           ),
         ),
         expect: () => [isA<SoundWaveformLoading>(), isA<SoundWaveformLoaded>()],
+        verify: (_) {
+          final source = mockProVideoEditor.lastWaveformSource;
+          expect(source?.hasAssetPath, isTrue);
+          expect(source?.assetPath, equals('assets/sounds/test.mp3'));
+          expect(source?.hasFile, isFalse);
+          expect(source?.hasNetworkUrl, isFalse);
+        },
       );
 
       blocTest<SoundWaveformBloc, SoundWaveformState>(
-        'handles local file path extraction',
+        'builds a file source for file-kind extraction',
         build: buildBloc,
         act: (bloc) => bloc.add(
           const SoundWaveformExtract(
@@ -167,6 +184,38 @@ void main() {
           ),
         ),
         expect: () => [isA<SoundWaveformLoading>(), isA<SoundWaveformLoaded>()],
+        verify: (_) {
+          final source = mockProVideoEditor.lastWaveformSource;
+          expect(source?.hasFile, isTrue);
+          expect(
+            source?.file?.path,
+            equals('/var/mobile/Containers/Data/draft_audio/import.mp3'),
+          );
+          expect(source?.hasNetworkUrl, isFalse);
+          expect(source?.hasAssetPath, isFalse);
+        },
+      );
+
+      blocTest<SoundWaveformBloc, SoundWaveformState>(
+        'builds a network source for network-kind extraction',
+        build: buildBloc,
+        act: (bloc) => bloc.add(
+          const SoundWaveformExtract(
+            path: 'https://example.com/audio.mp3',
+            soundId: 'remote-sound-id',
+          ),
+        ),
+        expect: () => [isA<SoundWaveformLoading>(), isA<SoundWaveformLoaded>()],
+        verify: (_) {
+          final source = mockProVideoEditor.lastWaveformSource;
+          expect(source?.hasNetworkUrl, isTrue);
+          expect(
+            source?.networkUrl,
+            equals('https://example.com/audio.mp3'),
+          );
+          expect(source?.hasFile, isFalse);
+          expect(source?.hasAssetPath, isFalse);
+        },
       );
     });
 

--- a/mobile/test/blocs/video_editor/audio_timing/audio_timing_cubit_test.dart
+++ b/mobile/test/blocs/video_editor/audio_timing/audio_timing_cubit_test.dart
@@ -278,6 +278,38 @@ void main() {
         },
       );
 
+      test(
+        'resolves imported-audio duration from a file source, not a URL',
+        () async {
+          final editor = _MockProVideoEditor(
+            metadataDuration: const Duration(seconds: 12),
+          );
+          final cubit = buildCubit(
+            // No duration → forces metadata resolution.
+            sound: AudioEvent.fromLocalImport(
+              id: '${AudioEvent.localImportMarker}_1',
+              filePath: '/var/mobile/draft_audio/import.mp3',
+              createdAt: 0,
+              title: 'Imported',
+              mimeType: 'audio/mpeg',
+            ),
+            proVideoEditor: editor,
+          );
+
+          await cubit.initialize();
+
+          expect(editor.getMetadataCallCount, equals(1));
+          expect(editor.lastMetadataSource?.hasFile, isTrue);
+          expect(
+            editor.lastMetadataSource?.file?.path,
+            equals('/var/mobile/draft_audio/import.mp3'),
+          );
+          expect(cubit.state.audioDuration, equals(12));
+
+          await cubit.close();
+        },
+      );
+
       blocTest<AudioTimingCubit, AudioTimingState>(
         'handles bundled sound with asset path',
         build: () => buildCubit(sound: _createBundledSound()),

--- a/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
+++ b/mobile/test/blocs/video_recorder/video_recorder_bloc_test.dart
@@ -7,7 +7,7 @@ import 'package:divine_camera/divine_camera.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:models/models.dart' as model show AspectRatio;
+import 'package:models/models.dart' as model show AspectRatio, AudioEvent;
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
@@ -22,6 +22,7 @@ import 'package:path_provider_platform_interface/path_provider_platform_interfac
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:sound_service/sound_service.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:wakelock_plus_platform_interface/wakelock_plus_platform_interface.dart';
 
@@ -81,6 +82,8 @@ class _GatedWakelockPlatform extends WakelockPlusPlatformInterface {
 class _MockProVideoEditor extends Mock
     with MockPlatformInterfaceMixin
     implements ProVideoEditor {}
+
+class _MockAudioPlaybackService extends Mock implements AudioPlaybackService {}
 
 void main() {
   late _MockCameraService cameraService;
@@ -725,6 +728,81 @@ void main() {
               maxDuration: any(named: 'maxDuration'),
             ),
           );
+        },
+      );
+    });
+
+    group('sound playback source selection', () {
+      late _MockAudioPlaybackService audioService;
+
+      setUp(() {
+        audioService = _MockAudioPlaybackService();
+        when(audioService.configureForRecording).thenAnswer((_) async {});
+        when(
+          () => audioService.loadAudio(any()),
+        ).thenAnswer((_) async => const Duration(seconds: 5));
+        when(
+          () => audioService.loadAudioFromFile(any()),
+        ).thenAnswer((_) async => const Duration(seconds: 5));
+        when(audioService.play).thenAnswer((_) async {});
+        when(audioService.dispose).thenAnswer((_) async {});
+        when(
+          () => cameraService.startRecording(
+            maxDuration: any(named: 'maxDuration'),
+          ),
+        ).thenAnswer((_) async => true);
+      });
+
+      VideoRecorderBloc buildBlocWithSound(model.AudioEvent sound) {
+        return VideoRecorderBloc(
+          readClipManager: () => clipManager,
+          readVideoEditor: () => videoEditor,
+          readVideoEditorState: () =>
+              VideoEditorProviderState(selectedSound: sound),
+          readSharedPreferences: () => prefs,
+          cameraService: cameraService,
+          audioPlaybackServiceFactory: () => audioService,
+        );
+      }
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'loads imported audio from file instead of parsing it as a URL',
+        build: () => buildBlocWithSound(
+          model.AudioEvent.fromLocalImport(
+            id: '${model.AudioEvent.localImportMarker}_1',
+            filePath: '/var/mobile/draft_audio/import.mp3',
+            createdAt: 0,
+            title: 'Imported',
+            mimeType: 'audio/mpeg',
+          ),
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
+        verify: (_) {
+          verify(
+            () => audioService.loadAudioFromFile(
+              '/var/mobile/draft_audio/import.mp3',
+            ),
+          ).called(1);
+          verifyNever(() => audioService.loadAudio(any()));
+        },
+      );
+
+      blocTest<VideoRecorderBloc, VideoRecorderBlocState>(
+        'loads remote audio via loadAudio',
+        build: () => buildBlocWithSound(
+          const model.AudioEvent(
+            id: 'remote',
+            pubkey: 'abc',
+            createdAt: 0,
+            url: 'https://example.com/audio.mp3',
+          ),
+        ),
+        act: (bloc) => bloc.add(const VideoRecorderRecordingStartRequested()),
+        verify: (_) {
+          verify(
+            () => audioService.loadAudio('https://example.com/audio.mp3'),
+          ).called(1);
+          verifyNever(() => audioService.loadAudioFromFile(any()));
         },
       );
     });


### PR DESCRIPTION
## What

Imported (local) audio now plays and renders a waveform in the lip-sync recorder. Previously a user who imported their own audio file heard nothing when they hit record, and saw no waveform — only bundled and Nostr sounds worked.

## Why

Imported audio stores its on-disk path in `AudioEvent.url` (e.g. `/var/mobile/.../import.mp3`). Two paths treated that path as a URL:

- **No sound** (the reported symptom): the recorder loaded it via `AudioPlaybackService.loadAudio(url)`, which runs the value through `Uri.parse` and hands a scheme-less path to the iOS player → `(-1002) unsupported URL`.
- **No waveform**: `SoundWaveformBloc` called `EditorVideo.network(localPath)` → `No host specified in URI`.

Bundled/Nostr sounds worked because their URLs carry an `asset://` or `http(s)` scheme. The video-editor timeline playback already handled bare paths correctly (`AudioSourceConfig.file`); only the recorder + waveform paths were wrong.

## How

The "asset vs file vs network" decision was duplicated across three call sites and two of them were wrong for local imports, so I centralized it on the model instead of fixing each spot in isolation:

- `AudioEvent` gains an `AudioSourceKind` enum and a `resolvedSource` getter (`asset` / `file` / `network`).
- The recorder loads `file`-kind sources with `loadAudioFromFile`; everything else via `loadAudio`.
- `SoundWaveformExtract.forSound(...)` builds the correct event kind, and the bloc maps it to `EditorVideo.asset` / `.file` / `.network`. Both dispatch screens use it.

## Tests

- `resolvedSource` classification (models package).
- `SoundWaveformExtract.forSound` + a `file`-kind waveform extraction.
- Recorder regression: imported audio → `loadAudioFromFile` (not `loadAudio`); remote → `loadAudio`.

`flutter analyze lib test` clean (app + models); affected bloc suites and both changed screen widget tests pass.

## Manual test plan

- Lip-sync → import your own audio → hit record: you should hear the audio and see its waveform.
- Bundled sound and a Nostr/remote sound still play + show a waveform (no regression).

Closes #5579