### PR TITLE
fix(router): make the welcome→shell swap transition-free

### DIFF
--- a/mobile/lib/router/routes/shell.dart
+++ b/mobile/lib/router/routes/shell.dart
@@ -28,9 +28,18 @@ List<RouteBase> shellRoutes() {
     // pageContextProvider per branch so each tab sees *its own* route context
     // (not the active tab's) and keeps rendering real content while inactive.
     StatefulShellRoute(
-      builder: (context, state, navigationShell) => AppShell(
-        currentIndex: navigationShell.currentIndex,
-        child: navigationShell,
+      // Transition-free on purpose: the shell replaces `/welcome` on the root
+      // navigator when the authenticated redirect lands (startup restore,
+      // login), and the startup splash lifts at the *start* of that
+      // navigation. A default MaterialPage here plays a ~400ms slide that
+      // shows the welcome screen exiting — the "sign-in page glimpse" of
+      // #5242 in its post-splash form. Pinned by shell_transition_test.
+      pageBuilder: (context, state, navigationShell) => NoTransitionPage<void>(
+        key: state.pageKey,
+        child: AppShell(
+          currentIndex: navigationShell.currentIndex,
+          child: navigationShell,
+        ),
       ),
       navigatorContainerBuilder: (context, navigationShell, children) =>
           AppShellBranchContainer(

--- a/mobile/test/router/shell_transition_test.dart
+++ b/mobile/test/router/shell_transition_test.dart
@@ -1,0 +1,61 @@
+// ABOUTME: Pins the transition-free shell page on the root navigator
+// ABOUTME: Regression test for the startup/login sign-in-page glimpse (#5242)
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:openvine/router/router.dart';
+import 'package:openvine/router/routes/shell.dart';
+
+class _FakeGoRouterState extends Fake implements GoRouterState {
+  @override
+  ValueKey<String> get pageKey => const ValueKey('shell');
+}
+
+class _FakeNavigationShell extends Fake
+    with Diagnosticable
+    implements StatefulNavigationShell {
+  @override
+  int get currentIndex => 0;
+}
+
+void main() {
+  group('bottom-nav shell route', () {
+    testWidgets('builds a zero-duration page on the root navigator', (
+      tester,
+    ) async {
+      final shellRoute = shellRoutes().single as StatefulShellRoute;
+
+      // The shell replaces /welcome on the root navigator when the
+      // authenticated redirect lands (startup restore, login), and the
+      // startup splash lifts at the start of that navigation. A `builder:`
+      // here would fall back to a default MaterialPage whose ~400ms slide
+      // shows the welcome screen exiting — the sign-in glimpse of #5242.
+      expect(
+        shellRoute.pageBuilder,
+        isNotNull,
+        reason:
+            'The shell StatefulShellRoute must use pageBuilder (not '
+            'builder) so the welcome→home startup redirect swaps without '
+            'a visible transition.',
+      );
+
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+      final context = tester.element(find.byType(SizedBox));
+
+      final page = shellRoute.pageBuilder!(
+        context,
+        _FakeGoRouterState(),
+        _FakeNavigationShell(),
+      );
+
+      expect(page, isA<NoTransitionPage<void>>());
+      final transitionPage = page as NoTransitionPage<void>;
+      expect(transitionPage.transitionDuration, Duration.zero);
+      expect(transitionPage.reverseTransitionDuration, Duration.zero);
+      expect(transitionPage.key, const ValueKey('shell'));
+      expect(transitionPage.child, isA<AppShell>());
+    });
+  });
+}


### PR DESCRIPTION
## Description

Fixes the "sign-in page glimpse": on every cold start, hot restart, and login while signed in, the welcome screen ("Continue as …") was briefly visible sliding out before the feed appeared.

**Root cause.** The bottom-nav `StatefulShellRoute` in `mobile/lib/router/routes/shell.dart` used `builder:`, so go_router wrapped the shell in a default `MaterialPage` on the root navigator. The authenticated `/welcome → /home/0` redirect (fired by `RouterRefreshListenable` once auth restore lands, which is structurally after the first frame — `AuthService.initialize()` only runs in the post-frame `essential` startup phase) is therefore an ordinary animated navigation: a ~400ms platform slide on iOS. `StartupSplashReleaseController` (#5271) releases the native splash the moment the redirect lands — i.e. at the **start** of that slide — so the welcome screen was visible exiting in all three scenarios. Confirmed by frame-by-frame analysis of simulator recordings of both a cold debug launch and a hot restart, correlated with startup logs (`authenticated` at 06.426 → redirect at 06.428 → feed push at 06.475 → splash lift reveals the welcome screen at transition t=0).

**Fix.** Give the shell route a `pageBuilder` returning `NoTransitionPage` (same pattern `_branchPage` already uses for within-branch navigation), so the welcome→shell swap on the root navigator is zero-duration. The page key stays `state.pageKey`, matching what go_router's default adapter page used, so the shell is not remounted across branch switches and tab state preservation is unchanged.

This is the post-splash form of the flash history (#2749 → #2953 → regressed by #5074 → #5242 → #5271): #5271 closed the pre-redirect static-paint window under the splash, but never covered the transition itself. It reads as more prominent on iOS because the Cupertino slide is longer and more visible than Android's M3 fade-forwards.

**Related Issue:** Relates to #5242

## Out of Scope

- The sign-out direction (feed → `/welcome`) keeps its default entrance transition — the welcome route's page type is unchanged.
- The hot-restart stale-frame window (~1s of the previous isolate's last frame while the Dart VM restarts) is inherent to hot restart + `deferFirstFrame` and dev-only; after it, the feed now appears directly instead of the welcome slide.

## Verification

Automated:

- `flutter analyze lib test integration_test` — no issues.
- New regression test `test/router/shell_transition_test.dart` pins that the shell `StatefulShellRoute` supplies a zero-duration `NoTransitionPage` (with the stable `state.pageKey` and `AppShell` child). Verified red on the pre-fix code (`pageBuilder` was null) and green with the fix.
- Full `flutter test test/router/` — 232 passed (65 pre-existing skips), including the tab cross-fade and branch-scoped context suites that guard shell behavior.

Real device / simulator test cases (signed-in account unless noted):

| # | Steps | Expected |
|---|---|---|
| TC1 | Cold start: kill the app, relaunch from home screen | Splash → feed directly; the welcome screen is never visible, no slide |
| TC2 | Hot restart from `flutter run` / IDE | Brief frozen frame (inherent) → feed directly; no welcome flash, no slide |
| TC3 | Sign out, then tap "Continue as <account>" on the welcome screen | Feed appears as an instant swap once auth completes; no slide of the welcome screen |
| TC4 | Sign in via "Use another account" → login options flow | After auth completes, instant swap to the feed |
| TC5 | Sign out from settings | Welcome screen appears normally (transition intentionally unchanged), no black frame |
| TC6 | Switch bottom-nav tabs Home ↔ Explore ↔ Inbox ↔ Profile, scroll a tab, switch away and back | Tab cross-fade unchanged, scroll/tab state preserved (shell not remounted) |
| TC7 | From the feed, open a fullscreen video and a settings screen, then navigate back | Push/pop animations over the shell unchanged, back returns to the feed correctly |
| TC8 | Cold start while signed out | Splash → welcome screen shows normally |

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
