### PR TITLE
refactor(auth): port the bunker auth-url launch behind AuthUrlLauncher (#4741)

### DIFF
--- a/mobile/lib/providers/auth_providers.dart
+++ b/mobile/lib/providers/auth_providers.dart
@@ -33,6 +33,7 @@ import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:unified_logger/unified_logger.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 part 'auth_providers.g.dart';
 
@@ -136,6 +137,13 @@ AuthService authService(Ref ref) {
     profileCheckIndexerUrl: authEnv.indexerRelays.first,
     indexerRelays: authEnv.indexerRelays,
     primaryRelayUrl: authEnv.relayUrl,
+    launchAuthUrl: (uri) async {
+      // Preserves the pre-port behavior exactly: only the canLaunchUrl gate
+      // decides launchability; launchUrl's own result stays ignored.
+      if (!await canLaunchUrl(uri)) return false;
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+      return true;
+    },
     preFetchFollowing: (pubkeyHex) async {
       // Pre-fetch following list from funnelcake REST API during login
       // setup. This populates SharedPreferences BEFORE auth state is

--- a/mobile/lib/providers/auth_providers.g.dart
+++ b/mobile/lib/providers/auth_providers.g.dart
@@ -472,7 +472,7 @@ final class AuthServiceProvider
   }
 }
 
-String _$authServiceHash() => r'f92bfcd639fa7dcef969befb2fb50db08e2aba14';
+String _$authServiceHash() => r'6d7775312ba0405bc806d528cfcccf929b0fa77f';
 
 /// Provider that returns current auth state and rebuilds when it changes.
 /// Widgets should watch this instead of authService.authState directly

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -30,7 +30,6 @@ import 'package:openvine/utils/divine_login_banner_dismissal.dart';
 import 'package:openvine/utils/nostr_key_utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 export 'package:openvine/models/authentication_source.dart';
 
@@ -166,6 +165,14 @@ class UserProfile {
 /// router redirect has accurate following data before it fires synchronously.
 typedef PreFetchFollowingCallback = Future<void> Function(String pubkeyHex);
 
+/// Port for launching the NIP-46 bunker auth URL in an external browser.
+///
+/// Returns whether the URL could be launched. Wired in the app layer to
+/// url_launcher so this service carries no Flutter-plugin dependency for the
+/// launch; when unset (tests), the auth URL is logged as unlaunchable instead
+/// of hitting a platform channel.
+typedef AuthUrlLauncher = Future<bool> Function(Uri url);
+
 /// Callback invoked when NIP-65 relay discovery completes with a non-empty list.
 /// Used by NostrService to add discovered relays to the current client without
 /// blocking app startup.
@@ -213,6 +220,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     FlutterSecureStorage? flutterSecureStorage,
     OAuthConfig? oauthConfig,
     PreFetchFollowingCallback? preFetchFollowing,
+    AuthUrlLauncher? launchAuthUrl,
     String? profileCheckIndexerUrl,
     List<String>? indexerRelays,
     String? primaryRelayUrl,
@@ -227,6 +235,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
        _oauthClient = oauthClient,
        _flutterSecureStorage = flutterSecureStorage,
        _preFetchFollowing = preFetchFollowing,
+       _launchAuthUrl = launchAuthUrl,
        _profileCheckIndexerUrl = profileCheckIndexerUrl,
        _primaryRelayUrl = primaryRelayUrl ?? AppConstants.defaultRelayUrl,
        _relayDiscoveryService =
@@ -255,6 +264,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     crashReporter: _reportAuthError,
   );
   final PreFetchFollowingCallback? _preFetchFollowing;
+  final AuthUrlLauncher? _launchAuthUrl;
   final String? _profileCheckIndexerUrl;
   final RemoteSignerFactory _remoteSignerFactory;
   final Duration _startupNetworkOperationTimeout;
@@ -2166,9 +2176,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
         category: LogCategory.auth,
       );
       final uri = Uri.parse(authUrl);
