### PR TITLE
feat(auth): in-app PIN entry fallback for email verification

### DIFF
--- a/local_stack/docker-compose.yml
+++ b/local_stack/docker-compose.yml
@@ -29,8 +29,8 @@ services:
       retries: 10
 
   keycast-migrate:
-    image: ghcr.io/divinevideo/keycast:latest
-    pull_policy: always
+    image: ${KEYCAST_IMAGE:-ghcr.io/divinevideo/keycast:latest}
+    pull_policy: ${KEYCAST_PULL_POLICY:-always}
     entrypoint: ["./keycast"]
     command: ["--migrate"]
     depends_on:
@@ -40,8 +40,8 @@ services:
       DATABASE_URL: postgres://postgres:password@keycast-postgres:5432/keycast
 
   keycast:
-    image: ghcr.io/divinevideo/keycast:latest
-    pull_policy: always
+    image: ${KEYCAST_IMAGE:-ghcr.io/divinevideo/keycast:latest}
+    pull_policy: ${KEYCAST_PULL_POLICY:-always}
     ports:
       - "43000:3000"
       - "45173:5173"

--- a/mobile/integration_test/auth/pin_verification_test.dart
+++ b/mobile/integration_test/auth/pin_verification_test.dart
@@ -1,0 +1,210 @@
+// ABOUTME: E2E for the in-app PIN fallback + cold-start verification restore
+// ABOUTME: Register -> seed PIN -> relaunch app.main (cold start) -> PIN sign-in
+
+import 'package:divine_ui/divine_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/l10n/generated/app_localizations.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/screens/auth/email_verification_screen.dart';
+import 'package:patrol/patrol.dart';
+
+import '../helpers/db_helpers.dart';
+import '../helpers/navigation_helpers.dart';
+import '../helpers/test_setup.dart';
+
+AppLocalizations get _en => lookupAppLocalizations(const Locale('en'));
+
+Finder _closeButton() => find.byWidgetPredicate(
+  (w) => w is DivineIcon && w.icon == DivineIconName.x,
+);
+
+Finder _pinField() => find.descendant(
+  of: find.widgetWithText(
+    DivineAuthTextField,
+    _en.authVerificationPinFieldLabel,
+  ),
+  matching: find.byType(TextField),
+);
+
+void main() {
+  group('Email verification PIN fallback', () {
+    // Requires a keycast image with the verify-pin endpoint + the
+    // oauth_codes.pin_hash migration (keycast#262). Until ghcr:latest rebuilds
+    // with that migration, run against a local image:
+    //   KEYCAST_IMAGE=keycast:262-local KEYCAST_PULL_POLICY=never \
+    //     mise run e2e_test integration_test/auth/pin_verification_test.dart
+    patrolTest(
+      'cold reopen restores the verify screen and a seeded PIN signs in',
+      ($) async {
+        final tester = $.tester;
+        final testEmail =
+            'pin-restore-${DateTime.now().millisecondsSinceEpoch}'
+            '@test.divine.video';
+        const password = 'TestPass123!';
+
+        final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
+        final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
+        final semanticsHandle = tester.ensureSemantics();
+
+        // 1. First launch + register -> land on the verification screen.
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+
+        await navigateToCreateAccount(tester);
+        await registerNewUser(tester, testEmail, password);
+
+        expect(
+          await waitForText(tester, _en.authCompleteRegistration),
+          isTrue,
+          reason: 'Registration should land on the verification screen',
+        );
+
+        // 2. Seed a PIN keycast can verify (the real PIN is bcrypt-hashed and
+        // never surfaced, so we write a known hash and type the known value).
+        await seedKnownPin(testEmail);
+
+        // 3. Simulate a cold start. A literal OS kill ends a patrol test, so
+        // re-launching app.main() (local storage persists) is the faithful way
+        // to exercise the startup restore path.
+        logPhase('Cold start: relaunching app.main()');
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+
+        // 4. The app should restore to the verification screen with the PIN
+        // field visible and still polling — not Welcome.
+        expect(
+          await waitForText(tester, _en.authCompleteRegistration),
+          isTrue,
+          reason: 'Cold start should restore the verification screen',
+        );
+        expect(
+          find.text(_en.authVerificationPinPrompt),
+          findsOneWidget,
+          reason: 'Restored screen should show the PIN entry field',
+        );
+        expect(
+          find.text(_en.authWaitingForVerification),
+          findsOneWidget,
+          reason: 'Restored screen should still be polling',
+        );
+
+        // 5. The escape hatch must be reachable (register / log in as a
+        // different user) without being a dead-end.
+        expect(
+          _closeButton(),
+          findsOneWidget,
+          reason:
+              'Restored screen must offer a close / start-over escape hatch',
+        );
+
+        // 6. Type the seeded PIN and submit -> sign-in completes via the
+        // restored deviceCode/verifier (proves the persisted record still
+        // exchanges).
+        await tester.enterText(_pinField(), knownPin);
+        await tester.pumpAndSettle();
+        await tester.tap(
+          find.widgetWithText(DivineButton, _en.authVerificationPinSubmit),
+        );
+
+        expect(
+          await waitForTextGone(tester, _en.authCompleteRegistration),
+          isTrue,
+          reason: 'Submitting the PIN should leave the verification screen',
+        );
+        await pumpUntilSettled(tester);
+
+        final container = ProviderScope.containerOf(
+          tester.element(find.byType(MaterialApp)),
+        );
+        expect(
+          container.read(authServiceProvider).isAuthenticated,
+          isTrue,
+          reason: 'PIN verification should complete sign-in',
+        );
+
+        semanticsHandle.dispose();
+        drainAsyncErrors(tester);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
+        restoreErrorWidgetBuilder(originalErrorBuilder);
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+    );
+
+    patrolTest(
+      'escape hatch on the restored screen clears the record and exits to '
+      'Welcome',
+      ($) async {
+        final tester = $.tester;
+        final testEmail =
+            'pin-escape-${DateTime.now().millisecondsSinceEpoch}'
+            '@test.divine.video';
+        const password = 'TestPass123!';
+
+        final originalOnError = suppressSetStateErrors();
+        addTearDown(() => restoreErrorHandler(originalOnError));
+        final originalErrorBuilder = saveErrorWidgetBuilder();
+        addTearDown(() => restoreErrorWidgetBuilder(originalErrorBuilder));
+        final semanticsHandle = tester.ensureSemantics();
+
+        // Register, then cold-start to land on the restored screen.
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+
+        await navigateToCreateAccount(tester);
+        await registerNewUser(tester, testEmail, password);
+        expect(await waitForText(tester, _en.authCompleteRegistration), isTrue);
+
+        logPhase('Cold start: relaunching app.main()');
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+        expect(
+          await waitForText(tester, _en.authCompleteRegistration),
+          isTrue,
+          reason: 'Cold start should restore the verification screen',
+        );
+
+        // Tap the escape hatch -> back to Welcome.
+        await tester.tap(_closeButton());
+        await tester.pumpAndSettle(const Duration(seconds: 1));
+        expect(
+          await waitForText(tester, _en.authCreateNewAccount),
+          isTrue,
+          reason: 'Escape hatch should return to the Welcome screen',
+        );
+        expect(
+          find.byType(EmailVerificationScreen),
+          findsNothing,
+          reason: 'Escape hatch should leave the verification screen',
+        );
+
+        // The record must be cleared: a second cold start must NOT restore.
+        logPhase('Cold start 2: should NOT restore (record cleared)');
+        launchAppGuarded(app.main);
+        await tester.pumpAndSettle(const Duration(seconds: 3));
+        expect(
+          await waitForText(tester, _en.authCreateNewAccount),
+          isTrue,
+          reason: 'Cleared record means the second cold start stays on Welcome',
+        );
+        expect(
+          find.text(_en.authCompleteRegistration),
+          findsNothing,
+          reason: 'Cleared record must not restore the verification screen',
+        );
+
+        semanticsHandle.dispose();
+        drainAsyncErrors(tester);
+        // Inline restore is required by the framework's end-of-body
+        // ErrorWidget.builder check; the addTearDown above covers throws.
+        restoreErrorWidgetBuilder(originalErrorBuilder);
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+    );
+  });
+}

--- a/mobile/integration_test/helpers/db_helpers.dart
+++ b/mobile/integration_test/helpers/db_helpers.dart
@@ -20,6 +20,71 @@ Future<Connection> _openKeycastConnection() async {
   );
 }
 
+/// The plaintext 6-digit PIN the e2e types into the verification screen.
+///
+/// keycast stores PINs bcrypt-hashed and never surfaces the plaintext, so the
+/// test seeds a KNOWN hash ([knownPinHash]) instead of trying to read the real
+/// one, then types this value. keycast still verifies it for real through
+/// `/api/headless/verify-pin`.
+const knownPin = '123456';
+
+/// A real bcrypt hash of [knownPin] (`123456`, cost 12).
+///
+/// Written into `oauth_codes.pin_hash` by [seedKnownPin]. The cost is encoded
+/// in the hash, so keycast's bcrypt verify reads it back regardless of the
+/// cost keycast itself uses when issuing PINs.
+const knownPinHash =
+    r'$2b$12$zmj2GR8M0AJVKHSLtnE.SumQqxgVumEcPLqi5oN0mdW6KXZQW2Df6';
+
+/// Seed a known PIN for [email] so the e2e can type [knownPin].
+///
+/// Sets `oauth_codes.pin_hash` to [knownPinHash] and resets `pin_attempts` on
+/// the most recent pending row for [email]. Mirrors the DB access the token
+/// helper uses — no keycast prod changes, no mail-catcher. Requires a keycast
+/// image that has the verify-pin migration (keycast#262 / `keycast:262-local`).
+/// Retries because the row may not be written immediately after registration.
+Future<void> seedKnownPin(
+  String email, {
+  int retries = 10,
+  Duration delay = const Duration(seconds: 2),
+}) async {
+  for (var i = 0; i < retries; i++) {
+    try {
+      final conn = await _openKeycastConnection();
+      try {
+        final result = await conn.execute(
+          Sql.named(
+            'UPDATE oauth_codes '
+            'SET pin_hash = @pinHash, pin_attempts = 0 '
+            'WHERE id = ('
+            '  SELECT id FROM oauth_codes '
+            '  WHERE pending_email = @email '
+            '  ORDER BY created_at DESC '
+            '  LIMIT 1)',
+          ),
+          parameters: {'pinHash': knownPinHash, 'email': email},
+        );
+        if (result.affectedRows > 0) {
+          debugPrint('seedKnownPin: seeded PIN for $email');
+          return;
+        }
+      } finally {
+        await conn.close();
+      }
+    } catch (e) {
+      debugPrint('seedKnownPin attempt ${i + 1} failed: $e');
+    }
+
+    if (i < retries - 1) {
+      await Future<void>.delayed(delay);
+    }
+  }
+
+  throw Exception(
+    'Failed to seed known PIN for $email after $retries retries',
+  );
+}
+
 /// Query the email verification token from local keycast postgres.
 ///
 /// Connects to postgres via the host-mapped port (15432) from the Android

--- a/mobile/lib/blocs/email_verification/email_verification_cubit.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_cubit.dart
@@ -15,11 +15,7 @@ import 'package:unified_logger/unified_logger.dart';
 
 part 'email_verification_state.dart';
 
-enum EmailTokenVerificationStatus {
-  success,
-  terminalFailure,
-  transientFailure,
-}
+enum EmailTokenVerificationStatus { success, terminalFailure, transientFailure }
 
 final class EmailTokenVerificationResult extends Equatable {
   const EmailTokenVerificationResult._(this.status, {this.errorCode});
@@ -81,11 +77,47 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
 
   Timer? _pollTimer;
   Timer? _timeoutTimer;
+  Timer? _resendTimer;
   String? _pendingDeviceCode;
   String? _pendingVerifier;
   String? _pendingInviteCode;
   String? _pendingVerificationToken;
   bool _isVerifyingEmailToken = false;
+  int _verificationGeneration = 0;
+
+  /// True once a terminal completion has been claimed for the current
+  /// verification. Set synchronously at the top of [_exchangeCodeAndLogin]
+  /// before the first await, so a racing poll completion and a racing PIN
+  /// submit cannot both reach token exchange / invite consumption. Reset
+  /// only by [startPolling] when a fresh verification begins.
+  bool _completionClaimed = false;
+
+  /// Whether a terminal completion has already been claimed for the current
+  /// verification — either by an in-flight/finished exchange on this instance
+  /// ([_completionClaimed]) or by another cubit instance that already
+  /// exchanged the same device code (the static [_completedDeviceCode]).
+  bool get _isCompletionClaimed =>
+      _completionClaimed ||
+      (_completedDeviceCode != null &&
+          _completedDeviceCode == _pendingDeviceCode);
+
+  bool _matchesActiveVerification({
+    required int generation,
+    required String deviceCode,
+    required String verifier,
+    required String? email,
+  }) {
+    return !isClosed &&
+        generation == _verificationGeneration &&
+        _pendingDeviceCode == deviceCode &&
+        _pendingVerifier == verifier &&
+        state.pendingEmail == email;
+  }
+
+  /// Client-side cooldown between resend requests, matching keycast's 5-minute
+  /// server-side rate limit. The server always returns success (anti-
+  /// enumeration), so the client owns surfacing the cooldown to the user.
+  static const resendCooldown = Duration(minutes: 5);
 
   /// Cubit-internal backoff counter for [_schedulePoll]. Lives outside
   /// state because the UI never reads it — analogous to [_pollTimer] and
@@ -144,6 +176,7 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
       category: LogCategory.auth,
     );
 
+    _verificationGeneration++;
     _pendingDeviceCode = deviceCode;
     _pendingVerifier = verifier;
     _pendingInviteCode = inviteCode == null
@@ -157,11 +190,16 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
       ),
     );
 
-    // Cancel any existing timers
+    // Cancel any existing timers. The resend cooldown timer is nulled too
+    // (it is not reassigned below, unlike the poll/timeout timers) so a re-init
+    // can't leave an orphaned Timer.periodic ticking onto the reset state.
     _pollTimer?.cancel();
     _timeoutTimer?.cancel();
+    _resendTimer?.cancel();
+    _resendTimer = null;
 
     _pollTickIndex = 0;
+    _completionClaimed = false;
     _schedulePoll();
 
     // Set timeout to stop polling after 15 minutes
@@ -169,6 +207,7 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
   }
 
   void _schedulePoll() {
+    final scheduledGeneration = _verificationGeneration;
     final delay = _delayForTick(_pollTickIndex);
     _pollTimer = Timer(delay, () async {
       _pollTickIndex++;
@@ -178,7 +217,16 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
       // _pendingDeviceCode, which stops the recursion cleanly. Using the
       // pending state — not _pollTimer — as the guard keeps intent explicit
       // and survives future cleanup paths that forget to clear the timer.
-      if (!isClosed && _pendingDeviceCode != null) {
+      //
+      // Also bail once the poll window has elapsed: _onTimeout keeps the
+      // pending device code (so PIN entry still works) but the poll loop must
+      // stop. Without this, an in-flight _poll() resuming after the timeout
+      // would re-arm the timer and poll forever. resumePollingAfterTimeout()
+      // restarts cleanly via startPolling when a late link click warrants it.
+      if (!isClosed &&
+          scheduledGeneration == _verificationGeneration &&
+          _pendingDeviceCode != null &&
+          state.status != EmailVerificationStatus.pollingTimedOut) {
         _schedulePoll();
       }
     });
@@ -394,17 +442,29 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
   }
 
   void _onTimeout() {
+    // A poll/PIN completion already landing (or finished) owns the terminal
+    // state — don't clobber its success with pollingTimedOut.
+    if (_isCompletionClaimed) return;
     Log.warning(
       'Email verification polling timed out after '
-      '${_pollingTimeout.inMinutes} minutes',
+      '${_pollingTimeout.inMinutes} minutes — keeping PIN entry available',
       name: 'EmailVerificationCubit',
       category: LogCategory.auth,
     );
-    _cleanup();
+    // Stop the poll/timeout timers but KEEP the pending device code + verifier
+    // so the user can still finish via the emailed PIN. Dropping to a terminal
+    // failure here would force a re-registration (and trip the duplicate-email
+    // edge); instead the screen stays usable for PIN entry / resend.
+    _stopPollTimers();
+    // Also tear down the resend cooldown timer so its periodic tick can't
+    // revive resendCooldownSeconds onto the fresh timed-out state emitted
+    // below (which resets resend fields to idle/0).
+    _resendTimer?.cancel();
+    _resendTimer = null;
     emit(
-      const EmailVerificationState(
-        status: EmailVerificationStatus.failure,
-        errorCode: EmailVerificationError.timeout,
+      EmailVerificationState(
+        status: EmailVerificationStatus.pollingTimedOut,
+        pendingEmail: state.pendingEmail,
       ),
     );
   }
@@ -421,6 +481,283 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
       case null:
         return EmailVerificationError.pollFailed;
     }
+  }
+
+  /// Cancel the poll + timeout timers without clearing the pending
+  /// verification context (unlike [_cleanup], which also nulls the device
+  /// code / verifier and is used on terminal completion).
+  void _stopPollTimers() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+    _timeoutTimer?.cancel();
+    _timeoutTimer = null;
+  }
+
+  /// Re-arm polling after a [EmailVerificationStatus.pollingTimedOut], reusing
+  /// the device code / verifier the timeout retained.
+  ///
+  /// Used when a late email-link click marks the email verified on the server
+  /// *after* the 15-minute poll window already elapsed: re-arming lets the next
+  /// poll pick up the completion so the flow auto-finishes instead of waiting
+  /// on manual PIN entry. No-ops unless we are timed out and still hold the
+  /// pending context.
+  void resumePollingAfterTimeout() {
+    if (state.status != EmailVerificationStatus.pollingTimedOut) return;
+    final deviceCode = _pendingDeviceCode;
+    final verifier = _pendingVerifier;
+    if (deviceCode == null || verifier == null) return;
+    Log.info(
+      'Re-arming polling after timeout following a late verifyEmail',
+      name: 'EmailVerificationCubit',
+      category: LogCategory.auth,
+    );
+    startPolling(
+      deviceCode: deviceCode,
+      verifier: verifier,
+      email: state.pendingEmail ?? '',
+      inviteCode: _pendingInviteCode,
+    );
+  }
+
+  /// Submit the 6-digit PIN the user read from the verification email.
+  ///
+  /// On success keycast returns the OAuth authorization code synchronously,
+  /// which is fed into the same [_exchangeCodeAndLogin] path as the link/poll
+  /// flow — no separate completion logic. Failures surface as a
+  /// [PinSubmissionStatus.failure] with a [EmailVerificationError] code; the
+  /// link/poll affordances stay intact.
+  Future<void> submitPin(String pin) async {
+    if (_isCompletionClaimed) {
+      // A poll completion or an earlier PIN submit already claimed the
+      // exchange. Submitting again would burn a server-side PIN attempt (and
+      // could double-consume the invite) or overwrite the landed success.
+      Log.info(
+        'submitPin ignored — completion already claimed',
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      );
+      return;
+    }
+
+    final deviceCode = _pendingDeviceCode;
+    final verifier = _pendingVerifier;
+    final email = state.pendingEmail;
+    final generation = _verificationGeneration;
+    if (deviceCode == null || verifier == null) {
+      // No pending context to exchange against (e.g. expired persistence).
+      // Retrying the PIN can't help — surface a generic failure.
+      Log.warning(
+        'submitPin called without pending device code / verifier',
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      );
+      emit(
+        state.copyWith(
+          pinStatus: PinSubmissionStatus.failure,
+          pinErrorCode: EmailVerificationError.pinFailed,
+        ),
+      );
+      return;
+    }
+
+    emit(state.copyWith(pinStatus: PinSubmissionStatus.submitting));
+
+    try {
+      final result = await _oauthClient.verifyPin(
+        deviceCode: deviceCode,
+        pin: pin,
+      );
+
+      if (!_matchesActiveVerification(
+        generation: generation,
+        deviceCode: deviceCode,
+        verifier: verifier,
+        email: email,
+      )) {
+        Log.info(
+          'submitPin: active verification changed during verifyPin — abandoning',
+          name: 'EmailVerificationCubit',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+
+      if (result.alreadyCompleted) {
+        Log.info(
+          'PIN verification already completed; leaving polling/link recovery active',
+          name: 'EmailVerificationCubit',
+          category: LogCategory.auth,
+        );
+        emit(
+          state.copyWith(
+            pinStatus: PinSubmissionStatus.idle,
+            pinErrorCode: null,
+          ),
+        );
+        return;
+      }
+
+      if (result.success && result.code != null) {
+        if (_isCompletionClaimed) {
+          // A poll completion won the race while verifyPin was in flight.
+          // Don't re-exchange or stop timers it already owns.
+          return;
+        }
+        Log.info(
+          'PIN verification succeeded, exchanging code',
+          name: 'EmailVerificationCubit',
+          category: LogCategory.auth,
+        );
+        _stopPollTimers();
+        await _exchangeCodeAndLogin(result.code!, verifier);
+        return;
+      }
+
+      Log.warning(
+        'PIN verification failed: ${result.errorCode}',
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      );
+      if (result.errorCode == VerifyPinError.emailAlreadyRegistered) {
+        _stopPollTimers();
+        emit(
+          state.copyWith(
+            status: EmailVerificationStatus.failure,
+            errorCode: EmailVerificationError.emailAlreadyRegistered,
+            pinStatus: PinSubmissionStatus.idle,
+            pinErrorCode: null,
+          ),
+        );
+        return;
+      }
+      emit(
+        state.copyWith(
+          pinStatus: PinSubmissionStatus.failure,
+          pinErrorCode: _pinErrorFor(result.errorCode),
+        ),
+      );
+    } catch (e, stackTrace) {
+      if (!_matchesActiveVerification(
+        generation: generation,
+        deviceCode: deviceCode,
+        verifier: verifier,
+        email: email,
+      )) {
+        return;
+      }
+      Log.error(
+        'PIN verification exception: $e',
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      );
+      addError(e, stackTrace);
+      emit(
+        state.copyWith(
+          pinStatus: PinSubmissionStatus.failure,
+          pinErrorCode: EmailVerificationError.pinFailed,
+        ),
+      );
+    }
+  }
+
+  static EmailVerificationError _pinErrorFor(VerifyPinError? error) {
+    return switch (error) {
+      VerifyPinError.invalid => EmailVerificationError.pinInvalid,
+      VerifyPinError.expired => EmailVerificationError.pinExpired,
+      VerifyPinError.locked => EmailVerificationError.pinLocked,
+      VerifyPinError.unavailable => EmailVerificationError.pinUnavailable,
+      VerifyPinError.emailAlreadyRegistered =>
+        EmailVerificationError.emailAlreadyRegistered,
+      VerifyPinError.network ||
+      VerifyPinError.server ||
+      null => EmailVerificationError.pinFailed,
+    };
+  }
+
+  /// Request a fresh verification email (link + PIN) and start the 5-minute
+  /// resend cooldown. No-ops while a resend is in flight or on cooldown.
+  Future<void> resendVerification() async {
+    final email = state.pendingEmail;
+    final deviceCode = _pendingDeviceCode;
+    final verifier = _pendingVerifier;
+    final generation = _verificationGeneration;
+    if (email == null || email.isEmpty) return;
+    if (deviceCode == null || verifier == null) return;
+    if (state.resendStatus == ResendStatus.sending ||
+        state.resendStatus == ResendStatus.cooldown) {
+      return;
+    }
+
+    emit(state.copyWith(resendStatus: ResendStatus.sending));
+    try {
+      final result = await _oauthClient.resendHeadlessVerification(deviceCode);
+      if (!_matchesActiveVerification(
+        generation: generation,
+        deviceCode: deviceCode,
+        verifier: verifier,
+        email: email,
+      )) {
+        return;
+      }
+      if (result.success) {
+        _startResendCooldown();
+        return;
+      }
+      // The request reached the server but it declined to send. Leave resend
+      // retryable and surface a visible failure instead of a silent dead button.
+      Log.warning(
+        'Resend verification returned failure; keeping resend available',
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      );
+      emit(state.copyWith(resendStatus: ResendStatus.failure));
+    } catch (e, stackTrace) {
+      if (!_matchesActiveVerification(
+        generation: generation,
+        deviceCode: deviceCode,
+        verifier: verifier,
+        email: email,
+      )) {
+        return;
+      }
+      // Transient network failure — leave resend available to retry.
+      Log.warning(
+        'Resend verification request failed: $e',
+        name: 'EmailVerificationCubit',
+        category: LogCategory.auth,
+      );
+      addError(e, stackTrace);
+      emit(state.copyWith(resendStatus: ResendStatus.failure));
+    }
+  }
+
+  void _startResendCooldown() {
+    _resendTimer?.cancel();
+    var remaining = resendCooldown.inSeconds;
+    emit(
+      state.copyWith(
+        resendStatus: ResendStatus.cooldown,
+        resendCooldownSeconds: remaining,
+      ),
+    );
+    _resendTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (isClosed) {
+        timer.cancel();
+        return;
+      }
+      remaining--;
+      if (remaining <= 0) {
+        timer.cancel();
+        emit(
+          state.copyWith(
+            resendStatus: ResendStatus.idle,
+            resendCooldownSeconds: 0,
+          ),
+        );
+      } else {
+        emit(state.copyWith(resendCooldownSeconds: remaining));
+      }
+    });
   }
 
   Future<void> _poll() async {
@@ -485,12 +822,45 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
         name: 'EmailVerificationCubit',
         category: LogCategory.auth,
       );
