### PR TITLE
test(auth): stop signout_cleanup nulling the shared secure-storage channel (#4741)

### DIFF
--- a/mobile/test/services/auth_service_signout_cleanup_test.dart
+++ b/mobile/test/services/auth_service_signout_cleanup_test.dart
@@ -496,10 +496,12 @@ void main() {
                 }
                 return null;
               });
-          addTearDown(() {
-            TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-                .setMockMethodCallHandler(secureStorageChannel, null);
-          });
+          // Restore the shared handler installed by setupTestEnvironment()
+          // rather than nulling it: this channel is global, and clearing it
+          // strands later suites (e.g. nostr_key_manager_profile_fetch_test)
+          // with MissingPluginException under CI's --optimization
+          // single-isolate run with shuffled ordering.
+          addTearDown(setupTestEnvironment);
 
           fakeAsync((async) {
             when(() => mockKeyStorage.clearCache()).thenReturn(null);


### PR DESCRIPTION
## Problem

#5713's Tests check went red (9 failures in `nostr_key_manager_profile_fetch_test.dart`, all `MissingPluginException` on `plugins.it_nomads.com/flutter_secure_storage`). Root cause — a latent **order-dependence** exposed under CI's `very_good test --optimization` (all suites in one isolate) with `--test-randomize-ordering-seed random`:

- The `signout_cleanup` "callbacks share one timeout budget" test (added by #5713's de-flake) stubs the flutter_secure_storage channel, then its `addTearDown` sets that **global** handler to `null`.
- `nostr_key_manager_profile_fetch_test` never mocks the channel itself — it relies on the ambient handler installed once by `setupTestEnvironment()`.
- On seeds where signout_cleanup runs first, its teardown leaves the channel dead, and the profile-fetch suite's `importPrivateKey`/`importFromNsec` (which write to secure storage) throw `MissingPluginException` → all 9 fail.

#5713 merged on a lucky seed, so this latent flake now lives on `main` (`auth_service_signout_cleanup_test.dart:501`). It does **not** reproduce on macOS locally — nulling the mock there falls through to the real `flutter_secure_storage_macos` plugin; Linux CI has no such fallback.

## Fix

Restore the shared handler via `setupTestEnvironment()` in the teardown instead of nulling it. This mirrors the pattern already documented in the shared harness (`AuthServiceChannelMocks.remove()`), which explicitly warns about this exact case and names `nostr_key_manager_profile_fetch_test` as the victim. The during-test stub is unchanged (no reflake risk); the global channel is simply left working for later suites.

## Verification

- `flutter analyze` — no issues
- `auth_service_signout_cleanup_test.dart` — 21 tests pass (de-flake intact)
- `very_good test --optimization` over culprit + victim — all pass
- Pre-commit hooks green (format, analyze)

One-line change; the guarantee is structural — the global secure-storage channel is never left `null` after teardown, so no later suite can hit `MissingPluginException` from this cause on any seed.

Follow-up to #5713. Part of #4741.