### PR TITLE
fix(relay): retry video subscriptions after relay reconnect

### DIFF
--- a/mobile/lib/providers/video_events_providers.dart
+++ b/mobile/lib/providers/video_events_providers.dart
@@ -293,8 +293,22 @@ class VideoEvents extends _$VideoEvents {
         category: LogCategory.video,
       );
       // Use NIP-50 search for trending/popular discovery (otherstuff-relay)
-      service.subscribeToDiscovery(
-        nip50Sort: NIP50SortMode.hot, // Recent events with high engagement
+      unawaited(
+        service
+            .subscribeToDiscovery(
+              nip50Sort:
+                  NIP50SortMode.hot, // Recent events with high engagement
+            )
+            .catchError((Object error) {
+              if (error is! RelayNotReadyException) {
+                throw error;
+              }
+              Log.warning(
+                'VideoEvents: Discovery subscription deferred until relay connection is ready',
+                name: 'VideoEventsProvider',
+                category: LogCategory.video,
+              );
+            }),
       );
       // NOTE: We don't set a local _isSubscribed flag here because we rely on
       // service.isSubscribed() which accurately tracks actual subscription state

--- a/mobile/lib/providers/video_events_providers.dart
+++ b/mobile/lib/providers/video_events_providers.dart
@@ -9,7 +9,6 @@ import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/providers/moderation_providers.dart';
 import 'package:openvine/providers/readiness_gate_providers.dart';
 import 'package:openvine/providers/seen_videos_notifier.dart';
-import 'package:openvine/providers/tab_visibility_provider.dart';
 import 'package:openvine/providers/video_providers.dart';
 import 'package:openvine/services/subscription_manager.dart';
 import 'package:openvine/services/video_event_service.dart';
@@ -457,41 +456,6 @@ class VideoEvents extends _$VideoEvents {
       if (a[i].id != b[i].id) return false;
     }
     return true;
-  }
-
-  /// Start discovery subscription when Explore tab is visible
-  void startDiscoverySubscription() {
-    final isExploreActive = ref.read(isExploreTabActiveProvider);
-    if (!isExploreActive) {
-      Log.debug(
-        'VideoEvents: Ignoring discovery start; Explore inactive',
-        name: 'VideoEventsProvider',
-        category: LogCategory.video,
-      );
-      return;
-    }
-    final videoEventService = ref.read(videoEventServiceProvider);
-    // Avoid noisy re-requests if already subscribed
-    if (videoEventService.isSubscribed(SubscriptionType.discovery)) {
-      Log.debug(
-        'VideoEvents: Discovery already active; skipping start',
-        name: 'VideoEventsProvider',
-        category: LogCategory.video,
-      );
-      return;
-    }
-
-    Log.info(
-      'VideoEvents: Starting discovery subscription on demand with NIP-50 search (sort:hot)',
-      name: 'VideoEventsProvider',
-      category: LogCategory.video,
-    );
-
-    // Subscribe to discovery videos using NIP-50 search for trending/popular
-    // NostrService now handles deduplication automatically
-    videoEventService.subscribeToDiscovery(
-      nip50Sort: NIP50SortMode.hot, // Recent events with high engagement
-    );
   }
 
   /// Load more historical events

--- a/mobile/lib/providers/video_events_providers.g.dart
+++ b/mobile/lib/providers/video_events_providers.g.dart
@@ -137,7 +137,7 @@ final class VideoEventsProvider
   VideoEvents create() => VideoEvents();
 }
 
-String _$videoEventsHash() => r'c85e9a98766eee60ba6c15e78f11470924433eeb';
+String _$videoEventsHash() => r'5176084e8aca99f7fde8fe3a2f78724df33aec10';
 
 /// Stream provider for video events from Nostr
 

--- a/mobile/lib/providers/video_events_providers.g.dart
+++ b/mobile/lib/providers/video_events_providers.g.dart
@@ -137,7 +137,7 @@ final class VideoEventsProvider
   VideoEvents create() => VideoEvents();
 }
 
