### PR TITLE
feat(minor-safety): consume verified_minor + protected-minor state (#5730)

### DIFF
--- a/mobile/lib/models/protected_minor_status.dart
+++ b/mobile/lib/models/protected_minor_status.dart
@@ -1,0 +1,36 @@
+// ABOUTME: Non-blocking protected-minor (13-15) state derived from Keycast's
+// ABOUTME: verified_minor flag. Distinct from the blocking minor-review gate.
+
+import 'package:keycast_flutter/keycast_flutter.dart';
+
+/// Client-side "protected minor" state for an approved 13-15 account.
+///
+/// This is deliberately separate from [AccountRestrictionStatus] /
+/// `MinorAccountReviewStatus`, which drive the *blocking* under-review gate.
+/// A protected minor may use the app; the content-lock and DM-restriction
+/// protections (#175/#176) consume this state.
+class ProtectedMinorStatus {
+  const ProtectedMinorStatus({
+    required this.isProtectedMinor,
+    this.verifiedMinorAt,
+  });
+
+  factory ProtectedMinorStatus.notProtected() =>
+      const ProtectedMinorStatus(isProtectedMinor: false);
+
+  /// Maps a Keycast account status to protected-minor state. A null status
+  /// (fetch failed / unavailable) or `verified_minor == false` is treated as
+  /// not protected — #174 is detection-only, so it fails to not-protected.
+  factory ProtectedMinorStatus.fromKeycast(KeycastAccountStatus? status) {
+    if (status == null || !status.verifiedMinor) {
+      return ProtectedMinorStatus.notProtected();
+    }
+    return ProtectedMinorStatus(
+      isProtectedMinor: true,
+      verifiedMinorAt: status.verifiedMinorAt,
+    );
+  }
+
+  final bool isProtectedMinor;
+  final DateTime? verifiedMinorAt;
+}

--- a/mobile/lib/models/protected_minor_status.dart
+++ b/mobile/lib/models/protected_minor_status.dart
@@ -3,6 +3,12 @@
 
 import 'package:keycast_flutter/keycast_flutter.dart';
 
+enum ProtectedMinorStatusKind {
+  unknown,
+  notProtected,
+  protected,
+}
+
 /// Client-side "protected minor" state for an approved 13-15 account.
 ///
 /// This is deliberately separate from [AccountRestrictionStatus] /
@@ -11,26 +17,41 @@ import 'package:keycast_flutter/keycast_flutter.dart';
 /// protections (#175/#176) consume this state.
 class ProtectedMinorStatus {
   const ProtectedMinorStatus({
-    required this.isProtectedMinor,
+    required this.kind,
     this.verifiedMinorAt,
   });
 
+  factory ProtectedMinorStatus.unknown() =>
+      const ProtectedMinorStatus(kind: ProtectedMinorStatusKind.unknown);
+
   factory ProtectedMinorStatus.notProtected() =>
-      const ProtectedMinorStatus(isProtectedMinor: false);
+      const ProtectedMinorStatus(kind: ProtectedMinorStatusKind.notProtected);
+
+  factory ProtectedMinorStatus.protected({DateTime? verifiedMinorAt}) =>
+      ProtectedMinorStatus(
+        kind: ProtectedMinorStatusKind.protected,
+        verifiedMinorAt: verifiedMinorAt,
+      );
 
   /// Maps a Keycast account status to protected-minor state. A null status
-  /// (fetch failed / unavailable) or `verified_minor == false` is treated as
-  /// not protected — #174 is detection-only, so it fails to not-protected.
+  /// (fetch failed / unavailable) is preserved as unknown so enforcement
+  /// layers can choose their own fail-safe behavior; `verified_minor == false`
+  /// is the only confirmed not-protected response.
   factory ProtectedMinorStatus.fromKeycast(KeycastAccountStatus? status) {
-    if (status == null || !status.verifiedMinor) {
+    if (status == null) {
+      return ProtectedMinorStatus.unknown();
+    }
+    if (!status.verifiedMinor) {
       return ProtectedMinorStatus.notProtected();
     }
-    return ProtectedMinorStatus(
-      isProtectedMinor: true,
+    return ProtectedMinorStatus.protected(
       verifiedMinorAt: status.verifiedMinorAt,
     );
   }
 
-  final bool isProtectedMinor;
+  final ProtectedMinorStatusKind kind;
   final DateTime? verifiedMinorAt;
+
+  bool get isProtectedMinor => kind == ProtectedMinorStatusKind.protected;
+  bool get isKnown => kind != ProtectedMinorStatusKind.unknown;
 }

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -34,6 +34,16 @@ final protectedMinorRepositoryProvider = Provider<ProtectedMinorRepository>((
 /// Unauthenticated accounts are never protected. In debug builds a local
 /// override short-circuits the real fetch. Otherwise the repository reads the
 /// Keycast flag, failing to not-protected on any error (#174 is detection-only).
+///
+/// Notes for consumers (#175/#176):
+/// - Resolving this may trigger a Keycast token refresh via
+///   `getSessionOrRefresh()` (a network call + storage write) when the cached
+///   session is stale. In the common case a valid session is reused with no
+///   refresh.
+/// - This only recomputes when auth state changes. An account approved as a
+///   minor mid-session (no auth-state transition) will not refetch until the
+///   provider is invalidated — call `ref.invalidate(protectedMinorStatusProvider)`
+///   when fresh state is required.
 final protectedMinorStatusProvider = FutureProvider<ProtectedMinorStatus>((
   ref,
 ) async {

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -66,10 +66,18 @@ final protectedMinorStatusProvider = FutureProvider<ProtectedMinorStatus>((
   return ref.watch(protectedMinorRepositoryProvider).fetchCurrentStatus();
 });
 
-/// Convenience boolean for widgets/protections: true only once the status has
-/// resolved to a protected minor (loading/error read as not protected).
+/// Convenience boolean seam for the protections (#175/#176).
+///
+/// Reads the last-known status via `.value`, so a protected minor stays protected
+/// through a refetch (AsyncLoading) instead of flickering to not-protected —
+/// matching the blocking review gate, which reads `reviewStatusAsync.value`
+/// (`app_router.dart`). `false` only until the first resolution.
+///
+/// Note: the data layer still fails *open* to not-protected on a transient fetch
+/// error (a decided #174 detection behavior — a network blip resolves to
+/// not-protected). The enforcement fail-safe (retain protection across a
+/// transient error) is #175's to add on top of this seam.
 final isProtectedMinorProvider = Provider<bool>((ref) {
-  return ref
-      .watch(protectedMinorStatusProvider)
-      .maybeWhen(data: (s) => s.isProtectedMinor, orElse: () => false);
+  return ref.watch(protectedMinorStatusProvider).value?.isProtectedMinor ??
+      false;
 });

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -1,0 +1,65 @@
+// ABOUTME: Riverpod providers exposing the non-blocking protected-minor (13-15)
+// ABOUTME: state from Keycast's verified_minor flag, for #175/#176 to consume.
+
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/models/protected_minor_status.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/repositories/protected_minor_repository.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/protected_minor_override_service.dart';
+
+/// Developer-only override service (debug builds).
+final protectedMinorOverrideServiceProvider =
+    Provider<ProtectedMinorOverrideService>((ref) {
+      final prefs = ref.watch(sharedPreferencesProvider);
+      return ProtectedMinorOverrideService(prefs: prefs);
+    });
+
+/// Repository that reads `verified_minor` from Keycast for the current session.
+final protectedMinorRepositoryProvider = Provider<ProtectedMinorRepository>((
+  ref,
+) {
+  final oauthClient = ref.watch(oauthClientProvider);
+  return ProtectedMinorRepository(
+    oauthClient: oauthClient,
+    readAccessToken: () async =>
+        (await oauthClient.getSessionOrRefresh())?.accessToken,
+  );
+});
+
+/// Non-blocking protected-minor state for the authenticated account.
+///
+/// Unauthenticated accounts are never protected. In debug builds a local
+/// override short-circuits the real fetch. Otherwise the repository reads the
+/// Keycast flag, failing to not-protected on any error (#174 is detection-only).
+final protectedMinorStatusProvider = FutureProvider<ProtectedMinorStatus>((
+  ref,
+) async {
+  final authState = ref.watch(currentAuthStateProvider);
+  if (authState != AuthState.authenticated) {
+    return ProtectedMinorStatus.notProtected();
+  }
+
+  if (kDebugMode) {
+    final override = ref
+        .watch(protectedMinorOverrideServiceProvider)
+        .getOverride();
+    if (override != null) {
+      return override
+          ? const ProtectedMinorStatus(isProtectedMinor: true)
+          : ProtectedMinorStatus.notProtected();
+    }
+  }
+
+  return ref.watch(protectedMinorRepositoryProvider).fetchCurrentStatus();
+});
+
+/// Convenience boolean for widgets/protections: true only once the status has
+/// resolved to a protected minor (loading/error read as not protected).
+final isProtectedMinorProvider = Provider<bool>((ref) {
+  return ref
+      .watch(protectedMinorStatusProvider)
+      .maybeWhen(data: (s) => s.isProtectedMinor, orElse: () => false);
+});

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -33,7 +33,8 @@ final protectedMinorRepositoryProvider = Provider<ProtectedMinorRepository>((
 ///
 /// Unauthenticated accounts are never protected. In debug builds a local
 /// override short-circuits the real fetch. Otherwise the repository reads the
-/// Keycast flag, failing to not-protected on any error (#174 is detection-only).
+/// Keycast flag, preserving fetch failures as unknown so #175/#176 can choose
+/// their own enforcement posture.
 ///
 /// Notes for consumers (#175/#176):
 /// - Resolving this may trigger a Keycast token refresh via
@@ -58,7 +59,7 @@ final protectedMinorStatusProvider = FutureProvider<ProtectedMinorStatus>((
         .getOverride();
     if (override != null) {
       return override
-          ? const ProtectedMinorStatus(isProtectedMinor: true)
+          ? ProtectedMinorStatus.protected()
           : ProtectedMinorStatus.notProtected();
     }
   }
@@ -68,15 +69,15 @@ final protectedMinorStatusProvider = FutureProvider<ProtectedMinorStatus>((
 
 /// Convenience boolean seam for the protections (#175/#176).
 ///
-/// Reads the last-known status via `.value`, so a protected minor stays protected
-/// through a refetch (AsyncLoading) instead of flickering to not-protected —
-/// matching the blocking review gate, which reads `reviewStatusAsync.value`
-/// (`app_router.dart`). `false` only until the first resolution.
+/// Reads the last-known status via `.value`, so a protected minor stays
+/// protected through a refetch (AsyncLoading) instead of flickering to
+/// not-protected — matching the blocking review gate, which reads
+/// `reviewStatusAsync.value` (`app_router.dart`). `false` only until the first
+/// resolution.
 ///
-/// Note: the data layer still fails *open* to not-protected on a transient fetch
-/// error (a decided #174 detection behavior — a network blip resolves to
-/// not-protected). The enforcement fail-safe (retain protection across a
-/// transient error) is #175's to add on top of this seam.
+/// Note: unknown/error status is still exposed on [protectedMinorStatusProvider]
+/// for consumers that need to distinguish an unavailable check from confirmed
+/// not-protected.
 final isProtectedMinorProvider = Provider<bool>((ref) {
   return ref.watch(protectedMinorStatusProvider).value?.isProtectedMinor ??
       false;

--- a/mobile/lib/repositories/protected_minor_repository.dart
+++ b/mobile/lib/repositories/protected_minor_repository.dart
@@ -1,0 +1,36 @@
+// ABOUTME: Fetches the protected-minor state from Keycast (verified_minor) and
+// ABOUTME: maps it to ProtectedMinorStatus. Fails to not-protected on any error.
+
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:openvine/models/protected_minor_status.dart';
+
+/// Reads the durable approved-minor flag from Keycast's `GET /user/account`
+/// (via [KeycastOAuth.getAccountStatus]) and maps it to [ProtectedMinorStatus].
+///
+/// [readAccessToken] supplies the current Keycast bearer token; a null/empty
+/// token (e.g. a non-OAuth signer session) yields not-protected. Any failure
+/// fails to not-protected — detection-only for #174; #175/#176 will decide
+/// their own fail-safe posture when they attach real protections.
+class ProtectedMinorRepository {
+  ProtectedMinorRepository({
+    required KeycastOAuth oauthClient,
+    required Future<String?> Function() readAccessToken,
+  }) : _oauthClient = oauthClient,
+       _readAccessToken = readAccessToken;
+
+  final KeycastOAuth _oauthClient;
+  final Future<String?> Function() _readAccessToken;
+
+  Future<ProtectedMinorStatus> fetchCurrentStatus() async {
+    try {
+      final token = await _readAccessToken();
+      if (token == null || token.isEmpty) {
+        return ProtectedMinorStatus.notProtected();
+      }
+      final status = await _oauthClient.getAccountStatus(token);
+      return ProtectedMinorStatus.fromKeycast(status);
+    } catch (_) {
+      return ProtectedMinorStatus.notProtected();
+    }
+  }
+}

--- a/mobile/lib/repositories/protected_minor_repository.dart
+++ b/mobile/lib/repositories/protected_minor_repository.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Fetches the protected-minor state from Keycast (verified_minor) and
-// ABOUTME: maps it to ProtectedMinorStatus. Fails to not-protected on any error.
+// ABOUTME: maps it to ProtectedMinorStatus, preserving fetch failures as unknown.
 
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:openvine/models/protected_minor_status.dart';
@@ -8,9 +8,9 @@ import 'package:openvine/models/protected_minor_status.dart';
 /// (via [KeycastOAuth.getAccountStatus]) and maps it to [ProtectedMinorStatus].
 ///
 /// [readAccessToken] supplies the current Keycast bearer token; a null/empty
-/// token (e.g. a non-OAuth signer session) yields not-protected. Any failure
-/// fails to not-protected — detection-only for #174; #175/#176 will decide
-/// their own fail-safe posture when they attach real protections.
+/// token (e.g. a non-OAuth signer session) yields not-protected. Keycast fetch
+/// failure yields unknown so #175/#176 can decide their own fail-safe posture
+/// when they attach real protections.
 class ProtectedMinorRepository {
   ProtectedMinorRepository({
     required KeycastOAuth oauthClient,
@@ -30,7 +30,7 @@ class ProtectedMinorRepository {
       final status = await _oauthClient.getAccountStatus(token);
       return ProtectedMinorStatus.fromKeycast(status);
     } catch (_) {
-      return ProtectedMinorStatus.notProtected();
+      return ProtectedMinorStatus.unknown();
     }
   }
 }

--- a/mobile/lib/repositories/protected_minor_repository.dart
+++ b/mobile/lib/repositories/protected_minor_repository.dart
@@ -4,7 +4,7 @@
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:openvine/models/protected_minor_status.dart';
 
-/// Reads the durable approved-minor flag from Keycast's `GET /user/account`
+/// Reads the durable approved-minor flag from Keycast's `GET /api/user/account`
 /// (via [KeycastOAuth.getAccountStatus]) and maps it to [ProtectedMinorStatus].
 ///
 /// [readAccessToken] supplies the current Keycast bearer token; a null/empty

--- a/mobile/lib/services/protected_minor_override_service.dart
+++ b/mobile/lib/services/protected_minor_override_service.dart
@@ -1,0 +1,25 @@
+// ABOUTME: Developer-only local override for simulating the protected-minor
+// ABOUTME: (13-15) state without a real approved-minor account. Debug builds only.
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Stores a debug-only override for the protected-minor state so QA can
+/// exercise the #175/#176 protections without a real approved-minor account.
+///
+/// `null` means "no override" (use the real Keycast flag); `true`/`false`
+/// force protected / not-protected respectively.
+class ProtectedMinorOverrideService {
+  ProtectedMinorOverrideService({required SharedPreferences prefs})
+    : _prefs = prefs;
+
+  static const _prefsKey = 'protected_minor_override';
+
+  final SharedPreferences _prefs;
+
+  bool? getOverride() => _prefs.getBool(_prefsKey);
+
+  Future<void> setOverride(bool isProtectedMinor) =>
+      _prefs.setBool(_prefsKey, isProtectedMinor);
+
+  Future<void> clear() => _prefs.remove(_prefsKey);
+}

--- a/mobile/lib/services/protected_minor_override_service.dart
+++ b/mobile/lib/services/protected_minor_override_service.dart
@@ -21,5 +21,5 @@ class ProtectedMinorOverrideService {
   Future<void> setOverride(bool isProtectedMinor) =>
       _prefs.setBool(_prefsKey, isProtectedMinor);
 
-  Future<void> clear() => _prefs.remove(_prefsKey);
+  Future<void> clearOverride() => _prefs.remove(_prefsKey);
 }

--- a/mobile/packages/keycast_flutter/lib/keycast_flutter.dart
+++ b/mobile/packages/keycast_flutter/lib/keycast_flutter.dart
@@ -4,6 +4,7 @@
 export 'src/crypto/key_utils.dart';
 export 'src/models/exceptions.dart';
 export 'src/models/keycast_session.dart';
+export 'src/oauth/account_status.dart';
 export 'src/oauth/callback_result.dart';
 export 'src/oauth/headless_models.dart';
 export 'src/oauth/oauth_client.dart';

--- a/mobile/packages/keycast_flutter/lib/src/oauth/account_status.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/account_status.dart
@@ -1,7 +1,7 @@
-// ABOUTME: Parsed GET /user/account response from Keycast, including the
+// ABOUTME: Parsed GET /api/user/account response from Keycast, including the
 // ABOUTME: durable approved-minor flag (verified_minor, keycast#263).
 
-/// Account status returned by Keycast's `GET /user/account`.
+/// Account status returned by Keycast's `GET /api/user/account`.
 ///
 /// [verifiedMinor] is the durable approved-minor (13-15) flag and is always
 /// present; [verifiedMinorAt] is set only when the account was flagged.

--- a/mobile/packages/keycast_flutter/lib/src/oauth/account_status.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/account_status.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Parsed GET /user/account response from Keycast, including the
+// ABOUTME: durable approved-minor flag (verified_minor, keycast#263).
+
+/// Account status returned by Keycast's `GET /user/account`.
+///
+/// [verifiedMinor] is the durable approved-minor (13-15) flag and is always
+/// present; [verifiedMinorAt] is set only when the account was flagged.
+class KeycastAccountStatus {
+  const KeycastAccountStatus({
+    required this.email,
+    required this.emailVerified,
+    required this.publicKey,
+    required this.verifiedMinor,
+    this.accountStatus,
+    this.suspendedReason,
+    this.verifiedMinorAt,
+  });
+
+  factory KeycastAccountStatus.fromJson(Map<String, dynamic> json) {
+    final verifiedMinorAtRaw = json['verified_minor_at'] as String?;
+    return KeycastAccountStatus(
+      email: json['email'] as String? ?? '',
+      emailVerified: json['email_verified'] as bool? ?? false,
+      publicKey: json['public_key'] as String? ?? '',
+      accountStatus: json['account_status'] as String?,
+      suspendedReason: json['suspended_reason'] as String?,
+      verifiedMinor: json['verified_minor'] as bool? ?? false,
+      verifiedMinorAt: verifiedMinorAtRaw == null
+          ? null
+          : DateTime.tryParse(verifiedMinorAtRaw),
+    );
+  }
+
+  final String email;
+  final bool emailVerified;
+  final String publicKey;
+
+  /// Present only when the account is not active (suspended/banned/etc.).
+  final String? accountStatus;
+  final String? suspendedReason;
+
+  /// Durable approved-minor (13-15) flag. Independent of [accountStatus] —
+  /// an approved minor is active, so this can be true on a normal account.
+  final bool verifiedMinor;
+  final DateTime? verifiedMinorAt;
+}

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -733,10 +733,7 @@ class KeycastOAuth {
       final response = await _client
           .get(
             Uri.parse('${config.serverUrl}/api/user/account'),
-            headers: {
-              'Authorization': 'Bearer $token',
-              'Content-Type': 'application/json',
-            },
+            headers: {'Authorization': 'Bearer $token'},
           )
           .timeout(requestTimeout);
 

--- a/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
+++ b/mobile/packages/keycast_flutter/lib/src/oauth/oauth_client.dart
@@ -9,6 +9,7 @@ import 'package:http/http.dart' as http;
 import 'package:keycast_flutter/src/crypto/key_utils.dart';
 import 'package:keycast_flutter/src/models/exceptions.dart';
 import 'package:keycast_flutter/src/models/keycast_session.dart';
+import 'package:keycast_flutter/src/oauth/account_status.dart';
 import 'package:keycast_flutter/src/oauth/callback_result.dart';
 import 'package:keycast_flutter/src/oauth/headless_models.dart';
 import 'package:keycast_flutter/src/oauth/oauth_config.dart';
@@ -718,6 +719,32 @@ class KeycastOAuth {
         'Network error: $e',
         failure: KeycastAuthFailure.network,
       );
+    }
+  }
+
+  /// Fetch the current account status from Keycast, including the durable
+  /// approved-minor flag (`verified_minor`, keycast#263).
+  ///
+  /// Requires an active bearer [token]. Returns the parsed
+  /// [KeycastAccountStatus], or null on any non-200 response, timeout, or
+  /// network/parse error — callers treat null as "unknown / not a minor".
+  Future<KeycastAccountStatus?> getAccountStatus(String token) async {
+    try {
+      final response = await _client
+          .get(
+            Uri.parse('${config.serverUrl}/api/user/account'),
+            headers: {
+              'Authorization': 'Bearer $token',
+              'Content-Type': 'application/json',
+            },
+          )
+          .timeout(requestTimeout);
+
+      if (response.statusCode != 200) return null;
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      return KeycastAccountStatus.fromJson(json);
+    } catch (_) {
+      return null;
     }
   }
 

--- a/mobile/packages/keycast_flutter/test/account_status_test.dart
+++ b/mobile/packages/keycast_flutter/test/account_status_test.dart
@@ -1,0 +1,84 @@
+// ABOUTME: Tests for KeycastAccountStatus parsing and getAccountStatus over HTTP
+// ABOUTME: Covers the GET /user/account verified_minor contract (keycast#263)
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:keycast_flutter/src/oauth/account_status.dart';
+import 'package:keycast_flutter/src/oauth/oauth_client.dart';
+import 'package:keycast_flutter/src/oauth/oauth_config.dart';
+
+void main() {
+  group('KeycastAccountStatus.fromJson', () {
+    test('parses an approved minor with timestamp', () {
+      final status = KeycastAccountStatus.fromJson({
+        'email': 'a@b.com',
+        'email_verified': true,
+        'public_key': 'abc',
+        'verified_minor': true,
+        'verified_minor_at': '2026-06-30T12:00:00Z',
+      });
+
+      expect(status.verifiedMinor, isTrue);
+      expect(status.verifiedMinorAt, DateTime.utc(2026, 6, 30, 12));
+      expect(status.email, 'a@b.com');
+      expect(status.emailVerified, isTrue);
+      expect(status.publicKey, 'abc');
+    });
+
+    test('defaults verified_minor false and timestamp null when absent', () {
+      final status = KeycastAccountStatus.fromJson({
+        'email': 'a@b.com',
+        'email_verified': false,
+        'public_key': 'abc',
+      });
+
+      expect(status.verifiedMinor, isFalse);
+      expect(status.verifiedMinorAt, isNull);
+    });
+  });
+
+  group('KeycastOAuth.getAccountStatus', () {
+    const config = OAuthConfig(
+      serverUrl: 'https://login.divine.video',
+      clientId: 'test-client',
+      redirectUri: 'divine://oauth/callback',
+    );
+
+    test(
+      'GETs /api/user/account with bearer token and parses the flag',
+      () async {
+        late http.Request captured;
+        final client = MockClient((request) async {
+          captured = request;
+          return http.Response(
+            '{"email":"a@b.com","email_verified":true,"public_key":"abc",'
+            '"verified_minor":true,"verified_minor_at":"2026-06-30T12:00:00Z"}',
+            200,
+          );
+        });
+        final oauth = KeycastOAuth(config: config, httpClient: client);
+
+        final status = await oauth.getAccountStatus('tok123');
+
+        expect(captured.method, 'GET');
+        expect(
+          captured.url.toString(),
+          'https://login.divine.video/api/user/account',
+        );
+        expect(captured.headers['Authorization'], 'Bearer tok123');
+        expect(status, isNotNull);
+        expect(status!.verifiedMinor, isTrue);
+      },
+    );
+
+    test('returns null on server error', () async {
+      final client = MockClient((request) async => http.Response('err', 500));
+      final oauth = KeycastOAuth(config: config, httpClient: client);
+
+      final status = await oauth.getAccountStatus('tok');
+
+      expect(status, isNull);
+    });
+  });
+}

--- a/mobile/packages/keycast_flutter/test/account_status_test.dart
+++ b/mobile/packages/keycast_flutter/test/account_status_test.dart
@@ -36,6 +36,19 @@ void main() {
       expect(status.verifiedMinor, isFalse);
       expect(status.verifiedMinorAt, isNull);
     });
+
+    test('keeps verified_minor true but null timestamp on a bad date', () {
+      final status = KeycastAccountStatus.fromJson({
+        'email': 'a@b.com',
+        'email_verified': true,
+        'public_key': 'abc',
+        'verified_minor': true,
+        'verified_minor_at': 'not-a-date',
+      });
+
+      expect(status.verifiedMinor, isTrue);
+      expect(status.verifiedMinorAt, isNull);
+    });
   });
 
   group('KeycastOAuth.getAccountStatus', () {

--- a/mobile/test/models/protected_minor_status_test.dart
+++ b/mobile/test/models/protected_minor_status_test.dart
@@ -20,17 +20,28 @@ KeycastAccountStatus _status({
 
 void main() {
   group('ProtectedMinorStatus', () {
-    test('notProtected() is not a protected minor', () {
-      final s = ProtectedMinorStatus.notProtected();
+    test('unknown() is not known and not a protected minor', () {
+      final s = ProtectedMinorStatus.unknown();
+      expect(s.kind, ProtectedMinorStatusKind.unknown);
+      expect(s.isKnown, isFalse);
       expect(s.isProtectedMinor, isFalse);
       expect(s.verifiedMinorAt, isNull);
     });
 
-    test('fromKeycast(null) -> not protected', () {
-      expect(
-        ProtectedMinorStatus.fromKeycast(null).isProtectedMinor,
-        isFalse,
-      );
+    test('notProtected() is known and not a protected minor', () {
+      final s = ProtectedMinorStatus.notProtected();
+      expect(s.kind, ProtectedMinorStatusKind.notProtected);
+      expect(s.isKnown, isTrue);
+      expect(s.isProtectedMinor, isFalse);
+      expect(s.verifiedMinorAt, isNull);
+    });
+
+    test('fromKeycast(null) -> unknown', () {
+      final status = ProtectedMinorStatus.fromKeycast(null);
+
+      expect(status.kind, ProtectedMinorStatusKind.unknown);
+      expect(status.isKnown, isFalse);
+      expect(status.isProtectedMinor, isFalse);
     });
 
     test('verified_minor true -> protected, carries timestamp', () {
@@ -38,17 +49,20 @@ void main() {
       final s = ProtectedMinorStatus.fromKeycast(
         _status(verifiedMinor: true, verifiedMinorAt: at),
       );
+      expect(s.kind, ProtectedMinorStatusKind.protected);
+      expect(s.isKnown, isTrue);
       expect(s.isProtectedMinor, isTrue);
       expect(s.verifiedMinorAt, at);
     });
 
     test('verified_minor false -> not protected', () {
-      expect(
-        ProtectedMinorStatus.fromKeycast(
-          _status(verifiedMinor: false),
-        ).isProtectedMinor,
-        isFalse,
+      final status = ProtectedMinorStatus.fromKeycast(
+        _status(verifiedMinor: false),
       );
+
+      expect(status.kind, ProtectedMinorStatusKind.notProtected);
+      expect(status.isKnown, isTrue);
+      expect(status.isProtectedMinor, isFalse);
     });
   });
 }

--- a/mobile/test/models/protected_minor_status_test.dart
+++ b/mobile/test/models/protected_minor_status_test.dart
@@ -1,0 +1,54 @@
+// ABOUTME: Tests mapping Keycast account status to the protected-minor state
+// ABOUTME: Covers #174 detection semantics (verified_minor -> protected)
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:openvine/models/protected_minor_status.dart';
+
+KeycastAccountStatus _status({
+  required bool verifiedMinor,
+  DateTime? verifiedMinorAt,
+}) {
+  return KeycastAccountStatus(
+    email: 'a@b.com',
+    emailVerified: true,
+    publicKey: 'abc',
+    verifiedMinor: verifiedMinor,
+    verifiedMinorAt: verifiedMinorAt,
+  );
+}
+
+void main() {
+  group('ProtectedMinorStatus', () {
+    test('notProtected() is not a protected minor', () {
+      final s = ProtectedMinorStatus.notProtected();
+      expect(s.isProtectedMinor, isFalse);
+      expect(s.verifiedMinorAt, isNull);
+    });
+
+    test('fromKeycast(null) -> not protected', () {
+      expect(
+        ProtectedMinorStatus.fromKeycast(null).isProtectedMinor,
+        isFalse,
+      );
+    });
+
+    test('verified_minor true -> protected, carries timestamp', () {
+      final at = DateTime.utc(2026, 6, 30, 12);
+      final s = ProtectedMinorStatus.fromKeycast(
+        _status(verifiedMinor: true, verifiedMinorAt: at),
+      );
+      expect(s.isProtectedMinor, isTrue);
+      expect(s.verifiedMinorAt, at);
+    });
+
+    test('verified_minor false -> not protected', () {
+      expect(
+        ProtectedMinorStatus.fromKeycast(
+          _status(verifiedMinor: false),
+        ).isProtectedMinor,
+        isFalse,
+      );
+    });
+  });
+}

--- a/mobile/test/providers/protected_minor_providers_test.dart
+++ b/mobile/test/providers/protected_minor_providers_test.dart
@@ -1,0 +1,46 @@
+// ABOUTME: Tests protectedMinorStatusProvider guard branches (#174):
+// ABOUTME: unauthenticated -> not protected, debug override forces protected.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/auth_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('unauthenticated resolves to not-protected without any fetch', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        currentAuthStateProvider.overrideWithValue(AuthState.unauthenticated),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final status = await container.read(protectedMinorStatusProvider.future);
+
+    expect(status.isProtectedMinor, isFalse);
+  });
+
+  test('debug override forces protected when authenticated', () async {
+    SharedPreferences.setMockInitialValues({'protected_minor_override': true});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+        sharedPreferencesProvider.overrideWithValue(prefs),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final status = await container.read(protectedMinorStatusProvider.future);
+
+    expect(status.isProtectedMinor, isTrue);
+  });
+}

--- a/mobile/test/providers/protected_minor_providers_test.dart
+++ b/mobile/test/providers/protected_minor_providers_test.dart
@@ -97,4 +97,29 @@ void main() {
       expect(status.verifiedMinorAt, DateTime.utc(2026, 6, 30, 12));
     },
   );
+
+  test(
+    'isProtectedMinorProvider: false until resolved, true once protected',
+    () async {
+      SharedPreferences.setMockInitialValues({
+        'protected_minor_override': true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      // Before the async status resolves, the seam reads false (safe default).
+      expect(container.read(isProtectedMinorProvider), isFalse);
+
+      // After resolution (override forces protected) it reads true, and reading
+      // via `.value` means it won't flicker back to false on a later refetch.
+      await container.read(protectedMinorStatusProvider.future);
+      expect(container.read(isProtectedMinorProvider), isTrue);
+    },
+  );
 }

--- a/mobile/test/providers/protected_minor_providers_test.dart
+++ b/mobile/test/providers/protected_minor_providers_test.dart
@@ -1,8 +1,13 @@
 // ABOUTME: Tests protectedMinorStatusProvider guard branches (#174):
 // ABOUTME: unauthenticated -> not protected, debug override forces protected.
 
-import 'package:flutter_test/flutter_test.dart';
+import 'dart:convert';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
@@ -43,4 +48,53 @@ void main() {
 
     expect(status.isProtectedMinor, isTrue);
   });
+
+  test(
+    'authenticated: real path reads session token and fetches the flag',
+    () async {
+      SharedPreferences.setMockInitialValues({}); // no override -> real fetch
+      final prefs = await SharedPreferences.getInstance();
+
+      // Seed a valid Keycast session so getSessionOrRefresh() yields its token.
+      final storage = MemoryKeycastStorage();
+      final session = KeycastSession(
+        bunkerUrl: 'bunker://t',
+        accessToken: 'tok123',
+        expiresAt: DateTime.now().add(const Duration(hours: 1)),
+      );
+      await storage.write('keycast_session', jsonEncode(session.toJson()));
+
+      final oauth = KeycastOAuth(
+        config: const OAuthConfig(
+          serverUrl: 'https://login.divine.video',
+          clientId: 'c',
+          redirectUri: 'divine://cb',
+        ),
+        storage: storage,
+        httpClient: MockClient((req) async {
+          // Proves the provider threads the session token into the request.
+          expect(req.headers['Authorization'], 'Bearer tok123');
+          return http.Response(
+            '{"email":"a","email_verified":true,"public_key":"p",'
+            '"verified_minor":true,"verified_minor_at":"2026-06-30T12:00:00Z"}',
+            200,
+          );
+        }),
+      );
+
+      final container = ProviderContainer(
+        overrides: [
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          oauthClientProvider.overrideWithValue(oauth),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final status = await container.read(protectedMinorStatusProvider.future);
+
+      expect(status.isProtectedMinor, isTrue);
+      expect(status.verifiedMinorAt, DateTime.utc(2026, 6, 30, 12));
+    },
+  );
 }

--- a/mobile/test/repositories/protected_minor_repository_test.dart
+++ b/mobile/test/repositories/protected_minor_repository_test.dart
@@ -68,7 +68,7 @@ void main() {
       expect(s.isProtectedMinor, isFalse);
     });
 
-    test('not protected (fails safe) when reading the token throws', () async {
+    test('not protected (fails open) when reading the token throws', () async {
       final repo = ProtectedMinorRepository(
         oauthClient: _oauthReturning(_minorBody, 200),
         readAccessToken: () async => throw Exception('boom'),

--- a/mobile/test/repositories/protected_minor_repository_test.dart
+++ b/mobile/test/repositories/protected_minor_repository_test.dart
@@ -1,0 +1,60 @@
+// ABOUTME: Tests the protected-minor repository: token gating, mapping, and
+// ABOUTME: fail-closed-to-not-protected behavior on errors (#174)
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:openvine/repositories/protected_minor_repository.dart';
+
+KeycastOAuth _oauthReturning(String body, int status) {
+  return KeycastOAuth(
+    config: const OAuthConfig(
+      serverUrl: 'https://login.divine.video',
+      clientId: 'c',
+      redirectUri: 'divine://cb',
+    ),
+    httpClient: MockClient((_) async => http.Response(body, status)),
+  );
+}
+
+const _minorBody =
+    '{"email":"a","email_verified":true,"public_key":"p",'
+    '"verified_minor":true,"verified_minor_at":"2026-06-30T12:00:00Z"}';
+
+void main() {
+  group('ProtectedMinorRepository.fetchCurrentStatus', () {
+    test('protected when keycast reports verified_minor true', () async {
+      final repo = ProtectedMinorRepository(
+        oauthClient: _oauthReturning(_minorBody, 200),
+        readAccessToken: () async => 'tok',
+      );
+
+      final s = await repo.fetchCurrentStatus();
+
+      expect(s.isProtectedMinor, isTrue);
+    });
+
+    test('not protected when there is no access token', () async {
+      final repo = ProtectedMinorRepository(
+        oauthClient: _oauthReturning(_minorBody, 200),
+        readAccessToken: () async => null,
+      );
+
+      final s = await repo.fetchCurrentStatus();
+
+      expect(s.isProtectedMinor, isFalse);
+    });
+
+    test('not protected on server error', () async {
+      final repo = ProtectedMinorRepository(
+        oauthClient: _oauthReturning('err', 500),
+        readAccessToken: () async => 'tok',
+      );
+
+      final s = await repo.fetchCurrentStatus();
+
+      expect(s.isProtectedMinor, isFalse);
+    });
+  });
+}

--- a/mobile/test/repositories/protected_minor_repository_test.dart
+++ b/mobile/test/repositories/protected_minor_repository_test.dart
@@ -1,5 +1,5 @@
 // ABOUTME: Tests the protected-minor repository: token gating, mapping, and
-// ABOUTME: fail-closed-to-not-protected behavior on errors (#174)
+// ABOUTME: fail-open-to-not-protected behavior on errors (#174)
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;

--- a/mobile/test/repositories/protected_minor_repository_test.dart
+++ b/mobile/test/repositories/protected_minor_repository_test.dart
@@ -56,5 +56,27 @@ void main() {
 
       expect(s.isProtectedMinor, isFalse);
     });
+
+    test('not protected when the access token is empty', () async {
+      final repo = ProtectedMinorRepository(
+        oauthClient: _oauthReturning(_minorBody, 200),
+        readAccessToken: () async => '',
+      );
+
+      final s = await repo.fetchCurrentStatus();
+
+      expect(s.isProtectedMinor, isFalse);
+    });
+
+    test('not protected (fails safe) when reading the token throws', () async {
+      final repo = ProtectedMinorRepository(
+        oauthClient: _oauthReturning(_minorBody, 200),
+        readAccessToken: () async => throw Exception('boom'),
+      );
+
+      final s = await repo.fetchCurrentStatus();
+
+      expect(s.isProtectedMinor, isFalse);
+    });
   });
 }

--- a/mobile/test/repositories/protected_minor_repository_test.dart
+++ b/mobile/test/repositories/protected_minor_repository_test.dart
@@ -1,10 +1,11 @@
 // ABOUTME: Tests the protected-minor repository: token gating, mapping, and
-// ABOUTME: fail-open-to-not-protected behavior on errors (#174)
+// ABOUTME: unknown status on Keycast fetch errors (#174)
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:openvine/models/protected_minor_status.dart';
 import 'package:openvine/repositories/protected_minor_repository.dart';
 
 KeycastOAuth _oauthReturning(String body, int status) {
@@ -46,7 +47,7 @@ void main() {
       expect(s.isProtectedMinor, isFalse);
     });
 
-    test('not protected on server error', () async {
+    test('unknown on server error', () async {
       final repo = ProtectedMinorRepository(
         oauthClient: _oauthReturning('err', 500),
         readAccessToken: () async => 'tok',
@@ -54,6 +55,8 @@ void main() {
 
       final s = await repo.fetchCurrentStatus();
 
+      expect(s.kind, ProtectedMinorStatusKind.unknown);
+      expect(s.isKnown, isFalse);
       expect(s.isProtectedMinor, isFalse);
     });
 
@@ -68,7 +71,7 @@ void main() {
       expect(s.isProtectedMinor, isFalse);
     });
 
-    test('not protected (fails open) when reading the token throws', () async {
+    test('unknown when reading the token throws', () async {
       final repo = ProtectedMinorRepository(
         oauthClient: _oauthReturning(_minorBody, 200),
         readAccessToken: () async => throw Exception('boom'),
@@ -76,6 +79,8 @@ void main() {
 
       final s = await repo.fetchCurrentStatus();
 
+      expect(s.kind, ProtectedMinorStatusKind.unknown);
+      expect(s.isKnown, isFalse);
       expect(s.isProtectedMinor, isFalse);
     });
   });

--- a/mobile/test/services/protected_minor_override_service_test.dart
+++ b/mobile/test/services/protected_minor_override_service_test.dart
@@ -1,0 +1,26 @@
+// ABOUTME: Tests the debug-only protected-minor override service (#174 QA aid)
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/protected_minor_override_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('override is null by default, then reflects set and clear', () async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final service = ProtectedMinorOverrideService(prefs: prefs);
+
+    expect(service.getOverride(), isNull);
+
+    await service.setOverride(true);
+    expect(service.getOverride(), isTrue);
+
+    await service.setOverride(false);
+    expect(service.getOverride(), isFalse);
+
+    await service.clear();
+    expect(service.getOverride(), isNull);
+  });
+}

--- a/mobile/test/services/protected_minor_override_service_test.dart
+++ b/mobile/test/services/protected_minor_override_service_test.dart
@@ -20,7 +20,7 @@ void main() {
     await service.setOverride(false);
     expect(service.getOverride(), isFalse);
 
-    await service.clear();
+    await service.clearOverride();
     expect(service.getOverride(), isNull);
   });
 }


### PR DESCRIPTION
## What

Client foundation for protected-minor (13-15) safeguards on mobile: detect an approved minor via Keycast's `verified_minor` flag and expose a **non-blocking** protected-minor state for the content-lock and DM-restriction work to consume.

Closes #5730.

Part of the protected-minor safeguards epic raised by Liz and tracked privately in the T&S repo. Consumes the `divinevideo/keycast#263` `GET /api/user/account` contract.

**Scope is detection + state only** — no protections, no UI/router changes.

## Design

- Reads `verified_minor` **directly from Keycast** (`GET /api/user/account`), per the epic decision — independent of the relay-manager `moderation-status` pipeline that drives the existing *blocking* under-review gate.
- The new state is deliberately **separate** from the blocking `restrictedMinorReview` machinery (`minor_account_review_*`); a protected minor may use the app.
- `ProtectedMinorStatus` is tri-state: `protected`, `notProtected`, or `unknown`.
- Unauthenticated accounts and accounts without a Keycast token resolve as not protected.
- Keycast fetch/parsing failures resolve as `unknown`, not confirmed not-protected, so enforcement work can choose the correct fail-safe behavior when it attaches real protections.

### Components

- `keycast_flutter`: `KeycastAccountStatus` model + `KeycastOAuth.getAccountStatus(token)` (mirrors the existing `deleteAccount` endpoint).
- app: `ProtectedMinorStatus`, `ProtectedMinorRepository`, `protectedMinorStatusProvider` + `isProtectedMinorProvider` (the seam future protections watch), and a `kDebugMode` `ProtectedMinorOverrideService`.

Hand-written `Provider`/`FutureProvider` (no `@riverpod` codegen) — no `.g.dart` regeneration.

## Tests

Covered by model, repository, provider, override-service, and Keycast client tests:

- keycast: parse `verified_minor` true/false/missing/bad-timestamp; `getAccountStatus` asserts method + URL + bearer header, and null on 5xx.
- app model: unknown/not-protected/protected mapping, including null Keycast status -> unknown.
- repository: protected response, no-token/empty-token not protected, server error and token-read error unknown.
- providers: unauthenticated guard, debug override, real provider -> repository token seam, and boolean provider behavior.

## Validation

- `flutter test test/models/protected_minor_status_test.dart test/repositories/protected_minor_repository_test.dart test/providers/protected_minor_providers_test.dart test/services/protected_minor_override_service_test.dart`
- `flutter test test/account_status_test.dart` from `mobile/packages/keycast_flutter`
- `flutter analyze`
- Pre-push hook: no merge conflicts, changed-file analyzer, changed-file tests

## Follow-ups

- Dev-options UI toggle for the debug override.
- Web parity and the protections themselves.
