### PR TITLE
fix(video-editor): stop doubling the split clip filename suffix

### DIFF
--- a/mobile/lib/services/video_editor/video_editor_split_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_split_service.dart
@@ -110,8 +110,11 @@ class VideoEditorSplitService {
     );
 
     final documentsPath = await getDocumentsPath();
-    final startClipPath = p.join(documentsPath, '${startClipId}_start.mp4');
-    final endClipPath = p.join(documentsPath, '${endClipId}_end.mp4');
+    // startClipId / endClipId already carry the `_start` / `_end` suffix, so
+    // the filename is just `<id>.mp4` — appending another suffix produced the
+    // doubled `_start_start.mp4` / `_end_end.mp4` names.
+    final startClipPath = p.join(documentsPath, '$startClipId.mp4');
+    final endClipPath = p.join(documentsPath, '$endClipId.mp4');
 
     Log.debug(
       '📁 Created split clips - Start: ${splitPosition.inSeconds}s, '

--- a/mobile/test/services/video_editor/video_editor_split_service_test.dart
+++ b/mobile/test/services/video_editor/video_editor_split_service_test.dart
@@ -312,12 +312,17 @@ void main() {
           onThumbnailExtracted: null,
           onClipRendered: (clip, video) => renderedVideos.add(video),
         );
-
         expect(renderedVideos, hasLength(2));
         final paths = renderedVideos.map((v) => v.file?.path).toList();
         expect(paths.any((p) => p?.contains('_start.mp4') ?? false), isTrue);
         expect(paths.any((p) => p?.contains('_end.mp4') ?? false), isTrue);
         expect(paths.first, isNot(paths.last));
+
+        // Regression: the clip id already ends in `_start` / `_end`, so the
+        // filename must not double that suffix (`_start_start.mp4`).
+        final request = mockProVideoEditor.splitRequests.single;
+        expect(request.startOutputPath, isNot(contains('_start_start')));
+        expect(request.endOutputPath, isNot(contains('_end_end')));
       });
 
       test('a second split immediately afterwards still works', () async {


### PR DESCRIPTION
Closes #5692

## Description

When splitting a clip, the two output files were written with a doubled suffix in their names: `<timestamp>_start_start.mp4` and `<timestamp>_end_end.mp4`. The clip ids (`startClipId` / `endClipId`) already end in `_start` / `_end`, but the output-path templates appended the suffix a second time. The files are otherwise functional — the doubled names are purely cosmetic — but they're confusing in logs and on disk.

This drops the redundant suffix so the filename matches the clip id (`<timestamp>_start.mp4` / `<timestamp>_end.mp4`), and adds a regression assertion that the output paths never contain the doubled `_start_start` / `_end_end` form. The existing `contains('_start.mp4')` checks passed for the doubled names too, so they did not lock this.

This is a standalone, pre-existing nit independent of the split-reliability work in #5690 — split semantics, output locations, and frame accuracy are unchanged.

## Out of Scope

None.

## Related Issue



## Verification

- `flutter analyze` on the changed files → clean
- `flutter test video_editor_split_service_test.dart` → all pass (incl. the new doubled-suffix regression assertion)

## Type of Change

- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)