### PR TITLE
refactor(auth): dead-code cull + NostrKeyManager consolidation (#4741)

### DIFF
--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -124,7 +124,6 @@ NostrKeyManager nostrKeyManager(Ref ref) {
 @Riverpod(keepAlive: true)
 AuthService authService(Ref ref) {
   final keyStorage = ref.watch(secureKeyStorageProvider);
-  final nostrKeyManager = ref.watch(nostrKeyManagerProvider);
   final userDataCleanupService = ref.watch(userDataCleanupServiceProvider);
   final oauthClient = ref.watch(oauthClientProvider);
   final flutterSecureStorage = ref.watch(flutterSecureStorageProvider);
@@ -137,7 +136,6 @@ AuthService authService(Ref ref) {
   return AuthService(
     userDataCleanupService: userDataCleanupService,
     keyStorage: keyStorage,
-    nostrKeyManager: nostrKeyManager,
     oauthClient: oauthClient,
     flutterSecureStorage: flutterSecureStorage,
     oauthConfig: oauthConfig,

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -519,7 +519,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'5ed8b2e4f69b956cef94207839973aa1f676df4c';
+String _$authServiceHash() => r'f92bfcd639fa7dcef969befb2fb50db08e2aba14';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -4667,12 +4667,12 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     return false;
   }
 
-  /// Fast path: reuse the already-loaded PRIMARY key when it matches the
-  /// last-used npub, avoiding a redundant per-identity storage read.
+  /// Fast path: reuse the PRIMARY key when it matches the last-used npub,
+  /// avoiding a redundant per-identity storage read.
   ///
-  /// Reads the primary container straight from [SecureKeyStorage] (its own
-  /// cache) rather than a separate NostrKeyManager cache; both resolve to the
-  /// same primary key, and the npub guard keeps the reuse correct.
+  /// Reads the primary container from [SecureKeyStorage] — a cache hit when it
+  /// was already loaded during init, otherwise a single platform read. The
+  /// npub guard keeps the reuse correct.
   Future<SecureKeyContainer?> _restoreFromLoadedPrimaryIdentity(
     String lastNpub,
   ) async {

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -13,11 +13,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
 import 'package:nostr_client/nostr_client.dart' show Nip89ClientTag;
 import 'package:nostr_key_manager/nostr_key_manager.dart'
-    show
-        NostrKeyManager,
-        SecureKeyContainer,
-        SecureKeyStorage,
-        SecureKeyStorageException;
+    show SecureKeyContainer, SecureKeyStorage, SecureKeyStorageException;
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:openvine/constants/app_constants.dart';
 import 'package:openvine/models/auth_rpc_capability.dart';
@@ -254,7 +250,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   AuthService({
     required UserDataCleanupService userDataCleanupService,
     SecureKeyStorage? keyStorage,
-    NostrKeyManager? nostrKeyManager,
     KeycastOAuth? oauthClient,
     FlutterSecureStorage? flutterSecureStorage,
     OAuthConfig? oauthConfig,
@@ -269,7 +264,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     Duration expiredSessionRefreshTimeout = defaultExpiredSessionRefreshTimeout,
     Duration? startupNetworkOperationTimeout,
   }) : _keyStorage = keyStorage ?? SecureKeyStorage(),
-       _nostrKeyManager = nostrKeyManager,
        _userDataCleanupService = userDataCleanupService,
        _oauthClient = oauthClient,
        _flutterSecureStorage = flutterSecureStorage,
@@ -290,7 +284,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
            startupNetworkOperationTimeout ??
            defaultStartupNetworkOperationTimeout;
   final SecureKeyStorage _keyStorage;
-  final NostrKeyManager? _nostrKeyManager;
   final UserDataCleanupService _userDataCleanupService;
   final KeycastOAuth? _oauthClient;
   final FlutterSecureStorage? _flutterSecureStorage;
@@ -4543,7 +4536,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
           name: 'AuthService',
           category: LogCategory.auth,
         );
-        final cachedPrimaryIdentity = _restoreFromLoadedPrimaryIdentity(
+        final cachedPrimaryIdentity = await _restoreFromLoadedPrimaryIdentity(
           lastNpub,
         );
         if (cachedPrimaryIdentity != null) {
@@ -4674,22 +4667,45 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     return false;
   }
 
-  SecureKeyContainer? _restoreFromLoadedPrimaryIdentity(String lastNpub) {
-    final keyManager = _nostrKeyManager;
-    final publicKeyHex = keyManager?.publicKey;
-    final privateKeyHex = keyManager?.privateKey;
-
-    if (publicKeyHex == null || privateKeyHex == null) {
+  /// Fast path: reuse the already-loaded PRIMARY key when it matches the
+  /// last-used npub, avoiding a redundant per-identity storage read.
+  ///
+  /// Reads the primary container straight from [SecureKeyStorage] (its own
+  /// cache) rather than a separate NostrKeyManager cache; both resolve to the
+  /// same primary key, and the npub guard keeps the reuse correct.
+  Future<SecureKeyContainer?> _restoreFromLoadedPrimaryIdentity(
+    String lastNpub,
+  ) async {
+    final SecureKeyContainer? primary;
+    try {
+      primary = await _keyStorage.getKeyContainer();
+    } catch (e) {
+      Log.warning(
+        '_restoreFromLoadedPrimaryIdentity: failed to load primary identity: '
+        '$e',
+        name: 'AuthService',
+        category: LogCategory.auth,
+      );
       return null;
     }
 
-    final primaryNpub = NostrKeyUtils.encodePubKey(publicKeyHex);
+    if (primary == null || !primary.hasPrivateKey) {
+      return null;
+    }
+
+    final primaryNpub = NostrKeyUtils.encodePubKey(primary.publicKeyHex);
     if (primaryNpub != lastNpub) {
       return null;
     }
 
+    String? privateKeyHex;
+    primary.withPrivateKey<void>((hex) => privateKeyHex = hex);
+    if (privateKeyHex == null || privateKeyHex!.isEmpty) {
+      return null;
+    }
+
     try {
-      return SecureKeyContainer.fromPrivateKeyHex(privateKeyHex);
+      return SecureKeyContainer.fromPrivateKeyHex(privateKeyHex!);
     } catch (e) {
       Log.warning(
         '_restoreFromLoadedPrimaryIdentity: failed to reuse loaded identity: '

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -412,9 +412,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Current user profile (null if not authenticated)
   UserProfile? get currentProfile => _currentProfile;
 
-  /// Stream of profile changes
-  Stream<UserProfile?> get profileStream => _profileController.stream;
-
   /// Current public key (npub format).
   ///
   /// Reads from [currentIdentity] when available (post-authentication),
@@ -431,13 +428,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       _currentIdentity?.pubkey ??
       _currentKeyContainer?.publicKeyHex ??
       _currentProfile?.publicKeyHex;
-
-  /// Current secure key container (null if not authenticated).
-  ///
-  /// Production code should use [currentIdentity] instead. This getter
-  /// exists for tests that need direct access to the key container.
-  @visibleForTesting
-  SecureKeyContainer? get currentKeyContainer => _currentKeyContainer;
 
   /// Check if user is authenticated
   @override
@@ -1209,46 +1199,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     }
   }
 
-  /// Check if there are saved keys on device (without authenticating)
-  ///
-  /// Useful for showing different UI on welcome screen when user has
-  /// previously used the app vs fresh install.
-  Future<bool> hasSavedKeys() async {
-    try {
-      return await _keyStorage.hasKeys();
-    } catch (e, stack) {
-      Log.error(
-        'Secure storage error checking for saved keys: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      _reportStorageError(e, stack, 'hasSavedKeys()');
-      return false;
-    }
-  }
-
-  /// Get the saved npub from storage (without authenticating)
-  ///
-  /// Returns null if no keys are saved. Used to show which identity
-  /// will be resumed on welcome screen.
-  Future<String?> getSavedNpub() async {
-    try {
-      final hasKeys = await _keyStorage.hasKeys();
-      if (!hasKeys) return null;
-
-      final keyContainer = await _keyStorage.getKeyContainer();
-      return keyContainer?.npub;
-    } catch (e, stack) {
-      Log.error(
-        'Secure storage error loading saved npub: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      _reportStorageError(e, stack, 'getSavedNpub()');
-      return null;
-    }
-  }
-
   /// Initialize the authentication service
   Future<void> initialize() async {
     Log.debug(
@@ -1864,32 +1814,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// Set this before calling [signOut] when the user picks a different account
   /// from the account-switcher. [WelcomeBloc] reads and clears this on start.
   String? pendingAccountSwitchPubkey;
-
-  /// Updates [lastUsedAt] for an existing known account without signing in.
-  ///
-  /// Use this before [signOut] when the user explicitly selects a different
-  /// account from the account-switcher, so the welcome screen presents that
-  /// account as the pre-selected returning user.
-  Future<void> touchKnownAccount(String pubkeyHex) async {
-    final accounts = await getKnownAccounts();
-    final index = accounts.indexWhere((a) => a.pubkeyHex == pubkeyHex);
-    if (index < 0) return;
-    final updated = accounts[index].copyWith(lastUsedAt: DateTime.now());
-    accounts[index] = updated;
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(
-        kKnownAccountsKey,
-        jsonEncode(accounts.map((a) => a.toJson()).toList()),
-      );
-    } catch (e) {
-      Log.warning(
-        'touchKnownAccount: failed to persist for $pubkeyHex: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
 
   // ---------------------------------------------------------------------------
   // Per-account signer info archival
@@ -4407,25 +4331,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         category: LogCategory.auth,
       );
       return false;
-    }
-  }
-
-  /// Get the private key for signing operations
-  Future<String?> getPrivateKeyForSigning({String? biometricPrompt}) async {
-    if (!isAuthenticated) return null;
-
-    try {
-      return await _keyStorage.withPrivateKey<String?>(
-        (privateKeyHex) => privateKeyHex,
-        biometricPrompt: biometricPrompt,
-      );
-    } catch (e) {
-      Log.error(
-        'Failed to get private key: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return null;
     }
   }
 

--- a/mobile/test/services/auth_service_data_cleanup_ordering_test.dart
+++ b/mobile/test/services/auth_service_data_cleanup_ordering_test.dart
@@ -17,8 +17,6 @@ import '../test_setup.dart';
 
 class _MockSecureKeyStorage extends Mock implements SecureKeyStorage {}
 
-class _MockNostrKeyManager extends Mock implements NostrKeyManager {}
-
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
@@ -95,7 +93,6 @@ void main() {
   setupTestEnvironment();
 
   late _MockSecureKeyStorage mockKeyStorage;
-  late _MockNostrKeyManager mockNostrKeyManager;
   late _MockUserDataCleanupService mockCleanupService;
   late _MockKeycastOAuth mockOAuthClient;
   late _FakeFlutterSecureStorage fakeSecureStorage;
@@ -117,7 +114,6 @@ void main() {
 
   setUp(() {
     mockKeyStorage = _MockSecureKeyStorage();
-    mockNostrKeyManager = _MockNostrKeyManager();
     mockCleanupService = _MockUserDataCleanupService();
     mockOAuthClient = _MockKeycastOAuth();
     fakeSecureStorage = _FakeFlutterSecureStorage();
@@ -149,8 +145,6 @@ void main() {
         biometricPrompt: any(named: 'biometricPrompt'),
       ),
     ).thenAnswer((_) async => true);
-    when(() => mockNostrKeyManager.publicKey).thenReturn(null);
-    when(() => mockNostrKeyManager.privateKey).thenReturn(null);
 
     when(
       () => mockCleanupService.clearUserSpecificData(
@@ -170,7 +164,6 @@ void main() {
     return AuthService(
       userDataCleanupService: mockCleanupService,
       keyStorage: mockKeyStorage,
-      nostrKeyManager: mockNostrKeyManager,
       flutterSecureStorage: fakeSecureStorage,
       oauthClient: mockOAuthClient,
     );

--- a/mobile/test/services/auth_service_multi_account_test.dart
+++ b/mobile/test/services/auth_service_multi_account_test.dart
@@ -19,8 +19,6 @@ import '../test_setup.dart';
 
 class _MockSecureKeyStorage extends Mock implements SecureKeyStorage {}
 
-class _MockNostrKeyManager extends Mock implements NostrKeyManager {}
-
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
@@ -63,7 +61,6 @@ void main() {
   setupTestEnvironment();
 
   late _MockSecureKeyStorage mockKeyStorage;
-  late _MockNostrKeyManager mockNostrKeyManager;
   late _MockUserDataCleanupService mockCleanupService;
   late _MockFlutterSecureStorage mockSecureStorage;
   late _MockKeycastOAuth mockOAuthClient;
@@ -77,7 +74,6 @@ void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
     mockKeyStorage = _MockSecureKeyStorage();
-    mockNostrKeyManager = _MockNostrKeyManager();
     mockCleanupService = _MockUserDataCleanupService();
     mockSecureStorage = _MockFlutterSecureStorage();
     mockOAuthClient = _MockKeycastOAuth();
@@ -116,8 +112,6 @@ void main() {
         biometricPrompt: any(named: 'biometricPrompt'),
       ),
     ).thenAnswer((_) async => true);
-    when(() => mockNostrKeyManager.publicKey).thenReturn(null);
-    when(() => mockNostrKeyManager.privateKey).thenReturn(null);
 
     when(
       () => mockCleanupService.shouldClearDataForUser(any()),
@@ -155,7 +149,6 @@ void main() {
     authService = AuthService(
       userDataCleanupService: mockCleanupService,
       keyStorage: mockKeyStorage,
-      nostrKeyManager: mockNostrKeyManager,
       flutterSecureStorage: mockSecureStorage,
     );
   });
@@ -1804,15 +1797,20 @@ void main() {
         authService.currentPublicKeyHex,
         equals(accountBContainer.publicKeyHex),
       );
-      verifyNever(() => mockKeyStorage.getKeyContainer());
+      // The consolidated fast path reads the primary via getKeyContainer to
+      // check for a match; here it does NOT match last_used_npub, so the
+      // per-identity key is restored via getIdentityKeyContainer.
+      verify(
+        () => mockKeyStorage.getIdentityKeyContainer(
+          accountBContainer.npub,
+          biometricPrompt: any(named: 'biometricPrompt'),
+        ),
+      ).called(1);
     });
 
     test(
-      'reuses loaded primary identity when last_used_npub matches key manager',
+      'reuses loaded primary identity when last_used_npub matches primary key',
       () async {
-        final accountBPrivateKey = accountBContainer.withPrivateKey(
-          (privateKeyHex) => privateKeyHex,
-        );
         SharedPreferences.setMockInitialValues({
           'authentication_source': 'automatic',
           'last_used_npub': accountBContainer.npub,
@@ -1820,11 +1818,8 @@ void main() {
         });
 
         when(
-          () => mockNostrKeyManager.publicKey,
-        ).thenReturn(accountBContainer.publicKeyHex);
-        when(
-          () => mockNostrKeyManager.privateKey,
-        ).thenReturn(accountBPrivateKey);
+          () => mockKeyStorage.getKeyContainer(),
+        ).thenAnswer((_) async => accountBContainer);
 
         await _ignoringDiscoveryErrors(authService.initialize);
 
@@ -2056,7 +2051,6 @@ void main() {
         authService = AuthService(
           userDataCleanupService: mockCleanupService,
           keyStorage: mockKeyStorage,
-          nostrKeyManager: mockNostrKeyManager,
           oauthClient: mockOAuthClient,
           flutterSecureStorage: mockSecureStorage,
         );
@@ -2164,7 +2158,6 @@ void main() {
         authService = AuthService(
           userDataCleanupService: mockCleanupService,
           keyStorage: mockKeyStorage,
-          nostrKeyManager: mockNostrKeyManager,
           flutterSecureStorage: mockSecureStorage,
           preFetchFollowing: (_) async {
             prefetchCalls++;
@@ -2196,7 +2189,6 @@ void main() {
       authService = AuthService(
         userDataCleanupService: mockCleanupService,
         keyStorage: mockKeyStorage,
-        nostrKeyManager: mockNostrKeyManager,
         flutterSecureStorage: mockSecureStorage,
         preFetchFollowing: (pubkeyHex) async {
           prefetchedPubkeys.add(pubkeyHex);
@@ -2815,7 +2807,6 @@ void main() {
         final localAuthService = AuthService(
           userDataCleanupService: mockCleanupService,
           keyStorage: mockKeyStorage,
-          nostrKeyManager: mockNostrKeyManager,
           flutterSecureStorage: mockSecureStorage,
           oauthClient: mockOAuthClient,
         );

--- a/mobile/test/services/auth_service_oauth_local_signing_test.dart
+++ b/mobile/test/services/auth_service_oauth_local_signing_test.dart
@@ -17,8 +17,6 @@ import '../test_setup.dart';
 
 class _MockSecureKeyStorage extends Mock implements SecureKeyStorage {}
 
-class _MockNostrKeyManager extends Mock implements NostrKeyManager {}
-
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
@@ -97,7 +95,6 @@ void main() {
   setupTestEnvironment();
 
   late _MockSecureKeyStorage mockKeyStorage;
-  late _MockNostrKeyManager mockNostrKeyManager;
   late _MockUserDataCleanupService mockCleanupService;
   late _MockKeycastOAuth mockOAuthClient;
   late _FakeFlutterSecureStorage fakeSecureStorage;
@@ -113,7 +110,6 @@ void main() {
 
   setUp(() {
     mockKeyStorage = _MockSecureKeyStorage();
-    mockNostrKeyManager = _MockNostrKeyManager();
     mockCleanupService = _MockUserDataCleanupService();
     mockOAuthClient = _MockKeycastOAuth();
     fakeSecureStorage = _FakeFlutterSecureStorage();
@@ -146,9 +142,6 @@ void main() {
       () => mockKeyStorage.storeIdentityKeyContainer(any(), any()),
     ).thenAnswer((_) async {});
 
-    when(() => mockNostrKeyManager.publicKey).thenReturn(null);
-    when(() => mockNostrKeyManager.privateKey).thenReturn(null);
-
     when(
       () => mockCleanupService.shouldClearDataForUser(any()),
     ).thenReturn(false);
@@ -176,7 +169,6 @@ void main() {
     return AuthService(
       userDataCleanupService: mockCleanupService,
       keyStorage: mockKeyStorage,
-      nostrKeyManager: mockNostrKeyManager,
       flutterSecureStorage: fakeSecureStorage,
       oauthClient: mockOAuthClient,
       oauthConfig: const OAuthConfig(

--- a/mobile/test/services/auth_service_oauth_recovery_test.dart
+++ b/mobile/test/services/auth_service_oauth_recovery_test.dart
@@ -18,8 +18,6 @@ import '../test_setup.dart';
 
 class _MockSecureKeyStorage extends Mock implements SecureKeyStorage {}
 
-class _MockNostrKeyManager extends Mock implements NostrKeyManager {}
-
 class _MockUserDataCleanupService extends Mock
     implements UserDataCleanupService {}
 
@@ -101,7 +99,6 @@ void main() {
   setupTestEnvironment();
 
   late _MockSecureKeyStorage mockKeyStorage;
-  late _MockNostrKeyManager mockNostrKeyManager;
   late _MockUserDataCleanupService mockCleanupService;
   late _MockKeycastOAuth mockOAuthClient;
   late _FakeFlutterSecureStorage fakeSecureStorage;
@@ -118,7 +115,6 @@ void main() {
 
   setUp(() {
     mockKeyStorage = _MockSecureKeyStorage();
-    mockNostrKeyManager = _MockNostrKeyManager();
     mockCleanupService = _MockUserDataCleanupService();
     mockOAuthClient = _MockKeycastOAuth();
     fakeSecureStorage = _FakeFlutterSecureStorage();
@@ -169,8 +165,6 @@ void main() {
         biometricPrompt: any(named: 'biometricPrompt'),
       ),
     ).thenAnswer((_) async => true);
-    when(() => mockNostrKeyManager.publicKey).thenReturn(null);
-    when(() => mockNostrKeyManager.privateKey).thenReturn(null);
 
     when(
       () => mockCleanupService.shouldClearDataForUser(any()),
@@ -204,7 +198,6 @@ void main() {
     return AuthService(
       userDataCleanupService: mockCleanupService,
       keyStorage: mockKeyStorage,
-      nostrKeyManager: mockNostrKeyManager,
       flutterSecureStorage: fakeSecureStorage,
       oauthClient: mockOAuthClient,
     );


### PR DESCRIPTION
## Description

PR2 of the #4741 `auth_service` extraction: subtractive cleanup that shrinks the surface the
extraction must preserve. Two commits.

**1. Dead-code cull.** Removes 6 public `AuthService` members with **zero callers anywhere**
(verified across `lib`, `test`, `integration_test`, `packages`): `profileStream`,
`currentKeyContainer`, `hasSavedKeys`, `getSavedNpub`, `touchKnownAccount`,
`getPrivateKeyForSigning`. No behavior change.

**2. NostrKeyManager consolidation.** The injected `NostrKeyManager` was near-redundant — all key
CRUD already flows through `SecureKeyStorage`, and its only reader was the last-used-account fast
path (`_restoreFromLoadedPrimaryIdentity`). This:
- Removes the `nostrKeyManager` constructor param / field / import from `AuthService`.
- Rewires `_restoreFromLoadedPrimaryIdentity` to read the primary container via
  `SecureKeyStorage.getKeyContainer()` (now `async`). Both resolve to the same primary key, and the
  `npub == last_used_npub` guard keeps the reuse correct, so **the restored identity is unchanged**.
  Behavior note: the fast path now reads the primary to check for a match (one extra, cached read)
  even when the last-used account differs from the primary — an outcome-preserving difference.
- Drops the `nostrKeyManager` wiring from `authService` provider (`nostrKeyManagerProvider` stays —
  `main.dart` still uses it); regenerates the provider hash.
- Rewires 4 auth tests off the `NostrKeyManager` mock (`multi_account`, `oauth_recovery`,
  `oauth_local_signing`, `data_cleanup_ordering`), including the two fast-path assertions.

**Related Issue:** Relates to #4741 (epic #4338 Wave 2). Plan: `tasks/plan_4741.md` (Approach C).
Independent of #5713 (PR1, test-only) — no overlapping files; either merge order is fine.

## Out of Scope

- The physical package extraction (subsequent #4741 PRs).
- Whether `NostrKeyManager` / its `main.dart` init is now wholly vestigial — left as a separate
  question; this PR only removes AuthService's dependency on it.

## Verification

- `flutter analyze lib test integration_test` → No issues found
- `flutter test test/services/auth_service_*_test.dart` → 197 tests pass (incl. the 2 rewired
  multi_account fast-path tests)
- `flutter test` on the other real-AuthService consumers (video_editor_route, provider tests) → pass
- `dart run build_runner build` → only `auth_providers.g.dart` hash changed (committed)

## Type of Change

- [x] 🧹 Code refactor