-String _$videoEventsHash() => r'5176084e8aca99f7fde8fe3a2f78724df33aec10';
+String _$videoEventsHash() => r'cc2a61f9a82df16bd01a3fae6a5b4a2c73cb8985';
 
 /// Stream provider for video events from Nostr
 

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -2081,6 +2081,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             _handleNewVideoEvent(event, subscriptionType);
           },
           onError: (error) {
+            feedLoadingTimeout?.cancel();
             Log.error(
               '❌ Subscription error for $subscriptionType after $eventCount events: $error',
               name: 'VideoEventService',
@@ -2090,6 +2091,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
             _handleSubscriptionError(error, subscriptionType);
           },
           onDone: () {
+            feedLoadingTimeout?.cancel();
             final totalDuration = DateTime.now().difference(
               subscriptionStartTime,
             );
@@ -4194,6 +4196,9 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
 
     if (_relayReadyRetrySubscription != null) return;
 
+    // Deliberately event-bounded rather than attempt-bounded: pending types are
+    // enum-bounded, and each retry is triggered only by a relay status update.
+    // A hard cap here can leave a feed dead forever after relay flapping.
     _relayReadyRetrySubscription = _nostrService.relayStatusStream.listen((
       statuses,
     ) {
@@ -4317,6 +4322,15 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               name: 'VideoEventService',
               category: LogCategory.video,
             );
+            if (e is RelayNotReadyException) {
+              _typesAwaitingRetry.remove(type);
+              if (_typesAwaitingRetry.isEmpty) {
+                timer.cancel();
+                _retryAttempts = 0;
+              }
+              _scheduleRetryWhenRelayReady(type);
+              return;
+            }
             if (_retryAttempts >= _maxRetryAttempts) {
               _typesAwaitingRetry.clear();
               timer.cancel();

--- a/mobile/lib/services/video_event_service.dart
+++ b/mobile/lib/services/video_event_service.dart
@@ -184,10 +184,13 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   bool _isLoading = false;
   String? _error;
   Timer? _retryTimer;
+  StreamSubscription<Map<String, RelayConnectionStatus>>?
+  _relayReadyRetrySubscription;
 
   // Feed types whose relay subscription failed on a connection error and
   // should be re-established by the online-retry cycle.
   final Set<SubscriptionType> _typesAwaitingRetry = {};
+  final Set<SubscriptionType> _typesAwaitingRelayReady = {};
   int _retryAttempts = 0;
 
   // Track subscription parameters per type
@@ -1388,11 +1391,29 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     }
 
     if (_nostrService.connectedRelayCount == 0) {
+      _isLoading = false;
+
       Log.warning(
-        'WARNING: No relays connected - subscription will likely fail',
+        'No relays connected, will retry when relay connection is restored',
         name: 'VideoEventService',
         category: LogCategory.video,
       );
+      if (scheduleOnlineRetry) {
+        _storeSubscriptionParams(
+          subscriptionType: subscriptionType,
+          authors: authors,
+          hashtags: hashtags,
+          group: group,
+          since: since,
+          until: until,
+          limit: limit,
+          includeReposts: includeReposts,
+          sortBy: sortBy,
+          nip50Sort: nip50Sort,
+        );
+        _scheduleRetryWhenRelayReady(subscriptionType);
+      }
+      throw const RelayNotReadyException('No connected relays');
     }
 
     // Avoid churn: if params match existing subscription, skip re-subscribe
@@ -1643,15 +1664,6 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
           category: LogCategory.video,
         );
         throw Exception('NostrService not initialized');
-      }
-
-      if (_nostrService.connectedRelayCount == 0) {
-        Log.error(
-          '❌ No connected relays - cannot create subscription',
-          name: 'VideoEventService',
-          category: LogCategory.video,
-        );
-        throw Exception('No connected relays');
       }
 
       // BYPASS SubscriptionManager for main video feed - go directly to NostrService
@@ -4164,6 +4176,78 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
         errorString.contains('unreachable');
   }
 
