### PR TITLE
fix(video-player): scope Apple plugin registrar and register-time cleanup per engine

### DIFF
--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
@@ -13,7 +13,13 @@ import FlutterMacOS
 /// registers the platform view factory for rendering.
 public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
 
-    private static var registrar: FlutterPluginRegistrar?
+    /// The registrar for THIS plugin instance's engine. Per-instance rather
+    /// than a process-wide static so `create` uses the messenger / texture
+    /// registry of the engine that received the method call. A second
+    /// FlutterEngine (e.g. the FCM background isolate that also runs the
+    /// plugin registrant) registering the plugin must not repoint player
+    /// creation at its own messenger. See #5397.
+    private var registrar: FlutterPluginRegistrar?
 
     private var globalChannel: FlutterMethodChannel?
 
@@ -38,24 +44,28 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
-        // Hot restart re-calls register(with:) without disposing the
-        // previous engine's players. Clean up zombie players so timers
-        // and observers are released.
-        PlayerRegistry.shared.disposeAll()
-
-        self.registrar = registrar
-
         #if os(iOS)
         let messenger = registrar.messenger()
         #elseif os(macOS)
         let messenger = registrar.messenger
         #endif
 
+        // Hot restart re-calls register(with:) on the SAME engine without
+        // disposing the previous run's players, leaving zombie timers /
+        // display links. Scope cleanup to THIS engine (keyed on its binary
+        // messenger) so a second FlutterEngine registering the plugin — the
+        // FCM background isolate — never disposes another live engine's
+        // players. The previous-run plugin instance can leak (retain cycle
+        // with its channel), so we key on the engine's messenger, which is
+        // stable across hot restart, not the plugin instance. See #5397.
+        PlayerRegistry.shared.disposeForEngine(messenger)
+
         let globalChannel = FlutterMethodChannel(
             name: "divine_video_player",
             binaryMessenger: messenger
         )
         let plugin = DivineVideoPlayerPlugin()
+        plugin.registrar = registrar
         plugin.globalChannel = globalChannel
         plugin.installLogSink()
         registrar.addMethodCallDelegate(plugin, channel: globalChannel)
@@ -102,7 +112,7 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
     /// `CADisplayLink` (which strongly retains the output) keeps firing
     /// `textureFrameAvailable` into the freed engine shell.
     ///
-    /// Scoped to this engine's own players via `disposeOwned(by:)` so that
+    /// Scoped to this engine's own players via `disposeForEngine(_:)` so that
     /// the FCM background isolate's engine detaching does not dispose the UI
     /// engine's live players (`PlayerRegistry.shared` is process-wide).
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
@@ -110,7 +120,12 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             "Engine detaching — disposing this engine's players",
             name: "DivineVideoPlayer.Lifecycle"
         )
-        PlayerRegistry.shared.disposeOwned(by: self)
+        #if os(iOS)
+        let messenger = registrar.messenger()
+        #elseif os(macOS)
+        let messenger = registrar.messenger
+        #endif
+        PlayerRegistry.shared.disposeForEngine(messenger)
         NotificationCenter.default.removeObserver(self)
     }
 
