### PR TITLE
fix(video-editor): bump pro_video_editor to 2.2.2 for rendering fixes

### DIFF
--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: "6a9a4929252f67948d58ac2424edcd96e46e0aa4c0736535dda30bf125a0da29"
+      sha256: ca1af2b67c883c6344b3ca7697736ab8390658bd8d78835ab26a0247e5200e67
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.2"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -311,7 +311,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^2.2.0
+  pro_video_editor: ^2.2.2
   pro_image_editor: ^12.11.1
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7


### PR DESCRIPTION
Closes #5719

## What

Bumps `pro_video_editor` from `^2.2.0` to `^2.2.2`.

## Why

The iOS/macOS layer rendering issue is fixed upstream in `pro_video_editor`, so the app should consume the package fix directly instead of adding app-layer compensation logic.

The original failure mode was a slide-in overlay layer briefly shifting and shrinking the video when a custom output resolution was set, often showing a black bar at the top. `2.2.1` fixed that by clipping off-frame overlay content to the video frame before letterboxing.

`2.2.2` includes that fix plus two additional rendering fixes:

- layers with `animateOut` / `animateInOut` now animate out correctly when their `endTime` is unset and they run until the end of the video
- iOS/macOS clip transitions are smoother because pre-rendered transition clips use the composition frame rate and directional transitions use one easing ramp per output frame

## Changes

- `mobile/pubspec.yaml`: `pro_video_editor: ^2.2.0` -> `^2.2.2`
- `mobile/pubspec.lock`: resolved `pro_video_editor` to `2.2.2`
- preserved `pro_image_editor: ^12.11.1` from current `main`

## Validation

- `flutter pub get`
- `flutter analyze`
