### PR TITLE
fix(video-editor): bump pro_image_editor to 12.11.1 for layer animation fix

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1800,10 +1800,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_image_editor
-      sha256: b48d60ad171bf0fb167e3ef854a52ae55437ce9dcb62f40fbea10ac9797ed6f4
+      sha256: "2a7897e1e73d747598baa49297a7ad9b09dab0c84789b7a1f1c9cbe7a19b40da"
       url: "https://pub.dev"
     source: hosted
-    version: "12.8.0"
+    version: "12.11.1"
   pro_video_editor:
     dependency: "direct main"
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -308,7 +308,7 @@ dependencies:
   convert: ^3.1.2
   audio_session: ^0.2.2
   pro_video_editor: ^2.2.0
-  pro_image_editor: ^12.8.0
+  pro_image_editor: ^12.11.1
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7
   sensors_plus: ^7.0.0


### PR DESCRIPTION
Closes #5715

## What

Bumps `pro_image_editor` from `^12.8.0` to `^12.11.1`.

## Why

This fixes the editor layer animation, but the fix itself lives on the package side — not in this repo. The video-timeline `scale` layer animation was drifting the layer in diagonally instead of sliding it straight in, because scaling was anchored on the layout-box center while the layer content is painted off-center. `pro_image_editor` 12.11.1 anchors the scale animation on the layer's visual center, so a `scale` combined with a `slide` (e.g. slide-in from the top) now moves straight.

Since the actual change ships in the package, this PR is just the dependency bump that pulls it into the app — there's no app-side code change to review beyond `pubspec.yaml` / `pubspec.lock`.