### PR TITLE
test(auth): characterization gap-fill before auth_service extraction (#4741)

### DIFF
--- a/mobile/test/services/auth_service_amber_test.dart
+++ b/mobile/test/services/auth_service_amber_test.dart
@@ -1,0 +1,245 @@
+// ABOUTME: Unit tests for AuthService NIP-55 Amber (Android signer) sign-in and
+// ABOUTME: session-restore flows. Runs on CI without an emulator via channel mocks.
+//
+// Covers the previously-uncovered Amber concern (#4741 PR1 gap-fill): the
+// connectWithAmber platform/availability guards and the _reconnectAmber restore
+// path reached through initialize(). The Amber signer talks to the native
+// `nostrmoPlugin` MethodChannel, which is stubbed here; AndroidNostrSigner is
+// constructed with a known pubkey on the restore path, so no intent round-trip
+// is needed.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_identity.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+/// Runs [body] while silencing unhandled async errors from the fire-and-forget
+/// _performDiscovery() that initialize()/reconnect kicks off (it attempts real
+/// relay WebSocket connections which fail fast in the test environment).
+Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
+  final completer = Completer<T>();
+  runZonedGuarded(
+    () async {
+      try {
+        completer.complete(await body());
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    },
+    (_, _) {},
+  );
+  return completer.future;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AuthService NIP-55 Amber', () {
+    late _MockUserDataCleanupService mockCleanupService;
+    late Map<String, String> secureStorage;
+    late bool androidSignerInstalled;
+
+    setUp(() {
+      mockCleanupService = _MockUserDataCleanupService();
+      when(
+        () => mockCleanupService.shouldClearDataForUser(any()),
+      ).thenReturn(false);
+      when(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: any(named: 'reason'),
+          isIdentityChange: any(named: 'isIdentityChange'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
+
+      secureStorage = {};
+      androidSignerInstalled = true;
+
+      const secureStorageChannel = MethodChannel(
+        'plugins.it_nomads.com/flutter_secure_storage',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(secureStorageChannel, (call) async {
+            switch (call.method) {
+              case 'read':
+                return secureStorage[call.arguments['key'] as String?];
+              case 'write':
+                final key = call.arguments['key'] as String?;
+                final value = call.arguments['value'] as String?;
+                if (key != null && value != null) secureStorage[key] = value;
+                return null;
+              case 'delete':
+                secureStorage.remove(call.arguments['key'] as String?);
+                return null;
+              case 'deleteAll':
+                secureStorage.clear();
+                return null;
+              case 'readAll':
+                return secureStorage;
+              case 'containsKey':
+                return secureStorage.containsKey(
+                  call.arguments['key'] as String?,
+                );
+              case 'getCapabilities':
+                return {'basicSecureStorage': true};
+              default:
+                return null;
+            }
+          });
+
+      const capabilityChannel = MethodChannel('openvine.secure_storage');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(capabilityChannel, (call) async {
+            if (call.method == 'getCapabilities') {
+              return {
+                'hasHardwareSecurity': false,
+                'hasBiometrics': false,
+                'hasKeychain': true,
+              };
+            }
+            return null;
+          });
+
+      // Native NIP-55 signer probe. existAndroidNostrSigner reflects the
+      // per-test [androidSignerInstalled] flag.
+      const androidPluginChannel = MethodChannel('nostrmoPlugin');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(androidPluginChannel, (call) async {
+            if (call.method == 'existAndroidNostrSigner') {
+              return androidSignerInstalled;
+            }
+            return null;
+          });
+    });
+
+    tearDown(() {
+      debugDefaultTargetPlatformOverride = null;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        ..setMockMethodCallHandler(
+          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+          null,
+        )
+        ..setMockMethodCallHandler(
+          const MethodChannel('openvine.secure_storage'),
+          null,
+        )
+        ..setMockMethodCallHandler(const MethodChannel('nostrmoPlugin'), null);
+    });
+
+    AuthService createAuthService() {
+      final keyStorage = SecureKeyStorage(
+        securityConfig: const SecurityConfig(requireHardwareBacked: false),
+      );
+      return AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: keyStorage,
+        flutterSecureStorage: const FlutterSecureStorage(),
+      );
+    }
+
+    String freshPubkey() =>
+        SecureKeyContainer.fromPrivateKeyHex(generatePrivateKey()).publicKeyHex;
+
+    group('connectWithAmber', () {
+      test('returns failure on non-Android platforms', () async {
+        SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+        debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        final result = await authService.connectWithAmber();
+
+        expect(result.success, isFalse);
+        expect(
+          result.errorMessage,
+          contains('Android signer only supported on Android'),
+        );
+        expect(authService.isAuthenticated, isFalse);
+        expect(authService.currentIdentity, isNull);
+      });
+
+      test('returns failure when no signer app is installed', () async {
+        SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+        debugDefaultTargetPlatformOverride = TargetPlatform.android;
+        androidSignerInstalled = false;
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        final result = await authService.connectWithAmber();
+
+        expect(result.success, isFalse);
+        expect(result.errorMessage, contains('No Android signer app'));
+        expect(authService.isAuthenticated, isFalse);
+      });
+    });
+
+    group('restore via initialize()', () {
+      test(
+        'reconnects an Amber account into an AmberNostrIdentity',
+        () async {
+          final pubkey = freshPubkey();
+          secureStorage['amber_pubkey'] = pubkey;
+          secureStorage['amber_package'] = 'com.greenart7c3.nostrsigner';
+          SharedPreferences.setMockInitialValues({
+            'authentication_source': 'amber',
+            kKnownAccountsKey: '[]',
+          });
+          debugDefaultTargetPlatformOverride = TargetPlatform.android;
+          androidSignerInstalled = true;
+          final authService = createAuthService();
+          addTearDown(authService.dispose);
+
+          await _ignoringDiscoveryErrors(authService.initialize);
+
+          expect(authService.isAuthenticated, isTrue);
+          expect(
+            authService.authenticationSource,
+            equals(AuthenticationSource.amber),
+          );
+          expect(authService.currentIdentity, isA<AmberNostrIdentity>());
+          expect(authService.currentPublicKeyHex, equals(pubkey));
+        },
+      );
+
+      test(
+        'stays unauthenticated when the signer app is gone on restore',
+        () async {
+          secureStorage['amber_pubkey'] = freshPubkey();
+          SharedPreferences.setMockInitialValues({
+            'authentication_source': 'amber',
+            kKnownAccountsKey: '[]',
+          });
+          debugDefaultTargetPlatformOverride = TargetPlatform.android;
+          androidSignerInstalled = false;
+          final authService = createAuthService();
+          addTearDown(authService.dispose);
+
+          await _ignoringDiscoveryErrors(authService.initialize);
+
+          expect(authService.isAuthenticated, isFalse);
+          expect(authService.currentIdentity, isNull);
+        },
+      );
+    });
+  });
+}

--- a/mobile/test/services/auth_service_amber_test.dart
+++ b/mobile/test/services/auth_service_amber_test.dart
@@ -8,157 +8,40 @@
 // constructed with a known pubkey on the restore path, so no intent round-trip
 // is needed.
 
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nostr_key_manager/nostr_key_manager.dart';
-import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_identity.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'support/auth_service_test_harness.dart';
+
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
-
-/// Runs [body] while silencing unhandled async errors from the fire-and-forget
-/// _performDiscovery() that initialize()/reconnect kicks off (it attempts real
-/// relay WebSocket connections which fail fast in the test environment).
-Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
-  final completer = Completer<T>();
-  runZonedGuarded(
-    () async {
-      try {
-        completer.complete(await body());
-      } catch (e, st) {
-        completer.completeError(e, st);
-      }
-    },
-    (_, _) {},
-  );
-  return completer.future;
-}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('AuthService NIP-55 Amber', () {
     late _MockUserDataCleanupService mockCleanupService;
-    late Map<String, String> secureStorage;
-    late bool androidSignerInstalled;
+    late AuthServiceChannelMocks channels;
 
     setUp(() {
       mockCleanupService = _MockUserDataCleanupService();
-      when(
-        () => mockCleanupService.shouldClearDataForUser(any()),
-      ).thenReturn(false);
-      when(
-        () => mockCleanupService.clearUserSpecificData(
-          reason: any(named: 'reason'),
-          isIdentityChange: any(named: 'isIdentityChange'),
-          userPubkey: any(named: 'userPubkey'),
-          deleteUserData: any(named: 'deleteUserData'),
-        ),
-      ).thenAnswer((_) async => 0);
-      when(
-        () => mockCleanupService.claimLegacyRows(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
-      ).thenAnswer((_) async {});
-
-      secureStorage = {};
-      androidSignerInstalled = true;
-
-      const secureStorageChannel = MethodChannel(
-        'plugins.it_nomads.com/flutter_secure_storage',
-      );
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(secureStorageChannel, (call) async {
-            switch (call.method) {
-              case 'read':
-                return secureStorage[call.arguments['key'] as String?];
-              case 'write':
-                final key = call.arguments['key'] as String?;
-                final value = call.arguments['value'] as String?;
-                if (key != null && value != null) secureStorage[key] = value;
-                return null;
-              case 'delete':
-                secureStorage.remove(call.arguments['key'] as String?);
-                return null;
-              case 'deleteAll':
-                secureStorage.clear();
-                return null;
-              case 'readAll':
-                return secureStorage;
-              case 'containsKey':
-                return secureStorage.containsKey(
-                  call.arguments['key'] as String?,
-                );
-              case 'getCapabilities':
-                return {'basicSecureStorage': true};
-              default:
-                return null;
-            }
-          });
-
-      const capabilityChannel = MethodChannel('openvine.secure_storage');
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(capabilityChannel, (call) async {
-            if (call.method == 'getCapabilities') {
-              return {
-                'hasHardwareSecurity': false,
-                'hasBiometrics': false,
-                'hasKeychain': true,
-              };
-            }
-            return null;
-          });
-
-      // Native NIP-55 signer probe. existAndroidNostrSigner reflects the
-      // per-test [androidSignerInstalled] flag.
-      const androidPluginChannel = MethodChannel('nostrmoPlugin');
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(androidPluginChannel, (call) async {
-            if (call.method == 'existAndroidNostrSigner') {
-              return androidSignerInstalled;
-            }
-            return null;
-          });
+      stubUserDataCleanupSuccess(mockCleanupService);
+      channels = AuthServiceChannelMocks.install();
     });
 
     tearDown(() {
       debugDefaultTargetPlatformOverride = null;
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        ..setMockMethodCallHandler(
-          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
-          null,
-        )
-        ..setMockMethodCallHandler(
-          const MethodChannel('openvine.secure_storage'),
-          null,
-        )
-        ..setMockMethodCallHandler(const MethodChannel('nostrmoPlugin'), null);
+      AuthServiceChannelMocks.remove();
     });
 
-    AuthService createAuthService() {
-      final keyStorage = SecureKeyStorage(
-        securityConfig: const SecurityConfig(requireHardwareBacked: false),
-      );
-      return AuthService(
-        userDataCleanupService: mockCleanupService,
-        keyStorage: keyStorage,
-        flutterSecureStorage: const FlutterSecureStorage(),
-      );
-    }
-
-    String freshPubkey() =>
-        SecureKeyContainer.fromPrivateKeyHex(generatePrivateKey()).publicKeyHex;
+    AuthService createAuthService() =>
+        buildTestAuthService(cleanupService: mockCleanupService);
 
     group('connectWithAmber', () {
       test('returns failure on non-Android platforms', () async {
@@ -181,7 +64,7 @@ void main() {
       test('returns failure when no signer app is installed', () async {
         SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
-        androidSignerInstalled = false;
+        channels.androidSignerInstalled = false;
         final authService = createAuthService();
         addTearDown(authService.dispose);
 
@@ -197,19 +80,20 @@ void main() {
       test(
         'reconnects an Amber account into an AmberNostrIdentity',
         () async {
-          final pubkey = freshPubkey();
-          secureStorage['amber_pubkey'] = pubkey;
-          secureStorage['amber_package'] = 'com.greenart7c3.nostrsigner';
+          final pubkey = freshPubkeyHex();
+          channels.secureStorage['amber_pubkey'] = pubkey;
+          channels.secureStorage['amber_package'] =
+              'com.greenart7c3.nostrsigner';
           SharedPreferences.setMockInitialValues({
             'authentication_source': 'amber',
             kKnownAccountsKey: '[]',
           });
           debugDefaultTargetPlatformOverride = TargetPlatform.android;
-          androidSignerInstalled = true;
+          channels.androidSignerInstalled = true;
           final authService = createAuthService();
           addTearDown(authService.dispose);
 
-          await _ignoringDiscoveryErrors(authService.initialize);
+          await ignoringDiscoveryErrors(authService.initialize);
 
           expect(authService.isAuthenticated, isTrue);
           expect(
@@ -224,17 +108,17 @@ void main() {
       test(
         'stays unauthenticated when the signer app is gone on restore',
         () async {
-          secureStorage['amber_pubkey'] = freshPubkey();
+          channels.secureStorage['amber_pubkey'] = freshPubkeyHex();
           SharedPreferences.setMockInitialValues({
             'authentication_source': 'amber',
             kKnownAccountsKey: '[]',
           });
           debugDefaultTargetPlatformOverride = TargetPlatform.android;
-          androidSignerInstalled = false;
+          channels.androidSignerInstalled = false;
           final authService = createAuthService();
           addTearDown(authService.dispose);
 
-          await _ignoringDiscoveryErrors(authService.initialize);
+          await ignoringDiscoveryErrors(authService.initialize);
 
           expect(authService.isAuthenticated, isFalse);
           expect(authService.currentIdentity, isNull);

--- a/mobile/test/services/auth_service_bunker_connect_test.dart
+++ b/mobile/test/services/auth_service_bunker_connect_test.dart
@@ -13,143 +13,43 @@
 // records the invocation inside the stubbing zone) and cannot be a tearoff.
 // ignore_for_file: unnecessary_lambdas
 
-import 'dart:async';
-
-import 'package:flutter/services.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart'
-    show NostrRemoteSigner, NostrRemoteSignerInfo, generatePrivateKey;
+    show NostrRemoteSigner, NostrRemoteSignerInfo;
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/nostr_identity.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'support/auth_service_test_harness.dart';
+
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
 class _MockNostrRemoteSigner extends Mock implements NostrRemoteSigner {}
-
-/// Silences unhandled async errors from the fire-and-forget _performDiscovery().
-Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
-  final completer = Completer<T>();
-  runZonedGuarded(
-    () async {
-      try {
-        completer.complete(await body());
-      } catch (e, st) {
-        completer.completeError(e, st);
-      }
-    },
-    (_, _) {},
-  );
-  return completer.future;
-}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('AuthService NIP-46 bunker connect', () {
     late _MockUserDataCleanupService mockCleanupService;
-    late Map<String, String> secureStorage;
 
     setUp(() {
       mockCleanupService = _MockUserDataCleanupService();
-      when(
-        () => mockCleanupService.shouldClearDataForUser(any()),
-      ).thenReturn(false);
-      when(
-        () => mockCleanupService.clearUserSpecificData(
-          reason: any(named: 'reason'),
-          isIdentityChange: any(named: 'isIdentityChange'),
-          userPubkey: any(named: 'userPubkey'),
-          deleteUserData: any(named: 'deleteUserData'),
-        ),
-      ).thenAnswer((_) async => 0);
-      when(
-        () => mockCleanupService.claimLegacyRows(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
-      ).thenAnswer((_) async {});
-
-      secureStorage = {};
-      const secureStorageChannel = MethodChannel(
-        'plugins.it_nomads.com/flutter_secure_storage',
-      );
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(secureStorageChannel, (call) async {
-            switch (call.method) {
-              case 'read':
-                return secureStorage[call.arguments['key'] as String?];
-              case 'write':
-                final key = call.arguments['key'] as String?;
-                final value = call.arguments['value'] as String?;
-                if (key != null && value != null) secureStorage[key] = value;
-                return null;
-              case 'delete':
-                secureStorage.remove(call.arguments['key'] as String?);
-                return null;
-              case 'deleteAll':
-                secureStorage.clear();
-                return null;
-              case 'readAll':
-                return secureStorage;
-              case 'containsKey':
-                return secureStorage.containsKey(
-                  call.arguments['key'] as String?,
-                );
-              case 'getCapabilities':
-                return {'basicSecureStorage': true};
-              default:
-                return null;
-            }
-          });
-
-      const capabilityChannel = MethodChannel('openvine.secure_storage');
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(capabilityChannel, (call) async {
-            if (call.method == 'getCapabilities') {
-              return {
-                'hasHardwareSecurity': false,
-                'hasBiometrics': false,
-                'hasKeychain': true,
-              };
-            }
-            return null;
-          });
-
+      stubUserDataCleanupSuccess(mockCleanupService);
+      AuthServiceChannelMocks.install();
       SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
     });
 
-    tearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        ..setMockMethodCallHandler(
-          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
-          null,
-        )
-        ..setMockMethodCallHandler(
-          const MethodChannel('openvine.secure_storage'),
-          null,
+    tearDown(AuthServiceChannelMocks.remove);
+
+    AuthService createAuthService(RemoteSignerFactory factory) =>
+        buildTestAuthService(
+          cleanupService: mockCleanupService,
+          remoteSignerFactory: factory,
         );
-    });
-
-    String freshPubkey() =>
-        SecureKeyContainer.fromPrivateKeyHex(generatePrivateKey()).publicKeyHex;
-
-    AuthService createAuthService(RemoteSignerFactory factory) {
-      return AuthService(
-        userDataCleanupService: mockCleanupService,
-        keyStorage: SecureKeyStorage(
-          securityConfig: const SecurityConfig(requireHardwareBacked: false),
-        ),
-        flutterSecureStorage: const FlutterSecureStorage(),
-        remoteSignerFactory: factory,
-      );
-    }
 
     String bunkerUrlFor(String remoteSignerPubkey) =>
         'bunker://$remoteSignerPubkey'
@@ -157,8 +57,8 @@ void main() {
 
     group('connectWithBunker', () {
       test('connects and sets a BunkerNostrIdentity on success', () async {
-        final remoteSignerPubkey = freshPubkey();
-        final userPubkey = freshPubkey();
+        final remoteSignerPubkey = freshPubkeyHex();
+        final userPubkey = freshPubkeyHex();
         final url = bunkerUrlFor(remoteSignerPubkey);
 
         final signer = _MockNostrRemoteSigner();
@@ -171,7 +71,7 @@ void main() {
         final authService = createAuthService((_, _) => signer);
         addTearDown(authService.dispose);
 
-        final result = await _ignoringDiscoveryErrors(
+        final result = await ignoringDiscoveryErrors(
           () => authService.connectWithBunker(url),
         );
 
@@ -185,7 +85,7 @@ void main() {
       });
 
       test('fails when the bunker returns no public key', () async {
-        final url = bunkerUrlFor(freshPubkey());
+        final url = bunkerUrlFor(freshPubkeyHex());
 
         final signer = _MockNostrRemoteSigner();
         when(

--- a/mobile/test/services/auth_service_bunker_connect_test.dart
+++ b/mobile/test/services/auth_service_bunker_connect_test.dart
@@ -1,0 +1,255 @@
+// ABOUTME: Unit tests for AuthService NIP-46 bunker:// connect flow and the
+// ABOUTME: client-initiated nostrconnect:// session guards. No network needed.
+//
+// #4741 PR1 gap-fill: connectWithBunker (heavily uncovered) is driven through
+// the injectable remoteSignerFactory with a mock NostrRemoteSigner, so no real
+// relay round-trip happens. The nostrconnect:// happy path (initiateNostrConnect
+// -> waitForNostrConnectResponse) connects to public relays via
+// NostrConnectSession.start() and has no injection seam, so only its no-session
+// guards are covered here — adding a session seam is a follow-up for the
+// extraction.
+
+// mocktail's `when(() => mock.method())` capture idiom must be a closure (it
+// records the invocation inside the stubbing zone) and cannot be a tearoff.
+// ignore_for_file: unnecessary_lambdas
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart'
+    show NostrRemoteSigner, NostrRemoteSignerInfo, generatePrivateKey;
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_identity.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+class _MockNostrRemoteSigner extends Mock implements NostrRemoteSigner {}
+
+/// Silences unhandled async errors from the fire-and-forget _performDiscovery().
+Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
+  final completer = Completer<T>();
+  runZonedGuarded(
+    () async {
+      try {
+        completer.complete(await body());
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    },
+    (_, _) {},
+  );
+  return completer.future;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AuthService NIP-46 bunker connect', () {
+    late _MockUserDataCleanupService mockCleanupService;
+    late Map<String, String> secureStorage;
+
+    setUp(() {
+      mockCleanupService = _MockUserDataCleanupService();
+      when(
+        () => mockCleanupService.shouldClearDataForUser(any()),
+      ).thenReturn(false);
+      when(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: any(named: 'reason'),
+          isIdentityChange: any(named: 'isIdentityChange'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
+
+      secureStorage = {};
+      const secureStorageChannel = MethodChannel(
+        'plugins.it_nomads.com/flutter_secure_storage',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(secureStorageChannel, (call) async {
+            switch (call.method) {
+              case 'read':
+                return secureStorage[call.arguments['key'] as String?];
+              case 'write':
+                final key = call.arguments['key'] as String?;
+                final value = call.arguments['value'] as String?;
+                if (key != null && value != null) secureStorage[key] = value;
+                return null;
+              case 'delete':
+                secureStorage.remove(call.arguments['key'] as String?);
+                return null;
+              case 'deleteAll':
+                secureStorage.clear();
+                return null;
+              case 'readAll':
+                return secureStorage;
+              case 'containsKey':
+                return secureStorage.containsKey(
+                  call.arguments['key'] as String?,
+                );
+              case 'getCapabilities':
+                return {'basicSecureStorage': true};
+              default:
+                return null;
+            }
+          });
+
+      const capabilityChannel = MethodChannel('openvine.secure_storage');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(capabilityChannel, (call) async {
+            if (call.method == 'getCapabilities') {
+              return {
+                'hasHardwareSecurity': false,
+                'hasBiometrics': false,
+                'hasKeychain': true,
+              };
+            }
+            return null;
+          });
+
+      SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        ..setMockMethodCallHandler(
+          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+          null,
+        )
+        ..setMockMethodCallHandler(
+          const MethodChannel('openvine.secure_storage'),
+          null,
+        );
+    });
+
+    String freshPubkey() =>
+        SecureKeyContainer.fromPrivateKeyHex(generatePrivateKey()).publicKeyHex;
+
+    AuthService createAuthService(RemoteSignerFactory factory) {
+      return AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: SecureKeyStorage(
+          securityConfig: const SecurityConfig(requireHardwareBacked: false),
+        ),
+        flutterSecureStorage: const FlutterSecureStorage(),
+        remoteSignerFactory: factory,
+      );
+    }
+
+    String bunkerUrlFor(String remoteSignerPubkey) =>
+        'bunker://$remoteSignerPubkey'
+        '?relay=wss%3A%2F%2Frelay.example.com&secret=testsecret';
+
+    group('connectWithBunker', () {
+      test('connects and sets a BunkerNostrIdentity on success', () async {
+        final remoteSignerPubkey = freshPubkey();
+        final userPubkey = freshPubkey();
+        final url = bunkerUrlFor(remoteSignerPubkey);
+
+        final signer = _MockNostrRemoteSigner();
+        when(
+          () => signer.info,
+        ).thenReturn(NostrRemoteSignerInfo.parseBunkerUrl(url));
+        when(() => signer.connect()).thenAnswer((_) async => 'ack');
+        when(() => signer.pullPubkey()).thenAnswer((_) async => userPubkey);
+
+        final authService = createAuthService((_, _) => signer);
+        addTearDown(authService.dispose);
+
+        final result = await _ignoringDiscoveryErrors(
+          () => authService.connectWithBunker(url),
+        );
+
+        expect(result.success, isTrue);
+        expect(
+          authService.authenticationSource,
+          equals(AuthenticationSource.bunker),
+        );
+        expect(authService.currentIdentity, isA<BunkerNostrIdentity>());
+        expect(authService.currentPublicKeyHex, equals(userPubkey));
+      });
+
+      test('fails when the bunker returns no public key', () async {
+        final url = bunkerUrlFor(freshPubkey());
+
+        final signer = _MockNostrRemoteSigner();
+        when(
+          () => signer.info,
+        ).thenReturn(NostrRemoteSignerInfo.parseBunkerUrl(url));
+        when(() => signer.connect()).thenAnswer((_) async => 'ack');
+        when(() => signer.pullPubkey()).thenAnswer((_) async => null);
+
+        final authService = createAuthService((_, _) => signer);
+        addTearDown(authService.dispose);
+
+        final result = await authService.connectWithBunker(url);
+
+        expect(result.success, isFalse);
+        expect(result.errorMessage, contains('Failed to get public key'));
+        expect(authService.isAuthenticated, isFalse);
+      });
+
+      test('fails on an invalid bunker URL', () async {
+        var factoryCalled = false;
+        final authService = createAuthService((_, _) {
+          factoryCalled = true;
+          return _MockNostrRemoteSigner();
+        });
+        addTearDown(authService.dispose);
+
+        final result = await authService.connectWithBunker('not-a-bunker-url');
+
+        expect(result.success, isFalse);
+        expect(authService.isAuthenticated, isFalse);
+        expect(factoryCalled, isFalse);
+      });
+    });
+
+    group('nostrconnect:// guards', () {
+      test(
+        'waitForNostrConnectResponse fails with no active session',
+        () async {
+          final authService = createAuthService(
+            (_, _) => _MockNostrRemoteSigner(),
+          );
+          addTearDown(authService.dispose);
+
+          final result = await authService.waitForNostrConnectResponse();
+
+          expect(result.success, isFalse);
+          expect(
+            result.errorMessage,
+            contains('No active nostrconnect session'),
+          );
+        },
+      );
+
+      test('exposes null nostrconnect state before any session', () {
+        final authService = createAuthService(
+          (_, _) => _MockNostrRemoteSigner(),
+        );
+        addTearDown(authService.dispose);
+
+        expect(authService.nostrConnectUrl, isNull);
+        expect(authService.nostrConnectState, isNull);
+        // Cancelling with no active session is a safe no-op.
+        expect(authService.cancelNostrConnect, returnsNormally);
+      });
+    });
+  });
+}

--- a/mobile/test/services/auth_service_create_anonymous_test.dart
+++ b/mobile/test/services/auth_service_create_anonymous_test.dart
@@ -6,10 +6,6 @@
 // using a real channel-backed SecureKeyStorage. Transitively exercises
 // createNewIdentity and acceptTerms.
 
-import 'dart:async';
-
-import 'package:flutter/services.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
@@ -20,129 +16,35 @@ import 'package:openvine/services/nostr_identity.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'support/auth_service_test_harness.dart';
+
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
-
-/// Silences unhandled async errors from the fire-and-forget _performDiscovery().
-Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
-  final completer = Completer<T>();
-  runZonedGuarded(
-    () async {
-      try {
-        completer.complete(await body());
-      } catch (e, st) {
-        completer.completeError(e, st);
-      }
-    },
-    (_, _) {},
-  );
-  return completer.future;
-}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('AuthService anonymous account creation', () {
     late _MockUserDataCleanupService mockCleanupService;
-    late Map<String, String> secureStorage;
 
     setUp(() {
       mockCleanupService = _MockUserDataCleanupService();
-      when(
-        () => mockCleanupService.shouldClearDataForUser(any()),
-      ).thenReturn(false);
-      when(
-        () => mockCleanupService.clearUserSpecificData(
-          reason: any(named: 'reason'),
-          isIdentityChange: any(named: 'isIdentityChange'),
-          userPubkey: any(named: 'userPubkey'),
-          deleteUserData: any(named: 'deleteUserData'),
-        ),
-      ).thenAnswer((_) async => 0);
-      when(
-        () => mockCleanupService.claimLegacyRows(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
-      ).thenAnswer((_) async {});
-
-      secureStorage = {};
-      const secureStorageChannel = MethodChannel(
-        'plugins.it_nomads.com/flutter_secure_storage',
-      );
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(secureStorageChannel, (call) async {
-            switch (call.method) {
-              case 'read':
-                return secureStorage[call.arguments['key'] as String?];
-              case 'write':
-                final key = call.arguments['key'] as String?;
-                final value = call.arguments['value'] as String?;
-                if (key != null && value != null) secureStorage[key] = value;
-                return null;
-              case 'delete':
-                secureStorage.remove(call.arguments['key'] as String?);
-                return null;
-              case 'deleteAll':
-                secureStorage.clear();
-                return null;
-              case 'readAll':
-                return secureStorage;
-              case 'containsKey':
-                return secureStorage.containsKey(
-                  call.arguments['key'] as String?,
-                );
-              case 'getCapabilities':
-                return {'basicSecureStorage': true};
-              default:
-                return null;
-            }
-          });
-
-      const capabilityChannel = MethodChannel('openvine.secure_storage');
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(capabilityChannel, (call) async {
-            if (call.method == 'getCapabilities') {
-              return {
-                'hasHardwareSecurity': false,
-                'hasBiometrics': false,
-                'hasKeychain': true,
-              };
-            }
-            return null;
-          });
-
+      stubUserDataCleanupSuccess(mockCleanupService);
+      AuthServiceChannelMocks.install();
       SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
     });
 
-    tearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        ..setMockMethodCallHandler(
-          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
-          null,
-        )
-        ..setMockMethodCallHandler(
-          const MethodChannel('openvine.secure_storage'),
-          null,
-        );
-    });
+    tearDown(AuthServiceChannelMocks.remove);
 
-    AuthService createAuthService() {
-      return AuthService(
-        userDataCleanupService: mockCleanupService,
-        keyStorage: SecureKeyStorage(
-          securityConfig: const SecurityConfig(requireHardwareBacked: false),
-        ),
-        flutterSecureStorage: const FlutterSecureStorage(),
-      );
-    }
+    AuthService createAuthService() =>
+        buildTestAuthService(cleanupService: mockCleanupService);
 
     test('createAnonymousAccount generates an automatic identity and '
         'accepts terms', () async {
       final authService = createAuthService();
       addTearDown(authService.dispose);
 
-      await _ignoringDiscoveryErrors(authService.createAnonymousAccount);
+      await ignoringDiscoveryErrors(authService.createAnonymousAccount);
 
       expect(authService.isAuthenticated, isTrue);
       expect(
@@ -165,7 +67,7 @@ void main() {
       final authService = createAuthService();
       addTearDown(authService.dispose);
 
-      await _ignoringDiscoveryErrors(
+      await ignoringDiscoveryErrors(
         () => authService.createAnonymousAccountFromKeyContainer(container),
       );
 
@@ -188,7 +90,13 @@ void main() {
 
       await expectLater(
         authService.createAnonymousAccountFromKeyContainer(pubkeyOnly),
-        throwsA(isA<Exception>()),
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            'message',
+            contains('Failed to read generated identity key'),
+          ),
+        ),
       );
       expect(authService.isAuthenticated, isFalse);
     });

--- a/mobile/test/services/auth_service_create_anonymous_test.dart
+++ b/mobile/test/services/auth_service_create_anonymous_test.dart
@@ -1,0 +1,196 @@
+// ABOUTME: Unit tests for AuthService anonymous-account creation —
+// ABOUTME: createAnonymousAccount, ...FromKeyContainer, ...FromPrivateKeyHex.
+//
+// #4741 PR1 gap-fill: covers the previously-uncovered anonymous-signup paths
+// (fresh identity generation + acceptTerms, invite-gated key-container import)
+// using a real channel-backed SecureKeyStorage. Transitively exercises
+// createNewIdentity and acceptTerms.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_identity.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+/// Silences unhandled async errors from the fire-and-forget _performDiscovery().
+Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
+  final completer = Completer<T>();
+  runZonedGuarded(
+    () async {
+      try {
+        completer.complete(await body());
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    },
+    (_, _) {},
+  );
+  return completer.future;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AuthService anonymous account creation', () {
+    late _MockUserDataCleanupService mockCleanupService;
+    late Map<String, String> secureStorage;
+
+    setUp(() {
+      mockCleanupService = _MockUserDataCleanupService();
+      when(
+        () => mockCleanupService.shouldClearDataForUser(any()),
+      ).thenReturn(false);
+      when(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: any(named: 'reason'),
+          isIdentityChange: any(named: 'isIdentityChange'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
+
+      secureStorage = {};
+      const secureStorageChannel = MethodChannel(
+        'plugins.it_nomads.com/flutter_secure_storage',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(secureStorageChannel, (call) async {
+            switch (call.method) {
+              case 'read':
+                return secureStorage[call.arguments['key'] as String?];
+              case 'write':
+                final key = call.arguments['key'] as String?;
+                final value = call.arguments['value'] as String?;
+                if (key != null && value != null) secureStorage[key] = value;
+                return null;
+              case 'delete':
+                secureStorage.remove(call.arguments['key'] as String?);
+                return null;
+              case 'deleteAll':
+                secureStorage.clear();
+                return null;
+              case 'readAll':
+                return secureStorage;
+              case 'containsKey':
+                return secureStorage.containsKey(
+                  call.arguments['key'] as String?,
+                );
+              case 'getCapabilities':
+                return {'basicSecureStorage': true};
+              default:
+                return null;
+            }
+          });
+
+      const capabilityChannel = MethodChannel('openvine.secure_storage');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(capabilityChannel, (call) async {
+            if (call.method == 'getCapabilities') {
+              return {
+                'hasHardwareSecurity': false,
+                'hasBiometrics': false,
+                'hasKeychain': true,
+              };
+            }
+            return null;
+          });
+
+      SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        ..setMockMethodCallHandler(
+          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+          null,
+        )
+        ..setMockMethodCallHandler(
+          const MethodChannel('openvine.secure_storage'),
+          null,
+        );
+    });
+
+    AuthService createAuthService() {
+      return AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: SecureKeyStorage(
+          securityConfig: const SecurityConfig(requireHardwareBacked: false),
+        ),
+        flutterSecureStorage: const FlutterSecureStorage(),
+      );
+    }
+
+    test('createAnonymousAccount generates an automatic identity and '
+        'accepts terms', () async {
+      final authService = createAuthService();
+      addTearDown(authService.dispose);
+
+      await _ignoringDiscoveryErrors(authService.createAnonymousAccount);
+
+      expect(authService.isAuthenticated, isTrue);
+      expect(
+        authService.authenticationSource,
+        equals(AuthenticationSource.automatic),
+      );
+      expect(authService.currentIdentity, isA<LocalNostrIdentity>());
+      expect(authService.currentPublicKeyHex, isNotNull);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('terms_accepted_at'), isNotNull);
+      expect(prefs.getBool('age_verified_16_plus'), isTrue);
+    });
+
+    test('createAnonymousAccountFromKeyContainer imports the provided key '
+        'as an automatic identity', () async {
+      final privateKeyHex = generatePrivateKey();
+      final container = SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
+      final expectedPubkey = container.publicKeyHex;
+      final authService = createAuthService();
+      addTearDown(authService.dispose);
+
+      await _ignoringDiscoveryErrors(
+        () => authService.createAnonymousAccountFromKeyContainer(container),
+      );
+
+      expect(authService.isAuthenticated, isTrue);
+      expect(
+        authService.authenticationSource,
+        equals(AuthenticationSource.automatic),
+      );
+      expect(authService.currentPublicKeyHex, equals(expectedPubkey));
+    });
+
+    test('createAnonymousAccountFromKeyContainer throws for a '
+        'public-key-only container', () async {
+      final pubkey = SecureKeyContainer.fromPrivateKeyHex(
+        generatePrivateKey(),
+      ).publicKeyHex;
+      final pubkeyOnly = SecureKeyContainer.fromPublicKey(pubkey);
+      final authService = createAuthService();
+      addTearDown(authService.dispose);
+
+      await expectLater(
+        authService.createAnonymousAccountFromKeyContainer(pubkeyOnly),
+        throwsA(isA<Exception>()),
+      );
+      expect(authService.isAuthenticated, isFalse);
+    });
+  });
+}

--- a/mobile/test/services/auth_service_destructive_signout_test.dart
+++ b/mobile/test/services/auth_service_destructive_signout_test.dart
@@ -10,135 +10,36 @@
 // unwrapped in the destructive branch), with a real channel-backed
 // SecureKeyStorage for the authenticated starting state.
 
-import 'dart:async';
-
-import 'package:flutter/services.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'support/auth_service_test_harness.dart';
+
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
-
-/// Silences unhandled async errors from the fire-and-forget _performDiscovery().
-Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
-  final completer = Completer<T>();
-  runZonedGuarded(
-    () async {
-      try {
-        completer.complete(await body());
-      } catch (e, st) {
-        completer.completeError(e, st);
-      }
-    },
-    (_, _) {},
-  );
-  return completer.future;
-}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('AuthService destructive sign-out recovery', () {
     late _MockUserDataCleanupService mockCleanupService;
-    late Map<String, String> secureStorage;
 
     setUp(() {
       mockCleanupService = _MockUserDataCleanupService();
-      when(
-        () => mockCleanupService.shouldClearDataForUser(any()),
-      ).thenReturn(false);
-      when(
-        () => mockCleanupService.clearUserSpecificData(
-          reason: any(named: 'reason'),
-          isIdentityChange: any(named: 'isIdentityChange'),
-          userPubkey: any(named: 'userPubkey'),
-          deleteUserData: any(named: 'deleteUserData'),
-        ),
-      ).thenAnswer((_) async => 0);
-      when(
-        () => mockCleanupService.claimLegacyRows(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
-      ).thenAnswer((_) async {});
-
-      secureStorage = {};
-      const secureStorageChannel = MethodChannel(
-        'plugins.it_nomads.com/flutter_secure_storage',
-      );
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(secureStorageChannel, (call) async {
-            switch (call.method) {
-              case 'read':
-                return secureStorage[call.arguments['key'] as String?];
-              case 'write':
-                final key = call.arguments['key'] as String?;
-                final value = call.arguments['value'] as String?;
-                if (key != null && value != null) secureStorage[key] = value;
-                return null;
-              case 'delete':
-                secureStorage.remove(call.arguments['key'] as String?);
-                return null;
-              case 'deleteAll':
-                secureStorage.clear();
-                return null;
-              case 'readAll':
-                return secureStorage;
-              case 'containsKey':
-                return secureStorage.containsKey(
-                  call.arguments['key'] as String?,
-                );
-              case 'getCapabilities':
-                return {'basicSecureStorage': true};
-              default:
-                return null;
-            }
-          });
-
-      const capabilityChannel = MethodChannel('openvine.secure_storage');
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(capabilityChannel, (call) async {
-            if (call.method == 'getCapabilities') {
-              return {
-                'hasHardwareSecurity': false,
-                'hasBiometrics': false,
-                'hasKeychain': true,
-              };
-            }
-            return null;
-          });
-
+      stubUserDataCleanupSuccess(mockCleanupService);
+      AuthServiceChannelMocks.install();
       SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
     });
 
-    tearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        ..setMockMethodCallHandler(
-          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
-          null,
-        )
-        ..setMockMethodCallHandler(
-          const MethodChannel('openvine.secure_storage'),
-          null,
-        );
-    });
+    tearDown(AuthServiceChannelMocks.remove);
 
-    AuthService createAuthService() {
-      return AuthService(
-        userDataCleanupService: mockCleanupService,
-        keyStorage: SecureKeyStorage(
-          securityConfig: const SecurityConfig(requireHardwareBacked: false),
-        ),
-        flutterSecureStorage: const FlutterSecureStorage(),
-      );
-    }
+    AuthService createAuthService() =>
+        buildTestAuthService(cleanupService: mockCleanupService);
 
     test('completes destructive sign-out and lands unauthenticated when a '
         'cleanup step throws after key deletion', () async {
@@ -146,7 +47,7 @@ void main() {
       addTearDown(authService.dispose);
 
       // Authenticated starting state.
-      await _ignoringDiscoveryErrors(
+      await ignoringDiscoveryErrors(
         () => authService.importFromHex(generatePrivateKey()),
       );
       expect(authService.isAuthenticated, isTrue);
@@ -157,7 +58,7 @@ void main() {
         () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
       ).thenAnswer((_) async => throw Exception('cleanup boom'));
 
-      await _ignoringDiscoveryErrors(
+      await ignoringDiscoveryErrors(
         () => authService.signOut(
           deleteKeys: true,
           abortOnKeyDeletionFailure: true,

--- a/mobile/test/services/auth_service_destructive_signout_test.dart
+++ b/mobile/test/services/auth_service_destructive_signout_test.dart
@@ -1,0 +1,173 @@
+// ABOUTME: Unit test for AuthService destructive sign-out recovery —
+// ABOUTME: _completeDestructiveSignOutAfterDeletedKeys when cleanup throws.
+//
+// #4741 PR1 gap-fill: signOut(deleteKeys: true, abortOnKeyDeletionFailure: true)
+// deletes local login material BEFORE session cleanup. If a later cleanup step
+// then throws, the app must NOT stay authenticated-in-memory with no keys on
+// disk — signOut routes to _completeDestructiveSignOutAfterDeletedKeys, which
+// tears down the session and lands unauthenticated. Failure is injected via the
+// mocked UserDataCleanupService.markOwnerScopedLegacyDataForUser (called
+// unwrapped in the destructive branch), with a real channel-backed
+// SecureKeyStorage for the authenticated starting state.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+/// Silences unhandled async errors from the fire-and-forget _performDiscovery().
+Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
+  final completer = Completer<T>();
+  runZonedGuarded(
+    () async {
+      try {
+        completer.complete(await body());
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    },
+    (_, _) {},
+  );
+  return completer.future;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AuthService destructive sign-out recovery', () {
+    late _MockUserDataCleanupService mockCleanupService;
+    late Map<String, String> secureStorage;
+
+    setUp(() {
+      mockCleanupService = _MockUserDataCleanupService();
+      when(
+        () => mockCleanupService.shouldClearDataForUser(any()),
+      ).thenReturn(false);
+      when(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: any(named: 'reason'),
+          isIdentityChange: any(named: 'isIdentityChange'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
+
+      secureStorage = {};
+      const secureStorageChannel = MethodChannel(
+        'plugins.it_nomads.com/flutter_secure_storage',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(secureStorageChannel, (call) async {
+            switch (call.method) {
+              case 'read':
+                return secureStorage[call.arguments['key'] as String?];
+              case 'write':
+                final key = call.arguments['key'] as String?;
+                final value = call.arguments['value'] as String?;
+                if (key != null && value != null) secureStorage[key] = value;
+                return null;
+              case 'delete':
+                secureStorage.remove(call.arguments['key'] as String?);
+                return null;
+              case 'deleteAll':
+                secureStorage.clear();
+                return null;
+              case 'readAll':
+                return secureStorage;
+              case 'containsKey':
+                return secureStorage.containsKey(
+                  call.arguments['key'] as String?,
+                );
+              case 'getCapabilities':
+                return {'basicSecureStorage': true};
+              default:
+                return null;
+            }
+          });
+
+      const capabilityChannel = MethodChannel('openvine.secure_storage');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(capabilityChannel, (call) async {
+            if (call.method == 'getCapabilities') {
+              return {
+                'hasHardwareSecurity': false,
+                'hasBiometrics': false,
+                'hasKeychain': true,
+              };
+            }
+            return null;
+          });
+
+      SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        ..setMockMethodCallHandler(
+          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+          null,
+        )
+        ..setMockMethodCallHandler(
+          const MethodChannel('openvine.secure_storage'),
+          null,
+        );
+    });
+
+    AuthService createAuthService() {
+      return AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: SecureKeyStorage(
+          securityConfig: const SecurityConfig(requireHardwareBacked: false),
+        ),
+        flutterSecureStorage: const FlutterSecureStorage(),
+      );
+    }
+
+    test('completes destructive sign-out and lands unauthenticated when a '
+        'cleanup step throws after key deletion', () async {
+      final authService = createAuthService();
+      addTearDown(authService.dispose);
+
+      // Authenticated starting state.
+      await _ignoringDiscoveryErrors(
+        () => authService.importFromHex(generatePrivateKey()),
+      );
+      expect(authService.isAuthenticated, isTrue);
+
+      // Fail a cleanup step that runs AFTER the pre-flight key deletion in the
+      // destructive branch, forcing the recovery path.
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async => throw Exception('cleanup boom'));
+
+      await _ignoringDiscoveryErrors(
+        () => authService.signOut(
+          deleteKeys: true,
+          abortOnKeyDeletionFailure: true,
+        ),
+      );
+
+      // The recovery path tore down the session rather than leaving an
+      // authenticated-in-memory state with no keys on disk.
+      expect(authService.isAuthenticated, isFalse);
+      expect(authService.currentIdentity, isNull);
+    });
+  });
+}

--- a/mobile/test/services/auth_service_import_test.dart
+++ b/mobile/test/services/auth_service_import_test.dart
@@ -5,10 +5,6 @@
 // (invalid nsec, invalid hex, wrong ncryptsec password) plus the happy path into
 // a LocalNostrIdentity, using a real channel-backed SecureKeyStorage.
 
-import 'dart:async';
-
-import 'package:flutter/services.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
@@ -19,122 +15,28 @@ import 'package:openvine/services/nostr_identity.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'support/auth_service_test_harness.dart';
+
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
-
-/// Silences unhandled async errors from the fire-and-forget _performDiscovery().
-Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
-  final completer = Completer<T>();
-  runZonedGuarded(
-    () async {
-      try {
-        completer.complete(await body());
-      } catch (e, st) {
-        completer.completeError(e, st);
-      }
-    },
-    (_, _) {},
-  );
-  return completer.future;
-}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('AuthService key import', () {
     late _MockUserDataCleanupService mockCleanupService;
-    late Map<String, String> secureStorage;
 
     setUp(() {
       mockCleanupService = _MockUserDataCleanupService();
-      when(
-        () => mockCleanupService.shouldClearDataForUser(any()),
-      ).thenReturn(false);
-      when(
-        () => mockCleanupService.clearUserSpecificData(
-          reason: any(named: 'reason'),
-          isIdentityChange: any(named: 'isIdentityChange'),
-          userPubkey: any(named: 'userPubkey'),
-          deleteUserData: any(named: 'deleteUserData'),
-        ),
-      ).thenAnswer((_) async => 0);
-      when(
-        () => mockCleanupService.claimLegacyRows(any()),
-      ).thenAnswer((_) async {});
-      when(
-        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
-      ).thenAnswer((_) async {});
-
-      secureStorage = {};
-      const secureStorageChannel = MethodChannel(
-        'plugins.it_nomads.com/flutter_secure_storage',
-      );
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(secureStorageChannel, (call) async {
-            switch (call.method) {
-              case 'read':
-                return secureStorage[call.arguments['key'] as String?];
-              case 'write':
-                final key = call.arguments['key'] as String?;
-                final value = call.arguments['value'] as String?;
-                if (key != null && value != null) secureStorage[key] = value;
-                return null;
-              case 'delete':
-                secureStorage.remove(call.arguments['key'] as String?);
-                return null;
-              case 'deleteAll':
-                secureStorage.clear();
-                return null;
-              case 'readAll':
-                return secureStorage;
-              case 'containsKey':
-                return secureStorage.containsKey(
-                  call.arguments['key'] as String?,
-                );
-              case 'getCapabilities':
-                return {'basicSecureStorage': true};
-              default:
-                return null;
-            }
-          });
-
-      const capabilityChannel = MethodChannel('openvine.secure_storage');
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(capabilityChannel, (call) async {
-            if (call.method == 'getCapabilities') {
-              return {
-                'hasHardwareSecurity': false,
-                'hasBiometrics': false,
-                'hasKeychain': true,
-              };
-            }
-            return null;
-          });
-
+      stubUserDataCleanupSuccess(mockCleanupService);
+      AuthServiceChannelMocks.install();
       SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
     });
 
-    tearDown(() {
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        ..setMockMethodCallHandler(
-          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
-          null,
-        )
-        ..setMockMethodCallHandler(
-          const MethodChannel('openvine.secure_storage'),
-          null,
-        );
-    });
+    tearDown(AuthServiceChannelMocks.remove);
 
-    AuthService createAuthService() {
-      return AuthService(
-        userDataCleanupService: mockCleanupService,
-        keyStorage: SecureKeyStorage(
-          securityConfig: const SecurityConfig(requireHardwareBacked: false),
-        ),
-        flutterSecureStorage: const FlutterSecureStorage(),
-      );
-    }
+    AuthService createAuthService() =>
+        buildTestAuthService(cleanupService: mockCleanupService);
 
     group('importFromNsec', () {
       test('imports a valid nsec into a LocalNostrIdentity', () async {
@@ -146,7 +48,7 @@ void main() {
         final authService = createAuthService();
         addTearDown(authService.dispose);
 
-        final result = await _ignoringDiscoveryErrors(
+        final result = await ignoringDiscoveryErrors(
           () => authService.importFromNsec(nsec),
         );
 
@@ -177,7 +79,7 @@ void main() {
         final authService = createAuthService();
         addTearDown(authService.dispose);
 
-        final result = await _ignoringDiscoveryErrors(
+        final result = await ignoringDiscoveryErrors(
           () => authService.importFromHex(privateKeyHex),
         );
 
@@ -209,7 +111,7 @@ void main() {
         final authService = createAuthService();
         addTearDown(authService.dispose);
 
-        final result = await _ignoringDiscoveryErrors(
+        final result = await ignoringDiscoveryErrors(
           () => authService.importFromNcryptsec(ncryptsec, 'correct horse'),
         );
 

--- a/mobile/test/services/auth_service_import_test.dart
+++ b/mobile/test/services/auth_service_import_test.dart
@@ -1,0 +1,240 @@
+// ABOUTME: Unit tests for AuthService key-import flows — importFromNsec,
+// ABOUTME: importFromHex, and importFromNcryptsec (NIP-49). No emulator needed.
+//
+// #4741 PR1 gap-fill: covers the previously-uncovered validation/error branches
+// (invalid nsec, invalid hex, wrong ncryptsec password) plus the happy path into
+// a LocalNostrIdentity, using a real channel-backed SecureKeyStorage.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show Nip19, Nip49, generatePrivateKey;
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/nostr_identity.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+/// Silences unhandled async errors from the fire-and-forget _performDiscovery().
+Future<T> _ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
+  final completer = Completer<T>();
+  runZonedGuarded(
+    () async {
+      try {
+        completer.complete(await body());
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    },
+    (_, _) {},
+  );
+  return completer.future;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AuthService key import', () {
+    late _MockUserDataCleanupService mockCleanupService;
+    late Map<String, String> secureStorage;
+
+    setUp(() {
+      mockCleanupService = _MockUserDataCleanupService();
+      when(
+        () => mockCleanupService.shouldClearDataForUser(any()),
+      ).thenReturn(false);
+      when(
+        () => mockCleanupService.clearUserSpecificData(
+          reason: any(named: 'reason'),
+          isIdentityChange: any(named: 'isIdentityChange'),
+          userPubkey: any(named: 'userPubkey'),
+          deleteUserData: any(named: 'deleteUserData'),
+        ),
+      ).thenAnswer((_) async => 0);
+      when(
+        () => mockCleanupService.claimLegacyRows(any()),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockCleanupService.markOwnerScopedLegacyDataForUser(any()),
+      ).thenAnswer((_) async {});
+
+      secureStorage = {};
+      const secureStorageChannel = MethodChannel(
+        'plugins.it_nomads.com/flutter_secure_storage',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(secureStorageChannel, (call) async {
+            switch (call.method) {
+              case 'read':
+                return secureStorage[call.arguments['key'] as String?];
+              case 'write':
+                final key = call.arguments['key'] as String?;
+                final value = call.arguments['value'] as String?;
+                if (key != null && value != null) secureStorage[key] = value;
+                return null;
+              case 'delete':
+                secureStorage.remove(call.arguments['key'] as String?);
+                return null;
+              case 'deleteAll':
+                secureStorage.clear();
+                return null;
+              case 'readAll':
+                return secureStorage;
+              case 'containsKey':
+                return secureStorage.containsKey(
+                  call.arguments['key'] as String?,
+                );
+              case 'getCapabilities':
+                return {'basicSecureStorage': true};
+              default:
+                return null;
+            }
+          });
+
+      const capabilityChannel = MethodChannel('openvine.secure_storage');
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(capabilityChannel, (call) async {
+            if (call.method == 'getCapabilities') {
+              return {
+                'hasHardwareSecurity': false,
+                'hasBiometrics': false,
+                'hasKeychain': true,
+              };
+            }
+            return null;
+          });
+
+      SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        ..setMockMethodCallHandler(
+          const MethodChannel('plugins.it_nomads.com/flutter_secure_storage'),
+          null,
+        )
+        ..setMockMethodCallHandler(
+          const MethodChannel('openvine.secure_storage'),
+          null,
+        );
+    });
+
+    AuthService createAuthService() {
+      return AuthService(
+        userDataCleanupService: mockCleanupService,
+        keyStorage: SecureKeyStorage(
+          securityConfig: const SecurityConfig(requireHardwareBacked: false),
+        ),
+        flutterSecureStorage: const FlutterSecureStorage(),
+      );
+    }
+
+    group('importFromNsec', () {
+      test('imports a valid nsec into a LocalNostrIdentity', () async {
+        final privateKeyHex = generatePrivateKey();
+        final expectedPubkey = SecureKeyContainer.fromPrivateKeyHex(
+          privateKeyHex,
+        ).publicKeyHex;
+        final nsec = Nip19.encodePrivateKey(privateKeyHex);
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        final result = await _ignoringDiscoveryErrors(
+          () => authService.importFromNsec(nsec),
+        );
+
+        expect(result.success, isTrue);
+        expect(
+          authService.authenticationSource,
+          equals(AuthenticationSource.importedKeys),
+        );
+        expect(authService.currentIdentity, isA<LocalNostrIdentity>());
+        expect(authService.currentPublicKeyHex, equals(expectedPubkey));
+      });
+
+      test('rejects an invalid nsec', () async {
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        final result = await authService.importFromNsec('not-a-valid-nsec');
+
+        expect(result.success, isFalse);
+        expect(result.errorMessage, contains('Invalid nsec format'));
+        expect(authService.isAuthenticated, isFalse);
+      });
+    });
+
+    group('importFromHex', () {
+      test('imports a valid hex key into a LocalNostrIdentity', () async {
+        final privateKeyHex = generatePrivateKey();
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        final result = await _ignoringDiscoveryErrors(
+          () => authService.importFromHex(privateKeyHex),
+        );
+
+        expect(result.success, isTrue);
+        expect(authService.currentIdentity, isA<LocalNostrIdentity>());
+      });
+
+      test('rejects an invalid hex key', () async {
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        final result = await authService.importFromHex('not-hex');
+
+        expect(result.success, isFalse);
+        expect(result.errorMessage, contains('Invalid private key format'));
+        expect(authService.isAuthenticated, isFalse);
+      });
+    });
+
+    group('importFromNcryptsec', () {
+      test('decrypts and imports with the correct password', () async {
+        final privateKeyHex = generatePrivateKey();
+        // logN kept low so scrypt stays fast in tests.
+        final ncryptsec = await Nip49.encode(
+          privateKeyHex,
+          'correct horse',
+          logN: 4,
+        );
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        final result = await _ignoringDiscoveryErrors(
+          () => authService.importFromNcryptsec(ncryptsec, 'correct horse'),
+        );
+
+        expect(result.success, isTrue);
+        expect(authService.currentIdentity, isA<LocalNostrIdentity>());
+      });
+
+      test('fails with Incorrect password on a wrong password', () async {
+        final ncryptsec = await Nip49.encode(
+          generatePrivateKey(),
+          'correct horse',
+          logN: 4,
+        );
+        final authService = createAuthService();
+        addTearDown(authService.dispose);
+
+        final result = await authService.importFromNcryptsec(
+          ncryptsec,
+          'wrong password',
+        );
+
+        expect(result.success, isFalse);
+        expect(result.errorMessage, equals('Incorrect password'));
+        expect(authService.isAuthenticated, isFalse);
+      });
+    });
+  });
+}

--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 
 import 'package:cache_sync/cache_sync.dart';
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
@@ -480,6 +481,26 @@ void main() {
       test(
         'callbacks share one timeout budget but later callbacks still run',
         () {
+          // signOut's OAuth cleanup falls back to a real FlutterSecureStorage
+          // when none is injected; without a channel handler it throws
+          // MissingPluginException and retries via real async, which races
+          // fakeAsync's virtual time (flaky under parallel CI load). Stub the
+          // channel so cleanup returns synchronously and stays virtualizable.
+          const secureStorageChannel = MethodChannel(
+            'plugins.it_nomads.com/flutter_secure_storage',
+          );
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+              .setMockMethodCallHandler(secureStorageChannel, (call) async {
+                if (call.method == 'getCapabilities') {
+                  return <String, bool>{'basicSecureStorage': true};
+                }
+                return null;
+              });
+          addTearDown(() {
+            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+                .setMockMethodCallHandler(secureStorageChannel, null);
+          });
+
           fakeAsync((async) {
             when(() => mockKeyStorage.clearCache()).thenReturn(null);
             final events = <String>[];

--- a/mobile/test/services/support/auth_service_test_harness.dart
+++ b/mobile/test/services/support/auth_service_test_harness.dart
@@ -46,64 +46,70 @@ class AuthServiceChannelMocks {
   /// AuthService reaches during sign-in / restore.
   static AuthServiceChannelMocks install() {
     final mocks = AuthServiceChannelMocks._();
-    final messenger =
-        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
-
-    messenger.setMockMethodCallHandler(_secureStorageChannel, (call) async {
-      switch (call.method) {
-        case 'read':
-          return mocks.secureStorage[call.arguments['key'] as String?];
-        case 'write':
-          final key = call.arguments['key'] as String?;
-          final value = call.arguments['value'] as String?;
-          if (key != null && value != null) mocks.secureStorage[key] = value;
+    _installSecureStorageHandlers(mocks.secureStorage);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(_androidPluginChannel, (call) async {
+          if (call.method == 'existAndroidNostrSigner') {
+            return mocks.androidSignerInstalled;
+          }
           return null;
-        case 'delete':
-          mocks.secureStorage.remove(call.arguments['key'] as String?);
-          return null;
-        case 'deleteAll':
-          mocks.secureStorage.clear();
-          return null;
-        case 'readAll':
-          return mocks.secureStorage;
-        case 'containsKey':
-          return mocks.secureStorage.containsKey(
-            call.arguments['key'] as String?,
-          );
-        case 'getCapabilities':
-          return {'basicSecureStorage': true};
-        default:
-          return null;
-      }
-    });
-
-    messenger.setMockMethodCallHandler(_capabilityChannel, (call) async {
-      if (call.method == 'getCapabilities') {
-        return {
-          'hasHardwareSecurity': false,
-          'hasBiometrics': false,
-          'hasKeychain': true,
-        };
-      }
-      return null;
-    });
-
-    messenger.setMockMethodCallHandler(_androidPluginChannel, (call) async {
-      if (call.method == 'existAndroidNostrSigner') {
-        return mocks.androidSignerInstalled;
-      }
-      return null;
-    });
-
+        });
     return mocks;
   }
 
-  /// Removes every handler installed by [install]. Call from `tearDown`.
+  /// Tears the test's handlers down. Call from `tearDown`.
+  ///
+  /// The secure-storage and capability channels are shared: `setupTestEnvironment()`
+  /// installs them once at collection time and other suites (e.g.
+  /// `nostr_key_manager_profile_fetch_test`) rely on them without re-installing.
+  /// Under CI's `--optimization` single-isolate run with shuffled ordering,
+  /// nulling those channels here would strand a later suite with no handler
+  /// (MissingPluginException on `flutter_secure_storage`). So we restore a fresh
+  /// working default rather than clearing them; only the auth-only native-signer
+  /// channel is removed.
   static void remove() {
+    _installSecureStorageHandlers(<String, String>{});
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      ..setMockMethodCallHandler(_secureStorageChannel, null)
-      ..setMockMethodCallHandler(_capabilityChannel, null)
-      ..setMockMethodCallHandler(_androidPluginChannel, null);
+        .setMockMethodCallHandler(_androidPluginChannel, null);
+  }
+
+  static void _installSecureStorageHandlers(Map<String, String> store) {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      ..setMockMethodCallHandler(_secureStorageChannel, (call) async {
+        switch (call.method) {
+          case 'read':
+            return store[call.arguments['key'] as String?];
+          case 'write':
+            final key = call.arguments['key'] as String?;
+            final value = call.arguments['value'] as String?;
+            if (key != null && value != null) store[key] = value;
+            return null;
+          case 'delete':
+            store.remove(call.arguments['key'] as String?);
+            return null;
+          case 'deleteAll':
+            store.clear();
+            return null;
+          case 'readAll':
+            return store;
+          case 'containsKey':
+            return store.containsKey(call.arguments['key'] as String?);
+          case 'getCapabilities':
+            return {'basicSecureStorage': true};
+          default:
+            return null;
+        }
+      })
+      ..setMockMethodCallHandler(_capabilityChannel, (call) async {
+        if (call.method == 'getCapabilities') {
+          return {
+            'hasHardwareSecurity': false,
+            'hasBiometrics': false,
+            'hasKeychain': true,
+          };
+        }
+        return null;
+      });
   }
 }
 

--- a/mobile/test/services/support/auth_service_test_harness.dart
+++ b/mobile/test/services/support/auth_service_test_harness.dart
@@ -1,0 +1,173 @@
+// ABOUTME: Shared harness for the #4741 AuthService characterization suite —
+// ABOUTME: channel mocks, cleanup-service stubs, and discovery-error silencing.
+//
+// Every file in the characterization suite spins a real AuthService up against
+// channel-backed storage and needs the same secure-storage / capability /
+// native-signer channel mocks, the same UserDataCleanupService success stubs,
+// and the same guard around the fire-and-forget _performDiscovery(). Centralising
+// that plumbing here keeps the upcoming extraction PRs editing one place.
+//
+// Note: each test file still declares its own private mock class — the repo
+// forbids sharing mock *classes* across files (see testing.md). Only the
+// non-mock setup lives here.
+
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show generatePrivateKey;
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+
+const _secureStorageChannel = MethodChannel(
+  'plugins.it_nomads.com/flutter_secure_storage',
+);
+const _capabilityChannel = MethodChannel('openvine.secure_storage');
+const _androidPluginChannel = MethodChannel('nostrmoPlugin');
+
+/// Installed platform-channel mocks for an AuthService characterization test.
+///
+/// Create with [install] in `setUp`, tear down with [remove] in `tearDown`.
+/// The public fields are mutable so individual tests can seed storage or flip
+/// the native-signer probe.
+class AuthServiceChannelMocks {
+  AuthServiceChannelMocks._();
+
+  /// Backing store for the mocked flutter_secure_storage channel.
+  final Map<String, String> secureStorage = {};
+
+  /// Reported by the native `existAndroidNostrSigner` probe (NIP-55 Amber).
+  bool androidSignerInstalled = true;
+
+  /// Installs the secure-storage, capability, and native-signer channel mocks
+  /// AuthService reaches during sign-in / restore.
+  static AuthServiceChannelMocks install() {
+    final mocks = AuthServiceChannelMocks._();
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+    messenger.setMockMethodCallHandler(_secureStorageChannel, (call) async {
+      switch (call.method) {
+        case 'read':
+          return mocks.secureStorage[call.arguments['key'] as String?];
+        case 'write':
+          final key = call.arguments['key'] as String?;
+          final value = call.arguments['value'] as String?;
+          if (key != null && value != null) mocks.secureStorage[key] = value;
+          return null;
+        case 'delete':
+          mocks.secureStorage.remove(call.arguments['key'] as String?);
+          return null;
+        case 'deleteAll':
+          mocks.secureStorage.clear();
+          return null;
+        case 'readAll':
+          return mocks.secureStorage;
+        case 'containsKey':
+          return mocks.secureStorage.containsKey(
+            call.arguments['key'] as String?,
+          );
+        case 'getCapabilities':
+          return {'basicSecureStorage': true};
+        default:
+          return null;
+      }
+    });
+
+    messenger.setMockMethodCallHandler(_capabilityChannel, (call) async {
+      if (call.method == 'getCapabilities') {
+        return {
+          'hasHardwareSecurity': false,
+          'hasBiometrics': false,
+          'hasKeychain': true,
+        };
+      }
+      return null;
+    });
+
+    messenger.setMockMethodCallHandler(_androidPluginChannel, (call) async {
+      if (call.method == 'existAndroidNostrSigner') {
+        return mocks.androidSignerInstalled;
+      }
+      return null;
+    });
+
+    return mocks;
+  }
+
+  /// Removes every handler installed by [install]. Call from `tearDown`.
+  static void remove() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      ..setMockMethodCallHandler(_secureStorageChannel, null)
+      ..setMockMethodCallHandler(_capabilityChannel, null)
+      ..setMockMethodCallHandler(_androidPluginChannel, null);
+  }
+}
+
+/// Applies the default success stubs for a mocked [UserDataCleanupService] so
+/// AuthService sign-in / sign-out paths run without a real cleanup backend.
+void stubUserDataCleanupSuccess(UserDataCleanupService cleanupService) {
+  when(() => cleanupService.shouldClearDataForUser(any())).thenReturn(false);
+  when(
+    () => cleanupService.clearUserSpecificData(
+      reason: any(named: 'reason'),
+      isIdentityChange: any(named: 'isIdentityChange'),
+      userPubkey: any(named: 'userPubkey'),
+      deleteUserData: any(named: 'deleteUserData'),
+    ),
+  ).thenAnswer((_) async => 0);
+  when(() => cleanupService.claimLegacyRows(any())).thenAnswer((_) async {});
+  when(
+    () => cleanupService.markOwnerScopedLegacyDataForUser(any()),
+  ).thenAnswer((_) async {});
+}
+
+/// Builds an [AuthService] wired to a real channel-backed [SecureKeyStorage]
+/// (hardware backing disabled for tests) and the mocked secure storage.
+AuthService buildTestAuthService({
+  required UserDataCleanupService cleanupService,
+  RemoteSignerFactory? remoteSignerFactory,
+}) {
+  return AuthService(
+    userDataCleanupService: cleanupService,
+    keyStorage: SecureKeyStorage(
+      securityConfig: const SecurityConfig(requireHardwareBacked: false),
+    ),
+    flutterSecureStorage: const FlutterSecureStorage(),
+    remoteSignerFactory: remoteSignerFactory,
+  );
+}
+
+/// Runs [body], completing with its result, while guarding the fire-and-forget
+/// `_performDiscovery()` that initialize()/sign-in kicks off — it opens real
+/// relay WebSockets that fail fast under test and would otherwise surface as
+/// unhandled async errors.
+///
+/// Errors from the awaited [body] itself still propagate. Only errors that
+/// escape as unhandled are caught, and they are reported via [printOnFailure]
+/// so a genuine async bug shows up in a failing test rather than vanishing.
+Future<T> ignoringDiscoveryErrors<T>(Future<T> Function() body) async {
+  final completer = Completer<T>();
+  runZonedGuarded(
+    () async {
+      try {
+        completer.complete(await body());
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    },
+    (error, stack) {
+      printOnFailure(
+        'Ignored unhandled async error (discovery): $error\n$stack',
+      );
+    },
+  );
+  return completer.future;
+}
+
+/// A fresh random public key hex, for identity assertions.
+String freshPubkeyHex() =>
+    SecureKeyContainer.fromPrivateKeyHex(generatePrivateKey()).publicKeyHex;


### PR DESCRIPTION
## Description

First increment of the #4741 `auth_service` god-file extraction: it establishes the
**behavior-preservation safety net** before any restructuring begins.

`mobile/lib/services/auth_service.dart` (5,798 lines) has no single `auth_service_test.dart`
(so the `untested_services` floor still defers it by basename), and several concerns had **zero**
characterization coverage. This PR adds targeted characterization tests for the previously
uncovered / thinly-covered concerns that will move into the extracted package, raising
`auth_service.dart` line coverage **63.1% → 72.8%** (+168 lines). **No production code changes** —
tests only.

Test files added (19 tests), all runnable on CI without an emulator (platform-channel +
`mocktail` stubs, real channel-backed `SecureKeyStorage`):

- `auth_service_amber_test.dart` — NIP-55 Amber (**was zero coverage**): `connectWithAmber`
  platform/availability guards + `initialize()` Amber-restore path (happy + signer-uninstalled).
- `auth_service_bunker_connect_test.dart` — NIP-46 `connectWithBunker` (happy → `BunkerNostrIdentity`,
  pullPubkey-null, invalid URL) via the injectable `remoteSignerFactory`; plus `nostrconnect://`
  no-session guards.
- `auth_service_import_test.dart` — `importFromNsec` / `importFromHex` / `importFromNcryptsec` (NIP-49)
  happy paths + validation/error branches (invalid nsec/hex, wrong password).
- `auth_service_create_anonymous_test.dart` — `createAnonymousAccount` + `...FromKeyContainer`
  (transitively `createNewIdentity` + `acceptTerms`).
- `auth_service_destructive_signout_test.dart` — the `_completeDestructiveSignOutAfterDeletedKeys`
  recovery branch (destructive `signOut` when a post-key-deletion cleanup step throws).

**Related Issue:** Relates to #4741 (epic #4338 Wave 2). Full investigation, brainstorm, and staged
plan live in `tasks/{findings,brainstorm,plan}_4741.md` (Approach C: one `packages/auth_repository`
with internal client/repository tiers).

## Out of Scope

- The `nostrconnect://` **happy path** (`initiateNostrConnect` → `waitForNostrConnectResponse`) needs a
  `NostrConnectSession` injection seam (`start()` connects to public relays) — best added as part of the
  extraction PRs. Only its no-session guards are covered here.
- The actual extraction (package scaffolding, in-place split behind the facade, consumer cutover) —
  subsequent #4741 PRs per `tasks/plan_4741.md`.

## Verification

- `flutter analyze lib test integration_test` → No issues found
- `flutter test test/services/auth_service_*_test.dart` → 216 tests pass
- `flutter test --coverage` over the suite → `auth_service.dart` 72.8% (from 63.1%)

## Type of Change

- [x] 🧹 Code refactor (extraction-prep; test-only, no production changes)
