### PR TITLE
fix(notifications): map kind-16 reposts when notification_type is absent

### DIFF
--- a/mobile/packages/notification_repository/lib/src/notification_repository.dart
+++ b/mobile/packages/notification_repository/lib/src/notification_repository.dart
@@ -1629,6 +1629,7 @@ class NotificationRepository {
       'mention' => NotificationKind.mention,
       'follow' || 'contact' => NotificationKind.follow,
       _ when n.sourceKind == 6 => NotificationKind.repost,
+      _ when n.sourceKind == 16 => NotificationKind.repost,
       _ when n.sourceKind == 3 => NotificationKind.follow,
       _ when n.sourceKind == 1 => NotificationKind.comment,
       _ => NotificationKind.system,

--- a/mobile/packages/notification_repository/test/src/notification_repository_test.dart
+++ b/mobile/packages/notification_repository/test/src/notification_repository_test.dart
@@ -1585,6 +1585,20 @@ void main() {
         expect(item.type, equals(NotificationKind.repost));
       });
 
+      test(
+        'kind 16 generic repost with no type falls back to repost',
+        () async {
+          stubNotifications([
+            makeNotification(notificationType: '', sourceKind: 16),
+          ]);
+          stubProfiles({});
+
+          final page = await repository.getNotifications();
+          final item = page.items.single as VideoNotification;
+          expect(item.type, equals(NotificationKind.repost));
+        },
+      );
+
       test('mention maps to mention ($ActorNotification)', () async {
         stubNotifications([
           makeNotification(


### PR DESCRIPTION
Closes #5710

## What

`_mapNotificationKind` in `notification_repository.dart` already falls back on `sourceKind` for kinds **6** (repost), **3** (follow) and **1** (comment) when the server sends an empty/unrecognized `notification_type`. It had **no arm for kind 16** — NIP-18 *generic* reposts of addressable videos, which is exactly what divine publishes (`nostr_client.dart::sendGenericRepost`, `EventKind.genericRepost`). Such a row fell through to `NotificationKind.system` and rendered as a generic actor row instead of a repost.

This adds the missing `sourceKind == 16 => repost` arm next to the existing `sourceKind == 6` one, plus a unit test.

## Why this is hardening, not the reported break

Funnelcake currently **always** stamps `notification_type` (`notification_type_for_candidate` returns `"repost"` for both kind 6 and 16), so today the string-match arm handles kind-16 reposts before the fallback is reached. This closes the gap for the empty/unknown-type path so it matches the other three sourceKind fallbacks.

Context: part of triaging a user report that comments/reposts/follows are missing from notifications. That symptom is **not** caused by this — it traces to the funnelcake notification-inbox materializer (see divinevideo/divine-funnelcake#432) and the intentional kind-3 follow removal. This is a small correctness/consistency fix surfaced during that investigation.

## Testing

- `flutter test` (notification_repository mapping group) — all pass, including new `kind 16 generic repost with no type falls back to repost`.
- `flutter analyze lib test` — no issues.
- `dart format` — clean.

Related: divine-mobile#4200 (notifications epic)