### PR TITLE
fix(ui): tighten search icon padding in prefix-icon text fields

### DIFF
--- a/mobile/lib/screens/sounds_screen.dart
+++ b/mobile/lib/screens/sounds_screen.dart
@@ -194,9 +194,13 @@ class _SearchInput extends StatelessWidget {
         decoration: InputDecoration(
           hintText: context.l10n.soundsSearchHint,
           hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
-          prefixIcon: const DivineIcon(
-            icon: DivineIconName.search,
-            color: VineTheme.onSurfaceMuted,
+          prefixIconConstraints: const BoxConstraints(),
+          prefixIcon: const Padding(
+            padding: EdgeInsetsDirectional.only(start: 12, end: 8),
+            child: DivineIcon(
+              icon: DivineIconName.search,
+              color: VineTheme.onSurfaceMuted,
+            ),
           ),
           filled: true,
           fillColor: VineTheme.backgroundColor,

--- a/mobile/lib/widgets/find_people_sheet.dart
+++ b/mobile/lib/widgets/find_people_sheet.dart
@@ -89,9 +89,13 @@ class _FindPeopleSheetState extends ConsumerState<FindPeopleSheet> {
                 decoration: InputDecoration(
                   hintText: context.l10n.shareFindPeople,
                   hintStyle: const TextStyle(color: VineTheme.secondaryText),
-                  prefixIcon: const DivineIcon(
-                    icon: DivineIconName.search,
-                    color: VineTheme.secondaryText,
+                  prefixIconConstraints: const BoxConstraints(),
+                  prefixIcon: const Padding(
+                    padding: EdgeInsetsDirectional.only(start: 12, end: 8),
+                    child: DivineIcon(
+                      icon: DivineIconName.search,
+                      color: VineTheme.secondaryText,
+                    ),
                   ),
                   filled: true,
                   fillColor: VineTheme.containerLow,

--- a/mobile/lib/widgets/library/sounds_tab.dart
+++ b/mobile/lib/widgets/library/sounds_tab.dart
@@ -287,9 +287,13 @@ class _SearchInput extends StatelessWidget {
         decoration: InputDecoration(
           hintText: context.l10n.soundsSearchHint,
           hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
-          prefixIcon: const DivineIcon(
-            icon: DivineIconName.search,
-            color: VineTheme.onSurfaceMuted,
+          prefixIconConstraints: const BoxConstraints(),
+          prefixIcon: const Padding(
+            padding: EdgeInsetsDirectional.only(start: 12, end: 8),
+            child: DivineIcon(
+              icon: DivineIconName.search,
+              color: VineTheme.onSurfaceMuted,
+            ),
           ),
           filled: true,
           fillColor: VineTheme.surfaceContainer,

--- a/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
+++ b/mobile/lib/widgets/video_editor/audio_editor/audio_selection_bottom_sheet.dart
@@ -553,9 +553,13 @@ class _PickerSearchInput extends StatelessWidget {
         decoration: InputDecoration(
           hintText: context.l10n.soundsSearchHint,
           hintStyle: const TextStyle(color: VineTheme.onSurfaceMuted),
-          prefixIcon: const DivineIcon(
-            icon: DivineIconName.search,
-            color: VineTheme.onSurfaceMuted,
+          prefixIconConstraints: const BoxConstraints(),
+          prefixIcon: const Padding(
+            padding: EdgeInsetsDirectional.only(start: 12, end: 8),
+            child: DivineIcon(
+              icon: DivineIconName.search,
+              color: VineTheme.onSurfaceMuted,
+            ),
           ),
           filled: true,
           fillColor: VineTheme.backgroundColor,


### PR DESCRIPTION
Closes #5737

## Summary
- The main `DivineSearchBar` already overrides Flutter's default 48x48 `prefixIcon` box with tight custom padding, but 4 other search fields never got that treatment after the Material→DivineIcon migration, so their 24px search icon (matches the 24x24 Figma spec) sat loose inside the default box and read as oversized next to the field text.
- Applies the same `prefixIconConstraints: BoxConstraints()` + `Padding(start: 12, end: 8)` pattern used by `DivineSearchBar` to: `find_people_sheet.dart`, `sounds_screen.dart`, `sounds_tab.dart`, and `audio_selection_bottom_sheet.dart`.

## Test plan
- [x] `flutter analyze` on changed files — no issues
- [x] `flutter test` on the 4 corresponding widget test suites (64 tests) — all pass
- [x] `dart format` — clean