+      final pollGeneration = _verificationGeneration;
+      final deviceCode = _pendingDeviceCode;
+      final verifier = _pendingVerifier;
+      if (deviceCode == null) {
+        Log.warning(
+          'Poll called but pending device code was cleared, cleaning up',
+          name: 'EmailVerificationCubit',
+          category: LogCategory.auth,
+        );
+        _cleanup();
+        return;
+      }
+
       final tokenResult = await _verifyPendingTokenIfNeeded();
+      if (pollGeneration != _verificationGeneration ||
+          _pendingDeviceCode != deviceCode ||
+          _pendingVerifier != verifier) {
+        Log.info(
+          'Poll context changed during token verification — abandoning stale poll',
+          name: 'EmailVerificationCubit',
+          category: LogCategory.auth,
+        );
+        return;
+      }
       if (tokenResult.status == EmailTokenVerificationStatus.terminalFailure) {
         return;
       }
 
-      final result = await _oauthClient.pollForCode(_pendingDeviceCode!);
+      final result = await _oauthClient.pollForCode(deviceCode);
+      if (pollGeneration != _verificationGeneration ||
+          _pendingDeviceCode != deviceCode ||
+          _pendingVerifier != verifier) {
+        Log.info(
+          'Poll context changed during pollForCode — abandoning stale poll',
+          name: 'EmailVerificationCubit',
+          category: LogCategory.auth,
+        );
+        return;
+      }
 
       Log.info(
         'Poll result: status=${result.status}, hasCode=${result.code != null}, '
@@ -503,13 +873,25 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
         case PollStatus.complete:
           Log.info(
             'Email verification complete! code=${result.code != null}, '
-            'verifier=${_pendingVerifier != null}',
+            'verifier=${verifier != null}',
             name: 'EmailVerificationCubit',
             category: LogCategory.auth,
           );
           _pollTimer?.cancel();
-          if (result.code != null && _pendingVerifier != null) {
-            await _exchangeCodeAndLogin(result.code!, _pendingVerifier!);
+          if (_isCompletionClaimed) {
+            // A PIN submit (or an earlier completion) already claimed the
+            // exchange while this poll was in flight. Bail instead of emitting
+            // a missingAuthCode failure over the success it is landing.
+            Log.info(
+              'Completion already claimed, ignoring in-flight poll result '
+              '(cubit=$hashCode)',
+              name: 'EmailVerificationCubit',
+              category: LogCategory.auth,
+            );
+            return;
+          }
+          if (result.code != null && verifier != null) {
+            await _exchangeCodeAndLogin(result.code!, verifier);
           } else {
             // Edge case: completion detected but missing code or verifier.
             // Log presence only — BYOK verifiers embed the raw nsec and
@@ -517,7 +899,7 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
             Log.error(
               'Verification complete but missing code or verifier! '
               'code=${result.code != null}, '
-              'verifier=${_pendingVerifier != null}',
+              'verifier=${verifier != null}',
               name: 'EmailVerificationCubit',
               category: LogCategory.auth,
             );
@@ -552,6 +934,39 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
             // Don't stop polling - it will retry in 3 seconds
           } else {
             final errorCode = _errorForPollFailure(result);
+
+            // A completion was already claimed (an in-flight/finished exchange
+            // on this instance, or another cubit finished this device code).
+            // A late poll error is stale and must not clobber that success.
+            if (_isCompletionClaimed) {
+              Log.warning(
+                'Ignoring post-completion poll error (cubit=$hashCode): '
+                '$errorMsg',
+                name: 'EmailVerificationCubit',
+                category: LogCategory.auth,
+              );
+              return;
+            }
+
+            // After the poll window elapsed, _onTimeout deliberately retains
+            // the pending device code / verifier so PIN entry still works. A
+            // recoverable/unknown poll error that lands late must not tear that
+            // down — only a genuinely expired / already-registered device code
+            // is truly terminal.
+            final isTerminalFailure =
+                errorCode == EmailVerificationError.emailAlreadyRegistered ||
+                errorCode == EmailVerificationError.verificationLinkExpired;
+            if (!isTerminalFailure &&
+                state.status == EmailVerificationStatus.pollingTimedOut) {
+              Log.warning(
+                'Recoverable poll error after timeout — keeping PIN entry '
+                'available: $errorMsg',
+                name: 'EmailVerificationCubit',
+                category: LogCategory.auth,
+              );
+              return;
+            }
+
             final pendingEmail = state.pendingEmail;
             Log.error(
               'Email verification polling error (stopping): '
@@ -606,6 +1021,24 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
   static const _consumeRetryDelay = Duration(milliseconds: 500);
 
   Future<void> _exchangeCodeAndLogin(String code, String verifier) async {
+    // Atomically claim completion before the first await. A racing poll
+    // completion or a second PIN submit that reaches here after the claim
+    // returns immediately, preventing a duplicate token exchange or a double
+    // invite consumption. Snapshot then null the pending device code / verifier
+    // under the claim so a resuming in-flight _poll() reads the cleared context
+    // and bails (see the PollStatus.complete guard) instead of landing a second
+    // exchange or emitting missingAuthCode over this success.
+    if (_isCompletionClaimed) {
+      return;
+    }
+    _completionClaimed = true;
+    final exchangeGeneration = _verificationGeneration;
+    final claimedDeviceCode = _pendingDeviceCode;
+    _pendingDeviceCode = null;
+    _pendingVerifier = null;
+
+    bool isStaleExchange() => exchangeGeneration != _verificationGeneration;
+
     for (var attempt = 1; attempt <= _maxExchangeRetries; attempt++) {
       try {
         Log.info(
@@ -618,9 +1051,15 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
           code: code,
           verifier: verifier,
         );
+        if (isStaleExchange()) {
+          return;
+        }
 
         final session = KeycastSession.fromTokenResponse(tokenResponse);
         await _consumeInviteWithSessionIfNeeded(session);
+        if (isStaleExchange()) {
+          return;
+        }
 
         Log.info(
           'Token exchange successful, showing verification confirmation',
@@ -630,7 +1069,9 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
 
         // Mark this device code as completed so zombie cubits from engine
         // restarts (which hold different AuthService instances) will stop.
-        _completedDeviceCode = _pendingDeviceCode;
+        // Uses the snapshot taken at claim time because _pendingDeviceCode was
+        // nulled under the completion claim above.
+        _completedDeviceCode = claimedDeviceCode;
 
         // Emit success BEFORE signing in, because signInWithDivineOAuth
         // triggers an auth state change that causes GoRouter to redirect
@@ -665,6 +1106,9 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
 
         return; // Success - exit the retry loop
       } on InviteApiException catch (e) {
+        if (isStaleExchange()) {
+          return;
+        }
         await _authService.clearPendingDivineOAuthSession();
         Log.error(
           'Invite activation failed: '
@@ -684,6 +1128,9 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
         );
         return;
       } on OAuthException catch (e) {
+        if (isStaleExchange()) {
+          return;
+        }
         // OAuth errors are not retryable (e.g., invalid code, expired code)
         Log.error(
           'OAuth exchange failed: ${e.message}',
@@ -699,6 +1146,9 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
         );
         return; // Don't retry OAuth errors
       } catch (e) {
+        if (isStaleExchange()) {
+          return;
+        }
         // Network errors - retry if we have attempts left
         final isLastAttempt = attempt == _maxExchangeRetries;
         Log.warning(
@@ -725,11 +1175,15 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
 
         // Wait before retrying
         await Future<void>.delayed(_exchangeRetryDelay);
+        if (isStaleExchange()) {
+          return;
+        }
       }
     }
   }
 
   void _cleanup() {
+    _verificationGeneration++;
     Log.info(
       '_cleanup (cubit=$hashCode, hadPollTimer=${_pollTimer != null}, '
       'hadTimeoutTimer=${_timeoutTimer != null})',
@@ -740,6 +1194,8 @@ class EmailVerificationCubit extends Cubit<EmailVerificationState> {
     _pollTimer = null;
     _timeoutTimer?.cancel();
     _timeoutTimer = null;
+    _resendTimer?.cancel();
+    _resendTimer = null;
     _pollTickIndex = 0;
     _pendingDeviceCode = null;
     _pendingVerifier = null;

--- a/mobile/lib/blocs/email_verification/email_verification_state.dart
+++ b/mobile/lib/blocs/email_verification/email_verification_state.dart
@@ -3,6 +3,12 @@
 
 part of 'email_verification_cubit.dart';
 
+/// Sentinel for [EmailVerificationState.copyWith] so the nullable reason codes
+/// can distinguish "argument omitted" (preserve the current value) from
+/// "explicit null" (clear the value). Without it, the only way to express
+/// "leave it alone" collides with "set it to null".
+const Object _unset = Object();
+
 /// Status of email verification polling
 enum EmailVerificationStatus {
   /// Not polling
@@ -11,10 +17,43 @@ enum EmailVerificationStatus {
   /// Actively polling for verification
   polling,
 
+  /// The 15-minute poll window elapsed without verification, but the screen
+  /// stays usable: the user can still enter the emailed PIN (or resend it)
+  /// instead of being dropped to a terminal "Start Over" dead end.
+  pollingTimedOut,
+
   /// Verification completed successfully
   success,
 
   /// Polling failed with an error
+  failure,
+}
+
+/// Status of an in-app PIN submission, surfaced alongside [polling] /
+/// [pollingTimedOut] so PIN feedback never replaces the link/poll affordances.
+enum PinSubmissionStatus {
+  /// No PIN submission in flight.
+  idle,
+
+  /// A PIN is being verified against the server.
+  submitting,
+
+  /// The last PIN submission failed; see [EmailVerificationState.pinErrorCode].
+  failure,
+}
+
+/// Status of the "resend verification email" affordance.
+enum ResendStatus {
+  /// Resend is available.
+  idle,
+
+  /// A resend request is in flight.
+  sending,
+
+  /// Resend is on its post-send 5-minute cooldown.
+  cooldown,
+
+  /// The last resend attempt failed; the user may retry.
   failure,
 }
 
@@ -62,6 +101,22 @@ enum EmailVerificationError {
 
   /// Invite activation failed for an unspecified reason.
   inviteUnknown,
+
+  /// The submitted PIN was incorrect.
+  pinInvalid,
+
+  /// The submitted PIN (or its verify window) has expired.
+  pinExpired,
+
+  /// The PIN is locked after too many failed attempts; a resend is required.
+  pinLocked,
+
+  /// PIN verification failed for a network / server / unexpected reason.
+  pinFailed,
+
+  /// The verify-pin endpoint is unavailable (absent / unclassified 4xx); the
+  /// user should fall back to the email link or request a fresh code.
+  pinUnavailable,
 }
 
 /// State for email verification polling
@@ -72,6 +127,10 @@ final class EmailVerificationState extends Equatable {
     this.errorCode,
     this.showInviteGateRecovery = false,
     this.inviteRecoveryCode,
+    this.pinStatus = PinSubmissionStatus.idle,
+    this.pinErrorCode,
+    this.resendStatus = ResendStatus.idle,
+    this.resendCooldownSeconds = 0,
   });
 
   /// Current polling status
@@ -92,23 +151,57 @@ final class EmailVerificationState extends Equatable {
   /// Invite code to prefill when recovering through the invite gate.
   final String? inviteRecoveryCode;
 
+  /// Status of the in-app PIN submission.
+  final PinSubmissionStatus pinStatus;
+
+  /// Reason code for the last PIN failure. Read by the UI only when
+  /// [pinStatus] is [PinSubmissionStatus.failure]; mapped to localized copy
+  /// the same way as [errorCode] — never a raw English string.
+  final EmailVerificationError? pinErrorCode;
+
+  /// Status of the resend-verification affordance.
+  final ResendStatus resendStatus;
+
+  /// Seconds remaining on the resend cooldown (0 when [resendStatus] is not
+  /// [ResendStatus.cooldown]).
+  final int resendCooldownSeconds;
+
   /// Whether currently polling
   bool get isPolling => status == EmailVerificationStatus.polling;
 
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// The nullable reason codes [errorCode] and [pinErrorCode] use a sentinel
+  /// default: omitting the argument preserves the current value, while passing
+  /// an explicit `null` clears it. Every other field follows the usual
+  /// `value ?? this.value` preserve-on-omit shape.
   EmailVerificationState copyWith({
     EmailVerificationStatus? status,
     String? pendingEmail,
-    EmailVerificationError? errorCode,
+    Object? errorCode = _unset,
     bool? showInviteGateRecovery,
     String? inviteRecoveryCode,
+    PinSubmissionStatus? pinStatus,
+    Object? pinErrorCode = _unset,
+    ResendStatus? resendStatus,
+    int? resendCooldownSeconds,
   }) {
     return EmailVerificationState(
       status: status ?? this.status,
       pendingEmail: pendingEmail ?? this.pendingEmail,
-      errorCode: errorCode,
+      errorCode: identical(errorCode, _unset)
+          ? this.errorCode
+          : errorCode as EmailVerificationError?,
       showInviteGateRecovery:
           showInviteGateRecovery ?? this.showInviteGateRecovery,
       inviteRecoveryCode: inviteRecoveryCode ?? this.inviteRecoveryCode,
+      pinStatus: pinStatus ?? this.pinStatus,
+      pinErrorCode: identical(pinErrorCode, _unset)
+          ? this.pinErrorCode
+          : pinErrorCode as EmailVerificationError?,
+      resendStatus: resendStatus ?? this.resendStatus,
+      resendCooldownSeconds:
+          resendCooldownSeconds ?? this.resendCooldownSeconds,
     );
   }
 
@@ -119,5 +212,9 @@ final class EmailVerificationState extends Equatable {
     errorCode,
     showInviteGateRecovery,
     inviteRecoveryCode,
+    pinStatus,
+    pinErrorCode,
+    resendStatus,
+    resendCooldownSeconds,
   ];
 }

--- a/mobile/lib/features/feature_flags/models/feature_flag.dart
+++ b/mobile/lib/features/feature_flags/models/feature_flag.dart
@@ -63,6 +63,11 @@ enum FeatureFlag {
     'Suggest content-warning labels on videos and blur videos whose labels '
         'crossed the community threshold. Off by default pending T&S '
         'rollout sign-off.',
+  ),
+  emailVerificationPinFallback(
+    'Email Verification PIN Fallback',
+    'Show the in-app email verification PIN and resend fallback. Off by '
+        'default until keycast verify-pin support is deployed.',
   );
 
   const FeatureFlag(this.displayName, this.description);

--- a/mobile/lib/features/feature_flags/services/build_configuration.dart
+++ b/mobile/lib/features/feature_flags/services/build_configuration.dart
@@ -49,6 +49,9 @@ class BuildConfiguration {
         // Default OFF pending T&S sign-off on surfacing warnings from
         // unverified community votes (#4771).
         return const bool.fromEnvironment('FF_COMMUNITY_CONTENT_WARNINGS');
+      case FeatureFlag.emailVerificationPinFallback:
+        // Default OFF until keycast verify-pin support is deployed.
+        return const bool.fromEnvironment('FF_EMAIL_VERIFICATION_PIN_FALLBACK');
     }
   }
 
@@ -91,6 +94,8 @@ class BuildConfiguration {
         return 'FF_ADAPTIVE_MEDIA_CHROME';
       case FeatureFlag.communityContentWarnings:
         return 'FF_COMMUNITY_CONTENT_WARNINGS';
+      case FeatureFlag.emailVerificationPinFallback:
+        return 'FF_EMAIL_VERIFICATION_PIN_FALLBACK';
     }
   }
 }

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1724,6 +1724,19 @@
   "authPleaseWaitVerifying": "Please wait while we verify your email...",
   "authWaitingForVerification": "Waiting for verification",
   "authOpenEmailApp": "Open email app",
+  "authVerificationPinPrompt": "Or enter the 6-digit code from your email",
+  "authVerificationPinFieldLabel": "6-digit code",
+  "authVerificationPinSubmit": "Verify code",
+  "authVerificationResendPrompt": "Didn't get it?",
+  "authVerificationResend": "Resend",
+  "authVerificationResendCooldown": "Resend in {time}",
+  "@authVerificationResendCooldown": {
+    "description": "Disabled-state label for the resend button during its cooldown. {time} is a preformatted m:ss countdown (e.g. 4:59).",
+    "placeholders": {
+      "time": { "type": "String" }
+    }
+  },
+  "authVerificationResendFailed": "We couldn't resend the email. Try again.",
   "authWelcomeToDivine": "Welcome to Divine!",
   "authEmailVerified": "Your email has been verified.",
   "authSigningYouIn": "Signing you in",
@@ -1842,6 +1855,11 @@
   "authVerificationErrorOAuthExchange": "Verification failed. Please try registering again.",
   "authVerificationErrorSignInFailed": "Sign-in failed. Please try logging in manually.",
   "authVerificationEmailAlreadyRegistered": "This email is already registered. Sign in instead.",
+  "authVerificationErrorPinInvalid": "That code didn't match. Double-check it and try again.",
+  "authVerificationErrorPinExpired": "That code has expired. Tap resend to get a new one.",
+  "authVerificationErrorPinLocked": "Too many tries. Tap resend to get a fresh code.",
+  "authVerificationErrorPinFailed": "We couldn't verify that code. Please try again.",
+  "authVerificationErrorPinUnavailable": "Code entry isn't available right now. Tap the link in your email, or resend to get a fresh one.",
   "authInviteErrorAlreadyUsed": "That invite code is no longer available. Go back to your invite code, join the waitlist, or contact support.",
   "authInviteErrorInvalid": "That invite code cannot be used right now. Go back to your invite code, join the waitlist, or contact support.",
   "authInviteErrorTemporary": "We couldn't confirm your invite right now. Go back to your invite code and try again, or contact support.",

--- a/mobile/lib/l10n/email_verification_error_l10n.dart
+++ b/mobile/lib/l10n/email_verification_error_l10n.dart
@@ -39,6 +39,16 @@ extension EmailVerificationErrorL10n on AppLocalizations {
         return authInviteErrorTemporary;
       case EmailVerificationError.inviteUnknown:
         return authInviteErrorUnknown;
+      case EmailVerificationError.pinInvalid:
+        return authVerificationErrorPinInvalid;
+      case EmailVerificationError.pinExpired:
+        return authVerificationErrorPinExpired;
+      case EmailVerificationError.pinLocked:
+        return authVerificationErrorPinLocked;
+      case EmailVerificationError.pinFailed:
+        return authVerificationErrorPinFailed;
+      case EmailVerificationError.pinUnavailable:
+        return authVerificationErrorPinUnavailable;
     }
   }
 }

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -5232,6 +5232,48 @@ abstract class AppLocalizations {
   /// **'Open email app'**
   String get authOpenEmailApp;
 
+  /// No description provided for @authVerificationPinPrompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Or enter the 6-digit code from your email'**
+  String get authVerificationPinPrompt;
+
+  /// No description provided for @authVerificationPinFieldLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'6-digit code'**
+  String get authVerificationPinFieldLabel;
+
+  /// No description provided for @authVerificationPinSubmit.
+  ///
+  /// In en, this message translates to:
+  /// **'Verify code'**
+  String get authVerificationPinSubmit;
+
+  /// No description provided for @authVerificationResendPrompt.
+  ///
+  /// In en, this message translates to:
+  /// **'Didn\'t get it?'**
+  String get authVerificationResendPrompt;
+
+  /// No description provided for @authVerificationResend.
+  ///
+  /// In en, this message translates to:
+  /// **'Resend'**
+  String get authVerificationResend;
+
+  /// Disabled-state label for the resend button during its cooldown. {time} is a preformatted m:ss countdown (e.g. 4:59).
+  ///
+  /// In en, this message translates to:
+  /// **'Resend in {time}'**
+  String authVerificationResendCooldown(String time);
+
+  /// No description provided for @authVerificationResendFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'We couldn\'t resend the email. Try again.'**
+  String get authVerificationResendFailed;
+
   /// No description provided for @authWelcomeToDivine.
   ///
   /// In en, this message translates to:
@@ -5747,6 +5789,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'This email is already registered. Sign in instead.'**
   String get authVerificationEmailAlreadyRegistered;
+
+  /// No description provided for @authVerificationErrorPinInvalid.
+  ///
+  /// In en, this message translates to:
+  /// **'That code didn\'t match. Double-check it and try again.'**
+  String get authVerificationErrorPinInvalid;
+
+  /// No description provided for @authVerificationErrorPinExpired.
+  ///
+  /// In en, this message translates to:
+  /// **'That code has expired. Tap resend to get a new one.'**
+  String get authVerificationErrorPinExpired;
+
+  /// No description provided for @authVerificationErrorPinLocked.
+  ///
+  /// In en, this message translates to:
+  /// **'Too many tries. Tap resend to get a fresh code.'**
+  String get authVerificationErrorPinLocked;
+
+  /// No description provided for @authVerificationErrorPinFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'We couldn\'t verify that code. Please try again.'**
+  String get authVerificationErrorPinFailed;
+
+  /// No description provided for @authVerificationErrorPinUnavailable.
+  ///
+  /// In en, this message translates to:
+  /// **'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.'**
+  String get authVerificationErrorPinUnavailable;
 
   /// No description provided for @authInviteErrorAlreadyUsed.
   ///

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2943,6 +2943,31 @@ class AppLocalizationsAm extends AppLocalizations {
   String get authOpenEmailApp => 'የኢሜል መተግበሪያን ይክፈቱ';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'እንኳን ወደ Divine በደህና መጣህ!';
 
   @override
@@ -3225,6 +3250,26 @@ class AppLocalizationsAm extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'ይህ ኢሜይል አስቀድሞ ተመዝግቧል። በምትኩ ግባ።';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2978,6 +2978,31 @@ class AppLocalizationsAr extends AppLocalizations {
   String get authOpenEmailApp => 'فتح تطبيق البريد';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'أهلاً بك في Divine!';
 
   @override
@@ -3264,6 +3289,26 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'هذا البريد الإلكتروني مسجل بالفعل. سجّل الدخول بدلًا من ذلك.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -3044,6 +3044,31 @@ class AppLocalizationsBg extends AppLocalizations {
   String get authOpenEmailApp => 'Отвори имейл приложението';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Радваме се, че си в Divine!';
 
   @override
@@ -3336,6 +3361,26 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Този имейл вече е регистриран. Влез вместо това.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -3031,6 +3031,31 @@ class AppLocalizationsDe extends AppLocalizations {
   String get authOpenEmailApp => 'E-Mail-App öffnen';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Willkommen bei Divine!';
 
   @override
@@ -3328,6 +3353,26 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Diese E-Mail ist bereits registriert. Melde dich stattdessen an.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2997,6 +2997,31 @@ class AppLocalizationsEn extends AppLocalizations {
   String get authOpenEmailApp => 'Open email app';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Welcome to Divine!';
 
   @override
@@ -3289,6 +3314,26 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'This email is already registered. Sign in instead.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -3032,6 +3032,31 @@ class AppLocalizationsEs extends AppLocalizations {
   String get authOpenEmailApp => 'Abrir la app de email';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => '¡Bienvenido a Divine!';
 
   @override
@@ -3327,6 +3352,26 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Este email ya está registrado. Iniciá sesión en su lugar.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -3043,6 +3043,31 @@ class AppLocalizationsFil extends AppLocalizations {
   String get authOpenEmailApp => 'Buksan ang email app';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Welcome sa Divine!';
 
   @override
@@ -3340,6 +3365,26 @@ class AppLocalizationsFil extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Nakarehistro na ang email na ito. Mag-sign in na lang.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -3039,6 +3039,31 @@ class AppLocalizationsFr extends AppLocalizations {
   String get authOpenEmailApp => 'Ouvrir l\'app e-mail';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Bienvenue sur Divine !';
 
   @override
@@ -3335,6 +3360,26 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Cet e-mail est déjà inscrit. Connecte-toi plutôt.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2972,6 +2972,31 @@ class AppLocalizationsId extends AppLocalizations {
   String get authOpenEmailApp => 'Buka aplikasi email';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Selamat datang di Divine!';
 
   @override
@@ -3264,6 +3289,26 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Email ini sudah terdaftar. Masuk saja.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -3031,6 +3031,31 @@ class AppLocalizationsIt extends AppLocalizations {
   String get authOpenEmailApp => 'Apri app email';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Benvenuto su Divine!';
 
   @override
@@ -3325,6 +3350,26 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Questa email è già registrata. Accedi invece.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2856,6 +2856,31 @@ class AppLocalizationsJa extends AppLocalizations {
   String get authOpenEmailApp => 'メールアプリを開く';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'やった！入れたよ！';
 
   @override
@@ -3126,6 +3151,26 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'このメールアドレスはすでに登録されているよ。代わりにログインしてね。';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2869,6 +2869,31 @@ class AppLocalizationsKo extends AppLocalizations {
   String get authOpenEmailApp => '이메일 앱 열기';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Divine에 오신 걸 환영해요!';
 
   @override
@@ -3143,6 +3168,26 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       '이 이메일은 이미 등록되어 있어요. 대신 로그인해 주세요.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -3012,6 +3012,31 @@ class AppLocalizationsNl extends AppLocalizations {
   String get authOpenEmailApp => 'E-mail-app openen';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Welkom bij Divine!';
 
   @override
@@ -3303,6 +3328,26 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Dit e-mailadres is al geregistreerd. Log in plaats daarvan in.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -3077,6 +3077,31 @@ class AppLocalizationsPl extends AppLocalizations {
   String get authOpenEmailApp => 'Otwórz aplikację e-mail';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Witaj w Divine!';
 
   @override
@@ -3370,6 +3395,26 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Ten adres e-mail jest już zarejestrowany. Zaloguj się zamiast tego.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -3023,6 +3023,31 @@ class AppLocalizationsPt extends AppLocalizations {
   String get authOpenEmailApp => 'Abrir app de e-mail';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Bem-vindo ao Divine!';
 
   @override
@@ -3315,6 +3340,26 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Este email já está registrado. Entre em vez disso.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -3092,6 +3092,31 @@ class AppLocalizationsRo extends AppLocalizations {
   String get authOpenEmailApp => 'Deschide aplicația de email';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Bun venit pe Divine!';
 
   @override
@@ -3386,6 +3411,26 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Acest e-mail este deja înregistrat. Conectează-te în schimb.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2995,6 +2995,31 @@ class AppLocalizationsSv extends AppLocalizations {
   String get authOpenEmailApp => 'Öppna e-postappen';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Välkommen till Divine!';
 
   @override
@@ -3284,6 +3309,26 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Den här mejladressen är redan registrerad. Logga in i stället.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2982,6 +2982,31 @@ class AppLocalizationsTr extends AppLocalizations {
   String get authOpenEmailApp => 'E-posta uygulamasını aç';
 
   @override
+  String get authVerificationPinPrompt =>
+      'Or enter the 6-digit code from your email';
+
+  @override
+  String get authVerificationPinFieldLabel => '6-digit code';
+
+  @override
+  String get authVerificationPinSubmit => 'Verify code';
+
+  @override
+  String get authVerificationResendPrompt => 'Didn\'t get it?';
+
+  @override
+  String get authVerificationResend => 'Resend';
+
+  @override
+  String authVerificationResendCooldown(String time) {
+    return 'Resend in $time';
+  }
+
+  @override
+  String get authVerificationResendFailed =>
+      'We couldn\'t resend the email. Try again.';
+
+  @override
   String get authWelcomeToDivine => 'Divine\'a Hoş Geldin!';
 
   @override
@@ -3272,6 +3297,26 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get authVerificationEmailAlreadyRegistered =>
       'Bu e-posta zaten kayıtlı. Bunun yerine giriş yap.';
+
+  @override
+  String get authVerificationErrorPinInvalid =>
+      'That code didn\'t match. Double-check it and try again.';
+
+  @override
+  String get authVerificationErrorPinExpired =>
+      'That code has expired. Tap resend to get a new one.';
+
+  @override
+  String get authVerificationErrorPinLocked =>
+      'Too many tries. Tap resend to get a fresh code.';
+
+  @override
+  String get authVerificationErrorPinFailed =>
+      'We couldn\'t verify that code. Please try again.';
+
+  @override
+  String get authVerificationErrorPinUnavailable =>
+      'Code entry isn\'t available right now. Tap the link in your email, or resend to get a fresh one.';
 
   @override
   String get authInviteErrorAlreadyUsed =>

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -1502,11 +1502,49 @@ Future<void> _initializeCoreServices(ProviderContainer container) async {
     category: LogCategory.system,
   );
 
+  await restorePendingEmailVerificationOnStartup(container);
+
   Log.info(
     '[INIT] ✅ Core services initialized',
     name: 'Main',
     category: LogCategory.system,
   );
+}
+
+/// Restore the email-verification screen on a plain cold reopen (no deep link).
+///
+/// Registration persists the deviceCode/verifier/email (24h TTL) but nothing
+/// consults it on a normal startup, so a user who killed the app to read the
+/// 6-digit PIN from their email would otherwise land on Welcome. When the user
+/// has an unexpired pending record belonging to the current startup identity,
+/// route them back to the polling-mode verification screen (PIN field visible)
+/// so they can finish. Verification deep links (token mode) are handled by
+/// [EmailVerificationListener]; this only fires from the Welcome landing and
+/// never overrides a screen a deep link already opened.
+Future<void> restorePendingEmailVerificationOnStartup(
+  ProviderContainer container,
+) async {
+  final authService = container.read(authServiceProvider);
+  final pending = await container
+      .read(pendingVerificationServiceProvider)
+      .load();
+  final router = container.read(goRouterProvider);
+  final currentPath = router.routeInformationProvider.value.uri.path;
+  final target = pendingEmailVerificationStartupLocation(
+    pending: pending,
+    authState: authService.authState,
+    isAnonymous: authService.isAnonymous,
+    currentPublicKeyHex: authService.currentPublicKeyHex,
+    currentPath: currentPath,
+  );
+  if (target == null) return;
+
+  Log.info(
+    'Restoring pending email verification on cold start',
+    name: 'Main',
+    category: LogCategory.auth,
+  );
+  router.go(target);
 }
 
 Future<void> _configurePlaybackAudioSession() async {
@@ -1992,7 +2030,8 @@ class _DivineAppState extends ConsumerState<DivineApp>
           final currentLocation = router.routeInformationProvider.value.uri
               .toString();
           Log.info(
-            '🔗 Current router location: $currentLocation',
+            '🔗 Current router location: '
+            '${redactUriStringForLogs(currentLocation)}',
             name: 'DeepLinkHandler',
             category: LogCategory.ui,
           );

--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -45,7 +45,12 @@ import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 export 'routes/router_guards.dart'
-    show homeInitialIndexFromPathParameters, rewriteResetPasswordDeepLink;
+    show
+        homeInitialIndexFromPathParameters,
+        pendingEmailVerificationLocation,
+        pendingEmailVerificationRestoreLocation,
+        pendingEmailVerificationStartupLocation,
+        rewriteResetPasswordDeepLink;
 
 part 'app_router_redirect.dart';
 

--- a/mobile/lib/router/routes/auth_routes.dart
+++ b/mobile/lib/router/routes/auth_routes.dart
@@ -93,6 +93,7 @@ List<RouteBase> authRoutes() {
           deviceCode: params['deviceCode'],
           verifier: params['verifier'],
           email: params['email'],
+          restored: params['restored'] == 'true',
         );
       },
     ),

--- a/mobile/lib/router/routes/router_guards.dart
+++ b/mobile/lib/router/routes/router_guards.dart
@@ -1,7 +1,11 @@
 // ABOUTME: Pure router helper functions shared between route modules and tests
 // ABOUTME: Kept dependency-free of app_router.dart so route modules import them cycle-free
 
+import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/pending_verification_service.dart';
+import 'package:openvine/utils/pending_verification_restore_policy.dart';
 
 /// Rewrites a `/reset-password` deep link to the nested
 /// [WelcomeScreen.resetPasswordPath] route, preserving `token` and
@@ -22,6 +26,54 @@ String rewriteResetPasswordDeepLink(Uri uri) {
       ..write(Uri.encodeQueryComponent(email));
   }
   return buffer.toString();
+}
+
+/// Builds the verify-email restore location for a cold start that found an
+/// unexpired pending email-verification record, or `null` when there is
+/// nothing to restore.
+///
+/// Used by the app-bootstrap restore step in `main.dart` so a user who killed
+/// the app to read their PIN lands back on the polling-mode verification
+/// screen instead of Welcome. The `restored=true` flag tells the screen the
+/// close / "Start over" affordance is an escape hatch that should clear the
+/// persisted record.
+String? pendingEmailVerificationRestoreLocation(PendingVerification? pending) {
+  if (pending == null || pending.isExpired) return null;
+  // The deviceCode and verifier are secrets and must never ride on a URL that
+  // could be logged or leaked. Only the (log-redacted) email and the restore
+  // flag travel here; the screen rehydrates deviceCode / verifier / inviteCode
+  // from the persisted record on the restore path.
+  return pendingEmailVerificationLocation(email: pending.email);
+}
+
+/// Builds a route intent for verification backed by the persisted pending
+/// record. OAuth credentials deliberately never travel in this location.
+String pendingEmailVerificationLocation({required String email}) {
+  final encodedEmail = Uri.encodeQueryComponent(email);
+  return '${EmailVerificationScreen.path}?email=$encodedEmail&restored=true';
+}
+
+/// Returns the secret-free verification location when a pending transaction
+/// belongs to the startup identity and the router is still on Welcome.
+String? pendingEmailVerificationStartupLocation({
+  required PendingVerification? pending,
+  required AuthState authState,
+  required bool isAnonymous,
+  required String? currentPublicKeyHex,
+  required String currentPath,
+}) {
+  if (pending == null || pending.isExpired) return null;
+  if (currentPath != WelcomeScreen.path) return null;
+  if (!canRestorePendingEmailVerification(
+    pending: pending,
+    authState: authState,
+    isAnonymous: isAnonymous,
+    currentPublicKeyHex: currentPublicKeyHex,
+  )) {
+    return null;
+  }
+
+  return pendingEmailVerificationRestoreLocation(pending);
 }
 
 int homeInitialIndexFromPathParameters(Map<String, String> pathParameters) {

--- a/mobile/lib/screens/auth/email_verification_screen.dart
+++ b/mobile/lib/screens/auth/email_verification_screen.dart
@@ -11,18 +11,23 @@ import 'package:android_intent_plus/flag.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart' show SemanticsService;
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/email_verification/email_verification_cubit.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_event.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/welcome_screen.dart';
 import 'package:openvine/screens/explore/explore_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/utils/pending_verification_restore_policy.dart';
 import 'package:openvine/utils/sensitive_uri_for_logs.dart';
 import 'package:unified_logger/unified_logger.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -40,6 +45,7 @@ class EmailVerificationScreen extends ConsumerStatefulWidget {
     this.deviceCode,
     this.verifier,
     this.email,
+    this.restored = false,
   });
 
   /// Token from deep link (token mode)
@@ -53,6 +59,13 @@ class EmailVerificationScreen extends ConsumerStatefulWidget {
 
   /// User's email address (polling mode)
   final String? email;
+
+  /// Whether the screen was restored on a cold start from the persisted
+  /// pending-verification record (see `pendingEmailVerificationRestoreLocation`
+  /// in the router). When true, the close / "Start over" affordance is treated
+  /// as an escape hatch: it clears the persisted record so the user can
+  /// register or log in as a different user without being restored back here.
+  final bool restored;
 
   /// Check if this is polling mode
   bool get isPollingMode =>
@@ -119,12 +132,17 @@ class _EmailVerificationScreenState
         name: 'EmailVerificationScreen',
         category: LogCategory.auth,
       );
-      _cubit.startPolling(
-        deviceCode: widget.deviceCode!,
-        verifier: widget.verifier!,
-        email: widget.email ?? '',
-        inviteCode: context.read<InviteGateBloc>().state.accessGrant?.code,
+      unawaited(_startPollingWithHydratedInvite());
+    } else if (widget.restored) {
+      // Cold-start restore: the URL deliberately carries no deviceCode /
+      // verifier (they are secrets), so rehydrate the full context from the
+      // persisted record.
+      Log.info(
+        'Restoring verification from persisted record (cubit=${_cubit.hashCode})',
+        name: 'EmailVerificationScreen',
+        category: LogCategory.auth,
       );
+      unawaited(_restoreFromPersistedRecord());
     } else if (widget.isTokenMode) {
       // Token mode - check for persisted verification data for auto-login
       _isTokenMode = true;
@@ -136,6 +154,69 @@ class _EmailVerificationScreenState
         category: LogCategory.auth,
       );
     }
+  }
+
+  /// Starts polling for the URL's device code / verifier (the fresh
+  /// post-registration path), hydrating the invite code from the persisted
+  /// record.
+  ///
+  /// The registration URL carries deviceCode/verifier but not the invite, and
+  /// the in-memory [InviteGateBloc] grant may already be gone. Reading the
+  /// invite from the matching persisted record — mirroring the token-mode path
+  /// — keeps the invite so it is consumed on completion. Falls back to the
+  /// in-memory grant when no matching record is present.
+  Future<void> _startPollingWithHydratedInvite() async {
+    final pending = await ref.read(pendingVerificationServiceProvider).load();
+    if (!mounted) return;
+    final recordInvite =
+        (pending != null && pending.deviceCode == widget.deviceCode)
+        ? pending.inviteCode
+        : null;
+    final inviteCode =
+        recordInvite ?? context.read<InviteGateBloc>().state.accessGrant?.code;
+    _cubit.startPolling(
+      deviceCode: widget.deviceCode!,
+      verifier: widget.verifier!,
+      email: widget.email ?? '',
+      inviteCode: inviteCode,
+    );
+  }
+
+  /// Rehydrates the full verification context from the persisted record and
+  /// starts polling, for the cold-start restore path whose URL carries no
+  /// secrets (deviceCode / verifier). If no record survives, there is nothing
+  /// to restore — leave the screen so the user can use the escape hatch.
+  Future<void> _restoreFromPersistedRecord() async {
+    final pending = await ref.read(pendingVerificationServiceProvider).load();
+    if (!mounted) return;
+    if (pending == null) {
+      Log.warning(
+        'Cold-start restore found no pending record',
+        name: 'EmailVerificationScreen',
+        category: LogCategory.auth,
+      );
+      return;
+    }
+    final authService = ref.read(authServiceProvider);
+    if (!canRestorePendingEmailVerification(
+      pending: pending,
+      authState: authService.authState,
+      isAnonymous: authService.isAnonymous,
+      currentPublicKeyHex: authService.currentPublicKeyHex,
+    )) {
+      Log.warning(
+        'Cold-start restore rejected for the active identity',
+        name: 'EmailVerificationScreen',
+        category: LogCategory.auth,
+      );
+      return;
+    }
+    _cubit.startPolling(
+      deviceCode: pending.deviceCode,
+      verifier: pending.verifier,
+      email: pending.email,
+      inviteCode: pending.inviteCode,
+    );
   }
 
   /// Initialize token mode, checking for persisted data for auto-login.
@@ -243,6 +324,11 @@ class _EmailVerificationScreenState
       return;
     }
 
+    // A late link click after the 15-minute poll window: re-arm polling so it
+    // auto-completes instead of waiting on manual PIN entry. No-ops unless the
+    // cubit is in pollingTimedOut with retained context.
+    _cubit.resumePollingAfterTimeout();
+
     Log.info(
       'Email verification successful from token update',
       name: 'EmailVerificationScreen',
@@ -313,9 +399,12 @@ class _EmailVerificationScreenState
 
   void _handleCancel() {
     _cubit.stopPolling();
-    // Don't clear pending verification data - user may still verify via email
-    // link later. Data will be cleared on: successful login, logout, or
-    // expiration (30 minutes).
+    // On a normal post-registration cancel, don't clear pending verification
+    // data — the user may still verify via the email link or PIN later. Data is
+    // cleared on successful login, logout, or expiration (24h verify window).
+    // On a cold-start restore, closing is the escape hatch ("register / log in
+    // as a different user"), so clear the record to avoid restoring back here.
+    _maybeClearRestoredRecord();
     // Go back to previous screen (registration form)
     if (context.canPop()) {
       context.pop();
@@ -325,6 +414,10 @@ class _EmailVerificationScreenState
   }
 
   void _handleStartOver() {
+    // Start Over is a terminal exit: verification failed and the persisted
+    // record is unusable, so clear it unconditionally (not just in restored
+    // mode) so a later cold start doesn't restore the user into a dead flow.
+    ref.read(pendingVerificationServiceProvider).clear();
     context.go('/');
   }
 
@@ -338,6 +431,13 @@ class _EmailVerificationScreenState
         error: context.l10n.emailVerificationErrorMessage(errorCode),
       ),
     );
+  }
+
+  /// Clears the persisted pending-verification record when this screen was
+  /// restored on a cold start, so leaving it doesn't trap the user back here.
+  void _maybeClearRestoredRecord() {
+    if (!widget.restored) return;
+    ref.read(pendingVerificationServiceProvider).clear();
   }
 
   void _handleInviteRecovery(
@@ -360,12 +460,31 @@ class _EmailVerificationScreenState
       resizeToAvoidBottomInset: false,
       body: SafeArea(
         child: BlocConsumer<EmailVerificationCubit, EmailVerificationState>(
+          listenWhen: (previous, current) =>
+              previous.status != current.status ||
+              previous.pinStatus != current.pinStatus ||
+              previous.pinErrorCode != current.pinErrorCode,
           listener: (context, state) {
             if (state.status == EmailVerificationStatus.success) {
               _handleSuccess();
             }
+            if (state.pinStatus == PinSubmissionStatus.failure) {
+              final message = context.l10n.emailVerificationErrorMessage(
+                state.pinErrorCode ?? EmailVerificationError.pinFailed,
+              );
+              SemanticsService.sendAnnouncement(
+                View.of(context),
+                message,
+                Directionality.of(context),
+              );
+            }
           },
           builder: (context, state) {
+            final pinFallbackEnabled = ref.watch(
+              isFeatureEnabledProvider(
+                FeatureFlag.emailVerificationPinFallback,
+              ),
+            );
             final showCloseButton =
                 state.status != EmailVerificationStatus.success;
             return Column(
@@ -395,11 +514,20 @@ class _EmailVerificationScreenState
                       EmailVerificationStatus.initial => _PollingContent(
                         email: null,
                         isPollingMode: widget.isPollingMode || !_isTokenMode,
+                        showPinFallback: pinFallbackEnabled,
                       ),
                       EmailVerificationStatus.polling => _PollingContent(
                         email: state.pendingEmail,
                         isPollingMode: widget.isPollingMode || !_isTokenMode,
+                        showPinFallback: pinFallbackEnabled,
                       ),
+                      EmailVerificationStatus.pollingTimedOut =>
+                        _PollingContent(
+                          email: state.pendingEmail,
+                          isPollingMode: widget.isPollingMode || !_isTokenMode,
+                          showPinFallback: pinFallbackEnabled,
+                          isActivelyPolling: false,
+                        ),
                       EmailVerificationStatus.success =>
                         const _SuccessContent(),
                       EmailVerificationStatus.failure => _ErrorContent(
@@ -507,10 +635,21 @@ class _StatusButton extends StatelessWidget {
 
 /// Polling/loading content shown while waiting for email verification.
 class _PollingContent extends StatelessWidget {
-  const _PollingContent({required this.email, required this.isPollingMode});
+  const _PollingContent({
+    required this.email,
+    required this.isPollingMode,
+    required this.showPinFallback,
+    this.isActivelyPolling = true,
+  });
 
   final String? email;
   final bool isPollingMode;
+  final bool showPinFallback;
+
+  /// Whether the poll loop is still running. When the 15-minute window
+  /// elapses this becomes false: the spinner is dropped but PIN entry / resend
+  /// stay available instead of a terminal failure screen.
+  final bool isActivelyPolling;
 
   Future<void> _openEmailApp() async {
     Log.info(
@@ -575,96 +714,289 @@ class _PollingContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Scroll-safe so the added PIN entry never overflows on short screens,
+    // while still vertically centering the content on tall ones.
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minHeight: constraints.maxHeight),
+            child: IntrinsicHeight(
+              child: Column(
+                children: [
+                  const Spacer(),
+
+                  // Email sticker
+                  Transform.rotate(
+                    angle: -8 * pi / 180,
+                    child: const DivineSticker(
+                      sticker: DivineStickerName.email,
+                      size: 120,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+
+                  // Title
+                  Text(
+                    isPollingMode
+                        ? context.l10n.authCompleteRegistration
+                        : context.l10n.authVerifying,
+                    style: const TextStyle(
+                      fontFamily: VineTheme.fontFamilyBricolage,
+                      fontSize: 28,
+                      fontWeight: FontWeight.w700,
+                      color: VineTheme.whiteText,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 16),
+
+                  if (isPollingMode && email != null && email!.isNotEmpty) ...[
+                    Text(
+                      context.l10n.authVerificationLinkSent,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        color: VineTheme.secondaryText,
+                        height: 1.4,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      email!,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                        color: VineTheme.whiteText,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      context.l10n.authClickVerificationLink,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: VineTheme.secondaryText,
+                        height: 1.4,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ] else ...[
+                    Text(
+                      context.l10n.authPleaseWaitVerifying,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        color: VineTheme.secondaryText,
+                        height: 1.4,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+
+                  const Spacer(),
+
+                  // Status + action buttons at bottom
+                  Padding(
+                    padding: const EdgeInsets.only(top: 32, bottom: 32),
+                    child: Column(
+                      children: [
+                        if (isPollingMode && showPinFallback) ...[
+                          const _PinEntrySection(),
+                          const SizedBox(height: 20),
+                        ],
+                        if (isActivelyPolling)
+                          _StatusButton(
+                            label: context.l10n.authWaitingForVerification,
+                          ),
+                        if (isPollingMode) ...[
+                          const SizedBox(height: 20),
+                          DivineButton(
+                            expanded: true,
+                            type: DivineButtonType.secondary,
+                            label: context.l10n.authOpenEmailApp,
+                            onPressed: _openEmailApp,
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// In-app PIN entry: a 6-digit code field the user reads from the verification
+/// email, submitted to keycast as a fallback when the email link / poll never
+/// completes (e.g. sandboxed in-app browsers). Additive — shown alongside the
+/// link/poll affordances, never replacing them.
+class _PinEntrySection extends StatefulWidget {
+  const _PinEntrySection();
+
+  @override
+  State<_PinEntrySection> createState() => _PinEntrySectionState();
+}
+
+class _PinEntrySectionState extends State<_PinEntrySection> {
+  static const _pinLength = 6;
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_controller.text.length != _pinLength) return;
+    if (context.read<EmailVerificationCubit>().state.pinStatus ==
+        PinSubmissionStatus.submitting) {
+      return;
+    }
+    context.read<EmailVerificationCubit>().submitPin(_controller.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final pinStatus = context.select(
+      (EmailVerificationCubit c) => c.state.pinStatus,
+    );
+    final pinErrorCode = context.select(
+      (EmailVerificationCubit c) => c.state.pinErrorCode,
+    );
+    final submitting = pinStatus == PinSubmissionStatus.submitting;
+    final errorText = pinStatus == PinSubmissionStatus.failure
+        ? l10n.emailVerificationErrorMessage(
+            pinErrorCode ?? EmailVerificationError.pinFailed,
+          )
+        : null;
+    final canSubmit = _controller.text.length == _pinLength && !submitting;
+
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const Spacer(),
-
-        // Email sticker
-        Transform.rotate(
-          angle: -8 * pi / 180,
-          child: const DivineSticker(
-            sticker: DivineStickerName.email,
-            size: 120,
-          ),
-        ),
-        const SizedBox(height: 32),
-
-        // Title
         Text(
-          isPollingMode
-              ? context.l10n.authCompleteRegistration
-              : context.l10n.authVerifying,
-          style: const TextStyle(
-            fontFamily: VineTheme.fontFamilyBricolage,
-            fontSize: 28,
-            fontWeight: FontWeight.w700,
-            color: VineTheme.whiteText,
-          ),
+          l10n.authVerificationPinPrompt,
+          style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
           textAlign: TextAlign.center,
         ),
-        const SizedBox(height: 16),
-
-        if (isPollingMode && email != null && email!.isNotEmpty) ...[
-          Text(
-            context.l10n.authVerificationLinkSent,
-            style: const TextStyle(
-              fontSize: 16,
-              color: VineTheme.secondaryText,
-              height: 1.4,
-            ),
-            textAlign: TextAlign.center,
+        const SizedBox(height: 12),
+        // Material wrap keeps the field's ink / overlay layer stable across the
+        // verification screen's route transitions.
+        Material(
+          type: MaterialType.transparency,
+          child: DivineAuthTextField(
+            label: l10n.authVerificationPinFieldLabel,
+            controller: _controller,
+            enabled: !submitting,
+            autocorrect: false,
+            keyboardType: TextInputType.number,
+            textInputAction: TextInputAction.done,
+            inputFormatters: [
+              FilteringTextInputFormatter.digitsOnly,
+              LengthLimitingTextInputFormatter(_pinLength),
+            ],
+            errorText: errorText,
+            onChanged: (_) => setState(() {}),
+            onSubmitted: (_) => _submit(),
           ),
+        ),
+        const SizedBox(height: 16),
+        DivineButton(
+          expanded: true,
+          label: l10n.authVerificationPinSubmit,
+          isLoading: submitting,
+          onPressed: canSubmit ? _submit : null,
+        ),
+        const SizedBox(height: 12),
+        const _ResendRow(),
+      ],
+    );
+  }
+}
+
+/// Resend-verification affordance with the 5-minute cooldown surfaced.
+class _ResendRow extends StatelessWidget {
+  const _ResendRow();
+
+  static String _formatCooldown(int totalSeconds) {
+    final minutes = totalSeconds ~/ 60;
+    final seconds = totalSeconds % 60;
+    return '$minutes:${seconds.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final resendStatus = context.select(
+      (EmailVerificationCubit c) => c.state.resendStatus,
+    );
+    final cooldownSeconds = context.select(
+      (EmailVerificationCubit c) => c.state.resendCooldownSeconds,
+    );
+    final disabled =
+        resendStatus == ResendStatus.sending ||
+        resendStatus == ResendStatus.cooldown;
+    final label = resendStatus == ResendStatus.cooldown
+        ? l10n.authVerificationResendCooldown(_formatCooldown(cooldownSeconds))
+        : l10n.authVerificationResend;
+
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              l10n.authVerificationResendPrompt,
+              style: VineTheme.bodyMediumFont(color: VineTheme.secondaryText),
+            ),
+            const SizedBox(width: 4),
+            Semantics(
+              button: true,
+              enabled: !disabled,
+              label: label,
+              child: ExcludeSemantics(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: disabled
+                      ? null
+                      : () => context
+                            .read<EmailVerificationCubit>()
+                            .resendVerification(),
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(
+                      minWidth: 48,
+                      minHeight: 48,
+                    ),
+                    child: Center(
+                      child: Text(
+                        label,
+                        style: VineTheme.labelLargeFont(
+                          color: disabled
+                              ? VineTheme.secondaryText
+                              : VineTheme.vineGreen,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+        if (resendStatus == ResendStatus.failure) ...[
           const SizedBox(height: 4),
           Text(
-            email!,
-            style: const TextStyle(
-              fontSize: 16,
-              fontWeight: FontWeight.w700,
-              color: VineTheme.whiteText,
-            ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 8),
-          Text(
-            context.l10n.authClickVerificationLink,
-            style: const TextStyle(
-              fontSize: 14,
-              color: VineTheme.secondaryText,
-              height: 1.4,
-            ),
-            textAlign: TextAlign.center,
-          ),
-        ] else ...[
-          Text(
-            context.l10n.authPleaseWaitVerifying,
-            style: const TextStyle(
-              fontSize: 16,
-              color: VineTheme.secondaryText,
-              height: 1.4,
-            ),
+            l10n.authVerificationResendFailed,
+            style: VineTheme.bodySmallFont(color: VineTheme.error),
             textAlign: TextAlign.center,
           ),
         ],
-
-        const Spacer(),
-
-        // Status + action buttons at bottom
-        Padding(
-          padding: const EdgeInsets.only(bottom: 32),
-          child: Column(
-            children: [
-              _StatusButton(label: context.l10n.authWaitingForVerification),
-              if (isPollingMode) ...[
-                const SizedBox(height: 20),
-                DivineButton(
-                  expanded: true,
-                  label: context.l10n.authOpenEmailApp,
-                  onPressed: _openEmailApp,
-                ),
-              ],
-            ],
-          ),
-        ),
       ],
     );
   }

--- a/mobile/lib/screens/auth/secure_account_screen.dart
+++ b/mobile/lib/screens/auth/secure_account_screen.dart
@@ -4,15 +4,12 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
-import 'package:openvine/blocs/email_verification/email_verification_cubit.dart';
-import 'package:openvine/l10n/email_verification_error_l10n.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
-import 'package:openvine/screens/explore/explore_screen.dart';
+import 'package:openvine/router/routes/router_guards.dart';
 import 'package:openvine/utils/validators.dart';
 import 'package:openvine/widgets/auth/auth_error_box.dart';
 import 'package:openvine/widgets/auth/auth_form_scaffold.dart';
@@ -112,6 +109,7 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
         email: email,
         password: password,
         nsec: nsec,
+        ownerPublicKeyHex: authService.currentPublicKeyHex,
       );
     } catch (e) {
       Log.error(
@@ -132,6 +130,7 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
     required String email,
     required String password,
     required String nsec,
+    required String? ownerPublicKeyHex,
   }) async {
     final (result, verifier) = await oauth.headlessRegister(
       email: email,
@@ -147,53 +146,23 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
       return;
     }
 
-    if (result.verificationRequired && result.deviceCode != null) {
-      // Start polling
-      if (mounted) {
-        context.read<EmailVerificationCubit>().startPolling(
-          deviceCode: result.deviceCode!,
-          verifier: verifier,
-          email: email,
-        );
+    final deviceCode = result.deviceCode;
+    if (result.verificationRequired && deviceCode != null) {
+      await ref
+          .read(pendingVerificationServiceProvider)
+          .save(
+            deviceCode: deviceCode,
+            verifier: verifier,
+            email: email,
+            ownerPublicKeyHex: ownerPublicKeyHex,
+          );
+      if (!mounted) return;
 
-        // Show verification dialog but let user continue
-        _showVerificationDialog(email);
-      }
+      TextInput.finishAutofillContext();
+      context.go(pendingEmailVerificationLocation(email: email));
     } else {
       _setGeneralError(context.l10n.authRegistrationComplete);
     }
-  }
-
-  void _showVerificationDialog(String email) {
-    showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (dialogContext) => PopScope(
-        canPop: false,
-        child: _VerificationDialog(
-          email: email,
-          onContinue: () {
-            Navigator.of(dialogContext).pop();
-            _continueToApp();
-          },
-          onSuccess: () {
-            // Signal password managers to save credentials BEFORE we unmount
-            // the form via navigation.
-            if (!mounted) return;
-            TextInput.finishAutofillContext();
-            context.go(ExploreScreen.path);
-          },
-        ),
-      ),
-    );
-  }
-
-  void _continueToApp() {
-    if (!mounted) return;
-    // Signal password managers to save credentials BEFORE we unmount
-    // the form via navigation.
-    TextInput.finishAutofillContext();
-    context.go(ExploreScreen.path);
   }
 
   @override
@@ -235,170 +204,6 @@ class _SecureAccountScreenState extends ConsumerState<SecureAccountScreen> {
         isLoading: _isLoading,
         onPressed: _handleSubmit,
       ),
-    );
-  }
-}
-
-/// Reactive dialog that watches verification state and auto-closes on success
-class _VerificationDialog extends ConsumerWidget {
-  const _VerificationDialog({
-    required this.email,
-    required this.onContinue,
-    required this.onSuccess,
-  });
-
-  final String email;
-  final VoidCallback onContinue;
-  final VoidCallback onSuccess;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final authService = ref.watch(authServiceProvider);
-
-    return BlocBuilder<EmailVerificationCubit, EmailVerificationState>(
-      builder: (context, verificationState) {
-        // Auto-close when verification completes (user is no longer anonymous)
-        if (!verificationState.isPolling &&
-            verificationState.errorCode == null &&
-            !authService.isAnonymous) {
-          // Use post-frame callback to avoid calling Navigator during build
-          WidgetsBinding.instance.addPostFrameCallback((_) {
-            onSuccess();
-          });
-        }
-
-        // Show error state if verification failed
-        final errorCode = verificationState.errorCode;
-        if (errorCode != null) {
-          return AlertDialog(
-            backgroundColor: VineTheme.cardBackground,
-            title: Row(
-              children: [
-                const DivineIcon(
-                  icon: DivineIconName.warningCircle,
-                  color: VineTheme.error,
-                ),
-                const SizedBox(width: 12),
-                Text(
-                  context.l10n.authVerificationFailedTitle,
-                  style: const TextStyle(color: VineTheme.whiteText),
-                ),
-              ],
-            ),
-            content: Text(
-              context.l10n.emailVerificationErrorMessage(errorCode),
-              style: const TextStyle(color: VineTheme.secondaryText),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(context).pop(),
-                child: Text(
-                  context.l10n.authClose,
-                  style: const TextStyle(color: VineTheme.vineGreen),
-                ),
-              ),
-            ],
-          );
-        }
-
-        // Show success state briefly before auto-closing
-        if (!authService.isAnonymous) {
-          return AlertDialog(
-            backgroundColor: VineTheme.cardBackground,
-            title: Row(
-              children: [
-                const DivineIcon(
-                  icon: DivineIconName.checkCircle,
-                  color: VineTheme.vineGreen,
-                ),
-                const SizedBox(width: 12),
-                Text(
-                  context.l10n.authAccountSecured,
-                  style: const TextStyle(color: VineTheme.whiteText),
-                ),
-              ],
-            ),
-            content: Text(
-              context.l10n.authAccountLinkedToEmail,
-              style: const TextStyle(color: VineTheme.onSurfaceVariant),
-            ),
-          );
-        }
-
-        // Show waiting state
-        return AlertDialog(
-          backgroundColor: VineTheme.cardBackground,
-          title: Row(
-            children: [
-              const DivineIcon(
-                icon: DivineIconName.envelope,
-                color: VineTheme.vineGreen,
-              ),
-              const SizedBox(width: 12),
-              Text(
-                context.l10n.authVerifyYourEmail,
-                style: const TextStyle(color: VineTheme.whiteText),
-              ),
-            ],
-          ),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                context.l10n.authVerificationLinkSent,
-                style: const TextStyle(color: VineTheme.secondaryText),
-              ),
-              const SizedBox(height: 8),
-              Text(
-                email,
-                style: const TextStyle(
-                  color: VineTheme.whiteText,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Text(
-                context.l10n.authClickLinkContinue,
-                style: const TextStyle(
-                  color: VineTheme.secondaryText,
-                  fontSize: 14,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Row(
-                children: [
-                  const SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: VineTheme.vineGreen,
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Text(
-                    context.l10n.authWaitingForVerificationEllipsis,
-                    style: const TextStyle(
-                      color: VineTheme.vineGreen,
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: onContinue,
-              child: Text(
-                context.l10n.authContinueToApp,
-                style: const TextStyle(color: VineTheme.vineGreen),
-              ),
-            ),
-          ],
-        );
-      },
     );
   }
 }

--- a/mobile/lib/services/pending_verification_service.dart
+++ b/mobile/lib/services/pending_verification_service.dart
@@ -13,6 +13,7 @@ class PendingVerification {
     required this.email,
     required this.createdAt,
     this.inviteCode,
+    this.ownerPublicKeyHex,
   });
 
   final String deviceCode;
@@ -20,10 +21,15 @@ class PendingVerification {
   final String email;
   final DateTime createdAt;
   final String? inviteCode;
+  final String? ownerPublicKeyHex;
 
-  /// Expiration duration for pending verification data (30 minutes).
-  /// OAuth device codes typically expire in 15-30 minutes.
-  static const expirationDuration = Duration(minutes: 30);
+  /// Expiration duration for pending verification data (24 hours).
+  ///
+  /// Matches keycast's 24h email-verify window (keycast#262). The deviceCode +
+  /// verifier must survive that long so a user who returns late — e.g. after
+  /// reading the PIN from their email hours later — still has the verifier to
+  /// exchange the synchronously-returned OAuth code.
+  static const expirationDuration = Duration(hours: 24);
 
   /// Check if this pending verification has expired
   bool get isExpired =>
@@ -46,6 +52,8 @@ class PendingVerificationService {
   static const _keyEmail = 'pending_verification_email';
   static const _keyCreatedAt = 'pending_verification_created_at';
   static const _keyInviteCode = 'pending_verification_invite_code';
+  static const _keyOwnerPublicKeyHex =
+      'pending_verification_owner_public_key_hex';
 
   /// Save pending verification data to secure storage.
   ///
@@ -55,6 +63,7 @@ class PendingVerificationService {
     required String verifier,
     required String email,
     String? inviteCode,
+    String? ownerPublicKeyHex,
   }) async {
     try {
       final createdAt = DateTime.now().toIso8601String();
@@ -64,6 +73,10 @@ class PendingVerificationService {
         _storage.write(key: _keyEmail, value: email),
         _storage.write(key: _keyCreatedAt, value: createdAt),
         _storage.write(key: _keyInviteCode, value: inviteCode),
+        _storage.write(
+          key: _keyOwnerPublicKeyHex,
+          value: ownerPublicKeyHex,
+        ),
       ]);
       Log.info(
         'Saved pending verification for ${redactEmailForLogs(email)}',
@@ -83,7 +96,7 @@ class PendingVerificationService {
   /// Load pending verification data from secure storage.
   ///
   /// Returns null if no pending verification exists, data is incomplete,
-  /// or data has expired (after 30 minutes).
+  /// or data has expired (after the 24h verify window).
   Future<PendingVerification?> load() async {
     try {
       final results = await Future.wait([
@@ -92,6 +105,7 @@ class PendingVerificationService {
         _storage.read(key: _keyEmail),
         _storage.read(key: _keyCreatedAt),
         _storage.read(key: _keyInviteCode),
+        _storage.read(key: _keyOwnerPublicKeyHex),
       ]);
 
       final deviceCode = results[0];
@@ -99,6 +113,7 @@ class PendingVerificationService {
       final email = results[2];
       final createdAtStr = results[3];
       final inviteCode = results[4];
+      final ownerPublicKeyHex = results[5];
 
       // All fields required
       if (deviceCode == null || verifier == null || email == null) {
@@ -117,6 +132,7 @@ class PendingVerificationService {
         email: email,
         createdAt: createdAt,
         inviteCode: inviteCode,
+        ownerPublicKeyHex: ownerPublicKeyHex,
       );
 
       // Check expiration
@@ -161,6 +177,7 @@ class PendingVerificationService {
         _storage.delete(key: _keyEmail),
         _storage.delete(key: _keyCreatedAt),
         _storage.delete(key: _keyInviteCode),
+        _storage.delete(key: _keyOwnerPublicKeyHex),
       ]);
       Log.info(
         'Cleared pending verification',

--- a/mobile/lib/utils/pending_verification_restore_policy.dart
+++ b/mobile/lib/utils/pending_verification_restore_policy.dart
@@ -1,0 +1,22 @@
+// ABOUTME: Shared authorization policy for restoring persisted email verification
+// ABOUTME: Keeps startup routing and in-screen rehydration on the same identity rules
+
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/pending_verification_service.dart';
+
+/// Whether [pending] may be restored for the active authentication identity.
+bool canRestorePendingEmailVerification({
+  required PendingVerification pending,
+  required AuthState authState,
+  required bool isAnonymous,
+  required String? currentPublicKeyHex,
+}) {
+  if (pending.isExpired) return false;
+
+  final ownerPublicKeyHex = pending.ownerPublicKeyHex;
+  return ownerPublicKeyHex == null
+      ? authState == AuthState.unauthenticated
+      : authState == AuthState.authenticated &&
+            isAnonymous &&
+            currentPublicKeyHex == ownerPublicKeyHex;
+}

--- a/mobile/lib/widgets/auth/auth_hero_section.dart
+++ b/mobile/lib/widgets/auth/auth_hero_section.dart
@@ -106,10 +106,15 @@ class AuthHeroSection extends StatelessWidget {
           // auth_hero_section_test.dart pins it against retired brand assets.
           // The label is the brand name, not copy: it stays out of the ARB
           // catalog so no locale can translate or transliterate it.
-          SvgPicture.asset(
-            DivineIconName.logo.assetPath,
-            width: 120,
-            semanticsLabel: AppConfig.appName,
+          Semantics(
+            label: AppConfig.appName,
+            image: true,
+            child: ExcludeSemantics(
+              child: SvgPicture.asset(
+                DivineIconName.logo.assetPath,
+                width: 120,
+              ),
+            ),
           ),
         ],
       ),

--- a/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/headless_models.dart
@@ -194,6 +194,95 @@ enum PollStatus {
   error, // Something went wrong
 }
 
+/// Reason a [VerifyPinResult] failed.
+///
+/// keycast intentionally returns uniform anti-enumeration errors, so the
+/// server may collapse several of these into one generic failure. Callers
+/// should treat distinct cases as advisory and fall back to generic copy.
+enum VerifyPinError {
+  /// The submitted PIN was incorrect.
+  invalid,
+
+  /// The PIN (or its 24h verification window) has expired.
+  expired,
+
+  /// Too many failed attempts — the PIN is locked until a new one is sent.
+  locked,
+
+  /// Transient network error or timeout.
+  network,
+
+  /// Server returned a 5xx or otherwise unexpected/malformed response.
+  server,
+
+  /// The verify-pin endpoint is absent (404) or returned an unclassified 4xx.
+  /// The PIN path isn't usable here; the UI should steer the user back to the
+  /// email link / resend rather than claiming the PIN was incorrect.
+  unavailable,
+
+  /// Finalizing verification found the email already attached to an account.
+  emailAlreadyRegistered,
+}
+
+/// Result from POST /api/headless/verify-pin
+class VerifyPinResult {
+  VerifyPinResult({
+    required this.success,
+    this.alreadyCompleted = false,
+    this.code,
+    this.errorCode,
+    this.errorDescription,
+  });
+
+  factory VerifyPinResult.success(String code) =>
+      VerifyPinResult(success: true, code: code);
+
+  factory VerifyPinResult.alreadyCompleted() =>
+      VerifyPinResult(success: true, alreadyCompleted: true);
+
+  factory VerifyPinResult.failure(
+    VerifyPinError errorCode, {
+    String? description,
+  }) => VerifyPinResult(
+    success: false,
+    errorCode: errorCode,
+    errorDescription: description,
+  );
+
+  final bool success;
+
+  /// True when keycast reports this registration was already finalized.
+  final bool alreadyCompleted;
+
+  /// OAuth authorization code, returned synchronously on success.
+  final String? code;
+
+  /// Reason code on failure (null on success).
+  final VerifyPinError? errorCode;
+
+  /// Human-readable description from the server, for logs only — never shown
+  /// to the user (the UI localizes [errorCode]).
+  final String? errorDescription;
+}
+
+/// Result from POST /api/auth/resend-verification
+class ResendVerificationResult {
+  ResendVerificationResult({required this.success, this.message});
+
+  factory ResendVerificationResult.fromJson(Map<String, dynamic> json) {
+    return ResendVerificationResult(
+      success: json['success'] as bool? ?? false,
+      message: json['message'] as String?,
+    );
+  }
+
+  factory ResendVerificationResult.failure() =>
+      ResendVerificationResult(success: false);
+
+  final bool success;
+  final String? message;
+}
+
 /// Result from POST /api/auth/forgot-password
 class ForgotPasswordResult {
   ForgotPasswordResult({required this.success, this.message, this.error});

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -759,6 +759,216 @@ class KeycastOAuth {
     }
   }
 
+  /// Verify a pending registration with the 6-digit PIN from the email.
+  ///
+  /// Submits `{device_code, pin}` to `/api/headless/verify-pin`. On success the
+  /// server finalizes verification and returns the OAuth authorization code
+  /// synchronously in [VerifyPinResult.code]; the caller exchanges it via
+  /// [exchangeCode] using the registration verifier (Redis-independent — no
+  /// polling needed).
+  ///
+  /// Never throws for expected failures (mirrors [headlessRegister] /
+  /// [verifyEmail]): a wrong / expired / locked PIN, a malformed response, or a
+  /// network error all return a [VerifyPinResult] carrying a [VerifyPinError].
+  Future<VerifyPinResult> verifyPin({
+    required String deviceCode,
+    required String pin,
+  }) async {
+    try {
+      final response = await _client
+          .post(
+            Uri.parse('${config.serverUrl}/api/headless/verify-pin'),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'device_code': deviceCode, 'pin': pin}),
+          )
+          .timeout(requestTimeout);
+
+      // Endpoint absent — mirror the endpoint_not_found handling in
+      // headlessRegister / headlessLogin. Checked before JSON parsing because
+      // a 404 body is typically non-JSON (proxy/CDN HTML), which would
+      // otherwise be misread as a server error.
+      if (response.statusCode == 404) {
+        return VerifyPinResult.failure(
+          VerifyPinError.unavailable,
+          description: 'verify-pin endpoint not available (404)',
+        );
+      }
+
+      if (response.statusCode >= 500) {
+        return VerifyPinResult.failure(
+          VerifyPinError.server,
+          description: 'Server error (${response.statusCode})',
+        );
+      }
+
+      Map<String, dynamic> json;
+      try {
+        json = jsonDecode(response.body) as Map<String, dynamic>;
+      } catch (_) {
+        return VerifyPinResult.failure(
+          VerifyPinError.server,
+          description: 'Invalid server response (${response.statusCode})',
+        );
+      }
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        final code = json['code'] as String?;
+        if (code != null && code.isNotEmpty) {
+          return VerifyPinResult.success(code);
+        }
+        return VerifyPinResult.alreadyCompleted();
+      }
+
+      // Honor `code` first (then `error`), matching the 2xx success path and
+      // the register/login helpers, so a keycast response that carries the
+      // failure identifier under `code` is classified correctly.
+      final errorCode = _responseErrorCode(json, '');
+      final description = _responseErrorMessage(json, errorCode);
+      return VerifyPinResult.failure(
+        _classifyPinError(response.statusCode, errorCode),
+        description: description,
+      );
+    } on TimeoutException {
+      return VerifyPinResult.failure(
+        VerifyPinError.network,
+        description: 'Request timed out',
+      );
+    } catch (e) {
+      return VerifyPinResult.failure(
+        VerifyPinError.network,
+        description: 'Network error: $e',
+      );
+    }
+  }
+
+  /// Map an HTTP status + server error code to a [VerifyPinError].
+  ///
+  /// Known keycast PIN error codes are matched first (typed), so a generic
+  /// OAuth/request error such as `invalid_request` is classified as
+  /// [VerifyPinError.unavailable] rather than masquerading as a wrong PIN.
+  /// Status-code hints and substring matching are kept only as a last-resort
+  /// fallback for when the endpoint returns a bare/opaque failure — preserving
+  /// tolerance of keycast's anti-enumeration posture.
+  static VerifyPinError _classifyPinError(int statusCode, String errorCode) {
+    final code = errorCode.toLowerCase();
+
+    // 1) Known keycast PIN error codes take precedence over any heuristic.
+    const expiredCodes = {'pin_expired', 'expired', 'code_expired'};
+    const lockedCodes = {
+      'pin_locked',
+      'locked',
+      'too_many_attempts',
+      'pin_attempts_exceeded',
+    };
+    const invalidCodes = {
+      'pin_invalid',
+      'invalid_pin',
+      'incorrect_pin',
+      'wrong_pin',
+    };
+    // Generic OAuth/request errors are NOT wrong-PIN signals — route them to
+    // unavailable so they can't fall through to the bare 400/401 -> invalid
+    // rule below.
+    const unavailableCodes = {
+      'endpoint_not_found',
+      'not_found',
+      'pin_unavailable',
+      'invalid_request',
+      'bad_request',
+      'unsupported_grant_type',
+    };
+    if (expiredCodes.contains(code)) return VerifyPinError.expired;
+    if (lockedCodes.contains(code)) return VerifyPinError.locked;
+    if (invalidCodes.contains(code)) return VerifyPinError.invalid;
+    if (unavailableCodes.contains(code)) return VerifyPinError.unavailable;
+    if (statusCode == 409 || code == 'email_already_exists') {
+      return VerifyPinError.emailAlreadyRegistered;
+    }
+
+    // 2) Status-code hints for a bare/opaque failure.
+    if (statusCode == 423 || statusCode == 429) return VerifyPinError.locked;
+    if (statusCode == 410) return VerifyPinError.expired;
+
+    // 3) Last-resort substring / bare-status fallback. A generic invalid_request
+    //    was already routed to unavailable above, so it never reaches the
+    //    400/401 -> invalid rule here.
+    if (code.contains('lock') || code.contains('attempt')) {
+      return VerifyPinError.locked;
+    }
+    if (code.contains('expired')) return VerifyPinError.expired;
+    if (statusCode == 400 ||
+        statusCode == 401 ||
+        code.contains('invalid') ||
+        code.contains('pin')) {
+      return VerifyPinError.invalid;
+    }
+    // Any other unclassified 4xx: the PIN path is unavailable here, so steer
+    // the user to the email link / resend rather than claiming an incorrect PIN.
+    return VerifyPinError.unavailable;
+  }
+
+  /// Request a fresh verification email (link + PIN) for [email].
+  ///
+  /// Posts to `/api/auth/resend-verification`. The server always responds with
+  /// success to avoid email enumeration and rate-limits to one send per
+  /// 5 minutes; callers surface their own client-side cooldown.
+  Future<ResendVerificationResult> resendVerification(String email) async {
+    try {
+      final response = await _client
+          .post(
+            Uri.parse('${config.serverUrl}/api/auth/resend-verification'),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'email': email}),
+          )
+          .timeout(requestTimeout);
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        try {
+          final json = jsonDecode(response.body) as Map<String, dynamic>;
+          return ResendVerificationResult.fromJson(json);
+        } catch (_) {
+          // A 2xx with a non-JSON body still means the request was accepted.
+          return ResendVerificationResult(success: true);
+        }
+      }
+      return ResendVerificationResult.failure();
+    } catch (_) {
+      return ResendVerificationResult.failure();
+    }
+  }
+
+  /// Request a fresh link + PIN for a pending headless verification session.
+  ///
+  /// Posts to `/api/headless/resend-pin` with the active `device_code`, which
+  /// lets keycast re-arm the pending `oauth_codes` row used by headless
+  /// registration. Use [resendVerification] for users-table email-token flows.
+  Future<ResendVerificationResult> resendHeadlessVerification(
+    String deviceCode,
+  ) async {
+    try {
+      final response = await _client
+          .post(
+            Uri.parse('${config.serverUrl}/api/headless/resend-pin'),
+            headers: {'Content-Type': 'application/json'},
+            body: jsonEncode({'device_code': deviceCode}),
+          )
+          .timeout(requestTimeout);
+
+      if (response.statusCode == 200 || response.statusCode == 201) {
+        try {
+          final json = jsonDecode(response.body) as Map<String, dynamic>;
+          return ResendVerificationResult.fromJson(json);
+        } catch (_) {
+          // A 2xx with a non-JSON body still means the request was accepted.
+          return ResendVerificationResult(success: true);
+        }
+      }
+      return ResendVerificationResult.failure();
+    } catch (_) {
+      return ResendVerificationResult.failure();
+    }
+  }
+
   /// Delete the user's account permanently from Keycast
   ///
   /// Requires an active bearer token from headless login/register flow.

--- a/mobile/packages/keycast_flutter/test/oauth_client_test.dart
+++ b/mobile/packages/keycast_flutter/test/oauth_client_test.dart
@@ -827,6 +827,372 @@ void main() {
       });
     });
 
+    group('verifyPin', () {
+      test('returns success with code on 200 with code', () async {
+        final mockClient = MockClient((request) async {
+          expect(request.url.path, '/api/headless/verify-pin');
+          expect(request.method, 'POST');
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(body['device_code'], 'device123');
+          expect(body['pin'], '123456');
+          return http.Response(jsonEncode({'code': 'auth_code_789'}), 200);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.code, 'auth_code_789');
+        expect(result.errorCode, isNull);
+      });
+
+      test('returns success on 201 with code', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(jsonEncode({'code': 'auth_code_789'}), 201);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.code, 'auth_code_789');
+      });
+
+      test('treats 200 with an empty code as already completed', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(jsonEncode({'success': true, 'code': ''}), 200);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isTrue);
+        expect(result.alreadyCompleted, isTrue);
+        expect(result.code, isNull);
+        expect(result.errorCode, isNull);
+      });
+
+      test('maps 400 to an invalid-PIN error', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(
+            jsonEncode({
+              'error': 'invalid_pin',
+              'error_description': 'Incorrect code',
+            }),
+            400,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '000000',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.invalid);
+      });
+
+      test('maps an expired error code to an expired-PIN error', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(jsonEncode({'error': 'pin_expired'}), 410);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.expired);
+      });
+
+      test('maps a lockout response to a locked-PIN error', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(jsonEncode({'error': 'too_many_attempts'}), 429);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.locked);
+      });
+
+      test('maps a 404 (endpoint absent) to an unavailable error', () async {
+        // A 404 means the verify-pin endpoint isn't deployed on this server.
+        // Surfaced as "use the email link / resend", not "incorrect PIN".
+        final mockClient = MockClient((request) async {
+          return http.Response('Not Found', 404);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.unavailable);
+      });
+
+      test('maps an unclassified 4xx to an unavailable error', () async {
+        // Anything that isn't the expected wrong-PIN response (400/401) and
+        // isn't locked/expired is treated as the PIN path being unavailable.
+        final mockClient = MockClient((request) async {
+          return http.Response(jsonEncode({'error': 'forbidden'}), 403);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.unavailable);
+      });
+
+      test(
+        'maps 409 EMAIL_ALREADY_EXISTS to duplicate-email recovery',
+        () async {
+          final mockClient = MockClient((request) async {
+            return http.Response(
+              jsonEncode({'code': 'EMAIL_ALREADY_EXISTS'}),
+              409,
+            );
+          });
+
+          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+          final result = await oauth.verifyPin(
+            deviceCode: 'device123',
+            pin: '123456',
+          );
+
+          expect(result.success, isFalse);
+          expect(result.errorCode, VerifyPinError.emailAlreadyRegistered);
+        },
+      );
+
+      test('maps a 401 to an invalid-PIN error', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(jsonEncode({'error': 'unauthorized'}), 401);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '000000',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.invalid);
+      });
+
+      test('maps a 5xx response to a server error', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response('Internal Server Error', 500);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.server);
+      });
+
+      test('maps invalid JSON to a server error', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response('not json {{{', 400);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.server);
+      });
+
+      test('maps a network failure to a network error', () async {
+        final mockClient = MockClient((request) async {
+          throw Exception('Network failure');
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '123456',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.network);
+      });
+
+      test(
+        'honors json[code] for the failure identifier (no error field)',
+        () async {
+          // keycast may return the error identifier under `code` (same as the
+          // 2xx success path and register/login helpers). A 400 whose status
+          // alone would read as wrong-PIN must still map to expired via the code.
+          final mockClient = MockClient((request) async {
+            return http.Response(jsonEncode({'code': 'pin_expired'}), 400);
+          });
+
+          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+          final result = await oauth.verifyPin(
+            deviceCode: 'device123',
+            pin: '123456',
+          );
+
+          expect(result.success, isFalse);
+          expect(result.errorCode, VerifyPinError.expired);
+        },
+      );
+
+      test(
+        'maps a generic invalid_request 400 to unavailable, not invalid',
+        () async {
+          // A generic OAuth/request error is NOT a wrong-PIN signal; treat it as
+          // the PIN path being unavailable so the user is steered to the link /
+          // resend instead of being told their PIN was wrong.
+          final mockClient = MockClient((request) async {
+            return http.Response(jsonEncode({'error': 'invalid_request'}), 400);
+          });
+
+          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+          final result = await oauth.verifyPin(
+            deviceCode: 'device123',
+            pin: '123456',
+          );
+
+          expect(result.success, isFalse);
+          expect(result.errorCode, VerifyPinError.unavailable);
+        },
+      );
+
+      test('maps a genuine wrong-PIN 400 to an invalid-PIN error', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response(jsonEncode({'error': 'invalid_pin'}), 400);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.verifyPin(
+          deviceCode: 'device123',
+          pin: '000000',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorCode, VerifyPinError.invalid);
+      });
+    });
+
+    group('resendVerification', () {
+      test('posts the email and returns success on 200', () async {
+        final mockClient = MockClient((request) async {
+          expect(request.url.path, '/api/auth/resend-verification');
+          expect(request.method, 'POST');
+          final body = jsonDecode(request.body) as Map<String, dynamic>;
+          expect(body['email'], 'test@example.com');
+          return http.Response(
+            jsonEncode({'success': true, 'message': 'Sent'}),
+            200,
+          );
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.resendVerification('test@example.com');
+
+        expect(result.success, isTrue);
+      });
+
+      test('returns success even when the body is not JSON', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response('OK', 200);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.resendVerification('test@example.com');
+
+        expect(result.success, isTrue);
+      });
+
+      test('returns failure on a network error', () async {
+        final mockClient = MockClient((request) async {
+          throw Exception('Network failure');
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.resendVerification('test@example.com');
+
+        expect(result.success, isFalse);
+      });
+    });
+
+    group('resendHeadlessVerification', () {
+      test(
+        'posts the device code to the headless resend-pin endpoint',
+        () async {
+          final mockClient = MockClient((request) async {
+            expect(request.url.path, '/api/headless/resend-pin');
+            expect(request.method, 'POST');
+            final body = jsonDecode(request.body) as Map<String, dynamic>;
+            expect(body['device_code'], 'device123');
+            expect(body.containsKey('email'), isFalse);
+            return http.Response(
+              jsonEncode({'success': true, 'message': 'Sent'}),
+              200,
+            );
+          });
+
+          final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+          final result = await oauth.resendHeadlessVerification('device123');
+
+          expect(result.success, isTrue);
+        },
+      );
+
+      test('returns success even when the body is not JSON', () async {
+        final mockClient = MockClient((request) async {
+          return http.Response('OK', 200);
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.resendHeadlessVerification('device123');
+
+        expect(result.success, isTrue);
+      });
+
+      test('returns failure on a network error', () async {
+        final mockClient = MockClient((request) async {
+          throw Exception('Network failure');
+        });
+
+        final oauth = KeycastOAuth(config: config, httpClient: mockClient);
+        final result = await oauth.resendHeadlessVerification('device123');
+
+        expect(result.success, isFalse);
+      });
+    });
+
     group('sendPasswordResetEmail', () {
       test('returns success on 200 response', () async {
         final mockClient = MockClient((request) async {

--- a/mobile/scripts/baseline/material_buttons.txt
+++ b/mobile/scripts/baseline/material_buttons.txt
@@ -15,7 +15,6 @@ lib/notifications/view/notifications_view.dart	2
 lib/screens/auth/create_account_screen.dart	3
 lib/screens/auth/invite_gate_screen.dart	2
 lib/screens/auth/nostr_connect_screen.dart	1
-lib/screens/auth/secure_account_screen.dart	2
 lib/screens/category_gallery_screen.dart	1
 lib/screens/comments/widgets/comment_input.dart	3
 lib/screens/comments/widgets/comment_options_modal.dart	1

--- a/mobile/scripts/baseline/raw_dialogs.txt
+++ b/mobile/scripts/baseline/raw_dialogs.txt
@@ -13,7 +13,6 @@ lib/screens/apps/nostr_app_sandbox_screen.dart	1
 lib/screens/auth/create_account_screen.dart	1
 lib/screens/auth/invite_gate_screen.dart	1
 lib/screens/auth/nostr_connect_screen.dart	1
-lib/screens/auth/secure_account_screen.dart	1
 lib/screens/category_gallery_screen.dart	1
 lib/screens/curated_list_feed_screen.dart	1
 lib/screens/developer_options_screen.dart	1

--- a/mobile/scripts/baseline/raw_textstyle.txt
+++ b/mobile/scripts/baseline/raw_textstyle.txt
@@ -21,7 +21,6 @@ lib/screens/auth/invite_gate_screen.dart	12
 lib/screens/auth/login_options_screen.dart	4
 lib/screens/auth/nostr_connect_screen.dart	12
 lib/screens/auth/reset_password.dart	2
-lib/screens/auth/secure_account_screen.dart	11
 lib/screens/auth/welcome_screen.dart	1
 lib/screens/blossom_settings_screen.dart	12
 lib/screens/category_gallery_screen.dart	2

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -30,7 +30,6 @@ nip07_service # defer: #4338 C2 singleton-to-DI
 nostr_list_service_mixin # noise: mixin
 openvine_media_cache
 outgoing_dm_retry_service_reportable_sites # noise: reportable-sites constants
-pending_verification_service
 push_notification_session_coordinator
 social_event_service_base
 social_service # decision: OD-2 keep-vs-delete (#4337)

--- a/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
+++ b/mobile/test/blocs/email_verification/email_verification_cubit_test.dart
@@ -213,9 +213,9 @@ void main() {
         () {
           when(() => mockAuthService.isAuthenticated).thenReturn(false);
           when(() => mockAuthService.isRegistered).thenReturn(false);
-          when(() => mockOAuth.pollForCode(testDeviceCode)).thenAnswer(
-            (_) async => PollResult(status: PollStatus.pending),
-          );
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult(status: PollStatus.pending));
 
           var verifyCalls = 0;
           when(() => mockOAuth.verifyEmail(token: 'verify-token')).thenAnswer((
@@ -1211,6 +1211,1375 @@ void main() {
         }
       });
     });
+
+    group('submitPin', () {
+      const pin = '123456';
+      const pinCode = 'pin-auth-code';
+
+      void stubExchangeSuccess() {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isAnonymous).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+        ).thenAnswer((_) async => VerifyPinResult.success(pinCode));
+        when(
+          () => mockOAuth.exchangeCode(code: pinCode, verifier: testVerifier),
+        ).thenAnswer(
+          (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+        );
+        when(
+          () => mockAuthService.signInWithDivineOAuth(any()),
+        ).thenAnswer((_) async {});
+      }
+
+      test('valid PIN exchanges the code and authenticates', () {
+        stubExchangeSuccess();
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.submitPin(pin));
+          fake.elapse(const Duration(seconds: 2));
+
+          expect(cubit.state.status, EmailVerificationStatus.success);
+          verifyInOrder([
+            () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+            () => mockOAuth.exchangeCode(code: pinCode, verifier: testVerifier),
+            () => mockAuthService.signInWithDivineOAuth(any()),
+          ]);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test(
+        'already-completed PIN response clears submission without error',
+        () {
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+          when(
+            () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+          ).thenAnswer((_) async => VerifyPinResult.alreadyCompleted());
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+              );
+
+            unawaited(cubit.submitPin(pin));
+            fake.elapse(const Duration(milliseconds: 100));
+
+            expect(cubit.state.status, EmailVerificationStatus.polling);
+            expect(cubit.state.pinStatus, PinSubmissionStatus.idle);
+            expect(cubit.state.pinErrorCode, isNull);
+            verifyNever(
+              () => mockOAuth.exchangeCode(
+                code: any(named: 'code'),
+                verifier: any(named: 'verifier'),
+              ),
+            );
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test('duplicate email from PIN routes to sign-in recovery failure', () {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+        ).thenAnswer(
+          (_) async =>
+              VerifyPinResult.failure(VerifyPinError.emailAlreadyRegistered),
+        );
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.submitPin(pin));
+          fake.elapse(const Duration(milliseconds: 100));
+
+          expect(cubit.state.status, EmailVerificationStatus.failure);
+          expect(
+            cubit.state.errorCode,
+            EmailVerificationError.emailAlreadyRegistered,
+          );
+          expect(cubit.state.pinStatus, PinSubmissionStatus.idle);
+          expect(cubit.state.pinErrorCode, isNull);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test(
+        'abandons exchange when pending context is cleared during verifyPin',
+        () {
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isAnonymous).thenReturn(false);
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+          // verifyPin hangs so the escape hatch can clear the pending context
+          // before it resolves.
+          when(
+            () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(seconds: 5));
+            return VerifyPinResult.success(pinCode);
+          });
+          when(
+            () => mockOAuth.exchangeCode(code: pinCode, verifier: testVerifier),
+          ).thenAnswer(
+            (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+          );
+          when(
+            () => mockAuthService.signInWithDivineOAuth(any()),
+          ).thenAnswer((_) async {});
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+              );
+
+            unawaited(cubit.submitPin(pin));
+            fake.elapse(const Duration(milliseconds: 100));
+            expect(cubit.state.pinStatus, PinSubmissionStatus.submitting);
+
+            // The user leaves (escape hatch) while verifyPin is still in
+            // flight; stopPolling clears the pending context WITHOUT claiming
+            // completion.
+            cubit.stopPolling();
+
+            // verifyPin now resolves success — the abandoned submit must NOT
+            // exchange or sign in.
+            fake.elapse(const Duration(seconds: 6));
+
+            verifyNever(
+              () => mockOAuth.exchangeCode(
+                code: any(named: 'code'),
+                verifier: any(named: 'verifier'),
+              ),
+            );
+            verifyNever(() => mockAuthService.signInWithDivineOAuth(any()));
+            expect(cubit.state.status, isNot(EmailVerificationStatus.success));
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test(
+        'delayed PIN failure after a new attempt does not emit on current state',
+        () {
+          const secondDeviceCode = 'second-device-code-def456';
+          const secondVerifier = 'second-verifier-uvw123';
+          const secondEmail = 'second@example.com';
+
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+          when(
+            () => mockOAuth.pollForCode(secondDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+          when(
+            () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(seconds: 5));
+            return VerifyPinResult.failure(VerifyPinError.invalid);
+          });
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+              );
+
+            unawaited(cubit.submitPin(pin));
+            fake.elapse(const Duration(milliseconds: 100));
+            expect(cubit.state.pinStatus, PinSubmissionStatus.submitting);
+
+            cubit.startPolling(
+              deviceCode: secondDeviceCode,
+              verifier: secondVerifier,
+              email: secondEmail,
+            );
+
+            fake.elapse(const Duration(seconds: 6));
+            fake.flushMicrotasks();
+
+            expect(cubit.state.status, EmailVerificationStatus.polling);
+            expect(cubit.state.pendingEmail, secondEmail);
+            expect(cubit.state.pinStatus, PinSubmissionStatus.idle);
+            expect(cubit.state.pinErrorCode, isNull);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      void stubPinFailure(VerifyPinError error) {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+        ).thenAnswer((_) async => VerifyPinResult.failure(error));
+      }
+
+      test('invalid PIN surfaces pinInvalid and keeps polling status', () {
+        stubPinFailure(VerifyPinError.invalid);
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.submitPin(pin));
+          fake.elapse(const Duration(milliseconds: 100));
+
+          expect(cubit.state.pinStatus, PinSubmissionStatus.failure);
+          expect(cubit.state.pinErrorCode, EmailVerificationError.pinInvalid);
+          expect(cubit.state.status, EmailVerificationStatus.polling);
+          verifyNever(
+            () => mockOAuth.exchangeCode(
+              code: any(named: 'code'),
+              verifier: any(named: 'verifier'),
+            ),
+          );
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('expired PIN surfaces pinExpired', () {
+        stubPinFailure(VerifyPinError.expired);
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.submitPin(pin));
+          fake.elapse(const Duration(milliseconds: 100));
+
+          expect(cubit.state.pinErrorCode, EmailVerificationError.pinExpired);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('locked PIN surfaces pinLocked', () {
+        stubPinFailure(VerifyPinError.locked);
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.submitPin(pin));
+          fake.elapse(const Duration(milliseconds: 100));
+
+          expect(cubit.state.pinErrorCode, EmailVerificationError.pinLocked);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('unavailable PIN endpoint surfaces pinUnavailable', () {
+        stubPinFailure(VerifyPinError.unavailable);
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.submitPin(pin));
+          fake.elapse(const Duration(milliseconds: 100));
+
+          expect(
+            cubit.state.pinErrorCode,
+            EmailVerificationError.pinUnavailable,
+          );
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('without pending context fails without calling the server', () {
+        final cubit = buildCubit();
+
+        cubit.submitPin(pin);
+
+        expect(cubit.state.pinStatus, PinSubmissionStatus.failure);
+        expect(cubit.state.pinErrorCode, EmailVerificationError.pinFailed);
+        verifyNever(
+          () => mockOAuth.verifyPin(
+            deviceCode: any(named: 'deviceCode'),
+            pin: any(named: 'pin'),
+          ),
+        );
+
+        cubit.close();
+      });
+    });
+
+    group('completion race (poll vs PIN submit)', () {
+      const pin = '123456';
+      const pinCode = 'pin-auth-code';
+      const pollCode = 'poll-auth-code';
+
+      // A PIN submit and a poll completion can land on the same cubit at once
+      // (user types the PIN while the link's poll is mid-flight). Only one may
+      // reach token exchange / invite consumption, and the in-flight poll must
+      // not overwrite the PIN-driven success with a missingAuthCode failure.
+      test(
+        'PIN submit wins; in-flight poll bails without a second exchange',
+        () {
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isAnonymous).thenReturn(false);
+          when(() => mockOAuth.config).thenReturn(
+            const OAuthConfig(
+              serverUrl: 'https://login.divine.video',
+              clientId: 'client-id',
+              redirectUri: 'divine://auth',
+            ),
+          );
+          // pollForCode resolves slowly so the poll is still in flight when
+          // the PIN submit claims completion.
+          when(() => mockOAuth.pollForCode(testDeviceCode)).thenAnswer((
+            _,
+          ) async {
+            await Future<void>.delayed(const Duration(seconds: 5));
+            return PollResult.complete(pollCode);
+          });
+          when(
+            () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+          ).thenAnswer((_) async => VerifyPinResult.success(pinCode));
+          when(
+            () => mockOAuth.exchangeCode(
+              code: any(named: 'code'),
+              verifier: any(named: 'verifier'),
+            ),
+          ).thenAnswer(
+            (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+          );
+          when(
+            () => mockInviteApiClient.consumeInviteWithSession(
+              code: any(named: 'code'),
+              oauthConfig: any(named: 'oauthConfig'),
+              session: any(named: 'session'),
+            ),
+          ).thenAnswer(
+            (_) async => const InviteConsumeResult(
+              message: 'Welcome',
+              codesAllocated: 5,
+            ),
+          );
+          when(
+            () => mockAuthService.signInWithDivineOAuth(any()),
+          ).thenAnswer((_) async {});
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+                inviteCode: 'ab12ef34',
+              );
+
+            // Fire the first poll tick; _poll() is now awaiting the slow
+            // pollForCode (in flight).
+            fake.elapse(const Duration(seconds: 3));
+
+            // User submits the PIN mid-flight. It claims completion and runs
+            // the exchange + consume to success.
+            unawaited(cubit.submitPin(pin));
+            fake.elapse(const Duration(seconds: 2));
+
+            expect(cubit.state.status, EmailVerificationStatus.success);
+
+            // Let the in-flight poll resolve. It must observe the claim and
+            // bail — no second exchange, no missingAuthCode over success.
+            fake.elapse(const Duration(seconds: 10));
+
+            expect(cubit.state.status, EmailVerificationStatus.success);
+            expect(cubit.state.errorCode, isNull);
+            verify(
+              () => mockOAuth.exchangeCode(
+                code: any(named: 'code'),
+                verifier: any(named: 'verifier'),
+              ),
+            ).called(1);
+            verify(
+              () => mockInviteApiClient.consumeInviteWithSession(
+                code: any(named: 'code'),
+                oauthConfig: any(named: 'oauthConfig'),
+                session: any(named: 'session'),
+              ),
+            ).called(1);
+            verify(
+              () => mockAuthService.signInWithDivineOAuth(any()),
+            ).called(1);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test('a second PIN submit after one is claimed does not re-exchange', () {
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isAnonymous).thenReturn(false);
+        when(() => mockOAuth.config).thenReturn(
+          const OAuthConfig(
+            serverUrl: 'https://login.divine.video',
+            clientId: 'client-id',
+            redirectUri: 'divine://auth',
+          ),
+        );
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+        ).thenAnswer((_) async => VerifyPinResult.success(pinCode));
+        when(
+          () => mockOAuth.exchangeCode(code: pinCode, verifier: testVerifier),
+        ).thenAnswer(
+          (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+        );
+        when(
+          () => mockInviteApiClient.consumeInviteWithSession(
+            code: any(named: 'code'),
+            oauthConfig: any(named: 'oauthConfig'),
+            session: any(named: 'session'),
+          ),
+        ).thenAnswer(
+          (_) async =>
+              const InviteConsumeResult(message: 'Welcome', codesAllocated: 5),
+        );
+        when(
+          () => mockAuthService.signInWithDivineOAuth(any()),
+        ).thenAnswer((_) async {});
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+              inviteCode: 'ab12ef34',
+            );
+
+          unawaited(cubit.submitPin(pin));
+          fake.elapse(const Duration(seconds: 2));
+          expect(cubit.state.status, EmailVerificationStatus.success);
+
+          // Second submit after completion is already claimed must no-op.
+          unawaited(cubit.submitPin(pin));
+          fake.elapse(const Duration(seconds: 2));
+
+          expect(cubit.state.status, EmailVerificationStatus.success);
+          verify(
+            () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: pin),
+          ).called(1);
+          verify(
+            () => mockOAuth.exchangeCode(code: pinCode, verifier: testVerifier),
+          ).called(1);
+          verify(
+            () => mockInviteApiClient.consumeInviteWithSession(
+              code: any(named: 'code'),
+              oauthConfig: any(named: 'oauthConfig'),
+              session: any(named: 'session'),
+            ),
+          ).called(1);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test(
+        'stale poll completion after a new attempt does not exchange or cleanup',
+        () {
+          const secondDeviceCode = 'second-device-code-def456';
+          const secondVerifier = 'second-verifier-uvw123';
+          const secondEmail = 'second@example.com';
+
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isAnonymous).thenReturn(false);
+          when(() => mockOAuth.pollForCode(testDeviceCode)).thenAnswer((
+            _,
+          ) async {
+            await Future<void>.delayed(const Duration(seconds: 5));
+            return PollResult.complete(pollCode);
+          });
+          when(
+            () => mockOAuth.pollForCode(secondDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+          when(
+            () => mockOAuth.exchangeCode(
+              code: pollCode,
+              verifier: secondVerifier,
+            ),
+          ).thenAnswer(
+            (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+          );
+          when(
+            () => mockInviteApiClient.consumeInviteWithSession(
+              code: any(named: 'code'),
+              oauthConfig: any(named: 'oauthConfig'),
+              session: any(named: 'session'),
+            ),
+          ).thenAnswer(
+            (_) async => const InviteConsumeResult(
+              message: 'Welcome',
+              codesAllocated: 5,
+            ),
+          );
+          when(
+            () => mockAuthService.signInWithDivineOAuth(any()),
+          ).thenAnswer((_) async {});
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+              );
+
+            fake.elapse(const Duration(seconds: 3));
+            verify(() => mockOAuth.pollForCode(testDeviceCode)).called(1);
+
+            cubit.startPolling(
+              deviceCode: secondDeviceCode,
+              verifier: secondVerifier,
+              email: secondEmail,
+            );
+
+            fake.elapse(const Duration(seconds: 5));
+            fake.flushMicrotasks();
+
+            expect(cubit.state.status, EmailVerificationStatus.polling);
+            expect(cubit.state.pendingEmail, secondEmail);
+            verifyNever(
+              () => mockOAuth.exchangeCode(
+                code: any(named: 'code'),
+                verifier: any(named: 'verifier'),
+              ),
+            );
+            verifyNever(
+              () => mockOAuth.exchangeCode(
+                code: pollCode,
+                verifier: secondVerifier,
+              ),
+            );
+
+            verify(() => mockOAuth.pollForCode(secondDeviceCode)).called(1);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test(
+        'stale terminal poll error after a new attempt does not emit or cleanup',
+        () {
+          const secondDeviceCode = 'second-device-code-def456';
+          const secondVerifier = 'second-verifier-uvw123';
+          const secondEmail = 'second@example.com';
+
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockOAuth.pollForCode(testDeviceCode)).thenAnswer((
+            _,
+          ) async {
+            await Future<void>.delayed(const Duration(seconds: 5));
+            return PollResult.error(
+              'Invalid or expired verification token',
+              statusCode: 401,
+              failure: KeycastAuthFailure.expiredVerification,
+            );
+          });
+          when(
+            () => mockOAuth.pollForCode(secondDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+              );
+
+            fake.elapse(const Duration(seconds: 3));
+            verify(() => mockOAuth.pollForCode(testDeviceCode)).called(1);
+
+            cubit.startPolling(
+              deviceCode: secondDeviceCode,
+              verifier: secondVerifier,
+              email: secondEmail,
+            );
+
+            fake.elapse(const Duration(seconds: 5));
+            fake.flushMicrotasks();
+
+            expect(cubit.state.status, EmailVerificationStatus.polling);
+            expect(cubit.state.pendingEmail, secondEmail);
+            expect(cubit.state.errorCode, isNull);
+
+            verify(() => mockOAuth.pollForCode(secondDeviceCode)).called(1);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test(
+        'stale exchange retry after a new attempt does not emit cleanup or sign in',
+        () {
+          const secondDeviceCode = 'second-device-code-def456';
+          const secondVerifier = 'second-verifier-uvw123';
+          const secondEmail = 'second@example.com';
+          const firstCode = 'first-auth-code';
+
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isAnonymous).thenReturn(false);
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.complete(firstCode));
+          when(
+            () => mockOAuth.pollForCode(secondDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+
+          var firstExchangeCalls = 0;
+          when(
+            () =>
+                mockOAuth.exchangeCode(code: firstCode, verifier: testVerifier),
+          ).thenAnswer((_) async {
+            firstExchangeCalls++;
+            if (firstExchangeCalls == 1) {
+              throw Exception('transient network error');
+            }
+            return const TokenResponse(bunkerUrl: 'wss://first-session.test');
+          });
+          when(
+            () => mockAuthService.signInWithDivineOAuth(any()),
+          ).thenAnswer((_) async {});
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+              );
+
+            // First poll completes and starts exchange attempt A. Its first
+            // exchange throws, putting A into the 2s retry delay.
+            fake.elapse(const Duration(seconds: 4));
+            expect(firstExchangeCalls, 1);
+
+            // A fresh attempt B starts while A is waiting to retry. This bumps
+            // the generation and must keep its polling context/timers intact.
+            cubit.startPolling(
+              deviceCode: secondDeviceCode,
+              verifier: secondVerifier,
+              email: secondEmail,
+            );
+            expect(cubit.state.status, EmailVerificationStatus.polling);
+            expect(cubit.state.pendingEmail, secondEmail);
+
+            // Let A's retry delay elapse and its second exchange return a
+            // session. A is stale and must not commit, cleanup B, emit failure
+            // or success, or sign in with the first session.
+            fake.elapse(const Duration(seconds: 3));
+            fake.flushMicrotasks();
+
+            expect(firstExchangeCalls, 1);
+            expect(cubit.state.status, EmailVerificationStatus.polling);
+            expect(cubit.state.pendingEmail, secondEmail);
+            expect(cubit.state.errorCode, isNull);
+            verifyNever(() => mockAuthService.signInWithDivineOAuth(any()));
+
+            // B's scheduled poll should still be alive.
+            verify(() => mockOAuth.pollForCode(secondDeviceCode)).called(1);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+    });
+
+    group('resendVerification', () {
+      test('sends, enters cooldown, then re-enables after 5 minutes', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+        ).thenAnswer((_) async => ResendVerificationResult(success: true));
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.resendVerification());
+          fake.elapse(const Duration(milliseconds: 100));
+
+          expect(cubit.state.resendStatus, ResendStatus.cooldown);
+          expect(cubit.state.resendCooldownSeconds, 300);
+
+          fake.elapse(const Duration(seconds: 1));
+          expect(cubit.state.resendCooldownSeconds, 299);
+
+          fake.elapse(const Duration(minutes: 5));
+          expect(cubit.state.resendStatus, ResendStatus.idle);
+          expect(cubit.state.resendCooldownSeconds, 0);
+
+          verify(
+            () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+          ).called(1);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('is ignored while already on cooldown', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+        ).thenAnswer((_) async => ResendVerificationResult(success: true));
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.resendVerification());
+          fake.elapse(const Duration(milliseconds: 100));
+          unawaited(cubit.resendVerification());
+          fake.elapse(const Duration(milliseconds: 100));
+
+          verify(
+            () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+          ).called(1);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('a failure() result surfaces retryable failure', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+        ).thenAnswer((_) async => ResendVerificationResult.failure());
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.resendVerification());
+          fake.elapse(const Duration(milliseconds: 100));
+
+          expect(cubit.state.resendStatus, ResendStatus.failure);
+          expect(cubit.state.resendCooldownSeconds, 0);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('a thrown error surfaces retryable failure', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+        ).thenThrow(Exception('network down'));
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.resendVerification());
+          fake.elapse(const Duration(milliseconds: 100));
+
+          expect(cubit.state.resendStatus, ResendStatus.failure);
+          expect(cubit.state.resendCooldownSeconds, 0);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('startPolling cancels an active resend cooldown timer', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+        ).thenAnswer((_) async => ResendVerificationResult(success: true));
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          unawaited(cubit.resendVerification());
+          fake.elapse(const Duration(milliseconds: 100));
+          expect(cubit.state.resendStatus, ResendStatus.cooldown);
+          expect(cubit.state.resendCooldownSeconds, 300);
+
+          // Re-init polling (e.g. re-arm after timeout, or a fresh
+          // registration). The cooldown timer must be cancelled so it cannot
+          // keep ticking onto the reset state.
+          cubit.startPolling(
+            deviceCode: testDeviceCode,
+            verifier: testVerifier,
+            email: testEmail,
+          );
+          expect(cubit.state.resendStatus, ResendStatus.idle);
+          expect(cubit.state.resendCooldownSeconds, 0);
+
+          // An orphaned cooldown timer would fire here and mutate the state.
+          fake.elapse(const Duration(seconds: 3));
+          expect(cubit.state.resendStatus, ResendStatus.idle);
+          expect(
+            cubit.state.resendCooldownSeconds,
+            0,
+            reason: 'orphaned resend timer must be cancelled on re-init',
+          );
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test(
+        'delayed resend completion after a new attempt does not start cooldown',
+        () {
+          const secondDeviceCode = 'second-device-code-def456';
+          const secondVerifier = 'second-verifier-uvw123';
+          const secondEmail = 'second@example.com';
+
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+          when(
+            () => mockOAuth.pollForCode(secondDeviceCode),
+          ).thenAnswer((_) async => PollResult.pending());
+          when(
+            () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+          ).thenAnswer((_) async {
+            await Future<void>.delayed(const Duration(seconds: 5));
+            return ResendVerificationResult(success: true);
+          });
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+              );
+
+            unawaited(cubit.resendVerification());
+            fake.elapse(const Duration(milliseconds: 100));
+            expect(cubit.state.resendStatus, ResendStatus.sending);
+
+            cubit.startPolling(
+              deviceCode: secondDeviceCode,
+              verifier: secondVerifier,
+              email: secondEmail,
+            );
+
+            fake.elapse(const Duration(seconds: 6));
+            fake.flushMicrotasks();
+
+            expect(cubit.state.status, EmailVerificationStatus.polling);
+            expect(cubit.state.pendingEmail, secondEmail);
+            expect(cubit.state.resendStatus, ResendStatus.idle);
+            expect(cubit.state.resendCooldownSeconds, 0);
+            verify(
+              () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+            ).called(1);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+    });
+
+    group('resumePollingAfterTimeout', () {
+      const lateCode = 'late-poll-code';
+
+      test('re-arms polling and completes after a late link click', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAnonymous).thenReturn(false);
+        // Pending the whole 15-min window, so the cubit times out.
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.exchangeCode(code: lateCode, verifier: testVerifier),
+        ).thenAnswer(
+          (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+        );
+        when(
+          () => mockAuthService.signInWithDivineOAuth(any()),
+        ).thenAnswer((_) async {});
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          fake.elapse(const Duration(minutes: 16));
+          expect(cubit.state.status, EmailVerificationStatus.pollingTimedOut);
+
+          // The late link click has now marked the email verified server-side,
+          // so the re-armed poll returns a code.
+          when(
+            () => mockOAuth.pollForCode(testDeviceCode),
+          ).thenAnswer((_) async => PollResult.complete(lateCode));
+
+          cubit.resumePollingAfterTimeout();
+          fake.elapse(const Duration(seconds: 4));
+
+          expect(cubit.state.status, EmailVerificationStatus.success);
+          verify(
+            () =>
+                mockOAuth.exchangeCode(code: lateCode, verifier: testVerifier),
+          ).called(1);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('no-ops when not timed out', () {
+        final cubit = buildCubit();
+
+        cubit.resumePollingAfterTimeout();
+
+        expect(cubit.state.status, EmailVerificationStatus.initial);
+        verifyNever(() => mockOAuth.pollForCode(any()));
+
+        cubit.close();
+      });
+    });
+
+    group('poll timeout keeps PIN entry available', () {
+      test(
+        'an in-flight poll that resumes after timeout does not reschedule',
+        () {
+          when(() => mockAuthService.isAuthenticated).thenReturn(false);
+          when(() => mockAuthService.isRegistered).thenReturn(false);
+
+          // Each poll hangs for ~1000s so a poll is still in flight when the
+          // 15-minute timeout fires, and the resume is driven by the fake clock
+          // (a timer) rather than a microtask — making the recursion-guard
+          // decision observable via elapse().
+          var pollCalls = 0;
+          when(() => mockOAuth.pollForCode(testDeviceCode)).thenAnswer((
+            _,
+          ) async {
+            pollCalls++;
+            await Future<void>.delayed(const Duration(seconds: 1000));
+            return PollResult.pending();
+          });
+
+          fakeAsync((fake) {
+            final cubit = buildCubit()
+              ..startPolling(
+                deviceCode: testDeviceCode,
+                verifier: testVerifier,
+                email: testEmail,
+              );
+
+            // First poll fires at +3s and is still in flight (resolves ~1003s).
+            fake.elapse(const Duration(seconds: 4));
+            expect(pollCalls, 1);
+
+            // The 15-minute timeout fires while the poll is still in flight.
+            fake.elapse(const Duration(minutes: 15));
+            expect(cubit.state.status, EmailVerificationStatus.pollingTimedOut);
+
+            // Drive past the in-flight poll's resolution (~1003s). It must NOT
+            // re-arm the poll loop — _onTimeout retains the pending device code
+            // for PIN entry, but the poll loop is over. Without the guard, the
+            // resumed poll reschedules and pollCalls climbs.
+            fake.elapse(const Duration(minutes: 10));
+
+            expect(
+              pollCalls,
+              1,
+              reason: 'a poll resuming after timeout must not reschedule',
+            );
+            expect(cubit.state.status, EmailVerificationStatus.pollingTimedOut);
+
+            cubit.close();
+            fake.flushMicrotasks();
+          });
+        },
+      );
+
+      test('timeout transitions to pollingTimedOut, not failure', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          fake.elapse(const Duration(minutes: 16));
+
+          expect(cubit.state.status, EmailVerificationStatus.pollingTimedOut);
+          expect(cubit.state.pendingEmail, testEmail);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('PIN can still be submitted after the poll timeout', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAnonymous).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.verifyPin(deviceCode: testDeviceCode, pin: '123456'),
+        ).thenAnswer((_) async => VerifyPinResult.success('late-code'));
+        when(
+          () =>
+              mockOAuth.exchangeCode(code: 'late-code', verifier: testVerifier),
+        ).thenAnswer(
+          (_) async => const TokenResponse(bunkerUrl: 'wss://relay.test'),
+        );
+        when(
+          () => mockAuthService.signInWithDivineOAuth(any()),
+        ).thenAnswer((_) async {});
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          fake.elapse(const Duration(minutes: 16));
+          expect(cubit.state.status, EmailVerificationStatus.pollingTimedOut);
+
+          unawaited(cubit.submitPin('123456'));
+          fake.elapse(const Duration(seconds: 2));
+
+          expect(cubit.state.status, EmailVerificationStatus.success);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('timeout does not clobber an in-flight claimed completion', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(() => mockAuthService.isAnonymous).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.complete('race-code'));
+        // Exchange hangs past the 15-minute timeout, so the completion is
+        // claimed (set synchronously in _exchangeCodeAndLogin) but unfinished
+        // when _onTimeout fires.
+        when(
+          () =>
+              mockOAuth.exchangeCode(code: 'race-code', verifier: testVerifier),
+        ).thenAnswer((_) async {
+          await Future<void>.delayed(const Duration(minutes: 20));
+          return const TokenResponse(bunkerUrl: 'wss://relay.test');
+        });
+        when(
+          () => mockAuthService.signInWithDivineOAuth(any()),
+        ).thenAnswer((_) async {});
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          // First poll at +3s returns complete and claims the exchange.
+          fake.elapse(const Duration(seconds: 4));
+
+          // The 15-minute timeout fires while the exchange is still in flight.
+          fake.elapse(const Duration(minutes: 15));
+          expect(
+            cubit.state.status,
+            isNot(EmailVerificationStatus.pollingTimedOut),
+            reason: 'a claimed completion must not be clobbered by the timeout',
+          );
+
+          // Let the exchange finish — success lands.
+          fake.elapse(const Duration(minutes: 6));
+          expect(cubit.state.status, EmailVerificationStatus.success);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('in-flight recoverable poll error after timeout keeps PIN entry '
+          'available', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+
+        // The poll hangs past the 15-minute timeout, then resolves with a
+        // non-transient but recoverable/unknown failure.
+        when(() => mockOAuth.pollForCode(testDeviceCode)).thenAnswer((_) async {
+          await Future<void>.delayed(const Duration(seconds: 1000));
+          // No explicit failure -> defaults to the non-transient
+          // KeycastAuthFailure.unknown (a recoverable/unknown poll error).
+          return PollResult.error('server error');
+        });
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          fake.elapse(const Duration(seconds: 4)); // poll in flight
+          fake.elapse(const Duration(minutes: 15)); // timeout fires
+          expect(cubit.state.status, EmailVerificationStatus.pollingTimedOut);
+
+          // The in-flight poll resolves with a recoverable error after the
+          // window elapsed. It must NOT tear down the preserved PIN path.
+          fake.elapse(const Duration(minutes: 10));
+
+          expect(
+            cubit.state.status,
+            EmailVerificationStatus.pollingTimedOut,
+            reason:
+                'a recoverable poll error after timeout must keep PIN entry '
+                'usable, not drop to terminal failure',
+          );
+          expect(cubit.state.pendingEmail, testEmail);
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('in-flight expired poll error after timeout still terminates', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+
+        when(() => mockOAuth.pollForCode(testDeviceCode)).thenAnswer((_) async {
+          await Future<void>.delayed(const Duration(seconds: 1000));
+          return PollResult.error(
+            'expired',
+            failure: KeycastAuthFailure.expiredVerification,
+          );
+        });
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          fake.elapse(const Duration(seconds: 4));
+          fake.elapse(const Duration(minutes: 15));
+          expect(cubit.state.status, EmailVerificationStatus.pollingTimedOut);
+
+          fake.elapse(const Duration(minutes: 10));
+
+          expect(
+            cubit.state.status,
+            EmailVerificationStatus.failure,
+            reason:
+                'a genuinely-expired device code must still terminate even '
+                'after the poll window elapsed',
+          );
+          expect(
+            cubit.state.errorCode,
+            EmailVerificationError.verificationLinkExpired,
+          );
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+
+      test('timeout cancels an active resend cooldown timer', () {
+        when(() => mockAuthService.isAuthenticated).thenReturn(false);
+        when(() => mockAuthService.isRegistered).thenReturn(false);
+        when(
+          () => mockOAuth.pollForCode(testDeviceCode),
+        ).thenAnswer((_) async => PollResult.pending());
+        when(
+          () => mockOAuth.resendHeadlessVerification(testDeviceCode),
+        ).thenAnswer((_) async => ResendVerificationResult(success: true));
+
+        fakeAsync((fake) {
+          final cubit = buildCubit()
+            ..startPolling(
+              deviceCode: testDeviceCode,
+              verifier: testVerifier,
+              email: testEmail,
+            );
+
+          // Resend late (minute 12) so the 5-minute cooldown is still active
+          // when the 15-minute timeout fires.
+          fake.elapse(const Duration(minutes: 12));
+          unawaited(cubit.resendVerification());
+          fake.elapse(const Duration(milliseconds: 100));
+          expect(cubit.state.resendStatus, ResendStatus.cooldown);
+          expect(cubit.state.resendCooldownSeconds, 300);
+
+          // Timeout fires ~3 min into the cooldown.
+          fake.elapse(const Duration(minutes: 3));
+          expect(cubit.state.status, EmailVerificationStatus.pollingTimedOut);
+          expect(cubit.state.resendStatus, ResendStatus.idle);
+          expect(cubit.state.resendCooldownSeconds, 0);
+
+          // An orphaned cooldown tick would revive resendCooldownSeconds onto
+          // the timed-out state here.
+          fake.elapse(const Duration(seconds: 3));
+          expect(cubit.state.resendStatus, ResendStatus.idle);
+          expect(
+            cubit.state.resendCooldownSeconds,
+            0,
+            reason: 'resend timer must be cancelled on timeout',
+          );
+
+          cubit.close();
+          fake.flushMicrotasks();
+        });
+      });
+    });
   });
 
   group('EmailVerificationState', () {
@@ -1273,7 +2642,7 @@ void main() {
       expect(updated.errorCode, isNull);
     });
 
-    test('copyWith clears errorCode when not provided', () {
+    test('copyWith preserves errorCode when the argument is omitted', () {
       const original = EmailVerificationState(
         status: EmailVerificationStatus.failure,
         errorCode: EmailVerificationError.timeout,
@@ -1284,7 +2653,43 @@ void main() {
       );
 
       expect(updated.status, EmailVerificationStatus.polling);
+      expect(updated.errorCode, EmailVerificationError.timeout);
+    });
+
+    test('copyWith clears errorCode when passed explicit null', () {
+      const original = EmailVerificationState(
+        status: EmailVerificationStatus.failure,
+        errorCode: EmailVerificationError.timeout,
+      );
+
+      final updated = original.copyWith(errorCode: null);
+
       expect(updated.errorCode, isNull);
+    });
+
+    test('copyWith preserves pinErrorCode when an unrelated field changes', () {
+      const original = EmailVerificationState(
+        status: EmailVerificationStatus.pollingTimedOut,
+        pinStatus: PinSubmissionStatus.failure,
+        pinErrorCode: EmailVerificationError.pinInvalid,
+      );
+
+      final updated = original.copyWith(resendCooldownSeconds: 42);
+
+      expect(updated.resendCooldownSeconds, 42);
+      expect(updated.pinErrorCode, EmailVerificationError.pinInvalid);
+    });
+
+    test('copyWith clears pinErrorCode when passed explicit null', () {
+      const original = EmailVerificationState(
+        status: EmailVerificationStatus.pollingTimedOut,
+        pinStatus: PinSubmissionStatus.failure,
+        pinErrorCode: EmailVerificationError.pinInvalid,
+      );
+
+      final updated = original.copyWith(pinErrorCode: null);
+
+      expect(updated.pinErrorCode, isNull);
     });
 
     group('equality', () {
@@ -1326,12 +2731,13 @@ void main() {
 
   group('EmailVerificationStatus', () {
     test('has all expected values', () {
-      expect(EmailVerificationStatus.values, hasLength(4));
+      expect(EmailVerificationStatus.values, hasLength(5));
       expect(
         EmailVerificationStatus.values,
         containsAll([
           EmailVerificationStatus.initial,
           EmailVerificationStatus.polling,
+          EmailVerificationStatus.pollingTimedOut,
           EmailVerificationStatus.success,
           EmailVerificationStatus.failure,
         ]),

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -177,7 +177,6 @@ void main() {
   });
 }
 
-// Every key in app_en.arb is currently translated in all non-English locales.
 // Add keys here only when a translation pass is intentionally deferred.
 const _knownUntranslatedDebt = <String>{
   // #6217: light-mode experiment copy; translation deferred until rollout.
@@ -206,6 +205,21 @@ const _knownUntranslatedDebt = <String>{
   'communitySuggestFailure',
   'communitySuggestAlready',
   'communitySuggestActionLabel',
+  // Added by the in-app email-verification PIN fallback (#5578). The English
+  // source ships now; the non-English locales fall back to English until the
+  // next translation pass picks these up.
+  'authVerificationPinPrompt',
+  'authVerificationPinFieldLabel',
+  'authVerificationPinSubmit',
+  'authVerificationResendPrompt',
+  'authVerificationResend',
+  'authVerificationResendCooldown',
+  'authVerificationResendFailed',
+  'authVerificationErrorPinInvalid',
+  'authVerificationErrorPinExpired',
+  'authVerificationErrorPinLocked',
+  'authVerificationErrorPinFailed',
+  'authVerificationErrorPinUnavailable',
 };
 
 const _signatureVerificationKeys = <String>{

--- a/mobile/test/router/pending_verification_restore_test.dart
+++ b/mobile/test/router/pending_verification_restore_test.dart
@@ -1,0 +1,195 @@
+// ABOUTME: Unit tests for pendingEmailVerificationRestoreLocation
+// ABOUTME: Pure PendingVerification -> verify-email restore URL mapping
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/router/app_router.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/pending_verification_service.dart';
+
+PendingVerification _pending({
+  String deviceCode = 'device-123',
+  String verifier = 'verifier-abc',
+  String email = 'user@example.com',
+  DateTime? createdAt,
+  String? ownerPublicKeyHex,
+}) {
+  return PendingVerification(
+    deviceCode: deviceCode,
+    verifier: verifier,
+    email: email,
+    createdAt: createdAt ?? DateTime.now(),
+    ownerPublicKeyHex: ownerPublicKeyHex,
+  );
+}
+
+void main() {
+  group('pendingEmailVerificationRestoreLocation', () {
+    test('returns null when there is no pending record', () {
+      expect(pendingEmailVerificationRestoreLocation(null), isNull);
+    });
+
+    test('returns null when the pending record has expired', () {
+      final expired = _pending(
+        createdAt: DateTime.now().subtract(const Duration(hours: 25)),
+      );
+      expect(pendingEmailVerificationRestoreLocation(expired), isNull);
+    });
+
+    test('builds a restore URL with only email + restored flag', () {
+      final location = pendingEmailVerificationRestoreLocation(_pending());
+      expect(location, isNotNull);
+
+      final uri = Uri.parse(location!);
+      expect(uri.path, equals('/verify-email'));
+      expect(uri.queryParameters['email'], equals('user@example.com'));
+      expect(uri.queryParameters['restored'], equals('true'));
+    });
+
+    test('does not put the deviceCode or verifier secrets in the URL', () {
+      final location = pendingEmailVerificationRestoreLocation(_pending());
+      // deviceCode/verifier are secrets and are rehydrated from the persisted
+      // record on the restore path, never carried on a URL that could be
+      // logged or leaked.
+      expect(location, isNot(contains('device-123')));
+      expect(location, isNot(contains('verifier-abc')));
+      final uri = Uri.parse(location!);
+      expect(uri.queryParameters.containsKey('deviceCode'), isFalse);
+      expect(uri.queryParameters.containsKey('verifier'), isFalse);
+    });
+
+    test('percent-encodes the email so the URL round-trips', () {
+      final location = pendingEmailVerificationRestoreLocation(
+        _pending(email: 'a+b@example.com'),
+      );
+      final uri = Uri.parse(location!);
+      expect(uri.queryParameters['email'], equals('a+b@example.com'));
+    });
+  });
+
+  group('pendingEmailVerificationStartupLocation', () {
+    const ownerPublicKeyHex =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const differentPublicKeyHex =
+        'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+
+    String? startupLocation({
+      PendingVerification? pending,
+      AuthState authState = AuthState.unauthenticated,
+      bool isAnonymous = false,
+      String? currentPublicKeyHex,
+      String currentPath = '/welcome',
+    }) => pendingEmailVerificationStartupLocation(
+      pending: pending,
+      authState: authState,
+      isAnonymous: isAnonymous,
+      currentPublicKeyHex: currentPublicKeyHex,
+      currentPath: currentPath,
+    );
+
+    test('allows an ownerless record while unauthenticated', () {
+      expect(startupLocation(pending: _pending()), isNotNull);
+    });
+
+    test(
+      'allows an owner-bound record for its matching automatic identity',
+      () {
+        expect(
+          startupLocation(
+            pending: _pending(ownerPublicKeyHex: ownerPublicKeyHex),
+            authState: AuthState.authenticated,
+            isAnonymous: true,
+            currentPublicKeyHex: ownerPublicKeyHex,
+          ),
+          isNotNull,
+        );
+      },
+    );
+
+    test('denies an owner-bound record for a different automatic identity', () {
+      expect(
+        startupLocation(
+          pending: _pending(ownerPublicKeyHex: ownerPublicKeyHex),
+          authState: AuthState.authenticated,
+          isAnonymous: true,
+          currentPublicKeyHex: differentPublicKeyHex,
+        ),
+        isNull,
+      );
+    });
+
+    test(
+      'denies an ownerless record while an automatic identity is active',
+      () {
+        expect(
+          startupLocation(
+            pending: _pending(),
+            authState: AuthState.authenticated,
+            isAnonymous: true,
+            currentPublicKeyHex: ownerPublicKeyHex,
+          ),
+          isNull,
+        );
+      },
+    );
+
+    test('denies an owner-bound record while unauthenticated', () {
+      expect(
+        startupLocation(
+          pending: _pending(ownerPublicKeyHex: ownerPublicKeyHex),
+        ),
+        isNull,
+      );
+    });
+
+    for (final source in [
+      'registered Divine OAuth',
+      'imported keys',
+      'bunker',
+      'Amber',
+      'NIP-07',
+    ]) {
+      test('denies an owner-bound record for $source', () {
+        expect(
+          startupLocation(
+            pending: _pending(ownerPublicKeyHex: ownerPublicKeyHex),
+            authState: AuthState.authenticated,
+            currentPublicKeyHex: ownerPublicKeyHex,
+          ),
+          isNull,
+        );
+      });
+    }
+
+    test('denies an absent record', () {
+      expect(startupLocation(), isNull);
+    });
+
+    test('denies an expired record', () {
+      expect(
+        startupLocation(
+          pending: _pending(
+            createdAt: DateTime.now().subtract(const Duration(hours: 25)),
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('does not override an existing verify-email route', () {
+      expect(
+        startupLocation(
+          pending: _pending(),
+          currentPath: '/verify-email',
+        ),
+        isNull,
+      );
+    });
+
+    test('does not override a non-Welcome route', () {
+      expect(
+        startupLocation(pending: _pending(), currentPath: '/explore'),
+        isNull,
+      );
+    });
+  });
+}

--- a/mobile/test/screens/auth/email_verification_screen_test.dart
+++ b/mobile/test/screens/auth/email_verification_screen_test.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,6 +16,8 @@ import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/email_verification/email_verification_cubit.dart';
 import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
 import 'package:openvine/screens/auth/email_verification_screen.dart';
@@ -60,6 +63,9 @@ void main() {
       () => mockAuthService.authStateStream,
     ).thenAnswer((_) => authStateController.stream);
     when(() => mockAuthService.isAuthenticated).thenReturn(false);
+    when(() => mockAuthService.authState).thenReturn(AuthState.unauthenticated);
+    when(() => mockAuthService.isAnonymous).thenReturn(false);
+    when(() => mockAuthService.currentPublicKeyHex).thenReturn(null);
 
     // Stub pending verification service
     when(() => mockPendingVerification.clear()).thenAnswer((_) async {});
@@ -82,13 +88,16 @@ void main() {
     String? verifier,
     String? email,
     String? token,
+    bool restored = false,
+    bool pinFallbackEnabled = true,
     EmailVerificationState initialState = const EmailVerificationState(),
+    Stream<EmailVerificationState>? stateStream,
   }) {
     // Set up cubit state
     when(() => mockCubit.state).thenReturn(initialState);
     whenListen(
       mockCubit,
-      const Stream<EmailVerificationState>.empty(),
+      stateStream ?? const Stream<EmailVerificationState>.empty(),
       initialState: initialState,
     );
 
@@ -99,6 +108,9 @@ void main() {
         pendingVerificationServiceProvider.overrideWithValue(
           mockPendingVerification,
         ),
+        isFeatureEnabledProvider(
+          FeatureFlag.emailVerificationPinFallback,
+        ).overrideWithValue(pinFallbackEnabled),
       ],
       child: RepositoryProvider<InviteApiClient>.value(
         value: mockInviteApiClient,
@@ -121,6 +133,7 @@ void main() {
                       verifier: verifier,
                       email: email,
                       token: token,
+                      restored: restored,
                     ),
                   ),
                 ),
@@ -161,7 +174,10 @@ void main() {
     String? verifier,
     String? email,
     String? token,
+    bool restored = false,
+    bool pinFallbackEnabled = true,
     EmailVerificationState initialState = const EmailVerificationState(),
+    Stream<EmailVerificationState>? stateStream,
   }) async {
     await tester.binding.setSurfaceSize(const Size(800, 1200));
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -171,7 +187,10 @@ void main() {
         verifier: verifier,
         email: email,
         token: token,
+        restored: restored,
+        pinFallbackEnabled: pinFallbackEnabled,
         initialState: initialState,
+        stateStream: stateStream,
       ),
     );
   }
@@ -605,6 +624,56 @@ void main() {
       );
 
       testWidgets(
+        'does not start polling when disposed during persistence load',
+        (tester) async {
+          final loadCompleter = Completer<PendingVerification?>();
+          when(
+            () => mockPendingVerification.load(),
+          ).thenAnswer((_) => loadCompleter.future);
+          when(
+            () => mockOAuth.verifyEmail(token: any(named: 'token')),
+          ).thenAnswer((_) async => VerifyEmailResult(success: true));
+          when(
+            () => mockCubit.startPolling(
+              deviceCode: any(named: 'deviceCode'),
+              verifier: any(named: 'verifier'),
+              email: any(named: 'email'),
+              inviteCode: any(named: 'inviteCode'),
+            ),
+          ).thenReturn(null);
+
+          await tester.pumpWidget(createTestWidget(token: 'persisted-token'));
+          await tester.pump();
+
+          // Unmount the screen while the persistence load is still in flight.
+          await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+          await tester.pump();
+
+          // Resolve the load after dispose — the mounted guard must stop the
+          // resumed async path from re-arming polling on a dead widget.
+          loadCompleter.complete(
+            PendingVerification(
+              deviceCode: 'persisted-device-code',
+              verifier: 'persisted-verifier',
+              email: 'user@example.com',
+              createdAt: DateTime(2026),
+            ),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 10));
+
+          verifyNever(
+            () => mockCubit.startPolling(
+              deviceCode: any(named: 'deviceCode'),
+              verifier: any(named: 'verifier'),
+              email: any(named: 'email'),
+              inviteCode: any(named: 'inviteCode'),
+            ),
+          );
+        },
+      );
+
+      testWidgets(
         're-verifies when token changes while already in token mode',
         (tester) async {
           final tokenNotifier = ValueNotifier<String>('token-1');
@@ -619,9 +688,7 @@ void main() {
             const Stream<EmailVerificationState>.empty(),
             initialState: initialState,
           );
-          when(
-            () => mockCubit.verifyEmailToken(token: 'token-1'),
-          ).thenAnswer(
+          when(() => mockCubit.verifyEmailToken(token: 'token-1')).thenAnswer(
             (_) async => const EmailTokenVerificationResult.terminalFailure(
               EmailVerificationError.verificationLinkExpired,
             ),
@@ -664,9 +731,7 @@ void main() {
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 10));
 
-          verify(
-            () => mockCubit.verifyEmailToken(token: 'token-1'),
-          ).called(1);
+          verify(() => mockCubit.verifyEmailToken(token: 'token-1')).called(1);
 
           tokenNotifier.value = 'token-2';
           await tester.pump();
@@ -678,6 +743,531 @@ void main() {
               keepPollingOnTransient: true,
             ),
           ).called(1);
+        },
+      );
+
+      testWidgets(
+        'late link click after timeout re-arms polling on verifyEmail success',
+        (tester) async {
+          // Start with no token: the link click below delivers the first
+          // token to an already-open, timed-out screen (the real late-click).
+          final tokenNotifier = ValueNotifier<String>('');
+          const timedOutState = EmailVerificationState(
+            status: EmailVerificationStatus.pollingTimedOut,
+            pendingEmail: 'user@example.com',
+          );
+
+          when(() => mockCubit.state).thenReturn(timedOutState);
+          whenListen(
+            mockCubit,
+            const Stream<EmailVerificationState>.empty(),
+            initialState: timedOutState,
+          );
+          when(() => mockCubit.resumePollingAfterTimeout()).thenReturn(null);
+          when(
+            () => mockCubit.verifyEmailToken(
+              token: any(named: 'token'),
+              pendingEmail: any(named: 'pendingEmail'),
+              keepPollingOnTransient: any(named: 'keepPollingOnTransient'),
+            ),
+          ).thenAnswer(
+            (_) async => const EmailTokenVerificationResult.success(),
+          );
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                ...getStandardTestOverrides(mockAuthService: mockAuthService),
+                oauthClientProvider.overrideWithValue(mockOAuth),
+                pendingVerificationServiceProvider.overrideWithValue(
+                  mockPendingVerification,
+                ),
+              ],
+              child: MaterialApp(
+                localizationsDelegates: AppLocalizations.localizationsDelegates,
+                supportedLocales: AppLocalizations.supportedLocales,
+                theme: VineTheme.theme,
+                home: BlocProvider<EmailVerificationCubit>.value(
+                  value: mockCubit,
+                  child: ValueListenableBuilder<String>(
+                    valueListenable: tokenNotifier,
+                    builder: (context, token, _) =>
+                        EmailVerificationScreen(token: token),
+                  ),
+                ),
+              ),
+            ),
+          );
+
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 10));
+
+          // A late link click arrives while the screen sits in pollingTimedOut.
+          tokenNotifier.value = 'token-2';
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 10));
+
+          verify(
+            () => mockCubit.verifyEmailToken(
+              token: 'token-2',
+              pendingEmail: 'user@example.com',
+              keepPollingOnTransient: true,
+            ),
+          ).called(1);
+          verify(() => mockCubit.resumePollingAfterTimeout()).called(1);
+        },
+      );
+    });
+
+    group('PIN entry fallback', () {
+      final l10n = lookupAppLocalizations(const Locale('en'));
+
+      const pollingState = EmailVerificationState(
+        status: EmailVerificationStatus.polling,
+        pendingEmail: 'user@example.com',
+      );
+
+      testWidgets('renders the PIN field, prompt, and submit in polling mode', (
+        tester,
+      ) async {
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: pollingState,
+        );
+        await tester.pump();
+
+        expect(find.text(l10n.authVerificationPinPrompt), findsOneWidget);
+        expect(find.byType(TextFormField), findsOneWidget);
+        expect(
+          find.widgetWithText(DivineButton, l10n.authVerificationPinSubmit),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('hides the PIN fallback when the feature flag is disabled', (
+        tester,
+      ) async {
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          pinFallbackEnabled: false,
+          initialState: pollingState,
+        );
+        await tester.pump();
+
+        expect(find.text(l10n.authVerificationPinPrompt), findsNothing);
+        expect(find.byType(TextFormField), findsNothing);
+        expect(
+          find.widgetWithText(DivineButton, l10n.authVerificationPinSubmit),
+          findsNothing,
+        );
+        expect(
+          find.widgetWithText(DivineButton, l10n.authOpenEmailApp),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('submitting a 6-digit PIN dispatches submitPin', (
+        tester,
+      ) async {
+        when(() => mockCubit.submitPin(any())).thenAnswer((_) async {});
+
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: pollingState,
+        );
+        await tester.pump();
+
+        await tester.enterText(find.byType(TextFormField), '123456');
+        await tester.pump();
+        await tester.tap(
+          find.widgetWithText(DivineButton, l10n.authVerificationPinSubmit),
+        );
+        await tester.pump();
+
+        verify(() => mockCubit.submitPin('123456')).called(1);
+      });
+
+      testWidgets('shows the localized error when a PIN submission failed', (
+        tester,
+      ) async {
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: const EmailVerificationState(
+            status: EmailVerificationStatus.polling,
+            pendingEmail: 'user@example.com',
+            pinStatus: PinSubmissionStatus.failure,
+            pinErrorCode: EmailVerificationError.pinInvalid,
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text(l10n.authVerificationErrorPinInvalid), findsOneWidget);
+      });
+
+      testWidgets('announces a PIN failure to assistive tech', (tester) async {
+        final announcements = <Map<Object?, Object?>>[];
+        tester.binding.defaultBinaryMessenger
+            .setMockDecodedMessageHandler<Object?>(
+              SystemChannels.accessibility,
+              (Object? message) async {
+                if (message is Map) announcements.add(message);
+                return null;
+              },
+            );
+        addTearDown(
+          () => tester.binding.defaultBinaryMessenger
+              .setMockDecodedMessageHandler<Object?>(
+                SystemChannels.accessibility,
+                null,
+              ),
+        );
+
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: pollingState,
+          stateStream: Stream<EmailVerificationState>.fromIterable(const [
+            EmailVerificationState(
+              status: EmailVerificationStatus.polling,
+              pendingEmail: 'user@example.com',
+              pinStatus: PinSubmissionStatus.failure,
+              pinErrorCode: EmailVerificationError.pinInvalid,
+            ),
+          ]),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(
+          announcements.any((message) {
+            final data = message['data'];
+            return message['type'] == 'announce' &&
+                data is Map &&
+                data['message'] == l10n.authVerificationErrorPinInvalid;
+          }),
+          isTrue,
+        );
+      });
+
+      testWidgets('surfaces the resend cooldown countdown', (tester) async {
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: const EmailVerificationState(
+            status: EmailVerificationStatus.polling,
+            pendingEmail: 'user@example.com',
+            resendStatus: ResendStatus.cooldown,
+            resendCooldownSeconds: 299,
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          find.text(l10n.authVerificationResendCooldown('4:59')),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('surfaces a retryable resend failure', (tester) async {
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: const EmailVerificationState(
+            status: EmailVerificationStatus.polling,
+            pendingEmail: 'user@example.com',
+            resendStatus: ResendStatus.failure,
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text(l10n.authVerificationResendFailed), findsOneWidget);
+        expect(find.text(l10n.authVerificationResend), findsOneWidget);
+      });
+
+      testWidgets('tapping resend dispatches resendVerification', (
+        tester,
+      ) async {
+        when(() => mockCubit.resendVerification()).thenAnswer((_) async {});
+
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: pollingState,
+        );
+        await tester.pump();
+
+        await tester.tap(find.text(l10n.authVerificationResend));
+        await tester.pump();
+
+        verify(() => mockCubit.resendVerification()).called(1);
+      });
+
+      testWidgets('pollingTimedOut keeps PIN entry but drops the spinner', (
+        tester,
+      ) async {
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          initialState: const EmailVerificationState(
+            status: EmailVerificationStatus.pollingTimedOut,
+            pendingEmail: 'user@example.com',
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text(l10n.authVerificationPinPrompt), findsOneWidget);
+        expect(find.text(l10n.authWaitingForVerification), findsNothing);
+      });
+    });
+
+    group('cold-start restore escape hatch', () {
+      const pollingState = EmailVerificationState(
+        status: EmailVerificationStatus.polling,
+        pendingEmail: 'user@example.com',
+      );
+
+      testWidgets('restored polling mode shows the PIN field', (tester) async {
+        await pumpVerificationScreen(
+          tester,
+          deviceCode: 'test-device-code',
+          verifier: 'test-verifier',
+          email: 'user@example.com',
+          restored: true,
+          initialState: pollingState,
+        );
+        await tester.pump();
+
+        expect(
+          find.text(
+            lookupAppLocalizations(
+              const Locale('en'),
+            ).authVerificationPinPrompt,
+          ),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets(
+        'closing in restored mode clears the pending record and returns home',
+        (tester) async {
+          await pumpVerificationScreen(
+            tester,
+            deviceCode: 'test-device-code',
+            verifier: 'test-verifier',
+            email: 'user@example.com',
+            restored: true,
+            initialState: pollingState,
+          );
+          await tester.pump();
+
+          await tester.tap(_divineIcon(DivineIconName.x));
+          await tester.pumpAndSettle();
+
+          verify(() => mockPendingVerification.clear()).called(1);
+          expect(find.byType(EmailVerificationScreen), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'closing in normal (non-restored) mode keeps the pending record',
+        (tester) async {
+          await pumpVerificationScreen(
+            tester,
+            deviceCode: 'test-device-code',
+            verifier: 'test-verifier',
+            email: 'user@example.com',
+            initialState: pollingState,
+          );
+          await tester.pump();
+
+          await tester.tap(_divineIcon(DivineIconName.x));
+          await tester.pumpAndSettle();
+
+          verifyNever(() => mockPendingVerification.clear());
+        },
+      );
+
+      testWidgets(
+        'polling-mode restore hydrates inviteCode from the persisted record',
+        (tester) async {
+          // The restore URL carries deviceCode/verifier/email but cannot carry
+          // the invite; on a cold start the in-memory grant is gone, so the
+          // invite must come from the persisted record.
+          when(() => mockPendingVerification.load()).thenAnswer(
+            (_) async => PendingVerification(
+              deviceCode: 'test-device-code',
+              verifier: 'test-verifier',
+              email: 'user@example.com',
+              createdAt: DateTime(2026),
+              inviteCode: 'INV-CODE',
+            ),
+          );
+          when(
+            () => mockCubit.startPolling(
+              deviceCode: any(named: 'deviceCode'),
+              verifier: any(named: 'verifier'),
+              email: any(named: 'email'),
+              inviteCode: any(named: 'inviteCode'),
+            ),
+          ).thenReturn(null);
+
+          await pumpVerificationScreen(
+            tester,
+            deviceCode: 'test-device-code',
+            verifier: 'test-verifier',
+            email: 'user@example.com',
+            restored: true,
+            initialState: pollingState,
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 10));
+
+          verify(
+            () => mockCubit.startPolling(
+              deviceCode: 'test-device-code',
+              verifier: 'test-verifier',
+              email: 'user@example.com',
+              inviteCode: 'INV-CODE',
+            ),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'Start Over from a terminal failure clears the pending record',
+        (tester) async {
+          await pumpVerificationScreen(
+            tester,
+            deviceCode: 'test-device-code',
+            verifier: 'test-verifier',
+            initialState: const EmailVerificationState(
+              status: EmailVerificationStatus.failure,
+              errorCode: EmailVerificationError.pollFailed,
+            ),
+          );
+          await tester.pump();
+
+          await tester.tap(find.widgetWithText(DivineButton, 'Start over'));
+          await tester.pumpAndSettle();
+
+          verify(() => mockPendingVerification.clear()).called(greaterThan(0));
+        },
+      );
+
+      testWidgets(
+        'restore rehydrates deviceCode/verifier from the record, not the URL',
+        (tester) async {
+          when(() => mockPendingVerification.load()).thenAnswer(
+            (_) async => PendingVerification(
+              deviceCode: 'record-device',
+              verifier: 'record-verifier',
+              email: 'user@example.com',
+              createdAt: DateTime.now(),
+              inviteCode: 'record-invite',
+            ),
+          );
+          when(
+            () => mockCubit.startPolling(
+              deviceCode: any(named: 'deviceCode'),
+              verifier: any(named: 'verifier'),
+              email: any(named: 'email'),
+              inviteCode: any(named: 'inviteCode'),
+            ),
+          ).thenReturn(null);
+
+          // The restore URL carries only email + restored=true; the secrets
+          // must come from the persisted record.
+          await pumpVerificationScreen(
+            tester,
+            email: 'user@example.com',
+            restored: true,
+            initialState: pollingState,
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 10));
+
+          verify(
+            () => mockCubit.startPolling(
+              deviceCode: 'record-device',
+              verifier: 'record-verifier',
+              email: 'user@example.com',
+              inviteCode: 'record-invite',
+            ),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'restore does not poll an owner-bound record for another identity',
+        (tester) async {
+          const recordOwner =
+              '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+          const activeOwner =
+              'abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789';
+          when(
+            () => mockAuthService.authState,
+          ).thenReturn(AuthState.authenticated);
+          when(() => mockAuthService.isAnonymous).thenReturn(true);
+          when(
+            () => mockAuthService.currentPublicKeyHex,
+          ).thenReturn(activeOwner);
+          when(() => mockPendingVerification.load()).thenAnswer(
+            (_) async => PendingVerification(
+              deviceCode: 'record-device',
+              verifier: 'record-verifier',
+              email: 'user@example.com',
+              createdAt: DateTime.now(),
+              ownerPublicKeyHex: recordOwner,
+            ),
+          );
+          when(
+            () => mockCubit.startPolling(
+              deviceCode: any(named: 'deviceCode'),
+              verifier: any(named: 'verifier'),
+              email: any(named: 'email'),
+              inviteCode: any(named: 'inviteCode'),
+            ),
+          ).thenReturn(null);
+
+          await pumpVerificationScreen(
+            tester,
+            email: 'user@example.com',
+            restored: true,
+            initialState: pollingState,
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 10));
+
+          verifyNever(
+            () => mockCubit.startPolling(
+              deviceCode: any(named: 'deviceCode'),
+              verifier: any(named: 'verifier'),
+              email: any(named: 'email'),
+              inviteCode: any(named: 'inviteCode'),
+            ),
+          );
         },
       );
     });

--- a/mobile/test/screens/auth/secure_account_screen_test.dart
+++ b/mobile/test/screens/auth/secure_account_screen_test.dart
@@ -1,20 +1,32 @@
 // ABOUTME: Tests for SecureAccountScreen
 // ABOUTME: Verifies registration form, validation, and email verification flow
 
+import 'dart:async';
+
+import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:invite_api_client/invite_api_client.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/email_verification/email_verification_cubit.dart';
+import 'package:openvine/blocs/invite_gate/invite_gate_bloc.dart';
+import 'package:openvine/features/feature_flags/models/feature_flag.dart';
+import 'package:openvine/features/feature_flags/providers/feature_flag_providers.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/app_router.dart';
+import 'package:openvine/router/providers/route_normalization_provider.dart';
+import 'package:openvine/screens/auth/email_verification_screen.dart';
 import 'package:openvine/screens/auth/secure_account_screen.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/pending_verification_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 import '../../helpers/autofill_context_mock.dart';
 import '../../helpers/test_provider_overrides.dart';
@@ -23,26 +35,52 @@ class _MockKeycastOAuth extends Mock implements KeycastOAuth {}
 
 class _MockAuthService extends Mock implements AuthService {}
 
+class _MockPendingVerificationService extends Mock
+    implements PendingVerificationService {}
+
+class _MockEmailVerificationCubit extends MockCubit<EmailVerificationState>
+    implements EmailVerificationCubit {}
+
+class _MockInviteApiClient extends Mock implements InviteApiClient {}
+
 Finder _divineIcon(DivineIconName name) =>
     find.byWidgetPredicate((w) => w is DivineIcon && w.icon == name);
 
 void main() {
   group(SecureAccountScreen, () {
+    const automaticOwnerPublicKeyHex =
+        '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
     late _MockKeycastOAuth mockOAuth;
     late _MockAuthService mockAuthService;
+    late _MockPendingVerificationService mockPendingVerification;
+    late StreamController<AuthState> authStateController;
 
     setUp(() {
       mockOAuth = _MockKeycastOAuth();
       mockAuthService = _MockAuthService();
+      mockPendingVerification = _MockPendingVerificationService();
+      authStateController = StreamController<AuthState>.broadcast();
 
       // Default stubs
+      when(() => mockAuthService.authState).thenReturn(AuthState.authenticated);
       when(() => mockAuthService.isAuthenticated).thenReturn(true);
       when(() => mockAuthService.isAnonymous).thenReturn(true);
       when(() => mockAuthService.isRegistered).thenReturn(false);
       when(() => mockAuthService.currentNpub).thenReturn('npub1test...');
       when(
+        () => mockAuthService.currentPublicKeyHex,
+      ).thenReturn(automaticOwnerPublicKeyHex);
+      when(
         () => mockAuthService.exportNsec(),
       ).thenAnswer((_) async => 'nsec1testabc123xyz');
+      when(
+        () => mockAuthService.authStateStream,
+      ).thenAnswer((_) => authStateController.stream);
+      when(() => mockPendingVerification.clear()).thenAnswer((_) async {});
+    });
+
+    tearDown(() async {
+      await authStateController.close();
     });
 
     setUpAll(() async {
@@ -285,6 +323,223 @@ void main() {
     });
 
     group('Registration Flow', () {
+      testWidgets(
+        'verification-required registration reaches shared PIN and resend flow '
+        'without routing credentials',
+        (tester) async {
+          await setRegistrationTestSurface(tester);
+          await LogCaptureService().clearAllLogs();
+          final autofillRecorder = AutofillContextRecorder.install();
+          final verificationCubit = _MockEmailVerificationCubit();
+          final inviteApiClient = _MockInviteApiClient();
+          const verificationState = EmailVerificationState(
+            status: EmailVerificationStatus.polling,
+            pendingEmail: 'test@example.com',
+          );
+          when(() => verificationCubit.state).thenReturn(verificationState);
+          whenListen(
+            verificationCubit,
+            const Stream<EmailVerificationState>.empty(),
+            initialState: verificationState,
+          );
+          when(
+            () => mockOAuth.headlessRegister(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+              nsec: any(named: 'nsec'),
+              scope: any(named: 'scope'),
+            ),
+          ).thenAnswer(
+            (_) async => (
+              HeadlessRegisterResult(
+                success: true,
+                pubkey: 'test-pubkey',
+                verificationRequired: true,
+                deviceCode: 'test-device-code',
+                email: 'test@example.com',
+              ),
+              'test-verifier',
+            ),
+          );
+          when(
+            () => mockPendingVerification.save(
+              deviceCode: any(named: 'deviceCode'),
+              verifier: any(named: 'verifier'),
+              email: any(named: 'email'),
+              inviteCode: any(named: 'inviteCode'),
+              ownerPublicKeyHex: any(named: 'ownerPublicKeyHex'),
+            ),
+          ).thenAnswer((_) async {});
+          when(() => mockPendingVerification.load()).thenAnswer(
+            (_) async => PendingVerification(
+              deviceCode: 'test-device-code',
+              verifier: 'test-verifier',
+              email: 'test@example.com',
+              createdAt: DateTime.now(),
+              ownerPublicKeyHex: automaticOwnerPublicKeyHex,
+            ),
+          );
+
+          final router = GoRouter(
+            initialLocation: '/welcome',
+            routes: [
+              GoRoute(
+                path: '/welcome',
+                builder: (_, _) => const SecureAccountScreen(),
+              ),
+              GoRoute(
+                path: EmailVerificationScreen.path,
+                builder: (_, state) {
+                  final params = state.uri.queryParameters;
+                  return EmailVerificationScreen(
+                    deviceCode: params['deviceCode'],
+                    verifier: params['verifier'],
+                    email: params['email'],
+                    restored: params['restored'] == 'true',
+                  );
+                },
+              ),
+            ],
+          );
+
+          await tester.pumpWidget(
+            ProviderScope(
+              overrides: [
+                ...getStandardTestOverrides(),
+                oauthClientProvider.overrideWithValue(mockOAuth),
+                authServiceProvider.overrideWithValue(mockAuthService),
+                pendingVerificationServiceProvider.overrideWithValue(
+                  mockPendingVerification,
+                ),
+                isFeatureEnabledProvider(
+                  FeatureFlag.emailVerificationPinFallback,
+                ).overrideWithValue(true),
+                goRouterProvider.overrideWithValue(router),
+              ],
+              child: Consumer(
+                builder: (context, ref, _) {
+                  ref.watch(routeNormalizationProvider);
+                  return RepositoryProvider<InviteApiClient>.value(
+                    value: inviteApiClient,
+                    child: BlocProvider(
+                      create: (_) =>
+                          InviteGateBloc(inviteApiClient: inviteApiClient),
+                      child: BlocProvider<EmailVerificationCubit>.value(
+                        value: verificationCubit,
+                        child: MaterialApp.router(
+                          theme: VineTheme.theme,
+                          localizationsDelegates:
+                              AppLocalizations.localizationsDelegates,
+                          supportedLocales: AppLocalizations.supportedLocales,
+                          routerConfig: router,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Email'),
+              matching: find.byType(TextField),
+            ),
+            'test@example.com',
+          );
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Password'),
+              matching: find.byType(TextField),
+            ),
+            'SecurePass123!',
+          );
+          await tester.enterText(
+            find.descendant(
+              of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
+              matching: find.byType(TextField),
+            ),
+            'SecurePass123!',
+          );
+
+          await tester.tap(
+            find.widgetWithText(DivineButton, 'Secure account'),
+          );
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 500));
+
+          verify(
+            () => mockPendingVerification.save(
+              deviceCode: 'test-device-code',
+              verifier: 'test-verifier',
+              email: 'test@example.com',
+              ownerPublicKeyHex: automaticOwnerPublicKeyHex,
+            ),
+          ).called(1);
+          final location = router.routeInformationProvider.value.uri.toString();
+          expect(location, startsWith('/verify-email?'));
+          expect(location, contains('restored=true'));
+          expect(location, isNot(contains('test-device-code')));
+          expect(location, isNot(contains('test-verifier')));
+          final normalizationLogs = LogCaptureService()
+              .getRecentLogs()
+              .where((entry) => entry.name == 'RouteNormalizationProvider')
+              .map((entry) => entry.message)
+              .join('\n');
+          expect(normalizationLogs, isNotEmpty);
+          expect(normalizationLogs, isNot(contains('test-device-code')));
+          expect(normalizationLogs, isNot(contains('test-verifier')));
+          verify(
+            () => verificationCubit.startPolling(
+              deviceCode: 'test-device-code',
+              verifier: 'test-verifier',
+              email: 'test@example.com',
+            ),
+          ).called(1);
+          expect(
+            find.text('Or enter the 6-digit code from your email'),
+            findsOneWidget,
+          );
+          expect(find.text('Resend'), findsOneWidget);
+          expect(find.text('Continue to App'), findsNothing);
+          expect(autofillRecorder.didFinishAutofillContext, isTrue);
+
+          clearInteractions(verificationCubit);
+          router.go('/welcome');
+          await tester.pumpAndSettle();
+          final coldStartLocation = pendingEmailVerificationStartupLocation(
+            pending: PendingVerification(
+              deviceCode: 'test-device-code',
+              verifier: 'test-verifier',
+              email: 'test@example.com',
+              createdAt: DateTime.now(),
+              ownerPublicKeyHex: automaticOwnerPublicKeyHex,
+            ),
+            authState: AuthState.authenticated,
+            isAnonymous: true,
+            currentPublicKeyHex: automaticOwnerPublicKeyHex,
+            currentPath: '/welcome',
+          );
+          expect(coldStartLocation, isNotNull);
+          expect(coldStartLocation, isNot(contains('test-device-code')));
+          expect(coldStartLocation, isNot(contains('test-verifier')));
+
+          router.go(coldStartLocation!);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 500));
+
+          verify(
+            () => verificationCubit.startPolling(
+              deviceCode: 'test-device-code',
+              verifier: 'test-verifier',
+              email: 'test@example.com',
+            ),
+          ).called(1);
+        },
+      );
+
       testWidgets('calls headlessRegister on valid form submission', (
         tester,
       ) async {
@@ -431,294 +686,6 @@ void main() {
           find.text('Unable to access your keys. Please try again.'),
           findsOneWidget,
         );
-      });
-    });
-
-    group('Autofill Context', () {
-      testWidgets(
-        'calls TextInput.finishAutofillContext when tapping Continue to App',
-        (tester) async {
-          await setRegistrationTestSurface(tester);
-
-          final recorder = AutofillContextRecorder.install();
-
-          // Return verification-required result so the dialog is shown.
-          when(
-            () => mockOAuth.headlessRegister(
-              email: any(named: 'email'),
-              password: any(named: 'password'),
-              nsec: any(named: 'nsec'),
-              scope: any(named: 'scope'),
-            ),
-          ).thenAnswer(
-            (_) async => (
-              HeadlessRegisterResult(
-                success: true,
-                pubkey: 'test-pubkey',
-                verificationRequired: true,
-                deviceCode: 'test-device-code',
-                email: 'test@example.com',
-              ),
-              'test-verifier',
-            ),
-          );
-
-          // Build with GoRouter so context.go() in _continueToApp() succeeds.
-          // BlocProvider and ProviderScope must wrap MaterialApp.router so
-          // that dialogs opened via showDialog (which uses the root overlay)
-          // can find both the BLoC and Riverpod providers.
-          final router = GoRouter(
-            routes: [
-              GoRoute(
-                path: '/',
-                builder: (_, _) => const SecureAccountScreen(),
-              ),
-              GoRoute(path: '/explore', builder: (_, _) => const Scaffold()),
-            ],
-          );
-
-          await tester.pumpWidget(
-            ProviderScope(
-              overrides: [
-                ...getStandardTestOverrides(),
-                oauthClientProvider.overrideWithValue(mockOAuth),
-                authServiceProvider.overrideWithValue(mockAuthService),
-              ],
-              child: BlocProvider<EmailVerificationCubit>(
-                create: (_) => EmailVerificationCubit(
-                  oauthClient: mockOAuth,
-                  authService: mockAuthService,
-                ),
-                child: MaterialApp.router(
-                  theme: VineTheme.theme,
-                  localizationsDelegates:
-                      AppLocalizations.localizationsDelegates,
-                  supportedLocales: AppLocalizations.supportedLocales,
-                  routerConfig: router,
-                ),
-              ),
-            ),
-          );
-          await tester.pumpAndSettle();
-
-          // Enter valid credentials.
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Email'),
-              matching: find.byType(TextField),
-            ),
-            'test@example.com',
-          );
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Password'),
-              matching: find.byType(TextField),
-            ),
-            'SecurePass123!',
-          );
-          await tester.enterText(
-            find.descendant(
-              of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-              matching: find.byType(TextField),
-            ),
-            'SecurePass123!',
-          );
-
-          // Submit the form — triggers headlessRegister → dialog shown.
-          await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-          // Pump through the async headlessRegister call and showDialog.
-          // Use pump() + pump(duration) to drain microtask + timer queues
-          // without relying on pumpAndSettle (which hangs on polling timers).
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 500));
-
-          // Tap "Continue to App" in the verification dialog.
-          await tester.tap(find.text('Continue to App'));
-          await tester.pump();
-          await tester.pump(const Duration(milliseconds: 100));
-
-          expect(recorder.didFinishAutofillContext, isTrue);
-        },
-      );
-
-      testWidgets('verification dialog is not dismissed by tapping outside', (
-        tester,
-      ) async {
-        await setRegistrationTestSurface(tester);
-
-        when(
-          () => mockOAuth.headlessRegister(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
-            scope: any(named: 'scope'),
-          ),
-        ).thenAnswer(
-          (_) async => (
-            HeadlessRegisterResult(
-              success: true,
-              pubkey: 'test-pubkey',
-              verificationRequired: true,
-              deviceCode: 'test-device-code',
-              email: 'test@example.com',
-            ),
-            'test-verifier',
-          ),
-        );
-
-        final router = GoRouter(
-          routes: [
-            GoRoute(path: '/', builder: (_, _) => const SecureAccountScreen()),
-            GoRoute(path: '/explore', builder: (_, _) => const Scaffold()),
-          ],
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              ...getStandardTestOverrides(),
-              oauthClientProvider.overrideWithValue(mockOAuth),
-              authServiceProvider.overrideWithValue(mockAuthService),
-            ],
-            child: BlocProvider<EmailVerificationCubit>(
-              create: (_) => EmailVerificationCubit(
-                oauthClient: mockOAuth,
-                authService: mockAuthService,
-              ),
-              child: MaterialApp.router(
-                theme: VineTheme.theme,
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                routerConfig: router,
-              ),
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'test@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
-
-        expect(find.text('Continue to App'), findsOneWidget);
-
-        await tester.tapAt(const Offset(10, 10));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
-
-        expect(find.text('Continue to App'), findsOneWidget);
-      });
-
-      testWidgets('verification dialog is not dismissed by system back', (
-        tester,
-      ) async {
-        await setRegistrationTestSurface(tester);
-
-        when(
-          () => mockOAuth.headlessRegister(
-            email: any(named: 'email'),
-            password: any(named: 'password'),
-            nsec: any(named: 'nsec'),
-            scope: any(named: 'scope'),
-          ),
-        ).thenAnswer(
-          (_) async => (
-            HeadlessRegisterResult(
-              success: true,
-              pubkey: 'test-pubkey',
-              verificationRequired: true,
-              deviceCode: 'test-device-code',
-              email: 'test@example.com',
-            ),
-            'test-verifier',
-          ),
-        );
-
-        final router = GoRouter(
-          routes: [
-            GoRoute(path: '/', builder: (_, _) => const SecureAccountScreen()),
-            GoRoute(path: '/explore', builder: (_, _) => const Scaffold()),
-          ],
-        );
-
-        await tester.pumpWidget(
-          ProviderScope(
-            overrides: [
-              ...getStandardTestOverrides(),
-              oauthClientProvider.overrideWithValue(mockOAuth),
-              authServiceProvider.overrideWithValue(mockAuthService),
-            ],
-            child: BlocProvider<EmailVerificationCubit>(
-              create: (_) => EmailVerificationCubit(
-                oauthClient: mockOAuth,
-                authService: mockAuthService,
-              ),
-              child: MaterialApp.router(
-                theme: VineTheme.theme,
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                routerConfig: router,
-              ),
-            ),
-          ),
-        );
-        await tester.pumpAndSettle();
-
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Email'),
-            matching: find.byType(TextField),
-          ),
-          'test@example.com',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-        await tester.enterText(
-          find.descendant(
-            of: find.widgetWithText(DivineAuthTextField, 'Confirm password'),
-            matching: find.byType(TextField),
-          ),
-          'SecurePass123!',
-        );
-
-        await tester.tap(find.widgetWithText(DivineButton, 'Secure account'));
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 500));
-
-        expect(find.text('Continue to App'), findsOneWidget);
-
-        await tester.binding.handlePopRoute();
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 100));
-
-        expect(find.text('Continue to App'), findsOneWidget);
       });
     });
   });

--- a/mobile/test/services/pending_verification_service_test.dart
+++ b/mobile/test/services/pending_verification_service_test.dart
@@ -1,0 +1,111 @@
+// ABOUTME: Tests for PendingVerification expiry window
+// ABOUTME: Verifies the 24h verify window so the PIN path works on late return
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/services/pending_verification_service.dart';
+
+class _MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  group(PendingVerification, () {
+    PendingVerification pendingCreatedAgo(Duration age) {
+      return PendingVerification(
+        deviceCode: 'device123',
+        verifier: 'verifier456',
+        email: 'test@example.com',
+        createdAt: DateTime.now().subtract(age),
+      );
+    }
+
+    test('expiration window is 24 hours', () {
+      expect(PendingVerification.expirationDuration, const Duration(hours: 24));
+    });
+
+    test('is not expired well within the 24h verify window', () {
+      expect(pendingCreatedAgo(const Duration(hours: 23)).isExpired, isFalse);
+    });
+
+    test('is not expired just before 24h', () {
+      expect(
+        pendingCreatedAgo(const Duration(hours: 23, minutes: 59)).isExpired,
+        isFalse,
+      );
+    });
+
+    test('is expired after the 24h verify window', () {
+      expect(pendingCreatedAgo(const Duration(hours: 25)).isExpired, isTrue);
+    });
+
+    test('data older than the previous 30-minute window is still valid', () {
+      // Regression guard for the late-return PIN path: a user who returns an
+      // hour later must still have the deviceCode + verifier to exchange.
+      expect(pendingCreatedAgo(const Duration(hours: 1)).isExpired, isFalse);
+    });
+  });
+
+  group(PendingVerificationService, () {
+    late _MockFlutterSecureStorage storage;
+    late Map<String, String> storedValues;
+    late PendingVerificationService service;
+
+    setUp(() {
+      storage = _MockFlutterSecureStorage();
+      storedValues = <String, String>{};
+      service = PendingVerificationService(storage);
+
+      when(
+        () => storage.write(
+          key: any(named: 'key'),
+          value: any(named: 'value'),
+        ),
+      ).thenAnswer((invocation) async {
+        final key = invocation.namedArguments[#key]! as String;
+        final value = invocation.namedArguments[#value] as String?;
+        if (value == null) {
+          storedValues.remove(key);
+        } else {
+          storedValues[key] = value;
+        }
+      });
+      when(() => storage.read(key: any(named: 'key'))).thenAnswer(
+        (invocation) async =>
+            storedValues[invocation.namedArguments[#key]! as String],
+      );
+      when(() => storage.delete(key: any(named: 'key'))).thenAnswer(
+        (invocation) async {
+          storedValues.remove(invocation.namedArguments[#key]! as String);
+        },
+      );
+    });
+
+    test('round-trips the full owner public-key hex', () async {
+      const ownerPublicKeyHex =
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+      await service.save(
+        deviceCode: 'device123',
+        verifier: 'verifier456',
+        email: 'test@example.com',
+        ownerPublicKeyHex: ownerPublicKeyHex,
+      );
+
+      final pending = await service.load();
+      expect(pending, isNotNull);
+      expect(pending!.ownerPublicKeyHex, ownerPublicKeyHex);
+    });
+
+    test('loads a legacy ownerless record as ownerless', () async {
+      await service.save(
+        deviceCode: 'device123',
+        verifier: 'verifier456',
+        email: 'test@example.com',
+      );
+
+      final pending = await service.load();
+      expect(pending, isNotNull);
+      expect(pending!.ownerPublicKeyHex, isNull);
+    });
+  });
+}

--- a/mobile/test/startup/pending_email_verification_startup_test.dart
+++ b/mobile/test/startup/pending_email_verification_startup_test.dart
@@ -1,0 +1,73 @@
+// ABOUTME: Startup-level regression tests for persisted email verification restore
+// ABOUTME: Exercises matching automatic identity routing through the real GoRouter
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/main.dart' as app;
+import 'package:openvine/models/minor_account_review_status.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/pending_verification_service.dart';
+
+import '../helpers/test_provider_overrides.dart';
+
+class _MockPendingVerificationService extends Mock
+    implements PendingVerificationService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(resetNavigationState);
+
+  test(
+    'matching automatic identity restores owner-bound pending before first frame',
+    () async {
+      const publicKeyHex =
+          '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+      final authService = createMockAuthService();
+      final pendingService = _MockPendingVerificationService();
+      when(() => authService.authState).thenReturn(AuthState.authenticated);
+      when(() => authService.isAuthenticated).thenReturn(true);
+      when(() => authService.isAnonymous).thenReturn(true);
+      when(() => authService.currentPublicKeyHex).thenReturn(publicKeyHex);
+      when(() => authService.hasExpiredOAuthSession).thenReturn(false);
+      when(pendingService.load).thenAnswer(
+        (_) async => PendingVerification(
+          deviceCode: 'device-code',
+          verifier: 'verifier',
+          email: 'user@example.com',
+          createdAt: DateTime.now(),
+          ownerPublicKeyHex: publicKeyHex,
+        ),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          ...getStandardTestOverrides(mockAuthService: authService),
+          pendingVerificationServiceProvider.overrideWithValue(
+            pendingService,
+          ),
+          currentMinorAccountReviewStatusProvider.overrideWith(
+            (ref) async => MinorAccountReviewStatus.active(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await app.restorePendingEmailVerificationOnStartup(container);
+
+      final uri = container
+          .read(goRouterProvider)
+          .routeInformationProvider
+          .value
+          .uri;
+      expect(uri.path, '/verify-email');
+      expect(uri.queryParameters, {
+        'email': 'user@example.com',
+        'restored': 'true',
+      });
+    },
+  );
+}


### PR DESCRIPTION
## Description

When a user verifies their email on Android, the in-app browser sometimes never POSTs the verification, so the link-and-poll flow stalls and the user is stuck. This adds an in-app fallback: the verification screen now lets the user type the 6-digit PIN from the email (or resend a fresh one), exchanging it for the OAuth code directly so login completes without the browser.

The change also hardens the completion flow against races and lifecycle edges found in review:
- Poll/PIN completion and the 15-minute timeout could collide; the timeout now bails if a completion is already claimed, and tears down the resend cooldown timer so an orphaned periodic tick cannot revive the cooldown onto the timed-out state.
- Token-mode auto-login awaited persistence/verify before calling `startPolling`; it now guards `mounted` after each await so it cannot re-arm polling on a disposed screen.
- A `verify-pin` 404 (endpoint absent) or other unclassified 4xx was reported as "incorrect PIN". These are now a distinct `unavailable` error that steers the user to the email link / resend, mirroring the `endpoint_not_found` handling in headlessRegister/headlessLogin.

**Related Issue:** Closes #5578

## Out of Scope

None.

## Verification

- `flutter analyze lib test` (mobile) and `flutter analyze lib test` (keycast_flutter): clean.
- `flutter test` for email_verification cubit + screen (81 tests) and the full keycast_flutter suite (207 tests): all pass. New regression tests cover the timeout-vs-completion race, the orphaned resend timer, post-dispose startPolling, and the 404/4xx PIN classification.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)

<!-- hub:author-pr-checklist:start -->
## Author checklist

- [ ] Secure Account: closing the verify-email screen deletes the pending record, so the in-app PIN fallback is lost for that flow <!-- hub:author-pr-checklist-item:22391e64325e -->
<!-- hub:author-pr-checklist:end -->