### PR TITLE
feat(minor-safety): protected-minor adult-content lock (mobile) (#175)

### DIFF
--- a/docs/superpowers/plans/2026-07-01-protected-minor-content-lock.md
+++ b/docs/superpowers/plans/2026-07-01-protected-minor-content-lock.md
@@ -1,0 +1,543 @@
+# Protected-minor adult-content lock (mobile) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Lock adult content off for protected minors and remove the self-attestation bypass, driven by a persisted, fail-safe protected-minor signal, through the single `AgeVerificationService.isAdultContentVerified` choke point.
+
+**Architecture:** A new `ProtectedMinorStickyStore` persists last-known protected status per account and backs the shared `isProtectedMinorProvider` seam with the decided fail-safe machine (sticky, lifts only on a positive not-a-minor signal). `AgeVerificationService` consults that signal and forces adult content off + blocks the self-attestation path, which cascades to every consumer. Safety Settings shows the adult toggle disabled for protected minors.
+
+**Tech Stack:** Flutter, Riverpod (plain providers — no codegen change), flutter_bloc, SharedPreferences, mocktail, flutter_test.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-01-protected-minor-content-lock-design.md`.
+- Fail-safe posture (verbatim from #175): once confirmed a protected minor, treat as protected at cold start and offline; lift only on a positive not-a-minor signal (`ProtectedMinorStatusKind.notProtected`); never weaken for a keycast fetch error/unknown; never guess "minor" for an unconfirmed account.
+- Mobile only (web parity is #453).
+- Tests run from `~/code/divine-mobile/mobile`: `flutter test test/<path>`.
+- No riverpod codegen change (new provider is a plain `Provider`), so no `build_runner`. Task 3 adds one l10n string, requiring `flutter gen-l10n` and committing generated files.
+- Existing behavior for non-protected accounts must be unchanged (the `isProtectedMinor` callback defaults to `() => false`).
+
+---
+
+### Task 1: `ProtectedMinorStickyStore` + seam wiring (the fail-safe)
+
+**Files:**
+- Create: `mobile/lib/services/protected_minor_sticky_store.dart`
+- Modify: `mobile/lib/providers/protected_minor_providers.dart` (add store provider; upgrade `isProtectedMinorProvider` to be sticky-backed)
+- Test: `mobile/test/services/protected_minor_sticky_store_test.dart`
+
+**Interfaces:**
+- Produces: `ProtectedMinorStickyStore({required SharedPreferences prefs})` with `bool isProtectedMinorFor(String? pubkey)` and `Future<void> applyLiveStatus(String? pubkey, ProtectedMinorStatus status)`; `protectedMinorStickyStoreProvider` (Provider); upgraded `isProtectedMinorProvider` (Provider<bool>).
+- Consumes: `ProtectedMinorStatus` / `ProtectedMinorStatusKind` (`models/protected_minor_status.dart`), `sharedPreferencesProvider`, `protectedMinorStatusProvider`, `currentAuthStateProvider`, `authServiceProvider`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mobile/test/services/protected_minor_sticky_store_test.dart`:
+
+```dart
+// ABOUTME: Unit tests for ProtectedMinorStickyStore — the persisted fail-safe
+// ABOUTME: state machine backing the protected-minor seam (#175).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/protected_minor_status.dart';
+import 'package:openvine/services/protected_minor_sticky_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  const pubkey = 'a' * 64;
+  const otherPubkey = 'b' * 64;
+
+  late SharedPreferences prefs;
+  late ProtectedMinorStickyStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    store = ProtectedMinorStickyStore(prefs: prefs);
+  });
+
+  test('unconfirmed account is not protected', () {
+    expect(store.isProtectedMinorFor(pubkey), false);
+    expect(store.isProtectedMinorFor(null), false);
+  });
+
+  test('confirmed protected persists true', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    expect(store.isProtectedMinorFor(pubkey), true);
+  });
+
+  test('confirmed not-protected lifts to false (positive signal)', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.notProtected());
+    expect(store.isProtectedMinorFor(pubkey), false);
+  });
+
+  test('unknown status retains last-known (sticky, never weakens)', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.unknown());
+    expect(store.isProtectedMinorFor(pubkey), true);
+  });
+
+  test('is per-account', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    expect(store.isProtectedMinorFor(otherPubkey), false);
+  });
+
+  test('null pubkey never persists', () async {
+    await store.applyLiveStatus(null, ProtectedMinorStatus.protected());
+    expect(store.isProtectedMinorFor(null), false);
+  });
+
+  test('persists across instances (cold-start read)', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    final fresh = ProtectedMinorStickyStore(prefs: prefs);
+    expect(fresh.isProtectedMinorFor(pubkey), true);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/code/divine-mobile/mobile && flutter test test/services/protected_minor_sticky_store_test.dart`
+Expected: FAIL to compile — `protected_minor_sticky_store.dart` does not exist.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `mobile/lib/services/protected_minor_sticky_store.dart`:
+
+```dart
+// ABOUTME: Persists last-known protected-minor status per account and applies
+// ABOUTME: the #175 fail-safe machine (sticky; lifts only on a positive signal).
+
+import 'package:openvine/models/protected_minor_status.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Durable, per-account last-known protected-minor state.
+///
+/// Reads/writes a synchronous [SharedPreferences] snapshot so the value is
+/// valid at cold start (local, no network). The fail-safe machine only ever
+/// lifts protection on a confirmed not-a-minor signal; unknown/error is sticky.
+class ProtectedMinorStickyStore {
+  ProtectedMinorStickyStore({required SharedPreferences prefs}) : _prefs = prefs;
+
+  final SharedPreferences _prefs;
+
+  static String _key(String pubkey) => 'protected_minor_sticky_$pubkey';
+
+  /// Last-known protected status for [pubkey]. Null/unconfirmed -> false.
+  bool isProtectedMinorFor(String? pubkey) =>
+      pubkey != null && (_prefs.getBool(_key(pubkey)) ?? false);
+
+  /// Apply a live keycast status: confirmed protected -> persist true;
+  /// confirmed not-protected -> persist false; unknown -> retain.
+  Future<void> applyLiveStatus(
+    String? pubkey,
+    ProtectedMinorStatus status,
+  ) async {
+    if (pubkey == null) return;
+    switch (status.kind) {
+      case ProtectedMinorStatusKind.protected:
+        await _prefs.setBool(_key(pubkey), true);
+      case ProtectedMinorStatusKind.notProtected:
+        await _prefs.setBool(_key(pubkey), false);
+      case ProtectedMinorStatusKind.unknown:
+        break;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/code/divine-mobile/mobile && flutter test test/services/protected_minor_sticky_store_test.dart`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Wire the store into the seam**
+
+In `mobile/lib/providers/protected_minor_providers.dart`, add imports for `sharedPreferencesProvider` (already imported), `auth_providers.dart` (already imported), the store, and `protected_minor_status.dart` (already imported). Add the store provider and replace `isProtectedMinorProvider`:
+
+```dart
+/// Persisted last-known protected-minor state (fail-safe backing, #175).
+final protectedMinorStickyStoreProvider = Provider<ProtectedMinorStickyStore>((
+  ref,
+) {
+  return ProtectedMinorStickyStore(prefs: ref.watch(sharedPreferencesProvider));
+});
+```
+
+Replace the existing `isProtectedMinorProvider` body with the sticky-backed, race-free version:
+
+```dart
+/// Effective protected-minor seam for the protections (#175/#176), fail-safe.
+///
+/// Effective value is the live status when known, else the persisted
+/// last-known (sticky). A live status is also persisted for the next cold
+/// start. Unknown/error never weakens protection.
+final isProtectedMinorProvider = Provider<bool>((ref) {
+  ref.watch(currentAuthStateProvider); // reactivity on account changes
+  final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
+  final store = ref.watch(protectedMinorStickyStoreProvider);
+  final live = ref.watch(protectedMinorStatusProvider).value;
+
+  if (live != null) {
+    // Persist for future cold starts (fire-and-forget).
+    store.applyLiveStatus(pubkey, live);
+    if (live.kind == ProtectedMinorStatusKind.protected) return true;
+    if (live.kind == ProtectedMinorStatusKind.notProtected) return false;
+  }
+  // Unknown / no live result yet -> last-known persisted value (sticky).
+  return store.isProtectedMinorFor(pubkey);
+});
+```
+
+Add the import at the top of the file: `import 'package:openvine/services/protected_minor_sticky_store.dart';`
+
+- [ ] **Step 6: Verify the provider file compiles + existing seam tests pass**
+
+Run: `cd ~/code/divine-mobile/mobile && flutter test test/providers/protected_minor_providers_test.dart`
+Expected: PASS (existing tests still green; the seam now sticky-backed). If an existing test asserted `isProtectedMinorProvider` on a bare fake without `sharedPreferencesProvider`/`authServiceProvider` overrides, add `sharedPreferencesProvider.overrideWithValue(await SharedPreferences.getInstance())` (with `SharedPreferences.setMockInitialValues({})`) to that test's `ProviderContainer` overrides.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/code/divine-mobile
+git add mobile/lib/services/protected_minor_sticky_store.dart mobile/test/services/protected_minor_sticky_store_test.dart mobile/lib/providers/protected_minor_providers.dart
+git commit -m "feat(minor-safety): persisted fail-safe protected-minor sticky store backing the seam (#175)"
+```
+
+---
+
+### Task 2: `AgeVerificationService` choke point
+
+**Files:**
+- Modify: `mobile/lib/services/age_verification_service.dart`
+- Modify: `mobile/lib/providers/moderation_providers.dart` (wire the callback in `ageVerificationService`)
+- Test: `mobile/test/services/age_verification_protected_minor_test.dart`
+
+**Interfaces:**
+- Consumes: `isProtectedMinorProvider` (Task 1).
+- Produces: `AgeVerificationService({bool Function()? isProtectedMinor})` where `isAdultContentVerified`, `verifyAdultContentAccess`, `setAdultContentVerified` respect the protected-minor signal.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mobile/test/services/age_verification_protected_minor_test.dart`:
+
+```dart
+// ABOUTME: Verifies the protected-minor lock on AgeVerificationService — the
+// ABOUTME: single choke point that forces adult content off for #175.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/age_verification_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test('isAdultContentVerified is false for a protected minor even if stored true', () async {
+    final service = AgeVerificationService(isProtectedMinor: () => true);
+    await service.initialize();
+    await service.setAdultContentVerified(true); // must be rejected below
+    expect(service.isAdultContentVerified, false);
+  });
+
+  test('setAdultContentVerified(true) is rejected for a protected minor', () async {
+    var protected = true;
+    final service = AgeVerificationService(isProtectedMinor: () => protected);
+    await service.initialize();
+    await service.setAdultContentVerified(true);
+    // Even after lifting the protection, nothing was persisted as true.
+    protected = false;
+    expect(service.isAdultContentVerified, false);
+  });
+
+  test('non-protected account behaves normally', () async {
+    final service = AgeVerificationService(isProtectedMinor: () => false);
+    await service.initialize();
+    await service.setAdultContentVerified(true);
+    expect(service.isAdultContentVerified, true);
+  });
+
+  test('defaults to not-protected when no callback supplied', () async {
+    final service = AgeVerificationService();
+    await service.initialize();
+    await service.setAdultContentVerified(true);
+    expect(service.isAdultContentVerified, true);
+  });
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/code/divine-mobile/mobile && flutter test test/services/age_verification_protected_minor_test.dart`
+Expected: FAIL — the `isProtectedMinor` named param does not exist / lock not enforced.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+In `mobile/lib/services/age_verification_service.dart`, add the constructor + field and guard the three members. Change the class opening from `class AgeVerificationService {` and the first fields to:
+
+```dart
+class AgeVerificationService {
+  AgeVerificationService({bool Function()? isProtectedMinor})
+    : _isProtectedMinor = isProtectedMinor ?? _notProtected;
+
+  static bool _notProtected() => false;
+
+  final bool Function() _isProtectedMinor;
+```
+
+Change the getter:
+
+```dart
+  bool get isAdultContentVerified =>
+      !_isProtectedMinor() && (_isAdultContentVerified ?? false);
+```
+
+At the top of `verifyAdultContentAccess`, before `checkAdultContentVerification`:
+
+```dart
+  Future<bool> verifyAdultContentAccess(BuildContext context) async {
+    // Protected minors can never unlock adult content; no dialog.
+    if (_isProtectedMinor()) return false;
+    // First check if already verified
+    if (await checkAdultContentVerification()) {
+```
+
+At the top of `setAdultContentVerified`:
+
+```dart
+  Future<void> setAdultContentVerified(bool verified) async {
+    if (verified && _isProtectedMinor()) {
+      Log.warning(
+        'Blocked adult-content verification for a protected minor',
+        name: 'AgeVerificationService',
+        category: LogCategory.system,
+      );
+      return;
+    }
+    try {
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd ~/code/divine-mobile/mobile && flutter test test/services/age_verification_protected_minor_test.dart test/services/age_verification_service_test.dart`
+Expected: PASS (new file + existing age_verification tests still green).
+
+- [ ] **Step 5: Wire the callback in the provider**
+
+In `mobile/lib/providers/moderation_providers.dart`, change the `ageVerificationService` provider body:
+
+```dart
+AgeVerificationService ageVerificationService(Ref ref) {
+  final service = AgeVerificationService(
+    isProtectedMinor: () => ref.read(isProtectedMinorProvider),
+  );
+  service.initialize(); // Initialize asynchronously
+  return service;
+}
+```
+
+Add the import at the top of `moderation_providers.dart`: `import 'package:openvine/providers/protected_minor_providers.dart';` (only if not already present). This is a body change to a codegen provider — no `build_runner` needed (signature unchanged).
+
+- [ ] **Step 6: Verify the wider content-filter path still compiles + passes**
+
+Run: `cd ~/code/divine-mobile/mobile && flutter test test/services/content_filter_service_test.dart`
+Expected: PASS (ContentFilterService reads the getter; unaffected for non-protected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/code/divine-mobile
+git add mobile/lib/services/age_verification_service.dart mobile/lib/providers/moderation_providers.dart mobile/test/services/age_verification_protected_minor_test.dart
+git commit -m "feat(minor-safety): force adult content off + block self-attestation for protected minors (#175)"
+```
+
+---
+
+### Task 3: Safety Settings locked affordance
+
+**Files:**
+- Modify: `mobile/lib/blocs/safety_settings/safety_settings_state.dart` (add `isAdultContentLocked`)
+- Modify: `mobile/lib/blocs/safety_settings/safety_settings_cubit.dart` (constructor param + load + guard)
+- Modify: `mobile/lib/screens/safety_settings_screen.dart` (compute lock, pass to cubit, disable tile)
+- Modify: `mobile/lib/l10n/app_en.arb` (one string) then run `flutter gen-l10n`
+- Test: `mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart` (extend)
+
+**Interfaces:**
+- Consumes: `isProtectedMinorProvider` (Task 1).
+- Produces: `SafetySettingsState.isAdultContentLocked`; `SafetySettingsCubit(... , bool isAdultContentLocked = false)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart` (inside `main()`'s group; the `setUp` already stubs the 7 services — construct the cubit with the new named arg). Add these tests:
+
+```dart
+    blocTest<SafetySettingsCubit, SafetySettingsState>(
+      'load() surfaces isAdultContentLocked for a protected minor',
+      build: () => SafetySettingsCubit(
+        ageVerificationService: ageService,
+        contentFilterService: filterService,
+        videoEventService: videoEventService,
+        divineHostFilterService: divineHostFilterService,
+        moderationLabelService: moderationLabelService,
+        followRepository: followRepository,
+        contentBlocklistRepository: blocklistRepository,
+        isAdultContentLocked: true,
+      ),
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        isA<SafetySettingsState>().having(
+          (s) => s.status,
+          'status',
+          SafetySettingsStatus.loading,
+        ),
+        isA<SafetySettingsState>()
+            .having((s) => s.status, 'status', SafetySettingsStatus.ready)
+            .having((s) => s.isAdultContentLocked, 'locked', true),
+      ],
+    );
+
+    blocTest<SafetySettingsCubit, SafetySettingsState>(
+      'setAgeVerified is a no-op when adult content is locked',
+      build: () => SafetySettingsCubit(
+        ageVerificationService: ageService,
+        contentFilterService: filterService,
+        videoEventService: videoEventService,
+        divineHostFilterService: divineHostFilterService,
+        moderationLabelService: moderationLabelService,
+        followRepository: followRepository,
+        contentBlocklistRepository: blocklistRepository,
+        isAdultContentLocked: true,
+      ),
+      act: (cubit) => cubit.setAgeVerified(true),
+      verify: (_) {
+        verifyNever(() => ageService.setAdultContentVerified(true));
+      },
+    );
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd ~/code/divine-mobile/mobile && flutter test test/blocs/safety_settings/safety_settings_cubit_test.dart`
+Expected: FAIL — `isAdultContentLocked` named arg and state field do not exist.
+
+- [ ] **Step 3: Add the state field**
+
+In `mobile/lib/blocs/safety_settings/safety_settings_state.dart`, add `this.isAdultContentLocked = false` to the constructor, `final bool isAdultContentLocked;`, the `copyWith` param + assignment, and add it to `props`. Full field additions:
+
+Constructor param line (after `this.isAgeVerified = false,`): `this.isAdultContentLocked = false,`
+Field (after `final bool isAgeVerified;`): `final bool isAdultContentLocked;`
+copyWith param (after `bool? isAgeVerified,`): `bool? isAdultContentLocked,`
+copyWith body (after `isAgeVerified: isAgeVerified ?? this.isAgeVerified,`): `isAdultContentLocked: isAdultContentLocked ?? this.isAdultContentLocked,`
+props (after `isAgeVerified,`): `isAdultContentLocked,`
+
+- [ ] **Step 4: Add the cubit param + guard**
+
+In `mobile/lib/blocs/safety_settings/safety_settings_cubit.dart`:
+
+Add constructor named param (after `required ContentBlocklistRepository contentBlocklistRepository,`): `bool isAdultContentLocked = false,`
+Add to initializer list (after `_contentBlocklistRepository = contentBlocklistRepository,`): `_isAdultContentLocked = isAdultContentLocked,`
+Add field (with the other finals): `final bool _isAdultContentLocked;`
+
+In `load()`, add `isAdultContentLocked: _isAdultContentLocked,` to the ready-state `copyWith`.
+
+In `setAgeVerified`, guard at the top:
+
+```dart
+  Future<void> setAgeVerified(bool value) async {
+    if (_isAdultContentLocked) return; // protected minors cannot toggle
+    await _ageVerificationService.setAdultContentVerified(value);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd ~/code/divine-mobile/mobile && flutter test test/blocs/safety_settings/safety_settings_cubit_test.dart`
+Expected: PASS (new + existing cubit tests green).
+
+- [ ] **Step 6: Add the l10n string + wire the screen**
+
+In `mobile/lib/l10n/app_en.arb`, after the `safetySettingsAgeRequired` entry add:
+
+```json
+  "safetySettingsAgeLockedForMinor": "Locked for your account",
+  "@safetySettingsAgeLockedForMinor": {
+    "description": "Subtitle shown on the disabled adult-content toggle for protected minors"
+  },
+```
+
+Run: `cd ~/code/divine-mobile/mobile && flutter gen-l10n`
+
+In `mobile/lib/screens/safety_settings_screen.dart`:
+- In `build`, add: `final isAdultContentLocked = ref.watch(isProtectedMinorProvider);` (import `protected_minor_providers.dart` if needed).
+- Pass `isAdultContentLocked: isAdultContentLocked,` to the `SafetySettingsCubit(...)` create call, and add `isAdultContentLocked` to the `ValueKey((...))` tuple so the cubit reloads if it flips.
+- Change `_AgeVerificationTile` to read the lock and disable:
+
+```dart
+class _AgeVerificationTile extends StatelessWidget {
+  const _AgeVerificationTile();
+
+  @override
+  Widget build(BuildContext context) {
+    final isAgeVerified = context.select(
+      (SafetySettingsCubit cubit) => cubit.state.isAgeVerified,
+    );
+    final isLocked = context.select(
+      (SafetySettingsCubit cubit) => cubit.state.isAdultContentLocked,
+    );
+    return CheckboxListTile(
+      value: isLocked ? false : isAgeVerified,
+      onChanged: isLocked
+          ? null
+          : (value) {
+              if (value != null) {
+                context.read<SafetySettingsCubit>().setAgeVerified(value);
+              }
+            },
+      title: Text(
+        context.l10n.safetySettingsAgeConfirmation,
+        style: const TextStyle(color: VineTheme.whiteText),
+      ),
+      subtitle: Text(
+        isLocked
+            ? context.l10n.safetySettingsAgeLockedForMinor
+            : context.l10n.safetySettingsAgeRequired,
+        style: const TextStyle(color: VineTheme.secondaryText),
+      ),
+      activeColor: VineTheme.vineGreen,
+      checkColor: VineTheme.backgroundColor,
+      controlAffinity: ListTileControlAffinity.leading,
+    );
+  }
+}
+```
+
+- [ ] **Step 7: Widget test for the disabled tile**
+
+Add to `mobile/test/screens/safety_settings_screen_test.dart` a focused test that pumps the screen (or `SafetySettingsView`) with a `SafetySettingsCubit` whose state has `isAdultContentLocked: true`, and asserts the adult `CheckboxListTile` has `onChanged == null` (disabled) and shows the locked subtitle. Follow the existing test-harness pattern in that file for providing the cubit/state. Expected: PASS.
+
+- [ ] **Step 8: Run the touched suites + analyzer**
+
+Run:
+```
+cd ~/code/divine-mobile/mobile
+flutter analyze lib/services/protected_minor_sticky_store.dart lib/services/age_verification_service.dart lib/blocs/safety_settings lib/screens/safety_settings_screen.dart lib/providers/protected_minor_providers.dart lib/providers/moderation_providers.dart
+flutter test test/services/protected_minor_sticky_store_test.dart test/services/age_verification_protected_minor_test.dart test/services/age_verification_service_test.dart test/services/content_filter_service_test.dart test/blocs/safety_settings/safety_settings_cubit_test.dart test/screens/safety_settings_screen_test.dart
+```
+Expected: analyzer clean; all tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd ~/code/divine-mobile
+git add mobile/lib/blocs/safety_settings mobile/lib/screens/safety_settings_screen.dart mobile/lib/l10n mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart mobile/test/screens/safety_settings_screen_test.dart
+git commit -m "feat(minor-safety): disable the adult-content toggle for protected minors (#175)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Unit 1 sticky store + seam (Task 1) ✔; Unit 2 choke point on `isAdultContentVerified` + `verifyAdultContentAccess` + `setAdultContentVerified` (Task 2) ✔; Unit 3 disabled toggle + cubit guard (Task 3) ✔; fail-safe machine (protected→persist, notProtected→lift, unknown→retain, per-account, cold-start) tested in Task 1 ✔; non-protected unchanged (default `() => false`) tested in Task 2 ✔. Scope mobile-only ✔.
+
+**Placeholder scan:** none — every code step carries real code. Task 3 Step 7 references the existing screen-test harness rather than inventing one; that's a deliberate "follow the file's pattern" instruction, not a placeholder for logic.
+
+**Type consistency:** `ProtectedMinorStickyStore({required SharedPreferences prefs})`, `isProtectedMinorFor(String?)`, `applyLiveStatus(String?, ProtectedMinorStatus)`, `AgeVerificationService({bool Function()? isProtectedMinor})`, `SafetySettingsState.isAdultContentLocked`, `SafetySettingsCubit(..., bool isAdultContentLocked = false)`, `isProtectedMinorProvider` (Provider<bool>) — all consistent across tasks and match the real APIs verified in the codebase (`ProtectedMinorStatusKind`, `currentAuthStateProvider`, `authServiceProvider.currentPublicKeyHex`, `sharedPreferencesProvider`).

--- a/docs/superpowers/specs/2026-07-01-protected-minor-content-lock-design.md
+++ b/docs/superpowers/specs/2026-07-01-protected-minor-content-lock-design.md
@@ -1,0 +1,73 @@
+# Protected-minor adult-content lock (mobile) — design
+
+**Issue:** divinevideo/support-trust-safety#175 (part of the protected-minor epic #173; consumes the #174 seam, merged as divine-mobile#5708)
+**Date:** 2026-07-01
+**Status:** design approved, ready for implementation plan
+
+## Problem
+
+For a protected minor (an approved 13-15 account), adult content must be locked off and the minor must be unable to turn it on. Today the lock exists but is trivially bypassable: `ContentFilterService` keeps adult categories at `hide` only while `AgeVerificationService.isAdultContentVerified` is false, and any user flips that true by tapping "Are you 18+?" in the self-attestation dialog (`verifyAdultContentAccess`). A teen just taps yes.
+
+This drives the lock from the protected-minor state instead, and removes the self-attestation escape for flagged minors.
+
+## Key insight: one choke point
+
+Every adult-content decision funnels through a single getter, `AgeVerificationService.isAdultContentVerified`:
+- `ContentFilterService.getPreference` / `setPreference` — settings lock
+- `media_auth_interceptor` — playback gate (and it triggers the self-attestation dialog)
+- `safety_settings_cubit` — the settings toggle
+- `individual_video_providers`, `pooled_age_restricted_retry` — playback retry paths
+
+Making that one getter protected-minor-aware locks all paths at once. (Approved: single-getter choke point.)
+
+## Design
+
+Three units.
+
+### Unit 1 — Sticky protected-minor state (the decided fail-safe)
+
+The #174 seam (`protectedMinorStatusProvider` / `isProtectedMinorProvider`) is async and evaluates to `false` at cold start until a network read resolves. #175's decided fail-safe requires an account, once confirmed a protected minor, to be treated as protected immediately at cold start and offline, lifting only on a positive "no longer a minor" signal.
+
+New `ProtectedMinorStickyStore` (service, `mobile/lib/services/protected_minor_sticky_store.dart`):
+- Persists last-known protected status **per account** in `SharedPreferences`, key `protected_minor_sticky_<pubkey>`.
+- `bool get isProtectedMinor` — synchronous, backed by an in-memory value loaded at init (local read only, no network), so it is valid at cold start.
+- `Future<void> loadForAccount(String? pubkey)` — loads the persisted value for the current account into memory (call on init and on account switch). Null/unknown pubkey → `false`.
+- `Future<void> applyLiveStatus(ProtectedMinorStatus status)` — the fail-safe state machine, keyed off `ProtectedMinorStatusKind`:
+  - `kind == protected` → persist + cache `true`.
+  - `kind == notProtected` (the only confirmed not-a-minor response; `isKnown && !isProtectedMinor`) → persist + cache `false` (the age-up / revocation lift).
+  - `kind == unknown` (fetch failed/unavailable) → **no change** (sticky; retain last-known).
+
+Wiring: `protectedMinorStickyStoreProvider` (keepAlive). A sync provider/listener watches `protectedMinorStatusProvider` (the #174 live fetch) and the current pubkey, and pushes resolved statuses into `applyLiveStatus`. This reuses #174's fetch rather than duplicating it.
+
+The shared seam `isProtectedMinorProvider` is upgraded to read the sticky store, so the fail-safe posture backs the seam itself (benefiting #176 later too). This supersedes #174's detection-only "fail open on error" note, exactly as the #175 issue states.
+
+We do not special-case keycast downtime: a keycast outage never weakens protection, and we never guess "minor" for an account we have not confirmed (an account never once confirmed simply stays unprotected).
+
+### Unit 2 — The choke point (`AgeVerificationService`)
+
+`AgeVerificationService` gains an injected `bool Function() isProtectedMinor` (named param, defaults to `() => false` so existing constructor calls and tests are unaffected):
+- `isAdultContentVerified` → returns `false` when `isProtectedMinor()`, regardless of the stored self-attestation bool.
+- `verifyAdultContentAccess(context)` → returns `false` immediately when `isProtectedMinor()`, without showing the dialog.
+- `setAdultContentVerified(value)` → when `value == true && isProtectedMinor()`, reject (log + return without persisting). Setting `false` is always allowed (more restrictive).
+
+Wired in `moderation_providers.dart`: `AgeVerificationService(isProtectedMinor: () => ref.read(protectedMinorStickyStoreProvider).isProtectedMinor)`. Because `ContentFilterService`, `media_auth_interceptor`, and the cubits all consult this getter, they inherit the lock with no changes.
+
+### Unit 3 — Settings affordance (`safety_settings`)
+
+`SafetySettingsState` gains `isAdultContentLocked` (bool). `SafetySettingsCubit.load()` sets it from the sticky store; `setAgeVerified` is a guarded no-op when locked (defense in depth; the service already blocks). `safety_settings_screen` renders the adult-content toggle **visible but disabled**, with a short explanation line ("Locked for your account") so the minor sees the protection exists rather than a silently dead toggle. (Approved UX.)
+
+## Scope
+
+Mobile only. Web (#453) is a separate stub, blocked on web#456 merging. This PR is the divine-mobile describing task for #175.
+
+## Testing
+
+- **Sticky store (unit):** persist-true on confirmed-protected; lift-to-false on confirmed-not-protected; retain on unknown/error; per-pubkey isolation; sync `isProtectedMinor` reflects the persisted value after `loadForAccount` (cold-start behavior).
+- **AgeVerificationService (unit):** `isAdultContentVerified` false when protected even with the stored bool true; `verifyAdultContentAccess` returns false and shows no dialog when protected; `setAdultContentVerified(true)` rejected when protected; all three behave normally when not protected.
+- **ContentFilterService (unit/integration):** adult categories resolve to `hide` and `setPreference` to non-hide is rejected when protected (through the overridden getter).
+- **SafetySettingsCubit (unit):** `state.isAdultContentLocked` true when protected; `setAgeVerified(true)` is a no-op when locked.
+- **Widget (light):** the adult-content toggle renders disabled when locked. (One focused widget test; UI-render coverage kept minimal per testing philosophy.)
+
+## Acceptance
+
+A protected-minor account cannot view adult content (categories forced `hide`, playback gate closed) and cannot enable the adult-content toggle (the self-attestation bypass is unavailable), including at cold start and offline once the account has been confirmed a protected minor.

--- a/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_cubit.dart
@@ -39,7 +39,9 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
     required ModerationLabelService moderationLabelService,
     required FollowRepository followRepository,
     required ContentBlocklistRepository contentBlocklistRepository,
-  }) : _ageVerificationService = ageVerificationService,
+    bool isAdultContentLocked = false,
+  }) : _isAdultContentLocked = isAdultContentLocked,
+       _ageVerificationService = ageVerificationService,
        _contentFilterService = contentFilterService,
        _videoEventService = videoEventService,
        _divineHostFilterService = divineHostFilterService,
@@ -55,6 +57,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
   final ModerationLabelService _moderationLabelService;
   final FollowRepository _followRepository;
   final ContentBlocklistRepository _contentBlocklistRepository;
+  final bool _isAdultContentLocked;
 
   StreamSubscription<ContentPolicyState>? _blocklistSub;
 
@@ -68,6 +71,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
       state.copyWith(
         status: SafetySettingsStatus.ready,
         isAgeVerified: _ageVerificationService.isAdultContentVerified,
+        isAdultContentLocked: _isAdultContentLocked,
         isPeopleIFollowEnabled:
             _moderationLabelService.isFollowingModerationEnabled,
         showDivineHostedOnly: _divineHostFilterService.showDivineHostedOnly,
@@ -91,6 +95,7 @@ class SafetySettingsCubit extends Cubit<SafetySettingsState> {
   /// On un-confirm: persist + lock adult categories + filter the existing
   /// feed (kept to mirror `_setAgeVerified` pre-migration behavior).
   Future<void> setAgeVerified(bool value) async {
+    if (_isAdultContentLocked) return; // protected minors cannot toggle
     await _ageVerificationService.setAdultContentVerified(value);
     if (value) {
       await _contentFilterService.unlockAdultCategories();

--- a/mobile/lib/blocs/safety_settings/safety_settings_state.dart
+++ b/mobile/lib/blocs/safety_settings/safety_settings_state.dart
@@ -20,6 +20,7 @@ class SafetySettingsState extends Equatable {
   const SafetySettingsState({
     this.status = SafetySettingsStatus.loading,
     this.isAgeVerified = false,
+    this.isAdultContentLocked = false,
     this.isPeopleIFollowEnabled = false,
     this.showDivineHostedOnly = true,
     this.customLabelers = const <String>{},
@@ -28,6 +29,10 @@ class SafetySettingsState extends Equatable {
 
   final SafetySettingsStatus status;
   final bool isAgeVerified;
+
+  /// True when the account is a protected minor: the adult-content toggle is
+  /// locked off and cannot be enabled (#175).
+  final bool isAdultContentLocked;
   final bool isPeopleIFollowEnabled;
   final bool showDivineHostedOnly;
 
@@ -41,6 +46,7 @@ class SafetySettingsState extends Equatable {
   SafetySettingsState copyWith({
     SafetySettingsStatus? status,
     bool? isAgeVerified,
+    bool? isAdultContentLocked,
     bool? isPeopleIFollowEnabled,
     bool? showDivineHostedOnly,
     Set<String>? customLabelers,
@@ -49,6 +55,7 @@ class SafetySettingsState extends Equatable {
     return SafetySettingsState(
       status: status ?? this.status,
       isAgeVerified: isAgeVerified ?? this.isAgeVerified,
+      isAdultContentLocked: isAdultContentLocked ?? this.isAdultContentLocked,
       isPeopleIFollowEnabled:
           isPeopleIFollowEnabled ?? this.isPeopleIFollowEnabled,
       showDivineHostedOnly: showDivineHostedOnly ?? this.showDivineHostedOnly,
@@ -61,6 +68,7 @@ class SafetySettingsState extends Equatable {
   List<Object?> get props => [
     status,
     isAgeVerified,
+    isAdultContentLocked,
     isPeopleIFollowEnabled,
     showDivineHostedOnly,
     customLabelers,

--- a/mobile/lib/l10n/app_en.arb
+++ b/mobile/lib/l10n/app_en.arb
@@ -1333,6 +1333,10 @@
   "safetySettingsAgeVerification": "AGE VERIFICATION",
   "safetySettingsAgeConfirmation": "I confirm I am 18 years or older",
   "safetySettingsAgeRequired": "Required to view adult content",
+  "safetySettingsAgeLockedForMinor": "Locked for your account",
+  "@safetySettingsAgeLockedForMinor": {
+    "description": "Subtitle on the disabled adult-content toggle for protected minors"
+  },
   "safetySettingsDivine": "Divine",
   "safetySettingsDivineSubtitle": "Official moderation service (on by default)",
   "safetySettingsPeopleIFollow": "People I follow",

--- a/mobile/lib/l10n/generated/app_localizations.dart
+++ b/mobile/lib/l10n/generated/app_localizations.dart
@@ -4232,6 +4232,12 @@ abstract class AppLocalizations {
   /// **'Required to view adult content'**
   String get safetySettingsAgeRequired;
 
+  /// Subtitle on the disabled adult-content toggle for protected minors
+  ///
+  /// In en, this message translates to:
+  /// **'Locked for your account'**
+  String get safetySettingsAgeLockedForMinor;
+
   /// No description provided for @safetySettingsDivine.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/generated/app_localizations_am.dart
+++ b/mobile/lib/l10n/generated/app_localizations_am.dart
@@ -2361,6 +2361,9 @@ class AppLocalizationsAm extends AppLocalizations {
   String get safetySettingsAgeRequired => 'የአዋቂ ይዘት ለማየት ያስፈልጋል';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ar.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ar.dart
@@ -2377,6 +2377,9 @@ class AppLocalizationsAr extends AppLocalizations {
   String get safetySettingsAgeRequired => 'مطلوب لعرض المحتوى للبالغين';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_bg.dart
+++ b/mobile/lib/l10n/generated/app_localizations_bg.dart
@@ -2443,6 +2443,9 @@ class AppLocalizationsBg extends AppLocalizations {
       'Изисква се за гледане на съдържание за възрастни';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_de.dart
+++ b/mobile/lib/l10n/generated/app_localizations_de.dart
@@ -2429,6 +2429,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Erforderlich, um Inhalte für Erwachsene zu sehen';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_en.dart
+++ b/mobile/lib/l10n/generated/app_localizations_en.dart
@@ -2406,6 +2406,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get safetySettingsAgeRequired => 'Required to view adult content';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_es.dart
+++ b/mobile/lib/l10n/generated/app_localizations_es.dart
@@ -2428,6 +2428,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Necesario para ver contenido para adultos';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fil.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fil.dart
@@ -2441,6 +2441,9 @@ class AppLocalizationsFil extends AppLocalizations {
       'Kailangan para makita ang adult content';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_fr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_fr.dart
@@ -2435,6 +2435,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Requis pour voir du contenu pour adultes';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_id.dart
+++ b/mobile/lib/l10n/generated/app_localizations_id.dart
@@ -2378,6 +2378,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Diperlukan untuk melihat konten dewasa';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_it.dart
+++ b/mobile/lib/l10n/generated/app_localizations_it.dart
@@ -2427,6 +2427,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Richiesto per vedere contenuti per adulti';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ja.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ja.dart
@@ -2282,6 +2282,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get safetySettingsAgeRequired => 'アダルトコンテンツの閲覧に必要だよ';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ko.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ko.dart
@@ -2293,6 +2293,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get safetySettingsAgeRequired => '성인 콘텐츠를 보려면 필요해요';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_nl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_nl.dart
@@ -2411,6 +2411,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Vereist om inhoud voor volwassenen te bekijken';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pl.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pl.dart
@@ -2475,6 +2475,9 @@ class AppLocalizationsPl extends AppLocalizations {
       'Wymagane do oglądania treści dla dorosłych';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_pt.dart
+++ b/mobile/lib/l10n/generated/app_localizations_pt.dart
@@ -2422,6 +2422,9 @@ class AppLocalizationsPt extends AppLocalizations {
   String get safetySettingsAgeRequired => 'Necessário para ver conteúdo adulto';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_ro.dart
+++ b/mobile/lib/l10n/generated/app_localizations_ro.dart
@@ -2488,6 +2488,9 @@ class AppLocalizationsRo extends AppLocalizations {
       'Necesar pentru a vedea conținut pentru adulți';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_sv.dart
+++ b/mobile/lib/l10n/generated/app_localizations_sv.dart
@@ -2398,6 +2398,9 @@ class AppLocalizationsSv extends AppLocalizations {
   String get safetySettingsAgeRequired => 'Krävs för att se vuxeninnehåll';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/l10n/generated/app_localizations_tr.dart
+++ b/mobile/lib/l10n/generated/app_localizations_tr.dart
@@ -2385,6 +2385,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'Yetişkin içeriği görüntülemek için gereklidir';
 
   @override
+  String get safetySettingsAgeLockedForMinor => 'Locked for your account';
+
+  @override
   String get safetySettingsDivine => 'Divine';
 
   @override

--- a/mobile/lib/providers/moderation_providers.dart
+++ b/mobile/lib/providers/moderation_providers.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/nostr_client_provider.dart';
 import 'package:openvine/providers/preferences_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/providers/repository_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/account_label_service.dart';
@@ -78,7 +79,9 @@ final divineHostFilterVersionProvider = Provider<int>((ref) {
 /// even when widgets that watch it dispose and rebuild
 @Riverpod(keepAlive: true)
 AgeVerificationService ageVerificationService(Ref ref) {
-  final service = AgeVerificationService();
+  final service = AgeVerificationService(
+    isProtectedMinor: () => ref.read(isProtectedMinorProvider),
+  );
   service.initialize(); // Initialize asynchronously
   return service;
 }

--- a/mobile/lib/providers/moderation_providers.g.dart
+++ b/mobile/lib/providers/moderation_providers.g.dart
@@ -244,7 +244,7 @@ final class AgeVerificationServiceProvider
 }
 
 String _$ageVerificationServiceHash() =>
-    r'e866f0341e541ba27ba2b4e4278ed4b35edb8d8b';
+    r'ee3695d785f1fae75124bc0fb7d4cdbad3b6da30';
 
 /// Content filter service for per-category Show/Warn/Hide preferences.
 /// keepAlive ensures preferences persist and are consistent across the app.

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -9,6 +9,7 @@ import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/repositories/protected_minor_repository.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:openvine/services/protected_minor_override_service.dart';
+import 'package:openvine/services/protected_minor_sticky_store.dart';
 
 /// Developer-only override service (debug builds).
 final protectedMinorOverrideServiceProvider =
@@ -78,7 +79,32 @@ final protectedMinorStatusProvider = FutureProvider<ProtectedMinorStatus>((
 /// Note: unknown/error status is still exposed on [protectedMinorStatusProvider]
 /// for consumers that need to distinguish an unavailable check from confirmed
 /// not-protected.
+/// Persisted last-known protected-minor state (fail-safe backing, #175).
+final protectedMinorStickyStoreProvider = Provider<ProtectedMinorStickyStore>((
+  ref,
+) {
+  return ProtectedMinorStickyStore(prefs: ref.watch(sharedPreferencesProvider));
+});
+
+/// Effective protected-minor seam for the protections (#175/#176), fail-safe.
+///
+/// The effective value is the live status when known, else the persisted
+/// last-known (sticky). A known live status is also persisted for the next
+/// cold start. Unknown/error never weakens protection: an account confirmed a
+/// protected minor stays protected offline and at cold start, and lifts only on
+/// a positive not-a-minor signal (age-up / revocation).
 final isProtectedMinorProvider = Provider<bool>((ref) {
-  return ref.watch(protectedMinorStatusProvider).value?.isProtectedMinor ??
-      false;
+  ref.watch(currentAuthStateProvider); // reactivity on account changes
+  final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
+  final store = ref.watch(protectedMinorStickyStoreProvider);
+  final live = ref.watch(protectedMinorStatusProvider).value;
+
+  if (live != null) {
+    // Persist for future cold starts (fire-and-forget).
+    store.applyLiveStatus(pubkey, live);
+    if (live.kind == ProtectedMinorStatusKind.protected) return true;
+    if (live.kind == ProtectedMinorStatusKind.notProtected) return false;
+  }
+  // Unknown / no live result yet -> last-known persisted value (sticky).
+  return store.isProtectedMinorFor(pubkey);
 });

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -86,25 +86,47 @@ final protectedMinorStickyStoreProvider = Provider<ProtectedMinorStickyStore>((
   return ProtectedMinorStickyStore(prefs: ref.watch(sharedPreferencesProvider));
 });
 
+/// Whether a live protected-minor status may be trusted as a fresh signal for
+/// the current account, or `null` to fall back to the persisted sticky value.
+///
+/// A status is only trustworthy when the session is **authenticated** and the
+/// value is **freshly resolved** (`AsyncData`). This rejects two fail-safe
+/// hazards: the `notProtected()` the #174 seam emits merely because auth has
+/// not completed (cold start / session restore), and a stale value retained
+/// from a previous account during a refetch (`AsyncLoading`/`AsyncError`).
+ProtectedMinorStatus? trustedProtectedMinorStatus({
+  required bool authenticated,
+  required AsyncValue<ProtectedMinorStatus> live,
+}) {
+  if (!authenticated) return null;
+  if (live is! AsyncData<ProtectedMinorStatus>) return null;
+  return live.value;
+}
+
 /// Effective protected-minor seam for the protections (#175/#176), fail-safe.
 ///
-/// The effective value is the live status when known, else the persisted
-/// last-known (sticky). A known live status is also persisted for the next
-/// cold start. Unknown/error never weakens protection: an account confirmed a
-/// protected minor stays protected offline and at cold start, and lifts only on
-/// a positive not-a-minor signal (age-up / revocation).
+/// The effective value is a trusted live status when available, else the
+/// persisted last-known (sticky). A trusted status is also persisted for the
+/// next cold start. Unknown/error and any untrusted status never weaken
+/// protection: an account confirmed a protected minor stays protected offline
+/// and at cold start, and lifts only on a positive not-a-minor signal from an
+/// authenticated check (age-up / revocation).
 final isProtectedMinorProvider = Provider<bool>((ref) {
-  ref.watch(currentAuthStateProvider); // reactivity on account changes
+  final authState = ref.watch(currentAuthStateProvider);
   final pubkey = ref.watch(authServiceProvider).currentPublicKeyHex;
   final store = ref.watch(protectedMinorStickyStoreProvider);
-  final live = ref.watch(protectedMinorStatusProvider).value;
+  final live = ref.watch(protectedMinorStatusProvider);
 
-  if (live != null) {
-    // Persist for future cold starts (fire-and-forget).
-    store.applyLiveStatus(pubkey, live);
-    if (live.kind == ProtectedMinorStatusKind.protected) return true;
-    if (live.kind == ProtectedMinorStatusKind.notProtected) return false;
+  final trusted = trustedProtectedMinorStatus(
+    authenticated: authState == AuthState.authenticated,
+    live: live,
+  );
+  if (trusted != null) {
+    // Persist trusted transitions for future cold starts (fire-and-forget).
+    store.applyLiveStatus(pubkey, trusted);
+    if (trusted.kind == ProtectedMinorStatusKind.protected) return true;
+    if (trusted.kind == ProtectedMinorStatusKind.notProtected) return false;
   }
-  // Unknown / no live result yet -> last-known persisted value (sticky).
+  // Untrusted / unknown -> last-known persisted value (sticky).
   return store.isProtectedMinorFor(pubkey);
 });

--- a/mobile/lib/providers/protected_minor_providers.dart
+++ b/mobile/lib/providers/protected_minor_providers.dart
@@ -117,6 +117,13 @@ final isProtectedMinorProvider = Provider<bool>((ref) {
   final store = ref.watch(protectedMinorStickyStoreProvider);
   final live = ref.watch(protectedMinorStatusProvider);
 
+  // Account-switch safety relies on the invariant that every account swap
+  // transits a non-authenticated authState (authenticating/checking), which
+  // invalidates protectedMinorStatusProvider (it watches currentAuthStateProvider)
+  // back into AsyncLoading before authState returns to authenticated for the new
+  // account. That is why a stale AsyncData from a previous account can never be
+  // trusted here. A future silent same-authState pubkey swap would need to also
+  // invalidate the status provider to preserve this guarantee.
   final trusted = trustedProtectedMinorStatus(
     authenticated: authState == AuthState.authenticated,
     live: live,

--- a/mobile/lib/screens/safety_settings_screen.dart
+++ b/mobile/lib/screens/safety_settings_screen.dart
@@ -10,6 +10,7 @@ import 'package:openvine/blocs/safety_settings/safety_settings_cubit.dart';
 import 'package:openvine/blocs/safety_settings/safety_settings_state.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/providers/user_profile_providers.dart';
 import 'package:openvine/screens/content_filters_screen.dart';
 import 'package:openvine/screens/settings/account_content_labels_tile.dart';
@@ -38,6 +39,7 @@ class SafetySettingsScreen extends ConsumerWidget {
     final contentBlocklistRepository = ref.watch(
       contentBlocklistRepositoryProvider,
     );
+    final isAdultContentLocked = ref.watch(isProtectedMinorProvider);
     return BlocProvider(
       // Auth-flippable services are re-keyed so the Cubit reloads with the
       // fresh instances rather than operating on stale ones.
@@ -49,6 +51,7 @@ class SafetySettingsScreen extends ConsumerWidget {
         moderationLabelService,
         followRepository,
         contentBlocklistRepository,
+        isAdultContentLocked,
       )),
       create: (_) => SafetySettingsCubit(
         ageVerificationService: ageVerificationService,
@@ -58,6 +61,7 @@ class SafetySettingsScreen extends ConsumerWidget {
         moderationLabelService: moderationLabelService,
         followRepository: followRepository,
         contentBlocklistRepository: contentBlocklistRepository,
+        isAdultContentLocked: isAdultContentLocked,
       )..load(),
       child: const SafetySettingsView(),
     );
@@ -172,19 +176,26 @@ class _AgeVerificationTile extends StatelessWidget {
     final isAgeVerified = context.select(
       (SafetySettingsCubit cubit) => cubit.state.isAgeVerified,
     );
+    final isLocked = context.select(
+      (SafetySettingsCubit cubit) => cubit.state.isAdultContentLocked,
+    );
     return CheckboxListTile(
-      value: isAgeVerified,
-      onChanged: (value) {
-        if (value != null) {
-          context.read<SafetySettingsCubit>().setAgeVerified(value);
-        }
-      },
+      value: !isLocked && isAgeVerified,
+      onChanged: isLocked
+          ? null
+          : (value) {
+              if (value != null) {
+                context.read<SafetySettingsCubit>().setAgeVerified(value);
+              }
+            },
       title: Text(
         context.l10n.safetySettingsAgeConfirmation,
         style: const TextStyle(color: VineTheme.whiteText),
       ),
       subtitle: Text(
-        context.l10n.safetySettingsAgeRequired,
+        isLocked
+            ? context.l10n.safetySettingsAgeLockedForMinor
+            : context.l10n.safetySettingsAgeRequired,
         style: const TextStyle(color: VineTheme.secondaryText),
       ),
       activeColor: VineTheme.vineGreen,

--- a/mobile/lib/screens/settings/account_content_labels_tile.dart
+++ b/mobile/lib/screens/settings/account_content_labels_tile.dart
@@ -150,9 +150,13 @@ class _AccountLabelMultiSelectState extends State<_AccountLabelMultiSelect> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    context.l10n.contentPreferencesAccountContentLabels,
-                    style: VineTheme.titleLargeFont(),
+                  Expanded(
+                    child: Text(
+                      context.l10n.contentPreferencesAccountContentLabels,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: VineTheme.titleLargeFont(),
+                    ),
                   ),
                   if (_selected.isNotEmpty)
                     TextButton(

--- a/mobile/lib/services/age_verification_service.dart
+++ b/mobile/lib/services/age_verification_service.dart
@@ -7,6 +7,15 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 class AgeVerificationService {
+  AgeVerificationService({bool Function()? isProtectedMinor})
+    : _isProtectedMinor = isProtectedMinor ?? _notProtected;
+
+  static bool _notProtected() => false;
+
+  /// Whether the current account is a protected minor. When true, adult content
+  /// is force-locked off and the self-attestation bypass is unavailable (#175).
+  final bool Function() _isProtectedMinor;
+
   static const String _ageVerifiedKey = 'age_verified';
   static const String _verificationDateKey = 'age_verification_date';
   static const String _adultContentVerifiedKey = 'adult_content_verified';
@@ -20,7 +29,8 @@ class AgeVerificationService {
 
   bool get isAgeVerified => _isAgeVerified ?? false;
   DateTime? get verificationDate => _verificationDate;
-  bool get isAdultContentVerified => _isAdultContentVerified ?? false;
+  bool get isAdultContentVerified =>
+      !_isProtectedMinor() && (_isAdultContentVerified ?? false);
   DateTime? get adultContentVerificationDate => _adultContentVerificationDate;
 
   Future<void> initialize() async {
@@ -93,6 +103,14 @@ class AgeVerificationService {
   }
 
   Future<void> setAdultContentVerified(bool verified) async {
+    if (verified && _isProtectedMinor()) {
+      Log.warning(
+        'Blocked adult-content verification for a protected minor',
+        name: 'AgeVerificationService',
+        category: LogCategory.system,
+      );
+      return;
+    }
     try {
       final prefs = await SharedPreferences.getInstance();
 
@@ -136,6 +154,8 @@ class AgeVerificationService {
 
   /// Check if user can view adult content, showing verification dialog if needed
   Future<bool> verifyAdultContentAccess(BuildContext context) async {
+    // Protected minors can never unlock adult content; no dialog.
+    if (_isProtectedMinor()) return false;
     // First check if already verified
     if (await checkAdultContentVerification()) {
       return true;

--- a/mobile/lib/services/protected_minor_sticky_store.dart
+++ b/mobile/lib/services/protected_minor_sticky_store.dart
@@ -22,19 +22,21 @@ class ProtectedMinorStickyStore {
       pubkey != null && (_prefs.getBool(_key(pubkey)) ?? false);
 
   /// Apply a live keycast status: confirmed protected -> persist true;
-  /// confirmed not-protected -> persist false; unknown -> retain.
+  /// confirmed not-protected -> persist false; unknown -> retain. A write is
+  /// skipped when the persisted value already matches (avoids redundant I/O on
+  /// every rebuild).
   Future<void> applyLiveStatus(
     String? pubkey,
     ProtectedMinorStatus status,
   ) async {
     if (pubkey == null) return;
-    switch (status.kind) {
-      case ProtectedMinorStatusKind.protected:
-        await _prefs.setBool(_key(pubkey), true);
-      case ProtectedMinorStatusKind.notProtected:
-        await _prefs.setBool(_key(pubkey), false);
-      case ProtectedMinorStatusKind.unknown:
-        break;
-    }
+    final bool? next = switch (status.kind) {
+      ProtectedMinorStatusKind.protected => true,
+      ProtectedMinorStatusKind.notProtected => false,
+      ProtectedMinorStatusKind.unknown => null, // retain last-known
+    };
+    if (next == null) return;
+    if (_prefs.getBool(_key(pubkey)) == next) return;
+    await _prefs.setBool(_key(pubkey), next);
   }
 }

--- a/mobile/lib/services/protected_minor_sticky_store.dart
+++ b/mobile/lib/services/protected_minor_sticky_store.dart
@@ -1,0 +1,40 @@
+// ABOUTME: Persists last-known protected-minor status per account and applies
+// ABOUTME: the #175 fail-safe machine (sticky; lifts only on a positive signal).
+
+import 'package:openvine/models/protected_minor_status.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Durable, per-account last-known protected-minor state.
+///
+/// Reads/writes a synchronous [SharedPreferences] snapshot so the value is
+/// valid at cold start (local, no network). The fail-safe machine only ever
+/// lifts protection on a confirmed not-a-minor signal; unknown/error is sticky.
+class ProtectedMinorStickyStore {
+  ProtectedMinorStickyStore({required SharedPreferences prefs})
+    : _prefs = prefs;
+
+  final SharedPreferences _prefs;
+
+  static String _key(String pubkey) => 'protected_minor_sticky_$pubkey';
+
+  /// Last-known protected status for [pubkey]. Null/unconfirmed -> false.
+  bool isProtectedMinorFor(String? pubkey) =>
+      pubkey != null && (_prefs.getBool(_key(pubkey)) ?? false);
+
+  /// Apply a live keycast status: confirmed protected -> persist true;
+  /// confirmed not-protected -> persist false; unknown -> retain.
+  Future<void> applyLiveStatus(
+    String? pubkey,
+    ProtectedMinorStatus status,
+  ) async {
+    if (pubkey == null) return;
+    switch (status.kind) {
+      case ProtectedMinorStatusKind.protected:
+        await _prefs.setBool(_key(pubkey), true);
+      case ProtectedMinorStatusKind.notProtected:
+        await _prefs.setBool(_key(pubkey), false);
+      case ProtectedMinorStatusKind.unknown:
+        break;
+    }
+  }
+}

--- a/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
+++ b/mobile/test/blocs/safety_settings/safety_settings_cubit_test.dart
@@ -113,14 +113,41 @@ void main() {
       await blocklistStream.close();
     });
 
-    SafetySettingsCubit buildCubit() => SafetySettingsCubit(
-      ageVerificationService: ageService,
-      contentFilterService: filterService,
-      videoEventService: videoEventService,
-      divineHostFilterService: divineHostFilterService,
-      moderationLabelService: moderationLabelService,
-      followRepository: followRepository,
-      contentBlocklistRepository: blocklistRepository,
+    SafetySettingsCubit buildCubit({bool isAdultContentLocked = false}) =>
+        SafetySettingsCubit(
+          ageVerificationService: ageService,
+          contentFilterService: filterService,
+          videoEventService: videoEventService,
+          divineHostFilterService: divineHostFilterService,
+          moderationLabelService: moderationLabelService,
+          followRepository: followRepository,
+          contentBlocklistRepository: blocklistRepository,
+          isAdultContentLocked: isAdultContentLocked,
+        );
+
+    blocTest<SafetySettingsCubit, SafetySettingsState>(
+      'load() surfaces isAdultContentLocked for a protected minor',
+      build: () => buildCubit(isAdultContentLocked: true),
+      act: (cubit) => cubit.load(),
+      expect: () => [
+        isA<SafetySettingsState>().having(
+          (s) => s.status,
+          'status',
+          SafetySettingsStatus.loading,
+        ),
+        isA<SafetySettingsState>()
+            .having((s) => s.status, 'status', SafetySettingsStatus.ready)
+            .having((s) => s.isAdultContentLocked, 'locked', true),
+      ],
+    );
+
+    blocTest<SafetySettingsCubit, SafetySettingsState>(
+      'setAgeVerified is a no-op when adult content is locked',
+      build: () => buildCubit(isAdultContentLocked: true),
+      act: (cubit) => cubit.setAgeVerified(true),
+      verify: (_) {
+        verifyNever(() => ageService.setAdultContentVerified(true));
+      },
     );
 
     blocTest<SafetySettingsCubit, SafetySettingsState>(

--- a/mobile/test/l10n/arb_consistency_test.dart
+++ b/mobile/test/l10n/arb_consistency_test.dart
@@ -174,6 +174,9 @@ const _knownUntranslatedDebt = {
   'contentFiltersFilterOut',
   'safetySettingsWhatYouSee',
   'safetySettingsWhatYouPublish',
+  // Protected-minor adult-content lock (#175). Falls back to English until the
+  // next translation pass.
+  'safetySettingsAgeLockedForMinor',
   'relaySettingsExternalRelay',
   'relaySettingsNotConnected',
   'relaySettingsDisconnectedAgo',

--- a/mobile/test/providers/age_verification_provider_test.dart
+++ b/mobile/test/providers/age_verification_provider_test.dart
@@ -4,6 +4,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/shared_preferences_provider.dart';
+import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
@@ -11,6 +13,22 @@ void main() {
     setUp(() {
       SharedPreferences.setMockInitialValues({});
     });
+
+    // ageVerificationServiceProvider now consults isProtectedMinorProvider,
+    // which needs sharedPreferencesProvider and an auth state. Pin auth to
+    // unauthenticated so the protected-minor signal resolves to false, leaving
+    // these tests' adult-content assertions unaffected.
+    Future<ProviderContainer> buildContainer() async {
+      final prefs = await SharedPreferences.getInstance();
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          currentAuthStateProvider.overrideWithValue(AuthState.unauthenticated),
+        ],
+      );
+      addTearDown(container.dispose);
+      return container;
+    }
 
     test('provider should have keepAlive configuration', () async {
       // This test verifies the provider is configured with keepAlive: true
@@ -25,8 +43,7 @@ void main() {
       // by checking that the provider returns the same instance across multiple reads
       // within the same container lifecycle.
 
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
+      final container = await buildContainer();
 
       // Get the service and verify adult content
       final service = container.read(ageVerificationServiceProvider);
@@ -65,8 +82,7 @@ void main() {
             DateTime.now().millisecondsSinceEpoch,
       });
 
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
+      final container = await buildContainer();
 
       final service = container.read(ageVerificationServiceProvider);
 
@@ -86,8 +102,7 @@ void main() {
     });
 
     test('should be a singleton across multiple reads', () async {
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
+      final container = await buildContainer();
 
       final service1 = container.read(ageVerificationServiceProvider);
       final service2 = container.read(ageVerificationServiceProvider);
@@ -100,8 +115,7 @@ void main() {
     test('verification state survives widget lifecycle changes', () async {
       // Simulates: User verifies age -> widget disposes -> widget rebuilds -> state should persist
 
-      final container = ProviderContainer();
-      addTearDown(container.dispose);
+      final container = await buildContainer();
 
       // User verifies age
       final service = container.read(ageVerificationServiceProvider);

--- a/mobile/test/providers/protected_minor_gate_test.dart
+++ b/mobile/test/providers/protected_minor_gate_test.dart
@@ -1,0 +1,61 @@
+// ABOUTME: Tests the trust gate for the protected-minor fail-safe — only an
+// ABOUTME: authenticated, freshly-resolved status may lift protection (#175).
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/protected_minor_status.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
+
+void main() {
+  group('trustedProtectedMinorStatus', () {
+    test(
+      'unauthenticated notProtected is NOT trusted (never wipes sticky)',
+      () {
+        // The #174 seam returns notProtected() while auth is still restoring.
+        // Treating it as a positive signal would wipe a confirmed minor. Reject.
+        final result = trustedProtectedMinorStatus(
+          authenticated: false,
+          live: AsyncData(ProtectedMinorStatus.notProtected()),
+        );
+        expect(result, isNull);
+      },
+    );
+
+    test('authenticated but still loading (stale value) is NOT trusted', () {
+      // During an account switch, .value retains the previous account. Reject
+      // anything that is not freshly resolved.
+      final result = trustedProtectedMinorStatus(
+        authenticated: true,
+        live: const AsyncLoading<ProtectedMinorStatus>(),
+      );
+      expect(result, isNull);
+    });
+
+    test('authenticated + resolved notProtected is trusted (a real lift)', () {
+      final result = trustedProtectedMinorStatus(
+        authenticated: true,
+        live: AsyncData(ProtectedMinorStatus.notProtected()),
+      );
+      expect(result?.kind, ProtectedMinorStatusKind.notProtected);
+    });
+
+    test('authenticated + resolved protected is trusted', () {
+      final result = trustedProtectedMinorStatus(
+        authenticated: true,
+        live: AsyncData(ProtectedMinorStatus.protected()),
+      );
+      expect(result?.kind, ProtectedMinorStatusKind.protected);
+    });
+
+    test('authenticated error is NOT trusted (fail-safe: keep sticky)', () {
+      final result = trustedProtectedMinorStatus(
+        authenticated: true,
+        live: AsyncError<ProtectedMinorStatus>(
+          Exception('keycast down'),
+          StackTrace.empty,
+        ),
+      );
+      expect(result, isNull);
+    });
+  });
+}

--- a/mobile/test/providers/protected_minor_providers_test.dart
+++ b/mobile/test/providers/protected_minor_providers_test.dart
@@ -8,11 +8,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:keycast_flutter/keycast_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:openvine/models/protected_minor_status.dart';
 import 'package:openvine/providers/auth_providers.dart';
 import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/providers/shared_preferences_provider.dart';
 import 'package:openvine/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockAuthService extends Mock implements AuthService {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -116,10 +120,77 @@ void main() {
       // Before the async status resolves, the seam reads false (safe default).
       expect(container.read(isProtectedMinorProvider), isFalse);
 
-      // After resolution (override forces protected) it reads true, and reading
-      // via `.value` means it won't flicker back to false on a later refetch.
+      // After resolution (override forces protected) an authenticated, freshly
+      // resolved status is trusted, so it reads true.
       await container.read(protectedMinorStatusProvider.future);
       expect(container.read(isProtectedMinorProvider), isTrue);
+    },
+  );
+
+  test(
+    'isProtectedMinorProvider: unauthenticated notProtected does NOT wipe a '
+    'confirmed minor (fail-safe)',
+    () async {
+      const minorPubkey =
+          'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+      SharedPreferences.setMockInitialValues({
+        'protected_minor_sticky_$minorPubkey': true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final authService = _MockAuthService();
+      when(() => authService.currentPublicKeyHex).thenReturn(minorPubkey);
+
+      final container = ProviderContainer(
+        overrides: [
+          // Auth still restoring: the #174 seam emits notProtected() here.
+          currentAuthStateProvider.overrideWithValue(AuthState.checking),
+          authServiceProvider.overrideWithValue(authService),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          protectedMinorStatusProvider.overrideWith(
+            (ref) async => ProtectedMinorStatus.notProtected(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(protectedMinorStatusProvider.future);
+
+      // Must stay protected (sticky), and the store must not be wiped to false.
+      expect(container.read(isProtectedMinorProvider), isTrue);
+      expect(prefs.getBool('protected_minor_sticky_$minorPubkey'), isTrue);
+    },
+  );
+
+  test(
+    'isProtectedMinorProvider: authenticated notProtected lifts and persists '
+    'the lift',
+    () async {
+      const pubkey =
+          'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      SharedPreferences.setMockInitialValues({
+        'protected_minor_sticky_$pubkey': true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final authService = _MockAuthService();
+      when(() => authService.currentPublicKeyHex).thenReturn(pubkey);
+
+      final container = ProviderContainer(
+        overrides: [
+          currentAuthStateProvider.overrideWithValue(AuthState.authenticated),
+          authServiceProvider.overrideWithValue(authService),
+          sharedPreferencesProvider.overrideWithValue(prefs),
+          protectedMinorStatusProvider.overrideWith(
+            (ref) async => ProtectedMinorStatus.notProtected(),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      await container.read(protectedMinorStatusProvider.future);
+
+      // A real (authenticated, resolved) not-protected signal lifts protection.
+      expect(container.read(isProtectedMinorProvider), isFalse);
+      expect(prefs.getBool('protected_minor_sticky_$pubkey'), isFalse);
     },
   );
 }

--- a/mobile/test/screens/safety_settings_screen_test.dart
+++ b/mobile/test/screens/safety_settings_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/content_label.dart';
 import 'package:openvine/providers/app_providers.dart';
+import 'package:openvine/providers/protected_minor_providers.dart';
 import 'package:openvine/screens/safety_settings_screen.dart';
 import 'package:openvine/services/account_label_service.dart';
 import 'package:openvine/services/age_verification_service.dart';
@@ -157,7 +158,7 @@ void main() {
       ).thenAnswer((_) => const Stream<List<String>>.empty());
     });
 
-    Widget createTestWidget() {
+    Widget createTestWidget({bool isProtectedMinor = false}) {
       final container = ProviderContainer(
         overrides: [
           contentBlocklistRepositoryProvider.overrideWithValue(
@@ -184,6 +185,7 @@ void main() {
           divineHostFilterServiceProvider.overrideWithValue(
             divineHostFilterService,
           ),
+          isProtectedMinorProvider.overrideWithValue(isProtectedMinor),
         ],
       );
 
@@ -323,6 +325,24 @@ void main() {
         ).called(1);
         verify(mockContentFilterService.unlockAdultCategories).called(1);
         verifyNever(() => mockContentFilterService.lockAdultCategories());
+      },
+    );
+
+    testWidgets(
+      'adult-content toggle is disabled and locked for a protected minor',
+      (tester) async {
+        await tester.pumpWidget(createTestWidget(isProtectedMinor: true));
+        await tester.pumpAndSettle();
+
+        final tile = tester.widget<CheckboxListTile>(
+          find.byType(CheckboxListTile),
+        );
+        expect(tile.onChanged, isNull); // disabled: cannot be toggled
+        expect(tile.value, isFalse);
+        expect(
+          find.text(l10n.safetySettingsAgeLockedForMinor),
+          findsOneWidget,
+        );
       },
     );
 

--- a/mobile/test/services/age_verification_protected_minor_test.dart
+++ b/mobile/test/services/age_verification_protected_minor_test.dart
@@ -1,0 +1,47 @@
+// ABOUTME: Verifies the protected-minor lock on AgeVerificationService — the
+// ABOUTME: single choke point that forces adult content off for #175.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/services/age_verification_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() => SharedPreferences.setMockInitialValues({}));
+
+  test(
+    'isAdultContentVerified is false for a protected minor even if stored true',
+    () async {
+      final service = AgeVerificationService(isProtectedMinor: () => true);
+      await service.initialize();
+      await service.setAdultContentVerified(true); // rejected below
+      expect(service.isAdultContentVerified, false);
+    },
+  );
+
+  test(
+    'setAdultContentVerified(true) is rejected for a protected minor',
+    () async {
+      var protected = true;
+      final service = AgeVerificationService(isProtectedMinor: () => protected);
+      await service.initialize();
+      await service.setAdultContentVerified(true);
+      // Even after lifting the protection, nothing was persisted as true.
+      protected = false;
+      expect(service.isAdultContentVerified, false);
+    },
+  );
+
+  test('non-protected account behaves normally', () async {
+    final service = AgeVerificationService(isProtectedMinor: () => false);
+    await service.initialize();
+    await service.setAdultContentVerified(true);
+    expect(service.isAdultContentVerified, true);
+  });
+
+  test('defaults to not-protected when no callback supplied', () async {
+    final service = AgeVerificationService();
+    await service.initialize();
+    await service.setAdultContentVerified(true);
+    expect(service.isAdultContentVerified, true);
+  });
+}

--- a/mobile/test/services/protected_minor_sticky_store_test.dart
+++ b/mobile/test/services/protected_minor_sticky_store_test.dart
@@ -1,0 +1,59 @@
+// ABOUTME: Unit tests for ProtectedMinorStickyStore — the persisted fail-safe
+// ABOUTME: state machine backing the protected-minor seam (#175).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:openvine/models/protected_minor_status.dart';
+import 'package:openvine/services/protected_minor_sticky_store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  final pubkey = 'a' * 64;
+  final otherPubkey = 'b' * 64;
+
+  late SharedPreferences prefs;
+  late ProtectedMinorStickyStore store;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    prefs = await SharedPreferences.getInstance();
+    store = ProtectedMinorStickyStore(prefs: prefs);
+  });
+
+  test('unconfirmed account is not protected', () {
+    expect(store.isProtectedMinorFor(pubkey), false);
+    expect(store.isProtectedMinorFor(null), false);
+  });
+
+  test('confirmed protected persists true', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    expect(store.isProtectedMinorFor(pubkey), true);
+  });
+
+  test('confirmed not-protected lifts to false (positive signal)', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.notProtected());
+    expect(store.isProtectedMinorFor(pubkey), false);
+  });
+
+  test('unknown status retains last-known (sticky, never weakens)', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.unknown());
+    expect(store.isProtectedMinorFor(pubkey), true);
+  });
+
+  test('is per-account', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    expect(store.isProtectedMinorFor(otherPubkey), false);
+  });
+
+  test('null pubkey never persists', () async {
+    await store.applyLiveStatus(null, ProtectedMinorStatus.protected());
+    expect(store.isProtectedMinorFor(null), false);
+  });
+
+  test('persists across instances (cold-start read)', () async {
+    await store.applyLiveStatus(pubkey, ProtectedMinorStatus.protected());
+    final fresh = ProtectedMinorStickyStore(prefs: prefs);
+    expect(fresh.isProtectedMinorFor(pubkey), true);
+  });
+}


### PR DESCRIPTION
Closes #5765.

Implements the mobile content lock for protected minors (support-trust-safety#175, part of epic #173). Consumes the #174 protected-minor seam (merged as #5708) and keycast's `verified_minor` exposure (keycast#266).

## What this does

Locks adult content off for a protected minor (an approved 13-15 account) and removes the self-attestation bypass, through a single choke point.

- **Sticky fail-safe state** (`ProtectedMinorStickyStore` + `isProtectedMinorProvider`): persists last-known protected status per account and exposes a synchronous signal that is protective at cold start and offline once an account has been confirmed a protected minor. Protection lifts only on a positive not-a-minor signal from an authenticated, freshly-resolved keycast check (age-up / revocation). It never weakens on a fetch error, a stale value, or the "still authenticating" state, and it never guesses "minor" for an unconfirmed account.
- **Choke point** (`AgeVerificationService.isAdultContentVerified`): returns false for protected minors, and `verifyAdultContentAccess` / `setAdultContentVerified(true)` are blocked. Every consumer inherits the lock: the content filter, the media auth interceptor (playback gate plus the self-attestation dialog), the settings cubits, and the playback retry paths.
- **Settings affordance**: the adult-content toggle renders visible-but-disabled with a "Locked for your account" explanation, so the minor sees the protection instead of a silently dead toggle.

## Safe to ship on its own

Every dependency is already merged (the #174 seam and keycast's flag exposure). Protection lifts only on a positive not-a-minor signal, which the client reads as `verified_minor` flipping to false from an authenticated keycast check. This PR contains no age logic of its own; it reacts to that signal whatever produces it.

Today the only such signal that is coming is **revocation** (a moderator reversing an approval), which lands once keycast#265's clear endpoint plus relay-manager#147's wiring ship. **Automatic age-up at 16 is deliberately not built** and is deferred to support-trust-safety#179 as a policy decision (no birthdate is captured anywhere in the flow). Until an age-up mechanism exists, an account that turns 16 stays protected rather than auto-lifting, which is the conservative, safe direction (over-protect, never under-protect a minor). Non-minors are unaffected: the signal only ever retains a confirmed minor.

## Scope

- **Mobile only.** Web parity is divine-web#453 (separate, blocked on divine-web#456).
- **Content lock only.** DM restriction for protected minors is #176 (separate). This PR does not make the epic complete on its own.

## Tests

- Store state machine; the trust gate (authenticated plus freshly-resolved); provider composition (a not-yet-authenticated or stale signal must not wipe a confirmed minor); the `AgeVerificationService` overrides (adult content forced off, self-attestation blocked); the settings cubit lock and guard; and a widget test for the disabled toggle. The provider-level no-wipe test was mutation-verified.
- A picky review caught a fail-safe defect (a still-authenticating state was treated as a confirmed not-a-minor signal, wiping the sticky flag at cold start). It is fixed by the trust gate above and covered by the provider tests.

Spec: `docs/superpowers/specs/2026-07-01-protected-minor-content-lock-design.md`. Plan: `docs/superpowers/plans/2026-07-01-protected-minor-content-lock.md`.
