### PR TITLE
fix(video-editor): show timeline clip poster instantly on first open

### DIFF
--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -538,12 +538,9 @@ class _ThumbnailImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Reuse the plain FileImage cache key that the clip poster and grid
-    // (video_editor_thumbnail.dart, video_clip_thumbnail_card.dart) already
-    // warmed, so the fallback paints instantly on first open. A cacheHeight
-    // here would key a separate cold resized decode, leaving the slot black
-    // for a frame. Strip thumbnails below keep cacheHeight — they are unique
-    // per slot with no warm entry to share.
+    // No cacheHeight: reuse the plain FileImage key the poster/grid already
+    // warmed so this is a cache hit, not a cold resized decode that flashes
+    // black. Strip thumbnails below keep it — they have no warm entry to share.
     final fallback = thumbnailPath != null
         ? Image.file(
             File(thumbnailPath!),

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_tiles.dart
@@ -538,11 +538,16 @@ class _ThumbnailImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Reuse the plain FileImage cache key that the clip poster and grid
+    // (video_editor_thumbnail.dart, video_clip_thumbnail_card.dart) already
+    // warmed, so the fallback paints instantly on first open. A cacheHeight
+    // here would key a separate cold resized decode, leaving the slot black
+    // for a frame. Strip thumbnails below keep cacheHeight — they are unique
+    // per slot with no warm entry to share.
     final fallback = thumbnailPath != null
         ? Image.file(
             File(thumbnailPath!),
             fit: BoxFit.cover,
-            cacheHeight: cacheHeight,
             excludeFromSemantics: true,
             errorBuilder: (_, _, _) =>
                 const ColoredBox(color: VineTheme.surfaceContainerHigh),

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -198,13 +198,9 @@ void main() {
     });
 
     group('thumbnail fallback', () {
-      // Regression: on first open the timeline slots flashed black for a
-      // frame while the poster preview showed instantly. The preview and the
-      // clip grid render the thumbnail as a plain FileImage, warming that
-      // cache key before the editor opens. The strip fallback used
-      // `cacheHeight`, which keys a separate ResizeImage — a cold decode that
-      // paints nothing (black) until it finishes. It must reuse the plain
-      // FileImage key so the warm entry paints on the first frame.
+      // Regression: the fallback must be a plain FileImage (not a
+      // cacheHeight-keyed ResizeImage) so it hits the warm poster cache entry
+      // instead of a cold decode that flashes black on first open.
       testWidgets(
         'poster fallback reuses the plain FileImage key (no resize)',
         (tester) async {

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -197,6 +197,48 @@ void main() {
       });
     });
 
+    group('thumbnail fallback', () {
+      // Regression: on first open the timeline slots flashed black for a
+      // frame while the poster preview showed instantly. The preview and the
+      // clip grid render the thumbnail as a plain FileImage, warming that
+      // cache key before the editor opens. The strip fallback used
+      // `cacheHeight`, which keys a separate ResizeImage — a cold decode that
+      // paints nothing (black) until it finishes. It must reuse the plain
+      // FileImage key so the warm entry paints on the first frame.
+      testWidgets(
+        'poster fallback reuses the plain FileImage key (no resize)',
+        (tester) async {
+          final clips = [
+            _createTestClip(
+              id: 'a',
+              thumbnailPath: '/tmp/nonexistent_thumb_a.jpg',
+            ),
+          ];
+
+          await tester.pumpWidget(buildWidget(clips: clips, totalWidth: 400));
+
+          // Before strip thumbnails stream in, every slot renders the poster
+          // fallback. Each must be a plain FileImage on the thumbnail path.
+          final images = tester.widgetList<Image>(find.byType(Image)).toList();
+          expect(images, isNotEmpty);
+          for (final image in images) {
+            expect(
+              image.image,
+              isA<FileImage>().having(
+                (provider) => provider.file.path,
+                'file.path',
+                '/tmp/nonexistent_thumb_a.jpg',
+              ),
+              reason:
+                  'Fallback must use a plain FileImage (not a cacheHeight-keyed '
+                  'ResizeImage) so it hits the warm poster cache entry and '
+                  'paints instantly instead of flashing black.',
+            );
+          }
+        },
+      );
+    });
+
     group('empty state', () {
       testWidgets('renders with empty clip list', (tester) async {
         await tester.pumpWidget(buildWidget(clips: [], totalWidth: 0));
@@ -344,6 +386,7 @@ DivineVideoClip _createTestClip({
   int seconds = 2,
   int trimStartMs = 0,
   int trimEndMs = 0,
+  String? thumbnailPath,
 }) {
   return DivineVideoClip(
     id: id,
@@ -354,5 +397,6 @@ DivineVideoClip _createTestClip({
     targetAspectRatio: .vertical,
     trimStart: Duration(milliseconds: trimStartMs),
     trimEnd: Duration(milliseconds: trimEndMs),
+    thumbnailPath: thumbnailPath,
   );
 }


### PR DESCRIPTION
Closes #5723

## What

On first open of the video editor, the timeline clip slots flashed black for a frame while the main preview poster showed instantly — even though both render the exact same `clip.thumbnailPath` file.

This drops `cacheHeight` from the timeline's poster fallback so it reuses the already-warm image-cache entry instead of triggering a separate cold decode.

## Why

The flash was an **image-cache key mismatch**, not a slow generation step:

- The main preview ([video_editor_thumbnail.dart](mobile/lib/widgets/video_editor/main_editor/video_editor_thumbnail.dart)) and the clip grid ([video_clip_thumbnail_card.dart](mobile/lib/widgets/video_clip/video_clip_thumbnail_card.dart)) render the poster as a plain `FileImage`. That key is already decoded and warm in the image cache before the editor even opens, so the preview paints in the first frame.
- The timeline fallback passed `cacheHeight`, which wraps the provider in a `ResizeImage` — a *different*, cold cache key. That forces a fresh async decode (~100 ms) during which the `Image` paints nothing, and the near-black `surfaceContainerHigh` background shows through. That is the black flash.

Reusing the plain `FileImage` key makes the fallback a cache hit → it paints on the first frame, matching the preview. It also collapses what were previously **two** cache entries for the same file (plain + resized) into one, so this is a net memory reduction. The streamed strip thumbnails keep `cacheHeight` — those are unique per slot with no warm entry to share.

## Testing

- Added a regression test asserting the fallback uses a plain `FileImage` (not a `cacheHeight`-keyed `ResizeImage`). It fails on the old code and passes on the fix.
- `flutter test` on the strip suite: all green.
- `flutter analyze` on the changed files: clean.

## Manual test plan

- Open the editor with existing clips (cold) and confirm the timeline thumbnails appear immediately, no black flash before the generated strip frames stream in.