### PR TITLE
fix(video-editor): reconcile orphan-only undo/redo state

### DIFF
--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:db_client/db_client.dart' show ClipsDao, DraftsDao;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -93,6 +94,22 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
   Timer? _autosaveTimer;
 
+  /// Clip/thumbnail files an autosave stopped referencing this session.
+  ///
+  /// They may still be reachable through the editor's undo/redo history (e.g.
+  /// the pre-split source clip after a split), so deleting them mid-session
+  /// breaks undo/redo — it lands on a clip whose source file is gone. We hold
+  /// them here and reap them on teardown via [_flushDeferredFileCleanup], once
+  /// the history that could resurrect them no longer exists. The reaper still
+  /// runs each path through the reference check, so a file the user restored
+  /// (and a later autosave re-referenced) is kept.
+  final Set<String> _deferredFileCleanup = {};
+
+  /// DAOs captured while a valid [Ref] is in scope, so the teardown reaper can
+  /// run from `onDispose` without reading providers after disposal.
+  DraftsDao? _deferredCleanupDraftsDao;
+  ClipsDao? _deferredCleanupClipsDao;
+
   /// Get clip manager notifier.
   ClipManagerNotifier get _clipManager =>
       ref.read(clipManagerProvider.notifier);
@@ -124,6 +141,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   VideoEditorProviderState build() {
     ref.onDispose(() {
       _autosaveTimer?.cancel();
+      // The session is over, so the undo/redo history that protected these
+      // files is gone — reap whatever is still unreferenced. Best-effort and
+      // fire-and-forget: the editor is tearing down.
+      unawaited(_flushDeferredFileCleanup());
       Log.debug(
         '🧹 VideoEditorNotifier disposed',
         name: 'VideoEditorNotifier',
@@ -676,7 +697,16 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
 
     try {
       final draft = getActiveDraft(isAutosave: isAutosavedDraft);
-      await _draftService.saveDraft(draft);
+      // Defer orphan cleanup: files this autosave drops may still be reachable
+      // through the live undo/redo history (see [_deferredFileCleanup]).
+      final db = ref.read(databaseProvider);
+      _deferredCleanupDraftsDao = db.draftsDao;
+      _deferredCleanupClipsDao = db.clipsDao;
+      await _draftService.saveDraft(
+        draft,
+        deferOrphanCleanup: (paths) =>
+            _deferredFileCleanup.addAll(paths.whereType<String>()),
+      );
 
       Log.info(
         '✅ Autosave completed - $clipCount clip(s), '
@@ -697,6 +727,34 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       return false;
     }
   }
+
+  /// Reap the clip/thumbnail files deferred during this session (see
+  /// [_deferredFileCleanup]). Runs once on teardown. Each path still goes
+  /// through the draft/library reference check, so anything a surviving draft
+  /// (or the library) references is kept — only genuinely-orphaned files are
+  /// removed.
+  Future<void> _flushDeferredFileCleanup() async {
+    if (_deferredFileCleanup.isEmpty) return;
+    final draftsDao = _deferredCleanupDraftsDao;
+    final clipsDao = _deferredCleanupClipsDao;
+    if (draftsDao == null || clipsDao == null) return;
+
+    final paths = _deferredFileCleanup.toList();
+    _deferredFileCleanup.clear();
+    await FileCleanupService.deleteFilesIfUnreferenced(
+      paths,
+      draftsDao: draftsDao,
+      clipsDao: clipsDao,
+    );
+  }
+
+  /// Test hook: the set of files awaiting teardown cleanup.
+  @visibleForTesting
+  Set<String> get deferredFileCleanupForTest => _deferredFileCleanup;
+
+  /// Test hook: run the teardown cleanup synchronously.
+  @visibleForTesting
+  Future<void> flushDeferredFileCleanupForTest() => _flushDeferredFileCleanup();
 
   /// Save the current video project as a draft.
   ///

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -99,10 +99,11 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   /// They may still be reachable through the editor's undo/redo history (e.g.
   /// the pre-split source clip after a split), so deleting them mid-session
   /// breaks undo/redo — it lands on a clip whose source file is gone. We hold
-  /// them here and reap them on teardown via [_flushDeferredFileCleanup], once
-  /// the history that could resurrect them no longer exists. The reaper still
-  /// runs each path through the reference check, so a file the user restored
-  /// (and a later autosave re-referenced) is kept.
+  /// them here and reap them at editor-session end via
+  /// [_flushDeferredFileCleanup] ([reset], with [build]'s `onDispose` as a
+  /// teardown safety net), once the history that could resurrect them no longer
+  /// exists. The reaper still runs each path through the reference check, so a
+  /// file the user restored (and a later autosave re-referenced) is kept.
   final Set<String> _deferredFileCleanup = {};
 
   /// DAOs captured while a valid [Ref] is in scope, so the teardown reaper can
@@ -141,9 +142,10 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   VideoEditorProviderState build() {
     ref.onDispose(() {
       _autosaveTimer?.cancel();
-      // The session is over, so the undo/redo history that protected these
-      // files is gone — reap whatever is still unreferenced. Best-effort and
-      // fire-and-forget: the editor is tearing down.
+      // Safety net for files [reset] didn't already reap (e.g. a crash before
+      // session end). Best-effort and fire-and-forget: the container is tearing
+      // down. On mobile this often never fires (OS kill), which is why [reset]
+      // is the primary reaper.
       unawaited(_flushDeferredFileCleanup());
       Log.debug(
         '🧹 VideoEditorNotifier disposed',
@@ -235,6 +237,12 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   ///
   /// Also cancels any pending autosave and deletes the autosaved draft
   /// unless [keepAutosavedDraft] is true.
+  ///
+  /// This is the editor-session boundary (publish, discard, start-over), so it
+  /// reaps any [_deferredFileCleanup] now that the undo/redo history protecting
+  /// those files is gone. [build]'s `onDispose` only fires at container
+  /// teardown (app shutdown), which a mobile OS kill routinely skips — relying
+  /// on it alone would leak the deferred files for the whole app run.
   Future<void> reset({bool keepAutosavedDraft = false}) async {
     Log.debug(
       '🔄 Resetting editor state',
@@ -246,6 +254,7 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
         .isAudioSharingEnabled;
     state = VideoEditorProviderState(allowAudioReuse: audioSharingEnabled);
     _autosaveTimer?.cancel();
+    unawaited(_flushDeferredFileCleanup());
     draftId = null;
     if (!keepAutosavedDraft) {
       unawaited(removeAutosavedDraft());
@@ -729,10 +738,11 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
   }
 
   /// Reap the clip/thumbnail files deferred during this session (see
-  /// [_deferredFileCleanup]). Runs once on teardown. Each path still goes
-  /// through the draft/library reference check, so anything a surviving draft
-  /// (or the library) references is kept — only genuinely-orphaned files are
-  /// removed.
+  /// [_deferredFileCleanup]). Runs at editor-session end ([reset]) and as a
+  /// teardown safety net ([build]'s `onDispose`); both call it, and it clears
+  /// the set so a second call is a no-op. Each path still goes through the
+  /// draft/library reference check, so anything a surviving draft (or the
+  /// library) references is kept — only genuinely-orphaned files are removed.
   Future<void> _flushDeferredFileCleanup() async {
     if (_deferredFileCleanup.isEmpty) return;
     final draftsDao = _deferredCleanupDraftsDao;
@@ -748,13 +758,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
     );
   }
 
-  /// Test hook: the set of files awaiting teardown cleanup.
+  /// Test hook: the set of files awaiting cleanup.
   @visibleForTesting
   Set<String> get deferredFileCleanupForTest => _deferredFileCleanup;
-
-  /// Test hook: run the teardown cleanup synchronously.
-  @visibleForTesting
-  Future<void> flushDeferredFileCleanupForTest() => _flushDeferredFileCleanup();
 
   /// Save the current video project as a draft.
   ///

--- a/mobile/lib/services/draft_storage_service.dart
+++ b/mobile/lib/services/draft_storage_service.dart
@@ -144,8 +144,15 @@ class DraftStorageService {
   }
 
   /// Save a draft to storage. If a draft with the same ID exists, it will be
-  /// updated. When updating, orphaned clip files (video/thumbnail) from the
-  /// old draft are deleted.
+  /// updated. When updating, clip/thumbnail files the old draft referenced but
+  /// the new one no longer does are orphaned.
+  ///
+  /// By default those orphans are deleted immediately. Pass
+  /// [deferOrphanCleanup] to instead hand the candidate paths to the caller —
+  /// the active editor session uses this to keep files that are still reachable
+  /// through its undo/redo history alive until teardown. Deleting them mid-
+  /// session would land undo/redo on a clip whose source file is gone
+  /// (`COMPOSITION_ERROR`); the session reaps them once that history is gone.
   ///
   /// Throws a `SqliteException` if the underlying Drift read/write fails —
   /// e.g. the database is locked, the disk is full, or the file is corrupt.
@@ -153,7 +160,10 @@ class DraftStorageService {
   /// per the reportability matrix they are expected rather than bugs. Orphaned
   /// clip-file deletions are best-effort: their failures are logged and
   /// swallowed, never thrown.
-  Future<void> saveDraft(DivineVideoDraft draft) async {
+  Future<void> saveDraft(
+    DivineVideoDraft draft, {
+    void Function(List<String?> orphanPaths)? deferOrphanCleanup,
+  }) async {
     Log.debug(
       '💾 Saving draft: ${draft.id}',
       name: 'DraftStorageService',
@@ -245,12 +255,19 @@ class DraftStorageService {
       ownerPubkey: ownerPubkey,
     );
 
-    // Delete orphaned files only after the new draft/clip rows are committed.
-    await FileCleanupService.deleteFilesIfUnreferenced(
-      orphanedFiles,
-      draftsDao: _draftsDao,
-      clipsDao: _clipsDao,
-    );
+    // Reap orphaned files only after the new draft/clip rows are committed, so
+    // this draft's old indexed references no longer protect them. When the
+    // caller defers, hand over the candidates instead — they may still be
+    // reachable through the editor's live undo/redo history.
+    if (deferOrphanCleanup != null) {
+      deferOrphanCleanup(orphanedFiles);
+    } else {
+      await FileCleanupService.deleteFilesIfUnreferenced(
+        orphanedFiles,
+        draftsDao: _draftsDao,
+        clipsDao: _clipsDao,
+      );
+    }
   }
 
   /// Get total count of drafts without loading their data.

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -45,6 +45,28 @@ import 'package:pro_image_editor/pro_image_editor.dart'
     hide AudioTrack, VideoClip;
 import 'package:unified_logger/unified_logger.dart';
 
+/// Direction an undo/redo navigation moved, used to bias which way
+/// [VideoEditorCanvas.resolveClipSnapshotSync] steps past an orphan-only
+/// history entry. [none] is for non-navigation syncs (init, add/remove layer).
+enum ClipHistoryDirection { undo, redo, none }
+
+/// What `_VideoEditorState._syncMainCapabilities` should do with the clip
+/// snapshot read from the editor's current undo/redo history entry.
+enum ClipSnapshotSyncOp {
+  /// Mirror the resolvable clips into the app clip state (normal path).
+  sync,
+
+  /// The entry carries no clip metadata at all — nothing to reconcile.
+  skip,
+
+  /// The entry's clips are all orphaned; step the editor history backward to
+  /// the nearest state whose media still exists.
+  stepBackward,
+
+  /// As [stepBackward], but step forward.
+  stepForward,
+}
+
 /// The main canvas area for the video editor.
 ///
 /// Wraps [ProImageEditor] and configures it for video editing with custom
@@ -161,6 +183,96 @@ class VideoEditorCanvas extends StatelessWidget {
       );
       return false;
     }
+  }
+
+  /// Decides how to reconcile the clip [snapshot] read from the editor's
+  /// current undo/redo history entry with the app clip state.
+  ///
+  /// An undo/redo can land on a state whose clips were all removed earlier in
+  /// the session — [FileCleanupService] has since deleted their source files,
+  /// so handing them to the native player fails the whole composition
+  /// (`COMPOSITION_ERROR`) and freezes the editor. Such an *orphan-only* entry
+  /// must neither sync into the app (the player would diverge from the
+  /// timeline) nor be left as the resting state (app clip state and editor
+  /// history would silently diverge). Instead the editor steps its own history
+  /// past it: [direction] biases which way to step, falling back to the
+  /// opposite direction once at a history boundary; [didReverse] records that a
+  /// reversal already happened so an all-orphan history can't ping-pong
+  /// forever.
+  ///
+  /// Returns the [ClipSnapshotSyncOp] to perform, the resolvable clips to
+  /// mirror (only meaningful for [ClipSnapshotSyncOp.sync]), and whether the
+  /// chosen step reverses the requested [direction].
+  @visibleForTesting
+  static ({
+    ClipSnapshotSyncOp op,
+    List<DivineVideoClip> resolvableClips,
+    bool reversed,
+  })
+  resolveClipSnapshotSync({
+    required List<DivineVideoClip> snapshot,
+    required ClipHistoryDirection direction,
+    required bool canUndo,
+    required bool canRedo,
+    required bool didReverse,
+  }) {
+    final resolvable = snapshot
+        .where((clip) => clip.hasResolvableVideoFile)
+        .toList();
+    if (resolvable.isNotEmpty) {
+      return (
+        op: ClipSnapshotSyncOp.sync,
+        resolvableClips: resolvable,
+        reversed: false,
+      );
+    }
+    if (snapshot.isEmpty) {
+      return (
+        op: ClipSnapshotSyncOp.skip,
+        resolvableClips: resolvable,
+        reversed: false,
+      );
+    }
+
+    // Orphan-only entry: prefer the navigated direction, fall back to the
+    // opposite direction once (at a history boundary), then give up so an
+    // all-orphan history can't loop forever.
+    final preferBackward = direction != ClipHistoryDirection.redo;
+    if (preferBackward && canUndo) {
+      return (
+        op: ClipSnapshotSyncOp.stepBackward,
+        resolvableClips: resolvable,
+        reversed: false,
+      );
+    }
+    if (!preferBackward && canRedo) {
+      return (
+        op: ClipSnapshotSyncOp.stepForward,
+        resolvableClips: resolvable,
+        reversed: false,
+      );
+    }
+    if (!didReverse) {
+      if (preferBackward && canRedo) {
+        return (
+          op: ClipSnapshotSyncOp.stepForward,
+          resolvableClips: resolvable,
+          reversed: true,
+        );
+      }
+      if (!preferBackward && canUndo) {
+        return (
+          op: ClipSnapshotSyncOp.stepBackward,
+          resolvableClips: resolvable,
+          reversed: true,
+        );
+      }
+    }
+    return (
+      op: ClipSnapshotSyncOp.skip,
+      resolvableClips: resolvable,
+      reversed: false,
+    );
   }
 
   @override
@@ -310,6 +422,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// Consumed (cleared) by the clip-snapshot listener on its next pass.
   bool _skipNextClipSnapshotSync = false;
 
+  /// Set while stepping the editor history past an orphan-only undo/redo state
+  /// (see [VideoEditorCanvas.resolveClipSnapshotSync]). Permits reversing the
+  /// step direction exactly once at a history boundary so the search can't
+  /// ping-pong forever when every neighbour is also orphaned. Cleared once a
+  /// state with resolvable media (or a genuinely clip-less entry) is reached.
+  bool _orphanStepDidReverse = false;
+
   /// Guards against duplicate [addHistory] calls when both
   /// [ClipEditorBloc.clipsVolumeRevision] and
   /// [TimelineOverlayBloc.audioTracksRevision] change in the same frame
@@ -423,9 +542,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         .read<VideoEditorMainBloc>()
         .state
         .currentPosition;
-    unawaited(
-      _swapComposition(clips, timelineStartPosition: currentPosition),
-    );
+    unawaited(_swapComposition(clips, timelineStartPosition: currentPosition));
   }
 
   /// Reloads the player composition while suppressing the stale position
@@ -904,9 +1021,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     if (!mounted || !identical(_videoPlayer, player)) return;
     final loaded = await _setClipsSafely(
       player,
-      [
-        ...buildSeamAwarePlayerClips(clips, _seamService),
-      ],
+      [...buildSeamAwarePlayerClips(clips, _seamService)],
       startPosition: startPosition != null && startPosition > Duration.zero
           ? _timelineToPlayer(startPosition)
           : null,
@@ -1080,7 +1195,17 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     );
   }
 
-  void _syncMainCapabilities(VideoEditorScope scope, VideoEditorMainBloc bloc) {
+  /// Mirrors the main editor's capabilities, overlay items and clip snapshot
+  /// into the BLoCs / providers after an editor change.
+  ///
+  /// [direction] tells the orphan-only reconciliation which way an undo/redo
+  /// navigated (see [VideoEditorCanvas.resolveClipSnapshotSync]); it defaults
+  /// to [ClipHistoryDirection.none] for non-navigation calls.
+  void _syncMainCapabilities(
+    VideoEditorScope scope,
+    VideoEditorMainBloc bloc, {
+    ClipHistoryDirection direction = ClipHistoryDirection.none,
+  }) {
     final editor = scope.editor;
     if (editor == null) return;
 
@@ -1107,19 +1232,41 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         ),
       );
 
-      // Drop clips whose source file no longer exists on disk before they
-      // reach the live timeline and the native player. Undo/redo can resurrect
-      // a clip that was removed earlier in the session — its media was already
-      // deleted by FileCleanupService, and handing that dead path to the
-      // player fails the whole composition (COMPOSITION_ERROR) and freezes the
-      // editor. Dropping it here also keeps the orphan out of the autosaved
-      // draft, so a later reopen can't reintroduce the freeze.
-      final clips = List<DivineVideoClip>.from(
-        editor.stateManager
-            .clipSnapshots(await _documentsPath)
-            .where((clip) => clip.hasResolvableVideoFile),
+      // Reconcile the editor's current history entry with the app clip state.
+      // Undo/redo can resurrect a clip removed earlier in the session — its
+      // media was already deleted by FileCleanupService, and handing that dead
+      // path to the player fails the whole composition (COMPOSITION_ERROR) and
+      // freezes the editor. Orphaned clips are filtered out, and an entry whose
+      // clips are *all* orphaned is stepped over (rather than left to diverge
+      // from, or empty the, native player).
+      final snapshot = editor.stateManager.clipSnapshots(await _documentsPath);
+      if (!mounted || _isImportingHistory) return;
+
+      final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+        snapshot: snapshot,
+        direction: direction,
+        canUndo: editor.canUndo,
+        canRedo: editor.canRedo,
+        didReverse: _orphanStepDidReverse,
       );
-      if (!mounted || clips.isEmpty || _isImportingHistory) return;
+
+      switch (decision.op) {
+        case ClipSnapshotSyncOp.skip:
+          _orphanStepDidReverse = false;
+          return;
+        case ClipSnapshotSyncOp.stepBackward:
+          _orphanStepDidReverse = _orphanStepDidReverse || decision.reversed;
+          editor.undoAction();
+          return;
+        case ClipSnapshotSyncOp.stepForward:
+          _orphanStepDidReverse = _orphanStepDidReverse || decision.reversed;
+          editor.redoAction();
+          return;
+        case ClipSnapshotSyncOp.sync:
+          _orphanStepDidReverse = false;
+      }
+
+      final clips = decision.resolvableClips;
 
       if (_skipNextClipSnapshotSync) {
         _skipNextClipSnapshotSync = false;
@@ -2066,8 +2213,16 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
               );
               _syncMainCapabilities(scope, bloc);
             },
-            onRedo: () => _syncMainCapabilities(scope, bloc),
-            onUndo: () => _syncMainCapabilities(scope, bloc),
+            onRedo: () => _syncMainCapabilities(
+              scope,
+              bloc,
+              direction: ClipHistoryDirection.redo,
+            ),
+            onUndo: () => _syncMainCapabilities(
+              scope,
+              bloc,
+              direction: ClipHistoryDirection.undo,
+            ),
             onCreateTextLayer: scope.onAddEditTextLayer,
             onEditTextLayer: scope.onAddEditTextLayer,
             helperLines: HelperLinesCallbacks(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1201,10 +1201,20 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// [direction] tells the orphan-only reconciliation which way an undo/redo
   /// navigated (see [VideoEditorCanvas.resolveClipSnapshotSync]); it defaults
   /// to [ClipHistoryDirection.none] for non-navigation calls.
+  ///
+  /// [allowOrphanStep] gates whether this pass may step the editor history
+  /// past an orphan-only entry. The directional `onUndo`/`onRedo` callbacks
+  /// and the post-import sync own the step. The generic `onStateHistoryChange`
+  /// reconcile must pass `false`: `undoAction()`/`redoAction()` fire
+  /// `onStateHistoryChange` (with no direction) *before* `onUndo`/`onRedo`, so
+  /// every navigation schedules this method twice. If the directionless pass
+  /// also stepped, its backward bias would preempt a forward (redo) recovery
+  /// and both passes would race the shared [_orphanStepDidReverse] flag.
   void _syncMainCapabilities(
     VideoEditorScope scope,
     VideoEditorMainBloc bloc, {
     ClipHistoryDirection direction = ClipHistoryDirection.none,
+    bool allowOrphanStep = true,
   }) {
     final editor = scope.editor;
     if (editor == null) return;
@@ -1250,20 +1260,29 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         didReverse: _orphanStepDidReverse,
       );
 
-      switch (decision.op) {
-        case ClipSnapshotSyncOp.skip:
-          _orphanStepDidReverse = false;
-          return;
-        case ClipSnapshotSyncOp.stepBackward:
-          _orphanStepDidReverse = _orphanStepDidReverse || decision.reversed;
-          editor.undoAction();
-          return;
-        case ClipSnapshotSyncOp.stepForward:
-          _orphanStepDidReverse = _orphanStepDidReverse || decision.reversed;
-          editor.redoAction();
-          return;
-        case ClipSnapshotSyncOp.sync:
-          _orphanStepDidReverse = false;
+      if (!allowOrphanStep) {
+        // Generic history-change reconcile: it fires alongside the directional
+        // onUndo/onRedo on every navigation, so it neither steps nor touches
+        // the walk's reverse-once flag — the directional pass (scheduled in the
+        // same frame) owns resolving an orphan-only entry. We only mirror a
+        // resolvable entry; an orphan-only or empty one is left to that pass.
+        if (decision.op != ClipSnapshotSyncOp.sync) return;
+      } else {
+        switch (decision.op) {
+          case ClipSnapshotSyncOp.skip:
+            _orphanStepDidReverse = false;
+            return;
+          case ClipSnapshotSyncOp.stepBackward:
+            _orphanStepDidReverse = _orphanStepDidReverse || decision.reversed;
+            editor.undoAction();
+            return;
+          case ClipSnapshotSyncOp.stepForward:
+            _orphanStepDidReverse = _orphanStepDidReverse || decision.reversed;
+            editor.redoAction();
+            return;
+          case ClipSnapshotSyncOp.sync:
+            _orphanStepDidReverse = false;
+        }
       }
 
       final clips = decision.resolvableClips;
@@ -1328,7 +1347,9 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   ) async {
     if (_isImportingHistory || !_isInitialized) return;
 
-    _syncMainCapabilities(scope, bloc);
+    // Directionless: the directional onUndo/onRedo pass owns stepping past an
+    // orphan-only entry (this callback fires first, before onUndo/onRedo).
+    _syncMainCapabilities(scope, bloc, allowOrphanStep: false);
     final result = await scope.requireEditor.exportStateHistory(
       configs: const ExportEditorConfigs(
         historySpan: .currentAndBackward,

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -8,6 +8,8 @@ import 'dart:typed_data';
 import 'dart:ui';
 
 import 'package:characters/characters.dart';
+import 'package:db_client/db_client.dart';
+import 'package:drift/native.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -19,17 +21,18 @@ import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/database_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/video_editor/video_editor_audio_render.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/widgets/video_editor/sticker_editor/video_editor_sticker.dart';
+import 'package:path/path.dart' as p;
 import 'package:pro_image_editor/pro_image_editor.dart'
     show CompleteParameters, WidgetLayer, WidgetLayerExportConfigs;
 import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:sqlite3/sqlite3.dart';
 
 class _MockDraftStorageService extends Mock implements DraftStorageService {}
 
@@ -1866,5 +1869,91 @@ void main() {
         );
       });
     });
+  });
+
+  group('VideoEditorProvider deferred file cleanup', () {
+    late _MockDraftStorageService mockDraftStorage;
+    late AppDatabase database;
+    late ProviderContainer container;
+    late Directory tempDir;
+
+    setUpAll(() {
+      registerFallbackValue(
+        DivineVideoDraft.create(
+          id: 'fallback',
+          clips: const [],
+          title: '',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+        ),
+      );
+    });
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      mockDraftStorage = _MockDraftStorageService();
+      database = AppDatabase.test(NativeDatabase.memory());
+      tempDir = Directory.systemTemp.createTempSync('editor_defer_test');
+      container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          draftStorageServiceProvider.overrideWithValue(mockDraftStorage),
+          databaseProvider.overrideWithValue(database),
+        ],
+      );
+    });
+
+    tearDown(() async {
+      container.dispose();
+      await database.close();
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+
+    test(
+      'an autosave keeps its orphaned files alive and reaps them on teardown',
+      () async {
+        final orphan = File(p.join(tempDir.path, 'orphan.mp4'))
+          ..writeAsBytesSync(const [0, 1, 2, 3]);
+
+        // The autosave hands the draft's now-unreferenced files to the deferral
+        // sink instead of deleting them — the editor's undo history may still
+        // need them.
+        when(
+          () => mockDraftStorage.saveDraft(
+            any(),
+            deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+          ),
+        ).thenAnswer((invocation) async {
+          final defer =
+              invocation.namedArguments[#deferOrphanCleanup]
+                  as void Function(List<String?>)?;
+          defer?.call([orphan.path]);
+        });
+
+        await container.read(videoEditorProvider.notifier).autosaveChanges();
+
+        expect(
+          orphan.existsSync(),
+          isTrue,
+          reason:
+              'a deferred orphan must survive the autosave so undo/redo can '
+              'still resolve the clip it backs',
+        );
+
+        final notifier = container.read(videoEditorProvider.notifier);
+        expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
+
+        await notifier.flushDeferredFileCleanupForTest();
+
+        expect(
+          orphan.existsSync(),
+          isFalse,
+          reason: 'teardown reaps a deferred file once nothing references it',
+        );
+        expect(notifier.deferredFileCleanupForTest, isEmpty);
+      },
+    );
   });
 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1876,6 +1876,13 @@ void main() {
     late AppDatabase database;
     late ProviderContainer container;
     late Directory tempDir;
+    var containerDisposed = false;
+
+    void disposeContainer() {
+      if (containerDisposed) return;
+      containerDisposed = true;
+      container.dispose();
+    }
 
     setUpAll(() {
       registerFallbackValue(
@@ -1896,6 +1903,7 @@ void main() {
       mockDraftStorage = _MockDraftStorageService();
       database = AppDatabase.test(NativeDatabase.memory());
       tempDir = Directory.systemTemp.createTempSync('editor_defer_test');
+      containerDisposed = false;
       container = ProviderContainer(
         overrides: [
           sharedPreferencesProvider.overrideWithValue(prefs),
@@ -1906,54 +1914,83 @@ void main() {
     });
 
     tearDown(() async {
-      container.dispose();
+      disposeContainer();
+      // Let any fire-and-forget onDispose flush finish querying the DB before
+      // we close it, so a still-deferred file doesn't race a closed database.
+      await pumpEventQueue();
       await database.close();
       if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
     });
 
-    test(
-      'an autosave keeps its orphaned files alive and reaps them on teardown',
-      () async {
-        final orphan = File(p.join(tempDir.path, 'orphan.mp4'))
-          ..writeAsBytesSync(const [0, 1, 2, 3]);
+    // Stubs the next autosave to hand [orphan] to the deferral sink instead of
+    // deleting it — the editor's undo history may still need it — and returns
+    // the file it created on disk.
+    File stubDeferringAutosave() {
+      final orphan = File(p.join(tempDir.path, 'orphan.mp4'))
+        ..writeAsBytesSync(const [0, 1, 2, 3]);
+      when(
+        () => mockDraftStorage.saveDraft(
+          any(),
+          deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+        ),
+      ).thenAnswer((invocation) async {
+        final defer =
+            invocation.namedArguments[#deferOrphanCleanup]
+                as void Function(List<String?>)?;
+        defer?.call([orphan.path]);
+      });
+      return orphan;
+    }
 
-        // The autosave hands the draft's now-unreferenced files to the deferral
-        // sink instead of deleting them — the editor's undo history may still
-        // need them.
-        when(
-          () => mockDraftStorage.saveDraft(
-            any(),
-            deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
-          ),
-        ).thenAnswer((invocation) async {
-          final defer =
-              invocation.namedArguments[#deferOrphanCleanup]
-                  as void Function(List<String?>)?;
-          defer?.call([orphan.path]);
-        });
+    test('an autosave keeps its orphaned files alive', () async {
+      final orphan = stubDeferringAutosave();
+      final notifier = container.read(videoEditorProvider.notifier);
 
-        await container.read(videoEditorProvider.notifier).autosaveChanges();
+      await notifier.autosaveChanges();
 
-        expect(
-          orphan.existsSync(),
-          isTrue,
-          reason:
-              'a deferred orphan must survive the autosave so undo/redo can '
-              'still resolve the clip it backs',
-        );
+      expect(
+        orphan.existsSync(),
+        isTrue,
+        reason:
+            'a deferred orphan must survive the autosave so undo/redo can '
+            'still resolve the clip it backs',
+      );
+      expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
+    });
 
-        final notifier = container.read(videoEditorProvider.notifier);
-        expect(notifier.deferredFileCleanupForTest, contains(orphan.path));
+    test('reset reaps deferred files at editor-session end', () async {
+      final orphan = stubDeferringAutosave();
+      final notifier = container.read(videoEditorProvider.notifier);
+      await notifier.autosaveChanges();
 
-        await notifier.flushDeferredFileCleanupForTest();
+      // reset() is the real session-end hook (publish / discard / start-over),
+      // not the @visibleForTesting flush — this exercises the wiring an app
+      // actually hits when the editor closes.
+      await notifier.reset(keepAutosavedDraft: true);
+      await pumpEventQueue();
 
-        expect(
-          orphan.existsSync(),
-          isFalse,
-          reason: 'teardown reaps a deferred file once nothing references it',
-        );
-        expect(notifier.deferredFileCleanupForTest, isEmpty);
-      },
-    );
+      expect(
+        orphan.existsSync(),
+        isFalse,
+        reason: 'session end reaps a deferred file once nothing references it',
+      );
+      expect(notifier.deferredFileCleanupForTest, isEmpty);
+    });
+
+    test('container teardown reaps deferred files as a safety net', () async {
+      final orphan = stubDeferringAutosave();
+      await container.read(videoEditorProvider.notifier).autosaveChanges();
+      expect(orphan.existsSync(), isTrue);
+
+      // Drives the real ref.onDispose wiring, not the @visibleForTesting flush.
+      disposeContainer();
+      await pumpEventQueue();
+
+      expect(
+        orphan.existsSync(),
+        isFalse,
+        reason: 'onDispose reaps deferred files left when reset never ran',
+      );
+    });
   });
 }

--- a/mobile/test/services/draft_storage_service_test.dart
+++ b/mobile/test/services/draft_storage_service_test.dart
@@ -1228,6 +1228,92 @@ void main() {
       });
     });
 
+    group('deferred orphan cleanup', () {
+      late Directory docsDir;
+
+      setUp(() {
+        docsDir = Directory(documentsPath)..createSync(recursive: true);
+      });
+
+      tearDown(() {
+        if (docsDir.existsSync()) docsDir.deleteSync(recursive: true);
+      });
+
+      File writeVideo(String name) {
+        final file = File(p.join(documentsPath, name));
+        file.writeAsBytesSync(const [0, 1, 2, 3]);
+        return file;
+      }
+
+      DivineVideoDraft draftWithClip(String videoPath) =>
+          DivineVideoDraft.create(
+            id: 'draft_defer',
+            clips: [
+              DivineVideoClip(
+                id: 'clip_${p.basenameWithoutExtension(videoPath)}',
+                video: EditorVideo.file(videoPath),
+                duration: const Duration(seconds: 6),
+                recordedAt: DateTime(2025),
+                targetAspectRatio: AspectRatio.square,
+                originalAspectRatio: 9 / 16,
+              ),
+            ],
+            title: 'Defer draft',
+            description: '',
+            hashtags: const {},
+            selectedApproach: 'video',
+          );
+
+      test(
+        'keeps an orphaned clip file alive and hands its path to the sink',
+        () async {
+          final oldVideo = writeVideo('old.mp4');
+          final newVideo = writeVideo('new.mp4');
+
+          await service.saveDraft(draftWithClip(oldVideo.path));
+
+          final deferred = <String>[];
+          await service.saveDraft(
+            draftWithClip(newVideo.path),
+            deferOrphanCleanup: (paths) =>
+                deferred.addAll(paths.whereType<String>()),
+          );
+
+          expect(
+            oldVideo.existsSync(),
+            isTrue,
+            reason:
+                'a deferred orphan must survive the save so undo can '
+                'restore the clip whose source it is',
+          );
+          expect(
+            deferred,
+            contains(oldVideo.path),
+            reason: 'the orphan path must reach the caller for later cleanup',
+          );
+        },
+      );
+
+      test('deletes the orphaned clip file when no sink is provided', () async {
+        final oldVideo = writeVideo('old.mp4');
+        final newVideo = writeVideo('new.mp4');
+
+        await service.saveDraft(draftWithClip(oldVideo.path));
+        await service.saveDraft(draftWithClip(newVideo.path));
+
+        expect(
+          oldVideo.existsSync(),
+          isFalse,
+          reason: 'without deferral the replaced clip file is reaped as before',
+        );
+        expect(
+          newVideo.existsSync(),
+          isTrue,
+          reason: 'the currently-referenced clip file must be kept',
+        );
+      });
+    });
+
     group('draft-local audio file hygiene', () {
       late Directory docsDir;
 

--- a/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
+++ b/mobile/test/widgets/video_editor/main_editor/video_editor_canvas_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show PlatformException;
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -74,53 +76,44 @@ void main() {
       await mainBloc.close();
     });
 
-    test(
-      'dispatches VideoEditorPositionChanged(startPosition) and updates '
-      'playTime when the trim-end position was not pre-dispatched',
-      () {
-        const startPosition = Duration(seconds: 2);
+    test('dispatches VideoEditorPositionChanged(startPosition) and updates '
+        'playTime when the trim-end position was not pre-dispatched', () {
+      const startPosition = Duration(seconds: 2);
 
-        VideoEditorCanvas.syncPositionAfterTrimRelease(
-          mainBloc: mainBloc,
-          proVideoController: controller,
-          startPosition: startPosition,
-          trimEndAlreadyDispatched: false,
-        );
+      VideoEditorCanvas.syncPositionAfterTrimRelease(
+        mainBloc: mainBloc,
+        proVideoController: controller,
+        startPosition: startPosition,
+        trimEndAlreadyDispatched: false,
+      );
 
-        expect(
-          mainBloc.events,
-          contains(
-            isA<VideoEditorPositionChanged>().having(
-              (e) => e.position,
-              'position',
-              startPosition,
-            ),
+      expect(
+        mainBloc.events,
+        contains(
+          isA<VideoEditorPositionChanged>().having(
+            (e) => e.position,
+            'position',
+            startPosition,
           ),
-        );
-        expect(controller.playTimeNotifier.value, equals(startPosition));
-      },
-    );
+        ),
+      );
+      expect(controller.playTimeNotifier.value, equals(startPosition));
+    });
 
-    test(
-      'skips the bloc dispatch but still updates playTime when the '
-      'trim-end position was already pushed pre-await',
-      () {
-        const startPosition = Duration(milliseconds: 1500);
+    test('skips the bloc dispatch but still updates playTime when the '
+        'trim-end position was already pushed pre-await', () {
+      const startPosition = Duration(milliseconds: 1500);
 
-        VideoEditorCanvas.syncPositionAfterTrimRelease(
-          mainBloc: mainBloc,
-          proVideoController: controller,
-          startPosition: startPosition,
-          trimEndAlreadyDispatched: true,
-        );
+      VideoEditorCanvas.syncPositionAfterTrimRelease(
+        mainBloc: mainBloc,
+        proVideoController: controller,
+        startPosition: startPosition,
+        trimEndAlreadyDispatched: true,
+      );
 
-        expect(
-          mainBloc.events.whereType<VideoEditorPositionChanged>(),
-          isEmpty,
-        );
-        expect(controller.playTimeNotifier.value, equals(startPosition));
-      },
-    );
+      expect(mainBloc.events.whereType<VideoEditorPositionChanged>(), isEmpty);
+      expect(controller.playTimeNotifier.value, equals(startPosition));
+    });
   });
 
   group('VideoEditorCanvas.shouldSeedSelectedSoundAsAudioTrack', () {
@@ -155,10 +148,7 @@ void main() {
       final start = _createClip(id: 'start');
       final previewEnd = _createClip(id: 'end');
 
-      final previous = ClipEditorState(
-        clips: [source],
-        isSplitting: true,
-      );
+      final previous = ClipEditorState(clips: [source], isSplitting: true);
       final current = ClipEditorState(
         clips: [start, previewEnd],
         isSplitting: true,
@@ -412,12 +402,144 @@ void main() {
       );
     });
   });
+
+  group('VideoEditorCanvas.resolveClipSnapshotSync', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('canvas_orphan_sync');
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
+    DivineVideoClip resolvableClip(String id) {
+      final path = '${tempDir.path}/$id.mp4';
+      File(path).writeAsBytesSync(const [0]);
+      return _createClip(id: id, videoPath: path);
+    }
+
+    DivineVideoClip orphanClip(String id) =>
+        _createClip(id: id, videoPath: '${tempDir.path}/$id-missing.mp4');
+
+    test('syncs only the clips whose source files still exist', () {
+      final resolvable = resolvableClip('a');
+      final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+        snapshot: [resolvable, orphanClip('b')],
+        direction: ClipHistoryDirection.undo,
+        canUndo: true,
+        canRedo: false,
+        didReverse: false,
+      );
+
+      expect(decision.op, ClipSnapshotSyncOp.sync);
+      expect(decision.resolvableClips, equals([resolvable]));
+      expect(decision.reversed, isFalse);
+    });
+
+    test('skips a history entry that carries no clips', () {
+      final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+        snapshot: const [],
+        direction: ClipHistoryDirection.none,
+        canUndo: true,
+        canRedo: true,
+        didReverse: false,
+      );
+
+      expect(decision.op, ClipSnapshotSyncOp.skip);
+      expect(decision.resolvableClips, isEmpty);
+    });
+
+    test('steps backward when undo restores only deleted-source clips', () {
+      final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+        snapshot: [orphanClip('a'), orphanClip('b')],
+        direction: ClipHistoryDirection.undo,
+        canUndo: true,
+        canRedo: false,
+        didReverse: false,
+      );
+
+      expect(decision.op, ClipSnapshotSyncOp.stepBackward);
+      expect(decision.resolvableClips, isEmpty);
+      expect(decision.reversed, isFalse);
+    });
+
+    test('steps forward when redo restores only deleted-source clips', () {
+      final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+        snapshot: [orphanClip('a')],
+        direction: ClipHistoryDirection.redo,
+        canUndo: false,
+        canRedo: true,
+        didReverse: false,
+      );
+
+      expect(decision.op, ClipSnapshotSyncOp.stepForward);
+      expect(decision.reversed, isFalse);
+    });
+
+    test(
+      'reverses to redo once when an orphan-only state is at the undo boundary',
+      () {
+        final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+          snapshot: [orphanClip('a')],
+          direction: ClipHistoryDirection.undo,
+          canUndo: false,
+          canRedo: true,
+          didReverse: false,
+        );
+
+        expect(decision.op, ClipSnapshotSyncOp.stepForward);
+        expect(decision.reversed, isTrue);
+      },
+    );
+
+    test(
+      'reverses to undo once when an orphan-only state is at the redo boundary',
+      () {
+        final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+          snapshot: [orphanClip('a')],
+          direction: ClipHistoryDirection.redo,
+          canUndo: true,
+          canRedo: false,
+          didReverse: false,
+        );
+
+        expect(decision.op, ClipSnapshotSyncOp.stepBackward);
+        expect(decision.reversed, isTrue);
+      },
+    );
+
+    test('does not reverse a second time once a reversal already happened', () {
+      final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+        snapshot: [orphanClip('a')],
+        direction: ClipHistoryDirection.undo,
+        canUndo: false,
+        canRedo: true,
+        didReverse: true,
+      );
+
+      expect(decision.op, ClipSnapshotSyncOp.skip);
+    });
+
+    test('skips when an orphan-only history has no reachable neighbour', () {
+      final decision = VideoEditorCanvas.resolveClipSnapshotSync(
+        snapshot: [orphanClip('a')],
+        direction: ClipHistoryDirection.none,
+        canUndo: false,
+        canRedo: false,
+        didReverse: false,
+      );
+
+      expect(decision.op, ClipSnapshotSyncOp.skip);
+    });
+  });
 }
 
