### PR TITLE
feat(video): 60s series recording, split-on-publish & feed swipe (POC)

### DIFF
--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_bloc.dart
@@ -13,6 +13,7 @@ import 'package:feed_tuning_repository/feed_tuning_repository.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:media_cache/media_cache.dart';
 import 'package:models/models.dart' hide LogCategory;
+import 'package:openvine/blocs/video_feed/video_series_grouping.dart';
 import 'package:openvine/extensions/video_event_extensions.dart';
 import 'package:openvine/services/media_availability_checker.dart';
 import 'package:openvine/utils/video_identity.dart';
@@ -264,7 +265,11 @@ class FullscreenFeedBloc
         // (e.g. the liked-videos like-change subscription / load-more, which
         // never re-filter) can't re-introduce an author who is blocked under
         // the current blocklist. Idempotent for sources that already filter.
-        final videos = _applyUnavailableFilter(_applyBlockFilter(incoming));
+        final filtered = _applyUnavailableFilter(_applyBlockFilter(incoming));
+        // Collapse series segments into one anchor per series so a longer
+        // recording shows as a single horizontally-swipeable card.
+        final grouped = groupVideoSeries(filtered);
+        final videos = grouped.items;
 
         Log.debug(
           'FullscreenFeedBloc: Videos updated, count=${videos.length}',
@@ -272,11 +277,15 @@ class FullscreenFeedBloc
           category: LogCategory.video,
         );
 
