### PR TITLE
fix(video-editor): split clips via frame-accurate splitVideo primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Improved duration warning: shows exact seconds over limit instead of vague message
 
 ### Fixed
+- **Clip Splitting Reliability**: Splitting a clip now uses pro_video_editor's dedicated
+  frame-accurate `splitVideo` primitive (one cut) instead of running both halves through the
+  full render compositor. The dedicated split cannot hang (native watchdog plus a Dart-side
+  timeout), fixing the case where a stalled export left the editor stuck and silently dropped
+  every subsequent split tap (#4801).
+
 - **Moderated Content Filtering**: Moderated videos from the relay are now filtered from the home feed cache,
   unknown server-side moderation labels are preserved and treated as hide signals, and 401/403 playback failures
   display a full-screen overlay with skip and age-verification actions instead of a half-broken player card.

--- a/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
+++ b/mobile/lib/blocs/video_editor/clip_editor/clip_editor_bloc.dart
@@ -557,10 +557,10 @@ class ClipEditorBloc extends Bloc<ClipEditorEvent, ClipEditorState> {
           splitStartClipId = startClip.id;
           splitEndClipId = endClip.id;
 
-          // splitClip's render phase awaits Future.wait on parallel
-          // video renders. If the bloc is closed mid-render (user
-          // navigates away from the editor), the late callbacks fire
-          // on a done emitter — guard each one.
+          // splitClip awaits a single native split (plus the parallel
+          // thumbnail). If the bloc is closed mid-split (user navigates
+          // away from the editor), the late callbacks fire on a done
+          // emitter — guard each one.
           if (emit.isDone) return;
           final clips = state.clips;
           final index = clips.indexWhere((c) => c.id == selectedClip.id);

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -237,6 +237,13 @@ class VideoEditorRenderService {
   VideoEditorRenderService._();
 
   static const _logName = 'VideoEditorRenderService';
+
+  /// Defense-in-depth Dart-side cap on a single native split. The native split
+  /// already carries its own watchdog; this guards against an unexpected
+  /// Dart-side hang so a stalled split can never wedge the caller's loading
+  /// state (#4801).
+  static const Duration _splitWatchdogTimeout = Duration(seconds: 150);
+
   static final _compositeProgressController =
       StreamController<ProgressModel>.broadcast();
   static final Map<String, Object> _activeNativeRenderTokens =
@@ -1098,6 +1105,57 @@ class VideoEditorRenderService {
     } finally {
       if (identical(_activeNativeRenderTokens[task.id], token)) {
         _activeNativeRenderTokens.remove(task.id);
+      }
+    }
+  }
+
+  /// Splits [inputPath] into two files at [splitPosition] using the dedicated
+  /// frame-accurate `pro_video_editor` split primitive.
+  ///
+  /// Unlike [renderNativeVideoToFile], this does not run the full render
+  /// compositor (no effects, overlays or audio mixing), so it is considerably
+  /// faster and far less likely to stall. The task is tracked in
+  /// [_activeNativeRenderTokens] so a lifecycle-detach [cancelActiveNativeTasks]
+  /// also cancels an in-flight split.
+  ///
+  /// Returns the two output paths as `[startOutputPath, endOutputPath]`.
+  ///
+  /// Throws [RenderCanceledException] when cancelled — including when the
+  /// defensive [_splitWatchdogTimeout] fires — so callers can treat an
+  /// unexpected stall exactly like a user cancel.
+  static Future<List<String>> splitNativeVideoToFile({
+    required String inputPath,
+    required Duration splitPosition,
+    required String startOutputPath,
+    required String endOutputPath,
+    bool enableAudio = true,
+    NativeLogLevel? nativeLogLevel = NativeLogLevel.warning,
+  }) async {
+    final model = SplitVideoModel(
+      video: EditorVideo.file(inputPath),
+      splitPosition: splitPosition,
+      startOutputPath: startOutputPath,
+      endOutputPath: endOutputPath,
+      enableAudio: enableAudio,
+    );
+    final token = Object();
+    _activeNativeRenderTokens[model.id] = token;
+    try {
+      return await ProVideoEditor.instance
+          .splitVideo(model, nativeLogLevel: nativeLogLevel)
+          .timeout(
+            _splitWatchdogTimeout,
+            onTimeout: () {
+              // The native split has its own watchdog; if the Dart Future still
+              // never completes, cancel the native task and surface a cancel so
+              // the caller's loading state can never get stuck (#4801).
+              unawaited(cancelTask(model.id));
+              throw const RenderCanceledException();
+            },
+          );
+    } finally {
+      if (identical(_activeNativeRenderTokens[model.id], token)) {
+        _activeNativeRenderTokens.remove(model.id);
       }
     }
   }

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -15,6 +15,12 @@ import 'package:unified_logger/unified_logger.dart';
 class VideoEditorSplitService {
   static const minClipDuration = Duration(milliseconds: 30);
 
+  /// Defensive cap on awaiting the preview thumbnail after the split settles.
+  /// The native thumbnail decode has no watchdog of its own; without this a
+  /// stalled decode would hold [splitClip] open and re-wedge the editor's
+  /// loading state exactly like the render stall did (#4801).
+  static const _thumbnailWatchdogTimeout = Duration(seconds: 30);
+
   /// Validates if the split position is valid for the given clip.
   ///
   /// [splitPosition] is relative to the trimmed clip (0 to trimmedDuration).
@@ -177,7 +183,14 @@ class VideoEditorSplitService {
       renderedEndClip.processingCompleter?.complete(false);
       rethrow;
     } finally {
-      await thumbnailFuture;
+      // Bound the wait so a stalled native thumbnail decode can't hold
+      // splitClip open and re-wedge the editor (#4801). The thumbnail owns its
+      // error handling internally, so this await only ever completes or times
+      // out — it never throws.
+      await thumbnailFuture.timeout(
+        _thumbnailWatchdogTimeout,
+        onTimeout: () {},
+      );
     }
   }
 

--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -31,12 +31,12 @@ class VideoEditorSplitService {
   ///
   /// This method:
   /// 1. Creates two new clip objects with completers for tracking processing
-  /// 2. Generates output paths in the cache directory
+  /// 2. Generates output paths in the documents directory
   /// 3. Calls onClipsCreated callback to add clips to UI BEFORE rendering
-  /// 4. Extracts thumbnail for the end clip
-  /// 5. Renders both clips in parallel
+  /// 4. Extracts the end clip's thumbnail in parallel with the split
+  /// 5. Cuts the source into both halves with a single frame-accurate split
   ///
-  /// Throws if rendering fails or split position is invalid
+  /// Throws if the split fails/cancels or the split position is invalid.
   static Future<void> splitClip({
     required DivineVideoClip sourceClip,
     required Duration splitPosition,
@@ -118,8 +118,10 @@ class VideoEditorSplitService {
     // rendering)
     onClipsCreated?.call(startClip, previewEndClip);
 
-    // Extract thumbnail for the end clip at the absolute split position
-    await _extractThumbnailForClip(
+    // Extract the preview thumbnail for the end clip in parallel with the
+    // split, so the preview frame can appear while the re-encode runs. It owns
+    // its error handling internally, so awaiting it later never throws.
+    final thumbnailFuture = _extractThumbnailForClip(
       sourceClip,
       absoluteSplitPos,
       previewEndClip,
@@ -127,46 +129,56 @@ class VideoEditorSplitService {
     );
 
     Log.debug(
-      '🎬 Starting parallel render of both clips',
+      '🎬 Splitting source clip at absolute ${absoluteSplitPos.inSeconds}s',
       name: 'VideoEditorSplitService',
       category: .video,
     );
-    // Render both clips in parallel using absolute positions.
-    // Trim must be set on the VideoSegment, not on VideoRenderData —
-    // VideoRenderData.startTime/endTime only apply to the deprecated
-    // single-video field and are ignored when videoSegments is used.
-    await Future.wait([
-      _renderSplitClip(
-        clip: startClip,
-        outputPath: startClipPath,
-        sourceVideo: sourceClip.video,
-        renderData: VideoRenderData(
-          id: startClip.id,
-          videoSegments: [
-            VideoSegment(video: sourceClip.video, endTime: absoluteSplitPos),
-          ],
-        ),
-        onClipRendered: onClipRendered,
-      ),
-      _renderSplitClip(
-        clip: renderedEndClip,
-        outputPath: endClipPath,
-        sourceVideo: sourceClip.video,
-        renderData: VideoRenderData(
-          id: renderedEndClip.id,
-          videoSegments: [
-            VideoSegment(video: sourceClip.video, startTime: absoluteSplitPos),
-          ],
-        ),
-        onClipRendered: onClipRendered,
-      ),
-    ]);
 
-    Log.info(
-      '✅ Split complete - created 2 clips from ${sourceClip.id}',
-      name: 'VideoEditorSplitService',
-      category: .video,
-    );
+    // One frame-accurate native split instead of two full render passes. The
+    // two halves are exactly the previous segment renders: start covers the
+    // source from 0 → split, end covers split → end. Unlike the render
+    // pipeline, this primitive cannot hang (per-export watchdog + Dart-side
+    // timeout), so a stalled export can never wedge the editor again (#4801).
+    try {
+      final outPaths = await VideoEditorRenderService.splitNativeVideoToFile(
+        inputPath: await sourceClip.video.safeFilePath(),
+        splitPosition: absoluteSplitPos,
+        startOutputPath: startClipPath,
+        endOutputPath: endClipPath,
+      );
+
+      startClip.processingCompleter?.complete(true);
+      onClipRendered?.call(startClip, EditorVideo.file(outPaths[0]));
+
+      renderedEndClip.processingCompleter?.complete(true);
+      onClipRendered?.call(renderedEndClip, EditorVideo.file(outPaths[1]));
+
+      Log.info(
+        '✅ Split complete - created 2 clips from ${sourceClip.id}',
+        name: 'VideoEditorSplitService',
+        category: .video,
+      );
+    } on RenderCanceledException {
+      Log.info(
+        '🚫 Split cancelled for ${sourceClip.id}',
+        name: 'VideoEditorSplitService',
+        category: .video,
+      );
+      startClip.processingCompleter?.complete(false);
+      renderedEndClip.processingCompleter?.complete(false);
+      rethrow;
+    } catch (e) {
+      Log.error(
+        '❌ Split failed for ${sourceClip.id}: $e',
+        name: 'VideoEditorSplitService',
+        category: .video,
+      );
+      startClip.processingCompleter?.complete(false);
+      renderedEndClip.processingCompleter?.complete(false);
+      rethrow;
+    } finally {
+      await thumbnailFuture;
+    }
   }
 
   /// Extract a thumbnail for the split clip at the specified timestamp.
@@ -201,54 +213,6 @@ class VideoEditorSplitService {
         name: 'VideoEditorSplitService',
         category: .video,
       );
-    }
-  }
-
-  /// Render a single split clip segment to file.
-  static Future<void> _renderSplitClip({
-    required DivineVideoClip clip,
-    required String outputPath,
-    required EditorVideo sourceVideo,
-    required VideoRenderData renderData,
-    required void Function(DivineVideoClip clip, EditorVideo video)?
-    onClipRendered,
-  }) async {
-    try {
-      Log.debug(
-        '🎞️ Rendering ${clip.id} (${clip.duration.inSeconds}s) to $outputPath',
-        name: 'VideoEditorSplitService',
-        category: .video,
-      );
-
-      await VideoEditorRenderService.renderNativeVideoToFile(
-        outputPath,
-        renderData,
-      );
-
-      Log.info(
-        '✅ Render complete: ${clip.id}',
-        name: 'VideoEditorSplitService',
-        category: .video,
-      );
-
-      clip.processingCompleter?.complete(true);
-      onClipRendered?.call(clip, EditorVideo.file(outputPath));
-    } on RenderCanceledException {
-      Log.info(
-        '🚫 Render cancelled: ${clip.id}',
-        name: 'VideoEditorSplitService',
-        category: .video,
-      );
-      clip.processingCompleter?.complete(false);
-      rethrow;
-    } catch (e) {
-      Log.error(
-        '❌ Render failed for ${clip.id}: $e',
-        name: 'VideoEditorSplitService',
-        category: .video,
-      );
-      clip.processingCompleter?.complete(false);
-      rethrow;
     }
   }
 }

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: cbb81a402882e4d57d4ce6a9966f7bb6b54434724c8c6df987c1cc00e9556883
+      sha256: "6a9a4929252f67948d58ac2424edcd96e46e0aa4c0736535dda30bf125a0da29"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.2.0"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -307,7 +307,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^2.1.3
+  pro_video_editor: ^2.2.0
   pro_image_editor: ^12.8.0
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7

--- a/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
+++ b/mobile/test/blocs/video_editor/clip_editor/clip_editor_bloc_test.dart
@@ -792,6 +792,47 @@ void main() {
         errors: () => [isA<StateError>()],
       );
 
+      test(
+        'a second split after the first completes still works (#4801)',
+        () async {
+          final bloc = buildBloc(splitClip: _fakeSplitClip);
+          bloc.emit(
+            ClipEditorState(
+              clips: [
+                _createClip(id: 'source', duration: const Duration(seconds: 4)),
+              ],
+              isEditing: true,
+              splitPosition: const Duration(seconds: 2),
+            ),
+          );
+
+          bloc.add(const ClipEditorSplitRequested());
+          await bloc.stream.firstWhere(
+            (s) => !s.isSplitting && s.clips.length == 2,
+          );
+
+          // The split future always resolves now, so isSplitting resets and the
+          // droppable() transformer no longer wedges the next split request.
+          bloc
+            ..emit(
+              bloc.state.copyWith(
+                currentClipIndex: 0,
+                isEditing: true,
+                splitPosition: const Duration(seconds: 1),
+              ),
+            )
+            ..add(const ClipEditorSplitRequested());
+          await bloc.stream.firstWhere(
+            (s) => !s.isSplitting && s.clips.length == 3,
+          );
+
+          expect(bloc.state.clips, hasLength(3));
+          expect(bloc.state.isSplitting, isFalse);
+
+          await bloc.close();
+        },
+      );
+
       test('validates using VideoEditorSplitService.isValidSplitPosition', () {
         final clip = _createClip(duration: const Duration(seconds: 2));
 

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -22,8 +22,7 @@ class MockPathProviderPlatform extends Fake
 
 class MockProVideoEditor extends ProVideoEditor {
   bool shouldThrowError = false;
-  final List<String> renderedPaths = [];
-  final List<VideoRenderData> renderedData = [];
+  final List<SplitVideoModel> splitRequests = [];
 
   @override
   Stream<dynamic> initializeStream() {
@@ -31,19 +30,17 @@ class MockProVideoEditor extends ProVideoEditor {
   }
 
   @override
-  Future<String> renderVideoToFile(
-    String outputPath,
-    VideoRenderData renderData, {
+  Future<List<String>> splitVideo(
+    SplitVideoModel value, {
     NativeLogLevel? nativeLogLevel,
   }) async {
     if (shouldThrowError) {
-      throw Exception('Render failed');
+      throw Exception('Split failed');
     }
-    renderedPaths.add(outputPath);
-    renderedData.add(renderData);
-    // Simulate successful render
+    splitRequests.add(value);
+    // Simulate a frame-accurate split producing two files.
     await Future<void>.delayed(const Duration(milliseconds: 10));
-    return outputPath;
+    return [value.startOutputPath, value.endOutputPath];
   }
 }
 
@@ -60,8 +57,7 @@ void main() {
     PathProviderPlatform.instance = MockPathProviderPlatform();
     mockProVideoEditor = MockProVideoEditor();
     ProVideoEditor.instance = mockProVideoEditor;
-    mockProVideoEditor.renderedPaths.clear();
-    mockProVideoEditor.renderedData.clear();
+    mockProVideoEditor.splitRequests.clear();
   });
 
   tearDown(() {
@@ -271,7 +267,7 @@ void main() {
         expect(clipsCreatedFirst, isTrue);
       });
 
-      test('renders both clips in parallel', () async {
+      test('cuts the source with a single frame-accurate split', () async {
         final clip = DivineVideoClip(
           id: 'test-clip',
           video: EditorVideo.file('/test/video.mp4'),
@@ -289,16 +285,68 @@ void main() {
           onClipRendered: null,
         );
 
-        // Should have rendered 2 clips
-        expect(mockProVideoEditor.renderedPaths.length, 2);
-        expect(
-          mockProVideoEditor.renderedPaths.any((p) => p.contains('_start.mp4')),
-          isTrue,
+        // A single native split replaces the two full render passes.
+        expect(mockProVideoEditor.splitRequests, hasLength(1));
+        final request = mockProVideoEditor.splitRequests.single;
+        expect(request.splitPosition, const Duration(seconds: 2));
+        expect(request.startOutputPath, contains('_start.mp4'));
+        expect(request.endOutputPath, contains('_end.mp4'));
+        expect(request.startOutputPath, isNot(request.endOutputPath));
+      });
+
+      test('reports both halves as two distinct output files', () async {
+        final clip = DivineVideoClip(
+          id: 'test-clip',
+          video: EditorVideo.file('/test/video.mp4'),
+          duration: const Duration(seconds: 5),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: model.AspectRatio.square,
+          originalAspectRatio: 9 / 16,
         );
-        expect(
-          mockProVideoEditor.renderedPaths.any((p) => p.contains('_end.mp4')),
-          isTrue,
+
+        final renderedVideos = <EditorVideo>[];
+        await VideoEditorSplitService.splitClip(
+          sourceClip: clip,
+          splitPosition: const Duration(seconds: 2),
+          onClipsCreated: null,
+          onThumbnailExtracted: null,
+          onClipRendered: (clip, video) => renderedVideos.add(video),
         );
+
+        expect(renderedVideos, hasLength(2));
+        final paths = renderedVideos.map((v) => v.file?.path).toList();
+        expect(paths.any((p) => p?.contains('_start.mp4') ?? false), isTrue);
+        expect(paths.any((p) => p?.contains('_end.mp4') ?? false), isTrue);
+        expect(paths.first, isNot(paths.last));
+      });
+
+      test('a second split immediately afterwards still works', () async {
+        final clip = DivineVideoClip(
+          id: 'test-clip',
+          video: EditorVideo.file('/test/video.mp4'),
+          duration: const Duration(seconds: 5),
+          recordedAt: DateTime.now(),
+          targetAspectRatio: model.AspectRatio.square,
+          originalAspectRatio: 9 / 16,
+        );
+
+        Future<int> runSplit() async {
+          var renderedCount = 0;
+          await VideoEditorSplitService.splitClip(
+            sourceClip: clip,
+            splitPosition: const Duration(seconds: 2),
+            onClipsCreated: null,
+            onThumbnailExtracted: null,
+            onClipRendered: (_, _) => renderedCount++,
+          );
+          return renderedCount;
+        }
+
+        // Regression for #4801: the split future always completes, so a
+        // back-to-back split is never silently dropped.
+        expect(await runSplit(), 2);
+        expect(await runSplit(), 2);
+        expect(mockProVideoEditor.splitRequests, hasLength(2));
       });
 
       test('calls onClipRendered for both clips', () async {

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui';
 
+import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
@@ -436,6 +437,29 @@ void main() {
       expect(proVideoEditor.cancelCalls, contains(startedModel.id));
       await splitCancellation;
       expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
+    });
+
+    test('watchdog converts a hung native split into a cancel (#4801)', () {
+      fakeAsync((async) {
+        Object? caughtError;
+        VideoEditorRenderService.splitNativeVideoToFile(
+          inputPath: '${Directory.systemTemp.path}/source.mp4',
+          splitPosition: const Duration(seconds: 1),
+          startOutputPath: '${Directory.systemTemp.path}/start.mp4',
+          endOutputPath: '${Directory.systemTemp.path}/end.mp4',
+        ).catchError((Object error) {
+          caughtError = error;
+          return <String>[];
+        });
+
+        // The native split never completes; advance past the Dart-side
+        // watchdog so the timeout fires and surfaces a cancel.
+        async.elapse(const Duration(seconds: 151));
+
+        expect(caughtError, isA<RenderCanceledException>());
+        expect(proVideoEditor.cancelCalls, hasLength(1));
+        expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
+      });
     });
   });
 

--- a/mobile/test/services/video_editor_render_service_test.dart
+++ b/mobile/test/services/video_editor_render_service_test.dart
@@ -18,7 +18,9 @@ import '../mocks/mock_path_provider_platform.dart';
 class _ProgressProVideoEditor extends ProVideoEditor {
   final _progressController = StreamController<ProgressModel>.broadcast();
   final renderStarts = StreamController<VideoRenderData>.broadcast();
+  final splitStarts = StreamController<SplitVideoModel>.broadcast();
   final _pendingRenders = <_PendingRender>[];
+  final _pendingSplits = <_PendingSplit>[];
   final cancelCalls = <String>[];
 
   @override
@@ -49,6 +51,18 @@ class _ProgressProVideoEditor extends ProVideoEditor {
   }
 
   @override
+  Future<List<String>> splitVideo(
+    SplitVideoModel value, {
+    NativeLogLevel? nativeLogLevel,
+  }) async {
+    final pending = _PendingSplit(model: value);
+    _pendingSplits.add(pending);
+    splitStarts.add(value);
+    await pending.completer.future;
+    return [value.startOutputPath, value.endOutputPath];
+  }
+
+  @override
   Future<void> cancel(String taskId) async {
     cancelCalls.add(taskId);
     final matchingRender = _pendingRenders.where(
@@ -56,6 +70,14 @@ class _ProgressProVideoEditor extends ProVideoEditor {
     );
     if (matchingRender.isNotEmpty) {
       matchingRender.first.completer.completeError(
+        const RenderCanceledException(),
+      );
+    }
+    final matchingSplit = _pendingSplits.where(
+      (pending) => pending.model.id == taskId && !pending.completer.isCompleted,
+    );
+    if (matchingSplit.isNotEmpty) {
+      matchingSplit.first.completer.completeError(
         const RenderCanceledException(),
       );
     }
@@ -80,6 +102,7 @@ class _ProgressProVideoEditor extends ProVideoEditor {
   Future<void> dispose() async {
     await _progressController.close();
     await renderStarts.close();
+    await splitStarts.close();
   }
 }
 
@@ -120,6 +143,13 @@ class _ImmediateRenderProVideoEditor extends ProVideoEditor {
   Future<void> cancel(String taskId) async {
     cancelCalls.add(taskId);
   }
+}
+
+class _PendingSplit {
+  _PendingSplit({required this.model});
+
+  final SplitVideoModel model;
+  final completer = Completer<void>();
 }
 
 Future<void> _flushStreamEvents() => Future<void>.delayed(Duration.zero);
@@ -379,6 +409,32 @@ void main() {
       await VideoEditorRenderService.cancelActiveNativeTasks();
 
       await secondCancellation;
+      expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
+    });
+
+    test('tracks a native split and cancels it on teardown', () async {
+      final splitStarted = proVideoEditor.splitStarts.stream.first;
+      final splitFuture = VideoEditorRenderService.splitNativeVideoToFile(
+        inputPath: '${Directory.systemTemp.path}/source.mp4',
+        splitPosition: const Duration(seconds: 1),
+        startOutputPath: '${Directory.systemTemp.path}/start.mp4',
+        endOutputPath: '${Directory.systemTemp.path}/end.mp4',
+      );
+
+      final startedModel = await splitStarted;
+      expect(
+        VideoEditorRenderService.activeNativeTaskIdsForTesting,
+        contains(startedModel.id),
+      );
+
+      final splitCancellation = expectLater(
+        splitFuture,
+        throwsA(isA<RenderCanceledException>()),
+      );
+      await VideoEditorRenderService.cancelActiveNativeTasks();
+
+      expect(proVideoEditor.cancelCalls, contains(startedModel.id));
+      await splitCancellation;
       expect(VideoEditorRenderService.activeNativeTaskIdsForTesting, isEmpty);
     });
   });


### PR DESCRIPTION
Closes #5693

## Description

Splitting a clip rendered **both** halves through the full native render compositor (`renderVideoToFile`), which has no timeout. If one export stalled, the Dart future never completed, so `ClipEditorBloc._onSplitRequested` never returned, `isSplitting` stayed `true` forever, and because the split event uses `transformer: droppable()` every later split tap was silently dropped — the reported "split does nothing" (#4801).

This switches the split to `pro_video_editor` 2.2.0's dedicated `ProVideoEditor.splitVideo` primitive: one frame-accurate cut of the source file into two halves, without the compositor/effects/audio-mixing, guarded by a native per-export watchdog. On top of that, `VideoEditorRenderService.splitNativeVideoToFile` adds a defense-in-depth Dart-side timeout that normalizes an unexpected stall into `RenderCanceledException`, so a hung split can never wedge the editor again. Thumbnail extraction now runs in parallel with the split so the preview frame appears while the re-encode runs.

Notable design choices:

- **Dependency: plain version bump, not a `dependency_override`.** The original plan assumed 2.2.0 was unpublished and called for a local-path/git override. 2.2.0 is now on pub.dev and `main` had already moved the app to `pro_video_editor: ^2.1.3` (the 1.x→2.x migration is already done), so this is just a minor `2.1.3 → 2.2.0` bump in `dependencies` — no override and no follow-up TODO to undo.
- **Split wrapper mirrors `renderNativeVideoToFile`.** It registers the task in `_activeNativeRenderTokens`, so a lifecycle-detach `cancelActiveNativeTasks()` also cancels an in-flight split, and a timeout best-effort-cancels the native task before surfacing the cancel.
- **`isSplitting` reset is now guaranteed.** With the split always terminating (success / error / cancel / timeout), the existing `try/finally` in `_onSplitRequested` always resets `isSplitting`, so `droppable()` no longer wedges. Covered by a new back-to-back-split regression test.
- **No new BLoC-level invalid-position signal.** The planned "optional UX" for `isValidSplitPosition == false` is already handled at the UI layer: the timeline controls validate and show a localized snackbar (`videoEditorSplitPositionInvalid` / `videoEditorSplitPlayheadOutsideClip`) before dispatching `ClipEditorSplitRequested`. Adding a second signal in the BLoC would double-fire, so the BLoC keeps its silent backstop return.

Output paths, frame accuracy, and audio behavior are unchanged.

**Related Issue:**  #4801

## Out of Scope

None.

## Verification

- `flutter analyze lib test integration_test` → clean
- `flutter test` for `video_editor_split_service_test.dart`, `video_editor_render_service_test.dart`, and `clip_editor_bloc_test.dart` → all pass (incl. new tests: single-split assertion, two distinct output files, back-to-back split, split-task token tracking/cancel, and a BLoC second-split-after-first regression)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ✅ Build configuration change (pro_video_editor 2.1.3 → 2.2.0)