### PR TITLE
chore(proofmode): downgrade expected missing proof logs

### DIFF
--- a/mobile/lib/services/native_proofmode_service.dart
+++ b/mobile/lib/services/native_proofmode_service.dart
@@ -98,9 +98,10 @@ class NativeProofModeService {
         // Read proof metadata from native library
         final metadata = await NativeProofModeService.readProofMetadata(
           proofHash,
+          warnIfMissing: false,
         );
         if (metadata == null) {
-          Log.warning(
+          Log.debug(
             '🔐 Could not read native proof metadata',
             name: 'VideoRecorderProofService',
             category: .video,
@@ -388,25 +389,24 @@ class NativeProofModeService {
   /// - 'hash': SHA256 hash of media file
   /// - 'timestamp': Timestamp data
   static Future<Map<String, String>?> readProofMetadata(
-    String proofHash,
-  ) async {
+    String proofHash, {
+    bool warnIfMissing = true,
+  }) async {
     try {
       final proofDir = await getProofDir(proofHash);
       if (proofDir == null) {
-        Log.warning(
+        _logMissingProofMetadata(
           '🔐 No proof directory found for hash: $proofHash',
-          name: 'NativeProofMode',
-          category: LogCategory.system,
+          warnIfMissing: warnIfMissing,
         );
         return null;
       }
 
       final dir = Directory(proofDir);
       if (!dir.existsSync()) {
-        Log.warning(
+        _logMissingProofMetadata(
           '🔐 Proof directory does not exist: $proofDir',
-          name: 'NativeProofMode',
-          category: LogCategory.system,
+          warnIfMissing: warnIfMissing,
         );
         return null;
       }
@@ -474,6 +474,22 @@ class NativeProofModeService {
       );
       return null;
     }
+  }
+
+  static void _logMissingProofMetadata(
+    String message, {
+    required bool warnIfMissing,
+  }) {
+    if (warnIfMissing) {
+      Log.warning(
+        message,
+        name: 'NativeProofMode',
+        category: LogCategory.system,
+      );
+      return;
+    }
+
+    Log.debug(message, name: 'NativeProofMode', category: LogCategory.system);
   }
 
   /// Check if native ProofMode is available on this platform

--- a/mobile/scripts/baseline/untested_services.txt
+++ b/mobile/scripts/baseline/untested_services.txt
@@ -24,7 +24,6 @@ identity_manager_service
 immediate_completion_helper # noise: helper
 js_stub # noise: web/io shim
 js_util_stub # noise: web/io shim
-native_proofmode_service
 nip05_verification_service
 nip07_interop # noise: web/io conditional-import
 nip07_interop_stub # noise: web/io shim

--- a/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
+++ b/mobile/test/blocs/dm/conversation/conversation_bloc_test.dart
@@ -52,6 +52,14 @@ OutgoingDm _outgoingDm({
   );
 }
 
+Future<void> _waitForConversationState(
+  ConversationBloc bloc,
+  bool Function(ConversationState state) matches,
+) async {
+  if (matches(bloc.state)) return;
+  await bloc.stream.firstWhere(matches);
+}
+
 void main() {
   // Full 64-char hex IDs per project rules
   const conversationId =
@@ -232,12 +240,15 @@ void main() {
         ],
       );
 
+      late StreamController<List<DmMessage>> messagesController;
+      late StreamController<List<OutgoingDm>> outgoingController;
+
       blocTest<ConversationBloc, ConversationState>(
         'does not re-mark read on an outgoing-queue-only tick, but does on a '
         'genuinely new message',
         setUp: () {
-          final messagesController = StreamController<List<DmMessage>>();
-          final outgoingController = StreamController<List<OutgoingDm>>();
+          messagesController = StreamController<List<DmMessage>>();
+          outgoingController = StreamController<List<OutgoingDm>>();
           when(
             () => mockDmRepository.markConversationAsRead(conversationId),
           ).thenAnswer((_) async {});
@@ -248,35 +259,63 @@ void main() {
             () => mockDmRepository.watchOutgoing(any()),
           ).thenAnswer((_) => outgoingController.stream);
 
-          Future<void>.delayed(Duration.zero).then((_) async {
-            // First message arrives: messages change -> marks read.
-            messagesController.add([testMessage]);
-            outgoingController.add(const <OutgoingDm>[]);
-            await Future<void>.delayed(const Duration(milliseconds: 10));
-            // Outgoing-queue status change only (e.g. pending -> delivered):
-            // combineLatest2 re-emits the SAME messages instance, so this tick
-            // must NOT re-mark the conversation read.
-            outgoingController.add([_outgoingDm(id: 'pending-rumor')]);
-            await Future<void>.delayed(const Duration(milliseconds: 10));
-            // A genuinely new incoming message: marks read again.
-            const secondMessage = DmMessage(
-              id: '7777777777777777777777777777777777777777777777777777777777777777',
-              conversationId: conversationId,
-              senderPubkey: recipientPubkey,
-              content: 'Reply message',
-              createdAt: 1700000100,
-              giftWrapId:
-                  '8888888888888888888888888888888888888888888888888888888888888888',
-            );
-            messagesController.add([testMessage, secondMessage]);
-            await Future<void>.delayed(const Duration(milliseconds: 10));
-            await messagesController.close();
-            await outgoingController.close();
+          addTearDown(() async {
+            if (!messagesController.isClosed) {
+              await messagesController.close();
+            }
+            if (!outgoingController.isClosed) {
+              await outgoingController.close();
+            }
           });
         },
         build: buildBloc,
-        act: (bloc) => bloc.add(const ConversationStarted()),
-        wait: const Duration(milliseconds: 80),
+        act: (bloc) async {
+          bloc.add(const ConversationStarted());
+          await untilCalled(
+            () => mockDmRepository.watchMessages(conversationId),
+          );
+
+          // First message arrives: messages change -> marks read.
+          messagesController.add([testMessage]);
+          outgoingController.add(const <OutgoingDm>[]);
+          await _waitForConversationState(
+            bloc,
+            (state) =>
+                state.status == ConversationStatus.loaded &&
+                state.messages.length == 1 &&
+                state.pendingOutgoing.isEmpty,
+          );
+
+          // Outgoing-queue status change only (e.g. pending -> delivered):
+          // combineLatest2 re-emits the SAME messages instance, so this tick
+          // must NOT re-mark the conversation read.
+          outgoingController.add([_outgoingDm(id: 'pending-rumor')]);
+          await _waitForConversationState(
+            bloc,
+            (state) =>
+                state.messages.length == 1 && state.pendingOutgoing.length == 1,
+          );
+
+          // A genuinely new incoming message: marks read again.
+          const secondMessage = DmMessage(
+            id: '7777777777777777777777777777777777777777777777777777777777777777',
+            conversationId: conversationId,
+            senderPubkey: recipientPubkey,
+            content: 'Reply message',
+            createdAt: 1700000100,
+            giftWrapId:
+                '8888888888888888888888888888888888888888888888888888888888888888',
+          );
+          messagesController.add([testMessage, secondMessage]);
+          await _waitForConversationState(
+            bloc,
+            (state) =>
+                state.messages.length == 2 && state.pendingOutgoing.length == 1,
+          );
+
+          await messagesController.close();
+          await outgoingController.close();
+        },
         verify: (bloc) {
           // The outgoing-only tick was processed (its row reached state)...
           expect(bloc.state.pendingOutgoing, hasLength(1));

--- a/mobile/test/services/native_proofmode_service_test.dart
+++ b/mobile/test/services/native_proofmode_service_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/native_proofmode_service.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const proofModeChannel = MethodChannel('org.openvine/proofmode');
+  const proofHash =
+      'bfe97053586981c5d2373625c3ee921d8af88c79fca442e189a82230d99bdc78';
+
+  setUp(() async {
+    await LogCaptureService().clearAllLogs();
+  });
+
+  tearDown(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(proofModeChannel, null);
+    await LogCaptureService().clearAllLogs();
+  });
+
+  group('readProofMetadata logging', () {
+    test(
+      'logs missing proof directory as debug for expected pre-generation read',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(proofModeChannel, (call) async {
+              expect(call.method, 'getProofDir');
+              expect(call.arguments, {'proofHash': proofHash});
+              return null;
+            });
+
+        final metadata = await NativeProofModeService.readProofMetadata(
+          proofHash,
+          warnIfMissing: false,
+        );
+
+        expect(metadata, isNull);
+        expect(
+          _logsContaining(
+            'No proof directory found for hash',
+          ).where((log) => log.level == LogLevel.warning),
+          isEmpty,
+        );
+        expect(
+          _latestLogContaining('No proof directory found for hash')?.level,
+          LogLevel.debug,
+        );
+      },
+    );
+
+    test(
+      'logs missing proof directory as warning for unexpected post-generation read',
+      () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(proofModeChannel, (call) async {
+              expect(call.method, 'getProofDir');
+              expect(call.arguments, {'proofHash': proofHash});
+              return null;
+            });
+
+        final metadata = await NativeProofModeService.readProofMetadata(
+          proofHash,
+        );
+
+        expect(metadata, isNull);
+        expect(
+          _latestLogContaining('No proof directory found for hash')?.level,
+          LogLevel.warning,
+        );
+      },
+    );
+
+    test(
+      'logs nonexistent proof directory as debug when missing proof is expected',
+      () async {
+        final missingProofDir =
+            '${Directory.systemTemp.path}/missing-proofmode-$proofHash';
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(proofModeChannel, (call) async {
+              expect(call.method, 'getProofDir');
+              expect(call.arguments, {'proofHash': proofHash});
+              return missingProofDir;
+            });
+
+        final metadata = await NativeProofModeService.readProofMetadata(
+          proofHash,
+          warnIfMissing: false,
+        );
+
+        expect(metadata, isNull);
+        expect(
+          _logsContaining(
+            'Proof directory does not exist',
+          ).where((log) => log.level == LogLevel.warning),
+          isEmpty,
+        );
+        expect(
+          _latestLogContaining('Proof directory does not exist')?.level,
+          LogLevel.debug,
+        );
+      },
+    );
+  });
+}
+
+Iterable<LogEntry> _logsContaining(String message) {
+  return LogCaptureService().getRecentLogs().where(
+    (log) => log.message.contains(message),
+  );
+}
+
+LogEntry? _latestLogContaining(String message) {
+  final matches = _logsContaining(message);
+  return matches.isEmpty ? null : matches.last;
+}


### PR DESCRIPTION
## Summary

- downgrade expected pre-generation missing ProofMode metadata logs from warning to debug
- preserve warning-level logging for unexpected post-generation proof metadata misses
- add focused regression coverage for ProofMode metadata missing-directory log severity
- shrink the untested-services baseline now that `native_proofmode_service` has coverage
- harden a timing-sensitive conversation BLoC test that failed under full CI load

## Root cause

The initial `proofFile()` metadata probe uses `readProofMetadata()` before native ProofMode generation to check whether proof metadata already exists. For first-time content, the native proof directory is expected to be absent, but both the lower-level `NativeProofMode` log and the caller-level `VideoRecorderProofService` log were emitted as warnings. Later post-generation reads should still warn when metadata cannot be read.

CI also exposed an existing timing-sensitive `ConversationBloc` test that drove streams with fixed sleeps. That test now waits for concrete BLoC states instead of relying on elapsed time.

## Validation

- `flutter test test/services/native_proofmode_service_test.dart`
- `flutter test test/services/video_event_publisher_native_proof_test.dart`
- `flutter test test/blocs/dm/conversation/conversation_bloc_test.dart`
- `flutter analyze lib test`
- `dart run build_runner build --delete-conflicting-outputs`
- `flutter gen-l10n`
- `bash mobile/scripts/check_untested_services_floor.sh`
- pre-push hook analyzer and changed-file tests

Closes #5698
