### PR TITLE
fix(upload): preserve resumable sessions on socket drops

### DIFF
--- a/mobile/lib/services/upload/upload_retry_policy.dart
+++ b/mobile/lib/services/upload/upload_retry_policy.dart
@@ -43,6 +43,7 @@ class UploadRetryPolicy {
     try {
       await AsyncUtils.retryWithBackoff(
         operation: () async {
+          await drainSessionPersist(upload.id);
           final currentUpload = _store.getUpload(upload.id) ?? upload;
 
           // autoAttempt is local to this performWithRetry invocation and is
@@ -89,7 +90,7 @@ class UploadRetryPolicy {
     int fileSizeBytes,
   ) {
     final previous = _sessionPersistFutures[uploadId] ?? Future<void>.value();
-    _sessionPersistFutures[uploadId] = previous.then((_) async {
+    final persistFuture = previous.then((_) async {
       try {
         await _storeResumableSessionProgress(uploadId, session, fileSizeBytes);
       } catch (e, s) {
@@ -102,6 +103,18 @@ class UploadRetryPolicy {
         );
       }
     });
+    _sessionPersistFutures[uploadId] = persistFuture;
+    unawaited(
+      persistFuture.whenComplete(() {
+        if (identical(_sessionPersistFutures[uploadId], persistFuture)) {
+          _sessionPersistFutures.remove(uploadId);
+        }
+      }),
+    );
+  }
+
+  Future<void> drainSessionPersist(String uploadId) async {
+    await (_sessionPersistFutures[uploadId] ?? Future<void>.value());
   }
 
   Future<void> retryUpload(

--- a/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
+++ b/mobile/packages/blossom_upload_service/lib/src/blossom_upload_service.dart
@@ -18,6 +18,64 @@ import 'package:image_metadata_stripper/image_metadata_stripper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
+bool _hasTransientDioSignal(DioException error) {
+  final statusCode = error.response?.statusCode;
+  if (statusCode != null && statusCode >= 500) return true;
+
+  return _hasTransientDioTransportSignal(error);
+}
+
+bool _hasTransientDioTransportSignal(DioException error) {
+  return _isTransientDioType(error.type) ||
+      _isRecoverableSocketCloseError(error);
+}
+
+bool _isTransientDioType(DioExceptionType type) {
+  return switch (type) {
+    DioExceptionType.connectionTimeout ||
+    DioExceptionType.sendTimeout ||
+    DioExceptionType.receiveTimeout ||
+    DioExceptionType.connectionError => true,
+    _ => false,
+  };
+}
+
+bool _isRecoverableSocketCloseError(DioException error) {
+  if (error.type != DioExceptionType.unknown &&
+      error.type != DioExceptionType.connectionError) {
+    return false;
+  }
+
+  final detail = _dioErrorDetail(error).toLowerCase();
+  return error.error is SocketException ||
+      detail.contains('bad file descriptor') ||
+      detail.contains('connection closed') ||
+      detail.contains('connection reset') ||
+      detail.contains('connection aborted') ||
+      detail.contains('broken pipe') ||
+      detail.contains('socket closed');
+}
+
+String _dioErrorDetail(DioException error) {
+  final parts = <String>[
+    if (error.message != null) error.message!,
+    if (error.error != null) error.error.toString(),
+  ];
+
+  final inner = error.error;
+  if (inner is HttpException) {
+    parts.add(inner.message);
+  } else if (inner is SocketException) {
+    parts
+      ..add(inner.message)
+      ..add(inner.osError?.message ?? '');
+  } else if (inner is OSError) {
+    parts.add(inner.message);
+  }
+
+  return parts.where((part) => part.isNotEmpty).join(' ');
+}
+
 /// Why a Blossom upload failed.
 ///
 /// Classification lives at the HTTP/service boundary so that callers
@@ -81,15 +139,12 @@ enum BlossomUploadFailureReason {
   ///
   /// [bad responses]: https://pub.dev/documentation/dio/latest/dio/DioExceptionType.html
   static BlossomUploadFailureReason fromDioException(DioException error) {
-    return switch (error.type) {
-      DioExceptionType.connectionTimeout ||
-      DioExceptionType.sendTimeout ||
-      DioExceptionType.receiveTimeout ||
-      DioExceptionType.connectionError => BlossomUploadFailureReason.network,
-      _ =>
-        fromStatusCode(error.response?.statusCode) ??
-            BlossomUploadFailureReason.unknown,
-    };
+    if (_hasTransientDioTransportSignal(error)) {
+      return BlossomUploadFailureReason.network;
+    }
+
+    return fromStatusCode(error.response?.statusCode) ??
+        BlossomUploadFailureReason.unknown;
   }
 }
 
@@ -213,6 +268,7 @@ class BlossomResumableUploadException implements Exception {
     this.message, {
     this.statusCode,
     this.failureReason,
+    this.isRecoverableResumableFailure = false,
   });
 
   /// The error message.
@@ -227,6 +283,15 @@ class BlossomResumableUploadException implements Exception {
   /// it apart from a missing-field/malformed-response throw. `null` lets
   /// the classifier fall back to [statusCode].
   final BlossomUploadFailureReason? failureReason;
+
+  /// Whether the session reached the resumable transfer phase and failed in a
+  /// way the caller can retry by querying/resuming that same session.
+  ///
+  /// This is deliberately separate from [failureReason]: a connection error
+  /// during `/upload/init` has no resumable state yet and can still use legacy
+  /// fallback, while the same connection error during chunk PUT should preserve
+  /// the session for resume.
+  final bool isRecoverableResumableFailure;
 
   @override
   String toString() => message;
@@ -608,31 +673,10 @@ class BlossomUploadService {
 
   /// Whether a [DioException] from a chunk PUT is safe to retry.
   /// Returns `true` for 5xx server errors and transient network issues.
-  bool _isTransientChunkError(DioException e) {
-    final statusCode = e.response?.statusCode;
-    if (statusCode != null && statusCode >= 500) return true;
+  bool _isTransientChunkError(DioException e) => _hasTransientDioSignal(e);
 
-    return switch (e.type) {
-      DioExceptionType.connectionTimeout ||
-      DioExceptionType.sendTimeout ||
-      DioExceptionType.receiveTimeout ||
-      DioExceptionType.connectionError => true,
-      _ => false,
-    };
-  }
-
-  bool _isTransientCapabilityDiscoveryError(DioException error) {
-    final statusCode = error.response?.statusCode;
-    if (statusCode != null && statusCode >= 500) return true;
-
-    return switch (error.type) {
-      DioExceptionType.connectionTimeout ||
-      DioExceptionType.sendTimeout || // coverage:ignore-line
-      DioExceptionType.receiveTimeout || // coverage:ignore-line
-      DioExceptionType.connectionError => true, // coverage:ignore-line
-      _ => false,
-    };
-  }
+  bool _isTransientCapabilityDiscoveryError(DioException error) =>
+      _hasTransientDioSignal(error);
 
   /// Whether an image-upload attempt threw a transient, retriable error.
   ///
@@ -657,16 +701,11 @@ class BlossomUploadService {
           _retriableUploadStatusCodes.contains(statusCode)) {
         return true;
       }
-      return switch (error.type) {
-        DioExceptionType.connectionTimeout ||
-        DioExceptionType.sendTimeout ||
-        DioExceptionType.receiveTimeout ||
-        DioExceptionType.connectionError => true,
-        _ => false,
-      };
+      return _hasTransientDioSignal(error);
     }
     if (error is BlossomResumableUploadException) {
-      if (error.failureReason == BlossomUploadFailureReason.authUnavailable) {
+      if (error.isRecoverableResumableFailure ||
+          error.failureReason == BlossomUploadFailureReason.authUnavailable) {
         return true;
       }
       final statusCode = error.statusCode;
@@ -862,6 +901,11 @@ class BlossomUploadService {
     }
 
     if (!isDivineOwnedHost || result.success) {
+      return result;
+    }
+
+    if (resumableError is BlossomResumableUploadException &&
+        resumableError.isRecoverableResumableFailure) {
       return result;
     }
 
@@ -1194,6 +1238,14 @@ class BlossomUploadService {
           } on DioException catch (e) {
             chunkAttempt++;
             if (chunkAttempt > _maxChunkRetries || !_isTransientChunkError(e)) {
+              if (_hasTransientDioSignal(e)) {
+                throw BlossomResumableUploadException(
+                  'Recoverable resumable upload failure: $e',
+                  statusCode: e.response?.statusCode,
+                  failureReason: BlossomUploadFailureReason.fromDioException(e),
+                  isRecoverableResumableFailure: true,
+                );
+              }
               rethrow;
             }
             Log.warning(

--- a/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
+++ b/mobile/packages/blossom_upload_service/test/src/blossom_upload_service_test.dart
@@ -1236,6 +1236,160 @@ void main() {
         await tempDir.delete(recursive: true);
       });
 
+      test('does not fall back to legacy PUT when a resumable chunk fails '
+          'with an unknown bad file descriptor socket close', () async {
+        const testPublicKey = _testPublicKey;
+        final sessionUrl = Uri.parse(
+          'https://upload.divine.video/sessions/up_bad_fd',
+        );
+
+        expect(
+          BlossomUploadFailureReason.fromDioException(
+            DioException(
+              requestOptions: RequestOptions(path: sessionUrl.toString()),
+              error: HttpException('Bad file descriptor', uri: sessionUrl),
+            ),
+          ),
+          BlossomUploadFailureReason.network,
+        );
+
+        when(() => mockAuthProvider.isAuthenticated).thenReturn(true);
+        when(
+          () => mockAuthProvider.createAndSignEvent(
+            kind: any(named: 'kind'),
+            content: any(named: 'content'),
+            tags: any(named: 'tags'),
+          ),
+        ).thenAnswer(
+          (_) async => _signedEvent(
+            testPublicKey,
+            24242,
+            const [],
+            'Upload video to Blossom server',
+          ),
+        );
+
+        final tempDir = await Directory.systemTemp.createTemp(
+          'blossom_resumable_bad_fd_test_',
+        );
+        final videoFile = File('${tempDir.path}/video.mp4')
+          ..writeAsBytesSync(List<int>.generate(10, (index) => index + 1));
+        final sessionUpdates = <BlossomResumableUploadSession>[];
+
+        when(
+          () => mockDio.head<dynamic>(any(), options: any(named: 'options')),
+        ).thenAnswer((invocation) async {
+          final url = invocation.positionalArguments.first as String;
+          if (url == 'https://media.divine.video/upload') {
+            return Response(
+              requestOptions: RequestOptions(path: '/upload'),
+              statusCode: 200,
+              headers: Headers.fromMap({
+                DivineUploadHeaders.extensions: [
+                  DivineUploadExtensions.resumableSessions,
+                ],
+              }),
+            );
+          }
+
+          throw StateError('Unexpected HEAD url: $url');
+        });
+
+        when(
+          () => mockDio.post<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          ),
+        ).thenAnswer((invocation) async {
+          final url = invocation.positionalArguments.first as String;
+
+          if (url == 'https://media.divine.video/upload/init') {
+            return Response(
+              requestOptions: RequestOptions(path: '/upload/init'),
+              statusCode: 200,
+              data: {
+                'uploadId': 'up_bad_fd',
+                'uploadUrl': sessionUrl.toString(),
+                'chunkSize': 5,
+                'nextOffset': 0,
+                'requiredHeaders': {'Authorization': 'Bearer session-token'},
+              },
+            );
+          }
+
+          throw StateError('Unexpected POST url: $url');
+        });
+
+        var failingChunkAttempts = 0;
+        when(
+          () => mockDio.put<dynamic>(
+            any(),
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        ).thenAnswer((invocation) async {
+          final url = invocation.positionalArguments.first as String;
+          final options = invocation.namedArguments[#options] as Options;
+
+          if (url == sessionUrl.toString()) {
+            final contentRange = options.headers?['Content-Range'] as String;
+            if (contentRange == 'bytes 0-4/10') {
+              return Response(
+                requestOptions: RequestOptions(path: '/sessions/up_bad_fd'),
+                statusCode: 204,
+                headers: Headers.fromMap({
+                  DivineUploadHeaders.uploadOffset: ['5'],
+                }),
+              );
+            }
+            if (contentRange == 'bytes 5-9/10') {
+              failingChunkAttempts++;
+              throw DioException(
+                requestOptions: RequestOptions(path: sessionUrl.toString()),
+                error: HttpException('Bad file descriptor', uri: sessionUrl),
+              );
+            }
+          }
+
+          throw StateError('Unexpected PUT url: $url');
+        });
+
+        final result = await service.uploadVideo(
+          videoFile: videoFile,
+          nostrPubkey: testPublicKey,
+          title: 'Recoverable Bad FD Video',
+          description: null,
+          hashtags: null,
+          proofManifestJson: null,
+          onResumableSessionUpdated: sessionUpdates.add,
+        );
+
+        expect(result.success, isFalse);
+        expect(result.failureReason, BlossomUploadFailureReason.network);
+        expect(failingChunkAttempts, equals(3));
+        expect(sessionUpdates.map((session) => session.nextOffset), [0, 5]);
+
+        verifyNever(
+          () => mockDio.put<dynamic>(
+            'https://media.divine.video/upload',
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+            onSendProgress: any(named: 'onSendProgress'),
+          ),
+        );
+        verifyNever(
+          () => mockDio.post<dynamic>(
+            'https://media.divine.video/upload/up_bad_fd/complete',
+            data: any(named: 'data'),
+            options: any(named: 'options'),
+          ),
+        );
+
+        await tempDir.delete(recursive: true);
+      });
+
       test(
         'should send PUT request with raw bytes and NIP-98 auth header',
         () async {
@@ -2582,6 +2736,33 @@ void main() {
             expect(
               BlossomUploadFailureReason.fromDioException(
                 dioException(DioExceptionType.connectionError),
+              ),
+              equals(BlossomUploadFailureReason.network),
+            );
+          });
+
+          test('returns network for unknown SocketException', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                DioException(
+                  requestOptions: RequestOptions(path: '/upload'),
+                  error: const SocketException(
+                    'Socket closed',
+                    osError: OSError('Broken pipe'),
+                  ),
+                ),
+              ),
+              equals(BlossomUploadFailureReason.network),
+            );
+          });
+
+          test('returns network for unknown OSError socket close detail', () {
+            expect(
+              BlossomUploadFailureReason.fromDioException(
+                DioException(
+                  requestOptions: RequestOptions(path: '/upload'),
+                  error: const OSError('Broken pipe'),
+                ),
               ),
               equals(BlossomUploadFailureReason.network),
             );

--- a/mobile/test/services/upload/upload_retry_policy_test.dart
+++ b/mobile/test/services/upload/upload_retry_policy_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Unit tests for UploadRetryPolicy — covers isRetriableError,
 // ABOUTME: retryUpload, resumeInterruptedUpload, and enqueueSessionPersist.
 
+import 'dart:async';
+
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -177,10 +179,7 @@ void main() {
       });
 
       test('session expired string → false', () {
-        expect(
-          policy.isRetriableError(Exception('session expired')),
-          isFalse,
-        );
+        expect(policy.isRetriableError(Exception('session expired')), isFalse);
       });
 
       test('session is no longer available → false', () {
@@ -236,10 +235,7 @@ void main() {
       });
 
       test('"file not found" → false', () {
-        expect(
-          policy.isRetriableError(Exception('file not found')),
-          isFalse,
-        );
+        expect(policy.isRetriableError(Exception('file not found')), isFalse);
       });
 
       test('"permission denied" → false', () {
@@ -250,10 +246,7 @@ void main() {
       });
 
       test('"cancelled" → false', () {
-        expect(
-          policy.isRetriableError(Exception('upload cancelled')),
-          isFalse,
-        );
+        expect(policy.isRetriableError(Exception('upload cancelled')), isFalse);
       });
 
       test('"thumbnail upload failed" → false', () {
@@ -263,6 +256,56 @@ void main() {
         );
       });
     });
+  });
+
+  // ---------------------------------------------------------------------------
+  group('performWithRetry', () {
+    test(
+      'drains queued session persistence before starting an attempt',
+      () async {
+        final upload = _makeUpload();
+        const session = BlossomResumableUploadSession(
+          uploadId: 'session-1',
+          uploadUrl: 'https://upload.divine.video/sessions/session-1',
+          chunkSize: 1024,
+          nextOffset: 512,
+        );
+        final persistStarted = Completer<void>();
+        final allowPersistToFinish = Completer<void>();
+
+        when(() => store.getUpload('upload-1')).thenReturn(upload);
+        when(() => store.update(any())).thenAnswer((invocation) async {
+          final updated = invocation.positionalArguments.first as PendingUpload;
+          if (updated.resumableSession != null) {
+            persistStarted.complete();
+            await allowPersistToFinish.future;
+          }
+        });
+
+        policy.enqueueSessionPersist('upload-1', session, 1024);
+
+        var executeCalled = false;
+        final retryFuture = policy.performWithRetry(upload, () async {
+          executeCalled = true;
+        }, isRetriable: (_) => false);
+
+        await persistStarted.future;
+        await Future<void>.delayed(Duration.zero);
+        expect(executeCalled, isFalse);
+
+        allowPersistToFinish.complete();
+        await retryFuture;
+
+        expect(executeCalled, isTrue);
+        final captured = verify(() => store.update(captureAny())).captured;
+        expect(captured, hasLength(2));
+        expect(
+          (captured.first as PendingUpload).resumableSession,
+          equals(session),
+        );
+        expect((captured.last as PendingUpload).status, UploadStatus.uploading);
+      },
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -440,10 +483,7 @@ void main() {
       () async {
         // createdAt defaults to 2024 (well over an hour ago) and completedAt
         // is null, so the reset window keys off createdAt and resets to 1.
-        final upload = _makeUpload(
-          status: UploadStatus.failed,
-          retryCount: 2,
-        );
+        final upload = _makeUpload(status: UploadStatus.failed, retryCount: 2);
         when(() => store.getUpload('upload-1')).thenReturn(upload);
         when(() => store.update(any())).thenAnswer((_) async {});
 


### PR DESCRIPTION
## Summary

Fixes #5696.

This preserves resumable Blossom upload progress when a background/socket-close transport failure interrupts a chunk upload. The observed failure was `DioExceptionType.unknown` wrapping `HttpException: Bad file descriptor`; before this change, Divine resumable upload fallback treated that as a generic resumable failure and immediately performed a full legacy `PUT /upload`, discarding the already committed resumable session progress.

## Root Cause

`BlossomUploadService._uploadWithSingleLegacyFallback` fell back to legacy upload for any failed Divine resumable attempt. The chunk retry classifier also did not recognize socket-close errors reported by Dio as `unknown`, so the recoverable transfer failure escaped the chunk loop and went straight into the broad legacy fallback path.

## Changes

- Centralized transient Dio classification for upload retries, capability discovery, and chunk retry handling.
- Classified `DioExceptionType.unknown` with socket-close details such as `HttpException: Bad file descriptor` as a transient transport failure.
- Added a resumable-specific recoverability marker to `BlossomResumableUploadException` so mid-session chunk failures can preserve session state without changing init/fatal fallback behavior.
- Prevented Divine legacy fallback from preempting retry/resume for recoverable resumable chunk failures.
- Kept legacy fallback intact for init failures, non-resumable/fatal errors, and existing custom-host behavior.
- Drained queued resumable-session persistence before automatic retry attempts read the current upload record, removing a timing race around persisted offsets.

## Validation

- `flutter test test/src/blossom_upload_service_test.dart` from `mobile/packages/blossom_upload_service`
- `flutter test test/services/upload/upload_retry_policy_test.dart` from `mobile`
- `flutter test test/services/upload_manager_resumable_upload_test.dart` from `mobile`
- `flutter analyze` from `mobile`
- Pre-push hook analyzer and changed-file tests passed