-      if (await canLaunchUrl(uri)) {
-        await launchUrl(uri, mode: LaunchMode.externalApplication);
-      } else {
+      final launched = await _launchAuthUrl?.call(uri) ?? false;
+      if (!launched) {
         Log.error(
           'Could not launch auth URL: $authUrl',
           name: 'AuthService',

--- a/mobile/test/services/auth_service_bunker_auth_url_test.dart
+++ b/mobile/test/services/auth_service_bunker_auth_url_test.dart
@@ -1,0 +1,119 @@
+// ABOUTME: Tests for the AuthUrlLauncher port — the NIP-46 bunker auth_url
+// ABOUTME: callback must launch through the injected seam, never a plugin.
+
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_sdk/nostr_sdk.dart'
+    show NostrRemoteSigner, NostrRemoteSignerInfo;
+import 'package:openvine/models/known_account.dart';
+import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/user_data_cleanup_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'support/auth_service_test_harness.dart';
+
+class _MockUserDataCleanupService extends Mock
+    implements UserDataCleanupService {}
+
+/// Mock signer that stores the auth-url callback AuthService installs, so the
+/// test can fire it like the remote signer would on an `auth_url` response.
+class _MockNostrRemoteSigner extends Mock implements NostrRemoteSigner {
+  void Function(String authUrl)? capturedAuthUrlCallback;
+
+  @override
+  set onAuthUrlReceived(void Function(String authUrl)? callback) {
+    capturedAuthUrlCallback = callback;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AuthService bunker auth_url launching', () {
+    late _MockUserDataCleanupService mockCleanupService;
+    late _MockNostrRemoteSigner signer;
+
+    setUp(() {
+      mockCleanupService = _MockUserDataCleanupService();
+      stubUserDataCleanupSuccess(mockCleanupService);
+      AuthServiceChannelMocks.install();
+      SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+      signer = _MockNostrRemoteSigner();
+    });
+
+    tearDown(AuthServiceChannelMocks.remove);
+
+    /// Connects a bunker through [signer] so AuthService installs its
+    /// auth-url callback on it. Returns the connected service.
+    Future<AuthService> connectBunker({AuthUrlLauncher? launchAuthUrl}) async {
+      final url =
+          'bunker://${freshPubkeyHex()}'
+          '?relay=wss%3A%2F%2Frelay.example.com&secret=testsecret';
+      when(
+        () => signer.info,
+      ).thenReturn(NostrRemoteSignerInfo.parseBunkerUrl(url));
+      when(() => signer.connect()).thenAnswer((_) async => 'ack');
+      when(() => signer.pullPubkey()).thenAnswer((_) async => freshPubkeyHex());
+
+      final authService = buildTestAuthService(
+        cleanupService: mockCleanupService,
+        remoteSignerFactory: (_, _) => signer,
+        launchAuthUrl: launchAuthUrl,
+      );
+      addTearDown(authService.dispose);
+
+      final result = await ignoringDiscoveryErrors(
+        () => authService.connectWithBunker(url),
+      );
+      expect(result.success, isTrue);
+      expect(signer.capturedAuthUrlCallback, isNotNull);
+      return authService;
+    }
+
+    test('launches the auth URL through the injected port', () async {
+      final launchedUris = <Uri>[];
+      final launched = Completer<void>();
+      await connectBunker(
+        launchAuthUrl: (uri) async {
+          launchedUris.add(uri);
+          launched.complete();
+          return true;
+        },
+      );
+
+      signer.capturedAuthUrlCallback!('https://bunker.example/authorize?x=1');
+      await launched.future;
+
+      expect(
+        launchedUris,
+        equals([Uri.parse('https://bunker.example/authorize?x=1')]),
+      );
+    });
+
+    test('does not throw when the launcher reports failure', () async {
+      final launcherCalled = Completer<void>();
+      await connectBunker(
+        launchAuthUrl: (uri) async {
+          launcherCalled.complete();
+          return false;
+        },
+      );
+
+      signer.capturedAuthUrlCallback!('https://bunker.example/denied');
+      await launcherCalled.future;
+      // Flush the callback's remaining microtasks (the Log.error branch).
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    test('does not throw when no launcher is wired', () async {
+      await connectBunker();
+
+      signer.capturedAuthUrlCallback!('https://bunker.example/unwired');
+      // Flush the callback's async body — must complete without a platform
+      // channel throw (the pre-port code hit url_launcher here).
+      await Future<void>.delayed(Duration.zero);
+    });
+  });
+}

--- a/mobile/test/services/support/auth_service_test_harness.dart
+++ b/mobile/test/services/support/auth_service_test_harness.dart
@@ -136,6 +136,7 @@ void stubUserDataCleanupSuccess(UserDataCleanupService cleanupService) {
 AuthService buildTestAuthService({
   required UserDataCleanupService cleanupService,
   RemoteSignerFactory? remoteSignerFactory,
+  AuthUrlLauncher? launchAuthUrl,
 }) {
   return AuthService(
     userDataCleanupService: cleanupService,
@@ -144,6 +145,7 @@ AuthService buildTestAuthService({
     ),
     flutterSecureStorage: const FlutterSecureStorage(),
     remoteSignerFactory: remoteSignerFactory,
+    launchAuthUrl: launchAuthUrl,
   );
 }
 


### PR DESCRIPTION
## What & why

Small #4741 slice, disjoint from #5739 (parallel, not stacked): AuthService's **only** url_launcher use — the NIP-46 bunker `auth_url` callback — moves behind an injected `AuthUrlLauncher` port, and the `url_launcher` import leaves `auth_service.dart`. That was the last Flutter-**plugin** dependency in the file blocking the future `packages/auth_repository` move.

## Changes

- `typedef AuthUrlLauncher = Future<bool> Function(Uri url)` in `auth_service.dart`, next to the existing `PreFetchFollowingCallback` precedent; nullable ctor param + field.
- `_setupBunkerAuthCallback` swaps the inline `canLaunchUrl`/`launchUrl` pair for `_launchAuthUrl?.call(uri)`; the not-launched log path is unchanged.
- Wiring closure in `auth_providers.dart` **preserves the pre-port behavior exactly**: only the `canLaunchUrl` gate decides launchability; `launchUrl`'s own bool stays ignored (as today). When no launcher is injected (tests), the callback logs the URL as unlaunchable instead of hitting an unmocked platform channel.
- `auth_providers.g.dart` regenerated (provider hash).

## Tests

First coverage for the auth-url path — it had none because the plugin call was unmockable. New `auth_service_bunker_auth_url_test.dart` (3 tests) drives `connectWithBunker` through the `remoteSignerFactory` seam with a signer fake that captures the installed callback, then fires it like a real `auth_url` response:
- launches through the port with the parsed `Uri`
- launcher-reports-failure → logs, no throw
- no launcher wired → no throw (pre-port this path threw `MissingPluginException` in tests)

`buildTestAuthService` harness gained the optional `launchAuthUrl` param.

## Verification

- `flutter analyze lib test integration_test` — no issues
- Full `auth_service_*` suite: **219 tests pass** (216 + 3 new)
- Pre-commit + pre-push hooks green (format, analyze, generated files, tests)

Note: overlaps #5739 only in the auth_service.dart import block + ctor region — whichever merges second needs a trivial rebase (same class of overlap as #5716/#5717).

No user-facing change. Part of #4741 (epic #4338 W2).