+  bool _hasConnectedRelay(Map<String, RelayConnectionStatus> statuses) {
+    return statuses.values.any((status) => status.isConnected);
+  }
+
+  /// Schedule retry of [subscriptionType] when at least one relay reconnects.
+  ///
+  /// This is intentionally separate from [_scheduleRetryWhenOnline]: the device
+  /// can have network connectivity while every Nostr relay is disconnected.
+  void _scheduleRetryWhenRelayReady(SubscriptionType subscriptionType) {
+    _typesAwaitingRelayReady.add(subscriptionType);
+
+    if (_nostrService.connectedRelayCount > 0) {
+      _retrySubscriptionsAwaitingRelayReady();
+      return;
+    }
+
+    if (_relayReadyRetrySubscription != null) return;
+
+    _relayReadyRetrySubscription = _nostrService.relayStatusStream.listen((
+      statuses,
+    ) {
+      if (_hasConnectedRelay(statuses)) {
+        _retrySubscriptionsAwaitingRelayReady();
+      }
+    });
+  }
+
+  void _retrySubscriptionsAwaitingRelayReady() {
+    final pendingTypes = Set<SubscriptionType>.of(_typesAwaitingRelayReady);
+    _typesAwaitingRelayReady.clear();
+    _cancelRelayReadyRetrySubscription();
+
+    if (pendingTypes.isEmpty) {
+      return;
+    }
+
+    Log.warning(
+      'Retrying video subscriptions after relay connection restored: '
+      '${pendingTypes.map((type) => type.name).join(", ")}',
+      name: 'VideoEventService',
+      category: LogCategory.video,
+    );
+
+    for (final type in pendingTypes) {
+      unawaited(
+        _resubscribeWithStoredParams(type)
+            .then((_) {
+              Log.info(
+                'Successfully resubscribed to ${type.name} feed after relay reconnect',
+                name: 'VideoEventService',
+                category: LogCategory.video,
+              );
+            })
+            .catchError((Object e) {
+              Log.error(
+                'Relay-ready retry for ${type.name} failed: $e',
+                name: 'VideoEventService',
+                category: LogCategory.video,
+              );
+              if (e is RelayNotReadyException) {
+                _scheduleRetryWhenRelayReady(type);
+              }
+            }),
+      );
+    }
+  }
+
+  void _cancelRelayReadyRetrySubscription() {
+    unawaited(_relayReadyRetrySubscription?.cancel());
+    _relayReadyRetrySubscription = null;
+  }
+
   /// Schedule retry of [subscriptionType] when the device is back online.
   ///
   /// The failed type is recorded so the retry re-establishes the feed
@@ -4213,22 +4297,8 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
   /// parameters, forcing past duplicate detection (the dead subscription
   /// is still registered after an onError, so a non-forced call no-ops).
   void _retrySubscription(SubscriptionType type, Timer timer) {
-    final params = _subscriptionParams[type];
     unawaited(
-      subscribeToVideoFeed(
-            subscriptionType: type,
-            authors: params?['authors'] as List<String>?,
-            hashtags: params?['hashtags'] as List<String>?,
-            group: params?['group'] as String?,
-            since: params?['since'] as int?,
-            until: params?['until'] as int?,
-            limit: (params?['limit'] as int?) ?? 200,
-            includeReposts: (params?['includeReposts'] as bool?) ?? false,
-            sortBy: params?['sortBy'] as VideoSortField?,
-            nip50Sort: params?['nip50Sort'] as NIP50SortMode?,
-            force: true,
-            scheduleOnlineRetry: false,
-          )
+      _resubscribeWithStoredParams(type)
           .then((_) {
             _typesAwaitingRetry.remove(type);
             Log.info(
@@ -4257,6 +4327,24 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
               );
             }
           }),
+    );
+  }
+
+  Future<void> _resubscribeWithStoredParams(SubscriptionType type) {
+    final params = _subscriptionParams[type];
+    return subscribeToVideoFeed(
+      subscriptionType: type,
+      authors: params?['authors'] as List<String>?,
+      hashtags: params?['hashtags'] as List<String>?,
+      group: params?['group'] as String?,
+      since: params?['since'] as int?,
+      until: params?['until'] as int?,
+      limit: (params?['limit'] as int?) ?? 200,
+      includeReposts: (params?['includeReposts'] as bool?) ?? false,
+      sortBy: params?['sortBy'] as VideoSortField?,
+      nip50Sort: params?['nip50Sort'] as NIP50SortMode?,
+      force: true,
+      scheduleOnlineRetry: false,
     );
   }
 
