### PR TITLE
fix(cache): initialize personal event cache after auth

### DIFF
--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -63,15 +63,39 @@ PersonalEventCacheService personalEventCacheService(Ref ref) {
   final service = PersonalEventCacheService();
   ref.onDispose(service.dispose);
 
-  // Initialize with current user's pubkey when authenticated
-  if (authService.isAuthenticated && authService.currentPublicKeyHex != null) {
-    service.initialize(authService.currentPublicKeyHex!).catchError((e) {
-      Log.warning(
-        'Failed to initialize PersonalEventCacheService: $e',
-        name: 'PersonalEventCacheService',
-      );
-    });
+  String? initializingPubkey;
+  void initializeIfReady() {
+    final pubkey = authService.currentPublicKeyHex;
+    if (!authService.isAuthenticated || pubkey == null) {
+      return;
+    }
+    if (initializingPubkey == pubkey) {
+      return;
+    }
+
+    initializingPubkey = pubkey;
+    unawaited(
+      service
+          .initialize(pubkey)
+          .catchError((e) {
+            Log.warning(
+              'Failed to initialize PersonalEventCacheService: $e',
+              name: 'PersonalEventCacheService',
+            );
+          })
+          .whenComplete(() {
+            if (initializingPubkey == pubkey) {
+              initializingPubkey = null;
+            }
+          }),
+    );
   }
+
+  final authSubscription = authService.authStateStream.listen((_) {
+    initializeIfReady();
+  });
+  ref.onDispose(authSubscription.cancel);
+  initializeIfReady();
 
   return service;
 }

--- a/mobile/lib/providers/video_providers.dart
+++ b/mobile/lib/providers/video_providers.dart
@@ -64,7 +64,13 @@ PersonalEventCacheService personalEventCacheService(Ref ref) {
   ref.onDispose(service.dispose);
 
   String? initializingPubkey;
-  void initializeIfReady() {
+  void syncWithAuthState(AuthState authState) {
+    if (authState == AuthState.unauthenticated) {
+      initializingPubkey = null;
+      service.resetCurrentUser();
+      return;
+    }
+
     final pubkey = authService.currentPublicKeyHex;
     if (!authService.isAuthenticated || pubkey == null) {
       return;
@@ -91,11 +97,11 @@ PersonalEventCacheService personalEventCacheService(Ref ref) {
     );
   }
 
-  final authSubscription = authService.authStateStream.listen((_) {
-    initializeIfReady();
-  });
+  final authSubscription = authService.authStateStream.listen(
+    syncWithAuthState,
+  );
   ref.onDispose(authSubscription.cancel);
-  initializeIfReady();
+  syncWithAuthState(authService.authState);
 
   return service;
 }

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -112,7 +112,7 @@ final class PersonalEventCacheServiceProvider
 }
 
 String _$personalEventCacheServiceHash() =>
-    r'b9119a989c8e8754b0a3b2d7252fb0490ac51221';
+    r'f8fbeaaa8db79abff62ce85e3ca683320c5f0e50';
 
 /// Seen videos service for tracking viewed content
 

--- a/mobile/lib/providers/video_providers.g.dart
+++ b/mobile/lib/providers/video_providers.g.dart
@@ -112,7 +112,7 @@ final class PersonalEventCacheServiceProvider
 }
 
 String _$personalEventCacheServiceHash() =>
-    r'ceb0fbabc806cb4f75a3c881bed3970e2664b428';
+    r'b9119a989c8e8754b0a3b2d7252fb0490ac51221';
 
 /// Seen videos service for tracking viewed content
 

--- a/mobile/lib/services/personal_event_cache_service.dart
+++ b/mobile/lib/services/personal_event_cache_service.dart
@@ -25,6 +25,14 @@ class PersonalEventCacheService {
   /// Check if the cache service is initialized
   bool get isInitialized => _isInitialized;
 
+  /// Reset the active user session without deleting the shared on-disk cache.
+  void resetCurrentUser() {
+    _initializationToken++;
+    _isInitialized = false;
+    _currentUserPubkey = null;
+    _pendingEventWrites.clear();
+  }
+
   /// Initialize the personal event cache
   Future<void> initialize(String userPubkey) async {
     _isDisposed = false;
@@ -260,6 +268,9 @@ class PersonalEventCacheService {
         final rawEventData = _eventsBox!.get(eventId);
         if (rawEventData != null) {
           final eventData = Map<String, dynamic>.from(rawEventData as Map);
+          if (!_eventDataBelongsToCurrentUser(eventData)) {
+            continue;
+          }
           final event = _eventDataToEvent(eventData);
           if (event != null) {
             events.add(event);
@@ -298,6 +309,9 @@ class PersonalEventCacheService {
       for (final rawEventData in _eventsBox!.values) {
         if (rawEventData == null) continue;
         final eventData = Map<String, dynamic>.from(rawEventData as Map);
+        if (!_eventDataBelongsToCurrentUser(eventData)) {
+          continue;
+        }
         final event = _eventDataToEvent(eventData);
         if (event != null) {
           events.add(event);
@@ -334,6 +348,9 @@ class PersonalEventCacheService {
       final rawEventData = _eventsBox!.get(eventId);
       if (rawEventData != null) {
         final eventData = Map<String, dynamic>.from(rawEventData as Map);
+        if (!_eventDataBelongsToCurrentUser(eventData)) {
+          return null;
+        }
         return _eventDataToEvent(eventData);
       }
     } catch (e) {
@@ -352,7 +369,22 @@ class PersonalEventCacheService {
     if (!_isInitialized || _eventsBox == null) {
       return false;
     }
-    return _eventsBox!.containsKey(eventId);
+
+    try {
+      final rawEventData = _eventsBox!.get(eventId);
+      if (rawEventData == null) {
+        return false;
+      }
+      final eventData = Map<String, dynamic>.from(rawEventData as Map);
+      return _eventDataBelongsToCurrentUser(eventData);
+    } catch (e) {
+      Log.error(
+        'Failed to check event by ID $eventId: $e',
+        name: 'PersonalEventCache',
+        category: LogCategory.storage,
+      );
+      return false;
+    }
   }
 
   /// Get cache statistics
@@ -362,7 +394,7 @@ class PersonalEventCacheService {
     }
 
     final stats = <String, dynamic>{
-      'total_events': _eventsBox!.length,
+      'total_events': 0,
       'by_kind': <String, int>{},
       'user_pubkey': _currentUserPubkey,
     };
@@ -375,7 +407,22 @@ class PersonalEventCacheService {
         final kindEvents = rawKindEvents != null
             ? Map<String, dynamic>.from(rawKindEvents as Map)
             : <String, dynamic>{};
-        (stats['by_kind'] as Map<String, int>)[kind] = kindEvents.length;
+        var currentUserEventCount = 0;
+        for (final eventId in kindEvents.keys) {
+          final rawEventData = _eventsBox!.get(eventId);
+          if (rawEventData == null) {
+            continue;
+          }
+          final eventData = Map<String, dynamic>.from(rawEventData as Map);
+          if (_eventDataBelongsToCurrentUser(eventData)) {
+            currentUserEventCount++;
+          }
+        }
+        if (currentUserEventCount > 0) {
+          (stats['by_kind'] as Map<String, int>)[kind] = currentUserEventCount;
+          stats['total_events'] =
+              (stats['total_events'] as int) + currentUserEventCount;
+        }
       }
     }
 
@@ -417,6 +464,12 @@ class PersonalEventCacheService {
         );
       }
     }
+  }
+
+  bool _eventDataBelongsToCurrentUser(Map<String, dynamic> eventData) {
+    final currentUserPubkey = _currentUserPubkey;
+    return currentUserPubkey != null &&
+        eventData['pubkey'] == currentUserPubkey;
   }
 
   /// Convert stored event data back to Event object

--- a/mobile/test/providers/personal_event_cache_service_provider_test.dart
+++ b/mobile/test/providers/personal_event_cache_service_provider_test.dart
@@ -1,0 +1,152 @@
+// ABOUTME: Tests provider auth reactivity for PersonalEventCacheService.
+// ABOUTME: Ensures late auth initialization flushes queued personal events.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce_flutter/hive_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/event.dart';
+import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/personal_event_cache_service.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
+
+const String _userPubkey =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const String _otherPubkey =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+String _hexId(int index) => index.toRadixString(16).padLeft(64, '0');
+
+Event _createEvent({required String pubkey, required String id}) {
+  final event = Event(
+    pubkey,
+    32222,
+    const [
+      ['d', 'test-video-id'],
+      ['title', 'Plants'],
+    ],
+    'A plant video',
+    createdAt: 1700000000,
+  );
+  event.id = id;
+  event.sig = id.padRight(128, '0').substring(0, 128);
+  return event;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(personalEventCacheServiceProvider, () {
+    late Directory testDir;
+    late _MockAuthService authService;
+    late StreamController<AuthState> authStateController;
+
+    setUp(() async {
+      testDir = await Directory.systemTemp.createTemp(
+        'personal_event_cache_service_provider_test_',
+      );
+      Hive.init(testDir.path);
+
+      authService = _MockAuthService();
+      authStateController = StreamController<AuthState>.broadcast();
+      when(() => authService.authState).thenReturn(AuthState.unauthenticated);
+      when(
+        () => authService.authStateStream,
+      ).thenAnswer((_) => authStateController.stream);
+      when(() => authService.isAuthenticated).thenReturn(false);
+      when(() => authService.currentPublicKeyHex).thenReturn(null);
+    });
+
+    tearDown(() async {
+      await authStateController.close();
+      try {
+        await Hive.close();
+      } on PathNotFoundException catch (_) {
+        // Hive may already have removed its lock file during async shutdown.
+      }
+      try {
+        await testDir.delete(recursive: true);
+      } on PathNotFoundException catch (_) {
+        // Lock file may already be gone after Hive.close().
+      }
+    });
+
+    ProviderContainer buildContainer() {
+      final container = ProviderContainer(
+        overrides: [authServiceProvider.overrideWithValue(authService)],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
+
+    Future<void> authenticate() async {
+      when(() => authService.authState).thenReturn(AuthState.authenticated);
+      when(() => authService.isAuthenticated).thenReturn(true);
+      when(() => authService.currentPublicKeyHex).thenReturn(_userPubkey);
+
+      authStateController.add(AuthState.authenticated);
+    }
+
+    Future<void> waitForInitialized(PersonalEventCacheService service) async {
+      for (var attempt = 0; attempt < 20; attempt++) {
+        await pumpEventQueue();
+        if (service.isInitialized) {
+          return;
+        }
+      }
+    }
+
+    test(
+      'initializes when auth becomes ready after provider construction',
+      () async {
+        final container = buildContainer();
+        final subscription = container.listen(
+          personalEventCacheServiceProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+
+        final service = subscription.read();
+        expect(service.isInitialized, isFalse);
+
+        await authenticate();
+        await waitForInitialized(service);
+
+        expect(service.isInitialized, isTrue);
+      },
+    );
+
+    test(
+      'flushes queued personal events after late auth initialization',
+      () async {
+        final container = buildContainer();
+        final subscription = container.listen(
+          personalEventCacheServiceProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        final ownEvent = _createEvent(pubkey: _userPubkey, id: _hexId(1));
+        final otherEvent = _createEvent(pubkey: _otherPubkey, id: _hexId(2));
+
+        final service = subscription.read();
+        service.cacheUserEvent(ownEvent);
+        service.cacheUserEvent(otherEvent);
+
+        await authenticate();
+        await waitForInitialized(service);
+
+        expect(service.hasEvent(ownEvent.id), isTrue);
+        expect(service.getEventById(ownEvent.id)?.id, ownEvent.id);
+        expect(service.hasEvent(otherEvent.id), isFalse);
+        expect(service.getEventById(otherEvent.id), isNull);
+      },
+    );
+  });
+}

--- a/mobile/test/providers/personal_event_cache_service_provider_test.dart
+++ b/mobile/test/providers/personal_event_cache_service_provider_test.dart
@@ -92,10 +92,38 @@ void main() {
       authStateController.add(AuthState.authenticated);
     }
 
+    void unauthenticate() {
+      when(() => authService.authState).thenReturn(AuthState.unauthenticated);
+      when(() => authService.isAuthenticated).thenReturn(false);
+      when(() => authService.currentPublicKeyHex).thenReturn(null);
+
+      authStateController.add(AuthState.unauthenticated);
+    }
+
+    void emitChecking() {
+      when(() => authService.authState).thenReturn(AuthState.checking);
+      when(() => authService.isAuthenticated).thenReturn(false);
+      when(() => authService.currentPublicKeyHex).thenReturn(null);
+
+      authStateController.add(AuthState.checking);
+    }
+
     Future<void> waitForInitialized(PersonalEventCacheService service) async {
       for (var attempt = 0; attempt < 20; attempt++) {
         await pumpEventQueue();
         if (service.isInitialized) {
+          return;
+        }
+      }
+    }
+
+    Future<void> waitForCachedEvent(
+      PersonalEventCacheService service,
+      String eventId,
+    ) async {
+      for (var attempt = 0; attempt < 20; attempt++) {
+        await pumpEventQueue();
+        if (service.hasEvent(eventId)) {
           return;
         }
       }
@@ -146,6 +174,58 @@ void main() {
         expect(service.getEventById(ownEvent.id)?.id, ownEvent.id);
         expect(service.hasEvent(otherEvent.id), isFalse);
         expect(service.getEventById(otherEvent.id), isNull);
+      },
+    );
+
+    test(
+      'keeps queued events through transient non-auth states',
+      () async {
+        final container = buildContainer();
+        final subscription = container.listen(
+          personalEventCacheServiceProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        final ownEvent = _createEvent(pubkey: _userPubkey, id: _hexId(3));
+
+        final service = subscription.read();
+        service.cacheUserEvent(ownEvent);
+
+        emitChecking();
+        await authenticate();
+        await waitForInitialized(service);
+
+        expect(service.hasEvent(ownEvent.id), isTrue);
+        expect(service.getEventById(ownEvent.id)?.id, ownEvent.id);
+      },
+    );
+
+    test(
+      'resets active cache session when auth becomes unauthenticated',
+      () async {
+        final container = buildContainer();
+        final subscription = container.listen(
+          personalEventCacheServiceProvider,
+          (_, _) {},
+          fireImmediately: true,
+        );
+        addTearDown(subscription.close);
+        final ownEvent = _createEvent(pubkey: _userPubkey, id: _hexId(4));
+
+        final service = subscription.read();
+        await authenticate();
+        await waitForInitialized(service);
+        service.cacheUserEvent(ownEvent);
+        await waitForCachedEvent(service, ownEvent.id);
+        expect(service.hasEvent(ownEvent.id), isTrue);
+
+        unauthenticate();
+        await pumpEventQueue();
+
+        expect(service.isInitialized, isFalse);
+        expect(service.hasEvent(ownEvent.id), isFalse);
+        expect(service.getEventById(ownEvent.id), isNull);
       },
     );
   });

--- a/mobile/test/services/personal_event_cache_service_test.dart
+++ b/mobile/test/services/personal_event_cache_service_test.dart
@@ -167,5 +167,53 @@ void main() {
         expect(service.getEventById(event.id), isNull);
       },
     );
+
+    test('reads only return events for the current initialized user', () async {
+      final userEvent = createEvent(pubkey: userPubkey, id: hexId(201));
+      final otherUserEvent = createEvent(pubkey: otherPubkey, id: hexId(202));
+
+      await service.initialize(userPubkey);
+      service.cacheUserEvent(userEvent);
+      await pumpEventQueue();
+
+      await service.initialize(otherPubkey);
+      service.cacheUserEvent(otherUserEvent);
+      await pumpEventQueue();
+
+      expect(service.hasEvent(userEvent.id), isFalse);
+      expect(service.getEventById(userEvent.id), isNull);
+      expect(service.hasEvent(otherUserEvent.id), isTrue);
+      expect(service.getEventById(otherUserEvent.id)?.id, otherUserEvent.id);
+      expect(
+        service.getEventsByKind(32222).map((event) => event.id),
+        containsAll(<String>[otherUserEvent.id]),
+      );
+      expect(
+        service.getEventsByKind(32222).map((event) => event.id),
+        isNot(contains(userEvent.id)),
+      );
+    });
+
+    test(
+      'resetCurrentUser makes cached events unreadable until reauth',
+      () async {
+        final event = createEvent(pubkey: userPubkey, id: hexId(203));
+
+        await service.initialize(userPubkey);
+        service.cacheUserEvent(event);
+        await pumpEventQueue();
+        expect(service.hasEvent(event.id), isTrue);
+
+        service.resetCurrentUser();
+
+        expect(service.isInitialized, isFalse);
+        expect(service.hasEvent(event.id), isFalse);
+        expect(service.getEventById(event.id), isNull);
+
+        await service.initialize(userPubkey);
+
+        expect(service.hasEvent(event.id), isTrue);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

- initialize personalEventCacheServiceProvider when AuthService emits an authenticated state after provider construction
- keep the same PersonalEventCacheService instance so queued personal events survive auth readiness transitions
- add provider-level regression coverage for late auth initialization, queued event flushing, and current-user filtering

## Root cause

personalEventCacheServiceProvider watched the stable keepAlive authServiceProvider instance and only checked auth synchronously during provider construction. If the cache provider was created before auth had a pubkey, it skipped initialization and never retried when auth later became ready.

## Validation

- flutter analyze
- flutter analyze lib test/providers/personal_event_cache_service_provider_test.dart test/services/personal_event_cache_service_test.dart
- flutter test test/providers/personal_event_cache_service_provider_test.dart test/services/personal_event_cache_service_test.dart
- pre-push hook: analyzer, generated-file verification, and changed-file tests

Closes #5697