### PR TITLE
fix(likes): align addressable liker counts

### DIFF
--- a/mobile/lib/blocs/video_engagement/video_engagement_bloc.dart
+++ b/mobile/lib/blocs/video_engagement/video_engagement_bloc.dart
@@ -9,6 +9,7 @@ import 'package:likes_repository/likes_repository.dart';
 import 'package:models/models.dart';
 import 'package:profile_repository/profile_repository.dart';
 import 'package:reposts_repository/reposts_repository.dart';
+import 'package:unified_logger/unified_logger.dart';
 
 part 'video_engagement_event.dart';
 part 'video_engagement_state.dart';
@@ -69,6 +70,12 @@ class VideoEngagementBloc
   ) async {
     emit(state.copyWith(status: VideoEngagementStatus.loading));
     try {
+      Log.info(
+        'Loading video engagement list: type=${type.name}, '
+        'eventId=$eventId, addressableId=${addressableId ?? '(none)'}',
+        name: 'VideoEngagementBloc',
+        category: LogCategory.video,
+      );
       final pubkeys = await _fetch();
 
       // Pre-warm the profile cache so UserProfileTile widgets render real
@@ -84,10 +91,7 @@ class VideoEngagementBloc
       }
 
       emit(
-        state.copyWith(
-          status: VideoEngagementStatus.success,
-          pubkeys: pubkeys,
-        ),
+        state.copyWith(status: VideoEngagementStatus.success, pubkeys: pubkeys),
       );
     } catch (e, stackTrace) {
       addError(e, stackTrace);

--- a/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
+++ b/mobile/lib/blocs/video_interactions/video_interactions_bloc.dart
@@ -165,9 +165,10 @@ class VideoInteractionsBloc
           ? _repostsRepository.getRepostCount(_addressableId)
           : _repostsRepository.getRepostCountByEventId(_eventId);
 
-      // Fetch a relay count for blocs that were not seeded from the feed
-      // payload. Seeded counts stay authoritative below because relay COUNT
-      // results can include unrelated historical reactions.
+      // Fetch a fallback like count for blocs that were not seeded from the
+      // feed payload. Addressable videos resolve the same filtered liker set as
+      // the "Liked by" list; non-addressable videos still use relay COUNT,
+      // whose results can include unrelated historical reactions.
       final likeCountFuture = _likesRepository.getLikeCount(
         _eventId,
         addressableId: _addressableId,
@@ -187,10 +188,10 @@ class VideoInteractionsBloc
       final fetchedCommentCount = results[1];
       final fetchedRepostCount = results[2];
 
-      // Feed/Funnelcake counts are the display baseline. Relay COUNT queries
-      // are still useful when a bloc has no seeded count, but they must not
-      // replace counts we already rendered from the video payload: the relay
-      // can aggregate unrelated historical reactions and surface bogus spikes.
+      // Feed/Funnelcake counts remain the display baseline pending the
+      // canonical stats decision tracked in #5751. The fallback count is useful
+      // when there is no seed, but should not replace a count already rendered
+      // from the video payload.
       final likeCount = preFetchLikeCount ?? fetchedLikeCount;
       final commentCount = preFetchCommentCount ?? fetchedCommentCount;
       final repostCount = preFetchRepostCount ?? fetchedRepostCount;

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -580,9 +580,6 @@ class LikesRepository {
     final cached = _likeCountCache[eventId];
     if (cached != null) return cached;
 
-    // Query relays for count of Kind 7 reactions on this event
-    final filterByE = Filter(kinds: const [EventKind.reaction], e: [eventId]);
-
     int count;
 
     if (addressableId != null && addressableId.isNotEmpty) {
@@ -592,6 +589,8 @@ class LikesRepository {
       );
       count = likersByEvent[eventId]?.length ?? 0;
     } else {
+      // Query relays for the count of Kind 7 reactions on this event.
+      final filterByE = Filter(kinds: const [EventKind.reaction], e: [eventId]);
       final result = await _nostrClient.countEvents([filterByE]);
       count = result.count;
     }
@@ -652,10 +651,9 @@ class LikesRepository {
         addressableIds: uncachedAddressableIds,
       );
       for (final id in uncachedIds) {
-        counts[id] = likersByEvent[id]?.length ?? 0;
-      }
-      for (final id in uncachedIds) {
-        _likeCountCache[id] = counts[id]!;
+        final count = likersByEvent[id]?.length ?? 0;
+        counts[id] = count;
+        _likeCountCache[id] = count;
       }
       return counts;
     }

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -571,8 +571,9 @@ class LikesRepository {
   /// Returns a cached count when available to avoid redundant relay queries
   /// (e.g. when scrolling back to a previously viewed video). Otherwise
   /// queries relays for the count of Kind 7 reactions on the event.
-  /// When [addressableId] is provided, queries by both 'e' and 'a' tags
-  /// and returns the maximum count (since relays may index differently).
+  /// When [addressableId] is provided, resolves the same active distinct liker
+  /// set used by [fetchEventLikers], so the visible count and "Liked by" list
+  /// cannot diverge for addressable videos.
   ///
   /// Note: This counts all likes, not just the current user's.
   Future<int> getLikeCount(String eventId, {String? addressableId}) async {
@@ -584,21 +585,12 @@ class LikesRepository {
 
     int count;
 
-    // If addressable ID provided, query by both e and a tags
     if (addressableId != null && addressableId.isNotEmpty) {
-      final filterByA = Filter(
-        kinds: const [EventKind.reaction],
-        a: [addressableId],
+      final likersByEvent = await _fetchResolvedLikersByEvent(
+        [eventId],
+        addressableIds: {eventId: addressableId},
       );
-
-      // Query both filters in parallel and return the maximum count
-      // Some relays may index by e-tag, others by a-tag
-      final results = await Future.wait([
-        _nostrClient.countEvents([filterByE]),
-        _nostrClient.countEvents([filterByA]),
-      ]);
-
-      count = max(results[0].count, results[1].count);
+      count = likersByEvent[eventId]?.length ?? 0;
     } else {
       final result = await _nostrClient.countEvents([filterByE]);
       count = result.count;
@@ -618,7 +610,7 @@ class LikesRepository {
   /// - [eventIds]: List of event IDs to get counts for
   /// - [addressableIds]: Optional map of event ID to addressable ID for
   ///   Kind 30000+ events. When provided, also queries by 'a' tag and
-  ///   merges results (taking max count per event).
+  ///   counts the active distinct liker set used by [fetchEventLikers].
   ///
   /// Returns a map of event ID to like count. Events with zero likes
   /// are included with a count of 0.
@@ -644,6 +636,30 @@ class LikesRepository {
 
     if (uncachedIds.isEmpty) return counts;
 
+    final uncachedAddressableIds = <String, String>{};
+    if (addressableIds != null && addressableIds.isNotEmpty) {
+      for (final id in uncachedIds) {
+        final aId = addressableIds[id];
+        if (aId != null && aId.isNotEmpty) {
+          uncachedAddressableIds[id] = aId;
+        }
+      }
+    }
+
+    if (uncachedAddressableIds.isNotEmpty) {
+      final likersByEvent = await _fetchResolvedLikersByEvent(
+        uncachedIds,
+        addressableIds: uncachedAddressableIds,
+      );
+      for (final id in uncachedIds) {
+        counts[id] = likersByEvent[id]?.length ?? 0;
+      }
+      for (final id in uncachedIds) {
+        _likeCountCache[id] = counts[id]!;
+      }
+      return counts;
+    }
+
     // Query relays for count of Kind 7 reactions on uncached events
     final filterByE = Filter(kinds: const [EventKind.reaction], e: uncachedIds);
 
@@ -664,51 +680,6 @@ class LikesRepository {
           if (uncachedIdSet.contains(targetId)) {
             counts[targetId] = (counts[targetId] ?? 0) + 1;
           }
-        }
-      }
-    }
-
-    // If addressable IDs provided, also query by a-tag and merge results
-    if (addressableIds != null && addressableIds.isNotEmpty) {
-      final uncachedAddressableIds = <String, String>{};
-      for (final id in uncachedIds) {
-        final aId = addressableIds[id];
-        if (aId != null) uncachedAddressableIds[id] = aId;
-      }
-
-      if (uncachedAddressableIds.isNotEmpty) {
-        final aTagValues = uncachedAddressableIds.values.toList();
-        final filterByA = Filter(
-          kinds: const [EventKind.reaction],
-          a: aTagValues,
-        );
-
-        final eventsByA = await _nostrClient.queryEvents([filterByA]);
-
-        final aTagToEventId = <String, String>{};
-        for (final entry in uncachedAddressableIds.entries) {
-          aTagToEventId[entry.value] = entry.key;
-        }
-
-        final countsFromA = <String, int>{};
-        for (final id in uncachedIds) {
-          countsFromA[id] = 0;
-        }
-
-        for (final event in eventsByA) {
-          for (final tag in event.tags) {
-            if (tag.isNotEmpty && tag[0] == 'a' && tag.length > 1) {
-              final aTagValue = tag[1];
-              final eventId = aTagToEventId[aTagValue];
-              if (eventId != null && countsFromA.containsKey(eventId)) {
-                countsFromA[eventId] = countsFromA[eventId]! + 1;
-              }
-            }
-          }
-        }
-
-        for (final id in uncachedIds) {
-          counts[id] = max(counts[id]!, countsFromA[id] ?? 0);
         }
       }
     }
@@ -1184,82 +1155,142 @@ class LikesRepository {
     String? addressableId,
   }) async {
     try {
-      final filterByE = Filter(kinds: const [EventKind.reaction], e: [eventId]);
-
-      final List<Event> reactions;
-      if (addressableId != null && addressableId.isNotEmpty) {
-        final filterByA = Filter(
-          kinds: const [EventKind.reaction],
-          a: [addressableId],
-        );
-        final results = await Future.wait([
-          _nostrClient.queryEvents([filterByE]),
-          _nostrClient.queryEvents([filterByA]),
-        ]);
-        reactions = [...results[0], ...results[1]];
-      } else {
-        reactions = await _nostrClient.queryEvents([filterByE]);
-      }
-
-      if (reactions.isEmpty) return <String>[];
-
-      // Deduplicate reactions by id first (the e-tag and a-tag queries can
-      // return the same event twice when both tags are present).
-      final reactionsById = <String, Event>{};
-      for (final event in reactions) {
-        reactionsById[event.id] = event;
-      }
-
-      // Fetch deletions authored by anyone who reacted, so we can drop
-      // reactions whose author later deleted them via Kind 5.
-      final reactionAuthors = reactionsById.values
-          .map((event) => event.pubkey)
-          .toSet()
-          .toList();
-      final deletionEvents = await _nostrClient.queryEvents([
-        Filter(
-          kinds: const [EventKind.eventDeletion],
-          authors: reactionAuthors,
-        ),
-      ]);
-
-      // Only honor a Kind 5 deletion when its author matches the reaction's
-      // author — otherwise anyone could suppress someone else's like by
-      // publishing a deletion that references the other user's reaction id.
-      final deletedReactionIds = <String>{};
-      for (final deletion in deletionEvents) {
-        for (final tag in deletion.tags) {
-          if (tag.length > 1 && tag[0] == 'e') {
-            final targetId = tag[1];
-            final target = reactionsById[targetId];
-            if (target != null && target.pubkey == deletion.pubkey) {
-              deletedReactionIds.add(targetId);
-            }
-          }
-        }
-      }
-
-      final survivors =
-          reactionsById.values
-              .where((event) => event.content != _downvoteContent)
-              .where((event) => !deletedReactionIds.contains(event.id))
-              .toList()
-            ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
-
-      final likerPubkeys = <String>[];
-      final seenPubkeys = <String>{};
-      for (final event in survivors) {
-        if (_blockFilter?.call(event.pubkey) ?? false) continue;
-        if (seenPubkeys.add(event.pubkey)) {
-          likerPubkeys.add(event.pubkey);
-        }
-      }
-      return likerPubkeys;
+      final likersByEvent = await _fetchResolvedLikersByEvent(
+        [eventId],
+        addressableIds: addressableId == null || addressableId.isEmpty
+            ? null
+            : {eventId: addressableId},
+      );
+      return likersByEvent[eventId] ?? <String>[];
     } catch (e) {
       throw FetchLikersFailedException(
         'Failed to fetch likers for event $eventId: $e',
       );
     }
+  }
+
+  Future<Map<String, List<String>>> _fetchResolvedLikersByEvent(
+    List<String> eventIds, {
+    Map<String, String>? addressableIds,
+  }) async {
+    if (eventIds.isEmpty) return const {};
+
+    final eventIdSet = eventIds.toSet();
+    final aTagToEventId = <String, String>{
+      for (final entry in (addressableIds ?? const <String, String>{}).entries)
+        if (entry.value.isNotEmpty) entry.value: entry.key,
+    };
+
+    final filterByE = Filter(kinds: const [EventKind.reaction], e: eventIds);
+    final eEventsFuture = _nostrClient.queryEvents([filterByE]);
+    final aEventsFuture = aTagToEventId.isEmpty
+        ? Future<List<Event>>.value(const <Event>[])
+        : _nostrClient.queryEvents([
+            Filter(
+              kinds: const [EventKind.reaction],
+              a: aTagToEventId.keys.toList(),
+            ),
+          ]);
+    final queryResults = await Future.wait([eEventsFuture, aEventsFuture]);
+
+    final reactionsByTarget = {
+      for (final eventId in eventIds) eventId: <String, Event>{},
+    };
+    final allReactionsById = <String, Event>{};
+    for (final event in [...queryResults[0], ...queryResults[1]]) {
+      allReactionsById[event.id] = event;
+      final targetIds = _reactionTargetEventIds(
+        event,
+        eventIdSet: eventIdSet,
+        aTagToEventId: aTagToEventId,
+      );
+      for (final targetId in targetIds) {
+        reactionsByTarget[targetId]?[event.id] = event;
+      }
+    }
+
+    if (allReactionsById.isEmpty) {
+      return {for (final eventId in eventIds) eventId: <String>[]};
+    }
+
+    final reactionAuthors = allReactionsById.values
+        .map((event) => event.pubkey)
+        .toSet()
+        .toList();
+    final deletionEvents = reactionAuthors.isEmpty
+        ? const <Event>[]
+        : await _nostrClient.queryEvents([
+            Filter(
+              kinds: const [EventKind.eventDeletion],
+              authors: reactionAuthors,
+            ),
+          ]);
+
+    // Only honor a Kind 5 deletion when its author matches the reaction's
+    // author — otherwise anyone could suppress someone else's like by
+    // publishing a deletion that references the other user's reaction id.
+    final deletedReactionIds = <String>{};
+    for (final deletion in deletionEvents) {
+      for (final tag in deletion.tags) {
+        if (tag.length > 1 && tag[0] == 'e') {
+          final targetId = tag[1];
+          final target = allReactionsById[targetId];
+          if (target != null && target.pubkey == deletion.pubkey) {
+            deletedReactionIds.add(targetId);
+          }
+        }
+      }
+    }
+
+    return {
+      for (final entry in reactionsByTarget.entries)
+        entry.key: _activeLikerPubkeys(
+          entry.value.values,
+          deletedReactionIds: deletedReactionIds,
+        ),
+    };
+  }
+
+  Set<String> _reactionTargetEventIds(
+    Event event, {
+    required Set<String> eventIdSet,
+    required Map<String, String> aTagToEventId,
+  }) {
+    final targetIds = <String>{};
+    for (final tag in event.tags) {
+      if (tag.length <= 1) continue;
+      final marker = tag[0];
+      final value = tag[1];
+      if (marker == 'e' && eventIdSet.contains(value)) {
+        targetIds.add(value);
+      } else if (marker == 'a') {
+        final eventId = aTagToEventId[value];
+        if (eventId != null) targetIds.add(eventId);
+      }
+    }
+    return targetIds;
+  }
+
+  List<String> _activeLikerPubkeys(
+    Iterable<Event> reactions, {
+    required Set<String> deletedReactionIds,
+  }) {
+    final survivors =
+        reactions
+            .where((event) => event.content != _downvoteContent)
+            .where((event) => !deletedReactionIds.contains(event.id))
+            .toList()
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
+    final likerPubkeys = <String>[];
+    final seenPubkeys = <String>{};
+    for (final event in survivors) {
+      if (_blockFilter?.call(event.pubkey) ?? false) continue;
+      if (seenPubkeys.add(event.pubkey)) {
+        likerPubkeys.add(event.pubkey);
+      }
+    }
+    return likerPubkeys;
   }
 
   /// Builds a [LikesSyncResult] from the current in-memory cache.

--- a/mobile/packages/likes_repository/lib/src/likes_repository.dart
+++ b/mobile/packages/likes_repository/lib/src/likes_repository.dart
@@ -573,7 +573,9 @@ class LikesRepository {
   /// queries relays for the count of Kind 7 reactions on the event.
   /// When [addressableId] is provided, resolves the same active distinct liker
   /// set used by [fetchEventLikers], so the visible count and "Liked by" list
-  /// cannot diverge for addressable videos.
+  /// cannot diverge at fetch time for addressable videos. (A cached count is
+  /// served as-is and is not re-resolved, so likes from others arriving after
+  /// the first fetch show up in the live list but not in a cache-served count.)
   ///
   /// Note: This counts all likes, not just the current user's.
   Future<int> getLikeCount(String eventId, {String? addressableId}) async {
@@ -583,6 +585,11 @@ class LikesRepository {
     int count;
 
     if (addressableId != null && addressableId.isNotEmpty) {
+      // Resolve the count from the same filtered event fetch as the "Liked by"
+      // list (not NIP-45 COUNT) so the two can't diverge. Trade-off: it shares
+      // the list's relay cap and query timeout, so a video with more reactions
+      // than the relay returns shows count == list, both capped below the true
+      // total. Keep it a fetch (not COUNT) to preserve that equality.
       final likersByEvent = await _fetchResolvedLikersByEvent(
         [eventId],
         addressableIds: {eventId: addressableId},
@@ -610,6 +617,13 @@ class LikesRepository {
   /// - [addressableIds]: Optional map of event ID to addressable ID for
   ///   Kind 30000+ events. When provided, also queries by 'a' tag and
   ///   counts the active distinct liker set used by [fetchEventLikers].
+  ///
+  /// Note: when any uncached id in the batch has an addressable id, *all*
+  /// uncached ids in that batch are counted via the resolved distinct-liker
+  /// path (deduped + filtered); a batch with no addressable ids uses the raw
+  /// e-tag tally. So a non-addressable id can get either count depending on
+  /// batch composition, and whichever result lands first is cached for the
+  /// session.
   ///
   /// Returns a map of event ID to like count. Events with zero likes
   /// are included with a count of 0.
@@ -1215,12 +1229,19 @@ class LikesRepository {
         .map((event) => event.pubkey)
         .toSet()
         .toList();
+    // Scope the deletion query to the reaction ids we actually fetched, in
+    // addition to their authors. The consumer below only honors a Kind 5 whose
+    // `e` tag points at a fetched reaction *and* whose author matches, so
+    // `#e`-scoping is semantics-preserving; without it the query pulls every
+    // deletion these (possibly prolific) authors ever published, inflating the
+    // response and risking crowd-out under the relay's per-REQ cap.
     final deletionEvents = reactionAuthors.isEmpty
         ? const <Event>[]
         : await _nostrClient.queryEvents([
             Filter(
               kinds: const [EventKind.eventDeletion],
               authors: reactionAuthors,
+              e: allReactionsById.keys.toList(),
             ),
           ]);
 

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -1844,6 +1844,115 @@ void main() {
         expect(counts[eventId], equals(4));
       });
 
+      test(
+        'applies resolved-liker semantics to non-addressable ids in a mixed '
+        'batch',
+        () async {
+          // Production shape: addressableIds covers only the addressable subset
+          // (video_event_service.dart:4809). When any uncached id is
+          // addressable, ALL uncached ids resolve through the distinct-liker
+          // path — so the non-addressable id here must be deduped + filtered
+          // too, not raw-tallied.
+          const addrEvent = 'addr_event_1234567890abcdef01234567890abcdef';
+          const plainEvent = 'plain_event_1234567890abcdef01234567890abcdef';
+          const aTag = '34236:author:d-tag';
+          const likerA = 'liker_a_pubkey_1234567890abcdef';
+          const likerB = 'liker_b_pubkey_1234567890abcdef';
+          const likerC = 'liker_c_pubkey_1234567890abcdef';
+
+          // plainEvent: same liker reacts twice (dedupe to 1) + a downvote
+          // (excluded) => resolved count 1; a raw tally would give 3.
+          final plainReaction1 = createMockReaction(
+            id: 'plain_reaction_1',
+            targetEventId: plainEvent,
+            authorPubkey: likerA,
+          );
+          final plainReactionDuplicatePubkey = createMockReaction(
+            id: 'plain_reaction_2',
+            targetEventId: plainEvent,
+            authorPubkey: likerA,
+          );
+          final plainDownvote = createMockReaction(
+            id: 'plain_reaction_downvote',
+            targetEventId: plainEvent,
+            authorPubkey: likerB,
+            content: '-',
+          );
+          // addrEvent: one e-tag liker + one a-tag liker => 2 distinct.
+          final addrReactionByE = createMockReaction(
+            id: 'addr_reaction_e',
+            targetEventId: addrEvent,
+            authorPubkey: likerB,
+          );
+          final addrReactionByA = createMockReaction(
+            id: 'addr_reaction_a',
+            targetEventId: addrEvent,
+            authorPubkey: likerC,
+            tags: [
+              ['a', aTag],
+            ],
+          );
+
+          mockQueryEventsSequence([
+            [
+              plainReaction1,
+              plainReactionDuplicatePubkey,
+              plainDownvote,
+              addrReactionByE,
+            ],
+            [addrReactionByA],
+            <Event>[],
+          ]);
+
+          repository = createRepository();
+          final counts = await repository.getLikeCounts(
+            [addrEvent, plainEvent],
+            addressableIds: {addrEvent: aTag},
+          );
+
+          expect(counts[plainEvent], equals(1));
+          expect(counts[addrEvent], equals(2));
+          verify(() => mockNostrClient.queryEvents(any())).called(3);
+        },
+      );
+
+      test(
+        'caches resolved addressable counts so a repeat batch skips relays',
+        () async {
+          const eventId = 'cached_addr_event_1234567890abcdef0123456789';
+          const aTag = '34236:author:d-tag';
+          const likerA = 'liker_a_pubkey_1234567890abcdef';
+
+          final reactionByE = createMockReaction(
+            id: 'reaction_e',
+            targetEventId: eventId,
+            authorPubkey: likerA,
+          );
+
+          mockQueryEventsSequence([
+            [reactionByE],
+            <Event>[],
+            <Event>[],
+          ]);
+
+          repository = createRepository();
+          final first = await repository.getLikeCounts(
+            [eventId],
+            addressableIds: {eventId: aTag},
+          );
+          final second = await repository.getLikeCounts(
+            [eventId],
+            addressableIds: {eventId: aTag},
+          );
+
+          expect(first[eventId], equals(1));
+          expect(second[eventId], equals(1));
+          // First batch: e + a + deletion = 3 queries; the second is served
+          // from _likeCountCache with no further relay calls.
+          verify(() => mockNostrClient.queryEvents(any())).called(3);
+        },
+      );
+
       test('skips relay query for already-cached event IDs', () async {
         const eventId1 = 'event_id_1_1234567890abcdef01234567890abcdef';
         const eventId2 = 'event_id_2_1234567890abcdef01234567890abcdef';

--- a/mobile/packages/likes_repository/test/src/likes_repository_test.dart
+++ b/mobile/packages/likes_repository/test/src/likes_repository_test.dart
@@ -40,16 +40,22 @@ void main() {
     MockEvent createMockReaction({
       required String id,
       required String targetEventId,
+      String authorPubkey = 'reaction_author_pubkey_1234567890abcdef',
       String content = '+',
       int createdAt = defaultTimestamp,
+      List<List<String>>? tags,
     }) {
       final event = MockEvent();
       when(() => event.id).thenReturn(id);
+      when(() => event.pubkey).thenReturn(authorPubkey);
       when(() => event.content).thenReturn(content);
       when(() => event.createdAt).thenReturn(createdAt);
-      when(() => event.tags).thenReturn([
-        ['e', targetEventId],
-      ]);
+      when(() => event.tags).thenReturn(
+        tags ??
+            [
+              ['e', targetEventId],
+            ],
+      );
       return event;
     }
 
@@ -1392,18 +1398,40 @@ void main() {
       });
 
       test(
-        'queries by both e and a tags when addressableId provided',
+        'counts active likers across e and a tags',
         () async {
           const testAddressableId = '34236:$testAuthorPubkey:test-d-tag';
+          const likerA = 'liker_a_pubkey_1234567890abcdef';
+          const likerB = 'liker_b_pubkey_1234567890abcdef';
 
-          // First call returns e-tag count, second call returns a-tag count
-          var callCount = 0;
-          when(() => mockNostrClient.countEvents(any())).thenAnswer((_) async {
-            callCount++;
-            return callCount == 1
-                ? const CountResult(count: 10)
-                : const CountResult(count: 15);
-          });
+          final eTagReaction = createMockReaction(
+            id: 'reaction_e',
+            targetEventId: testEventId,
+            authorPubkey: likerA,
+          );
+          final duplicateFromATag = createMockReaction(
+            id: 'reaction_e',
+            targetEventId: testEventId,
+            authorPubkey: likerA,
+            tags: [
+              ['e', testEventId],
+              ['a', testAddressableId],
+            ],
+          );
+          final aTagOnlyReaction = createMockReaction(
+            id: 'reaction_a',
+            targetEventId: testEventId,
+            authorPubkey: likerB,
+            tags: [
+              ['a', testAddressableId],
+            ],
+          );
+
+          mockQueryEventsSequence([
+            [eTagReaction],
+            [duplicateFromATag, aTagOnlyReaction],
+            <Event>[],
+          ]);
 
           repository = createRepository();
           final count = await repository.getLikeCount(
@@ -1411,31 +1439,80 @@ void main() {
             addressableId: testAddressableId,
           );
 
-          // Should return the max of both counts
-          expect(count, equals(15));
-          verify(() => mockNostrClient.countEvents(any())).called(2);
+          expect(count, equals(2));
+          verify(() => mockNostrClient.queryEvents(any())).called(3);
         },
       );
 
-      test('returns max count when e-tag count is higher', () async {
-        const testAddressableId = '34236:$testAuthorPubkey:test-d-tag';
+      test(
+        'applies the same active liker filters as fetchEventLikers',
+        () async {
+          const testAddressableId = '34236:$testAuthorPubkey:test-d-tag';
+          const likerA = 'liker_a_pubkey_1234567890abcdef';
+          const likerB = 'liker_b_pubkey_1234567890abcdef';
+          const likerC = 'liker_c_pubkey_1234567890abcdef';
+          const blockedLiker = 'blocked_liker_pubkey_1234567890abcdef';
 
-        var callCount = 0;
-        when(() => mockNostrClient.countEvents(any())).thenAnswer((_) async {
-          callCount++;
-          return callCount == 1
-              ? const CountResult(count: 20) // e-tag count
-              : const CountResult(count: 5); // a-tag count
-        });
+          final deletedReaction = createMockReaction(
+            id: 'reaction_deleted',
+            targetEventId: testEventId,
+            authorPubkey: likerA,
+          );
+          final downvote = createMockReaction(
+            id: 'reaction_downvote',
+            targetEventId: testEventId,
+            authorPubkey: likerB,
+            content: '-',
+          );
+          final liveReaction = createMockReaction(
+            id: 'reaction_live',
+            targetEventId: testEventId,
+            authorPubkey: likerC,
+            tags: [
+              ['a', testAddressableId],
+            ],
+          );
+          final blockedReaction = createMockReaction(
+            id: 'reaction_blocked',
+            targetEventId: testEventId,
+            authorPubkey: blockedLiker,
+            tags: [
+              ['a', testAddressableId],
+            ],
+          );
+          final deletion = MockEvent();
+          when(() => deletion.pubkey).thenReturn(likerA);
+          when(() => deletion.tags).thenReturn([
+            ['e', 'reaction_deleted'],
+          ]);
 
-        repository = createRepository();
-        final count = await repository.getLikeCount(
-          testEventId,
-          addressableId: testAddressableId,
-        );
+          mockQueryEventsSequence([
+            [deletedReaction, downvote],
+            [liveReaction, blockedReaction],
+            [deletion],
+            [deletedReaction, downvote],
+            [liveReaction, blockedReaction],
+            [deletion],
+          ]);
 
-        expect(count, equals(20));
-      });
+          repository = createRepository(
+            blockFilter: (pubkey) {
+              return pubkey == blockedLiker;
+            },
+          );
+          final count = await repository.getLikeCount(
+            testEventId,
+            addressableId: testAddressableId,
+          );
+          final likers = await repository.fetchEventLikers(
+            eventId: testEventId,
+            addressableId: testAddressableId,
+          );
+
+          expect(count, equals(likers.length));
+          expect(likers, [likerC]);
+        },
+      );
 
       test('ignores empty addressableId', () async {
         when(
@@ -1657,30 +1734,41 @@ void main() {
           const eventId2 = 'event_id_2_1234567890abcdef01234567890abcdef';
           const aTag1 = '34236:author1:d1';
           const aTag2 = '34236:author2:d2';
+          const likerA = 'liker_a_pubkey_1234567890abcdef';
+          const likerB = 'liker_b_pubkey_1234567890abcdef';
+          const likerC = 'liker_c_pubkey_1234567890abcdef';
 
           // Reaction found via e-tag for event1
-          final mockReactionByE = MockEvent();
-          when(() => mockReactionByE.tags).thenReturn([
-            ['e', eventId1],
-          ]);
+          final mockReactionByE = createMockReaction(
+            id: 'reaction_e_event1',
+            targetEventId: eventId1,
+            authorPubkey: likerA,
+          );
 
           // Reactions found via a-tag for event2
-          final mockReactionByA1 = MockEvent();
-          when(() => mockReactionByA1.tags).thenReturn([
-            ['a', aTag2],
-          ]);
-          final mockReactionByA2 = MockEvent();
-          when(() => mockReactionByA2.tags).thenReturn([
-            ['a', aTag2],
-          ]);
+          final mockReactionByA1 = createMockReaction(
+            id: 'reaction_a_event2_1',
+            targetEventId: eventId2,
+            authorPubkey: likerB,
+            tags: [
+              ['a', aTag2],
+            ],
+          );
+          final mockReactionByA2 = createMockReaction(
+            id: 'reaction_a_event2_2',
+            targetEventId: eventId2,
+            authorPubkey: likerC,
+            tags: [
+              ['a', aTag2],
+            ],
+          );
 
           var callCount = 0;
           when(() => mockNostrClient.queryEvents(any())).thenAnswer((_) async {
             callCount++;
-            // First call is e-tag query, second is a-tag query
-            return callCount == 1
-                ? [mockReactionByE]
-                : [mockReactionByA1, mockReactionByA2];
+            if (callCount == 1) return [mockReactionByE];
+            if (callCount == 2) return [mockReactionByA1, mockReactionByA2];
+            return <Event>[];
           });
 
           repository = createRepository();
@@ -1691,44 +1779,60 @@ void main() {
 
           // event1 has 1 from e-tag, event2 has 2 from a-tag
           expect(counts, {eventId1: 1, eventId2: 2});
-          verify(() => mockNostrClient.queryEvents(any())).called(2);
+          verify(() => mockNostrClient.queryEvents(any())).called(3);
         },
       );
 
-      test('returns max count when merging e and a tag results', () async {
+      test('counts distinct likers when merging e and a tag results', () async {
         const eventId = 'event_id_1234567890abcdef01234567890abcdef';
         const aTag = '34236:author:d-tag';
+        const likerA = 'liker_a_pubkey_1234567890abcdef';
+        const likerB = 'liker_b_pubkey_1234567890abcdef';
+        const likerC = 'liker_c_pubkey_1234567890abcdef';
+        const likerD = 'liker_d_pubkey_1234567890abcdef';
 
-        // 3 reactions via e-tag
-        final mockReactionByE1 = MockEvent();
-        when(() => mockReactionByE1.tags).thenReturn([
-          ['e', eventId],
-        ]);
-        final mockReactionByE2 = MockEvent();
-        when(() => mockReactionByE2.tags).thenReturn([
-          ['e', eventId],
-        ]);
-        final mockReactionByE3 = MockEvent();
-        when(() => mockReactionByE3.tags).thenReturn([
-          ['e', eventId],
-        ]);
+        final mockReactionByE1 = createMockReaction(
+          id: 'reaction_e_1',
+          targetEventId: eventId,
+          authorPubkey: likerA,
+        );
+        final mockReactionByE2 = createMockReaction(
+          id: 'reaction_e_2',
+          targetEventId: eventId,
+          authorPubkey: likerB,
+        );
+        final mockReactionByE3 = createMockReaction(
+          id: 'reaction_e_3',
+          targetEventId: eventId,
+          authorPubkey: likerC,
+        );
 
-        // 2 reactions via a-tag
-        final mockReactionByA1 = MockEvent();
-        when(() => mockReactionByA1.tags).thenReturn([
-          ['a', aTag],
-        ]);
-        final mockReactionByA2 = MockEvent();
-        when(() => mockReactionByA2.tags).thenReturn([
-          ['a', aTag],
-        ]);
+        // One a-tag reaction is from an e-tag liker; only likerD is new.
+        final mockReactionByA1 = createMockReaction(
+          id: 'reaction_a_duplicate_pubkey',
+          targetEventId: eventId,
+          authorPubkey: likerC,
+          tags: [
+            ['a', aTag],
+          ],
+        );
+        final mockReactionByA2 = createMockReaction(
+          id: 'reaction_a_new_pubkey',
+          targetEventId: eventId,
+          authorPubkey: likerD,
+          tags: [
+            ['a', aTag],
+          ],
+        );
 
         var callCount = 0;
         when(() => mockNostrClient.queryEvents(any())).thenAnswer((_) async {
           callCount++;
-          return callCount == 1
-              ? [mockReactionByE1, mockReactionByE2, mockReactionByE3]
-              : [mockReactionByA1, mockReactionByA2];
+          if (callCount == 1) {
+            return [mockReactionByE1, mockReactionByE2, mockReactionByE3];
+          }
+          if (callCount == 2) return [mockReactionByA1, mockReactionByA2];
+          return <Event>[];
         });
 
         repository = createRepository();
@@ -1737,8 +1841,7 @@ void main() {
           addressableIds: {eventId: aTag},
         );
 
-        // Should return 3 (max of 3 from e-tag and 2 from a-tag)
-        expect(counts[eventId], equals(3));
+        expect(counts[eventId], equals(4));
       });
 
       test('skips relay query for already-cached event IDs', () async {
@@ -2340,42 +2443,39 @@ void main() {
         },
       );
 
-      test(
-        'ignores Kind 5 deletions whose author does not match the reaction '
-        'author',
-        () async {
-          // likerA reacted, but likerB publishes a Kind 5 referencing likerA's
-          // reaction id. Without the same-author guard this would suppress
-          // likerA's like.
-          final reactionA = createReaction(
-            id: 'reaction_a',
-            authorPubkey: likerA,
-            createdAt: 1700000050,
-          );
-          final reactionB = createReaction(
-            id: 'reaction_b',
-            authorPubkey: likerB,
-            createdAt: 1700000100,
-          );
+      test('ignores Kind 5 deletions whose author does not match the reaction '
+          'author', () async {
+        // likerA reacted, but likerB publishes a Kind 5 referencing likerA's
+        // reaction id. Without the same-author guard this would suppress
+        // likerA's like.
+        final reactionA = createReaction(
+          id: 'reaction_a',
+          authorPubkey: likerA,
+          createdAt: 1700000050,
+        );
+        final reactionB = createReaction(
+          id: 'reaction_b',
+          authorPubkey: likerB,
+          createdAt: 1700000100,
+        );
 
-          final spoofedDeletion = MockEvent();
-          when(() => spoofedDeletion.pubkey).thenReturn(likerB);
-          when(() => spoofedDeletion.tags).thenReturn([
-            ['e', 'reaction_a'],
-          ]);
+        final spoofedDeletion = MockEvent();
+        when(() => spoofedDeletion.pubkey).thenReturn(likerB);
+        when(() => spoofedDeletion.tags).thenReturn([
+          ['e', 'reaction_a'],
+        ]);
 
-          mockQueryEventsSequence([
-            [reactionA, reactionB],
-            [spoofedDeletion],
-          ]);
+        mockQueryEventsSequence([
+          [reactionA, reactionB],
+          [spoofedDeletion],
+        ]);
 
-          repository = createRepository();
-          expect(await repository.fetchEventLikers(eventId: targetEventId), [
-            likerB,
-            likerA,
-          ]);
-        },
-      );
+        repository = createRepository();
+        expect(await repository.fetchEventLikers(eventId: targetEventId), [
+          likerB,
+          likerA,
+        ]);
+      });
 
       test('throws FetchLikersFailedException when relay query fails', () {
         when(


### PR DESCRIPTION
## Summary
- Align addressable video like counts with the same resolved active-liker set used by the "Liked by" screen.
- Share e-tag/a-tag union, reaction-id dedupe, pubkey dedupe, downvote filtering, same-author deletion filtering, and block filtering between count and list paths.
- Add full event/addressable identifiers to video engagement loading logs so future support reports can be traced without contacting the user.

## Root Cause
Addressable video counts used a different source of truth than the "Liked by" screen. Counts took the maximum of separate e-tag and a-tag relay COUNT responses, while the list queried actual reaction events across both tags, deduped by pubkey, and filtered inactive reactions. That made the list legitimately able to exceed the displayed count.

## Verification
- flutter test test/src/likes_repository_test.dart from mobile/packages/likes_repository
- flutter test test/blocs/video_engagement/video_engagement_bloc_test.dart from mobile
- flutter test test/screens/video_engagement/video_engagement_list_screen_test.dart from mobile
- flutter analyze from mobile
- pre-push analyzer and changed-file tests

Closes #5742