### PR TITLE
fix(share): lift the share-sheet message field above the keyboard

### DIFF
--- a/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
+++ b/mobile/lib/widgets/video_feed_item/actions/share_action_button.dart
@@ -591,6 +591,13 @@ class _UnifiedShareSheetView extends StatelessWidget {
         borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
         child: SafeArea(
           child: SingleChildScrollView(
+            // Lift the content above the keyboard so the message TextField
+            // stays visible when a recipient is selected. Without this the
+            // sheet is anchored at the screen bottom and the field hides
+            // behind the keyboard. Mirrors _ClipTitleSheet below.
+            padding: EdgeInsets.only(
+              bottom: MediaQuery.viewInsetsOf(context).bottom,
+            ),
             child: BlocBuilder<ShareSheetBloc, ShareSheetState>(
               builder: (context, state) {
                 final bloc = context.read<ShareSheetBloc>();

--- a/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
+++ b/mobile/test/widgets/video_feed_item/actions/share_action_button_test.dart
@@ -4,10 +4,12 @@
 
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:follow_repository/follow_repository.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart';
+import 'package:openvine/blocs/share_sheet/share_sheet_bloc.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/services/video_sharing_service.dart';
@@ -305,6 +307,67 @@ void main() {
         expect(find.text('Save to Gallery'), findsOneWidget);
         expect(find.text('Save with Watermark'), findsOneWidget);
       });
+
+      testWidgets(
+        'lifts message field above the keyboard when a recipient is selected',
+        (tester) async {
+          // Tall surface + dpr 1 so the short sheet stays bottom-anchored and
+          // logical pixels equal physical pixels for the inset math.
+          tester.view.devicePixelRatio = 1.0;
+          tester.view.physicalSize = const Size(1200, 6000);
+          addTearDown(tester.view.reset);
+
+          final mockAuth = createMockAuthService();
+
+          await tester.pumpWidget(
+            testMaterialApp(
+              home: Scaffold(body: ShareActionButton(video: testVideo)),
+              additionalOverrides: [
+                videoSharingServiceProvider.overrideWith(
+                  (ref) => mockVideoSharingService,
+                ),
+              ],
+              mockAuthService: mockAuth,
+              mockProfileRepository: mockProfileRepository,
+            ),
+          );
+
+          await tester.tap(find.byType(GestureDetector));
+          await tester.pumpAndSettle();
+
+          // Select a recipient so the message TextField is shown.
+          final blocContext = tester.element(find.text('Share with'));
+          blocContext.read<ShareSheetBloc>().add(
+            const ShareSheetRecipientSelected(
+              ShareableUser(
+                pubkey:
+                    'fedcba9876543210fedcba9876543210'
+                    'fedcba9876543210fedcba9876543210',
+                displayName: 'Alice',
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          expect(find.byType(TextField), findsOneWidget);
+
+          // Simulate the keyboard opening.
+          const keyboardHeight = 320.0;
+          tester.view.viewInsets = const FakeViewPadding(
+            bottom: keyboardHeight,
+          );
+          await tester.pumpAndSettle();
+
+          final logicalHeight =
+              tester.view.physicalSize.height / tester.view.devicePixelRatio;
+          final keyboardTop = logicalHeight - keyboardHeight;
+
+          // The field must sit above the keyboard, not behind it.
+          expect(
+            tester.getBottomLeft(find.byType(TextField)).dy,
+            lessThanOrEqualTo(keyboardTop),
+          );
+        },
+      );
     });
   });
 }


### PR DESCRIPTION
## Description

When sharing a video with someone who isn't already in your contacts row, you tap **Find people**, select the user, and the share sheet reveals a message text field. Tapping that field opened the keyboard over the bottom sheet, which stayed anchored to the screen bottom — so the field was hidden behind the keyboard and you couldn't see what you typed.

The unified share sheet's content (`_UnifiedShareSheetView`) is a bottom-anchored `SafeArea > SingleChildScrollView` presented via `showModalBottomSheet(isScrollControlled: true)`, but it never added the keyboard inset. This adds `padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom)` to the scroll view so the content lifts above the keyboard (and collapses to 0 when it closes), matching the sibling `_ClipTitleSheet` in the same file.

**Related Issue:** Closes #5688

## Out of Scope

None.

## Verification

- `flutter analyze` on the changed lib + test files — no issues.
- `flutter test test/widgets/video_feed_item/actions/share_action_button_test.dart` — 11/11 pass, including a new regression test that selects a recipient, simulates the keyboard, and asserts the message field sits above the keyboard.
- `flutter test test/widgets/share_video_menu_comprehensive_test.dart` — 28/28 pass.
- Confirmed the new test fails when the padding is removed, so it genuinely guards the regression.
- Pre-commit hook (format + analyze) passed.

Reproduction recording is from the original iOS report (see linked issue).

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