-DivineVideoClip _createClip({required String id}) {
+DivineVideoClip _createClip({required String id, String? videoPath}) {
   return DivineVideoClip(
     id: id,
-    video: EditorVideo.file('/test/$id.mp4'),
+    video: EditorVideo.file(videoPath ?? '/test/$id.mp4'),
     duration: const Duration(seconds: 2),
     recordedAt: DateTime(2024),
     targetAspectRatio: model.AspectRatio.vertical,


### PR DESCRIPTION
## Description

Follow-up from #5635. That PR stopped a deleted-source clip from reaching the native player (which freezes the preview with `COMPOSITION_ERROR`) by filtering orphaned clips out of `_syncMainCapabilities`. But when an undo/redo state contains *only* orphaned clips, the filter leaves an empty list and the method returned early — so the `pro_video_editor` history moved to that entry while the app clip state (`clipManagerProvider` / `ClipEditorBloc`) stayed on the previous valid clips. The two silently diverged: the timeline shows one thing, the editor's undo cursor points at another.

This PR makes the orphan-only case reconcile instead of diverge. The clip-snapshot handling now returns one of: **sync** the resolvable clips (the normal path, unchanged), **skip** a genuinely clip-less entry, or **step** the editor's own history past an orphan-only entry. Stepping calls the editor's `undoAction()` / `redoAction()` in the direction the user navigated, so it lands on the nearest history state whose media still exists and the existing sync wiring takes over from there. The decision lives in a pure, `@visibleForTesting` static `resolveClipSnapshotSync`, matching the other tested decision helpers on `VideoEditorCanvas`.

### Why step the history rather than clear app state or rewrite the entry

Clearing the app clip state to match the (empty) filtered snapshot is not viable: an empty clip list makes `firstClipOrNull` null, which unmounts the whole `ProImageEditor` subtree and destroys the undo history — the user could never redo back. Rewriting the dead entry's clip metadata in place would mutate the un-minified, ProofMode-readable history that #5635 is careful to preserve. Navigating with the editor's own undo/redo avoids both: app state, editor history, and the native player all stay aligned, the history bytes are untouched, and a dead path / empty composition never reaches the player.

A reverse-once guard (`didReverse`) lets the search bounce off a history boundary — e.g. undoing onto an orphan-only state that sits at index 0 reverses to redo to find the nearest valid neighbour — while staying loop-safe: it reverses at most once, so an (effectively impossible) all-orphan history stops instead of ping-ponging forever.

## Out of Scope

The eager file-cleanup-on-removal design and the existing orphan filtering in `restoreDraft` are unchanged; this PR only fixes the reconciliation gap for the live undo/redo path.

## Verification

- `flutter analyze lib test integration_test` — no issues
- `flutter test test/widgets/video_editor/main_editor/video_editor_canvas_test.dart` — 29 passed (8 new `resolveClipSnapshotSync` cases incl. "undo restores only deleted-source clips")
- Neighbouring suites green: `test/models/divine_video_clip_test.dart`, `test/providers/video_editor_provider_test.dart` (72 passed)
- `dart format` — clean

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

**Related Issue:** Closes #5640
