### PR TITLE
refactor(auth): extract SignerSecureStore from auth_service (#4741)

### DIFF
--- a/mobile/lib/services/auth/signer_secure_store.dart
+++ b/mobile/lib/services/auth/signer_secure_store.dart
@@ -1,0 +1,443 @@
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show NostrRemoteSignerInfo;
+import 'package:openvine/models/authentication_source.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+const _kBunkerInfoKey = 'bunker_info';
+const _kAmberPubkeyKey = 'amber_pubkey';
+const _kAmberPackageKey = 'amber_package';
+const _kKeycastRefreshTokenKey = 'keycast_refresh_token';
+const _kKeycastAuthHandleKey = 'keycast_auth_handle';
+String _keycastSessionKey(String pubkeyHex) => 'keycast_session_$pubkeyHex';
+
+/// Owns secure-storage persistence for external-signer credentials — NIP-46
+/// bunker, NIP-55 Amber, and Divine/Keycast OAuth sessions — plus the
+/// per-account archive used to swap signer keys when switching accounts.
+///
+/// Extracted from `AuthService` (#4741) as the first client-tier collaborator.
+/// `AuthService` delegates to it and keeps the auth-source SharedPreferences
+/// write; this store touches only [FlutterSecureStorage].
+class SignerSecureStore {
+  SignerSecureStore(this._storage);
+
+  final FlutterSecureStorage? _storage;
+
+  // === NIP-46 bunker ===
+
+  Future<void> saveBunker(NostrRemoteSignerInfo info) async {
+    if (_storage == null) return;
+    try {
+      // Serialize bunker info as bunker URL (includes all needed data)
+      final bunkerUrl = info.toString();
+      await _storage.write(key: _kBunkerInfoKey, value: bunkerUrl);
+      Log.info(
+        'Saved bunker info to secure storage',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.error(
+        'Failed to save bunker info: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  Future<NostrRemoteSignerInfo?> loadBunker() async {
+    if (_storage == null) return null;
+    try {
+      final bunkerUrl = await _storage.read(key: _kBunkerInfoKey);
+      if (bunkerUrl == null || bunkerUrl.isEmpty) return null;
+
+      final info = NostrRemoteSignerInfo.parseBunkerUrl(bunkerUrl);
+      Log.info(
+        'Loaded bunker info from secure storage',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+      return info;
+    } catch (e) {
+      Log.error(
+        'Failed to load bunker info: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+      return null;
+    }
+  }
+
+  Future<void> clearBunker() async {
+    if (_storage == null) return;
+    try {
+      await _storage.delete(key: _kBunkerInfoKey);
+      Log.info(
+        'Cleared bunker info from secure storage',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.error(
+        'Failed to clear bunker info: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  // === NIP-55 Amber ===
+
+  Future<void> saveAmber(String pubkey, String? package) async {
+    if (_storage == null) return;
+    try {
+      await _storage.write(key: _kAmberPubkeyKey, value: pubkey);
+      if (package != null) {
+        await _storage.write(key: _kAmberPackageKey, value: package);
+      }
+      Log.info(
+        'Saved Amber info to secure storage',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.error(
+        'Failed to save Amber info: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  Future<({String pubkey, String? package})?> loadAmber() async {
+    if (_storage == null) return null;
+    try {
+      final pubkey = await _storage.read(key: _kAmberPubkeyKey);
+      if (pubkey == null || pubkey.isEmpty) return null;
+
+      final package = await _storage.read(key: _kAmberPackageKey);
+      Log.info(
+        'Loaded Amber info from secure storage',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+      return (pubkey: pubkey, package: package);
+    } catch (e) {
+      Log.error(
+        'Failed to load Amber info: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+      return null;
+    }
+  }
+
+  Future<void> clearAmber() async {
+    if (_storage == null) return;
+    try {
+      await _storage.delete(key: _kAmberPubkeyKey);
+      await _storage.delete(key: _kAmberPackageKey);
+      Log.info(
+        'Cleared Amber info from secure storage',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.error(
+        'Failed to clear Amber info: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  // === Divine/Keycast OAuth session ===
+
+  /// Clears the global Keycast session, refresh token, and auth handle.
+  ///
+  /// Used when a stale or ambiguous OAuth session must be discarded
+  /// (e.g., during initialization tiebreaker branches).
+  Future<void> clearKeycastSessionAndTokens() async {
+    Object? firstError;
+    StackTrace? firstStack;
+
+    Future<void> deleteKey(Future<void> Function() delete) async {
+      try {
+        await delete();
+      } catch (e, stack) {
+        firstError ??= e;
+        firstStack ??= stack;
+      }
+    }
+
+    await deleteKey(() => KeycastSession.clear(_storage));
+    await deleteKey(() async {
+      await _storage?.delete(key: _kKeycastRefreshTokenKey);
+    });
+    await deleteKey(() async {
+      await _storage?.delete(key: _kKeycastAuthHandleKey);
+    });
+
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError!, firstStack!);
+    }
+  }
+
+  // === Per-account archive (account switching) ===
+
+  /// Archives the currently-active signer keys under per-account keys for
+  /// [pubkeyHex], so they can be restored when switching back to this account.
+  Future<void> archive(String pubkeyHex) async {
+    if (_storage == null) return;
+    try {
+      // Archive Amber info
+      final amberInfo = await loadAmber();
+      if (amberInfo != null) {
+        await _storage.write(
+          key: '${_kAmberPubkeyKey}_$pubkeyHex',
+          value: amberInfo.pubkey,
+        );
+        if (amberInfo.package != null) {
+          await _storage.write(
+            key: '${_kAmberPackageKey}_$pubkeyHex',
+            value: amberInfo.package,
+          );
+        }
+      }
+
+      // Archive Bunker info
+      final bunkerUrl = await _storage.read(key: _kBunkerInfoKey);
+      if (bunkerUrl != null && bunkerUrl.isNotEmpty) {
+        await _storage.write(
+          key: '${_kBunkerInfoKey}_$pubkeyHex',
+          value: bunkerUrl,
+        );
+      }
+
+      // Archive OAuth session — only if it has a bound userPubkey
+      // matching this account. Null userPubkey means the session was
+      // created before pubkey binding (legacy) and cannot be verified
+      // as belonging to any specific account; archiving an unverifiable
+      // session risks cross-contamination (Bug 2). A fresh OAuth
+      // sign-in via signInWithDivineOAuth always binds userPubkey.
+      final oauthSession = await KeycastSession.load(_storage);
+      final oauthOwnerMatches =
+          oauthSession?.userPubkey != null &&
+          oauthSession?.userPubkey == pubkeyHex;
+      final archiveOauth = oauthSession != null && oauthOwnerMatches;
+      if (archiveOauth) {
+        await _storage.write(
+          key: _keycastSessionKey(pubkeyHex),
+          value: jsonEncode(oauthSession.toJson()),
+        );
+      } else if (oauthSession != null) {
+        Log.warning(
+          'archive: skipping OAuth archive for $pubkeyHex — '
+          'global session pubkey='
+          '${oauthSession.userPubkey ?? "null (legacy)"} '
+          '(cannot verify ownership, not archiving to avoid corruption)',
+          name: 'SignerSecureStore',
+          category: LogCategory.auth,
+        );
+      }
+
+      Log.info(
+        'archive: archived for $pubkeyHex — '
+        'amber=${amberInfo != null}, '
+        'bunker=${bunkerUrl != null && bunkerUrl.isNotEmpty}, '
+        'oauth=$archiveOauth',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.warning(
+        'archive: failed for $pubkeyHex: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  /// Restores per-account archived signer keys to the active-session keys.
+  ///
+  /// The raw switch is kept here without a try/catch or auth-source write;
+  /// `AuthService` wraps this call and persists the auth source, preserving
+  /// the original error-handling scope.
+  Future<void> restoreActiveKeys(
+    String pubkeyHex,
+    AuthenticationSource source,
+  ) async {
+    final storage = _storage;
+    if (storage == null) return;
+    switch (source) {
+      case AuthenticationSource.amber:
+        final pubkey = await storage.read(
+          key: '${_kAmberPubkeyKey}_$pubkeyHex',
+        );
+        Log.debug(
+          'restoreActiveKeys: amber archive lookup — found=${pubkey != null}',
+          name: 'SignerSecureStore',
+          category: LogCategory.auth,
+        );
+        if (pubkey != null) {
+          await storage.write(key: _kAmberPubkeyKey, value: pubkey);
+          final package = await storage.read(
+            key: '${_kAmberPackageKey}_$pubkeyHex',
+          );
+          if (package != null) {
+            await storage.write(key: _kAmberPackageKey, value: package);
+          }
+        }
+
+      case AuthenticationSource.bunker:
+        final bunkerUrl = await storage.read(
+          key: '${_kBunkerInfoKey}_$pubkeyHex',
+        );
+        Log.debug(
+          'restoreActiveKeys: bunker archive lookup — '
+          'found=${bunkerUrl != null && bunkerUrl.isNotEmpty}',
+          name: 'SignerSecureStore',
+          category: LogCategory.auth,
+        );
+        if (bunkerUrl != null) {
+          await storage.write(key: _kBunkerInfoKey, value: bunkerUrl);
+        }
+
+      case AuthenticationSource.divineOAuth:
+        final sessionJson = await storage.read(
+          key: _keycastSessionKey(pubkeyHex),
+        );
+        Log.debug(
+          'restoreActiveKeys: OAuth session archive lookup — '
+          'found=${sessionJson != null}',
+          name: 'SignerSecureStore',
+          category: LogCategory.auth,
+        );
+        if (sessionJson != null) {
+          final sessionMap = jsonDecode(sessionJson) as Map<String, dynamic>;
+          final session = KeycastSession.fromJson(sessionMap);
+
+          // Validate archive ownership. If the archive's userPubkey
+          // is set and does NOT match the requested account, the
+          // archive is corrupt (e.g., from pre-fix cross-contamination).
+          // Delete it so Bug 1's recovery cascade can handle the
+          // fallback via SessionExpiredException → login options.
+          // Corrupt if userPubkey is null (legacy, unverifiable) or
+          // mismatches the requested account (cross-contamination).
+          final archivePubkey = session.userPubkey;
+          final corrupt = archivePubkey == null || archivePubkey != pubkeyHex;
+          if (corrupt) {
+            Log.warning(
+              'restoreActiveKeys: corrupt OAuth archive for '
+              '$pubkeyHex — archive pubkey='
+              '${archivePubkey ?? "null (legacy)"}. '
+              'Deleting corrupt archive.',
+              name: 'SignerSecureStore',
+              category: LogCategory.auth,
+            );
+            await storage.delete(key: _keycastSessionKey(pubkeyHex));
+          } else {
+            await session.save(storage);
+            // Also restore the refresh token and auth handle to
+            // their standalone keys — KeycastOAuth.refreshSession()
+            // reads these separately from the session JSON, and
+            // _oauthClient.logout() clears them. Without this,
+            // expired restored sessions can never be refreshed.
+            if (session.refreshToken != null) {
+              await storage.write(
+                key: _kKeycastRefreshTokenKey,
+                value: session.refreshToken,
+              );
+            }
+            if (session.authorizationHandle != null) {
+              await storage.write(
+                key: _kKeycastAuthHandleKey,
+                value: session.authorizationHandle,
+              );
+            }
+          }
+        }
+
+      case AuthenticationSource.automatic:
+      case AuthenticationSource.importedKeys:
+      case AuthenticationSource.none:
+      case AuthenticationSource.nip07:
+        // Clear any stale global signer keys so they don't hijack signing
+        // operations for the non-bunker/non-keycast account.
+        await clearBunker();
+        await clearAmber();
+        await KeycastSession.clear(storage);
+        Log.debug(
+          'restoreActiveKeys: local key-based auth — cleared stale signer keys',
+          name: 'SignerSecureStore',
+          category: LogCategory.auth,
+        );
+    }
+  }
+
+  /// Deletes all per-account archived signer keys for a given pubkey.
+  Future<void> clearArchive(String pubkeyHex) async {
+    if (_storage == null) return;
+    Log.info(
+      'clearArchive: removing all archives for $pubkeyHex',
+      name: 'SignerSecureStore',
+      category: LogCategory.auth,
+    );
+    try {
+      await _storage.delete(key: '${_kAmberPubkeyKey}_$pubkeyHex');
+      await _storage.delete(key: '${_kAmberPackageKey}_$pubkeyHex');
+      await _storage.delete(key: '${_kBunkerInfoKey}_$pubkeyHex');
+      await _storage.delete(key: _keycastSessionKey(pubkeyHex));
+    } catch (e) {
+      Log.warning(
+        'clearArchive: failed for $pubkeyHex: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  /// Whether a restorable per-account signer archive exists for [pubkeyHex]
+  /// under [source]. For divineOAuth, also validates the archived session's
+  /// bound pubkey matches.
+  Future<bool> hasArchive(String pubkeyHex, AuthenticationSource source) async {
+    final storage = _storage;
+    if (storage == null) return false;
+    try {
+      switch (source) {
+        case AuthenticationSource.amber:
+          final pubkey = await storage.read(
+            key: '${_kAmberPubkeyKey}_$pubkeyHex',
+          );
+          return pubkey != null && pubkey.isNotEmpty;
+        case AuthenticationSource.bunker:
+          final bunkerUrl = await storage.read(
+            key: '${_kBunkerInfoKey}_$pubkeyHex',
+          );
+          return bunkerUrl != null && bunkerUrl.isNotEmpty;
+        case AuthenticationSource.divineOAuth:
+          final sessionJson = await storage.read(
+            key: _keycastSessionKey(pubkeyHex),
+          );
+          if (sessionJson == null || sessionJson.isEmpty) return false;
+          final sessionMap = jsonDecode(sessionJson) as Map<String, dynamic>;
+          final session = KeycastSession.fromJson(sessionMap);
+          return session.userPubkey == pubkeyHex;
+        case AuthenticationSource.automatic:
+        case AuthenticationSource.importedKeys:
+        case AuthenticationSource.none:
+        case AuthenticationSource.nip07:
+          return false;
+      }
+    } catch (e) {
+      Log.warning(
+        'hasArchive: failed for $pubkeyHex: $e',
+        name: 'SignerSecureStore',
+        category: LogCategory.auth,
+      );
+      return false;
+    }
+  }
+}

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -20,6 +20,7 @@ import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/observability/reportable_error.dart';
+import 'package:openvine/services/auth/signer_secure_store.dart';
 import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/crash_reporting_service.dart';
 import 'package:openvine/services/local_key_signer.dart';
@@ -49,18 +50,6 @@ const _kLastUsedNpubKey = 'last_used_npub';
 // a confirmation banner before silently completing a switch. Cleared by
 // _setupUserSession() once the user has explicitly signed back in.
 const _kSessionRecoveryAnchorKey = 'session_recovery_anchor_npub';
-
-// Keys for bunker connection persistence
-const _kBunkerInfoKey = 'bunker_info';
-
-// Keys for Amber (NIP-55) connection persistence
-const _kAmberPubkeyKey = 'amber_pubkey';
-const _kAmberPackageKey = 'amber_package';
-
-// Keys for Keycast OAuth persistence
-const _kKeycastRefreshTokenKey = 'keycast_refresh_token';
-const _kKeycastAuthHandleKey = 'keycast_auth_handle';
-String _keycastSessionKey(String pubkeyHex) => 'keycast_session_$pubkeyHex';
 
 /// Authentication state for the user
 enum AuthState {
@@ -287,6 +276,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   final UserDataCleanupService _userDataCleanupService;
   final KeycastOAuth? _oauthClient;
   final FlutterSecureStorage? _flutterSecureStorage;
+  late final SignerSecureStore _signerStore = SignerSecureStore(
+    _flutterSecureStorage,
+  );
   final PreFetchFollowingCallback? _preFetchFollowing;
   final String? _profileCheckIndexerUrl;
   final RemoteSignerFactory _remoteSignerFactory;
@@ -1816,203 +1808,22 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   ///
   /// Called during non-destructive sign-out so the signer info can be
   /// restored when the user picks this account from the welcome screen.
-  Future<void> _archiveSignerInfo(String pubkeyHex) async {
-    if (_flutterSecureStorage == null) return;
-    try {
-      // Archive Amber info
-      final amberInfo = await _loadAmberInfo();
-      if (amberInfo != null) {
-        await _flutterSecureStorage.write(
-          key: '${_kAmberPubkeyKey}_$pubkeyHex',
-          value: amberInfo.pubkey,
-        );
-        if (amberInfo.package != null) {
-          await _flutterSecureStorage.write(
-            key: '${_kAmberPackageKey}_$pubkeyHex',
-            value: amberInfo.package,
-          );
-        }
-      }
-
-      // Archive Bunker info
-      final bunkerUrl = await _flutterSecureStorage.read(key: _kBunkerInfoKey);
-      if (bunkerUrl != null && bunkerUrl.isNotEmpty) {
-        await _flutterSecureStorage.write(
-          key: '${_kBunkerInfoKey}_$pubkeyHex',
-          value: bunkerUrl,
-        );
-      }
-
-      // Archive OAuth session — only if it has a bound userPubkey
-      // matching this account. Null userPubkey means the session was
-      // created before pubkey binding (legacy) and cannot be verified
-      // as belonging to any specific account; archiving an unverifiable
-      // session risks cross-contamination (Bug 2). A fresh OAuth
-      // sign-in via signInWithDivineOAuth always binds userPubkey.
-      final oauthSession = await KeycastSession.load(_flutterSecureStorage);
-      final oauthOwnerMatches =
-          oauthSession?.userPubkey != null &&
-          oauthSession?.userPubkey == pubkeyHex;
-      final archiveOauth = oauthSession != null && oauthOwnerMatches;
-      if (archiveOauth) {
-        await _flutterSecureStorage.write(
-          key: _keycastSessionKey(pubkeyHex),
-          value: jsonEncode(oauthSession.toJson()),
-        );
-      } else if (oauthSession != null) {
-        Log.warning(
-          '_archiveSignerInfo: skipping OAuth archive for $pubkeyHex — '
-          'global session pubkey='
-          '${oauthSession.userPubkey ?? "null (legacy)"} '
-          '(cannot verify ownership, not archiving to avoid corruption)',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-      }
-
-      Log.info(
-        '_archiveSignerInfo: archived for $pubkeyHex — '
-        'amber=${amberInfo != null}, '
-        'bunker=${bunkerUrl != null && bunkerUrl.isNotEmpty}, '
-        'oauth=$archiveOauth',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      Log.warning(
-        '_archiveSignerInfo: failed for $pubkeyHex: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
+  Future<void> _archiveSignerInfo(String pubkeyHex) =>
+      _signerStore.archive(pubkeyHex);
 
   /// Restores per-account signer keys to the active-session keys.
   ///
   /// Called before sign-in when switching to a previously used account.
+  /// Delegates the secure-storage swap to [SignerSecureStore] and keeps the
+  /// auth-source SharedPreferences write here so `initialize()` picks the
+  /// right path.
   Future<void> _restoreSignerInfo(
     String pubkeyHex,
     AuthenticationSource source,
   ) async {
     if (_flutterSecureStorage == null) return;
     try {
-      switch (source) {
-        case AuthenticationSource.amber:
-          final pubkey = await _flutterSecureStorage.read(
-            key: '${_kAmberPubkeyKey}_$pubkeyHex',
-          );
-          Log.debug(
-            '_restoreSignerInfo: amber archive lookup — '
-            'found=${pubkey != null}',
-            name: 'AuthService',
-            category: LogCategory.auth,
-          );
-          if (pubkey != null) {
-            await _flutterSecureStorage.write(
-              key: _kAmberPubkeyKey,
-              value: pubkey,
-            );
-            final package = await _flutterSecureStorage.read(
-              key: '${_kAmberPackageKey}_$pubkeyHex',
-            );
-            if (package != null) {
-              await _flutterSecureStorage.write(
-                key: _kAmberPackageKey,
-                value: package,
-              );
-            }
-          }
-
-        case AuthenticationSource.bunker:
-          final bunkerUrl = await _flutterSecureStorage.read(
-            key: '${_kBunkerInfoKey}_$pubkeyHex',
-          );
-          Log.debug(
-            '_restoreSignerInfo: bunker archive lookup — '
-            'found=${bunkerUrl != null && bunkerUrl.isNotEmpty}',
-            name: 'AuthService',
-            category: LogCategory.auth,
-          );
-          if (bunkerUrl != null) {
-            await _flutterSecureStorage.write(
-              key: _kBunkerInfoKey,
-              value: bunkerUrl,
-            );
-          }
-
-        case AuthenticationSource.divineOAuth:
-          final sessionJson = await _flutterSecureStorage.read(
-            key: _keycastSessionKey(pubkeyHex),
-          );
-          Log.debug(
-            '_restoreSignerInfo: OAuth session archive lookup — '
-            'found=${sessionJson != null}',
-            name: 'AuthService',
-            category: LogCategory.auth,
-          );
-          if (sessionJson != null) {
-            final sessionMap = jsonDecode(sessionJson) as Map<String, dynamic>;
-            final session = KeycastSession.fromJson(sessionMap);
-
-            // Validate archive ownership. If the archive's userPubkey
-            // is set and does NOT match the requested account, the
-            // archive is corrupt (e.g., from pre-fix cross-contamination).
-            // Delete it so Bug 1's recovery cascade can handle the
-            // fallback via SessionExpiredException → login options.
-            // Corrupt if userPubkey is null (legacy, unverifiable) or
-            // mismatches the requested account (cross-contamination).
-            final archivePubkey = session.userPubkey;
-            final corrupt = archivePubkey == null || archivePubkey != pubkeyHex;
-            if (corrupt) {
-              Log.warning(
-                '_restoreSignerInfo: corrupt OAuth archive for '
-                '$pubkeyHex — archive pubkey='
-                '${archivePubkey ?? "null (legacy)"}. '
-                'Deleting corrupt archive.',
-                name: 'AuthService',
-                category: LogCategory.auth,
-              );
-              await _flutterSecureStorage.delete(
-                key: _keycastSessionKey(pubkeyHex),
-              );
-            } else {
-              await session.save(_flutterSecureStorage);
-              // Also restore the refresh token and auth handle to
-              // their standalone keys — KeycastOAuth.refreshSession()
-              // reads these separately from the session JSON, and
-              // _oauthClient.logout() clears them. Without this,
-              // expired restored sessions can never be refreshed.
-              if (session.refreshToken != null) {
-                await _flutterSecureStorage.write(
-                  key: _kKeycastRefreshTokenKey,
-                  value: session.refreshToken,
-                );
-              }
-              if (session.authorizationHandle != null) {
-                await _flutterSecureStorage.write(
-                  key: _kKeycastAuthHandleKey,
-                  value: session.authorizationHandle,
-                );
-              }
-            }
-          }
-
-        case AuthenticationSource.automatic:
-        case AuthenticationSource.importedKeys:
-        case AuthenticationSource.none:
-        case AuthenticationSource.nip07:
-          // Clear any stale global signer keys so they don't hijack signing
-          // operations for the non-bunker/non-keycast account.
-          await _clearBunkerInfo();
-          await _clearAmberInfo();
-          await KeycastSession.clear(_flutterSecureStorage);
-          Log.debug(
-            '_restoreSignerInfo: local key-based auth — '
-            'cleared stale signer keys',
-            name: 'AuthService',
-            category: LogCategory.auth,
-          );
-      }
+      await _signerStore.restoreActiveKeys(pubkeyHex, source);
 
       // Set the auth source so initialize() picks the right path
       final prefs = await SharedPreferences.getInstance();
@@ -2033,28 +1844,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   }
 
   /// Deletes all per-account archived signer keys for a given pubkey.
-  Future<void> _clearArchivedSignerInfo(String pubkeyHex) async {
-    if (_flutterSecureStorage == null) return;
-    Log.info(
-      '_clearArchivedSignerInfo: removing all archives for $pubkeyHex',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-    try {
-      await _flutterSecureStorage.delete(key: '${_kAmberPubkeyKey}_$pubkeyHex');
-      await _flutterSecureStorage.delete(
-        key: '${_kAmberPackageKey}_$pubkeyHex',
-      );
-      await _flutterSecureStorage.delete(key: '${_kBunkerInfoKey}_$pubkeyHex');
-      await _flutterSecureStorage.delete(key: _keycastSessionKey(pubkeyHex));
-    } catch (e) {
-      Log.warning(
-        '_clearArchivedSignerInfo: failed for $pubkeyHex: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
+  Future<void> _clearArchivedSignerInfo(String pubkeyHex) =>
+      _signerStore.clearArchive(pubkeyHex);
 
   // ---------------------------------------------------------------------------
   // Multi-account sign-in
@@ -2326,98 +2117,19 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   }
 
   /// Save bunker connection info to secure storage
-  Future<void> _saveBunkerInfo(NostrRemoteSignerInfo info) async {
-    if (_flutterSecureStorage == null) return;
-    try {
-      // Serialize bunker info as bunker URL (includes all needed data)
-      final bunkerUrl = info.toString();
-      await _flutterSecureStorage.write(key: _kBunkerInfoKey, value: bunkerUrl);
-      Log.info(
-        'Saved bunker info to secure storage',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      Log.error(
-        'Failed to save bunker info: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
+  Future<void> _saveBunkerInfo(NostrRemoteSignerInfo info) =>
+      _signerStore.saveBunker(info);
 
-  /// Load bunker connection info from secure storage
-  Future<NostrRemoteSignerInfo?> _loadBunkerInfo() async {
-    if (_flutterSecureStorage == null) return null;
-    try {
-      final bunkerUrl = await _flutterSecureStorage.read(key: _kBunkerInfoKey);
-      if (bunkerUrl == null || bunkerUrl.isEmpty) return null;
+  Future<NostrRemoteSignerInfo?> _loadBunkerInfo() => _signerStore.loadBunker();
 
-      final info = NostrRemoteSignerInfo.parseBunkerUrl(bunkerUrl);
-      Log.info(
-        'Loaded bunker info from secure storage',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return info;
-    } catch (e) {
-      Log.error(
-        'Failed to load bunker info: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return null;
-    }
-  }
-
-  /// Clear bunker connection info from secure storage
-  Future<void> _clearBunkerInfo() async {
-    if (_flutterSecureStorage == null) return;
-    try {
-      await _flutterSecureStorage.delete(key: _kBunkerInfoKey);
-      Log.info(
-        'Cleared bunker info from secure storage',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      Log.error(
-        'Failed to clear bunker info: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
+  Future<void> _clearBunkerInfo() => _signerStore.clearBunker();
 
   /// Clears the global Keycast session, refresh token, and auth handle.
   ///
   /// Used when a stale or ambiguous OAuth session must be discarded
   /// (e.g., during initialization tiebreaker branches).
-  Future<void> _clearKeycastSessionAndTokens() async {
-    Object? firstError;
-    StackTrace? firstStack;
-
-    Future<void> deleteKey(Future<void> Function() delete) async {
-      try {
-        await delete();
-      } catch (e, stack) {
-        firstError ??= e;
-        firstStack ??= stack;
-      }
-    }
-
-    await deleteKey(() => KeycastSession.clear(_flutterSecureStorage));
-    await deleteKey(() async {
-      await _flutterSecureStorage?.delete(key: _kKeycastRefreshTokenKey);
-    });
-    await deleteKey(() async {
-      await _flutterSecureStorage?.delete(key: _kKeycastAuthHandleKey);
-    });
-
-    if (firstError != null) {
-      Error.throwWithStackTrace(firstError!, firstStack!);
-    }
-  }
+  Future<void> _clearKeycastSessionAndTokens() =>
+      _signerStore.clearKeycastSessionAndTokens();
 
   Future<void> _runSignOutCleanupWithRetry(
     String operation,
@@ -2737,73 +2449,13 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   }
 
   /// Save Amber connection info to secure storage
-  Future<void> _saveAmberInfo(String pubkey, String? package) async {
-    if (_flutterSecureStorage == null) return;
-    try {
-      await _flutterSecureStorage.write(key: _kAmberPubkeyKey, value: pubkey);
-      if (package != null) {
-        await _flutterSecureStorage.write(
-          key: _kAmberPackageKey,
-          value: package,
-        );
-      }
-      Log.info(
-        'Saved Amber info to secure storage',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      Log.error(
-        'Failed to save Amber info: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
+  Future<void> _saveAmberInfo(String pubkey, String? package) =>
+      _signerStore.saveAmber(pubkey, package);
 
-  /// Load Amber connection info from secure storage
-  Future<({String pubkey, String? package})?> _loadAmberInfo() async {
-    if (_flutterSecureStorage == null) return null;
-    try {
-      final pubkey = await _flutterSecureStorage.read(key: _kAmberPubkeyKey);
-      if (pubkey == null || pubkey.isEmpty) return null;
+  Future<({String pubkey, String? package})?> _loadAmberInfo() =>
+      _signerStore.loadAmber();
 
-      final package = await _flutterSecureStorage.read(key: _kAmberPackageKey);
-      Log.info(
-        'Loaded Amber info from secure storage',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return (pubkey: pubkey, package: package);
-    } catch (e) {
-      Log.error(
-        'Failed to load Amber info: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return null;
-    }
-  }
-
-  /// Clear Amber connection info from secure storage
-  Future<void> _clearAmberInfo() async {
-    if (_flutterSecureStorage == null) return;
-    try {
-      await _flutterSecureStorage.delete(key: _kAmberPubkeyKey);
-      await _flutterSecureStorage.delete(key: _kAmberPackageKey);
-      Log.info(
-        'Cleared Amber info from secure storage',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      Log.error(
-        'Failed to clear Amber info: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
+  Future<void> _clearAmberInfo() => _signerStore.clearAmber();
 
   /// Silent NIP-07 reconnect at startup.
   ///
@@ -4288,44 +3940,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     return false;
   }
 
-  Future<bool> _hasRestorableSignerArchive(KnownAccount account) async {
-    if (_flutterSecureStorage == null) return false;
-    try {
-      switch (account.authSource) {
-        case AuthenticationSource.amber:
-          final pubkey = await _flutterSecureStorage.read(
-            key: '${_kAmberPubkeyKey}_${account.pubkeyHex}',
-          );
-          return pubkey != null && pubkey.isNotEmpty;
-        case AuthenticationSource.bunker:
-          final bunkerUrl = await _flutterSecureStorage.read(
-            key: '${_kBunkerInfoKey}_${account.pubkeyHex}',
-          );
-          return bunkerUrl != null && bunkerUrl.isNotEmpty;
-        case AuthenticationSource.divineOAuth:
-          final sessionJson = await _flutterSecureStorage.read(
-            key: _keycastSessionKey(account.pubkeyHex),
-          );
-          if (sessionJson == null || sessionJson.isEmpty) return false;
-          final sessionMap = jsonDecode(sessionJson) as Map<String, dynamic>;
-          final session = KeycastSession.fromJson(sessionMap);
-          return session.userPubkey == account.pubkeyHex;
-        case AuthenticationSource.automatic:
-        case AuthenticationSource.importedKeys:
-        case AuthenticationSource.none:
-        case AuthenticationSource.nip07:
-          return false;
-      }
-    } catch (e) {
-      Log.warning(
-        'signOut: failed to verify signer archive for '
-        '${account.pubkeyHex}: $e',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      return false;
-    }
-  }
+  Future<bool> _hasRestorableSignerArchive(KnownAccount account) =>
+      _signerStore.hasArchive(account.pubkeyHex, account.authSource);
 
   /// Export nsec for backup purposes
   Future<String?> exportNsec({String? biometricPrompt}) async {

--- a/mobile/test/services/auth/signer_secure_store_test.dart
+++ b/mobile/test/services/auth/signer_secure_store_test.dart
@@ -1,0 +1,491 @@
+// ABOUTME: Characterization tests for SignerSecureStore — the client-tier
+// ABOUTME: collaborator extracted from AuthService (#4741, PR4).
+//
+// The store owns secure-storage persistence for external-signer credentials
+// (NIP-46 bunker, NIP-55 Amber, Divine/Keycast OAuth) plus the per-account
+// archive used when switching accounts. These tests run it against the shared
+// channel-backed in-memory secure storage so the KeycastSession static calls it
+// makes internally hit the same backing map.
+
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/nostr_sdk.dart' show NostrRemoteSignerInfo;
+import 'package:openvine/models/authentication_source.dart';
+import 'package:openvine/services/auth/signer_secure_store.dart';
+
+import '../support/auth_service_test_harness.dart';
+
+class _MockSecureStorage extends Mock implements FlutterSecureStorage {}
+
+const _pubkeyA =
+    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const _pubkeyB =
+    'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const _signerPubkey =
+    'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+NostrRemoteSignerInfo _bunkerInfo({String? userPubkey}) =>
+    NostrRemoteSignerInfo(
+      remoteSignerPubkey: _signerPubkey,
+      relays: const ['wss://relay.example.com'],
+      optionalSecret: 'secret123',
+      nsec: 'nsec1examplevalueforroundtrip',
+      userPubkey: userPubkey,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group(SignerSecureStore, () {
+    late AuthServiceChannelMocks mocks;
+    late SignerSecureStore store;
+
+    setUp(() {
+      mocks = AuthServiceChannelMocks.install();
+      store = SignerSecureStore(const FlutterSecureStorage());
+    });
+
+    tearDown(AuthServiceChannelMocks.remove);
+
+    group('bunker (NIP-46)', () {
+      test(
+        'saveBunker then loadBunker round-trips signer pubkey and relays',
+        () async {
+          await store.saveBunker(_bunkerInfo(userPubkey: _pubkeyA));
+
+          final loaded = await store.loadBunker();
+
+          expect(loaded, isNotNull);
+          expect(loaded!.remoteSignerPubkey, equals(_signerPubkey));
+          expect(loaded.relays, equals(const ['wss://relay.example.com']));
+          expect(loaded.userPubkey, equals(_pubkeyA));
+        },
+      );
+
+      test('loadBunker returns null when nothing is stored', () async {
+        expect(await store.loadBunker(), isNull);
+      });
+
+      test('clearBunker removes the stored bunker info', () async {
+        await store.saveBunker(_bunkerInfo());
+        expect(mocks.secureStorage['bunker_info'], isNotNull);
+
+        await store.clearBunker();
+
+        expect(mocks.secureStorage.containsKey('bunker_info'), isFalse);
+        expect(await store.loadBunker(), isNull);
+      });
+
+      test('null storage no-ops on save/load/clear', () async {
+        final nullStore = SignerSecureStore(null);
+
+        await nullStore.saveBunker(_bunkerInfo());
+        expect(await nullStore.loadBunker(), isNull);
+        await nullStore.clearBunker();
+
+        expect(mocks.secureStorage, isEmpty);
+      });
+    });
+
+    group('amber (NIP-55)', () {
+      test('saveAmber then loadAmber round-trips pubkey and package', () async {
+        await store.saveAmber(_pubkeyA, 'com.example.signer');
+
+        final loaded = await store.loadAmber();
+
+        expect(loaded, isNotNull);
+        expect(loaded!.pubkey, equals(_pubkeyA));
+        expect(loaded.package, equals('com.example.signer'));
+      });
+
+      test('saveAmber with null package stores only the pubkey', () async {
+        await store.saveAmber(_pubkeyA, null);
+
+        final loaded = await store.loadAmber();
+
+        expect(loaded!.pubkey, equals(_pubkeyA));
+        expect(loaded.package, isNull);
+      });
+
+      test('loadAmber returns null when nothing is stored', () async {
+        expect(await store.loadAmber(), isNull);
+      });
+
+      test('clearAmber removes pubkey and package', () async {
+        await store.saveAmber(_pubkeyA, 'com.example.signer');
+
+        await store.clearAmber();
+
+        expect(mocks.secureStorage.containsKey('amber_pubkey'), isFalse);
+        expect(mocks.secureStorage.containsKey('amber_package'), isFalse);
+        expect(await store.loadAmber(), isNull);
+      });
+
+      test('null storage no-ops on save/load/clear', () async {
+        final nullStore = SignerSecureStore(null);
+
+        await nullStore.saveAmber(_pubkeyA, 'com.example.signer');
+        expect(await nullStore.loadAmber(), isNull);
+        await nullStore.clearAmber();
+
+        expect(mocks.secureStorage, isEmpty);
+      });
+    });
+
+    group('clearKeycastSessionAndTokens', () {
+      test('deletes the session, refresh token, and auth handle', () async {
+        mocks.secureStorage['keycast_session'] = '{"bunker_url":"bunker://x"}';
+        mocks.secureStorage['keycast_refresh_token'] = 'refresh-tok';
+        mocks.secureStorage['keycast_auth_handle'] = 'handle';
+
+        await store.clearKeycastSessionAndTokens();
+
+        expect(mocks.secureStorage.containsKey('keycast_session'), isFalse);
+        expect(
+          mocks.secureStorage.containsKey('keycast_refresh_token'),
+          isFalse,
+        );
+        expect(mocks.secureStorage.containsKey('keycast_auth_handle'), isFalse);
+      });
+
+      test('completes without throwing when nothing is stored', () async {
+        await expectLater(store.clearKeycastSessionAndTokens(), completes);
+      });
+
+      test(
+        'rethrows the first delete error after attempting all deletes',
+        () async {
+          final throwingStorage = _MockSecureStorage();
+          when(
+            () => throwingStorage.delete(key: any(named: 'key')),
+          ).thenAnswer((_) async {});
+          when(
+            () => throwingStorage.delete(key: 'keycast_session'),
+          ).thenThrow(Exception('boom'));
+          final throwingStore = SignerSecureStore(throwingStorage);
+
+          await expectLater(
+            throwingStore.clearKeycastSessionAndTokens(),
+            throwsA(isA<Exception>()),
+          );
+          // The standalone token/handle deletes still ran despite the failure.
+          verify(
+            () => throwingStorage.delete(key: 'keycast_refresh_token'),
+          ).called(1);
+          verify(
+            () => throwingStorage.delete(key: 'keycast_auth_handle'),
+          ).called(1);
+        },
+      );
+    });
+
+    group('archive', () {
+      test('archives active amber info under per-account keys', () async {
+        await store.saveAmber(_pubkeyA, 'com.example.signer');
+
+        await store.archive(_pubkeyA);
+
+        expect(
+          mocks.secureStorage['amber_pubkey_$_pubkeyA'],
+          equals(_pubkeyA),
+        );
+        expect(
+          mocks.secureStorage['amber_package_$_pubkeyA'],
+          equals('com.example.signer'),
+        );
+      });
+
+      test('archives active bunker info under per-account keys', () async {
+        await store.saveBunker(_bunkerInfo());
+        final activeBunker = mocks.secureStorage['bunker_info'];
+
+        await store.archive(_pubkeyA);
+
+        expect(
+          mocks.secureStorage['bunker_info_$_pubkeyA'],
+          equals(activeBunker),
+        );
+      });
+
+      test(
+        'archives OAuth session when its userPubkey matches the account',
+        () async {
+          const session = KeycastSession(
+            bunkerUrl: 'bunker://x',
+            userPubkey: _pubkeyA,
+          );
+          await session.save(const FlutterSecureStorage());
+
+          await store.archive(_pubkeyA);
+
+          expect(
+            mocks.secureStorage.containsKey('keycast_session_$_pubkeyA'),
+            isTrue,
+          );
+        },
+      );
+
+      test('skips OAuth archive when the session pubkey mismatches', () async {
+        const session = KeycastSession(
+          bunkerUrl: 'bunker://x',
+          userPubkey: _pubkeyB,
+        );
+        await session.save(const FlutterSecureStorage());
+
+        await store.archive(_pubkeyA);
+
+        expect(
+          mocks.secureStorage.containsKey('keycast_session_$_pubkeyA'),
+          isFalse,
+        );
+      });
+
+      test(
+        'skips OAuth archive when the session pubkey is null (legacy)',
+        () async {
+          const session = KeycastSession(bunkerUrl: 'bunker://x');
+          await session.save(const FlutterSecureStorage());
+
+          await store.archive(_pubkeyA);
+
+          expect(
+            mocks.secureStorage.containsKey('keycast_session_$_pubkeyA'),
+            isFalse,
+          );
+        },
+      );
+
+      test('null storage no-ops', () async {
+        await SignerSecureStore(null).archive(_pubkeyA);
+        expect(mocks.secureStorage, isEmpty);
+      });
+    });
+
+    group('restoreActiveKeys', () {
+      test('restores archived amber to the active keys', () async {
+        mocks.secureStorage['amber_pubkey_$_pubkeyA'] = _pubkeyA;
+        mocks.secureStorage['amber_package_$_pubkeyA'] = 'com.example.signer';
+
+        await store.restoreActiveKeys(_pubkeyA, AuthenticationSource.amber);
+
+        expect(mocks.secureStorage['amber_pubkey'], equals(_pubkeyA));
+        expect(
+          mocks.secureStorage['amber_package'],
+          equals('com.example.signer'),
+        );
+      });
+
+      test('restores archived bunker to the active key', () async {
+        await store.saveBunker(_bunkerInfo());
+        final archived = mocks.secureStorage['bunker_info']!;
+        mocks.secureStorage['bunker_info_$_pubkeyA'] = archived;
+        await store.clearBunker();
+
+        await store.restoreActiveKeys(_pubkeyA, AuthenticationSource.bunker);
+
+        expect(mocks.secureStorage['bunker_info'], equals(archived));
+      });
+
+      test(
+        'restores a matching OAuth session and its standalone tokens',
+        () async {
+          const session = KeycastSession(
+            bunkerUrl: 'bunker://x',
+            userPubkey: _pubkeyA,
+            refreshToken: 'refresh-tok',
+            authorizationHandle: 'handle',
+          );
+          mocks.secureStorage['keycast_session_$_pubkeyA'] = jsonEncode(
+            session.toJson(),
+          );
+
+          await store.restoreActiveKeys(
+            _pubkeyA,
+            AuthenticationSource.divineOAuth,
+          );
+
+          final restored = await KeycastSession.load(
+            const FlutterSecureStorage(),
+          );
+          expect(restored?.userPubkey, equals(_pubkeyA));
+          expect(
+            mocks.secureStorage['keycast_refresh_token'],
+            equals('refresh-tok'),
+          );
+          expect(mocks.secureStorage['keycast_auth_handle'], equals('handle'));
+        },
+      );
+
+      test(
+        'deletes a corrupt OAuth archive (null userPubkey) on restore',
+        () async {
+          const session = KeycastSession(bunkerUrl: 'bunker://x');
+          mocks.secureStorage['keycast_session_$_pubkeyA'] = jsonEncode(
+            session.toJson(),
+          );
+
+          await store.restoreActiveKeys(
+            _pubkeyA,
+            AuthenticationSource.divineOAuth,
+          );
+
+          expect(
+            mocks.secureStorage.containsKey('keycast_session_$_pubkeyA'),
+            isFalse,
+          );
+          expect(
+            await KeycastSession.load(const FlutterSecureStorage()),
+            isNull,
+          );
+        },
+      );
+
+      test('local key-based sources clear stale global signer keys', () async {
+        await store.saveBunker(_bunkerInfo());
+        await store.saveAmber(_pubkeyA, 'com.example.signer');
+        await const KeycastSession(
+          bunkerUrl: 'bunker://x',
+        ).save(const FlutterSecureStorage());
+
+        await store.restoreActiveKeys(_pubkeyA, AuthenticationSource.nip07);
+
+        expect(mocks.secureStorage.containsKey('bunker_info'), isFalse);
+        expect(mocks.secureStorage.containsKey('amber_pubkey'), isFalse);
+        expect(mocks.secureStorage.containsKey('keycast_session'), isFalse);
+      });
+
+      test('null storage no-ops', () async {
+        await SignerSecureStore(
+          null,
+        ).restoreActiveKeys(_pubkeyA, AuthenticationSource.amber);
+        expect(mocks.secureStorage, isEmpty);
+      });
+    });
+
+    group('clearArchive', () {
+      test('deletes all per-account archived signer keys', () async {
+        mocks.secureStorage['amber_pubkey_$_pubkeyA'] = _pubkeyA;
+        mocks.secureStorage['amber_package_$_pubkeyA'] = 'com.example.signer';
+        mocks.secureStorage['bunker_info_$_pubkeyA'] = 'bunker://x';
+        mocks.secureStorage['keycast_session_$_pubkeyA'] = '{}';
+
+        await store.clearArchive(_pubkeyA);
+
+        expect(
+          mocks.secureStorage.containsKey('amber_pubkey_$_pubkeyA'),
+          isFalse,
+        );
+        expect(
+          mocks.secureStorage.containsKey('amber_package_$_pubkeyA'),
+          isFalse,
+        );
+        expect(
+          mocks.secureStorage.containsKey('bunker_info_$_pubkeyA'),
+          isFalse,
+        );
+        expect(
+          mocks.secureStorage.containsKey('keycast_session_$_pubkeyA'),
+          isFalse,
+        );
+      });
+
+      test('null storage no-ops', () async {
+        await SignerSecureStore(null).clearArchive(_pubkeyA);
+        expect(mocks.secureStorage, isEmpty);
+      });
+    });
+
+    group('hasArchive', () {
+      test('amber: true when archived, false when absent', () async {
+        expect(
+          await store.hasArchive(_pubkeyA, AuthenticationSource.amber),
+          isFalse,
+        );
+
+        mocks.secureStorage['amber_pubkey_$_pubkeyA'] = _pubkeyA;
+
+        expect(
+          await store.hasArchive(_pubkeyA, AuthenticationSource.amber),
+          isTrue,
+        );
+      });
+
+      test('bunker: true when archived, false when absent', () async {
+        expect(
+          await store.hasArchive(_pubkeyA, AuthenticationSource.bunker),
+          isFalse,
+        );
+
+        mocks.secureStorage['bunker_info_$_pubkeyA'] = 'bunker://x';
+
+        expect(
+          await store.hasArchive(_pubkeyA, AuthenticationSource.bunker),
+          isTrue,
+        );
+      });
+
+      test(
+        'divineOAuth: true only when the archived session pubkey matches',
+        () async {
+          const matching = KeycastSession(
+            bunkerUrl: 'bunker://x',
+            userPubkey: _pubkeyA,
+          );
+          mocks.secureStorage['keycast_session_$_pubkeyA'] = jsonEncode(
+            matching.toJson(),
+          );
+
+          expect(
+            await store.hasArchive(_pubkeyA, AuthenticationSource.divineOAuth),
+            isTrue,
+          );
+
+          const mismatched = KeycastSession(
+            bunkerUrl: 'bunker://x',
+            userPubkey: _pubkeyB,
+          );
+          mocks.secureStorage['keycast_session_$_pubkeyA'] = jsonEncode(
+            mismatched.toJson(),
+          );
+
+          expect(
+            await store.hasArchive(_pubkeyA, AuthenticationSource.divineOAuth),
+            isFalse,
+          );
+        },
+      );
+
+      test('local key-based sources always return false', () async {
+        expect(
+          await store.hasArchive(_pubkeyA, AuthenticationSource.nip07),
+          isFalse,
+        );
+        expect(
+          await store.hasArchive(_pubkeyA, AuthenticationSource.importedKeys),
+          isFalse,
+        );
+        expect(
+          await store.hasArchive(_pubkeyA, AuthenticationSource.none),
+          isFalse,
+        );
+        expect(
+          await store.hasArchive(_pubkeyA, AuthenticationSource.automatic),
+          isFalse,
+        );
+      });
+
+      test('null storage returns false', () async {
+        expect(
+          await SignerSecureStore(
+            null,
+          ).hasArchive(_pubkeyA, AuthenticationSource.amber),
+          isFalse,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Third in-place extraction of the staged `#4741` auth_service decomposition (after the coverage gap-fill #5713, the dead-code/NostrKeyManager cull #5716/#5724, and the layering fixes #5717). This PR lifts the **external-signer secure-storage cluster** out of the 5,798-line `AuthService` god-file into a dedicated client-tier collaborator.

New file `lib/services/auth/signer_secure_store.dart` (`SignerSecureStore`) now owns secure-storage persistence for:

- **NIP-46 bunker** credentials (`saveBunker` / `loadBunker` / `clearBunker`)
- **NIP-55 Amber** credentials (`saveAmber` / `loadAmber` / `clearAmber`)
- **Divine/Keycast OAuth** session teardown (`clearKeycastSessionAndTokens`)
- the **per-account signer archive** used when switching accounts (`archive` / `restoreActiveKeys` / `clearArchive` / `hasArchive`)

`AuthService` delegates through the **same private method names**, so the stable facade keeps all 108 downstream consumers untouched — this is a pure move, not a behavior change. `auth_service.dart` shrinks 5,798 → 5,335 lines.

The one deliberate seam: `_restoreSignerInfo` keeps the auth-source `SharedPreferences` write in `AuthService` (the store touches only `FlutterSecureStorage`) so `initialize()` still picks the right sign-in path on next launch. The store's `restoreActiveKeys` performs only the raw secure-storage swap.

**Related Issue:** Relates to #4741

## Out of Scope

- Lifting the store into `packages/auth_repository` (later PR in the staged sequence — this keeps it in `lib/services/auth/` behind the facade).
- Repository-tier extraction (signer-mode routing, `createAndSignEvent`), ports, and the #4743 B3 DI absorption.

## Verification

- `flutter analyze lib test` → No issues found
- `flutter test test/services/auth/signer_secure_store_test.dart` → 31 new tests pass
- `flutter test test/services/auth_service_*_test.dart` → 216 existing characterization tests stay green (behavior-preserving)
- `check_untested_services_floor.sh` → new `signer_secure_store.dart` ships with its same-named test (floor unchanged)
- `check_service_sentinel_ceiling.sh` → no growth
- pre-commit + pre-push hooks green

## Type of Change

- [x] 🧹 Code refactor