@@ -5259,6 +5347,7 @@ class VideoEventService extends ChangeNotifier implements VideoEventCache {
     LogBatcher.flush();
 
     _retryTimer?.cancel();
+    _cancelRelayReadyRetrySubscription();
     _likeCountBatchTimer?.cancel();
     _authStateSubscription?.cancel();
     unawaited(_blocklistChangesSubscription?.cancel());
@@ -5958,6 +6047,11 @@ class VideoEventServiceException implements Exception {
 
   @override
   String toString() => 'VideoEventServiceException: $message';
+}
+
+/// Exception thrown when video subscriptions must wait for relay connectivity.
+class RelayNotReadyException extends VideoEventServiceException {
+  const RelayNotReadyException(super.message);
 }
 
 extension _VideoEventSortingExtension on List<VideoEvent> {

--- a/mobile/test/providers/video_events_provider_buffering_test.dart
+++ b/mobile/test/providers/video_events_provider_buffering_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for videoEventsProvider buffering behavior
 // ABOUTME: Validates new video buffering system and banner functionality
 
+import 'dart:async';
+
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -31,6 +33,8 @@ void main() {
     late VideoEventService videoEventService;
     late ProviderContainer container;
     late SharedPreferences sharedPreferences;
+    late StreamController<Map<String, RelayConnectionStatus>>
+    relayStatusController;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -38,10 +42,14 @@ void main() {
       mockNostrService = _MockNostrClient();
       mockSubscriptionManager = _MockSubscriptionManager();
       mockBlocklistRepository = _MockContentBlocklistRepository();
+      relayStatusController = StreamController.broadcast();
 
       // Stub necessary methods
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.connectedRelayCount).thenReturn(0);
+      when(
+        () => mockNostrService.relayStatusStream,
+      ).thenAnswer((_) => relayStatusController.stream);
       when(
         () => mockBlocklistRepository.shouldFilterFromFeeds(any()),
       ).thenReturn(false);
@@ -70,6 +78,8 @@ void main() {
 
     tearDown(() {
       container.dispose();
+      videoEventService.dispose();
+      unawaited(relayStatusController.close());
     });
 
     test('buffering API exists and starts with zero buffered videos', () async {

--- a/mobile/test/providers/video_events_provider_list_stability_test.dart
+++ b/mobile/test/providers/video_events_provider_list_stability_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for videoEventsProvider list reference stability
 // ABOUTME: Ensures emitted lists maintain stable references for downstream caching
 
+import 'dart:async';
+
 import 'package:content_blocklist_repository/content_blocklist_repository.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -31,6 +33,8 @@ void main() {
     late VideoEventService videoEventService;
     late ProviderContainer container;
     late SharedPreferences sharedPreferences;
+    late StreamController<Map<String, RelayConnectionStatus>>
+    relayStatusController;
 
     setUp(() async {
       SharedPreferences.setMockInitialValues({});
@@ -38,10 +42,14 @@ void main() {
       mockNostrService = _MockNostrClient();
       mockSubscriptionManager = _MockSubscriptionManager();
       mockBlocklistRepository = _MockContentBlocklistRepository();
+      relayStatusController = StreamController.broadcast();
 
       // Stub necessary methods
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.connectedRelayCount).thenReturn(0);
+      when(
+        () => mockNostrService.relayStatusStream,
+      ).thenAnswer((_) => relayStatusController.stream);
       when(
         () => mockBlocklistRepository.shouldFilterFromFeeds(any()),
       ).thenReturn(false);
@@ -70,6 +78,8 @@ void main() {
 
     tearDown(() {
       container.dispose();
+      videoEventService.dispose();
+      unawaited(relayStatusController.close());
     });
 
     test('emits same list reference when contents unchanged', () async {

--- a/mobile/test/services/video_event_service_online_retry_test.dart
+++ b/mobile/test/services/video_event_service_online_retry_test.dart
@@ -58,6 +58,9 @@ void main() {
     late VideoEventService service;
     late List<List<Filter>> subscribeCalls;
     late List<StreamController<Event>> streamControllers;
+    late StreamController<Map<String, RelayConnectionStatus>>
+    relayStatusController;
+    late int connectedRelayCount;
 
     setUp(() {
       mockNostrService = _MockNostrClient();
@@ -66,10 +69,17 @@ void main() {
       connectionService = _FakeConnectionStatusService();
       subscribeCalls = [];
       streamControllers = [];
+      relayStatusController = StreamController.broadcast();
+      connectedRelayCount = 1;
 
       when(() => mockNostrService.isInitialized).thenReturn(true);
       when(() => mockNostrService.publicKey).thenReturn('');
-      when(() => mockNostrService.connectedRelayCount).thenReturn(1);
+      when(
+        () => mockNostrService.connectedRelayCount,
+      ).thenAnswer((_) => connectedRelayCount);
+      when(
+        () => mockNostrService.relayStatusStream,
+      ).thenAnswer((_) => relayStatusController.stream);
       when(
         () => mockNostrService.subscribe(any(), onEose: any(named: 'onEose')),
       ).thenAnswer((invocation) {
@@ -109,6 +119,7 @@ void main() {
 
     tearDown(() {
       service.dispose();
+      unawaited(relayStatusController.close());
       connectionService.dispose();
     });
 
@@ -191,6 +202,127 @@ void main() {
           ),
           isTrue,
         );
+      });
+    });
+
+    test('first subscribe with zero relays retries after relay reconnect with '
+        'the original authors', () {
+      fakeAsync((fake) {
+        connectedRelayCount = 0;
+        Object? caughtError;
+
+        unawaited(
+          service
+              .subscribeToVideoFeed(
+                subscriptionType: SubscriptionType.profile,
+                authors: [followedAuthor],
+              )
+              .catchError((Object error) {
+                caughtError = error;
+              }),
+        );
+        fake.flushMicrotasks();
+
+        expect(caughtError, isA<RelayNotReadyException>());
+        expect(subscribeCalls, isEmpty);
+
+        relayStatusController.add({
+          'wss://relay.divine.video': RelayConnectionStatus.disconnected(
+            'wss://relay.divine.video',
+          ),
+        });
+        fake.flushMicrotasks();
+        expect(subscribeCalls, isEmpty);
+
+        connectedRelayCount = 1;
+        relayStatusController.add({
+          'wss://relay.divine.video': RelayConnectionStatus.connected(
+            'wss://relay.divine.video',
+          ),
+        });
+        fake.flushMicrotasks();
+
+        expect(subscribeCalls, hasLength(1));
+        expect(
+          subscribeCalls.single.any(
+            (filter) => filter.authors?.contains(followedAuthor) ?? false,
+          ),
+          isTrue,
+        );
+
+        relayStatusController.add({
+          'wss://relay.divine.video': RelayConnectionStatus.connected(
+            'wss://relay.divine.video',
+          ),
+        });
+        fake.flushMicrotasks();
+
+        expect(
+          subscribeCalls,
+          hasLength(1),
+          reason: 'relay-ready retry must cancel after a successful retry',
+        );
+      });
+    });
+
+    test('relay-ready retry preserves each pending subscription params without '
+        'creating a retry storm', () {
+      fakeAsync((fake) {
+        connectedRelayCount = 0;
+
+        unawaited(
+          service
+              .subscribeToVideoFeed(
+                subscriptionType: SubscriptionType.profile,
+                authors: [followedAuthor],
+              )
+              .catchError((_) {}),
+        );
+        unawaited(
+          service
+              .subscribeToVideoFeed(
+                subscriptionType: SubscriptionType.hashtag,
+                hashtags: const ['Fresh'],
+              )
+              .catchError((_) {}),
+        );
+        fake.flushMicrotasks();
+
+        expect(subscribeCalls, isEmpty);
+
+        connectedRelayCount = 1;
+        relayStatusController.add({
+          'wss://relay.divine.video': RelayConnectionStatus.connected(
+            'wss://relay.divine.video',
+          ),
+        });
+        fake.flushMicrotasks();
+
+        expect(subscribeCalls, hasLength(2));
+        expect(
+          subscribeCalls.any(
+            (filters) => filters.any(
+              (filter) => filter.authors?.contains(followedAuthor) ?? false,
+            ),
+          ),
+          isTrue,
+        );
+        expect(
+          subscribeCalls.any(
+            (filters) =>
+                filters.any((filter) => filter.t?.contains('fresh') ?? false),
+          ),
+          isTrue,
+        );
+
+        relayStatusController.add({
+          'wss://relay.divine.video': RelayConnectionStatus.connected(
+            'wss://relay.divine.video',
+          ),
+        });
+        fake.flushMicrotasks();
+
+        expect(subscribeCalls, hasLength(2));
       });
     });
 

--- a/mobile/test/services/video_event_service_online_retry_test.dart
+++ b/mobile/test/services/video_event_service_online_retry_test.dart
@@ -326,6 +326,67 @@ void main() {
       });
     });
 
+    test('online retry waits for relay-ready retry when relays are down', () {
+      fakeAsync((fake) {
+        unawaited(
+          service.subscribeToVideoFeed(
+            subscriptionType: SubscriptionType.homeFeed,
+            authors: [followedAuthor],
+          ),
+        );
+        fake.flushMicrotasks();
+        expect(subscribeCalls, hasLength(1));
+
+        streamControllers.first.addError(
+          Exception('websocket connection failed'),
+        );
+        fake.flushMicrotasks();
+
+        connectedRelayCount = 0;
+        fake
+          ..elapse(const Duration(seconds: 10))
+          ..flushMicrotasks();
+
+        expect(
+          subscribeCalls,
+          hasLength(1),
+          reason:
+              'online retry must not create a relay REQ while relays are down',
+        );
+
+        fake
+          ..elapse(const Duration(seconds: 30))
+          ..flushMicrotasks();
+        expect(
+          subscribeCalls,
+          hasLength(1),
+          reason:
+              'RelayNotReadyException should hand off to relay-ready retry '
+              'instead of burning the online retry budget',
+        );
+
+        connectedRelayCount = 1;
+        relayStatusController.add({
+          'wss://relay.divine.video': RelayConnectionStatus.connected(
+            'wss://relay.divine.video',
+          ),
+        });
+        fake.flushMicrotasks();
+
+        expect(subscribeCalls, hasLength(2));
+        expect(
+          subscribeCalls.last.any(
+            (filter) => filter.authors?.contains(followedAuthor) ?? false,
+          ),
+          isTrue,
+          reason: subscribeCalls.last
+              .map((filter) => filter.toJson())
+              .toList()
+              .toString(),
+        );
+      });
+    });
+
     test('exhausted retry entries do not leak into a later retry cycle', () {
       fakeAsync((fake) {
         unawaited(


### PR DESCRIPTION
## Summary

- replace the generic no-relay subscription failure with a typed `RelayNotReadyException`
- store failed subscription params when the device is online but all Nostr relays are disconnected
- add a guarded relay-status retry path that replays pending subscriptions once `relayStatusStream` reports a connected relay
- reuse the stored-params resubscribe helper for both online retry and relay-ready retry to avoid drift
- treat relay-not-ready discovery startup as deferred in `VideoEventsProvider` instead of surfacing an error state
- keep the existing video detail route-id relay-ready retry untouched

## Root cause

Logs attached to #5695 show profile/video subscription setup failing after camera/background activity with `Exception: No connected relays`. The service only warned at the initial zero-relay check, later threw a generic exception, and the string-based connection classifier did not treat that message as retryable. That left the failed subscription dead until another unrelated resubscribe happened.

## Validation

- `flutter test test/services/video_event_service_online_retry_test.dart`
- `flutter test test/providers/video_events_provider_buffering_test.dart test/providers/video_events_provider_list_stability_test.dart`
- `flutter test test/screens/video_detail_screen_test.dart`
- `flutter analyze`
- `flutter test test/services/video_event_service_*_test.dart`
- `flutter test test/unit/services/video_event_service_*_test.dart`
- pre-push hook: analyzer, generated-file verification, changed-file tests

Closes #5695