### PR TITLE
docs(router): document route spread order invariant in app_router

### DIFF
--- a/mobile/lib/router/app_router.dart
+++ b/mobile/lib/router/app_router.dart
@@ -78,6 +78,17 @@ final goRouterProvider = Provider<GoRouter>((ref) {
     errorBuilder: (context, state) =>
         RouteErrorScreen(message: context.l10n.routeUnknownPath),
     redirect: (context, state) => appRouterRedirect(ref, state),
+    // go_router matches same-segment-count routes top-to-bottom, so spread
+    // order below is load-bearing whenever two routes share a literal first
+    // path segment. It's match-safe today because every module's
+    // parameterized routes (`:id`, `:listId`, etc.) sit under a first segment
+    // no other module uses. The one same-prefix case in this app
+    // (`/people-lists/new` vs. `/people-lists/:listId`) is contained inside
+    // `lists_routes.dart`, which orders the literal route first and is
+    // guarded by `people_lists_route_order_test.dart`. If you add a bare
+    // `/:slug`-style route or a route that shares a first segment with
+    // another module, place it deliberately and add a similar order guard —
+    // don't rely on this spread order by accident.
     routes: [
       ...videoRoutes(),
       ...shellRoutes(),


### PR DESCRIPTION
## Summary
- Follow-up to #5711 review feedback: [comment](https://github.com/divinevideo/divine-mobile/pull/5711#issuecomment-4859390580) from @NotThatKindOfDrLiz noted the module spread order in `app_router.dart` is match-safe today only because parameterized routes have distinct literal first segments, and asked for that invariant to be documented so it doesn't become silently load-bearing.
- Adds a comment above the `routes: [...]` spread in `app_router.dart` explaining the invariant, pointing at the one known same-prefix case (`/people-lists/new` vs. `/people-lists/:listId`, contained in `lists_routes.dart` and guarded by `people_lists_route_order_test.dart`), and telling future contributors to place same-prefix routes deliberately.

## Test plan
- [x] `flutter analyze lib/router/app_router.dart` — no issues
- [x] `flutter test test/router/people_lists_route_order_test.dart test/router/app_router_test.dart test/router/route_coverage_test.dart` — all pass
- [x] Pre-commit/pre-push hooks (format, analyze, changed-file tests) passed