@@ -137,7 +152,7 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
         switch call.method {
         case "create":
             guard let id = args["id"] as? Int,
-                  let registrar = Self.registrar else {
+                  let registrar = self.registrar else {
                 result(
                     FlutterError(
                         code: "INVALID_ARGS",
@@ -160,10 +175,12 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
                 messenger: messenger,
                 playerId: id
             )
-            // Record `self` as the owner: the plugin instance whose global
-            // channel received this `create` is the engine the Dart side is
-            // talking to, so it is the engine whose detach should dispose it.
-            PlayerRegistry.shared.set(instance, for: id, owner: self)
+            // Record the owning engine by its binary messenger. The plugin
+            // instance whose global channel received this `create` is the
+            // engine the Dart side is talking to, so its detach and its
+            // hot-restart re-register dispose this player; another live
+            // engine's never touches it. See #5397.
+            PlayerRegistry.shared.set(instance, for: id, engine: messenger)
 
             let useTexture = args["useTexture"] as? Bool ?? false
             DivineVideoPlayerLog.shared.info(
@@ -260,50 +277,57 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
 /// instances created during the `create` method call.
 ///
 /// `shared` is process-wide and outlives any single `FlutterEngine`. Each
-/// player records the plugin (engine) that created it so a teardown of one
-/// engine can dispose only its own players — see `disposeOwned(by:)`. A
-/// blanket `disposeAll()` on engine detach would otherwise free the UI
-/// engine's live players when the FCM background isolate's engine detaches.
+/// player records the engine that created it — keyed by the engine's binary
+/// messenger identity — so a teardown or hot-restart of one engine disposes
+/// only its own players via `disposeForEngine(_:)`. A blanket `disposeAll()`
+/// on detach or register would otherwise free the UI engine's live players
+/// when the FCM background isolate's engine detaches or registers.
 /// Main-thread only, like all plugin entry points.
 final class PlayerRegistry {
     static let shared = PlayerRegistry()
     private var players: [Int: DivineVideoPlayerInstance] = [:]
-    /// Owning plugin per player id. `ObjectIdentifier` is stable while the
-    /// owning plugin is alive, which it is throughout `detachFromEngine`.
-    private var owners: [Int: ObjectIdentifier] = [:]
+    /// Owning engine per player id, keyed by the engine's binary messenger
+    /// identity. The messenger is a stable singleton for the life of a
+    /// `FlutterEngine` and survives that engine's hot restart, so it
+    /// identifies the engine even when the previous-run plugin instance
+    /// leaks. `ObjectIdentifier` holds no strong reference, so an orphaned
+    /// record never keeps a torn-down messenger alive.
+    private var engines: [Int: ObjectIdentifier] = [:]
     private init() {}
 
     func get(_ id: Int) -> DivineVideoPlayerInstance? { players[id] }
     func set(
         _ instance: DivineVideoPlayerInstance,
         for id: Int,
-        owner: DivineVideoPlayerPlugin
+        engine messenger: FlutterBinaryMessenger
     ) {
         players[id] = instance
-        owners[id] = ObjectIdentifier(owner)
+        engines[id] = ObjectIdentifier(messenger as AnyObject)
     }
     @discardableResult
     func remove(_ id: Int) -> DivineVideoPlayerInstance? {
-        owners[id] = nil
+        engines[id] = nil
         let instance = players.removeValue(forKey: id)
         return instance
     }
     func disposeAll() {
         players.values.forEach { $0.dispose() }
         players.removeAll()
-        owners.removeAll()
+        engines.removeAll()
     }
 
-    /// Disposes only the players created by `owner` (one `FlutterEngine`),
-    /// leaving every other engine's players running. Called on engine detach
-    /// so a torn-down engine cannot leave a zombie `CADisplayLink` firing
-    /// `textureFrameAvailable` into its freed shell.
-    func disposeOwned(by owner: DivineVideoPlayerPlugin) {
-        let ownerId = ObjectIdentifier(owner)
-        let ownedIds = owners.compactMap { $0.value == ownerId ? $0.key : nil }
+    /// Disposes only the players created by the engine identified by
+    /// `messenger` (one `FlutterEngine`), leaving every other engine's
+    /// players running. Called on engine detach and at hot-restart register
+    /// so a torn-down or restarted engine cannot leave a zombie
+    /// `CADisplayLink` firing `textureFrameAvailable` into its freed shell —
+    /// without disposing a second live engine's players.
+    func disposeForEngine(_ messenger: FlutterBinaryMessenger) {
+        let engineId = ObjectIdentifier(messenger as AnyObject)
+        let ownedIds = engines.compactMap { $0.value == engineId ? $0.key : nil }
         for id in ownedIds {
             players.removeValue(forKey: id)?.dispose()
-            owners[id] = nil
+            engines[id] = nil
         }
     }
     func forAll(_ action: (DivineVideoPlayerInstance) -> Void) {

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
@@ -329,8 +329,7 @@ final class PlayerRegistry {
         let engineId = ObjectIdentifier(messenger as AnyObject)
         let ownedIds = engines.compactMap { $0.value == engineId ? $0.key : nil }
         for id in ownedIds {
-            players.removeValue(forKey: id)?.dispose()
-            engines[id] = nil
+            remove(id)?.dispose()
         }
     }
     func forAll(_ action: (DivineVideoPlayerInstance) -> Void) {

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerPlugin.swift
@@ -43,12 +43,23 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
         DivineVideoPlayerLog.shared.sink = logSink
     }
 
-    public static func register(with registrar: FlutterPluginRegistrar) {
+    /// Resolves the binary messenger for `registrar`, bridging the iOS
+    /// `messenger()` method vs the macOS `messenger` property. Every
+    /// ownership key (`register`, `create`, `detachFromEngine`) derives from
+    /// this single resolution so all three always agree on the engine's
+    /// identity.
+    private static func messenger(
+        for registrar: FlutterPluginRegistrar
+    ) -> FlutterBinaryMessenger {
         #if os(iOS)
-        let messenger = registrar.messenger()
+        return registrar.messenger()
         #elseif os(macOS)
-        let messenger = registrar.messenger
+        return registrar.messenger
         #endif
+    }
+
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let messenger = Self.messenger(for: registrar)
 
         // Hot restart re-calls register(with:) on the SAME engine without
         // disposing the previous run's players, leaving zombie timers /
@@ -120,11 +131,7 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             "Engine detaching — disposing this engine's players",
             name: "DivineVideoPlayer.Lifecycle"
         )
-        #if os(iOS)
-        let messenger = registrar.messenger()
-        #elseif os(macOS)
-        let messenger = registrar.messenger
-        #endif
+        let messenger = Self.messenger(for: registrar)
         PlayerRegistry.shared.disposeForEngine(messenger)
         NotificationCenter.default.removeObserver(self)
     }
@@ -166,11 +173,7 @@ public class DivineVideoPlayerPlugin: NSObject, FlutterPlugin {
             // creating the new one to avoid leaking zombie players.
             PlayerRegistry.shared.remove(id)?.dispose()
 
-            #if os(iOS)
-            let messenger = registrar.messenger()
-            #elseif os(macOS)
-            let messenger = registrar.messenger
-            #endif
+            let messenger = Self.messenger(for: registrar)
             let instance = DivineVideoPlayerInstance(
                 messenger: messenger,
                 playerId: id

--- a/mobile/packages/divine_video_player/test/src/apple_engine_teardown_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_engine_teardown_contract_test.dart
@@ -78,11 +78,29 @@ void main() {
             "and hot-restart register can identify this engine's players.",
       );
       expect(
-        source,
-        contains('ObjectIdentifier(messenger as AnyObject)'),
+        _registrySetBody(),
+        contains('engines[id] = ObjectIdentifier(messenger as AnyObject)'),
         reason:
-            'Ownership is matched by object identity of the engine messenger, '
-            'which is stable across that engine, including hot restart.',
+            'The recording side must key the owner map on the engine messenger '
+            'identity. If set keys on anything else (e.g. self) while the '
+            'lookup keeps keying on the messenger, recording and lookup keys '
+            'never match, ownedIds is always empty, and no player is disposed '
+            'on teardown / hot-restart register — the #5371 zombie '
+            'CADisplayLink returns. A whole-source match is satisfied by the '
+            'lookup side alone, so pin the set body.',
+      );
+      expect(
+        _disposeForEngineBody(),
+        allOf(
+          contains('ObjectIdentifier(messenger as AnyObject)'),
+          contains(r'$0.value == engineId'),
+        ),
+        reason:
+            'The lookup side must derive the engine identity from the '
+            "messenger and filter the owner map to that engine's own players. "
+            'A body that blanket-disposes every player (without any literal '
+            'disposeAll token) would still reintroduce the #5397 cross-engine '
+            'teardown undetected, so pin the per-engine filter explicitly.',
       );
     });
 
@@ -180,6 +198,19 @@ String _detachBody() => _slice(
 /// Slices the `create` switch case, up to the `dispose` case.
 String _createBody() =>
     _slice(_pluginSource(), 'case "create":', 'case "dispose":');
+
+/// Slices the `PlayerRegistry.set(...)` body — the *recording* side of the
+/// owner map — up to the `remove` method (`@discardableResult`) that follows.
+String _registrySetBody() =>
+    _slice(_pluginSource(), 'func set(', '@discardableResult');
+
+/// Slices the `PlayerRegistry.disposeForEngine(_:)` body — the *lookup* and
+/// teardown side — up to the `forAll` method that follows it.
+String _disposeForEngineBody() => _slice(
+  _pluginSource(),
+  'func disposeForEngine(_ messenger: FlutterBinaryMessenger)',
+  'func forAll(',
+);
 
 String _slice(String source, String start, String end) {
   final from = source.indexOf(start);

--- a/mobile/packages/divine_video_player/test/src/apple_engine_teardown_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_engine_teardown_contract_test.dart
@@ -94,13 +94,19 @@ void main() {
         allOf(
           contains('ObjectIdentifier(messenger as AnyObject)'),
           contains(r'$0.value == engineId'),
+          contains('remove(id)?.dispose()'),
         ),
         reason:
             'The lookup side must derive the engine identity from the '
-            "messenger and filter the owner map to that engine's own players. "
-            'A body that blanket-disposes every player (without any literal '
+            "messenger and filter the owner map to that engine's own players, "
+            'then dispose each matched id through remove(id) so the owner-map '
+            'entry is cleared in lockstep with the player. Open-coding the '
+            'removal (or dropping the engines[id] cleanup) lets stale ids '
+            'accumulate and re-process on every later disposeForEngine. A '
+            'body that blanket-disposes every player (without any literal '
             'disposeAll token) would still reintroduce the #5397 cross-engine '
-            'teardown undetected, so pin the per-engine filter explicitly.',
+            'teardown undetected, so pin the per-engine filter and the '
+            'remove() call explicitly.',
       );
     });
 
@@ -178,7 +184,12 @@ void main() {
   });
 }
 
-String _pluginSource() => _pluginSourceFile().readAsStringSync();
+String? _cachedPluginSource;
+
+/// The Swift source is static for the duration of the run, so read it once and
+/// reuse it across all helpers/tests instead of re-reading on every call.
+String _pluginSource() =>
+    _cachedPluginSource ??= _pluginSourceFile().readAsStringSync();
 
 /// Slices the `register(with:)` body, which runs from the function signature
 /// up to the first app-lifecycle selector that follows it.
@@ -201,8 +212,14 @@ String _createBody() =>
 
 /// Slices the `PlayerRegistry.set(...)` body — the *recording* side of the
 /// owner map — up to the `remove` method (`@discardableResult`) that follows.
-String _registrySetBody() =>
-    _slice(_pluginSource(), 'func set(', '@discardableResult');
+/// Anchored on the unique `engine messenger:` parameter label rather than the
+/// generic `func set(`, so a future `func set(` on any earlier class can't
+/// silently redirect the slice to the wrong body.
+String _registrySetBody() => _slice(
+  _pluginSource(),
+  'engine messenger: FlutterBinaryMessenger',
+  '@discardableResult',
+);
 
 /// Slices the `PlayerRegistry.disposeForEngine(_:)` body — the *lookup* and
 /// teardown side — up to the `forAll` method that follows it.

--- a/mobile/packages/divine_video_player/test/src/apple_engine_teardown_contract_test.dart
+++ b/mobile/packages/divine_video_player/test/src/apple_engine_teardown_contract_test.dart
@@ -3,19 +3,22 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 /// These assertions guard the Apple-side fix for the "zombie CADisplayLink"
-/// crash (#5371): a `FlutterEngine` torn down without routing through the Dart
+/// crash (#5371) and the multi-engine registration hardening that followed
+/// (#5397): a `FlutterEngine` torn down without routing through the Dart
 /// `dispose`/`disposeAll` channel must still invalidate its own players'
-/// frame drivers, and must do so without tearing down another engine's
-/// players. The native player has no host-side Swift test harness (it links
-/// Flutter), so the contract is asserted against the source like the sibling
-/// threading contract test.
+/// frame drivers, must do so without tearing down another engine's players,
+/// and must source the messenger / texture registry from the engine that
+/// received the call — never a process-wide static overwritten by the latest
+/// engine to register. The native player has no host-side Swift test harness
+/// (it links Flutter), so the contract is asserted against the source like
+/// the sibling threading contract test.
 void main() {
   group('Apple native player engine-teardown contract', () {
     test("disposes this engine's players on FlutterEngine detach", () {
-      final source = _pluginSourceFile().readAsStringSync();
+      final detach = _detachBody();
 
       expect(
-        source,
+        _pluginSource(),
         contains(
           'public func detachFromEngine(for registrar: FlutterPluginRegistrar)',
         ),
@@ -25,14 +28,21 @@ void main() {
             'the plugin so the CADisplayLink can be invalidated.',
       );
       expect(
-        source,
-        contains('PlayerRegistry.shared.disposeOwned(by: self)'),
+        detach,
+        contains('PlayerRegistry.shared.disposeForEngine(messenger)'),
         reason:
-            "Detach must dispose this engine's players so their display "
+            "Detach must dispose only this engine's players so their display "
             'links stop firing textureFrameAvailable into the freed shell.',
       );
       expect(
-        source,
+        detach,
+        isNot(contains('disposeAll')),
+        reason:
+            'Detach must never blanket-dispose: a process-wide disposeAll '
+            "would tear down a second live engine's players.",
+      );
+      expect(
+        detach,
         contains('NotificationCenter.default.removeObserver(self)'),
         reason:
             "Detach must drop this engine's lifecycle observers so a stray "
@@ -40,35 +50,95 @@ void main() {
       );
     });
 
-    test('scopes teardown to the detaching engine', () {
-      final source = _pluginSourceFile().readAsStringSync();
+    test('scopes teardown to the engine that owns the players', () {
+      final source = _pluginSource();
 
       expect(
         source,
-        contains('func disposeOwned(by owner: DivineVideoPlayerPlugin)'),
+        contains('func disposeForEngine(_ messenger: FlutterBinaryMessenger)'),
         reason:
             'PlayerRegistry.shared is process-wide and shared with the FCM '
             'background isolate; teardown must be scoped per owning engine, '
-            'never a blanket disposeAll on detach.',
+            'never a blanket disposeAll on detach or register.',
       );
       expect(
         source,
-        contains('owner: DivineVideoPlayerPlugin'),
-        reason: 'Each player must record the engine that created it.',
-      );
-      expect(
-        source,
-        contains('PlayerRegistry.shared.set(instance, for: id, owner: self)'),
+        contains('engine messenger: FlutterBinaryMessenger'),
         reason:
-            'create must record the receiving plugin (engine) as the owner so '
-            "detach can identify this engine's players.",
+            'Each player must record the engine (its binary messenger) that '
+            'created it.',
       );
       expect(
         source,
-        contains('ObjectIdentifier(owner)'),
-        reason: 'Ownership is matched by object identity of the owning plugin.',
+        contains(
+          'PlayerRegistry.shared.set(instance, for: id, engine: messenger)',
+        ),
+        reason:
+            'create must record the receiving engine as the owner so detach '
+            "and hot-restart register can identify this engine's players.",
+      );
+      expect(
+        source,
+        contains('ObjectIdentifier(messenger as AnyObject)'),
+        reason:
+            'Ownership is matched by object identity of the engine messenger, '
+            'which is stable across that engine, including hot restart.',
       );
     });
+
+    test(
+      'player creation uses the receiving instance registrar, not a static',
+      () {
+        final source = _pluginSource();
+
+        expect(
+          source,
+          isNot(contains('static var registrar')),
+          reason:
+              'A process-wide static registrar is overwritten by the last '
+              'engine to register; player creation would then use the wrong '
+              "engine's messenger / texture registry. See #5397.",
+        );
+        expect(
+          source,
+          contains('private var registrar: FlutterPluginRegistrar?'),
+          reason:
+              'The registrar must be per plugin instance so each engine keeps '
+              'its own messenger / texture registry.',
+        );
+        expect(
+          _createBody(),
+          contains('let registrar = self.registrar'),
+          reason:
+              'create must use the registrar of the plugin instance that '
+              'received the method call — the engine the Dart side is talking '
+              'to — not a static last-writer-wins registrar.',
+        );
+      },
+    );
+
+    test(
+      'scopes hot-restart register-time cleanup to the registering engine',
+      () {
+        final register = _registerBody();
+
+        expect(
+          register,
+          contains('PlayerRegistry.shared.disposeForEngine(messenger)'),
+          reason:
+              'Hot restart re-calls register on the same engine; cleanup must '
+              "dispose only that engine's previous-run players.",
+        );
+        expect(
+          register,
+          isNot(contains('disposeAll')),
+          reason:
+              'A process-wide disposeAll at register would free a second live '
+              "engine's players when the FCM background isolate registers "
+              'after the UI engine created players. See #5397.',
+        );
+      },
+    );
 
     test('guards resume against a disposed texture output', () {
       final source = _textureOutputSourceFile().readAsStringSync();
@@ -88,6 +158,35 @@ void main() {
       );
     });
   });
+}
+
+String _pluginSource() => _pluginSourceFile().readAsStringSync();
+
+/// Slices the `register(with:)` body, which runs from the function signature
+/// up to the first app-lifecycle selector that follows it.
+String _registerBody() => _slice(
+  _pluginSource(),
+  'public static func register(with registrar:',
+  '@objc private func appWillResignActive',
+);
+
+/// Slices the `detachFromEngine(for:)` body, up to the `handle` method.
+String _detachBody() => _slice(
+  _pluginSource(),
+  'public func detachFromEngine(for registrar:',
+  'public func handle(',
+);
+
+/// Slices the `create` switch case, up to the `dispose` case.
+String _createBody() =>
+    _slice(_pluginSource(), 'case "create":', 'case "dispose":');
+
+String _slice(String source, String start, String end) {
+  final from = source.indexOf(start);
+  final to = source.indexOf(end, from);
+  expect(from, isNonNegative, reason: 'expected to find "$start" in source');
+  expect(to, greaterThan(from), reason: 'expected "$end" after "$start"');
+  return source.substring(from, to);
 }
 
 /// The iOS and macOS players share a single Darwin source tree


### PR DESCRIPTION
Closes #5397

## Description

Follow-up to #5390. That PR scoped engine **detach** per engine, but the Apple video player plugin still carried two process-wide assumptions that are unsafe under multi-engine registration — the FCM background isolate runs the plugin registrant alongside the UI engine.

**1. Per-instance registrar instead of a process-wide static.** `DivineVideoPlayerPlugin.registrar` was a `static` field set on every `register(with:)`. A second `FlutterEngine` registering after the UI engine overwrites it, so `create` (which read `Self.registrar`) could build the player against the *last* engine's messenger / texture registry rather than the engine that received the call. The registrar is now a per-instance field assigned to each plugin instance, and `create` reads `self.registrar` — the instance whose global channel received the method call is, by construction, the engine the Dart side is talking to.

**2. Engine-scoped register-time cleanup instead of a blanket `disposeAll()`.** `register(with:)` called `PlayerRegistry.shared.disposeAll()` process-wide for hot-restart cleanup. In a multi-engine process that means: UI engine creates players → FCM background isolate registers → `disposeAll()` tears down the UI engine's live players. The cleanup is now `disposeForEngine(_:)`, scoped to the registering engine.

The non-obvious design choice is **why ownership is keyed on the binary messenger identity rather than the plugin instance.** Hot restart re-runs `register(with:)` on the *same* engine but creates a *new* plugin instance, and the previous-run instance can stay alive via a retain cycle with its method channel — so it can't be used as a reliable "is this engine's previous run" signal, and instance-liveness can't be detected. The engine's binary messenger is a cached singleton on the `FlutterEngine`: stable across that engine's hot restart, and distinct per engine. Keying on `ObjectIdentifier(messenger)` therefore lets a hot-restart re-register dispose only the previous run's players on the same engine, never another live engine's, and holds no strong reference so an orphaned record can't keep a torn-down messenger alive. Detach was moved onto the same key so there is a single ownership model.

## Out of Scope

- The plugin↔channel retain cycle that can keep an orphaned plugin instance alive on hot restart. The messenger-keyed cleanup is correct independent of whether the old instance is freed, so fixing the leak is a separate concern.
- The Dart-channel `disposeAll` (explicit "dispose everything" request) stays process-wide — that is the intended semantics of that call.

## Verification

- `flutter analyze lib test` (package `divine_video_player`) → No issues found.
- `flutter test` (package `divine_video_player`) → 242 passed, including 5 source-level contract tests.
- No local iOS build: the package links the Flutter framework, so there is no host `swift build` / Swift test harness — the native invariants are asserted by parsing the Swift source, same approach as #5390.

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)