-        final indexResolution = _nextIndexForVideos(videos);
+        final indexResolution = _nextIndexForVideos(
+          videos,
+          grouped.seriesSegments,
+        );
 
         return state.copyWith(
           status: FullscreenFeedStatus.ready,
           videos: videos,
+          seriesSegments: grouped.seriesSegments,
           currentIndex: indexResolution.index,
           isLoadingMore: false,
           initialTargetResolved:
@@ -298,17 +307,24 @@ class FullscreenFeedBloc
 
   ({int index, bool initialTargetResolved}) _nextIndexForVideos(
     List<VideoEvent> videos,
+    Map<String, List<VideoEvent>> seriesSegments,
   ) {
     if (videos.isEmpty) {
       return (index: state.currentIndex, initialTargetResolved: false);
     }
 
     if (!state.userChangedIndex && !state.initialTargetResolved) {
-      final initialTargetIndex = indexOfVideoIdentity(
+      var initialTargetIndex = indexOfVideoIdentity(
         videos,
         videoId: _initialVideoId,
         stableId: _initialStableId,
       );
+      // The launch target may be a non-anchor segment that was collapsed into
+      // its series anchor; resolve to the anchor's position so tapping any
+      // segment in a grid opens that series card.
+      if (initialTargetIndex < 0) {
+        initialTargetIndex = _anchorIndexForSegment(videos, seriesSegments);
+      }
       if (initialTargetIndex >= 0) {
         Log.debug(
           'FullscreenFeedBloc: resolved initial target '
@@ -349,6 +365,25 @@ class FullscreenFeedBloc
       index: state.currentIndex.clamp(0, videos.length - 1),
       initialTargetResolved: false,
     );
+  }
+
+  /// Finds the [videos] (grouped) index of the anchor whose series contains the
+  /// launch target segment, or -1 when the target isn't a collapsed segment.
+  int _anchorIndexForSegment(
+    List<VideoEvent> videos,
+    Map<String, List<VideoEvent>> seriesSegments,
+  ) {
+    for (final entry in seriesSegments.entries) {
+      final match = indexOfVideoIdentity(
+        entry.value,
+        videoId: _initialVideoId,
+        stableId: _initialStableId,
+      );
+      if (match >= 0) {
+        return videos.indexWhere((video) => video.series?.id == entry.key);
+      }
+    }
+    return -1;
   }
 
   void _onHasMoreChanged(

--- a/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
+++ b/mobile/lib/blocs/fullscreen_feed/fullscreen_feed_state.dart
@@ -50,6 +50,7 @@ final class FullscreenFeedState extends Equatable {
   const FullscreenFeedState({
     this.status = FullscreenFeedStatus.initial,
     this.videos = const [],
+    this.seriesSegments = const {},
     this.currentIndex = 0,
     this.isLoadingMore = false,
     this.canLoadMore = false,
@@ -63,8 +64,13 @@ final class FullscreenFeedState extends Equatable {
   /// The current status.
   final FullscreenFeedStatus status;
 
-  /// The list of videos from the source.
+  /// The list of videos from the source, with each series collapsed to one
+  /// anchor item.
   final List<VideoEvent> videos;
+
+  /// Maps a series id to its full, index-ordered segment list, so a series
+  /// anchor in [videos] can render a horizontal swipe of its segments.
+  final Map<String, List<VideoEvent>> seriesSegments;
 
   /// The currently displayed video index.
   final int currentIndex;
@@ -131,6 +137,7 @@ final class FullscreenFeedState extends Equatable {
   FullscreenFeedState copyWith({
     FullscreenFeedStatus? status,
     List<VideoEvent>? videos,
+    Map<String, List<VideoEvent>>? seriesSegments,
     int? currentIndex,
     bool? isLoadingMore,
     bool? canLoadMore,
@@ -144,6 +151,7 @@ final class FullscreenFeedState extends Equatable {
     return FullscreenFeedState(
       status: status ?? this.status,
       videos: videos ?? this.videos,
+      seriesSegments: seriesSegments ?? this.seriesSegments,
       currentIndex: currentIndex ?? this.currentIndex,
       isLoadingMore: isLoadingMore ?? this.isLoadingMore,
       canLoadMore: canLoadMore ?? this.canLoadMore,
@@ -162,6 +170,7 @@ final class FullscreenFeedState extends Equatable {
   List<Object?> get props => [
     status,
     videos,
+    seriesSegments,
     videoUpdateSignature,
     currentIndex,
     isLoadingMore,

--- a/mobile/lib/blocs/video_feed/video_feed_bloc.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_bloc.dart
@@ -14,6 +14,7 @@ import 'package:follow_repository/follow_repository.dart';
 import 'package:models/models.dart' hide LogCategory;
 import 'package:openvine/blocs/video_feed/home_feed_cache.dart';
 import 'package:openvine/blocs/video_feed/home_feed_resume_manager.dart';
+import 'package:openvine/blocs/video_feed/video_series_grouping.dart';
 import 'package:openvine/observability/reportable_error.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -404,9 +405,11 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
       final mergedListOnly = {...state.listOnlyVideoIds}
         ..addAll(result.listOnlyVideoIds);
 
+      final grouped = groupVideoSeries(updatedVideos);
       emit(
         state.copyWith(
-          videos: updatedVideos,
+          videos: grouped.items,
+          seriesSegments: grouped.seriesSegments,
           // Only stop pagination when the server returns nothing.
           // Fewer than _pageSize can happen due to server-side filtering.
           hasMore: _hasMoreForSource(
@@ -676,10 +679,14 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
         displayedVideos.length,
       );
 
+      // Collapse series segments for display; persist/enrich the raw list
+      // below so the cache keeps every segment.
+      final grouped = groupVideoSeries(displayedVideos);
       emit(
         state.copyWith(
           status: VideoFeedStatus.success,
-          videos: displayedVideos,
+          videos: grouped.items,
+          seriesSegments: grouped.seriesSegments,
           // Only stop pagination when no results at all.
           // Fewer than _pageSize can happen due to server-side filtering.
           hasMore: _hasMoreForSource(
@@ -768,10 +775,13 @@ class VideoFeedBloc extends Bloc<VideoFeedEvent, VideoFeedBlocState> {
     // The cached window already starts at the resume position (already-watched
     // videos were dropped on write), so it is served at index 0.
     _feedTracker?.markFirstVideosReceived(mode, cachedValid.length);
+    // The persisted window is raw (every segment); collapse series for display.
+    final grouped = groupVideoSeries(cachedValid);
     emit(
       state.copyWith(
         status: VideoFeedStatus.success,
-        videos: cachedValid,
+        videos: grouped.items,
+        seriesSegments: grouped.seriesSegments,
         currentIndex: 0,
         hasMore: true,
         clearPaginationCursor: true,

--- a/mobile/lib/blocs/video_feed/video_feed_state.dart
+++ b/mobile/lib/blocs/video_feed/video_feed_state.dart
@@ -158,6 +158,7 @@ final class VideoFeedBlocState extends Equatable {
     this.error,
     this.videoListSources = const {},
     this.listOnlyVideoIds = const {},
+    this.seriesSegments = const {},
     this.creatorProfiles = const {},
     this.paginationCursor,
     this.currentIndex = 0,
@@ -177,6 +178,10 @@ final class VideoFeedBlocState extends Equatable {
 
   /// The list of videos for the current feed mode.
   final List<VideoEvent> videos;
+
+  /// Ordered segment lists keyed by series id, for videos in [videos] that are
+  /// series anchors. Lets the feed render a swipeable card per series.
+  final Map<String, List<VideoEvent>> seriesSegments;
 
   /// The active feed source.
   final VideoFeedSource source;
@@ -261,6 +266,7 @@ final class VideoFeedBlocState extends Equatable {
     bool clearError = false,
     Map<String, Set<String>>? videoListSources,
     Set<String>? listOnlyVideoIds,
+    Map<String, List<VideoEvent>>? seriesSegments,
     Map<String, UserProfile>? creatorProfiles,
     String? paginationCursor,
     bool clearPaginationCursor = false,
@@ -279,6 +285,7 @@ final class VideoFeedBlocState extends Equatable {
       error: clearError ? null : (error ?? this.error),
       videoListSources: videoListSources ?? this.videoListSources,
       listOnlyVideoIds: listOnlyVideoIds ?? this.listOnlyVideoIds,
+      seriesSegments: seriesSegments ?? this.seriesSegments,
       creatorProfiles: creatorProfiles ?? this.creatorProfiles,
       paginationCursor: clearPaginationCursor
           ? null
@@ -299,6 +306,7 @@ final class VideoFeedBlocState extends Equatable {
     error,
     videoListSources,
     listOnlyVideoIds,
+    seriesSegments,
     creatorProfiles,
     paginationCursor,
     currentIndex,

--- a/mobile/lib/blocs/video_feed/video_series_grouping.dart
+++ b/mobile/lib/blocs/video_feed/video_series_grouping.dart
@@ -1,0 +1,49 @@
+// ABOUTME: Collapses series segments in a feed video list into one card.
+// ABOUTME: Pure helper so the grouping math is unit-testable in isolation.
+
+import 'package:models/models.dart';
+
+/// A feed video list after series collapsing.
+///
+/// [items] is the feed order with each series reduced to a single anchor
+/// (its first segment). [seriesSegments] maps a series id to its full,
+/// index-ordered segment list so the UI can render a swipeable card.
+typedef GroupedSeriesFeed = ({
+  List<VideoEvent> items,
+  Map<String, List<VideoEvent>> seriesSegments,
+});
+
+/// Collapses series segments in [videos] into a single anchor item per series.
+///
+/// A series is identified by a shared [VideoEvent.series] id. Every segment of
+/// a series is removed from [GroupedSeriesFeed.items] except one anchor, placed
+/// at the position the series was first seen so overall feed order is preserved.
+/// The anchor is the lowest-`index` segment, and the full ordered segment list
+/// is returned under the series id. Videos without a series pass through
+/// unchanged.
+GroupedSeriesFeed groupVideoSeries(List<VideoEvent> videos) {
+  final seriesSegments = <String, List<VideoEvent>>{};
+  for (final video in videos) {
+    final series = video.series;
+    if (series == null) continue;
+    (seriesSegments[series.id] ??= <VideoEvent>[]).add(video);
+  }
+
+  for (final segments in seriesSegments.values) {
+    segments.sort((a, b) => a.series!.index.compareTo(b.series!.index));
+  }
+
+  final items = <VideoEvent>[];
+  final placedSeries = <String>{};
+  for (final video in videos) {
+    final series = video.series;
+    if (series == null) {
+      items.add(video);
+    } else if (placedSeries.add(series.id)) {
+      // First segment of this series seen: place the ordered anchor here.
+      items.add(seriesSegments[series.id]!.first);
+    }
+  }
+
+  return (items: items, seriesSegments: seriesSegments);
+}

--- a/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
+++ b/mobile/lib/blocs/video_recorder/video_recorder_bloc.dart
@@ -1369,6 +1369,10 @@ class VideoRecorderBloc
       _readVideoEditor().reset(keepAutosavedDraft: keepAutosavedDraft);
     }
 
+    // Raise/lower the session recording-and-editing cap to match the new mode.
+    // Set after any clearAll above, which resets state to the default cap.
+    _readClipManager().setMaxDuration(mode.maxRecordingDuration);
+
     Log.debug(
       '🎬 Recorder mode changed to: ${mode.name}',
       name: 'VideoRecorderBloc',

--- a/mobile/lib/constants/video_editor_constants.dart
+++ b/mobile/lib/constants/video_editor_constants.dart
@@ -37,7 +37,12 @@ class VideoEditorConstants {
   /// Whether to enforce the tag limit in the UI.
   static const bool enableTagLimit = false;
 
-  /// Maximum recording duration for videos.
+  /// Standard maximum recording duration for videos (the classic 6s loop).
+  ///
+  /// This is the default cap only. The active, per-session cap lives in
+  /// `ClipManagerState.maxDuration`, which the 60s recorder mode raises. Read
+  /// the clip-manager value (not this constant) wherever a session-aware
+  /// limit is needed; this constant is the fallback/default seed.
   static const maxDuration = Duration(seconds: 6, milliseconds: 300);
 
   /// Default time offset for extracting video thumbnails.

--- a/mobile/lib/models/clip_manager_state.dart
+++ b/mobile/lib/models/clip_manager_state.dart
@@ -48,6 +48,7 @@ class ClipManagerState {
     this.activeRecordingDuration = .zero,
     this.mergeOutputPath,
     this.pendingDeletion,
+    this.maxDuration = VideoEditorConstants.maxDuration,
   });
 
   /// List of all recorded clips in order.
@@ -85,6 +86,14 @@ class ClipManagerState {
   /// library trash; UI uses this to drive the Undo snackbar.
   final ClipPendingDeletion? pendingDeletion;
 
+  /// Maximum total recording/editing duration allowed for this session.
+  ///
+  /// Defaults to [VideoEditorConstants.maxDuration] (6.3s). The 60s recorder
+  /// mode raises this; the recorder, editor, and export paths read the cap
+  /// from here rather than the constant so the whole session honours one
+  /// limit.
+  final Duration maxDuration;
+
   /// Total combined duration of all clips.
   Duration get totalDuration {
     return clips.fold(Duration.zero, (sum, clip) => sum + clip.duration);
@@ -94,7 +103,7 @@ class ClipManagerState {
   ///
   /// Returns zero if max duration has been reached or exceeded.
   Duration get remainingDuration {
-    final remaining = VideoEditorConstants.maxDuration - totalDuration;
+    final remaining = maxDuration - totalDuration;
     return remaining.isNegative ? Duration.zero : remaining;
   }
 
@@ -152,6 +161,7 @@ class ClipManagerState {
     bool clearMergeOutputPath = false,
     ClipPendingDeletion? pendingDeletion,
     bool clearPendingDeletion = false,
+    Duration? maxDuration,
   }) {
     return ClipManagerState(
       clips: clips ?? this.clips,
@@ -173,6 +183,7 @@ class ClipManagerState {
       pendingDeletion: clearPendingDeletion
           ? null
           : (pendingDeletion ?? this.pendingDeletion),
+      maxDuration: maxDuration ?? this.maxDuration,
     );
   }
 }

--- a/mobile/lib/models/video_recorder/video_recorder_mode.dart
+++ b/mobile/lib/models/video_recorder/video_recorder_mode.dart
@@ -1,8 +1,10 @@
 import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/constants/video_editor_constants.dart';
 
 enum VideoRecorderMode {
   upload,
   capture,
+  sixtySeconds,
   lipSync,
   classic,
   ;
@@ -21,6 +23,7 @@ enum VideoRecorderMode {
   String get label => switch (this) {
     .upload => 'Upload',
     .capture => 'Capture',
+    .sixtySeconds => '60s',
     .lipSync => 'Lip Sync',
     .classic => 'Classic',
   };
@@ -28,6 +31,7 @@ enum VideoRecorderMode {
   bool get hasRecordingLimit => switch (this) {
     .upload => false,
     .capture => false,
+    .sixtySeconds => false,
     .lipSync => true,
     .classic => true,
   };
@@ -35,6 +39,7 @@ enum VideoRecorderMode {
   bool get hasVideoEditor => switch (this) {
     .upload => false,
     .capture => true,
+    .sixtySeconds => true,
     .lipSync => true,
     .classic => false,
   };
@@ -42,6 +47,7 @@ enum VideoRecorderMode {
   bool get supportGridLines => switch (this) {
     .upload => false,
     .capture => false,
+    .sixtySeconds => false,
     .lipSync => false,
     .classic => true,
   };
@@ -49,6 +55,7 @@ enum VideoRecorderMode {
   bool get supportsCountdownTimer => switch (this) {
     .upload => false,
     .capture => true,
+    .sixtySeconds => true,
     .lipSync => true,
     .classic => false,
   };
@@ -56,7 +63,22 @@ enum VideoRecorderMode {
   model.AspectRatio get defaultAspectRatio => switch (this) {
     .upload => .vertical,
     .capture => .vertical,
+    .sixtySeconds => .vertical,
     .lipSync => .vertical,
     .classic => .square,
+  };
+
+  /// Maximum total recording and editing duration for this mode.
+  ///
+  /// The 60s mode raises the cap; every other mode keeps the standard
+  /// [VideoEditorConstants.defaultMaxDuration]. The recorder applies this to
+  /// the runtime [VideoEditorConstants.maxDuration] on mode change so the
+  /// recorder, editor, render and upload paths all honour the same limit.
+  Duration get maxRecordingDuration => switch (this) {
+    .sixtySeconds => const Duration(seconds: 60),
+    .upload ||
+    .capture ||
+    .lipSync ||
+    .classic => VideoEditorConstants.maxDuration,
   };
 }

--- a/mobile/lib/providers/clip_manager_provider.dart
+++ b/mobile/lib/providers/clip_manager_provider.dart
@@ -50,10 +50,10 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
 
   /// Calculates the remaining recording time available.
   ///
-  /// Returns the difference between [maxDuration] and the sum of all clip
-  /// durations.
+  /// Returns the difference between the session cap (`state.maxDuration`) and
+  /// the sum of all clip durations.
   Duration get remainingDuration {
-    return VideoEditorConstants.maxDuration - totalDuration;
+    return state.maxDuration - totalDuration;
   }
 
   /// Calculates the total duration of all recorded clips.
@@ -62,6 +62,15 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
       Duration.zero,
       (sum, clip) => sum + clip.duration,
     );
+  }
+
+  /// Sets the maximum recording/editing duration for the current session.
+  ///
+  /// Called by the recorder when the mode changes (the 60s mode raises the
+  /// cap). No-ops when unchanged so it doesn't churn state.
+  void setMaxDuration(Duration maxDuration) {
+    if (state.maxDuration == maxDuration) return;
+    state = state.copyWith(maxDuration: maxDuration);
   }
 
   @override
@@ -800,7 +809,10 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
       name: 'ClipManagerNotifier',
       category: .video,
     );
-    state = ClipManagerState();
+    // Preserve the session recording/editing cap: clearing clips must not reset
+    // the mode-derived maxDuration (a later reset cascade would clobber the 60s
+    // set by the recorder otherwise).
+    state = ClipManagerState(maxDuration: state.maxDuration);
   }
 
   /// Remove all clips and reset state.
@@ -819,7 +831,10 @@ class ClipManagerNotifier extends Notifier<ClipManagerState> {
       name: 'ClipManagerNotifier',
       category: .video,
     );
-    state = ClipManagerState();
+    // Preserve the session recording/editing cap: clearing clips must not reset
+    // the mode-derived maxDuration (a later reset cascade would clobber the 60s
+    // set by the recorder otherwise).
+    state = ClipManagerState(maxDuration: state.maxDuration);
 
     // Delete autosave draft and its associated files
     if (!keepAutosavedDraft) {

--- a/mobile/lib/providers/segment_clip_provider.dart
+++ b/mobile/lib/providers/segment_clip_provider.dart
@@ -1,0 +1,62 @@
+// ABOUTME: Lazily renders one 60s-series segment into a standalone clip.
+// ABOUTME: Backs the full-screen preview and cover picker for a single segment.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
+
+/// Resolves segment [index] of the rendered clip as its own [DivineVideoClip].
+///
+/// The full-screen preview and cover picker play/scrub a real video file, so a
+/// series segment must be rendered into its own file first — extracting a
+/// window on the fly is not enough. Single-video recordings (one window) return
+/// the shared rendered clip unchanged, avoiding a needless render.
+///
+/// Rendered files are kept alive per segment for the session so re-opening a
+/// segment is instant; the family re-runs when the rendered clip changes.
+final FutureProviderFamily<DivineVideoClip?, int> segmentClipProvider =
+    FutureProvider.autoDispose.family<DivineVideoClip?, int>((
+      ref,
+      index,
+    ) async {
+      final clip = ref.watch(
+        videoEditorProvider.select((s) => s.finalRenderedClip),
+      );
+      if (clip == null) return null;
+
+      final windows = VideoEditorRenderService.computeSegmentWindows(
+        totalDuration: clip.duration,
+        maxSegmentDuration: VideoEditorConstants.maxDuration,
+      );
+      // Not a series (a single window) — the full clip is the segment.
+      if (windows.length <= 1 || index < 0 || index >= windows.length) {
+        return clip;
+      }
+      final window = windows[index];
+
+      // Keep the entry alive before the first await so an off-screen
+      // `ref.read(...future)` (from a preview/cover tap) can't dispose the
+      // provider mid-render and cancel the work.
+      ref.keepAlive();
+
+      final sourcePath = await clip.video.safeFilePath();
+      final segmentPath = await VideoEditorRenderService.renderSegmentToFile(
+        sourcePath: sourcePath,
+        start: window.start,
+        end: window.end,
+      );
+      final thumbnail = await VideoThumbnailService.extractThumbnail(
+        videoPath: segmentPath,
+      );
+
+      return clip.copyWith(
+        video: EditorVideo.file(segmentPath),
+        duration: window.end - window.start,
+        thumbnailPath: thumbnail?.path ?? clip.thumbnailPath,
+      );
+    });

--- a/mobile/lib/providers/segment_thumbnail_provider.dart
+++ b/mobile/lib/providers/segment_thumbnail_provider.dart
@@ -1,0 +1,61 @@
+// ABOUTME: Per-segment cover frames for a 60s series before it is split.
+// ABOUTME: Pulls a frame from the shared rendered clip at each segment window.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/providers/series_metadata_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:openvine/services/video_thumbnail_service.dart';
+
+/// Resolves the cover-image path for series segment [index].
+///
+/// Segments are not rendered into separate files until publish, so each
+/// segment's cover is a frame pulled from the shared rendered clip at the
+/// segment's own time window. Segment 0 reuses the clip's existing thumbnail
+/// (the frame the renderer already produced). A user-picked
+/// [SegmentMetadata.thumbnailTimestamp] (offset within the segment) overrides
+/// the default first-frame position.
+///
+/// Keyed by segment index and kept alive on success so switching back to a tab
+/// shows its cover instantly. Re-runs when the rendered clip changes.
+final FutureProviderFamily<String?, int> segmentThumbnailProvider =
+    FutureProvider.autoDispose.family<String?, int>((ref, index) async {
+      final clip = ref.watch(
+        videoEditorProvider.select((s) => s.finalRenderedClip),
+      );
+      if (clip == null) return null;
+
+      final windows = VideoEditorRenderService.computeSegmentWindows(
+        totalDuration: clip.duration,
+        maxSegmentDuration: VideoEditorConstants.maxDuration,
+      );
+      if (index < 0 || index >= windows.length) return null;
+      final window = windows[index];
+
+      final pickedOffset = ref.watch(
+        seriesMetadataProvider.select(
+          (s) => index < s.segments.length
+              ? s.segments[index].thumbnailTimestamp
+              : null,
+        ),
+      );
+
+      // Segment 0 with no custom pick reuses the renderer's own thumbnail.
+      if (index == 0 && pickedOffset == null) return clip.thumbnailPath;
+
+      final frameOffset =
+          pickedOffset ?? VideoEditorConstants.defaultThumbnailExtractTime;
+      final target = window.start + frameOffset;
+
+      final videoPath = await clip.video.safeFilePath();
+      final result = await VideoThumbnailService.extractThumbnail(
+        videoPath: videoPath,
+        targetTimestamp: target,
+      );
+
+      final path = result?.path ?? clip.thumbnailPath;
+      if (path != null) ref.keepAlive();
+      return path;
+    });

--- a/mobile/lib/providers/series_metadata_provider.dart
+++ b/mobile/lib/providers/series_metadata_provider.dart
@@ -1,0 +1,114 @@
+// ABOUTME: Per-segment metadata (title/description/thumbnail) for a 60s series.
+// ABOUTME: Drives the per-segment tabs on the metadata screen before publish.
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+
+/// Per-segment metadata the user can customise before publishing a series.
+///
+/// Only the fields that differ per segment live here; shared fields (tags,
+/// expiration, collaborators, …) stay on the global video-editor state.
+class SegmentMetadata {
+  const SegmentMetadata({
+    this.title = '',
+    this.description = '',
+    this.thumbnailTimestamp,
+  });
+
+  final String title;
+  final String description;
+
+  /// Frame offset (within the segment) chosen as its thumbnail, or null for
+  /// the segment's default (first frame).
+  final Duration? thumbnailTimestamp;
+
+  SegmentMetadata copyWith({
+    String? title,
+    String? description,
+    Duration? thumbnailTimestamp,
+  }) => SegmentMetadata(
+    title: title ?? this.title,
+    description: description ?? this.description,
+    thumbnailTimestamp: thumbnailTimestamp ?? this.thumbnailTimestamp,
+  );
+}
+
+/// State for the per-segment metadata tabs.
+class SeriesMetadataState {
+  const SeriesMetadataState({this.segments = const [], this.activeIndex = 0});
+
+  final List<SegmentMetadata> segments;
+  final int activeIndex;
+
+  /// True when there is more than one segment, i.e. the tabs should be shown.
+  bool get isSeries => segments.length > 1;
+
+  int get count => segments.length;
+
+  /// The currently-selected segment, or null when there are no segments.
+  SegmentMetadata? get active => segments.isEmpty
+      ? null
+      : segments[activeIndex.clamp(0, segments.length - 1)];
+
+  SeriesMetadataState copyWith({
+    List<SegmentMetadata>? segments,
+    int? activeIndex,
+  }) => SeriesMetadataState(
+    segments: segments ?? this.segments,
+    activeIndex: activeIndex ?? this.activeIndex,
+  );
+}
+
+class SeriesMetadataNotifier extends Notifier<SeriesMetadataState> {
+  /// Derives one blank segment per per-video-limit slice of the rendered clip.
+  ///
+  /// Re-runs only when the rendered clip's duration changes (e.g. a re-render),
+  /// so the user's per-segment edits persist while they stay on the screen.
+  @override
+  SeriesMetadataState build() {
+    final duration = ref.watch(
+      videoEditorProvider.select((s) => s.finalRenderedClip?.duration),
+    );
+    final count = duration == null
+        ? 0
+        : VideoEditorRenderService.computeSegmentWindows(
+            totalDuration: duration,
+            maxSegmentDuration: VideoEditorConstants.maxDuration,
+          ).length;
+    return SeriesMetadataState(
+      segments: List.generate(count, (_) => const SegmentMetadata()),
+    );
+  }
+
+  void setActiveIndex(int index) {
+    if (index < 0 ||
+        index >= state.segments.length ||
+        index == state.activeIndex) {
+      return;
+    }
+    state = state.copyWith(activeIndex: index);
+  }
+
+  void updateActive({
+    String? title,
+    String? description,
+    Duration? thumbnailTimestamp,
+  }) {
+    final index = state.activeIndex;
+    if (index < 0 || index >= state.segments.length) return;
+    final segments = [...state.segments];
+    segments[index] = segments[index].copyWith(
+      title: title,
+      description: description,
+      thumbnailTimestamp: thumbnailTimestamp,
+    );
+    state = state.copyWith(segments: segments);
+  }
+}
+
+final seriesMetadataProvider =
+    NotifierProvider<SeriesMetadataNotifier, SeriesMetadataState>(
+      SeriesMetadataNotifier.new,
+    );

--- a/mobile/lib/providers/video_editor_provider.dart
+++ b/mobile/lib/providers/video_editor_provider.dart
@@ -1101,6 +1101,9 @@ class VideoEditorNotifier extends Notifier<VideoEditorProviderState> {
       parameters: renderParameters,
       editorStateHistory: state.editorStateHistory,
       taskId: draftId,
+      // Render the full session length so a 60s recording isn't truncated to
+      // the per-video limit; the publish step splits it into segments.
+      maxOutputDuration: ref.read(clipManagerProvider).maxDuration,
     );
 
     // A newer render was started while this one was running — discard.

--- a/mobile/lib/providers/video_publish_provider.dart
+++ b/mobile/lib/providers/video_publish_provider.dart
@@ -25,6 +25,7 @@ import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/preferences_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
+import 'package:openvine/providers/series_metadata_provider.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/providers/social_providers.dart';
 import 'package:openvine/providers/upload_media_providers.dart';
@@ -364,6 +365,10 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
             parameters: parameters,
             editorStateHistory: draft.editorStateHistory,
             taskId: draft.id,
+            // Render the full session length (60s mode) instead of the 6.3s
+            // default, so the preview isn't truncated and the publish step can
+            // split it into segments.
+            maxOutputDuration: ref.read(clipManagerProvider).maxDuration,
           );
 
           if (result == null) {
@@ -429,8 +434,15 @@ class VideoPublishNotifier extends Notifier<VideoPublishProviderState> {
         },
       );
 
+      final segmentMeta = ref.read(seriesMetadataProvider);
       final publishmentProcess = publishService.publishVideo(
         draft: publishDraft,
+        segmentTexts: segmentMeta.isSeries
+            ? [
+                for (final segment in segmentMeta.segments)
+                  (title: segment.title, description: segment.description),
+              ]
+            : null,
       );
       final videoReplyContext = publishDraft.videoReplyContext;
       final isVideoReply = videoReplyContext != null;

--- a/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
+++ b/mobile/lib/screens/feed/pooled_fullscreen_video_feed_screen.dart
@@ -791,6 +791,7 @@ class _FullscreenFeedContentState extends ConsumerState<FullscreenFeedContent>
                                         // keyboard.
                                         isActive: !_replyComposerFocused,
                                         videos: state.videos,
+                                        seriesSegments: state.seriesSegments,
                                         contextTitle: widget.contextTitle,
                                         currentIndex: state.currentIndex,
                                         hasMore: state.canLoadMore,

--- a/mobile/lib/screens/feed/video_feed_page.dart
+++ b/mobile/lib/screens/feed/video_feed_page.dart
@@ -359,6 +359,7 @@ class _VideoFeedViewState extends ConsumerState<VideoFeedView>
                   children: [
                     FeedVideos(
                       videos: state.videos,
+                      seriesSegments: state.seriesSegments,
                       contextTitle: state.feedContextTitle,
                       currentIndex: clampedIndex,
                       isActive: _isNewFeedActive,

--- a/mobile/lib/screens/video_editor/video_editor_screen.dart
+++ b/mobile/lib/screens/video_editor/video_editor_screen.dart
@@ -478,7 +478,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
       milliseconds: (durationSecs * 1000).toInt(),
     );
     final clipDuration = _clipEditorBloc.state.totalDuration;
-    const maxDuration = VideoEditorConstants.maxDuration;
+    final maxDuration = ref.read(clipManagerProvider).maxDuration;
     final endTime = [
       audioDuration,
       clipDuration,
@@ -510,7 +510,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
   Future<void> _openVoiceOver({required VideoEditorMainBloc mainBloc}) async {
     final availableDuration = resolveVoiceOverAvailableDuration(
       clipDuration: _clipEditorBloc.state.totalDuration,
-      maxDuration: VideoEditorConstants.maxDuration,
+      maxDuration: ref.read(clipManagerProvider).maxDuration,
     );
 
     // Count voice-over already on the timeline so the take numbering continues
@@ -648,7 +648,7 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
     if (editor == null) return;
 
     final clipDuration = _clipEditorBloc.state.totalDuration;
-    const maxDuration = VideoEditorConstants.maxDuration;
+    final maxDuration = ref.read(clipManagerProvider).maxDuration;
     final healed = editor.stateManager.audioTracks.map((track) {
       final secs = resolved[track.id];
       if (secs == null) return track;
@@ -692,7 +692,10 @@ class _VideoEditorScreenState extends ConsumerState<VideoEditorScreen>
               Duration(
                 milliseconds:
                     ((audio.duration ??
-                                VideoEditorConstants.maxDuration.inSeconds) *
+                                ref
+                                    .read(clipManagerProvider)
+                                    .maxDuration
+                                    .inSeconds) *
                             1000)
                         .toInt(),
               ),

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -11,6 +11,7 @@ import 'package:go_router/go_router.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/providers/series_metadata_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/widgets/branded_loading_indicator.dart';
@@ -37,6 +38,7 @@ class VideoMetadataCoverScreen extends ConsumerStatefulWidget {
   const VideoMetadataCoverScreen({
     required this.clip,
     this.thumbnailUrl,
+    this.editSeriesSegment = false,
     super.key,
   });
 
@@ -45,6 +47,11 @@ class VideoMetadataCoverScreen extends ConsumerStatefulWidget {
 
   /// Optional thumbnail URL shown while the player is not yet ready.
   final String? thumbnailUrl;
+
+  /// When `true`, [clip] is a single 60s-series segment: the picked position
+  /// (relative to the segment) is stored on the active segment's metadata
+  /// instead of the shared editor cover.
+  final bool editSeriesSegment;
 
   @override
   ConsumerState<VideoMetadataCoverScreen> createState() =>
@@ -207,29 +214,20 @@ class _VideoMetadataCoverScreenState
 
     var didSucceed = false;
     try {
-      final videoPath = await widget.clip.video.safeFilePath();
-      if (videoPath.isNotEmpty) {
-        final result = await VideoThumbnailService.extractThumbnail(
-          videoPath: videoPath,
-          targetTimestamp: _selectedPosition,
-        );
-        if (result != null && mounted) {
-          if (widget.clip.video.networkUrl != null) {
-            // Published video — return the local path to the caller.
-            // The Blossom upload and republish happen when the user presses Update.
-            Navigator.of(context).pop(result.path);
-            return;
-          } else {
-            // Draft video — update via videoEditorProvider.
-            ref
-                .read(videoEditorProvider.notifier)
-                .updateCover(
-                  thumbnailPath: result.path,
-                  thumbnailTimestamp: _selectedPosition,
-                );
-            didSucceed = true;
-          }
-        }
+      if (widget.editSeriesSegment) {
+        // The clip is a single segment; store the pick (relative to the
+        // segment) on the active segment. The inline preview re-derives its
+        // cover frame from this offset.
+        ref
+            .read(seriesMetadataProvider.notifier)
+            .updateActive(thumbnailTimestamp: _selectedPosition);
+        didSucceed = true;
+      } else {
+        final outcome = await _saveEditorCover();
+        // A null outcome means the published-edit flow already popped with the
+        // extracted path; nothing more to do here.
+        if (outcome == null) return;
+        didSucceed = outcome;
       }
     } catch (e, stackTrace) {
       Log.error(
@@ -262,6 +260,37 @@ class _VideoMetadataCoverScreenState
       context,
     ).showSnackBar(DivineSnackbarContainer.snackBar(message));
     setState(() => _isConfirming = false);
+  }
+
+  /// Extracts the cover at [_selectedPosition] and applies it to the shared
+  /// editor clip. Returns `true` when the draft cover was updated, `false` on
+  /// failure, or `null` when the published-edit flow already popped with the
+  /// extracted path.
+  Future<bool?> _saveEditorCover() async {
+    final videoPath = await widget.clip.video.safeFilePath();
+    if (videoPath.isEmpty) return false;
+
+    final result = await VideoThumbnailService.extractThumbnail(
+      videoPath: videoPath,
+      targetTimestamp: _selectedPosition,
+    );
+    if (result == null || !mounted) return false;
+
+    if (widget.clip.video.networkUrl != null) {
+      // Published video — return the local path to the caller. The Blossom
+      // upload and republish happen when the user presses Update.
+      Navigator.of(context).pop(result.path);
+      return null;
+    }
+
+    // Draft video — update via videoEditorProvider.
+    ref
+        .read(videoEditorProvider.notifier)
+        .updateCover(
+          thumbnailPath: result.path,
+          thumbnailTimestamp: _selectedPosition,
+        );
+    return true;
   }
 
   @override

--- a/mobile/lib/screens/video_metadata/video_metadata_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_screen.dart
@@ -60,8 +60,10 @@ class _VideoMetadataScreenState extends ConsumerState<VideoMetadataScreen> {
       child: GestureDetector(
         onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
         child: switch (recorderMode) {
-          // Lip-sync shares capture's editor + metadata flow.
-          .capture || .lipSync => const VideoMetadataCaptureStack(),
+          // Lip-sync and 60s share capture's editor + metadata flow.
+          .capture ||
+          .sixtySeconds ||
+          .lipSync => const VideoMetadataCaptureStack(),
           .classic => const VideoMetadataClassicStack(),
           // Deliberately unreachable: upload mode has no record button, so no
           // clips can be created and the user cannot navigate to the metadata

--- a/mobile/lib/screens/video_recorder_screen.dart
+++ b/mobile/lib/screens/video_recorder_screen.dart
@@ -442,6 +442,9 @@ class _VideoRecorderViewState extends ConsumerState<VideoRecorderView>
                         .capture => VideoRecorderCaptureStack(
                           fromEditor: widget.fromEditor,
                         ),
+                        .sixtySeconds => VideoRecorderCaptureStack(
+                          fromEditor: widget.fromEditor,
+                        ),
                         .lipSync => const VideoRecorderLipSyncStack(),
                         .classic => const VideoRecorderClassicStack(),
                       },

--- a/mobile/lib/services/video_editor/video_editor_render_service.dart
+++ b/mobile/lib/services/video_editor/video_editor_render_service.dart
@@ -334,6 +334,7 @@ class VideoEditorRenderService {
     required Map<String, dynamic> editorStateHistory,
     CompleteParameters? parameters,
     String? taskId,
+    Duration? maxOutputDuration = VideoEditorConstants.maxDuration,
   }) async {
     if (renderVideoToClipOverride != null) {
       return renderVideoToClipOverride!(
@@ -366,6 +367,7 @@ class VideoEditorRenderService {
         usePersistentStorage: true,
         parameters: parameters,
         taskId: effectiveTaskId,
+        maxOutputDuration: maxOutputDuration,
       );
 
       if (outputPath == null) return null;
@@ -587,6 +589,103 @@ class VideoEditorRenderService {
       unawaited(_cleanupTempFiles(tempFilePaths));
       return null;
     }
+  }
+
+  /// Computes the ordered `[start, end)` windows that tile
+  /// `[0, totalDuration)` in chunks of at most [maxSegmentDuration].
+  ///
+  /// The final window is shorter when [totalDuration] isn't an exact multiple.
+  /// Pure and native-free so the segmentation math is unit-testable.
+  static List<({Duration start, Duration end})> computeSegmentWindows({
+    required Duration totalDuration,
+    required Duration maxSegmentDuration,
+  }) {
+    assert(
+      maxSegmentDuration > Duration.zero,
+      'maxSegmentDuration must be positive',
+    );
+    final windows = <({Duration start, Duration end})>[];
+    var start = Duration.zero;
+    while (start < totalDuration) {
+      var end = start + maxSegmentDuration;
+      if (end > totalDuration) end = totalDuration;
+      windows.add((start: start, end: end));
+      start = end;
+    }
+    return windows;
+  }
+
+  /// Splits [sourcePath] into ordered segment files of at most
+  /// [maxSegmentDuration] each, covering `[0, totalDuration)`.
+  ///
+  /// Each segment is rendered from the source's `[start, end)` window via the
+  /// native renderer, used to publish a longer recording as a series of short
+  /// videos each within the per-video limit. Returns the segment file paths in
+  /// playback order (a single-element list when the source already fits).
+  static Future<List<String>> splitVideoIntoSegments({
+    required String sourcePath,
+    required Duration totalDuration,
+    required Duration maxSegmentDuration,
+  }) async {
+    final windows = computeSegmentWindows(
+      totalDuration: totalDuration,
+      maxSegmentDuration: maxSegmentDuration,
+    );
+    final tempDir = await getTemporaryDirectory();
+    final source = EditorVideo.file(sourcePath);
+    final segmentPaths = <String>[];
+    for (var index = 0; index < windows.length; index++) {
+      final (:start, :end) = windows[index];
+      final outputPath = path.join(
+        tempDir.path,
+        'segment_${DateTime.now().microsecondsSinceEpoch}_$index.mp4',
+      );
+      await renderNativeVideoToFile(
+        outputPath,
+        VideoRenderData(
+          videoSegments: [
+            VideoSegment(
+              video: source,
+              startTime: start == Duration.zero ? null : start,
+              endTime: end,
+            ),
+          ],
+          shouldOptimizeForNetworkUse: true,
+        ),
+      );
+      segmentPaths.add(outputPath);
+    }
+    return segmentPaths;
+  }
+
+  /// Renders a single `[start, end)` window of [sourcePath] to a temp file.
+  ///
+  /// Used to preview or pick a cover for one series segment on demand, without
+  /// splitting the whole recording. Returns the segment file path.
+  static Future<String> renderSegmentToFile({
+    required String sourcePath,
+    required Duration start,
+    required Duration end,
+  }) async {
+    final tempDir = await getTemporaryDirectory();
+    final outputPath = path.join(
+      tempDir.path,
+      'segment_preview_${DateTime.now().microsecondsSinceEpoch}.mp4',
+    );
+    await renderNativeVideoToFile(
+      outputPath,
+      VideoRenderData(
+        videoSegments: [
+          VideoSegment(
+            video: EditorVideo.file(sourcePath),
+            startTime: start == Duration.zero ? null : start,
+            endTime: end,
+          ),
+        ],
+        shouldOptimizeForNetworkUse: true,
+      ),
+    );
+    return outputPath;
   }
 
   /// Limits a clip's duration to a specified length.

--- a/mobile/lib/services/video_event_publisher.dart
+++ b/mobile/lib/services/video_event_publisher.dart
@@ -821,6 +821,8 @@ class VideoEventPublisher {
     String? contentWarning,
     VideoReplyContext? replyContext,
     bool addReplyToFeed = false,
+    VideoSeries? series,
+    String? dTagOverride,
   }) async {
     // Create a temporary upload with updated metadata
     final updatedUpload = upload.copyWith(
@@ -846,7 +848,42 @@ class VideoEventPublisher {
       thumbnailTimestamp: thumbnailTimestamp,
       replyContext: replyContext,
       addReplyToFeed: addReplyToFeed,
+      series: series,
+      dTagOverride: dTagOverride,
     );
+  }
+
+  /// Publishes a NIP-51 kind-30005 container linking the ordered segments of a
+  /// series, so clients can reconstruct or deeplink the whole series.
+  ///
+  /// [segmentAddresses] are `<kind>:<pubkey>:<d-tag>` coordinates in order.
+  Future<bool> publishSeriesContainer({
+    required String seriesId,
+    required List<String> segmentAddresses,
+    String? title,
+  }) async {
+    final authService = _authService;
+    if (authService == null) return false;
+    final tags = <List<String>>[
+      ['d', 'series-$seriesId'],
+      if (title != null && title.isNotEmpty) ['title', title],
+      for (final address in segmentAddresses) ['a', address],
+    ];
+    // NIP-51 curation set (kind 30005) reused as the series container.
+    final event = await authService.createAndSignEvent(
+      kind: 30005,
+      content: '',
+      tags: tags,
+    );
+    if (event == null) {
+      Log.error(
+        'Failed to sign series container event',
+        name: 'VideoEventPublisher',
+        category: LogCategory.video,
+      );
+      return false;
+    }
+    return _publishEventToNostr(event);
   }
 
   /// Publish a video directly without polling (for direct upload)
@@ -867,6 +904,8 @@ class VideoEventPublisher {
     String? contentWarning,
     VideoReplyContext? replyContext,
     bool addReplyToFeed = false,
+    VideoSeries? series,
+    String? dTagOverride,
   }) async {
     if (upload.videoId == null || upload.cdnUrl == null) {
       Log.error(
@@ -909,9 +948,13 @@ class VideoEventPublisher {
       // Generate unique identifier for the addressable event
       // Use videoId if available, otherwise generate from timestamp and upload ID
       final dTag =
+          dTagOverride ??
           upload.videoId ??
           '${DateTime.now().millisecondsSinceEpoch}_${upload.id}';
       tags.add(['d', dTag]);
+      if (series != null) {
+        tags.add(['series', series.id, '${series.index}', '${series.total}']);
+      }
 
       if (replyContext != null) {
         _addReplyTags(tags, replyContext);

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -143,6 +143,12 @@ class CollaboratorInviteWarning extends Equatable {
 typedef OnStateChanged = void Function(VideoPublishState state);
 typedef OnProgressChanged =
     void Function({required String draftId, required double progress});
+typedef SplitVideoIntoSegments =
+    Future<List<String>> Function({
+      required String sourcePath,
+      required Duration totalDuration,
+      required Duration maxSegmentDuration,
+    });
 
 class VideoPublishService {
   VideoPublishService({
@@ -155,7 +161,10 @@ class VideoPublishService {
     this.collaboratorInviteService,
     this.languagePreferenceService,
     this.mentionResolutionService,
-  });
+    SplitVideoIntoSegments? splitVideoIntoSegments,
+  }) : _splitVideoIntoSegments =
+           splitVideoIntoSegments ??
+           VideoEditorRenderService.splitVideoIntoSegments;
 
   /// Manages background video uploads.
   final UploadManager uploadManager;
@@ -184,6 +193,8 @@ class VideoPublishService {
   /// Resolves typed mentions before publishing Nostr video events.
   final MentionResolutionService? mentionResolutionService;
 
+  final SplitVideoIntoSegments _splitVideoIntoSegments;
+
   /// Tracks the current background upload ID.
   String? _backgroundUploadId;
 
@@ -201,7 +212,11 @@ class VideoPublishService {
     // applied per segment; a blank segment falls back to the shared draft text.
     final split = await _splitIntoSegmentDrafts(draft, segmentTexts);
     if (split != null) {
-      return _publishSeries(split.seriesId, split.drafts);
+      return _publishSeries(
+        seriesId: split.seriesId,
+        sourceDraft: draft,
+        drafts: split.drafts,
+      );
     }
 
     // Check if we have a background upload ID and its status
@@ -315,6 +330,7 @@ class VideoPublishService {
         draft: draft,
         upload: pendingUpload,
         creatorPubkey: pubkey,
+        videoDTag: dTagOverride ?? pendingUpload.videoId,
       );
 
       // Success: delete draft
@@ -345,7 +361,7 @@ class VideoPublishService {
     final sourcePath = await rendered.video.safeFilePath();
     if (!File(sourcePath).existsSync()) return null;
 
-    final segmentPaths = await VideoEditorRenderService.splitVideoIntoSegments(
+    final segmentPaths = await _splitVideoIntoSegments(
       sourcePath: sourcePath,
       totalDuration: rendered.duration,
       maxSegmentDuration: perVideoLimit,
@@ -389,11 +405,12 @@ class VideoPublishService {
   ///
   /// Each recurses into [publishVideo]; being within the per-video limit, the
   /// segment takes the normal single-video path. Aborts on the first failure;
-  /// returns the last segment's result on full success.
-  Future<PublishResult> _publishSeries(
-    String seriesId,
-    List<DivineVideoDraft> drafts,
-  ) async {
+  /// returns success only after the series container links all segments.
+  Future<PublishResult> _publishSeries({
+    required String seriesId,
+    required DivineVideoDraft sourceDraft,
+    required List<DivineVideoDraft> drafts,
+  }) async {
     final total = drafts.length;
     final pubkey = authService.currentPublicKeyHex;
     final kind = NIP71VideoKinds.getPreferredAddressableKind();
@@ -420,14 +437,31 @@ class VideoPublishService {
       }
       if (pubkey != null) segmentAddresses.add('$kind:$pubkey:$dTag');
     }
-    // Link the published segments into a NIP-51 container (best-effort).
+
+    // Link the published segments into a NIP-51 container before removing the
+    // source long-form draft. If the container fails, leave the source draft so
+    // the user can retry without losing their original edit.
     if (segmentAddresses.isNotEmpty) {
-      await videoEventPublisher.publishSeriesContainer(
-        seriesId: seriesId,
-        segmentAddresses: segmentAddresses,
-        title: drafts.first.title,
-      );
+      final containerPublished = await videoEventPublisher
+          .publishSeriesContainer(
+            seriesId: seriesId,
+            segmentAddresses: segmentAddresses,
+            title: drafts.first.title,
+          );
+      if (!containerPublished) {
+        Log.error(
+          '❌ Failed to publish series container for $seriesId',
+          category: .video,
+        );
+        return const PublishError(PublishErrorKind.nostrPublishFailed);
+      }
     }
+
+    await draftService.deleteDraft(sourceDraft.id);
+    Log.debug(
+      '🗑️ Deleted source draft after series publish: ${sourceDraft.id}',
+      category: .video,
+    );
     return last ?? const PublishError(PublishErrorKind.noRetry);
   }
 
@@ -463,18 +497,18 @@ class VideoPublishService {
     required DivineVideoDraft draft,
     required PendingUpload upload,
     required String creatorPubkey,
+    required String? videoDTag,
   }) async {
     final inviteService = collaboratorInviteService;
-    final videoId = upload.videoId;
     if (inviteService == null ||
         draft.collaboratorPubkeys.isEmpty ||
-        videoId == null ||
-        videoId.isEmpty) {
+        videoDTag == null ||
+        videoDTag.isEmpty) {
       return const [];
     }
 
     final videoKind = NIP71VideoKinds.getPreferredAddressableKind();
-    final videoAddress = '$videoKind:$creatorPubkey:$videoId';
+    final videoAddress = '$videoKind:$creatorPubkey:$videoDTag';
     final thumbnailUrl = _uploadedThumbnailUrl(upload);
     const relayHint = 'wss://relay.divine.video';
 

--- a/mobile/lib/services/video_publish/video_publish_service.dart
+++ b/mobile/lib/services/video_publish/video_publish_service.dart
@@ -7,7 +7,9 @@ import 'dart:io';
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
+import 'package:models/models.dart' show VideoSeries;
 import 'package:openvine/constants/nip71_migration.dart';
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/divine_video_draft.dart';
 import 'package:openvine/models/pending_upload.dart';
 import 'package:openvine/models/video_publish/video_publish_state.dart';
@@ -17,10 +19,12 @@ import 'package:openvine/services/draft_storage_service.dart';
 import 'package:openvine/services/language_preference_service.dart';
 import 'package:openvine/services/mention_resolution_service.dart';
 import 'package:openvine/services/upload_manager.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:openvine/services/video_event_publisher.dart';
 import 'package:openvine/services/video_publish/publish_error_kind.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:openvine/utils/public_identifier_normalizer.dart';
+import 'package:pro_video_editor/pro_video_editor.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 /// Result of a publish operation.
@@ -185,7 +189,21 @@ class VideoPublishService {
 
   /// Publishes a video draft.
   /// Returns [PublishSuccess] on success, [PublishError] on failure.
-  Future<PublishResult> publishVideo({required DivineVideoDraft draft}) async {
+  Future<PublishResult> publishVideo({
+    required DivineVideoDraft draft,
+    VideoSeries? series,
+    String? dTagOverride,
+    List<({String title, String description})>? segmentTexts,
+  }) async {
+    // A rendered clip longer than the per-video limit is published as a series
+    // of short videos (each within the limit), one per segment, plus a
+    // container linking them. Per-segment text (from the metadata tabs) is
+    // applied per segment; a blank segment falls back to the shared draft text.
+    final split = await _splitIntoSegmentDrafts(draft, segmentTexts);
+    if (split != null) {
+      return _publishSeries(split.seriesId, split.drafts);
+    }
+
     // Check if we have a background upload ID and its status
     if (_backgroundUploadId != null) {
       final error = await _handleActiveUpload(draft.id);
@@ -259,6 +277,8 @@ class VideoPublishService {
 
       final published = await videoEventPublisher.publishVideoEvent(
         upload: pendingUpload,
+        series: series,
+        dTagOverride: dTagOverride,
         title: draft.title,
         description: draft.description,
         hashtags: draft.hashtags.toList(),
@@ -306,6 +326,109 @@ class VideoPublishService {
     } catch (e, stackTrace) {
       return _handleUploadError(e, stackTrace, draft);
     }
+  }
+
+  /// Splits [draft]'s final rendered clip into a sequence of segment drafts
+  /// when it exceeds the per-video limit, so a longer recording publishes as a
+  /// series of short videos. Returns null when no split is needed (the normal
+  /// single-video publish).
+  Future<({String seriesId, List<DivineVideoDraft> drafts})?>
+  _splitIntoSegmentDrafts(
+    DivineVideoDraft draft,
+    List<({String title, String description})>? segmentTexts,
+  ) async {
+    final rendered = draft.finalRenderedClip;
+    if (rendered == null) return null;
+    const perVideoLimit = VideoEditorConstants.maxDuration;
+    if (rendered.duration <= perVideoLimit) return null;
+
+    final sourcePath = await rendered.video.safeFilePath();
+    if (!File(sourcePath).existsSync()) return null;
+
+    final segmentPaths = await VideoEditorRenderService.splitVideoIntoSegments(
+      sourcePath: sourcePath,
+      totalDuration: rendered.duration,
+      maxSegmentDuration: perVideoLimit,
+    );
+    if (segmentPaths.length <= 1) return null;
+
+    final windows = VideoEditorRenderService.computeSegmentWindows(
+      totalDuration: rendered.duration,
+      maxSegmentDuration: perVideoLimit,
+    );
+    final drafts = <DivineVideoDraft>[];
+    for (var i = 0; i < segmentPaths.length; i++) {
+      final text = segmentTexts != null && i < segmentTexts.length
+          ? segmentTexts[i]
+          : null;
+      drafts.add(
+        draft.copyWith(
+          id: '${draft.id}_seg$i',
+          // Blank per-segment text falls back to the shared draft text.
+          title: text != null && text.title.isNotEmpty ? text.title : null,
+          description: text != null && text.description.isNotEmpty
+              ? text.description
+              : null,
+          finalRenderedClip: rendered.copyWith(
+            id: '${rendered.id}_seg$i',
+            video: EditorVideo.file(segmentPaths[i]),
+            duration: windows[i].end - windows[i].start,
+          ),
+        ),
+      );
+    }
+    Log.info(
+      '✂️ Split ${rendered.duration.inSeconds}s render into '
+      '${drafts.length} segments for series publish',
+      category: .video,
+    );
+    return (seriesId: draft.id, drafts: drafts);
+  }
+
+  /// Publishes each segment draft sequentially through the single-video path.
+  ///
+  /// Each recurses into [publishVideo]; being within the per-video limit, the
+  /// segment takes the normal single-video path. Aborts on the first failure;
+  /// returns the last segment's result on full success.
+  Future<PublishResult> _publishSeries(
+    String seriesId,
+    List<DivineVideoDraft> drafts,
+  ) async {
+    final total = drafts.length;
+    final pubkey = authService.currentPublicKeyHex;
+    final kind = NIP71VideoKinds.getPreferredAddressableKind();
+    final segmentAddresses = <String>[];
+    PublishResult? last;
+    for (var i = 0; i < total; i++) {
+      Log.info(
+        '📤 Publishing series segment ${i + 1}/$total',
+        category: .video,
+      );
+      _backgroundUploadId = null;
+      final dTag = 'series-$seriesId-$i';
+      last = await publishVideo(
+        draft: drafts[i],
+        series: VideoSeries(id: seriesId, index: i, total: total),
+        dTagOverride: dTag,
+      );
+      if (last is PublishError) {
+        Log.error(
+          '❌ Series publish aborted at segment ${i + 1}/$total',
+          category: .video,
+        );
+        return last;
+      }
+      if (pubkey != null) segmentAddresses.add('$kind:$pubkey:$dTag');
+    }
+    // Link the published segments into a NIP-51 container (best-effort).
+    if (segmentAddresses.isNotEmpty) {
+      await videoEventPublisher.publishSeriesContainer(
+        seriesId: seriesId,
+        segmentAddresses: segmentAddresses,
+        title: drafts.first.title,
+      );
+    }
+    return last ?? const PublishError(PublishErrorKind.noRetry);
   }
 
   Future<List<String>> _resolveMentionedPubkeys(

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -1470,6 +1470,10 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       clipManagerProvider.select((s) => s.firstClipOrNull),
     );
     if (clip == null) return const SizedBox.shrink();
+    // Session cap (60s in the 60s mode) for the over-limit indicator.
+    final maxDurationMs = ref
+        .watch(clipManagerProvider.select((s) => s.maxDuration))
+        .inMilliseconds;
 
     final editorStateHistory = ref.read(
       videoEditorProvider.select((s) => s.editorStateHistory),
@@ -1991,7 +1995,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
                           selector: (state) => (
                             isOver:
                                 state.currentPosition.inMilliseconds >
-                                VideoEditorConstants.maxDuration.inMilliseconds,
+                                maxDurationMs,
                             isReordering: state.isReordering,
                             isSubEditorOpen: state.isSubEditorOpen,
                           ),

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_body.dart
@@ -4,12 +4,14 @@ import 'dart:typed_data';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/timeline_overlay_item.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strip.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_overlay_strips.dart';
@@ -17,7 +19,7 @@ import 'package:openvine/widgets/video_editor/timeline_editor/utils/hit_expanded
 import 'package:openvine/widgets/video_editor/timeline_editor/utils/vertical_only_clipper.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_timeline_rules_indicator.dart';
 
-class VideoEditorTimelineBody extends StatelessWidget {
+class VideoEditorTimelineBody extends ConsumerWidget {
   const VideoEditorTimelineBody({
     required this.totalDuration,
     required this.pixelsPerSecond,
@@ -79,9 +81,12 @@ class VideoEditorTimelineBody extends StatelessWidget {
   final ValueNotifier<Duration> playheadPosition;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final (isReordering) = context.select(
       (VideoEditorMainBloc b) => b.state.isReordering,
+    );
+    final maxDuration = ref.watch(
+      clipManagerProvider.select((s) => s.maxDuration),
     );
     final isVolumeEditMode = context.select(
       (VideoEditorMainBloc b) => b.state.isVolumeEditMode,
@@ -103,7 +108,7 @@ class VideoEditorTimelineBody extends StatelessWidget {
         ? clipTrimExpand
         : overlayTrimExpand;
     final showMaxDurationOverlays =
-        !isReordering && totalDuration > VideoEditorConstants.maxDuration;
+        !isReordering && totalDuration > maxDuration;
     final outsideExtendWidth = MediaQuery.sizeOf(context).width / 2;
 
     return HitExpandedBox(
@@ -118,6 +123,7 @@ class VideoEditorTimelineBody extends StatelessWidget {
             pixelsPerSecond: pixelsPerSecond,
             visible: showMaxDurationOverlays,
             outsideExtendWidth: outsideExtendWidth,
+            maxDuration: maxDuration,
           ),
 
           Column(
@@ -207,7 +213,19 @@ class VideoEditorTimelineBody extends StatelessWidget {
             pixelsPerSecond: pixelsPerSecond,
             visible: showMaxDurationOverlays,
             outsideExtendWidth: outsideExtendWidth,
+            maxDuration: maxDuration,
           ),
+          // Series mode: show a scissors cut marker at each per-segment
+          // boundary so the user sees where the recording will be split.
+          if (maxDuration > VideoEditorConstants.maxDuration)
+            Positioned.fill(
+              child: _SeriesCutMarkers(
+                pixelsPerSecond: pixelsPerSecond,
+                totalDuration: totalDuration,
+                maxDuration: maxDuration,
+                segmentDuration: VideoEditorConstants.maxDuration,
+              ),
+            ),
         ],
       ),
     );
@@ -310,19 +328,18 @@ class _TimelineMaxDurationStripeOverlay extends StatelessWidget {
     required this.pixelsPerSecond,
     required this.visible,
     required this.outsideExtendWidth,
+    required this.maxDuration,
   });
 
   final double pixelsPerSecond;
   final bool visible;
   final double outsideExtendWidth;
+  final Duration maxDuration;
 
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      left:
-          VideoEditorConstants.maxDuration.inMilliseconds /
-          1000 *
-          pixelsPerSecond,
+      left: maxDuration.inMilliseconds / 1000 * pixelsPerSecond,
       top: 0,
       bottom: 0,
       right: -outsideExtendWidth,
@@ -346,19 +363,18 @@ class _TimelineMaxDurationDimOverlay extends StatelessWidget {
     required this.pixelsPerSecond,
     required this.visible,
     required this.outsideExtendWidth,
+    required this.maxDuration,
   });
 
   final double pixelsPerSecond;
   final bool visible;
   final double outsideExtendWidth;
+  final Duration maxDuration;
 
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      left:
-          VideoEditorConstants.maxDuration.inMilliseconds /
-          1000 *
-          pixelsPerSecond,
+      left: maxDuration.inMilliseconds / 1000 * pixelsPerSecond,
       top: 0,
       bottom: 0,
       right: -outsideExtendWidth,
@@ -371,6 +387,63 @@ class _TimelineMaxDurationDimOverlay extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+/// Scissors markers at each per-segment cut boundary (every [segmentDuration]),
+/// shown in series mode so the user sees where the recording will be split into
+/// separate videos.
+class _SeriesCutMarkers extends StatelessWidget {
+  const _SeriesCutMarkers({
+    required this.pixelsPerSecond,
+    required this.totalDuration,
+    required this.maxDuration,
+    required this.segmentDuration,
+  });
+
+  final double pixelsPerSecond;
+  final Duration totalDuration;
+  final Duration maxDuration;
+  final Duration segmentDuration;
+
+  @override
+  Widget build(BuildContext context) {
+    final stepMs = segmentDuration.inMilliseconds;
+    if (stepMs <= 0) return const SizedBox.shrink();
+    // Only mark cuts within the content that survives the session cap; content
+    // beyond maxDuration is truncated, not split into further segments.
+    final limitMs = totalDuration < maxDuration
+        ? totalDuration.inMilliseconds
+        : maxDuration.inMilliseconds;
+    final markers = <Widget>[];
+    for (var boundaryMs = stepMs; boundaryMs < limitMs; boundaryMs += stepMs) {
+      final x = boundaryMs / 1000 * pixelsPerSecond;
+      markers
+        ..add(
+          Positioned(
+            left: x - 0.75,
+            top: 0,
+            bottom: 0,
+            width: 1.5,
+            child: const ColoredBox(color: VineTheme.primary),
+          ),
+        )
+        ..add(
+          Positioned(
+            left: x - 8,
+            top: -2,
+            child: const DivineIcon(
+              icon: .scissors,
+              color: VineTheme.primary,
+              size: 16,
+            ),
+          ),
+        );
+    }
+    if (markers.isEmpty) return const SizedBox.shrink();
+    return IgnorePointer(
+      child: Stack(clipBehavior: Clip.none, children: markers),
     );
   }
 }

--- a/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/video_editor_timeline_header.dart
@@ -1,12 +1,13 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
 import 'package:openvine/blocs/video_editor/timeline_overlay/timeline_overlay_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
+import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_editor/main_editor/video_editor_scope.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/video_editor_volume_mute_toggle.dart';
 import 'package:time_formatter/time_formatter.dart';
@@ -151,7 +152,7 @@ class _VolumeButton extends StatelessWidget {
   }
 }
 
-class _TimeDisplay extends StatelessWidget {
+class _TimeDisplay extends ConsumerWidget {
   const _TimeDisplay({required this.playheadPosition});
 
   final ValueNotifier<Duration> playheadPosition;
@@ -161,13 +162,18 @@ class _TimeDisplay extends StatelessWidget {
   );
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     // The editor timeline draws clips at full length, but an overlap transition
     // (dissolve/slide/push/wipe) blends two clips so the rendered output is
     // shorter. Show the output length — and the playhead mapped onto it — so the
     // header reflects the final video, not the editing space. The timeline
     // layout itself stays on the editor axis.
     final clips = context.select((ClipEditorBloc b) => b.state.clips);
+    // Session cap (60s in the 60s mode); the position only warns past this,
+    // not past the standard 6.3s.
+    final maxDuration = ref.watch(
+      clipManagerProvider.select((s) => s.maxDuration),
+    );
     final timelineMap = TransitionTimelineMap.fromClips(clips);
     final outputDuration = timelineMap.outputDuration;
 
@@ -176,8 +182,7 @@ class _TimeDisplay extends StatelessWidget {
       builder: (context, position, _) {
         final outputPosition = timelineMap.editorToOutput(position);
         final isOver =
-            outputPosition.inMilliseconds >
-            VideoEditorConstants.maxDuration.inMilliseconds;
+            outputPosition.inMilliseconds > maxDuration.inMilliseconds;
         final positionText = TextSpan(
           text: TimeFormatter.formatCompactDuration(outputPosition),
           style: isOver

--- a/mobile/lib/widgets/video_feed_item/feed_videos.dart
+++ b/mobile/lib/widgets/video_feed_item/feed_videos.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:divine_ui/divine_ui.dart';
 import 'package:divine_video_player/divine_video_player.dart'
     hide PlaybackStatus;
 import 'package:flutter/foundation.dart' show ValueListenable;
@@ -56,10 +57,15 @@ class FeedVideos extends ConsumerStatefulWidget {
     this.onActiveVideoChanged,
     this.trafficSource = ViewTrafficSource.unknown,
     this.sourceDetail,
+    this.seriesSegments = const {},
     super.key,
   });
 
   final List<VideoEvent> videos;
+
+  /// Ordered segment lists keyed by series id, for videos in [videos] that are
+  /// series anchors. Drives the nested horizontal swipe feed for a series.
+  final Map<String, List<VideoEvent>> seriesSegments;
   final VoidCallback onNearEnd;
   final int currentIndex;
   final String? contextTitle;
@@ -129,14 +135,27 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
   /// playback — a warned video must stay paused until revealed.
   final Set<String> _revealedContentWarningVideoIds = <String>{};
 
+  /// Whether [video] is a series anchor rendered as a nested horizontal swipe
+  /// feed (its segments played by that nested feed, not the outer pool).
+  bool _isSeriesAnchor(VideoEvent video) {
+    final series = video.series;
+    if (series == null) return false;
+    final segments = widget.seriesSegments[series.id];
+    return segments != null && segments.length > 1;
+  }
+
   /// Whether [video] may start playing: either it has no content-warning
   /// gate, or the user already chose "View Anyway" for it.
-  bool _canAutoPlayVideo(VideoEvent video) =>
-      !shouldShowContentWarningOverlay(
-        contentWarningLabels: video.contentWarningLabels,
-        warnLabels: video.warnLabels,
-      ) ||
-      _revealedContentWarningVideoIds.contains(video.id);
+  bool _canAutoPlayVideo(VideoEvent video) {
+    // Series anchors are played by the nested horizontal series feed, not the
+    // outer pool, so the outer must not also play them (avoids double audio).
+    if (_isSeriesAnchor(video)) return false;
+    return !shouldShowContentWarningOverlay(
+          contentWarningLabels: video.contentWarningLabels,
+          warnLabels: video.warnLabels,
+        ) ||
+        _revealedContentWarningVideoIds.contains(video.id);
+  }
 
   /// Marks [videoId] as revealed and starts playback of the active video.
   void _revealContentWarning(String videoId) {
@@ -314,6 +333,19 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
           }
           final video = widget.videos[index];
 
+          // Series anchor: render the ordered segments as a horizontal swipe
+          // feed (its own pooled controllers) instead of a single video.
+          final series = video.series;
+          final seriesSegments = series != null
+              ? widget.seriesSegments[series.id]
+              : null;
+          if (seriesSegments != null && seriesSegments.length > 1) {
+            return _SeriesSwipeFeed(
+              segments: seriesSegments,
+              shouldPortraitExpand: widget.shouldPortraitExpand,
+            );
+          }
+
           final thumbnailUrl = video.thumbnailUrl;
           final showBlurBackdrop =
               !video.isPortrait &&
@@ -325,6 +357,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
               if (showBlurBackdrop)
                 Positioned.fill(child: BlurredVideoBackdrop(url: thumbnailUrl)),
               child,
+              if (video.series != null) _SeriesBadge(series: video.series!),
             ],
           );
         },
@@ -394,6 +427,7 @@ class FeedVideosState extends ConsumerState<FeedVideos> with RouteAware {
               video: video,
               index: index,
               isActive: isActive,
+              isSeriesAnchor: _isSeriesAnchor(video),
               contextTitle: widget.contextTitle,
               contentWarningRevealed: _revealedContentWarningVideoIds.contains(
                 video.id,
@@ -416,6 +450,7 @@ class _Overlay extends ConsumerStatefulWidget {
     required this.video,
     required this.index,
     required this.isActive,
+    required this.isSeriesAnchor,
     required this.contentWarningRevealed,
     required this.onContentWarningRevealed,
     this.onToggleAutoAdvance,
@@ -427,6 +462,11 @@ class _Overlay extends ConsumerStatefulWidget {
   final VideoEvent video;
   final int index;
   final bool isActive;
+
+  /// Whether this item is a series anchor whose segments are played by the
+  /// nested horizontal feed. The outer paused-video overlay is suppressed for
+  /// it, since the outer controller is intentionally kept paused.
+  final bool isSeriesAnchor;
 
   /// Whether the user already dismissed this video's content warning.
   /// Owned by [FeedVideosState] so the autoplay gate can read it too.
@@ -686,7 +726,7 @@ class __OverlayState extends ConsumerState<_Overlay> {
                         : null,
                     child: Stack(
                       children: [
-                        if (widget.controller != null)
+                        if (widget.controller != null && !widget.isSeriesAnchor)
                           PausedVideoOverlay(
                             controller: widget.controller!,
                             isVisible: widget.isActive,
@@ -721,6 +761,132 @@ class __OverlayState extends ConsumerState<_Overlay> {
           ),
         );
     }
+  }
+}
+
+/// Overlay marking a feed card as one segment of a series (`x/N` + dots).
+///
+/// Driven by [VideoEvent.series] on the collapsed anchor, so the user sees a
+/// single card per series rather than a flooded feed. Full per-segment
+/// horizontal swipe playback is a follow-up (nested horizontal feed).
+class _SeriesBadge extends StatelessWidget {
+  const _SeriesBadge({required this.series});
+
+  final VideoSeries series;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned(
+      top: MediaQuery.paddingOf(context).top + 12,
+      left: 0,
+      right: 0,
+      child: IgnorePointer(
+        child: MediaQuery.withNoTextScaling(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: VineTheme.scrim65,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 4,
+                  ),
+                  child: Text(
+                    series.positionLabel,
+                    style: VineTheme.captionPillFont(),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 6),
+              _SeriesDots(index: series.index, total: series.total),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SeriesDots extends StatelessWidget {
+  const _SeriesDots({required this.index, required this.total});
+
+  final int index;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    // Cap rendered dots so a long series doesn't overflow the row.
+    const maxDots = 10;
+    final count = total > maxDots ? maxDots : total;
+    final activeDot = total > maxDots ? (index * maxDots ~/ total) : index;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var i = 0; i < count; i++)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: i == activeDot
+                    ? VineTheme.whiteText
+                    : VineTheme.whiteText.withValues(alpha: 0.4),
+              ),
+              child: const SizedBox.square(dimension: 5),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// A series rendered as a horizontal swipe of its segments, each played by its
+/// own pooled controller via a nested horizontal [InfiniteVideoFeed].
+///
+/// The outer feed does not auto-play series anchors (see [_canAutoPlayVideo]),
+/// so only this nested feed drives series playback — avoiding double audio.
+class _SeriesSwipeFeed extends ConsumerWidget {
+  const _SeriesSwipeFeed({
+    required this.segments,
+    required this.shouldPortraitExpand,
+  });
+
+  final List<VideoEvent> segments;
+  final bool shouldPortraitExpand;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return InfiniteVideoFeed(
+      videos: segments,
+      cache: ref.read(mediaCacheProvider),
+      urlResolver: (video) => video.getOptimalVideoUrlForPlatform(),
+      scrollDirection: Axis.horizontal,
+      shouldPortraitExpand: shouldPortraitExpand,
+      videoBuilder: (context, child, index, controller) {
+        if (index < 0 || index >= segments.length) {
+          return const SizedBox.shrink();
+        }
+        final video = segments[index];
+        final thumbnailUrl = video.thumbnailUrl;
+        final showBlurBackdrop =
+            !video.isPortrait &&
+            thumbnailUrl != null &&
+            thumbnailUrl.isNotEmpty;
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            if (showBlurBackdrop)
+              Positioned.fill(child: BlurredVideoBackdrop(url: thumbnailUrl)),
+            child,
+            if (video.series != null) _SeriesBadge(series: video.series!),
+          ],
+        );
+      },
+    );
   }
 }
 

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar.dart
@@ -7,9 +7,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_preview_screen.dart';
+import 'package:openvine/widgets/video_metadata/segment_clip_loader.dart';
 
 /// A custom header widget for video metadata screens.
 /// Unlike AppBar, this provides full control over layout and positioning.
@@ -22,8 +22,13 @@ class VideoMetadataCaptureAppBar extends ConsumerWidget
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 
   /// Opens the full-screen video preview with a fade transition.
-  Future<void> _openPreview(BuildContext context, DivineVideoClip clip) async {
+  ///
+  /// For a multi-segment series this previews the active segment (rendering it
+  /// on demand); for a single video it previews the whole clip.
+  Future<void> _openPreview(BuildContext context, WidgetRef ref) async {
     FocusManager.instance.primaryFocus?.unfocus();
+    final clip = await resolveActiveSegmentClip(context, ref);
+    if (clip == null || !context.mounted) return;
     await Navigator.push(
       context,
       PageRouteBuilder<void>(
@@ -77,9 +82,7 @@ class VideoMetadataCaptureAppBar extends ConsumerWidget
               type: .ghostSecondary,
               size: .small,
               semanticLabel: context.l10n.videoMetadataOpenPreviewSemanticLabel,
-              onPressed: isReady
-                  ? () => _openPreview(context, state.finalRenderedClip!)
-                  : null,
+              onPressed: isReady ? () => _openPreview(context, ref) : null,
             ),
           ],
         ),

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart
@@ -3,12 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
-import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
+import 'package:openvine/providers/segment_thumbnail_provider.dart';
+import 'package:openvine/providers/series_metadata_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_cover_screen.dart';
 import 'package:openvine/widgets/video_editor/video_editor_processing_overlay.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart';
+import 'package:openvine/widgets/video_metadata/segment_clip_loader.dart';
 
 /// Video clip preview widget with thumbnail and play button.
 ///
@@ -20,11 +22,14 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
   const VideoMetadataCaptureClipPreview({super.key});
 
   /// Opens the cover selection screen.
-  Future<void> _openCoverEditor(
-    BuildContext context,
-    DivineVideoClip clip,
-  ) async {
+  ///
+  /// For a multi-segment series this picks a cover for the active segment
+  /// (rendering it on demand); for a single video it edits the whole clip.
+  Future<void> _openCoverEditor(BuildContext context, WidgetRef ref) async {
     FocusManager.instance.primaryFocus?.unfocus();
+    final isSeries = ref.read(seriesMetadataProvider).isSeries;
+    final clip = await resolveActiveSegmentClip(context, ref);
+    if (clip == null || !context.mounted) return;
     final reduceMotion = MediaQuery.disableAnimationsOf(context);
     final duration = reduceMotion
         ? Duration.zero
@@ -34,7 +39,10 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
       PageRouteBuilder<void>(
         transitionDuration: duration,
         reverseTransitionDuration: duration,
-        pageBuilder: (_, _, _) => VideoMetadataCoverScreen(clip: clip),
+        pageBuilder: (_, _, _) => VideoMetadataCoverScreen(
+          clip: clip,
+          editSeriesSegment: isSeries,
+        ),
         transitionsBuilder: (_, animation, _, child) {
           if (reduceMotion) return child;
           return FadeTransition(opacity: animation, child: child);
@@ -60,6 +68,19 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
     final clip = state.finalRenderedClip ?? clips.first;
     final isReady = state.finalRenderedClip != null;
 
+    // For a multi-segment series, the preview shows the active segment's cover
+    // pulled from its own window of the shared clip. While it resolves, fall
+    // back to the clip's own thumbnail (segment 0's frame).
+    final series = ref.watch(
+      seriesMetadataProvider.select(
+        (s) => (isSeries: s.isSeries, activeIndex: s.activeIndex),
+      ),
+    );
+    final segmentThumbnailPath = series.isSeries
+        ? ref.watch(segmentThumbnailProvider(series.activeIndex)).value
+        : null;
+    final displayedThumbnailPath = segmentThumbnailPath ?? clip.thumbnailPath;
+
     return Center(
       child: SizedBox(
         height: 200,
@@ -77,10 +98,7 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
                 enabled: isReady,
                 label: context.l10n.videoMetadataOpenPreviewSemanticLabel,
                 child: GestureDetector(
-                  onTap: isReady
-                      ? () =>
-                            _openCoverEditor(context, state.finalRenderedClip!)
-                      : null,
+                  onTap: isReady ? () => _openCoverEditor(context, ref) : null,
                   child: Stack(
                     children: [
                       // Video thumbnail or placeholder
@@ -93,9 +111,14 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
                             ),
 
                         duration: const Duration(milliseconds: 150),
-                        child: clip.thumbnailPath != null
-                            ? // Video thumbnail image
-                              VideoMetadataCapturePreviewThumbnail(clip: clip)
+                        child: displayedThumbnailPath != null
+                            ? // Video thumbnail image; keyed on the segment path
+                              // so switching tabs cross-fades to the new cover.
+                              VideoMetadataCapturePreviewThumbnail(
+                                key: ValueKey(displayedThumbnailPath),
+                                clip: clip,
+                                thumbnailPathOverride: segmentThumbnailPath,
+                              )
                             : // Fallback placeholder
                               const ColoredBox(
                                 color: VineTheme.onSurfaceMuted,
@@ -121,10 +144,7 @@ class VideoMetadataCaptureClipPreview extends ConsumerWidget {
                               icon: .pencilSimpleLine,
                               type: .ghostSecondary,
                               size: .small,
-                              onPressed: () => _openCoverEditor(
-                                context,
-                                state.finalRenderedClip!,
-                              ),
+                              onPressed: () => _openCoverEditor(context, ref),
                             ),
                           ),
                         ),

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_preview_thumbnail.dart
@@ -10,9 +10,17 @@ import 'package:pro_image_editor/features/filter_editor/widgets/filter_generator
 import 'package:pro_image_editor/pro_image_editor.dart';
 
 class VideoMetadataCapturePreviewThumbnail extends ConsumerWidget {
-  const VideoMetadataCapturePreviewThumbnail({required this.clip, super.key});
+  const VideoMetadataCapturePreviewThumbnail({
+    required this.clip,
+    this.thumbnailPathOverride,
+    super.key,
+  });
 
   final DivineVideoClip clip;
+
+  /// Cover path for the active series segment; falls back to the clip's own
+  /// thumbnail when null (single-video case).
+  final String? thumbnailPathOverride;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -20,13 +28,14 @@ class VideoMetadataCapturePreviewThumbnail extends ConsumerWidget {
       videoEditorProvider.select((s) => s.editorEditingParameters),
     );
 
-    if (clip.thumbnailPath == null) {
+    final thumbnailPath = thumbnailPathOverride ?? clip.thumbnailPath;
+    if (thumbnailPath == null) {
       return const Center(
         child: DivineIcon(icon: .warning, size: 32, color: VineTheme.lightText),
       );
     }
 
-    final thumbnail = Image.file(File(clip.thumbnailPath!), fit: .cover);
+    final thumbnail = Image.file(File(thumbnailPath), fit: .cover);
 
     return Stack(
       fit: .expand,

--- a/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_stack.dart
+++ b/mobile/lib/widgets/video_metadata/modes/capture/video_metadata_capture_stack.dart
@@ -1,42 +1,116 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/providers/series_metadata_provider.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_app_bar.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_bottom_bar.dart';
 import 'package:openvine/widgets/video_metadata/modes/capture/video_metadata_capture_clip_preview.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_form_fields.dart';
 
-class VideoMetadataCaptureStack extends StatelessWidget {
+class VideoMetadataCaptureStack extends ConsumerWidget {
   const VideoMetadataCaptureStack({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
+  Widget build(BuildContext context, WidgetRef ref) {
+    // A rendered clip longer than the per-video limit exposes one tab per
+    // segment; each tab customises that segment's text and thumbnail before the
+    // series is published. The count is derived in seriesMetadataProvider.
+    final segmentCount = ref.watch(
+      seriesMetadataProvider.select((s) => s.count),
+    );
+
+    return Scaffold(
       backgroundColor: VineTheme.surfaceContainerHigh,
-      appBar: VideoMetadataCaptureAppBar(),
+      appBar: const VideoMetadataCaptureAppBar(),
       body: Column(
         spacing: 12,
         children: [
-          Expanded(
+          if (segmentCount > 1) const _SeriesMetadataTabs(),
+          const Expanded(
             child: SingleChildScrollView(
               child: Column(
                 mainAxisSize: .min,
                 crossAxisAlignment: .stretch,
                 children: [
-                  // Video preview at top
                   Padding(
                     padding: EdgeInsets.only(top: 8, bottom: 16),
                     child: VideoMetadataCaptureClipPreview(),
                   ),
-
-                  // Form fields
                   VideoMetadataFormFields(),
                 ],
               ),
             ),
           ),
-          // Post button at bottom
-          SafeArea(top: false, child: VideoMetadataCaptureBottomBar()),
+          const SafeArea(top: false, child: VideoMetadataCaptureBottomBar()),
         ],
+      ),
+    );
+  }
+}
+
+/// Horizontal pill row acting as tabs, one per series segment. Tapping a tab
+/// switches which segment the form and preview edit.
+class _SeriesMetadataTabs extends ConsumerWidget {
+  const _SeriesMetadataTabs();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final (:count, :activeIndex) = ref.watch(
+      seriesMetadataProvider.select(
+        (s) => (count: s.count, activeIndex: s.activeIndex),
+      ),
+    );
+    return SizedBox(
+      height: 40,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        itemCount: count,
+        separatorBuilder: (_, _) => const SizedBox(width: 8),
+        itemBuilder: (context, index) => _SegmentTab(
+          index: index,
+          selected: index == activeIndex,
+          onTap: () =>
+              ref.read(seriesMetadataProvider.notifier).setActiveIndex(index),
+        ),
+      ),
+    );
+  }
+}
+
+class _SegmentTab extends StatelessWidget {
+  const _SegmentTab({
+    required this.index,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final int index;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: selected ? VineTheme.primary : VineTheme.surfaceContainer,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              '${index + 1}',
+              style: VineTheme.labelLargeFont(
+                color: selected
+                    ? VineTheme.surfaceContainerHigh
+                    : VineTheme.onSurface,
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/mobile/lib/widgets/video_metadata/segment_clip_loader.dart
+++ b/mobile/lib/widgets/video_metadata/segment_clip_loader.dart
@@ -1,0 +1,45 @@
+// ABOUTME: Resolves the clip a preview/cover action targets (segment or full).
+// ABOUTME: Renders the active 60s-series segment on demand behind a spinner.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/providers/segment_clip_provider.dart';
+import 'package:openvine/providers/series_metadata_provider.dart';
+import 'package:openvine/providers/video_editor_provider.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
+
+/// Resolves the clip that a full-screen preview or cover picker should operate
+/// on for the currently active tab.
+///
+/// For a single video it returns the shared rendered clip immediately. For a
+/// multi-segment series it renders the active segment into its own file (via
+/// [segmentClipProvider]), showing a blocking spinner while the first render
+/// runs; cached segments resolve without a spinner. Returns null when nothing
+/// is ready or the render fails.
+Future<DivineVideoClip?> resolveActiveSegmentClip(
+  BuildContext context,
+  WidgetRef ref,
+) async {
+  final series = ref.read(seriesMetadataProvider);
+  if (!series.isSeries) {
+    return ref.read(videoEditorProvider).finalRenderedClip;
+  }
+
+  final index = series.activeIndex;
+  final cached = ref.read(segmentClipProvider(index));
+  if (cached.hasValue) return cached.value;
+
+  showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => const Center(child: BrandedLoadingIndicator()),
+  );
+  try {
+    return await ref.read(segmentClipProvider(index).future);
+  } catch (_) {
+    return null;
+  } finally {
+    if (context.mounted) Navigator.of(context, rootNavigator: true).pop();
+  }
+}

--- a/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
+++ b/mobile/lib/widgets/video_metadata/video_metadata_form_fields.dart
@@ -4,6 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
+import 'package:openvine/providers/series_metadata_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/providers/video_reply_context_provider.dart';
 import 'package:openvine/widgets/video_metadata/video_metadata_collaborators_input.dart';
@@ -50,10 +51,41 @@ class _VideoMetadataFormFieldsState
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      _seedControllers();
+    });
+  }
+
+  /// Seeds the title/description fields from the active segment (series) or the
+  /// shared editor metadata (single video).
+  void _seedControllers() {
+    final series = ref.read(seriesMetadataProvider);
+    if (series.isSeries) {
+      final active = series.active;
+      _titleController.text = active?.title ?? '';
+      _descriptionController.text = active?.description ?? '';
+    } else {
       final editorState = ref.read(videoEditorProvider);
       _titleController.text = editorState.title;
       _descriptionController.text = editorState.description;
-    });
+    }
+  }
+
+  void _onTitleChanged(String value) {
+    if (ref.read(seriesMetadataProvider).isSeries) {
+      ref.read(seriesMetadataProvider.notifier).updateActive(title: value);
+    } else {
+      ref.read(videoEditorProvider.notifier).updateMetadata(title: value);
+    }
+  }
+
+  void _onDescriptionChanged(String value) {
+    if (ref.read(seriesMetadataProvider).isSeries) {
+      ref
+          .read(seriesMetadataProvider.notifier)
+          .updateActive(description: value);
+    } else {
+      ref.read(videoEditorProvider.notifier).updateMetadata(description: value);
+    }
   }
 
   @override
@@ -67,6 +99,11 @@ class _VideoMetadataFormFieldsState
 
   @override
   Widget build(BuildContext context) {
+    // Re-seed the fields when the user switches series segments.
+    ref.listen(
+      seriesMetadataProvider.select((s) => s.activeIndex),
+      (_, _) => _seedControllers(),
+    );
     return Padding(
       padding: const .symmetric(horizontal: 16),
       child: Column(
@@ -86,11 +123,7 @@ class _VideoMetadataFormFieldsState
               primaryWhenFilled: true,
               minLines: 1,
               maxLines: 5,
-              onChanged: (value) {
-                ref
-                    .read(videoEditorProvider.notifier)
-                    .updateMetadata(title: value);
-              },
+              onChanged: _onTitleChanged,
               onSubmitted: (_) => _descriptionFocusNode.requestFocus(),
             ),
           ),
@@ -113,11 +146,7 @@ class _VideoMetadataFormFieldsState
                       VideoEditorConstants.descriptionLimit,
                     ),
                   ],
-                  onChanged: (value) {
-                    ref
-                        .read(videoEditorProvider.notifier)
-                        .updateMetadata(description: value);
-                  },
+                  onChanged: _onDescriptionChanged,
                 ),
                 Positioned(
                   // Align the counter to the field's content padding so a

--- a/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/capture/video_recorder_capture_top_bar.dart
@@ -4,7 +4,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/utils/video_editor_utils.dart';
@@ -93,16 +92,17 @@ class _RecordingProgressBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final (:totalDuration, :activeDuration) = ref.watch(
+    final (:totalDuration, :activeDuration, :maxDuration) = ref.watch(
       clipManagerProvider.select(
         (s) => (
           totalDuration: s.totalDuration,
           activeDuration: s.activeRecordingDuration,
+          maxDuration: s.maxDuration,
         ),
       ),
     );
 
-    final maxMs = VideoEditorConstants.maxDuration.inMilliseconds;
+    final maxMs = maxDuration.inMilliseconds;
     final currentMs = (totalDuration + activeDuration).inMilliseconds;
     // Under max: primary fills up, remaining (disabled bg) shrinks.
     // Over max: primary is capped at maxDuration, primaryContainer grows

--- a/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart
+++ b/mobile/lib/widgets/video_recorder/modes/classic/video_recorder_classic_top_bar.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/widgets/video_recorder/video_recorder_navigation.dart';
@@ -62,16 +61,17 @@ class _ProgressBar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final (:totalDuration, :activeDuration) = ref.watch(
+    final (:totalDuration, :activeDuration, :maxDuration) = ref.watch(
       clipManagerProvider.select(
         (s) => (
           totalDuration: s.totalDuration,
           activeDuration: s.activeRecordingDuration,
+          maxDuration: s.maxDuration,
         ),
       ),
     );
 
-    final maxMs = VideoEditorConstants.maxDuration.inMilliseconds;
+    final maxMs = maxDuration.inMilliseconds;
     final currentMs = (totalDuration + activeDuration).inMilliseconds;
     // Under max: primary fills up, remaining (disabled bg) shrinks.
     // Over max: primary is capped at maxDuration, primaryContainer grows

--- a/mobile/lib/widgets/video_recorder/video_recorder_audio_progress_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_audio_progress_bar.dart
@@ -10,7 +10,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/blocs/sound_waveform/sound_waveform_bloc.dart';
 import 'package:openvine/blocs/video_recorder/video_recorder_bloc.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/widgets/stereo_waveform_painter.dart';
@@ -141,16 +140,18 @@ class _AudioWaveformProgress extends ConsumerWidget {
   final Float32List? rightChannel;
   final Duration audioDuration;
 
-  /// Maximum allowed recording duration.
-  static const Duration _maxDuration = VideoEditorConstants.maxDuration;
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(
       clipManagerProvider.select(
-        (s) => (clips: s.clips, activeRecording: s.activeRecordingDuration),
+        (s) => (
+          clips: s.clips,
+          activeRecording: s.activeRecordingDuration,
+          maxDuration: s.maxDuration,
+        ),
       ),
     );
+    final maxDuration = state.maxDuration;
     final startOffset =
         ref.watch(
           videoEditorProvider.select((s) => s.selectedSound?.startOffset),
@@ -167,7 +168,7 @@ class _AudioWaveformProgress extends ConsumerWidget {
     // Calculate progress as ratio of recorded to max duration
     final progress =
         recordedDuration.inMilliseconds /
-        _maxDuration.inMilliseconds.clamp(1, double.infinity);
+        maxDuration.inMilliseconds.clamp(1, double.infinity);
 
     return TweenAnimationBuilder<double>(
       tween: Tween(begin: 0, end: 1),
@@ -189,7 +190,7 @@ class _AudioWaveformProgress extends ConsumerWidget {
               inactiveColor: VineTheme.whiteText.withValues(alpha: 0.32),
               activeBackgroundColor: VineTheme.scrim15,
               audioDuration: audioDuration,
-              maxDuration: _maxDuration,
+              maxDuration: maxDuration,
               heightFactor: heightFactor,
               startOffset: startOffset,
             ),

--- a/mobile/lib/widgets/video_recorder/video_recorder_segment_bar.dart
+++ b/mobile/lib/widgets/video_recorder/video_recorder_segment_bar.dart
@@ -4,7 +4,6 @@
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/providers/clip_manager_provider.dart';
 
 /// Displays a horizontal bar showing recording segments.
@@ -35,31 +34,33 @@ class VideoRecorderSegmentBar extends StatelessWidget {
 class _Segments extends ConsumerWidget {
   const _Segments({required this.constraints});
 
-  /// Maximum allowed recording duration.
-  static const Duration _maxDuration = VideoEditorConstants.maxDuration;
-
   final BoxConstraints constraints;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(
       clipManagerProvider.select(
-        (s) => (clips: s.clips, activeRecording: s.activeRecordingDuration),
+        (s) => (
+          clips: s.clips,
+          activeRecording: s.activeRecordingDuration,
+          maxDuration: s.maxDuration,
+        ),
       ),
     );
 
     final recordSegments = state.clips;
     final activeRecordingDuration = state.activeRecording;
+    final maxDuration = state.maxDuration;
 
     var used = Duration.zero;
     final segments = <Widget>[];
 
     // Build segments with Flexible based on duration
     for (var i = 0; i < recordSegments.length; i++) {
-      if (used >= _maxDuration) break;
+      if (used >= maxDuration) break;
 
       final segment = recordSegments[i];
-      final remaining = _maxDuration - used;
+      final remaining = maxDuration - used;
       final segmentDuration = segment.duration > remaining
           ? remaining
           : segment.duration;
@@ -76,7 +77,7 @@ class _Segments extends ConsumerWidget {
 
       // Add divider between segments
       if (i < recordSegments.length - 1 || activeRecordingDuration > .zero) {
-        if (used < _maxDuration) {
+        if (used < maxDuration) {
           segments.add(
             Container(
               height: 16,
@@ -89,8 +90,8 @@ class _Segments extends ConsumerWidget {
     }
 
     // Add active recording segment
-    if (activeRecordingDuration > .zero && used < _maxDuration) {
-      final remaining = _maxDuration - used;
+    if (activeRecordingDuration > .zero && used < maxDuration) {
+      final remaining = maxDuration - used;
       final activeDuration = activeRecordingDuration > remaining
           ? remaining
           : activeRecordingDuration;
@@ -121,8 +122,8 @@ class _Segments extends ConsumerWidget {
     }
 
     // Add remaining empty space as Flexible
-    if (used < _maxDuration) {
-      final remaining = _maxDuration - used;
+    if (used < maxDuration) {
+      final remaining = maxDuration - used;
       segments.add(
         Flexible(
           flex: remaining.inMilliseconds,

--- a/mobile/packages/models/lib/models.dart
+++ b/mobile/packages/models/lib/models.dart
@@ -50,6 +50,7 @@ export 'src/video_editor/sticker_data.dart';
 export 'src/video_event.dart';
 export 'src/video_event_filters.dart';
 export 'src/video_reply_visibility.dart';
+export 'src/video_series.dart';
 export 'src/video_state.dart';
 export 'src/video_stats.dart';
 export 'src/video_url_resolver.dart';

--- a/mobile/packages/models/lib/src/video_event.dart
+++ b/mobile/packages/models/lib/src/video_event.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 import 'package:models/src/nip71_video_kinds.dart';
 import 'package:models/src/video_attribution.dart';
+import 'package:models/src/video_series.dart';
 import 'package:models/src/video_url_resolver.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
 import 'package:text_sanitizer/text_sanitizer.dart';
@@ -202,6 +203,7 @@ class VideoEvent {
     this.proofSummary,
     this.eventKind,
     this.sourceRelay,
+    this.series,
   });
 
   /// Reconstructs a [VideoEvent] from a map produced by [toJson].
@@ -297,6 +299,7 @@ class VideoEvent {
           : ProofVerificationSummary.fromJson(
               json['proofSummary'] as Map<String, dynamic>,
             ),
+      series: VideoSeries.fromJson(json['series'] as Map<String, dynamic>?),
     );
   }
 
@@ -344,6 +347,7 @@ class VideoEvent {
     String? audioEventRelay;
     String? sourceRelay;
     final collaboratorPubkeys = <String>[];
+    VideoSeries? series;
     InspiredByInfo? inspiredByVideo;
     final textTrackRefsLocal = <String>[];
     final contentWarningLabels = <String>[];
@@ -482,6 +486,9 @@ class VideoEvent {
         case 'blurhash':
           // Blurhash for progressive image loading
           blurhash = tagValue as String?;
+        case 'series':
+          // Divine series membership: [series, <id>, <index>, <total>]
+          series = VideoSeries.fromTag(tag);
         case 'loops':
           // Original loop count from classic Vine
           originalLoops = int.tryParse(tagValue);
@@ -709,6 +716,7 @@ class VideoEvent {
       collaboratorPubkeys: collaboratorPubkeys,
       inspiredByVideo: inspiredByVideo,
       inspiredByNpub: inspiredByNpub,
+      series: series,
       nostrEventTags: event.tags
           .map((t) => (t as List).map((e) => e.toString()).toList())
           .toList(),
@@ -763,6 +771,10 @@ class VideoEvent {
   /// received. Prefers an `r` tag when present, then falls back to SDK
   /// receive-source metadata. Used as a relay hint when citing the video.
   final String? sourceRelay;
+
+  /// Series membership when this video is one segment of a published series,
+  /// parsed from a `["series", "<id>", "<index>", "<total>"]` tag.
+  final VideoSeries? series;
 
   // Repost metadata fields
   final bool isRepost;
@@ -1541,6 +1553,7 @@ class VideoEvent {
     ProofVerificationSummary? proofSummary,
     int? eventKind,
     String? sourceRelay,
+    VideoSeries? series,
   }) => VideoEvent(
     id: id ?? this.id,
     pubkey: pubkey ?? this.pubkey,
@@ -1603,6 +1616,7 @@ class VideoEvent {
     proofSummary: proofSummary ?? this.proofSummary,
     eventKind: eventKind ?? this.eventKind,
     sourceRelay: sourceRelay ?? this.sourceRelay,
+    series: series ?? this.series,
   );
 
   @override
@@ -1683,6 +1697,7 @@ class VideoEvent {
     'proofSummary': proofSummary?.toJson(),
     'eventKind': eventKind,
     'sourceRelay': sourceRelay,
+    'series': series?.toJson(),
   };
 
   /// Create a VideoEvent instance representing a repost

--- a/mobile/packages/models/lib/src/video_series.dart
+++ b/mobile/packages/models/lib/src/video_series.dart
@@ -1,0 +1,66 @@
+import 'package:meta/meta.dart';
+
+/// Membership of a video in an ordered series of short segments that were
+/// published together — a longer recording split into per-video-limit pieces.
+///
+/// Carried on each segment's video event as a
+/// `["series", "<id>", "<index>", "<total>"]` tag so a client can group and
+/// order the segments without needing the (optional) NIP-51 container event.
+@immutable
+class VideoSeries {
+  const VideoSeries({
+    required this.id,
+    required this.index,
+    required this.total,
+  });
+
+  /// Parses a `["series", "<id>", "<index>", "<total>"]` tag.
+  ///
+  /// Returns null when the tag is missing fields or has a non-numeric
+  /// index/total, so a malformed tag degrades to "not part of a series".
+  static VideoSeries? fromTag(List<dynamic> tag) {
+    if (tag.length < 4 || tag[0] != 'series') return null;
+    final id = tag[1]?.toString() ?? '';
+    final index = int.tryParse(tag[2]?.toString() ?? '');
+    final total = int.tryParse(tag[3]?.toString() ?? '');
+    if (id.isEmpty || index == null || total == null) return null;
+    return VideoSeries(id: id, index: index, total: total);
+  }
+
+  /// Restores a series from its [toJson] map, or null when absent/invalid.
+  static VideoSeries? fromJson(Map<String, dynamic>? json) {
+    if (json == null) return null;
+    final id = json['id'] as String?;
+    final index = (json['index'] as num?)?.toInt();
+    final total = (json['total'] as num?)?.toInt();
+    if (id == null || id.isEmpty || index == null || total == null) return null;
+    return VideoSeries(id: id, index: index, total: total);
+  }
+
+  /// Shared identifier of the series (identical across all its segments).
+  final String id;
+
+  /// Zero-based position of this segment within the series.
+  final int index;
+
+  /// Total number of segments in the series.
+  final int total;
+
+  /// Human-facing position label, e.g. `1/10` for the first of ten.
+  String get positionLabel => '${index + 1}/$total';
+
+  Map<String, dynamic> toJson() => {'id': id, 'index': index, 'total': total};
+
+  @override
+  bool operator ==(Object other) =>
+      other is VideoSeries &&
+      other.id == id &&
+      other.index == index &&
+      other.total == total;
+
+  @override
+  int get hashCode => Object.hash(id, index, total);
+
+  @override
+  String toString() => 'VideoSeries(id: $id, index: $index, total: $total)';
+}

--- a/mobile/packages/models/test/src/video_event_to_json_test.dart
+++ b/mobile/packages/models/test/src/video_event_to_json_test.dart
@@ -98,6 +98,7 @@ VideoEvent _fullVideo() => VideoEvent(
   ),
   eventKind: 34236,
   sourceRelay: 'wss://relay.divine.video',
+  series: const VideoSeries(id: 'series-abc123', index: 2, total: 5),
 );
 
 const _expectedKeys = <String>{
@@ -152,6 +153,7 @@ const _expectedKeys = <String>{
   'proofSummary',
   'eventKind',
   'sourceRelay',
+  'series',
 };
 
 const _excludedDerivedGetters = <String>{
@@ -370,6 +372,7 @@ void main() {
         equals(original.contentWarningLabels),
       );
       expect(restored.proofSummary, equals(original.proofSummary));
+      expect(restored.series, equals(original.series));
     });
 
     test('round-trips a minimal video with only required fields', () {

--- a/mobile/packages/models/test/src/video_series_test.dart
+++ b/mobile/packages/models/test/src/video_series_test.dart
@@ -1,0 +1,62 @@
+import 'package:models/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('VideoSeries.fromTag', () {
+    test('parses a well-formed series tag', () {
+      final series = VideoSeries.fromTag(['series', 'abc123', '2', '10']);
+      expect(series, isNotNull);
+      expect(series!.id, 'abc123');
+      expect(series.index, 2);
+      expect(series.total, 10);
+    });
+
+    test('accepts dynamic (non-string) tag values', () {
+      final series = VideoSeries.fromTag(['series', 'abc', 0, 3]);
+      expect(series, isNotNull);
+      expect(series!.index, 0);
+      expect(series.total, 3);
+    });
+
+    test('returns null when the tag name is not "series"', () {
+      expect(VideoSeries.fromTag(['t', 'abc', '0', '3']), isNull);
+    });
+
+    test('returns null when fields are missing', () {
+      expect(VideoSeries.fromTag(['series', 'abc', '0']), isNull);
+    });
+
+    test('returns null for a non-numeric index or total', () {
+      expect(VideoSeries.fromTag(['series', 'abc', 'x', '3']), isNull);
+      expect(VideoSeries.fromTag(['series', 'abc', '0', 'y']), isNull);
+    });
+
+    test('returns null for an empty id', () {
+      expect(VideoSeries.fromTag(['series', '', '0', '3']), isNull);
+    });
+  });
+
+  group('VideoSeries', () {
+    test('positionLabel is one-based', () {
+      const series = VideoSeries(id: 'a', index: 0, total: 10);
+      expect(series.positionLabel, '1/10');
+    });
+
+    test('json round-trips', () {
+      const series = VideoSeries(id: 'a', index: 3, total: 7);
+      expect(VideoSeries.fromJson(series.toJson()), series);
+    });
+
+    test('fromJson returns null for an invalid map', () {
+      expect(VideoSeries.fromJson(null), isNull);
+      expect(VideoSeries.fromJson({'id': 'a', 'index': 1}), isNull);
+    });
+
+    test('equality is by value', () {
+      expect(
+        const VideoSeries(id: 'a', index: 1, total: 5),
+        const VideoSeries(id: 'a', index: 1, total: 5),
+      );
+    });
+  });
+}

--- a/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
+++ b/mobile/test/blocs/fullscreen_feed/fullscreen_feed_bloc_test.dart
@@ -232,6 +232,7 @@ void main() {
         expect(state.props, [
           FullscreenFeedStatus.ready,
           [video],
+          <String, List<VideoEvent>>{},
           [
             '${video.id}|${video.stableId}|${video.videoUrl ?? ''}|${video.thumbnailUrl ?? ''}|${video.originalLoops ?? ''}|${video.rawTags['views'] ?? ''}',
           ],

--- a/mobile/test/blocs/video_feed/video_series_grouping_test.dart
+++ b/mobile/test/blocs/video_feed/video_series_grouping_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart';
+import 'package:openvine/blocs/video_feed/video_series_grouping.dart';
+
+VideoEvent _video(String id, {VideoSeries? series}) => VideoEvent(
+  id: id,
+  pubkey: 'pk',
+  createdAt: 0,
+  content: '',
+  timestamp: DateTime(2024),
+  series: series,
+);
+
+VideoSeries _series(int index, {String id = 's1', int total = 3}) =>
+    VideoSeries(id: id, index: index, total: total);
+
+void main() {
+  group('groupVideoSeries', () {
+    test('passes non-series videos through unchanged', () {
+      final videos = [_video('a'), _video('b'), _video('c')];
+      final grouped = groupVideoSeries(videos);
+      expect(grouped.items.map((v) => v.id), ['a', 'b', 'c']);
+      expect(grouped.seriesSegments, isEmpty);
+    });
+
+    test('collapses a series to a single ordered anchor', () {
+      final videos = [
+        _video('s0', series: _series(0)),
+        _video('s1', series: _series(1)),
+        _video('s2', series: _series(2)),
+      ];
+      final grouped = groupVideoSeries(videos);
+      expect(grouped.items, hasLength(1));
+      expect(grouped.items.single.id, 's0');
+      expect(grouped.seriesSegments['s1']!.map((v) => v.id), [
+        's0',
+        's1',
+        's2',
+      ]);
+    });
+
+    test(
+      'places the anchor at the first-seen position, keeping feed order',
+      () {
+        final videos = [
+          _video('a'),
+          _video('s1', series: _series(1)),
+          _video('b'),
+          _video('s0', series: _series(0)),
+        ];
+        final grouped = groupVideoSeries(videos);
+        // Anchor sits where the series first appeared (before 'b').
+        expect(grouped.items.map((v) => v.id), ['a', 's0', 'b']);
+      },
+    );
+
+    test('orders segments by index even when received out of order', () {
+      final videos = [
+        _video('s2', series: _series(2)),
+        _video('s0', series: _series(0)),
+        _video('s1', series: _series(1)),
+      ];
+      final grouped = groupVideoSeries(videos);
+      expect(grouped.items.single.id, 's0');
+      expect(grouped.seriesSegments['s1']!.map((v) => v.id), [
+        's0',
+        's1',
+        's2',
+      ]);
+    });
+
+    test('handles multiple distinct series independently', () {
+      final videos = [
+        _video('x0', series: _series(0, id: 'x', total: 2)),
+        _video('y0', series: _series(0, id: 'y', total: 2)),
+        _video('x1', series: _series(1, id: 'x', total: 2)),
+        _video('y1', series: _series(1, id: 'y', total: 2)),
+      ];
+      final grouped = groupVideoSeries(videos);
+      expect(grouped.items.map((v) => v.id), ['x0', 'y0']);
+      expect(grouped.seriesSegments['x']!.map((v) => v.id), ['x0', 'x1']);
+      expect(grouped.seriesSegments['y']!.map((v) => v.id), ['y0', 'y1']);
+    });
+  });
+}

--- a/mobile/test/models/video_recorder/video_recorder_mode_test.dart
+++ b/mobile/test/models/video_recorder/video_recorder_mode_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model show AspectRatio;
+import 'package:openvine/constants/video_editor_constants.dart';
 import 'package:openvine/models/video_recorder/video_recorder_mode.dart';
 
 void main() {
@@ -20,6 +21,10 @@ void main() {
       test('upload returns "Upload" label', () {
         expect(VideoRecorderMode.upload.label, equals('Upload'));
       });
+
+      test('sixtySeconds has label "60s"', () {
+        expect(VideoRecorderMode.sixtySeconds.label, equals('60s'));
+      });
     });
 
     group('hasRecordingLimit', () {
@@ -37,6 +42,10 @@ void main() {
 
       test('upload has no recording limit', () {
         expect(VideoRecorderMode.upload.hasRecordingLimit, isFalse);
+      });
+
+      test('sixtySeconds has no recording limit (mirrors capture)', () {
+        expect(VideoRecorderMode.sixtySeconds.hasRecordingLimit, isFalse);
       });
     });
 
@@ -56,6 +65,10 @@ void main() {
       test('upload has no video editor', () {
         expect(VideoRecorderMode.upload.hasVideoEditor, isFalse);
       });
+
+      test('sixtySeconds has video editor', () {
+        expect(VideoRecorderMode.sixtySeconds.hasVideoEditor, isTrue);
+      });
     });
 
     group('supportGridLines', () {
@@ -73,6 +86,10 @@ void main() {
 
       test('upload does not support grid lines', () {
         expect(VideoRecorderMode.upload.supportGridLines, isFalse);
+      });
+
+      test('sixtySeconds does not support grid lines', () {
+        expect(VideoRecorderMode.sixtySeconds.supportGridLines, isFalse);
       });
     });
 
@@ -102,6 +119,36 @@ void main() {
         expect(
           VideoRecorderMode.upload.defaultAspectRatio,
           equals(model.AspectRatio.vertical),
+        );
+      });
+
+      test('sixtySeconds defaults to vertical', () {
+        expect(
+          VideoRecorderMode.sixtySeconds.defaultAspectRatio,
+          equals(model.AspectRatio.vertical),
+        );
+      });
+    });
+
+    group('maxRecordingDuration', () {
+      test('sixtySeconds allows 60 seconds', () {
+        expect(
+          VideoRecorderMode.sixtySeconds.maxRecordingDuration,
+          equals(const Duration(seconds: 60)),
+        );
+      });
+
+      test('capture keeps the standard default duration', () {
+        expect(
+          VideoRecorderMode.capture.maxRecordingDuration,
+          equals(VideoEditorConstants.maxDuration),
+        );
+      });
+
+      test('classic keeps the standard default duration', () {
+        expect(
+          VideoRecorderMode.classic.maxRecordingDuration,
+          equals(VideoEditorConstants.maxDuration),
         );
       });
     });

--- a/mobile/test/services/video_editor/video_editor_render_service_split_test.dart
+++ b/mobile/test/services/video_editor/video_editor_render_service_split_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+
+void main() {
+  group('VideoEditorRenderService.computeSegmentWindows', () {
+    List<({Duration start, Duration end})> windows(int totalMs, int segMs) =>
+        VideoEditorRenderService.computeSegmentWindows(
+          totalDuration: Duration(milliseconds: totalMs),
+          maxSegmentDuration: Duration(milliseconds: segMs),
+        );
+
+    test('returns a single full window when the source already fits', () {
+      final result = windows(5000, 6300);
+      expect(result, hasLength(1));
+      expect(result.single.start, Duration.zero);
+      expect(result.single.end, const Duration(milliseconds: 5000));
+    });
+
+    test('returns a single window when the source equals the limit', () {
+      final result = windows(6300, 6300);
+      expect(result, hasLength(1));
+      expect(result.single.end, const Duration(milliseconds: 6300));
+    });
+
+    test('splits an exact multiple into equal windows', () {
+      final result = windows(12600, 6300);
+      expect(result, hasLength(2));
+      expect(
+        result[0],
+        (start: Duration.zero, end: const Duration(milliseconds: 6300)),
+      );
+      expect(
+        result[1],
+        (
+          start: const Duration(milliseconds: 6300),
+          end: const Duration(milliseconds: 12600),
+        ),
+      );
+    });
+
+    test('makes the final window shorter for a non-multiple total', () {
+      final result = windows(60000, 6300); // 9 full windows + a remainder
+
+      expect(result, hasLength(10));
+      expect(result.first.start, Duration.zero);
+      expect(result.last.end, const Duration(milliseconds: 60000));
+      expect(
+        result.last.end - result.last.start,
+        const Duration(milliseconds: 3300),
+      );
+
+      // Windows tile contiguously and none exceeds the per-segment limit.
+      for (var i = 0; i < result.length; i++) {
+        expect(
+          result[i].end - result[i].start,
+          lessThanOrEqualTo(const Duration(milliseconds: 6300)),
+        );
+        if (i > 0) expect(result[i].start, result[i - 1].end);
+      }
+    });
+
+    test('returns no windows for a zero-length source', () {
+      expect(windows(0, 6300), isEmpty);
+    });
+  });
+}

--- a/mobile/test/services/video_publish/video_publish_service_test.dart
+++ b/mobile/test/services/video_publish/video_publish_service_test.dart
@@ -1,6 +1,8 @@
 // ABOUTME: Tests for VideoPublishService
 // ABOUTME: Uses mocked dependencies to test publish flow without real uploads
 
+import 'dart:io';
+
 import 'package:blossom_upload_service/blossom_upload_service.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -435,6 +437,50 @@ void main() {
         ).called(1);
       });
 
+      test('collaborator invites use the effective published d-tag', () async {
+        _setupSuccessfulPublish(
+          mockAuthService: mockAuthService,
+          mockUploadManager: mockUploadManager,
+          mockDraftService: mockDraftService,
+          mockVideoEventPublisher: mockVideoEventPublisher,
+        );
+        when(
+          () => mockCollaboratorInviteService.sendInvites(
+            collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+            creatorPubkey: any(named: 'creatorPubkey'),
+            videoAddress: any(named: 'videoAddress'),
+            title: any(named: 'title'),
+            thumbnailUrl: any(named: 'thumbnailUrl'),
+            relayHint: any(named: 'relayHint'),
+          ),
+        ).thenAnswer(
+          (_) async => const CollaboratorInviteBatchResult(results: {}),
+        );
+
+        final draft = _createTestDraft(
+          collaboratorPubkeys: {
+            'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          },
+        );
+
+        final result = await service.publishVideo(
+          draft: draft,
+          dTagOverride: 'published-d-tag',
+        );
+
+        expect(result, isA<PublishSuccess>());
+        verify(
+          () => mockCollaboratorInviteService.sendInvites(
+            collaboratorPubkeys: draft.collaboratorPubkeys,
+            creatorPubkey: 'test_pubkey',
+            videoAddress: '34236:test_pubkey:published-d-tag',
+            title: 'Test Video',
+            thumbnailUrl: _defaultThumbnailPath,
+            relayHint: 'wss://relay.divine.video',
+          ),
+        ).called(1);
+      });
+
       test('collaborator invites include the uploaded thumbnail URL', () async {
         const thumbnailUrl = 'https://cdn.divine.video/thumbs/test_video.jpg';
         final readyUpload = _createPendingUpload(
@@ -713,6 +759,154 @@ void main() {
             'wss://relay.divine.video',
           );
           expect(success.inviteWarnings.single.error, 'relay unavailable');
+        },
+      );
+
+      test(
+        'series publish deletes the original long draft after the container '
+        'publishes',
+        () async {
+          final tempDir = Directory.systemTemp.createTempSync(
+            'video_publish_series_success_',
+          );
+          addTearDown(() async {
+            if (tempDir.existsSync()) {
+              await tempDir.delete(recursive: true);
+            }
+          });
+          final sourceFile = File('${tempDir.path}/source.mp4')
+            ..writeAsStringSync('source');
+          final segmentFiles = [
+            File('${tempDir.path}/segment-0.mp4')..writeAsStringSync('seg0'),
+            File('${tempDir.path}/segment-1.mp4')..writeAsStringSync('seg1'),
+          ];
+
+          _setupSeriesPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+          );
+          when(
+            () => mockVideoEventPublisher.publishSeriesContainer(
+              seriesId: any(named: 'seriesId'),
+              segmentAddresses: any(named: 'segmentAddresses'),
+              title: any(named: 'title'),
+            ),
+          ).thenAnswer((_) async => true);
+
+          final service = VideoPublishService(
+            uploadManager: mockUploadManager,
+            authService: mockAuthService,
+            videoEventPublisher: mockVideoEventPublisher,
+            blossomService: mockBlossomService,
+            draftService: mockDraftService,
+            collaboratorInviteService: mockCollaboratorInviteService,
+            mentionResolutionService: mockMentionResolutionService,
+            splitVideoIntoSegments:
+                ({
+                  required maxSegmentDuration,
+                  required sourcePath,
+                  required totalDuration,
+                }) async {
+                  expect(sourcePath, sourceFile.path);
+                  return segmentFiles.map((file) => file.path).toList();
+                },
+            onProgressChanged:
+                ({required double progress, required String draftId}) =>
+                    progressChanges.add(progress),
+          );
+
+          final draft = _createTestDraft(
+            finalRenderedClip: _createTestClip(
+              path: sourceFile.path,
+              duration: const Duration(seconds: 13),
+            ),
+          );
+
+          final result = await service.publishVideo(draft: draft);
+
+          expect(result, isA<PublishSuccess>());
+          verifyInOrder([
+            () => mockVideoEventPublisher.publishSeriesContainer(
+              seriesId: draft.id,
+              segmentAddresses: [
+                '34236:test_pubkey:series-${draft.id}-0',
+                '34236:test_pubkey:series-${draft.id}-1',
+              ],
+              title: 'Test Video',
+            ),
+            () => mockDraftService.deleteDraft(draft.id),
+          ]);
+        },
+      );
+
+      test(
+        'series publish does not delete the original long draft when the '
+        'container publish fails',
+        () async {
+          final tempDir = Directory.systemTemp.createTempSync(
+            'video_publish_series_container_failure_',
+          );
+          addTearDown(() async {
+            if (tempDir.existsSync()) {
+              await tempDir.delete(recursive: true);
+            }
+          });
+          final sourceFile = File('${tempDir.path}/source.mp4')
+            ..writeAsStringSync('source');
+          final segmentFiles = [
+            File('${tempDir.path}/segment-0.mp4')..writeAsStringSync('seg0'),
+            File('${tempDir.path}/segment-1.mp4')..writeAsStringSync('seg1'),
+          ];
+
+          _setupSeriesPublish(
+            mockAuthService: mockAuthService,
+            mockUploadManager: mockUploadManager,
+            mockDraftService: mockDraftService,
+            mockVideoEventPublisher: mockVideoEventPublisher,
+          );
+          when(
+            () => mockVideoEventPublisher.publishSeriesContainer(
+              seriesId: any(named: 'seriesId'),
+              segmentAddresses: any(named: 'segmentAddresses'),
+              title: any(named: 'title'),
+            ),
+          ).thenAnswer((_) async => false);
+
+          final service = VideoPublishService(
+            uploadManager: mockUploadManager,
+            authService: mockAuthService,
+            videoEventPublisher: mockVideoEventPublisher,
+            blossomService: mockBlossomService,
+            draftService: mockDraftService,
+            collaboratorInviteService: mockCollaboratorInviteService,
+            mentionResolutionService: mockMentionResolutionService,
+            splitVideoIntoSegments:
+                ({
+                  required maxSegmentDuration,
+                  required sourcePath,
+                  required totalDuration,
+                }) async {
+                  expect(sourcePath, sourceFile.path);
+                  return segmentFiles.map((file) => file.path).toList();
+                },
+            onProgressChanged:
+                ({required double progress, required String draftId}) =>
+                    progressChanges.add(progress),
+          );
+
+          final draft = _createTestDraft(
+            finalRenderedClip: _createTestClip(
+              path: sourceFile.path,
+              duration: const Duration(seconds: 13),
+            ),
+          );
+
+          final result = await service.publishVideo(draft: draft);
+
+          expect(result, isA<PublishError>());
+          verifyNever(() => mockDraftService.deleteDraft(draft.id));
         },
       );
 
@@ -1602,11 +1796,14 @@ void _stubFailedUpload({
 
 // Helper functions
 
-DivineVideoClip _createTestClip() {
+DivineVideoClip _createTestClip({
+  String path = '/test/video.mp4',
+  Duration duration = const Duration(seconds: 10),
+}) {
   return DivineVideoClip(
     id: 'test_clip',
-    video: EditorVideo.file('/test/video.mp4'),
-    duration: const Duration(seconds: 10),
+    video: EditorVideo.file(path),
+    duration: duration,
     recordedAt: DateTime.now(),
     targetAspectRatio: AspectRatio.square,
     originalAspectRatio: 9 / 16,
@@ -1617,6 +1814,7 @@ DivineVideoDraft _createTestDraft({
   String description = 'Test description',
   Map<String, dynamic> editorStateHistory = const {},
   Set<String> collaboratorPubkeys = const {},
+  DivineVideoClip? finalRenderedClip,
 }) {
   return DivineVideoDraft.create(
     clips: [_createTestClip()],
@@ -1627,6 +1825,7 @@ DivineVideoDraft _createTestDraft({
     id: 'test_draft_id',
     editorStateHistory: editorStateHistory,
     collaboratorPubkeys: collaboratorPubkeys,
+    finalRenderedClip: finalRenderedClip,
   );
 }
 
@@ -1634,16 +1833,19 @@ PendingUpload _createPendingUpload({
   required UploadStatus status,
   String? errorMessage,
   Object? thumbnailPath = _defaultThumbnailPath,
+  String id = 'test_upload_id',
+  String videoId = 'test_video_id',
+  String localVideoPath = '/test/video.mp4',
 }) {
   return PendingUpload(
-    id: 'test_upload_id',
-    localVideoPath: '/test/video.mp4',
+    id: id,
+    localVideoPath: localVideoPath,
     nostrPubkey: 'test_pubkey',
     status: status,
     createdAt: DateTime.now(),
     errorMessage: errorMessage,
     uploadProgress: status == UploadStatus.readyToPublish ? 1.0 : 0.5,
-    videoId: 'test_video_id',
+    videoId: videoId,
     cdnUrl: 'https://test.cdn/video.mp4',
     thumbnailPath: thumbnailPath as String?,
   );
@@ -1694,6 +1896,68 @@ void _setupSuccessfulPublish({
       thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
       replyContext: any(named: 'replyContext'),
       addReplyToFeed: any(named: 'addReplyToFeed'),
+      series: any(named: 'series'),
+      dTagOverride: any(named: 'dTagOverride'),
+    ),
+  ).thenAnswer((_) async => true);
+}
+
+void _setupSeriesPublish({
+  required MockAuthService mockAuthService,
+  required MockUploadManager mockUploadManager,
+  required MockDraftStorageService mockDraftService,
+  required MockVideoEventPublisher mockVideoEventPublisher,
+}) {
+  final uploadsById = <String, PendingUpload>{};
+  when(() => mockAuthService.isAuthenticated).thenReturn(true);
+  when(() => mockAuthService.currentPublicKeyHex).thenReturn('test_pubkey');
+  when(() => mockDraftService.saveDraft(any())).thenAnswer((_) async {});
+  when(() => mockDraftService.deleteDraft(any())).thenAnswer((_) async {});
+  when(() => mockUploadManager.isInitialized).thenReturn(true);
+  when(
+    () => mockUploadManager.startUploadFromDraft(
+      draft: any(named: 'draft'),
+      nostrPubkey: any(named: 'nostrPubkey'),
+      onProgress: any(named: 'onProgress'),
+    ),
+  ).thenAnswer((invocation) async {
+    final draft = invocation.namedArguments[#draft] as DivineVideoDraft;
+    final upload = _createPendingUpload(
+      id: 'upload-${draft.id}',
+      videoId: 'upload-video-${draft.id}',
+      localVideoPath: await draft.finalRenderedClip!.video.safeFilePath(),
+      status: UploadStatus.readyToPublish,
+    );
+    uploadsById[upload.id] = upload;
+    return upload;
+  });
+  when(() => mockUploadManager.getUpload(any())).thenAnswer((invocation) {
+    final uploadId = invocation.positionalArguments.single as String;
+    return uploadsById[uploadId];
+  });
+  when(
+    () => mockVideoEventPublisher.publishVideoEvent(
+      upload: any(named: 'upload'),
+      title: any(named: 'title'),
+      description: any(named: 'description'),
+      hashtags: any(named: 'hashtags'),
+      expirationTimestamp: any(named: 'expirationTimestamp'),
+      allowAudioReuse: any(named: 'allowAudioReuse'),
+      collaboratorPubkeys: any(named: 'collaboratorPubkeys'),
+      mentionedPubkeys: any(named: 'mentionedPubkeys'),
+      inspiredByAddressableId: any(named: 'inspiredByAddressableId'),
+      inspiredByRelayUrl: any(named: 'inspiredByRelayUrl'),
+      inspiredByNpub: any(named: 'inspiredByNpub'),
+      selectedAudio: any(named: 'selectedAudio'),
+      selectedAudioEventId: any(named: 'selectedAudioEventId'),
+      selectedAudioRelay: any(named: 'selectedAudioRelay'),
+      language: any(named: 'language'),
+      contentWarning: any(named: 'contentWarning'),
+      thumbnailTimestamp: any(named: 'thumbnailTimestamp'),
+      replyContext: any(named: 'replyContext'),
+      addReplyToFeed: any(named: 'addReplyToFeed'),
+      series: any(named: 'series'),
+      dTagOverride: any(named: 'dTagOverride'),
     ),
   ).thenAnswer((_) async => true);
 }

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_body_test.dart
@@ -5,6 +5,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/models.dart' as model;
@@ -77,28 +78,30 @@ void main() {
       addTearDown(playhead.dispose);
 
       await tester.pumpWidget(
-        MaterialApp(
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          home: MultiBlocProvider(
-            providers: [
-              BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
-              BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
-            ],
-            child: SizedBox(
-              height: 120000,
-              child: VideoEditorTimelineBody(
-                totalDuration: totalDuration,
-                pixelsPerSecond: 80,
-                scrollController: scrollController,
-                overlayStripsScrollController: overlayStripsScrollController,
-                scrollPadding: 16,
-                clips: clips,
-                totalWidth: 960,
-                isInteracting: false,
-                onReorder: (_) {},
-                onReorderChanged: (_) {},
-                playheadPosition: playhead,
+        ProviderScope(
+          child: MaterialApp(
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: MultiBlocProvider(
+              providers: [
+                BlocProvider<VideoEditorMainBloc>.value(value: mainBloc),
+                BlocProvider<TimelineOverlayBloc>.value(value: overlayBloc),
+              ],
+              child: SizedBox(
+                height: 120000,
+                child: VideoEditorTimelineBody(
+                  totalDuration: totalDuration,
+                  pixelsPerSecond: 80,
+                  scrollController: scrollController,
+                  overlayStripsScrollController: overlayStripsScrollController,
+                  scrollPadding: 16,
+                  clips: clips,
+                  totalWidth: 960,
+                  isInteracting: false,
+                  onReorder: (_) {},
+                  onReorderChanged: (_) {},
+                  playheadPosition: playhead,
+                ),
               ),
             ),
           ),

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_header_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_header_test.dart
@@ -5,6 +5,7 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:divine_ui/divine_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_editor/clip_editor/clip_editor_bloc.dart';
@@ -85,34 +86,36 @@ void main() {
         playheadPosition.value = position;
       }
 
-      return MaterialApp(
-        localizationsDelegates: AppLocalizations.localizationsDelegates,
-        supportedLocales: AppLocalizations.supportedLocales,
-        home: Scaffold(
-          body: VideoEditorScope(
-            editorKey: GlobalKey<ProImageEditorState>(),
-            removeAreaKey: GlobalKey(),
-            originalClipAspectRatio: 9 / 16,
-            bodySizeNotifier: ValueNotifier(const Size(400, 600)),
-            zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
-            fromLibrary: false,
-            onOpenCamera: () {},
-            onOpenClipsEditor: () {},
-            onAddStickers: () {},
-            onOpenMusicLibrary: () {},
-            onOpenVoiceOver: () {},
-            onAddEditTextLayer: ([layer]) async => null,
-            child: MultiBlocProvider(
-              providers: [
-                BlocProvider<VideoEditorMainBloc>.value(value: mockMainBloc),
-                BlocProvider<ClipEditorBloc>.value(value: mockClipBloc),
-                BlocProvider<TimelineOverlayBloc>.value(
-                  value: mockTimelineOverlayBloc,
+      return ProviderScope(
+        child: MaterialApp(
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: Scaffold(
+            body: VideoEditorScope(
+              editorKey: GlobalKey<ProImageEditorState>(),
+              removeAreaKey: GlobalKey(),
+              originalClipAspectRatio: 9 / 16,
+              bodySizeNotifier: ValueNotifier(const Size(400, 600)),
+              zoomMatrixNotifier: ValueNotifier(Matrix4.identity()),
+              fromLibrary: false,
+              onOpenCamera: () {},
+              onOpenClipsEditor: () {},
+              onAddStickers: () {},
+              onOpenMusicLibrary: () {},
+              onOpenVoiceOver: () {},
+              onAddEditTextLayer: ([layer]) async => null,
+              child: MultiBlocProvider(
+                providers: [
+                  BlocProvider<VideoEditorMainBloc>.value(value: mockMainBloc),
+                  BlocProvider<ClipEditorBloc>.value(value: mockClipBloc),
+                  BlocProvider<TimelineOverlayBloc>.value(
+                    value: mockTimelineOverlayBloc,
+                  ),
+                ],
+                child: VideoEditorTimelineHeader(
+                  playheadPosition: playheadPosition,
+                  volumePreviewNotifier: volumePreviewNotifier,
                 ),
-              ],
-              child: VideoEditorTimelineHeader(
-                playheadPosition: playheadPosition,
-                volumePreviewNotifier: volumePreviewNotifier,
               ),
             ),
           ),

--- a/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_interactive_body_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/video_editor_timeline_interactive_body_test.dart
@@ -4,6 +4,7 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.dart';
@@ -55,83 +56,85 @@ void main() {
         addTearDown(volumePreview.dispose);
 
         await tester.pumpWidget(
-          MaterialApp(
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            home: Scaffold(
-              body: Builder(
-                builder: (context) => MediaQuery(
-                  data: MediaQuery.of(context).copyWith(
-                    padding: const EdgeInsets.only(bottom: 34),
-                  ),
-                  child: SizedBox(
-                    width: 400,
-                    height: 800,
-                    child: MultiBlocProvider(
-                      providers: [
-                        BlocProvider<VideoEditorMainBloc>.value(
-                          value: mainBloc,
+          ProviderScope(
+            child: MaterialApp(
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              home: Scaffold(
+                body: Builder(
+                  builder: (context) => MediaQuery(
+                    data: MediaQuery.of(context).copyWith(
+                      padding: const EdgeInsets.only(bottom: 34),
+                    ),
+                    child: SizedBox(
+                      width: 400,
+                      height: 800,
+                      child: MultiBlocProvider(
+                        providers: [
+                          BlocProvider<VideoEditorMainBloc>.value(
+                            value: mainBloc,
+                          ),
+                          BlocProvider<TimelineOverlayBloc>.value(
+                            value: overlayBloc,
+                          ),
+                        ],
+                        child: VideoEditorTimelineInteractiveBody(
+                          playheadPosition: playhead,
+                          totalDuration: const Duration(seconds: 12),
+                          formatPosition: (_) => '',
+                          onStepPosition: (_, _, _) {},
+                          onPointerDown: (_) {},
+                          onPointerMove: (_) {},
+                          onPointerUp: (_) {},
+                          onPointerCancel: (_) {},
+                          onScrollNotification: (_) => false,
+                          scrollController: scrollController,
+                          isPinching: false,
+                          isTrimming: false,
+                          halfScreen: 200,
+                          pixelsPerSecond: 80,
+                          clips: const <DivineVideoClip>[],
+                          totalWidth: 960,
+                          isInteracting: false,
+                          onReorder: (_) {},
+                          onReorderChanged: (_) {},
+                          trimmingClipId: null,
+                          onTrimChanged:
+                              ({
+                                required clipId,
+                                required isStart,
+                                required trimStart,
+                                required trimEnd,
+                              }) {},
+                          onTrimDragChanged: (_) {},
+                          onClipTapped: (_) {},
+                          isMultiSelectMode: false,
+                          selectedClipIds: const <String>{},
+                          onOverlayItemMoved:
+                              ({
+                                required item,
+                                required startTime,
+                                required row,
+                                required insertAbove,
+                              }) {},
+                          onOverlayItemMoving:
+                              ({required item, required startTime}) {},
+                          onOverlayItemTrimmed:
+                              ({
+                                required item,
+                                required startTime,
+                                required endTime,
+                                required isStart,
+                              }) {},
+                          onOverlayTrimDragChanged: (_) {},
+                          onOverlayItemTapped: (_) {},
+                          onOverlayDragStarted: (_) {},
+                          onOverlayDragEnded: () {},
+                          verticalScrollController: verticalScrollController,
+                          overlayStripsScrollController:
+                              overlayStripsScrollController,
+                          volumePreviewNotifier: volumePreview,
                         ),
-                        BlocProvider<TimelineOverlayBloc>.value(
-                          value: overlayBloc,
-                        ),
-                      ],
-                      child: VideoEditorTimelineInteractiveBody(
-                        playheadPosition: playhead,
-                        totalDuration: const Duration(seconds: 12),
-                        formatPosition: (_) => '',
-                        onStepPosition: (_, _, _) {},
-                        onPointerDown: (_) {},
-                        onPointerMove: (_) {},
-                        onPointerUp: (_) {},
-                        onPointerCancel: (_) {},
-                        onScrollNotification: (_) => false,
-                        scrollController: scrollController,
-                        isPinching: false,
-                        isTrimming: false,
-                        halfScreen: 200,
-                        pixelsPerSecond: 80,
-                        clips: const <DivineVideoClip>[],
-                        totalWidth: 960,
-                        isInteracting: false,
-                        onReorder: (_) {},
-                        onReorderChanged: (_) {},
-                        trimmingClipId: null,
-                        onTrimChanged:
-                            ({
-                              required clipId,
-                              required isStart,
-                              required trimStart,
-                              required trimEnd,
-                            }) {},
-                        onTrimDragChanged: (_) {},
-                        onClipTapped: (_) {},
-                        isMultiSelectMode: false,
-                        selectedClipIds: const <String>{},
-                        onOverlayItemMoved:
-                            ({
-                              required item,
-                              required startTime,
-                              required row,
-                              required insertAbove,
-                            }) {},
-                        onOverlayItemMoving:
-                            ({required item, required startTime}) {},
-                        onOverlayItemTrimmed:
-                            ({
-                              required item,
-                              required startTime,
-                              required endTime,
-                              required isStart,
-                            }) {},
-                        onOverlayTrimDragChanged: (_) {},
-                        onOverlayItemTapped: (_) {},
-                        onOverlayDragStarted: (_) {},
-                        onOverlayDragEnded: () {},
-                        verticalScrollController: verticalScrollController,
-                        overlayStripsScrollController:
-                            overlayStripsScrollController,
-                        volumePreviewNotifier: volumePreview,
                       ),
                     ),
                   ),

--- a/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
+++ b/mobile/test/widgets/video_recorder/video_recorder_mode_selector_test.dart
@@ -22,7 +22,10 @@ void main() {
         home: Scaffold(
           body: Center(
             child: SizedBox(
-              width: 400,
+              // Wide enough for the horizontal picker to lay out all mode
+              // labels at once (5 modes × 96px item extent). In production the
+              // wheel is a scrollable picker, so not all fit on a phone width.
+              width: 700,
               child: VideoRecorderModeSelectorWheel(
                 selectedMode: mode ?? selectedMode,
                 onModeChanged: (m) => modeChanges.add(m),


### PR DESCRIPTION
Closes #5731

## ⚠️ Proof-of-concept

End-to-end POC for "60s series" — longer recordings published as a linked set of short segments. Intentionally a draft: the happy path works on device, but several edges are stubbed or deferred (see Known gaps). Opening it for early feedback on the approach and the Nostr shape, not as merge-ready code.

| Screenshot 1 | Screenshot 2 | Screenshot 3 |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/fa952068-5265-4d79-a9b9-e551c135c976" width="250"> | <img src="https://github.com/user-attachments/assets/f4e02e80-cc5a-48b2-bf44-747534ea11bb" width="250"> | <img src="https://github.com/user-attachments/assets/7d9da242-9520-4f11-892f-19cecac48332" width="250"> | 

https://github.com/user-attachments/assets/8a4c697d-e7ce-44df-b0f3-280fad8ec828

## Why

The per-video recording limit is 6.3s, but creators want to post longer (up to 60s) clips. Rather than raise that limit, this records the full duration and splits it on publish into ≤6.3s segments — each its own kind-34236 video event — linked so clients can group and play them as one swipeable card. Both linking mechanisms are included so we can evaluate which the client and relays prefer.

## What's in it

**Recorder** — new 60s mode alongside capture. The session cap lives in `ClipManagerState.maxDuration` (threaded from the clip manager); the global `VideoEditorConstants.maxDuration` (the 6.3s per-video limit) is left untouched. The editor works the full duration, with scissor cut-markers at each 6.3s boundary and over-limit indicators keyed to the session cap.

**Publish** — renders the full recording, splits into ≤6.3s segments, uploads each as its own kind-34236 event. Segments are linked two ways: a per-segment `["series", "<id>", "<index>", "<total>"]` tag and a NIP-51 kind-30005 curation-set container.

**Metadata** — a tab per segment lets the creator give each segment its own title, description and cover. The preview and cover picker render the active segment on demand.

**Feed** — series segments collapse into a single card that swipes horizontally between segments (a nested horizontal `InfiniteVideoFeed`) with an x/N badge. Wired into both the home feed (`VideoFeedBloc`) and the profile fullscreen viewer (`FullscreenFeedBloc`); the outer paused overlay is suppressed for series anchors so the nested feed drives playback.

**Fix** — `VideoEvent.fromJson` now restores the `series` field, so videos keep their series grouping through the home-feed cache round-trip.

## Known gaps & follow-ups

Deferred within this POC:

- **Per-segment likes/comments** — a series card's action overlay shows the anchor segment's like/comment counts, not the currently-swiped segment. The outer overlay needs to track the nested feed's active segment so likes and comments follow the visible segment.
- **Per-segment cover** — publish does not yet apply a per-segment picked cover frame; each segment uses its default first frame.
- **Tap-to-pause** on a series card toggles the outer (silent) controller rather than the nested one.
- Opening the full-screen preview / cover picker for a segment renders it on demand (brief spinner on first open).

Still needed for the full feature:

- **Funnelcake** — the search/index backend needs updating to understand the series relationship (per-segment `series` tags / the kind-30005 container) so series surface correctly there rather than as loose segments.
- **Feed "+N" affordance** — surface in the feed that a card is a series of N videos, e.g. a `+3` badge (or the pattern used on the search screen), in addition to the current per-segment `x/N` position badge.
- **Delete** — let the user delete the whole series or a single segment out of it; the current delete path only handles standalone videos.

## Test plan

- `flutter analyze lib test` clean.
- New/updated unit + widget tests: series grouping, `VideoEvent` series round-trip, segment windowing, per-segment metadata tabs, fullscreen-feed grouping. Affected suites green via the pre-push hook.
- Manual: record in 60s mode → editor shows cut-markers → publish → home feed and profile both show one swipeable series card with badge, no stuck pause overlay.