### PR TITLE
feat(video-editor): pre-render per-clip speed for smooth preview playback

### DIFF
--- a/mobile/lib/services/video_editor/clip_speed_render_service.dart
+++ b/mobile/lib/services/video_editor/clip_speed_render_service.dart
@@ -38,6 +38,7 @@ class RenderedSpeedClip {
 class ClipSpeedRenderService {
   final _cache = <String, RenderedSpeedClip>{};
   final _inFlight = <String, Future<RenderedSpeedClip?>>{};
+  int _clearGeneration = 0;
 
   /// Monotonic counter bumped on every cache mutation, so consumers can detect
   /// when the player composition needs rebuilding without diffing the cache.
@@ -61,7 +62,16 @@ class ClipSpeedRenderService {
     final key = _key(clip);
     final cached = _cache[key];
     if (cached != null) return Future<RenderedSpeedClip?>.value(cached);
-    return _inFlight[key] ??= _render(clip, key);
+    final inFlight = _inFlight[key];
+    if (inFlight != null) return inFlight;
+    final render = _render(clip, key);
+    _inFlight[key] = render;
+    render.whenComplete(() {
+      if (identical(_inFlight[key], render)) {
+        _inFlight.remove(key);
+      }
+    });
+    return render;
   }
 
   bool _needsRender(DivineVideoClip clip) {
@@ -70,18 +80,27 @@ class ClipSpeedRenderService {
   }
 
   Future<RenderedSpeedClip?> _render(DivineVideoClip clip, String key) async {
+    final renderGeneration = _clearGeneration;
+    String? tempOutput;
+    String? tempPath;
+    String? cachePath;
     try {
       // Wait for a still-processing recording to finish before rendering.
       await clip.processingCompleter?.future;
 
       final hash = sha256.convert(utf8.encode(key)).toString();
-      final persistentPath = await _persistentPath(hash);
+      cachePath = await _cachePath(hash);
+      if (_isStale(renderGeneration)) return null;
 
-      // Reuse a file rendered in a previous session; a truncated file left by a
-      // kill mid-write is detected and dropped so it re-renders.
-      if (File(persistentPath).existsSync()) {
-        final existing = await _fromPersistedFile(persistentPath);
+      // Reuse a file rendered earlier in this temp-cache lifetime; a truncated
+      // file left by a kill mid-write is detected and dropped so it re-renders.
+      if (File(cachePath).existsSync()) {
+        final existing = await _fromPersistedFile(cachePath);
         if (existing != null) {
+          if (_isStale(renderGeneration)) {
+            await _deleteQuietly(existing.path);
+            return null;
+          }
           _cache[key] = existing;
           _version++;
           return existing;
@@ -89,7 +108,7 @@ class ClipSpeedRenderService {
       }
 
       final tempDir = await getTemporaryDirectory();
-      final tempOutput =
+      tempOutput =
           '${tempDir.path}/speed_${DateTime.now().microsecondsSinceEpoch}.mp4';
 
       // Render only the trimmed body at the target speed, with no crop/transform
@@ -112,19 +131,35 @@ class ClipSpeedRenderService {
           shouldOptimizeForNetworkUse: true,
         ),
       );
+      if (_isStale(renderGeneration)) {
+        await _deleteQuietly(tempOutput);
+        return null;
+      }
 
-      // Publish atomically within the documents dir (temp→copy→rename) so a
+      // Publish atomically within the temp cache (temp→copy→rename) so a
       // crash mid-copy can only leave a stray `.tmp`, never a truncated keyed
       // file that would resolve to a corrupt render forever.
-      final tempPath = '$persistentPath.tmp';
+      tempPath = '$cachePath.tmp';
+      File(cachePath).parent.createSync(recursive: true);
       await File(tempOutput).copy(tempPath);
-      await File(tempPath).rename(persistentPath);
+      await File(tempPath).rename(cachePath);
       await _deleteQuietly(tempOutput);
+      if (_isStale(renderGeneration)) {
+        await _deleteQuietly(cachePath);
+        await _deleteEmptyParent(cachePath);
+        return null;
+      }
 
-      final rendered = await _fromPersistedFile(persistentPath);
+      final rendered = await _fromPersistedFile(cachePath);
       if (rendered == null) return null;
+      if (_isStale(renderGeneration)) {
+        await _deleteQuietly(rendered.path);
+        await _deleteEmptyParent(rendered.path);
+        return null;
+      }
       _cache[key] = rendered;
       _version++;
+      await _evictOldCacheFiles(protectedPath: rendered.path);
       Log.info(
         '🎬 Speed body rendered: ${clip.id} @${clip.playbackSpeed}× '
         '→ ${rendered.duration.inMilliseconds}ms',
@@ -142,9 +177,15 @@ class ClipSpeedRenderService {
       );
       return null;
     } finally {
-      _inFlight.remove(key);
+      if (_isStale(renderGeneration)) {
+        if (tempOutput != null) await _deleteQuietly(tempOutput);
+        if (tempPath != null) await _deleteQuietly(tempPath);
+        if (cachePath != null) await _deleteEmptyParent(cachePath);
+      }
     }
   }
+
+  bool _isStale(int renderGeneration) => renderGeneration != _clearGeneration;
 
   /// Loads a previously-rendered file from [path], or `null` (deleting it) when
   /// it can't be read or has no duration — e.g. a truncated file from a kill
@@ -185,10 +226,77 @@ class ClipSpeedRenderService {
     }
   }
 
+  Future<void> _deleteEmptyParent(String path) async {
+    try {
+      final parent = File(path).parent;
+      if (parent.existsSync() && parent.listSync().isEmpty) {
+        await parent.delete();
+      }
+    } catch (_) {
+      // Best-effort cleanup; temp cache can be reaped by the OS later.
+    }
+  }
+
+  void _deleteCachedFilesSync(Iterable<RenderedSpeedClip> clips) {
+    final parents = <String>{};
+    for (final clip in clips) {
+      parents.add(File(clip.path).parent.path);
+      try {
+        final file = File(clip.path);
+        if (file.existsSync()) file.deleteSync();
+      } catch (_) {
+        // Best-effort cleanup; temp cache can be reaped by the OS later.
+      }
+      try {
+        final tempFile = File('${clip.path}.tmp');
+        if (tempFile.existsSync()) tempFile.deleteSync();
+      } catch (_) {
+        // Best-effort cleanup; temp cache can be reaped by the OS later.
+      }
+    }
+    for (final parent in parents) {
+      try {
+        final dir = Directory(parent);
+        if (dir.existsSync() && dir.listSync().isEmpty) {
+          dir.deleteSync();
+        }
+      } catch (_) {
+        // Best-effort cleanup; temp cache can be reaped by the OS later.
+      }
+    }
+  }
+
+  static const _maxCachedFiles = 32;
+
+  Future<void> _evictOldCacheFiles({required String protectedPath}) async {
+    try {
+      final dir = File(protectedPath).parent;
+      if (!dir.existsSync()) return;
+      final files =
+          dir
+              .listSync()
+              .whereType<File>()
+              .where((file) => file.path.endsWith('.mp4'))
+              .toList()
+            ..sort(
+              (a, b) => a.statSync().modified.compareTo(b.statSync().modified),
+            );
+      var remainingCount = files.length;
+      if (remainingCount <= _maxCachedFiles) return;
+      for (final file in files) {
+        if (file.path == protectedPath) continue;
+        await _deleteQuietly(file.path);
+        remainingCount--;
+        if (remainingCount <= _maxCachedFiles) return;
+      }
+    } catch (_) {
+      // Best-effort bounded cache eviction.
+    }
+  }
+
   /// Bumped whenever the render inputs baked into the file change shape, so
   /// files rendered by an older algorithm are re-rendered after an app upgrade
-  /// instead of replayed stale (the keyed files live in the documents dir and
-  /// survive upgrades).
+  /// instead of replayed stale if the OS keeps temp cache files around.
   static const _cacheVersion = 1;
 
   String _key(DivineVideoClip clip) =>
@@ -197,19 +305,24 @@ class ClipSpeedRenderService {
       '${clip.trimEnd.inMicroseconds}:${clip.playbackSpeed ?? 1.0}';
 
   /// Deterministic on-disk path for a rendered body, keyed by [hash] so the same
-  /// clip + trims + speed reuse the file across editor sessions (like seams).
-  Future<String> _persistentPath(String hash) async {
-    final dir = await getApplicationDocumentsDirectory();
+  /// clip + trims + speed can reuse a temp-cache file while it remains valid.
+  Future<String> _cachePath(String hash) async {
+    final dir = await getTemporaryDirectory();
     final speedDir = Directory('${dir.path}/speed_clips');
     if (!speedDir.existsSync()) speedDir.createSync(recursive: true);
     return '${speedDir.path}/$hash.mp4';
   }
 
-  /// Drops the in-memory cache (e.g. when the editor closes). On-disk files stay
-  /// for the next session.
+  /// Drops the in-memory cache (e.g. when the editor closes) and deletes the
+  /// derived speed files it owns. In-flight renders are generation-invalidated
+  /// so a late native completion cleans itself up instead of repopulating disk.
   void clear() {
+    _clearGeneration++;
+    final cachedClips = _cache.values.toList();
     _cache.clear();
+    _inFlight.clear();
     _version++;
+    _deleteCachedFilesSync(cachedClips);
   }
 
   /// Seeds the cache directly so [buildSeamAwarePlayerClips] can be exercised

--- a/mobile/lib/services/video_editor/clip_speed_render_service.dart
+++ b/mobile/lib/services/video_editor/clip_speed_render_service.dart
@@ -49,10 +49,20 @@ class ClipSpeedRenderService {
   bool isRendering(DivineVideoClip clip) => _inFlight.containsKey(_key(clip));
 
   /// The already-rendered speed body for [clip], or `null` if it is not rendered
-  /// yet or the clip plays at 1×. Pure cache lookup — never triggers a render.
+  /// yet or the clip plays at 1×. Never triggers a render.
   RenderedSpeedClip? cached(DivineVideoClip clip) {
     if (!_needsRender(clip)) return null;
-    return _cache[_key(clip)];
+    return _cachedLive(_key(clip));
+  }
+
+  /// Returns the cached body for [key], promoting it to most-recently-used so
+  /// the bounded LRU eviction ([_evictOverflow]) never drops a body that is
+  /// still in use.
+  RenderedSpeedClip? _cachedLive(String key) {
+    final entry = _cache.remove(key);
+    if (entry == null) return null;
+    _cache[key] = entry;
+    return entry;
   }
 
   /// Renders (or returns the cached / in-flight) normal-rate body for [clip].
@@ -60,7 +70,7 @@ class ClipSpeedRenderService {
   Future<RenderedSpeedClip?> render(DivineVideoClip clip) {
     if (!_needsRender(clip)) return Future<RenderedSpeedClip?>.value();
     final key = _key(clip);
-    final cached = _cache[key];
+    final cached = _cachedLive(key);
     if (cached != null) return Future<RenderedSpeedClip?>.value(cached);
     final inFlight = _inFlight[key];
     if (inFlight != null) return inFlight;
@@ -101,8 +111,7 @@ class ClipSpeedRenderService {
             await _deleteQuietly(existing.path);
             return null;
           }
-          _cache[key] = existing;
-          _version++;
+          _store(key, existing);
           return existing;
         }
       }
@@ -157,9 +166,7 @@ class ClipSpeedRenderService {
         await _deleteEmptyParent(rendered.path);
         return null;
       }
-      _cache[key] = rendered;
-      _version++;
-      await _evictOldCacheFiles(protectedPath: rendered.path);
+      _store(key, rendered);
       Log.info(
         '🎬 Speed body rendered: ${clip.id} @${clip.playbackSpeed}× '
         '→ ${rendered.duration.inMilliseconds}ms',
@@ -268,29 +275,23 @@ class ClipSpeedRenderService {
 
   static const _maxCachedFiles = 32;
 
-  Future<void> _evictOldCacheFiles({required String protectedPath}) async {
-    try {
-      final dir = File(protectedPath).parent;
-      if (!dir.existsSync()) return;
-      final files =
-          dir
-              .listSync()
-              .whereType<File>()
-              .where((file) => file.path.endsWith('.mp4'))
-              .toList()
-            ..sort(
-              (a, b) => a.statSync().modified.compareTo(b.statSync().modified),
-            );
-      var remainingCount = files.length;
-      if (remainingCount <= _maxCachedFiles) return;
-      for (final file in files) {
-        if (file.path == protectedPath) continue;
-        await _deleteQuietly(file.path);
-        remainingCount--;
-        if (remainingCount <= _maxCachedFiles) return;
-      }
-    } catch (_) {
-      // Best-effort bounded cache eviction.
+  /// Publishes [rendered] for [key] as the most-recently-used entry, bumps the
+  /// version, and evicts the least-recently-used bodies once the cache exceeds
+  /// [_maxCachedFiles]. Eviction removes the map entry **and** its file
+  /// together, so the in-memory cache and the on-disk files stay in lockstep
+  /// and a later lookup can never resolve to an evicted file.
+  void _store(String key, RenderedSpeedClip rendered) {
+    _cache.remove(key);
+    _cache[key] = rendered;
+    _version++;
+    _evictOverflow();
+  }
+
+  void _evictOverflow() {
+    while (_cache.length > _maxCachedFiles) {
+      final oldestKey = _cache.keys.first;
+      final evicted = _cache.remove(oldestKey);
+      if (evicted != null) _deleteCachedFilesSync([evicted]);
     }
   }
 
@@ -329,7 +330,6 @@ class ClipSpeedRenderService {
   /// without running the native render pipeline.
   @visibleForTesting
   void cacheForTest(DivineVideoClip clip, RenderedSpeedClip rendered) {
-    _cache[_key(clip)] = rendered;
-    _version++;
+    _store(_key(clip), rendered);
   }
 }

--- a/mobile/lib/services/video_editor/clip_speed_render_service.dart
+++ b/mobile/lib/services/video_editor/clip_speed_render_service.dart
@@ -40,11 +40,6 @@ class ClipSpeedRenderService {
   final _inFlight = <String, Future<RenderedSpeedClip?>>{};
   int _clearGeneration = 0;
 
-  /// Monotonic counter bumped on every cache mutation, so consumers can detect
-  /// when the player composition needs rebuilding without diffing the cache.
-  int _version = 0;
-  int get version => _version;
-
   /// True while a speed body for this clip is being rendered.
   bool isRendering(DivineVideoClip clip) => _inFlight.containsKey(_key(clip));
 
@@ -184,10 +179,14 @@ class ClipSpeedRenderService {
       );
       return null;
     } finally {
-      if (_isStale(renderGeneration)) {
-        if (tempOutput != null) await _deleteQuietly(tempOutput);
-        if (tempPath != null) await _deleteQuietly(tempPath);
-        if (cachePath != null) await _deleteEmptyParent(cachePath);
+      // tempOutput and tempPath are always intermediate scratch files: on the
+      // success path they've already been consumed (deleted / renamed away), so
+      // deleting them again is a no-op — but if the native render or the publish
+      // threw while not stale, this is what stops the scratch file leaking.
+      if (tempOutput != null) await _deleteQuietly(tempOutput);
+      if (tempPath != null) await _deleteQuietly(tempPath);
+      if (_isStale(renderGeneration) && cachePath != null) {
+        await _deleteEmptyParent(cachePath);
       }
     }
   }
@@ -275,15 +274,14 @@ class ClipSpeedRenderService {
 
   static const _maxCachedFiles = 32;
 
-  /// Publishes [rendered] for [key] as the most-recently-used entry, bumps the
-  /// version, and evicts the least-recently-used bodies once the cache exceeds
-  /// [_maxCachedFiles]. Eviction removes the map entry **and** its file
-  /// together, so the in-memory cache and the on-disk files stay in lockstep
-  /// and a later lookup can never resolve to an evicted file.
+  /// Publishes [rendered] for [key] as the most-recently-used entry and evicts
+  /// the least-recently-used bodies once the cache exceeds [_maxCachedFiles].
+  /// Eviction removes the map entry **and** its file together, so the in-memory
+  /// cache and the on-disk files stay in lockstep and a later lookup can never
+  /// resolve to an evicted file.
   void _store(String key, RenderedSpeedClip rendered) {
     _cache.remove(key);
     _cache[key] = rendered;
-    _version++;
     _evictOverflow();
   }
 
@@ -322,7 +320,6 @@ class ClipSpeedRenderService {
     final cachedClips = _cache.values.toList();
     _cache.clear();
     _inFlight.clear();
-    _version++;
     _deleteCachedFilesSync(cachedClips);
   }
 

--- a/mobile/lib/services/video_editor/clip_speed_render_service.dart
+++ b/mobile/lib/services/video_editor/clip_speed_render_service.dart
@@ -1,0 +1,222 @@
+// ABOUTME: Pre-renders a clip's trimmed body at its playbackSpeed into a plain
+// ABOUTME: normal-rate file so the preview plays it at 1× instead of retiming live.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter/foundation.dart';
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/video_editor_render_service.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:pro_video_editor/pro_video_editor.dart'
+    show EditorVideo, ProVideoEditor, VideoRenderData, VideoSegment;
+import 'package:unified_logger/unified_logger.dart';
+
+/// A clip body rendered to a plain, normal-rate file with its
+/// [DivineVideoClip.playbackSpeed] baked in, so the preview plays it at 1×
+/// (no live retiming — smoother on both Android and iOS).
+class RenderedSpeedClip {
+  const RenderedSpeedClip({required this.path, required this.duration});
+
+  /// Path to the rendered normal-rate video.
+  final String path;
+
+  /// Playback duration of the rendered file (≈ the clip's `playbackDuration`).
+  final Duration duration;
+}
+
+/// Renders and caches per-clip speed bodies. Cache keys include the clip's
+/// file, trims and speed, so a trim/speed change naturally misses the cache and
+/// re-renders; the preview keeps playing the live-retimed clip until the new
+/// file lands.
+///
+/// Mirrors [TransitionSeamRenderService]: the preview plays the live-retimed
+/// clip instantly (no wait), this renders the smooth normal-rate file in the
+/// background, and the canvas swaps it in when ready. Volume is **not** baked in
+/// (the player applies it per clip), so a mute toggle never re-renders.
+class ClipSpeedRenderService {
+  final _cache = <String, RenderedSpeedClip>{};
+  final _inFlight = <String, Future<RenderedSpeedClip?>>{};
+
+  /// Monotonic counter bumped on every cache mutation, so consumers can detect
+  /// when the player composition needs rebuilding without diffing the cache.
+  int _version = 0;
+  int get version => _version;
+
+  /// True while a speed body for this clip is being rendered.
+  bool isRendering(DivineVideoClip clip) => _inFlight.containsKey(_key(clip));
+
+  /// The already-rendered speed body for [clip], or `null` if it is not rendered
+  /// yet or the clip plays at 1×. Pure cache lookup — never triggers a render.
+  RenderedSpeedClip? cached(DivineVideoClip clip) {
+    if (!_needsRender(clip)) return null;
+    return _cache[_key(clip)];
+  }
+
+  /// Renders (or returns the cached / in-flight) normal-rate body for [clip].
+  /// Returns `null` when the clip plays at 1× (nothing to render) or on failure.
+  Future<RenderedSpeedClip?> render(DivineVideoClip clip) {
+    if (!_needsRender(clip)) return Future<RenderedSpeedClip?>.value();
+    final key = _key(clip);
+    final cached = _cache[key];
+    if (cached != null) return Future<RenderedSpeedClip?>.value(cached);
+    return _inFlight[key] ??= _render(clip, key);
+  }
+
+  bool _needsRender(DivineVideoClip clip) {
+    final speed = clip.playbackSpeed ?? 1.0;
+    return speed > 0 && speed != 1.0 && clip.video.file != null;
+  }
+
+  Future<RenderedSpeedClip?> _render(DivineVideoClip clip, String key) async {
+    try {
+      // Wait for a still-processing recording to finish before rendering.
+      await clip.processingCompleter?.future;
+
+      final hash = sha256.convert(utf8.encode(key)).toString();
+      final persistentPath = await _persistentPath(hash);
+
+      // Reuse a file rendered in a previous session; a truncated file left by a
+      // kill mid-write is detected and dropped so it re-renders.
+      if (File(persistentPath).existsSync()) {
+        final existing = await _fromPersistedFile(persistentPath);
+        if (existing != null) {
+          _cache[key] = existing;
+          _version++;
+          return existing;
+        }
+      }
+
+      final tempDir = await getTemporaryDirectory();
+      final tempOutput =
+          '${tempDir.path}/speed_${DateTime.now().microsecondsSinceEpoch}.mp4';
+
+      // Render only the trimmed body at the target speed, with no crop/transform
+      // — the preview player crops the texture itself, exactly as it does for
+      // the raw live-retimed clip, so nothing is double-cropped.
+      await VideoEditorRenderService.renderNativeVideoToFile(
+        tempOutput,
+        VideoRenderData(
+          id: 'speed_$hash',
+          videoSegments: [
+            VideoSegment(
+              video: clip.video,
+              startTime: clip.trimStart == Duration.zero
+                  ? null
+                  : clip.trimStart,
+              endTime: clip.trimStart + clip.trimmedDuration,
+              playbackSpeed: clip.playbackSpeed,
+            ),
+          ],
+          shouldOptimizeForNetworkUse: true,
+        ),
+      );
+
+      // Publish atomically within the documents dir (temp→copy→rename) so a
+      // crash mid-copy can only leave a stray `.tmp`, never a truncated keyed
+      // file that would resolve to a corrupt render forever.
+      final tempPath = '$persistentPath.tmp';
+      await File(tempOutput).copy(tempPath);
+      await File(tempPath).rename(persistentPath);
+      await _deleteQuietly(tempOutput);
+
+      final rendered = await _fromPersistedFile(persistentPath);
+      if (rendered == null) return null;
+      _cache[key] = rendered;
+      _version++;
+      Log.info(
+        '🎬 Speed body rendered: ${clip.id} @${clip.playbackSpeed}× '
+        '→ ${rendered.duration.inMilliseconds}ms',
+        name: 'ClipSpeedRenderService',
+        category: LogCategory.video,
+      );
+      return rendered;
+    } catch (e, stackTrace) {
+      Log.error(
+        'Clip speed render failed',
+        name: 'ClipSpeedRenderService',
+        error: e,
+        stackTrace: stackTrace,
+        category: LogCategory.video,
+      );
+      return null;
+    } finally {
+      _inFlight.remove(key);
+    }
+  }
+
+  /// Loads a previously-rendered file from [path], or `null` (deleting it) when
+  /// it can't be read or has no duration — e.g. a truncated file from a kill
+  /// mid-write. Deleting lets the caller re-render instead of resolving to the
+  /// same corrupt file forever.
+  Future<RenderedSpeedClip?> _fromPersistedFile(String path) async {
+    try {
+      final metadata = await ProVideoEditor.instance.getMetadata(
+        EditorVideo.file(path),
+      );
+      if (metadata.duration <= Duration.zero) {
+        await _deleteQuietly(path);
+        return null;
+      }
+      return RenderedSpeedClip(path: path, duration: metadata.duration);
+    } catch (e, stackTrace) {
+      Log.warning(
+        'Dropping unreadable rendered speed clip at $path',
+        name: 'ClipSpeedRenderService',
+        category: LogCategory.video,
+      );
+      Log.debug(
+        'Rendered speed clip read failed: $e\n$stackTrace',
+        name: 'ClipSpeedRenderService',
+        category: LogCategory.video,
+      );
+      await _deleteQuietly(path);
+      return null;
+    }
+  }
+
+  Future<void> _deleteQuietly(String path) async {
+    try {
+      final file = File(path);
+      if (file.existsSync()) await file.delete();
+    } catch (_) {
+      // Best-effort cleanup; a failed delete just re-renders next time.
+    }
+  }
+
+  /// Bumped whenever the render inputs baked into the file change shape, so
+  /// files rendered by an older algorithm are re-rendered after an app upgrade
+  /// instead of replayed stale (the keyed files live in the documents dir and
+  /// survive upgrades).
+  static const _cacheVersion = 1;
+
+  String _key(DivineVideoClip clip) =>
+      'v$_cacheVersion|${clip.id}:${clip.video.file?.path}:'
+      '${clip.duration.inMicroseconds}:${clip.trimStart.inMicroseconds}:'
+      '${clip.trimEnd.inMicroseconds}:${clip.playbackSpeed ?? 1.0}';
+
+  /// Deterministic on-disk path for a rendered body, keyed by [hash] so the same
+  /// clip + trims + speed reuse the file across editor sessions (like seams).
+  Future<String> _persistentPath(String hash) async {
+    final dir = await getApplicationDocumentsDirectory();
+    final speedDir = Directory('${dir.path}/speed_clips');
+    if (!speedDir.existsSync()) speedDir.createSync(recursive: true);
+    return '${speedDir.path}/$hash.mp4';
+  }
+
+  /// Drops the in-memory cache (e.g. when the editor closes). On-disk files stay
+  /// for the next session.
+  void clear() {
+    _cache.clear();
+    _version++;
+  }
+
+  /// Seeds the cache directly so [buildSeamAwarePlayerClips] can be exercised
+  /// without running the native render pipeline.
+  @visibleForTesting
+  void cacheForTest(DivineVideoClip clip, RenderedSpeedClip rendered) {
+    _cache[_key(clip)] = rendered;
+    _version++;
+  }
+}

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'package:openvine/extensions/divine_video_clip_player_mapping.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
+import 'package:openvine/services/video_editor/clip_speed_render_service.dart';
 import 'package:openvine/services/video_editor/video_editor_render_service.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:pro_video_editor/pro_video_editor.dart'
@@ -525,10 +526,17 @@ Duration _maxDur(Duration a, Duration b) => a > b ? a : b;
 /// Transitions are taken from [clampTransitions] so the
 /// preview consumes exactly what the export will, and a clip touched by
 /// transitions on both sides is split between them rather than replayed.
+///
+/// When [speedRenders] is provided, a clip that runs at a non-1× speed and is
+/// **not** consumed by an adjacent seam plays its pre-rendered normal-rate file
+/// (speed baked in) at 1× instead of retiming live — smoother on both
+/// platforms. Until that render lands (or for a seam-consumed clip) it falls
+/// back to live per-clip retiming, so playback is never blocked on a render.
 List<player.VideoClip> buildSeamAwarePlayerClips(
   List<DivineVideoClip> clips,
-  TransitionSeamRenderService seams,
-) {
+  TransitionSeamRenderService seams, {
+  ClipSpeedRenderService? speedRenders,
+}) {
   final clamped = clampTransitions(clips);
   final result = <player.VideoClip>[];
   for (var i = 0; i < clips.length; i++) {
@@ -553,8 +561,20 @@ List<player.VideoClip> buildSeamAwarePlayerClips(
     final bodyStart = clip.trimStart + headConsumed;
     final bodyEnd = clip.duration - clip.trimEnd - tailConsumed;
     if (bodyEnd > bodyStart) {
-      final bodyClip = clip.toPlayerVideoClip(start: bodyStart, end: bodyEnd);
-      if (bodyClip != null) result.add(bodyClip);
+      // A pre-rendered normal-rate body is only used when no seam consumes part
+      // of this clip — the rendered file spans the full trimmed body, so a
+      // partial seam trim can't be expressed against it. Seam-consumed clips
+      // therefore stay on live retiming.
+      final rendered =
+          headConsumed == Duration.zero && tailConsumed == Duration.zero
+          ? speedRenders?.cached(clip)
+          : null;
+      if (rendered != null) {
+        result.add(player.VideoClip.file(rendered.path, volume: clip.volume));
+      } else {
+        final bodyClip = clip.toPlayerVideoClip(start: bodyStart, end: bodyEnd);
+        if (bodyClip != null) result.add(bodyClip);
+      }
     }
 
     if (outgoingSeam != null) {

--- a/mobile/lib/services/video_editor/transition_seam_render_service.dart
+++ b/mobile/lib/services/video_editor/transition_seam_render_service.dart
@@ -383,11 +383,18 @@ class TransitionSeamRenderService {
 
 /// Maps positions between the preview player's composite timeline (trimmed clip
 /// bodies + spliced seams, shorter than the editor timeline) and the editor
-/// timeline (clips at full length). Clip bodies map 1:1; each seam maps to the
-/// region straddling its clip boundary, so the on-screen transition lines up
-/// with the editor playhead. Identity when no seam is spliced.
+/// timeline (clips at full length). A clip body maps 1:1, or — when a
+/// pre-rendered speed body is spliced in — by that file's real duration (which
+/// encoder frame-rounding can nudge off `playbackDuration`); each seam maps to
+/// the region straddling its clip boundary, so the on-screen transition lines
+/// up with the editor playhead. Identity when neither a seam nor a speed body
+/// is spliced.
 class SeamTimeline {
-  SeamTimeline(List<DivineVideoClip> clips, TransitionSeamRenderService seams) {
+  SeamTimeline(
+    List<DivineVideoClip> clips,
+    TransitionSeamRenderService seams, {
+    ClipSpeedRenderService? speedRenders,
+  }) {
     final clamped = clampTransitions(clips);
     var composite = Duration.zero;
     var editor = Duration.zero; // start of the current clip on the editor line
@@ -421,9 +428,19 @@ class SeamTimeline {
       final bodyEditorStart = editor + headPb;
       final bodyEditorEnd = editor + clipDuration - tailPb;
       if (bodyEditorEnd > bodyEditorStart) {
-        final bodyComposite = bodyEditorEnd - bodyEditorStart;
         final editorStart = _maxDur(bodyEditorStart, editorCursor);
         final editorEnd = _maxDur(bodyEditorEnd, editorStart);
+        // A spliced speed body plays its pre-rendered file, whose real duration
+        // can differ from playbackDuration by encoder frame-rounding. Use that
+        // real duration as the composite span (as seams use seam.duration) so
+        // the player↔editor mapping stays accurate. The gate matches
+        // buildSeamAwarePlayerClips: the rendered file is only used when no seam
+        // consumes this clip (headPb == tailPb == 0).
+        final rendered = headPb == Duration.zero && tailPb == Duration.zero
+            ? speedRenders?.cached(clip)
+            : null;
+        final bodyComposite =
+            rendered?.duration ?? (bodyEditorEnd - bodyEditorStart);
         _segments.add(
           _Segment(
             composite,

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -645,18 +645,28 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   int? _cachedSeamTimelineVersion;
 
   /// Returns the current [SeamTimeline], rebuilding only when the clips change
-  /// identity or the seam cache mutates ([TransitionSeamRenderService.version]).
+  /// identity or either derived cache mutates — the seam cache
+  /// ([TransitionSeamRenderService.version]) or the speed-render cache
+  /// ([ClipSpeedRenderService.version]), since a landed speed body changes the
+  /// composite span the timeline maps.
   SeamTimeline get _seamTimeline {
     final clips = ref.read(clipManagerProvider).clips;
     final clipsHash = Object.hashAll(clips);
-    final version = _seamService.version;
+    final version = Object.hash(
+      _seamService.version,
+      _speedRenderService.version,
+    );
     final cached = _cachedSeamTimeline;
     if (cached != null &&
         _cachedSeamTimelineClipsHash == clipsHash &&
         _cachedSeamTimelineVersion == version) {
       return cached;
     }
-    final timeline = SeamTimeline(clips, _seamService);
+    final timeline = SeamTimeline(
+      clips,
+      _seamService,
+      speedRenders: _speedRenderService,
+    );
     _cachedSeamTimeline = timeline;
     _cachedSeamTimelineClipsHash = clipsHash;
     _cachedSeamTimelineVersion = version;

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -554,7 +554,25 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// clip, trim or speed change. The preview keeps playing the instant
   /// live-retimed clip until the swap lands.
   void _ensureSpeedClipsRendered(List<DivineVideoClip> clips) {
-    for (final clip in clips) {
+    final clamped = clampTransitions(clips);
+    for (var i = 0; i < clips.length; i++) {
+      final clip = clips[i];
+      // Skip a clip whose body is consumed by a rendered seam on either side:
+      // it stays on live retiming (the seam already bakes its speed), so its
+      // whole-body speed render would never be spliced in — matching the gate
+      // in [buildSeamAwarePlayerClips]. Avoids a native encode the player can't
+      // use. Until the seam lands the clip isn't consumed, so it still renders.
+      final incoming = i > 0 ? clamped[clips[i - 1].id] : null;
+      final consumedByIncoming =
+          incoming != null &&
+          _seamService.cached(clips[i - 1], clip, incoming) != null;
+      final outgoing = clamped[clip.id];
+      final consumedByOutgoing =
+          i + 1 < clips.length &&
+          outgoing != null &&
+          _seamService.cached(clip, clips[i + 1], outgoing) != null;
+      if (consumedByIncoming || consumedByOutgoing) continue;
+
       if (_speedRenderService.cached(clip) != null) continue;
       if (_speedRenderService.isRendering(clip)) continue;
       _speedRenderService.render(clip).then((rendered) {
@@ -617,11 +635,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     final ownerEpoch = _seekEpoch;
     try {
       final loaded = await _setClipsSafely(_videoPlayer, [
-        ...buildSeamAwarePlayerClips(
-          clips,
-          _seamService,
-          speedRenders: _speedRenderService,
-        ),
+        ..._buildPlayerClips(clips),
       ], startPosition: _timelineToPlayer(timelineStartPosition));
       if (!loaded) return;
       // Only pin the restored position if no newer swap took over during the
@@ -644,32 +658,54 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   int? _cachedSeamTimelineClipsHash;
   int? _cachedSeamTimelineVersion;
 
-  /// Returns the current [SeamTimeline], rebuilding only when the clips change
-  /// identity or either derived cache mutates — the seam cache
-  /// ([TransitionSeamRenderService.version]) or the speed-render cache
-  /// ([ClipSpeedRenderService.version]), since a landed speed body changes the
-  /// composite span the timeline maps.
+  /// Returns the current [SeamTimeline], rebuilding when the clips change
+  /// identity or the seam cache mutates ([TransitionSeamRenderService.version]).
+  ///
+  /// Deliberately **not** keyed on [ClipSpeedRenderService.version]: a landed
+  /// speed body must only shift the mapping once its file is actually spliced
+  /// into the player composition. Because a speed swap can be deferred while
+  /// playback runs (see [_resyncSpeedClipsWhenIdle]), keying on the cache
+  /// version would move the mapping ahead of the still-live-retimed player and
+  /// drift the playhead. Instead [_buildPlayerClips] refreshes this timeline
+  /// from the same snapshot it hands the player, so mapping and composition
+  /// always agree.
   SeamTimeline get _seamTimeline {
     final clips = ref.read(clipManagerProvider).clips;
     final clipsHash = Object.hashAll(clips);
-    final version = Object.hash(
-      _seamService.version,
-      _speedRenderService.version,
-    );
+    final version = _seamService.version;
     final cached = _cachedSeamTimeline;
     if (cached != null &&
         _cachedSeamTimelineClipsHash == clipsHash &&
         _cachedSeamTimelineVersion == version) {
       return cached;
     }
+    return _refreshSeamTimeline(clips);
+  }
+
+  /// Builds the preview player's clip list for [clips] (rendered seams + speed
+  /// bodies spliced in) and refreshes the memoized [SeamTimeline] from the same
+  /// cache snapshot, so the player↔editor position mapping always matches the
+  /// composition that was actually loaded — including a speed body that landed
+  /// while playing whose swap was deferred to the next pause.
+  List<VideoClip> _buildPlayerClips(List<DivineVideoClip> clips) {
+    final playerClips = buildSeamAwarePlayerClips(
+      clips,
+      _seamService,
+      speedRenders: _speedRenderService,
+    );
+    _refreshSeamTimeline(clips);
+    return playerClips;
+  }
+
+  SeamTimeline _refreshSeamTimeline(List<DivineVideoClip> clips) {
     final timeline = SeamTimeline(
       clips,
       _seamService,
       speedRenders: _speedRenderService,
     );
     _cachedSeamTimeline = timeline;
-    _cachedSeamTimelineClipsHash = clipsHash;
-    _cachedSeamTimelineVersion = version;
+    _cachedSeamTimelineClipsHash = Object.hashAll(clips);
+    _cachedSeamTimelineVersion = _seamService.version;
     return timeline;
   }
 
@@ -977,11 +1013,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     _pendingSeekTarget = currentPosition;
     unawaited(
       _setClipsSafely(_videoPlayer, [
-        ...buildSeamAwarePlayerClips(
-          clips,
-          _seamService,
-          speedRenders: _speedRenderService,
-        ),
+        ..._buildPlayerClips(clips),
       ], startPosition: _timelineToPlayer(currentPosition)),
     );
     _ensureSeamsRendered(clips);
@@ -1092,11 +1124,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     final loaded = await _setClipsSafely(
       player,
       [
-        ...buildSeamAwarePlayerClips(
-          clips,
-          _seamService,
-          speedRenders: _speedRenderService,
-        ),
+        ..._buildPlayerClips(clips),
       ],
       startPosition: startPosition != null && startPosition > Duration.zero
           ? _timelineToPlayer(startPosition)
@@ -1601,11 +1629,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         _pendingSeekTarget = currentPosition;
         unawaited(
           _setClipsSafely(_videoPlayer, [
-            ...buildSeamAwarePlayerClips(
-              clips,
-              _seamService,
-              speedRenders: _speedRenderService,
-            ),
+            ..._buildPlayerClips(clips),
           ], startPosition: _timelineToPlayer(currentPosition)),
         );
         _ensureSeamsRendered(clips);
@@ -1633,11 +1657,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         _pendingSeekTarget = currentPosition;
         unawaited(
           _setClipsSafely(_videoPlayer, [
-            ...buildSeamAwarePlayerClips(
-              clips,
-              _seamService,
-              speedRenders: _speedRenderService,
-            ),
+            ..._buildPlayerClips(clips),
           ], startPosition: _timelineToPlayer(currentPosition)),
         );
         _ensureSeamsRendered(clips);
@@ -1893,11 +1913,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
             try {
               final loaded = await _setClipsSafely(_videoPlayer, [
-                ...buildSeamAwarePlayerClips(
-                  state.clips,
-                  _seamService,
-                  speedRenders: _speedRenderService,
-                ),
+                ..._buildPlayerClips(state.clips),
               ], startPosition: _timelineToPlayer(currentPosition));
               if (!loaded) return;
 
@@ -1952,11 +1968,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
             try {
               final loaded = await _setClipsSafely(_videoPlayer, [
-                ...buildSeamAwarePlayerClips(
-                  state.clips,
-                  _seamService,
-                  speedRenders: _speedRenderService,
-                ),
+                ..._buildPlayerClips(state.clips),
               ], startPosition: _timelineToPlayer(startPosition));
               if (!loaded) return;
               if (mounted) {

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -489,6 +489,14 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// live-retimed clip until the render swaps in (no overlay, no wait).
   final _speedRenderService = ClipSpeedRenderService();
 
+  /// Set when a finished speed render's composition swap was deferred because
+  /// the player was playing; applied on the next pause (see
+  /// [_onPlayerStateChanged]). A `setClips` reload mid-playback is inherently
+  /// disruptive (Android setMediaItems + prepare, iOS AVQueuePlayer reload) and
+  /// restarts the current clip instead of advancing, so the swap must wait for
+  /// an idle player.
+  bool _speedResyncPendingWhilePlaying = false;
+
   @override
   void dispose() {
     Log.info(
@@ -551,9 +559,22 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
       if (_speedRenderService.isRendering(clip)) continue;
       _speedRenderService.render(clip).then((rendered) {
         if (!mounted) return;
-        if (rendered != null) _resyncPlayerClips();
+        if (rendered != null) _resyncSpeedClipsWhenIdle();
       });
     }
+  }
+
+  /// Swaps the composition onto a finished speed render — but only while the
+  /// player is idle. A `setClips` reload mid-playback restarts the current clip
+  /// instead of advancing to the next, so if playback is running the swap is
+  /// deferred to the next pause ([_onPlayerStateChanged]); the preview keeps
+  /// playing the live-retimed clip until then.
+  void _resyncSpeedClipsWhenIdle() {
+    if (_videoPlayer?.state.isPlaying ?? false) {
+      _speedResyncPendingWhilePlaying = true;
+      return;
+    }
+    _resyncPlayerClips();
   }
 
   /// Reloads the player with the current clips, splicing in rendered seams,
@@ -826,6 +847,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     if (isPlaying != _lastIsPlaying) {
       _lastIsPlaying = isPlaying;
       bloc.add(VideoEditorPlaybackChanged(isPlaying: isPlaying));
+      // Playback just stopped: apply any speed-render swap deferred while
+      // playing, now that the reload can happen without restarting a clip.
+      if (!isPlaying && _speedResyncPendingWhilePlaying) {
+        _speedResyncPendingWhilePlaying = false;
+        _resyncPlayerClips();
+      }
     }
 
     // Once playback resumes it owns the play time, so release any scrub / swap

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -30,6 +30,7 @@ import 'package:openvine/providers/clip_manager_provider.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_screen.dart';
 import 'package:openvine/services/haptic_service.dart';
+import 'package:openvine/services/video_editor/clip_speed_render_service.dart';
 import 'package:openvine/services/video_editor/transition_seam_render_service.dart';
 import 'package:openvine/utils/await_push_transition.dart';
 import 'package:openvine/utils/mounted_post_frame.dart';
@@ -482,6 +483,12 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// "rendering transition" overlay so the wait isn't silent.
   final _pendingSeamRenders = ValueNotifier<int>(0);
 
+  /// Renders and caches per-clip normal-rate speed bodies so a non-1× clip can
+  /// play its pre-rendered file at 1× instead of retiming live — smoother on
+  /// both platforms. Rendered in the background; the preview shows the instant
+  /// live-retimed clip until the render swaps in (no overlay, no wait).
+  final _speedRenderService = ClipSpeedRenderService();
+
   @override
   void dispose() {
     Log.info(
@@ -497,6 +504,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     _videoPlayer = null;
     _isPlayerReadyNotifier.dispose();
     _seamService.clear();
+    _speedRenderService.clear();
     _pendingSeamRenders.dispose();
     super.dispose();
   }
@@ -529,6 +537,22 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
             _pendingSeamRenders.value--;
             if (seam != null) _resyncPlayerClips();
           });
+    }
+  }
+
+  /// Kicks off background renders of the normal-rate body for any non-1× clip,
+  /// then swaps the player onto the rendered file when each finishes. Idempotent
+  /// — cached / in-flight clips are skipped — so it is safe to call on every
+  /// clip, trim or speed change. The preview keeps playing the instant
+  /// live-retimed clip until the swap lands.
+  void _ensureSpeedClipsRendered(List<DivineVideoClip> clips) {
+    for (final clip in clips) {
+      if (_speedRenderService.cached(clip) != null) continue;
+      if (_speedRenderService.isRendering(clip)) continue;
+      _speedRenderService.render(clip).then((rendered) {
+        if (!mounted) return;
+        if (rendered != null) _resyncPlayerClips();
+      });
     }
   }
 
@@ -572,7 +596,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     final ownerEpoch = _seekEpoch;
     try {
       final loaded = await _setClipsSafely(_videoPlayer, [
-        ...buildSeamAwarePlayerClips(clips, _seamService),
+        ...buildSeamAwarePlayerClips(
+          clips,
+          _seamService,
+          speedRenders: _speedRenderService,
+        ),
       ], startPosition: _timelineToPlayer(timelineStartPosition));
       if (!loaded) return;
       // Only pin the restored position if no newer swap took over during the
@@ -912,10 +940,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     _pendingSeekTarget = currentPosition;
     unawaited(
       _setClipsSafely(_videoPlayer, [
-        ...buildSeamAwarePlayerClips(clips, _seamService),
+        ...buildSeamAwarePlayerClips(
+          clips,
+          _seamService,
+          speedRenders: _speedRenderService,
+        ),
       ], startPosition: _timelineToPlayer(currentPosition)),
     );
     _ensureSeamsRendered(clips);
+    _ensureSpeedClipsRendered(clips);
   }
 
   /// Creates the [ProVideoController] (only once, not tied to a file).
@@ -1021,7 +1054,13 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
     if (!mounted || !identical(_videoPlayer, player)) return;
     final loaded = await _setClipsSafely(
       player,
-      [...buildSeamAwarePlayerClips(clips, _seamService)],
+      [
+        ...buildSeamAwarePlayerClips(
+          clips,
+          _seamService,
+          speedRenders: _speedRenderService,
+        ),
+      ],
       startPosition: startPosition != null && startPosition > Duration.zero
           ? _timelineToPlayer(startPosition)
           : null,
@@ -1033,6 +1072,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
     if (clips.isEmpty) return;
     _ensureSeamsRendered(clips);
+    _ensureSpeedClipsRendered(clips);
     await player.setLooping(looping: true);
     if (!mounted || !identical(_videoPlayer, player)) return;
 
@@ -1524,10 +1564,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         _pendingSeekTarget = currentPosition;
         unawaited(
           _setClipsSafely(_videoPlayer, [
-            ...buildSeamAwarePlayerClips(clips, _seamService),
+            ...buildSeamAwarePlayerClips(
+              clips,
+              _seamService,
+              speedRenders: _speedRenderService,
+            ),
           ], startPosition: _timelineToPlayer(currentPosition)),
         );
         _ensureSeamsRendered(clips);
+        _ensureSpeedClipsRendered(clips);
       },
     );
 
@@ -1551,10 +1596,15 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
         _pendingSeekTarget = currentPosition;
         unawaited(
           _setClipsSafely(_videoPlayer, [
-            ...buildSeamAwarePlayerClips(clips, _seamService),
+            ...buildSeamAwarePlayerClips(
+              clips,
+              _seamService,
+              speedRenders: _speedRenderService,
+            ),
           ], startPosition: _timelineToPlayer(currentPosition)),
         );
         _ensureSeamsRendered(clips);
+        _ensureSpeedClipsRendered(clips);
       },
     );
 
@@ -1579,6 +1629,7 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
           _swapComposition(clips, timelineStartPosition: currentPosition),
         );
         _ensureSeamsRendered(clips);
+        _ensureSpeedClipsRendered(clips);
       },
     );
 
@@ -1805,7 +1856,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
             try {
               final loaded = await _setClipsSafely(_videoPlayer, [
-                ...buildSeamAwarePlayerClips(state.clips, _seamService),
+                ...buildSeamAwarePlayerClips(
+                  state.clips,
+                  _seamService,
+                  speedRenders: _speedRenderService,
+                ),
               ], startPosition: _timelineToPlayer(currentPosition));
               if (!loaded) return;
 
@@ -1860,7 +1915,11 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
 
             try {
               final loaded = await _setClipsSafely(_videoPlayer, [
-                ...buildSeamAwarePlayerClips(state.clips, _seamService),
+                ...buildSeamAwarePlayerClips(
+                  state.clips,
+                  _seamService,
+                  speedRenders: _speedRenderService,
+                ),
               ], startPosition: _timelineToPlayer(startPosition));
               if (!loaded) return;
               if (mounted) {

--- a/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
+++ b/mobile/lib/widgets/video_editor/main_editor/video_editor_canvas.dart
@@ -661,14 +661,14 @@ class _VideoEditorState extends ConsumerState<_VideoEditor>
   /// Returns the current [SeamTimeline], rebuilding when the clips change
   /// identity or the seam cache mutates ([TransitionSeamRenderService.version]).
   ///
-  /// Deliberately **not** keyed on [ClipSpeedRenderService.version]: a landed
-  /// speed body must only shift the mapping once its file is actually spliced
-  /// into the player composition. Because a speed swap can be deferred while
-  /// playback runs (see [_resyncSpeedClipsWhenIdle]), keying on the cache
-  /// version would move the mapping ahead of the still-live-retimed player and
-  /// drift the playhead. Instead [_buildPlayerClips] refreshes this timeline
-  /// from the same snapshot it hands the player, so mapping and composition
-  /// always agree.
+  /// Deliberately **not** keyed on the speed render cache: a landed speed body
+  /// must only shift the mapping once its file is actually spliced into the
+  /// player composition. Because a speed swap can be deferred while playback
+  /// runs (see [_resyncSpeedClipsWhenIdle]), keying on the speed cache would
+  /// move the mapping ahead of the still-live-retimed player and drift the
+  /// playhead. Instead [_buildPlayerClips] refreshes this timeline from the
+  /// same snapshot it hands the player, so mapping and composition always
+  /// agree.
   SeamTimeline get _seamTimeline {
     final clips = ref.read(clipManagerProvider).clips;
     final clipsHash = Object.hashAll(clips);

--- a/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
+++ b/mobile/packages/divine_video_player/darwin/divine_video_player/Sources/divine_video_player/DivineVideoPlayerInstance.swift
@@ -192,10 +192,13 @@ final class DivineVideoPlayerInstance: NSObject, FlutterStreamHandler {
                 self.firstFrameRendered = false
 
                 let playerItem = AVPlayerItem(asset: composition)
-                // Prevent pitch distortion when clips play at a speed
-                // other than 1×. .spectral (phase vocoder) preserves
-                // pitch across the full speed range.
-                playerItem.audioTimePitchAlgorithm = .spectral
+                // Prevent pitch distortion when clips play at a speed other
+                // than 1×. .timeDomain preserves pitch across the editor's
+                // 0.25×–3× range at a fraction of .spectral's (phase vocoder)
+                // CPU cost — the phase vocoder is a real-time hog that steals
+                // cycles from video decode/render on weaker devices, showing up
+                // as dropped or stuttering frames during sped-up preview.
+                playerItem.audioTimePitchAlgorithm = .timeDomain
                 if let videoComposition {
                     playerItem.videoComposition = videoComposition
                 }

--- a/mobile/test/providers/video_editor_provider_test.dart
+++ b/mobile/test/providers/video_editor_provider_test.dart
@@ -1425,38 +1425,35 @@ void main() {
         },
       );
 
-      test(
-        'returns false when every clip has a missing source file',
-        () async {
-          final draft = DivineVideoDraft.create(
-            id: 'draft-1',
-            clips: [
-              DivineVideoClip(
-                id: 'orphan',
-                video: EditorVideo.file('${tempDir.path}/deleted.mp4'),
-                duration: const Duration(seconds: 3),
-                recordedAt: DateTime.now(),
-                targetAspectRatio: .vertical,
-                originalAspectRatio: 9 / 16,
-              ),
-            ],
-            title: 'Title',
-            description: '',
-            hashtags: const {},
-            selectedApproach: 'video',
-          );
-          when(
-            () => mockDraftStorage.getDraftById('draft-1'),
-          ).thenAnswer((_) async => draft);
+      test('returns false when every clip has a missing source file', () async {
+        final draft = DivineVideoDraft.create(
+          id: 'draft-1',
+          clips: [
+            DivineVideoClip(
+              id: 'orphan',
+              video: EditorVideo.file('${tempDir.path}/deleted.mp4'),
+              duration: const Duration(seconds: 3),
+              recordedAt: DateTime.now(),
+              targetAspectRatio: .vertical,
+              originalAspectRatio: 9 / 16,
+            ),
+          ],
+          title: 'Title',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+        );
+        when(
+          () => mockDraftStorage.getDraftById('draft-1'),
+        ).thenAnswer((_) async => draft);
 
-          final result = await container
-              .read(videoEditorProvider.notifier)
-              .restoreDraft('draft-1');
+        final result = await container
+            .read(videoEditorProvider.notifier)
+            .restoreDraft('draft-1');
 
-          expect(result, isFalse);
-          expect(container.read(clipManagerProvider).clips, isEmpty);
-        },
-      );
+        expect(result, isFalse);
+        expect(container.read(clipManagerProvider).clips, isEmpty);
+      });
 
       test('restores the saved cover position onto state', () async {
         final draft = DivineVideoDraft.create(
@@ -1991,6 +1988,105 @@ void main() {
         isFalse,
         reason: 'onDispose reaps deferred files left when reset never ran',
       );
+    });
+
+    test('container teardown reaps a replaced final rendered file', () async {
+      final suffix = DateTime.now().microsecondsSinceEpoch;
+      final documentsDir = Directory('/tmp/documents')
+        ..createSync(recursive: true);
+      final source = File(p.join(documentsDir.path, 'source-$suffix.mp4'))
+        ..writeAsBytesSync(const [1, 2, 3]);
+      final oldRendered = File(
+        p.join(documentsDir.path, 'old-rendered-$suffix.mp4'),
+      )..writeAsBytesSync(const [4, 5, 6]);
+      final newRendered = File(
+        p.join(documentsDir.path, 'new-rendered-$suffix.mp4'),
+      )..writeAsBytesSync(const [7, 8, 9]);
+      addTearDown(() async {
+        for (final file in [source, oldRendered, newRendered]) {
+          if (file.existsSync()) {
+            await file.delete();
+          }
+        }
+      });
+      final realDraftStorage = DraftStorageService(
+        draftsDao: database.draftsDao,
+        clipsDao: database.clipsDao,
+      );
+
+      DivineVideoClip timelineClip() => DivineVideoClip(
+        id: 'timeline',
+        video: EditorVideo.file(source.path),
+        duration: const Duration(seconds: 6),
+        recordedAt: DateTime(2025),
+        targetAspectRatio: AspectRatio.square,
+        originalAspectRatio: 9 / 16,
+      );
+
+      DivineVideoClip renderedClip(String id, File file) => DivineVideoClip(
+        id: id,
+        video: EditorVideo.file(file.path),
+        duration: const Duration(seconds: 6),
+        recordedAt: DateTime(2025),
+        targetAspectRatio: AspectRatio.square,
+        originalAspectRatio: 9 / 16,
+      );
+
+      await realDraftStorage.saveDraft(
+        DivineVideoDraft.create(
+          id: VideoEditorConstants.autoSaveId,
+          clips: [timelineClip()],
+          title: '',
+          description: '',
+          hashtags: const {},
+          selectedApproach: 'video',
+          finalRenderedClip: renderedClip('old-rendered', oldRendered),
+        ),
+      );
+
+      when(
+        () => mockDraftStorage.saveDraft(
+          any(),
+          deferOrphanCleanup: any(named: 'deferOrphanCleanup'),
+        ),
+      ).thenAnswer((invocation) async {
+        await realDraftStorage.saveDraft(
+          invocation.positionalArguments.first as DivineVideoDraft,
+          deferOrphanCleanup:
+              invocation.namedArguments[#deferOrphanCleanup]
+                  as void Function(List<String?>)?,
+        );
+      });
+
+      final notifier = container.read(videoEditorProvider.notifier);
+      container
+          .read(clipManagerProvider.notifier)
+          .addClip(
+            limitClipDuration: false,
+            video: EditorVideo.file(source.path),
+            targetAspectRatio: AspectRatio.square,
+            originalAspectRatio: 9 / 16,
+            duration: const Duration(seconds: 6),
+          );
+      notifier.state = notifier.state.copyWith(
+        finalRenderedClip: renderedClip('new-rendered', newRendered),
+      );
+
+      await notifier.autosaveChanges();
+      expect(oldRendered.existsSync(), isTrue);
+      expect(notifier.deferredFileCleanupForTest, contains(oldRendered.path));
+
+      disposeContainer();
+      await pumpEventQueue();
+
+      expect(
+        oldRendered.existsSync(),
+        isFalse,
+        reason:
+            'onDispose must reap a replaced rendered export once the new '
+            'draft row no longer references it',
+      );
+      expect(newRendered.existsSync(), isTrue);
     });
   });
 }

--- a/mobile/test/services/video_editor/clip_speed_render_service_test.dart
+++ b/mobile/test/services/video_editor/clip_speed_render_service_test.dart
@@ -341,5 +341,67 @@ void main() {
         },
       );
     });
+
+    group('eviction', () {
+      RenderedSpeedClip seedFile(String name) {
+        final file = File(p.join(tempDir.path, 'tmp', 'speed_clips', name))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('body');
+        return RenderedSpeedClip(
+          path: file.path,
+          duration: const Duration(milliseconds: 1500),
+        );
+      }
+
+      test('evicts the least-recently-used body — file and cache entry '
+          'together — once the cap is exceeded', () {
+        final service = ClipSpeedRenderService();
+        final clips = <DivineVideoClip>[];
+        final rendereds = <RenderedSpeedClip>[];
+        // Seed one past the cap (33 entries): the oldest must be evicted.
+        for (var i = 0; i <= 32; i++) {
+          final c = clip('a$i', playbackSpeed: 2);
+          final r = seedFile('a$i.mp4');
+          clips.add(c);
+          rendereds.add(r);
+          service.cacheForTest(c, r);
+        }
+
+        // Evicted entries are dropped from the in-memory cache AND from disk,
+        // so a lookup can never resolve to a dead path.
+        expect(service.cached(clips.first), isNull);
+        expect(File(rendereds.first.path).existsSync(), isFalse);
+        // The most-recent entry survives with its file intact.
+        expect(service.cached(clips.last), same(rendereds.last));
+        expect(File(rendereds.last.path).existsSync(), isTrue);
+      });
+
+      test('promotes on lookup so an in-use body is not the one evicted', () {
+        final service = ClipSpeedRenderService();
+        final clips = <DivineVideoClip>[];
+        final rendereds = <RenderedSpeedClip>[];
+        for (var i = 0; i < 32; i++) {
+          final c = clip('a$i', playbackSpeed: 2);
+          final r = seedFile('a$i.mp4');
+          clips.add(c);
+          rendereds.add(r);
+          service.cacheForTest(c, r);
+        }
+
+        // Touch the oldest so it becomes most-recently-used.
+        expect(service.cached(clips.first), same(rendereds.first));
+
+        // One more push over the cap evicts the now-oldest (a1), not the
+        // promoted a0.
+        service.cacheForTest(
+          clip('a32', playbackSpeed: 2),
+          seedFile('a32.mp4'),
+        );
+
+        expect(service.cached(clips.first), same(rendereds.first));
+        expect(service.cached(clips[1]), isNull);
+        expect(File(rendereds[1].path).existsSync(), isFalse);
+      });
+    });
   });
 }

--- a/mobile/test/services/video_editor/clip_speed_render_service_test.dart
+++ b/mobile/test/services/video_editor/clip_speed_render_service_test.dart
@@ -209,18 +209,14 @@ void main() {
       });
     });
 
-    group('version', () {
-      test('bumps on cache seed and clear, and clear drops the entry', () {
+    group('clear', () {
+      test('seeded entry is cached, then dropped after clear', () {
         final c = clip('a', playbackSpeed: 2);
-        final service = ClipSpeedRenderService();
-        final initial = service.version;
+        final service = ClipSpeedRenderService()..cacheForTest(c, rendered);
 
-        service.cacheForTest(c, rendered);
-        expect(service.version, greaterThan(initial));
+        expect(service.cached(c), same(rendered));
 
-        final afterSeed = service.version;
         service.clear();
-        expect(service.version, greaterThan(afterSeed));
         expect(service.cached(c), isNull);
       });
     });

--- a/mobile/test/services/video_editor/clip_speed_render_service_test.dart
+++ b/mobile/test/services/video_editor/clip_speed_render_service_test.dart
@@ -1,12 +1,98 @@
+import 'dart:async';
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/video_editor/clip_speed_render_service.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' as editor;
 
+class _FakePathProviderPlatform extends Fake
+    with MockPlatformInterfaceMixin
+    implements PathProviderPlatform {
+  _FakePathProviderPlatform({
+    required this.temporaryPath,
+    required this.documentsPath,
+  });
+
+  final String temporaryPath;
+  final String documentsPath;
+
+  @override
+  Future<String?> getTemporaryPath() async => temporaryPath;
+
+  @override
+  Future<String?> getApplicationDocumentsPath() async => documentsPath;
+
+  @override
+  Future<String?> getApplicationCachePath() async =>
+      p.join(p.dirname(temporaryPath), 'cache');
+}
+
+class _FakeProVideoEditor extends editor.ProVideoEditor {
+  final renderStarted = <Completer<void>>[];
+  final allowRenderToFinish = <Completer<void>>[];
+  int renderCount = 0;
+
+  Completer<void> renderStartedAt(int index) {
+    while (renderStarted.length <= index) {
+      renderStarted.add(Completer<void>());
+    }
+    return renderStarted[index];
+  }
+
+  Completer<void> allowRenderToFinishAt(int index) {
+    while (allowRenderToFinish.length <= index) {
+      allowRenderToFinish.add(Completer<void>());
+    }
+    return allowRenderToFinish[index];
+  }
+
+  @override
+  void initializeStream() {}
+
+  @override
+  Future<void> cancel(String taskId) async {}
+
+  @override
+  Future<String> renderVideoToFile(
+    String filePath,
+    editor.VideoRenderData value, {
+    editor.NativeLogLevel? nativeLogLevel,
+  }) async {
+    final renderIndex = renderCount++;
+    renderStartedAt(renderIndex).complete();
+    await allowRenderToFinishAt(renderIndex).future;
+    await File(filePath).writeAsString('rendered speed body');
+    return filePath;
+  }
+
+  @override
+  Future<editor.VideoMetadata> getMetadata(
+    editor.EditorVideo value, {
+    bool checkStreamingOptimization = false,
+    editor.NativeLogLevel? nativeLogLevel,
+  }) async {
+    return editor.VideoMetadata(
+      duration: const Duration(milliseconds: 1500),
+      extension: 'mp4',
+      fileSize: 1024,
+      resolution: const Size(1080, 1920),
+      rotation: 0,
+      bitrate: 1_000_000,
+    );
+  }
+}
+
 void main() {
+  late Directory tempDir;
+  late PathProviderPlatform originalPathProvider;
+  late editor.ProVideoEditor originalProVideoEditor;
+
   DivineVideoClip clip(
     String id, {
     double? playbackSpeed,
@@ -31,6 +117,29 @@ void main() {
   );
 
   group(ClipSpeedRenderService, () {
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      originalPathProvider = PathProviderPlatform.instance;
+      originalProVideoEditor = editor.ProVideoEditor.instance;
+      tempDir = await Directory.systemTemp.createTemp(
+        'clip_speed_render_service_test_',
+      );
+      PathProviderPlatform.instance = _FakePathProviderPlatform(
+        temporaryPath: p.join(tempDir.path, 'tmp'),
+        documentsPath: p.join(tempDir.path, 'documents'),
+      );
+      await Directory(p.join(tempDir.path, 'tmp')).create(recursive: true);
+      await Directory(
+        p.join(tempDir.path, 'documents'),
+      ).create(recursive: true);
+    });
+
+    tearDown(() async {
+      PathProviderPlatform.instance = originalPathProvider;
+      editor.ProVideoEditor.instance = originalProVideoEditor;
+      if (tempDir.existsSync()) await tempDir.delete(recursive: true);
+    });
+
     group('cached', () {
       test('returns the seeded render for a non-1× clip', () {
         final c = clip('a', playbackSpeed: 2);
@@ -114,6 +223,123 @@ void main() {
         expect(service.version, greaterThan(afterSeed));
         expect(service.cached(c), isNull);
       });
+    });
+
+    group('disk cleanup', () {
+      test(
+        'renders speed files under temporary cache instead of documents',
+        () async {
+          final c = clip(
+            'a',
+            playbackSpeed: 2,
+            path: p.join(tempDir.path, 'source.mp4'),
+          );
+          File(c.video.file!.path).writeAsStringSync('source');
+          final fakeEditor = _FakeProVideoEditor();
+          editor.ProVideoEditor.instance = fakeEditor;
+          final service = ClipSpeedRenderService();
+
+          final render = service.render(c);
+          await fakeEditor.renderStartedAt(0).future;
+          fakeEditor.allowRenderToFinishAt(0).complete();
+          final rendered = await render;
+
+          expect(rendered, isNotNull);
+          expect(
+            p.isWithin(
+              p.join(tempDir.path, 'tmp', 'speed_clips'),
+              rendered!.path,
+            ),
+            isTrue,
+          );
+          expect(
+            Directory(
+              p.join(tempDir.path, 'documents', 'speed_clips'),
+            ).existsSync(),
+            isFalse,
+          );
+        },
+      );
+
+      test('clear removes cached rendered speed files from disk', () {
+        final c = clip('a', playbackSpeed: 2);
+        final file = File(p.join(tempDir.path, 'tmp', 'speed_clips', 'a.mp4'))
+          ..createSync(recursive: true)
+          ..writeAsStringSync('rendered speed body');
+        final service = ClipSpeedRenderService()
+          ..cacheForTest(
+            c,
+            RenderedSpeedClip(
+              path: file.path,
+              duration: const Duration(milliseconds: 1500),
+            ),
+          );
+
+        service.clear();
+
+        expect(file.existsSync(), isFalse);
+        expect(service.cached(c), isNull);
+      });
+
+      test(
+        'clear prevents an in-flight render from publishing a file',
+        () async {
+          final c = clip(
+            'a',
+            playbackSpeed: 2,
+            path: p.join(tempDir.path, 'source.mp4'),
+          );
+          File(c.video.file!.path).writeAsStringSync('source');
+          final fakeEditor = _FakeProVideoEditor();
+          editor.ProVideoEditor.instance = fakeEditor;
+          final service = ClipSpeedRenderService();
+
+          final render = service.render(c);
+          await fakeEditor.renderStartedAt(0).future;
+          service.clear();
+
+          fakeEditor.allowRenderToFinishAt(0).complete();
+          final rendered = await render;
+
+          expect(rendered, isNull);
+          expect(service.cached(c), isNull);
+          expect(
+            Directory(p.join(tempDir.path, 'tmp', 'speed_clips')).existsSync(),
+            isFalse,
+          );
+        },
+      );
+
+      test(
+        'a stale render does not unregister the replacement in-flight render',
+        () async {
+          final c = clip(
+            'a',
+            playbackSpeed: 2,
+            path: p.join(tempDir.path, 'source.mp4'),
+          );
+          File(c.video.file!.path).writeAsStringSync('source');
+          final fakeEditor = _FakeProVideoEditor();
+          editor.ProVideoEditor.instance = fakeEditor;
+          final service = ClipSpeedRenderService();
+
+          final staleRender = service.render(c);
+          await fakeEditor.renderStartedAt(0).future;
+          service.clear();
+
+          final replacementRender = service.render(c);
+          await fakeEditor.renderStartedAt(1).future;
+          fakeEditor.allowRenderToFinishAt(0).complete();
+          await staleRender;
+
+          expect(service.isRendering(c), isTrue);
+          expect(service.render(c), same(replacementRender));
+
+          fakeEditor.allowRenderToFinishAt(1).complete();
+          expect(await replacementRender, isNotNull);
+          expect(service.isRendering(c), isFalse);
+        },
+      );
     });
   });
 }

--- a/mobile/test/services/video_editor/clip_speed_render_service_test.dart
+++ b/mobile/test/services/video_editor/clip_speed_render_service_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:models/models.dart' as model;
+import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/services/video_editor/clip_speed_render_service.dart';
+import 'package:pro_video_editor/pro_video_editor.dart' as editor;
+
+void main() {
+  DivineVideoClip clip(
+    String id, {
+    double? playbackSpeed,
+    Duration trimStart = Duration.zero,
+    Duration trimEnd = Duration.zero,
+    String? path,
+  }) => DivineVideoClip(
+    id: id,
+    video: editor.EditorVideo.file(File(path ?? '/tmp/$id.mp4')),
+    duration: const Duration(seconds: 3),
+    recordedAt: DateTime(2024),
+    targetAspectRatio: model.AspectRatio.square,
+    originalAspectRatio: 1,
+    playbackSpeed: playbackSpeed,
+    trimStart: trimStart,
+    trimEnd: trimEnd,
+  );
+
+  const rendered = RenderedSpeedClip(
+    path: '/tmp/a_speed.mp4',
+    duration: Duration(milliseconds: 1500),
+  );
+
+  group(ClipSpeedRenderService, () {
+    group('cached', () {
+      test('returns the seeded render for a non-1× clip', () {
+        final c = clip('a', playbackSpeed: 2);
+        final service = ClipSpeedRenderService()..cacheForTest(c, rendered);
+
+        expect(service.cached(c), same(rendered));
+      });
+
+      test('returns null for a clip at the default (1×) speed', () {
+        final c = clip('a'); // playbackSpeed null == 1×
+        final service = ClipSpeedRenderService()..cacheForTest(c, rendered);
+
+        expect(service.cached(c), isNull);
+      });
+
+      test('returns null for an explicit 1.0× clip', () {
+        final c = clip('a', playbackSpeed: 1);
+        final service = ClipSpeedRenderService()..cacheForTest(c, rendered);
+
+        expect(service.cached(c), isNull);
+      });
+
+      test('misses the cache when the speed changes', () {
+        final slow = clip('a', playbackSpeed: 2);
+        final faster = clip('a', playbackSpeed: 3);
+        final service = ClipSpeedRenderService()..cacheForTest(slow, rendered);
+
+        expect(service.cached(slow), same(rendered));
+        expect(service.cached(faster), isNull);
+      });
+
+      test('misses the cache when the trim changes', () {
+        final untrimmed = clip('a', playbackSpeed: 2);
+        final trimmed = clip(
+          'a',
+          playbackSpeed: 2,
+          trimStart: const Duration(milliseconds: 500),
+        );
+        final service = ClipSpeedRenderService()
+          ..cacheForTest(untrimmed, rendered);
+
+        expect(service.cached(untrimmed), same(rendered));
+        expect(service.cached(trimmed), isNull);
+      });
+
+      test('misses the cache when the source file changes (e.g. reverse)', () {
+        final forward = clip('a', playbackSpeed: 2);
+        final reversed = clip(
+          'a',
+          playbackSpeed: 2,
+          path: '/tmp/a_reversed.mp4',
+        );
+        final service = ClipSpeedRenderService()
+          ..cacheForTest(forward, rendered);
+
+        expect(service.cached(forward), same(rendered));
+        expect(service.cached(reversed), isNull);
+      });
+    });
+
+    group('render', () {
+      test('short-circuits to null for a 1× clip without touching native', () {
+        final service = ClipSpeedRenderService();
+
+        expect(service.render(clip('a')), completion(isNull));
+        expect(service.isRendering(clip('a')), isFalse);
+      });
+    });
+
+    group('version', () {
+      test('bumps on cache seed and clear, and clear drops the entry', () {
+        final c = clip('a', playbackSpeed: 2);
+        final service = ClipSpeedRenderService();
+        final initial = service.version;
+
+        service.cacheForTest(c, rendered);
+        expect(service.version, greaterThan(initial));
+
+        final afterSeed = service.version;
+        service.clear();
+        expect(service.version, greaterThan(afterSeed));
+        expect(service.cached(c), isNull);
+      });
+    });
+  });
+}

--- a/mobile/test/services/video_editor/transition_seam_render_service_test.dart
+++ b/mobile/test/services/video_editor/transition_seam_render_service_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:models/models.dart' as model;
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/transition_geometry.dart';
+import 'package:openvine/services/video_editor/clip_speed_render_service.dart';
 import 'package:openvine/services/video_editor/transition_seam_render_service.dart';
 import 'package:pro_video_editor/pro_video_editor.dart' as editor;
 
@@ -79,6 +80,111 @@ void main() {
       expect(result[2].uri, equals('/tmp/b.mp4'));
       expect(result[2].start, equals(const Duration(milliseconds: 500)));
       expect(result[2].end, equals(const Duration(seconds: 3)));
+    });
+
+    test('plays the pre-rendered normal-rate file at 1× when a speed render '
+        'is cached', () {
+      final clipA = DivineVideoClip(
+        id: 'a',
+        video: editor.EditorVideo.file(File('/tmp/a.mp4')),
+        duration: const Duration(seconds: 3),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.square,
+        originalAspectRatio: 1,
+        playbackSpeed: 2,
+        volume: 0.5,
+      );
+      final speeds = ClipSpeedRenderService()
+        ..cacheForTest(
+          clipA,
+          const RenderedSpeedClip(
+            path: '/tmp/a_speed.mp4',
+            duration: Duration(milliseconds: 1500),
+          ),
+        );
+
+      final result = buildSeamAwarePlayerClips(
+        [clipA],
+        TransitionSeamRenderService(),
+        speedRenders: speeds,
+      );
+
+      expect(result, hasLength(1));
+      // The rendered file plays at 1× (speed already baked in) …
+      expect(result[0].uri, equals('/tmp/a_speed.mp4'));
+      expect(result[0].playbackSpeed, equals(1.0));
+      // … but volume is still applied live, so a mute never re-renders.
+      expect(result[0].volume, equals(0.5));
+    });
+
+    test('falls back to live retiming when no speed render is cached', () {
+      final clipA = DivineVideoClip(
+        id: 'a',
+        video: editor.EditorVideo.file(File('/tmp/a.mp4')),
+        duration: const Duration(seconds: 3),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.square,
+        originalAspectRatio: 1,
+        playbackSpeed: 2,
+      );
+
+      final result = buildSeamAwarePlayerClips(
+        [clipA],
+        TransitionSeamRenderService(),
+        speedRenders: ClipSpeedRenderService(),
+      );
+
+      expect(result, hasLength(1));
+      // Source file retimed live by the player until the render lands.
+      expect(result[0].uri, equals('/tmp/a.mp4'));
+      expect(result[0].playbackSpeed, equals(2.0));
+    });
+
+    test('keeps a seam-consumed clip on live retiming even when a speed '
+        'render is cached', () {
+      final clipA = DivineVideoClip(
+        id: 'a',
+        video: editor.EditorVideo.file(File('/tmp/a.mp4')),
+        duration: const Duration(seconds: 3),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.square,
+        originalAspectRatio: 1,
+        playbackSpeed: 2,
+        transition: dissolve,
+      );
+      final clipB = clip('b');
+      final seams = TransitionSeamRenderService()
+        ..cacheSeamForTest(
+          clipA,
+          clipB,
+          dissolve,
+          const TransitionSeam(
+            path: '/tmp/seam.mp4',
+            duration: Duration(milliseconds: 500),
+            tailConsumed: Duration(milliseconds: 500),
+            headConsumed: Duration(milliseconds: 500),
+          ),
+        );
+      final speeds = ClipSpeedRenderService()
+        ..cacheForTest(
+          clipA,
+          const RenderedSpeedClip(
+            path: '/tmp/a_speed.mp4',
+            duration: Duration(milliseconds: 1250),
+          ),
+        );
+
+      final result = buildSeamAwarePlayerClips(
+        [clipA, clipB],
+        seams,
+        speedRenders: speeds,
+      );
+
+      // Clip A's tail feeds the seam, so its body can't use the whole-body
+      // rendered file — it stays live-retimed (source file at 2×).
+      expect(result[0].uri, equals('/tmp/a.mp4'));
+      expect(result[0].playbackSpeed, equals(2.0));
+      expect(result[1].uri, equals('/tmp/seam.mp4'));
     });
   });
 

--- a/mobile/test/services/video_editor/transition_seam_render_service_test.dart
+++ b/mobile/test/services/video_editor/transition_seam_render_service_test.dart
@@ -388,6 +388,79 @@ void main() {
       );
     });
 
+    test('maps a spliced speed body by its real rendered duration, not '
+        'playbackDuration', () {
+      // 3s clip at 2× → playbackDuration 1500ms, but the re-encoded file lands
+      // at 1400ms (frame-rounding). The composite span must follow the real
+      // file, else the playhead drifts by the 100ms delta.
+      final clipA = DivineVideoClip(
+        id: 'a',
+        video: editor.EditorVideo.file(File('/tmp/a.mp4')),
+        duration: const Duration(seconds: 3),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.square,
+        originalAspectRatio: 1,
+        playbackSpeed: 2,
+      );
+      final speeds = ClipSpeedRenderService()
+        ..cacheForTest(
+          clipA,
+          const RenderedSpeedClip(
+            path: '/tmp/a_speed.mp4',
+            duration: Duration(milliseconds: 1400),
+          ),
+        );
+      final timeline = SeamTimeline(
+        [clipA],
+        TransitionSeamRenderService(),
+        speedRenders: speeds,
+      );
+
+      // Composite (real file) span 1400ms ≠ editor (playbackDuration) span
+      // 1500ms, so the axes are no longer the identity.
+      expect(timeline.hasSeams, isTrue);
+      // Composite end (1400ms, where the file actually ends) → editor end
+      // (1500ms, the clip's full drawn length).
+      expect(
+        timeline.compositeToTimeline(const Duration(milliseconds: 1400)),
+        equals(const Duration(milliseconds: 1500)),
+      );
+      // Half the composite maps to half the editor body.
+      expect(
+        timeline.compositeToTimeline(const Duration(milliseconds: 700)),
+        equals(const Duration(milliseconds: 750)),
+      );
+      // Round-trips: editor end → composite end.
+      expect(
+        timeline.timelineToComposite(const Duration(milliseconds: 1500)),
+        equals(const Duration(milliseconds: 1400)),
+      );
+    });
+
+    test('leaves a speed body 1:1 when no render is cached yet', () {
+      final clipA = DivineVideoClip(
+        id: 'a',
+        video: editor.EditorVideo.file(File('/tmp/a.mp4')),
+        duration: const Duration(seconds: 3),
+        recordedAt: DateTime(2024),
+        targetAspectRatio: model.AspectRatio.square,
+        originalAspectRatio: 1,
+        playbackSpeed: 2,
+      );
+      final timeline = SeamTimeline(
+        [clipA],
+        TransitionSeamRenderService(),
+        speedRenders: ClipSpeedRenderService(),
+      );
+
+      // No rendered file → live retiming, composite span == playbackDuration.
+      expect(timeline.hasSeams, isFalse);
+      expect(
+        timeline.compositeToTimeline(const Duration(milliseconds: 750)),
+        equals(const Duration(milliseconds: 750)),
+      );
+    });
+
     test('maps the mid-seam position onto the clip boundary', () {
       // 500ms dissolve on 3s clips → consumed 1000ms/side, seam 1500ms.
       final clipA = clip('a', transition: dissolve);


### PR DESCRIPTION
Closes #5733

## Description

Per-clip speed made the editor preview stutter on **both** platforms, and for three distinct reasons that all trace back to live-retiming the original media:

- **iOS** retimes via `AVMutableComposition.scaleTimeRange` — no frame interpolation, so slow-mo (< 1×) duplicates frames (choppy) and fast (> 1×) drops frames.
- **Android** switches `ExoPlayer.setPlaybackParameters` per clip and forces a `seekTo(index, 0)` flush at every speed-changing clip boundary to keep audio continuous — a visible stutter at each such boundary.
- Both must decode the original media at N× realtime, so high-res/bitrate clips drop frames on weaker decoders when sped up.

This fixes it the way transitions already work (`TransitionSeamRenderService`): the preview keeps playing the **instant** live-retimed clip (no wait), each non-1× clip's trimmed body is rendered to a plain normal-rate file in the background (speed baked in), and the player swaps onto that file at 1× when it lands. Once swapped there is no live retiming, no boundary flush and no N× decode — playback is smooth and identical across platforms. Volume is applied live by the player (not baked into the file), so a mute toggle never triggers a re-render.

Also switches the iOS preview `audioTimePitchAlgorithm` from `.spectral` (phase vocoder) to `.timeDomain`: the phase vocoder is a real-time CPU hog across the editor's 0.25×–3× range and stole cycles from video decode/render. `.timeDomain` still preserves pitch; the export path is unaffected.

New `ClipSpeedRenderService` mirrors `TransitionSeamRenderService` (persistent keyed cache, in-flight dedup, atomic temp→rename publish, corruption detection). `buildSeamAwarePlayerClips` gains an optional `speedRenders` param and uses the rendered file only when the clip is not consumed by an adjacent seam; otherwise it falls back to live retiming, so playback is never blocked on a render.

**Related Issue:** 

## Out of Scope

Clips that are part of a transition stay on live retiming for now — the seam already bakes their speed, and splitting a seam-consumed body against a whole-body render needs its own design. Deferred to a follow-up.

## Verification

- `flutter analyze` on all changed files — no issues.
- `flutter test` — new `clip_speed_render_service_test.dart` (8) + extended `transition_seam_render_service_test.dart` (speed-substitution cases) + `video_editor_canvas_test.dart` regression, all green.
- ⚠️ **Not device-verified yet.** The native retiming and the background-render→swap need an on-device check (Android + iOS): set a clip speed → briefly janky live preview → smooth after the render swaps in. I can't run native builds here.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)