### PR TITLE
fix(feed): stop terminal playback retry loops

### DIFF
--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -635,10 +635,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     for (var i = startIndex; i < newWidget.videos.length; i++) {
       _terminalErrorTypesByVideoId.remove(newWidget.videos[i].id);
     }
-    final maxLength = oldWidget.videos.length > newWidget.videos.length
-        ? oldWidget.videos.length
-        : newWidget.videos.length;
-    for (var i = startIndex; i < maxLength; i++) {
+    for (var i = startIndex; i < oldWidget.videos.length; i++) {
       _errors.remove(i);
       _errorTypes.remove(i);
       _cancelAutoRetry(i);
@@ -1222,7 +1219,6 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       );
       final errorType = classifyVideoError(
         errorMessage: e.toString(),
-        source: _resolveUrl(video),
       );
       unawaited(_controllers.remove(index)?.dispose());
       if (_isTerminalPlaybackFailure(e)) {

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -1212,12 +1212,17 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         error: e,
         stackTrace: stackTrace,
       );
-      _errorTypes[index] = classifyVideoError(
+      final errorType = classifyVideoError(
         errorMessage: e.toString(),
         source: _resolveUrl(video),
       );
       unawaited(_controllers.remove(index)?.dispose());
-      _errors.add(index);
+      if (_isTerminalPlaybackFailure(e)) {
+        _stopAndMarkTerminalError(index, errorType);
+      } else {
+        _errorTypes[index] = errorType;
+        _errors.add(index);
+      }
     }
     // coverage:ignore-end
 
@@ -1575,10 +1580,6 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   void _scheduleAutoRetryIfEligible(int index) {
     if (index != _currentIndex || !_isActive) return;
     if (_hasTerminalError(index)) return;
-    if ((_errorTypes[index] ?? VideoErrorType.generic) !=
-        VideoErrorType.generic) {
-      return;
-    }
     final attempt = _autoRetryAttempts[index] ?? 0;
     final delay = InfiniteVideoFeed.autoRetryDelay(
       attempt: attempt,

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -621,6 +621,9 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     return i;
   }
 
+  /// Clears terminal errors for the changed tail (index >= [startIndex]) from
+  /// both the old and new lists, so a video id reused at a new position gets a
+  /// fresh playback attempt instead of inheriting a stale terminal error.
   void _clearTerminalErrorsFromChangedTail(
     InfiniteVideoFeed oldWidget,
     InfiniteVideoFeed newWidget,
@@ -1510,6 +1513,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _scheduleAutoRetryIfEligible(index);
   }
 
+  /// Like [_stopAndMarkError] but records the failure as terminal for this
+  /// video id, so it will not auto-retry and is restored on revisit.
   void _stopAndMarkTerminalError(int index, VideoErrorType type) {
     final videoId = _videoIdAt(index);
     if (videoId != null) {

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -345,6 +345,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   // UI-facing state — drives build(). Stays on the State.
   final _errors = <int>{};
   final _errorTypes = <int, VideoErrorType>{};
+  final _terminalErrorTypesByVideoId = <String, VideoErrorType>{};
   final _loopSeekInProgress = <int>{};
   // Viewer auth headers per index, applied to every resolved playback source
   // for that index. The age-gate token is a hash-bound BUD-01 (kind 24242)
@@ -410,6 +411,14 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   /// [InfiniteVideoFeed.releaseNeighboursWhenInactive]).
   @visibleForTesting
   Set<int> get debugLiveControllerIndices => _controllers.keys.toSet();
+
+  /// Video ids with terminal playback failures that should not auto-retry.
+  ///
+  /// Exposed for tests that assert a confirmed unplayable video remains an
+  /// error even after its off-screen controller is disposed.
+  @visibleForTesting
+  Set<String> get debugTerminalErrorVideoIds =>
+      _terminalErrorTypesByVideoId.keys.toSet();
 
   int _clampIndex(int index) {
     if (widget.videos.isEmpty) return 0;
@@ -540,6 +549,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     // that falls inside the live window; out-of-window ones it disposes itself.
     if (commonPrefix > _currentIndex) {
       _prefetcher.cancelActive();
+      _clearTerminalErrorsFromChangedTail(oldWidget, widget, commonPrefix);
       _controllers.keys
           .where((index) => index >= commonPrefix)
           .toList()
@@ -558,6 +568,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       '(old=${oldWidget.videos.length} new=${widget.videos.length})',
     );
 
+    _terminalErrorTypesByVideoId.clear();
     _teardownAllControllers();
 
     _currentIndex = _clampIndex(widget.initialIndex);
@@ -608,6 +619,19 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       i++;
     }
     return i;
+  }
+
+  void _clearTerminalErrorsFromChangedTail(
+    InfiniteVideoFeed oldWidget,
+    InfiniteVideoFeed newWidget,
+    int startIndex,
+  ) {
+    for (var i = startIndex; i < oldWidget.videos.length; i++) {
+      _terminalErrorTypesByVideoId.remove(oldWidget.videos[i].id);
+    }
+    for (var i = startIndex; i < newWidget.videos.length; i++) {
+      _terminalErrorTypesByVideoId.remove(newWidget.videos[i].id);
+    }
   }
 
   @override
@@ -846,7 +870,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         .forEach(_disposeAt);
 
     // Initialize the current index first for instant playback.
-    if (!_controllers.containsKey(index)) {
+    if (!_controllers.containsKey(index) && !_restoreTerminalErrorAt(index)) {
       await _initController(index);
     }
 
@@ -855,7 +879,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     if (widget.keepNextAlive &&
         keepNeighbours &&
         index + 1 <= lastIndex &&
-        !_controllers.containsKey(index + 1)) {
+        !_controllers.containsKey(index + 1) &&
+        !_restoreTerminalErrorAt(index + 1)) {
       unawaited(_initController(index + 1));
     }
 
@@ -873,7 +898,8 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     if (widget.keepPreviousAlive &&
         keepNeighbours &&
         index - 1 >= 0 &&
-        !_controllers.containsKey(index - 1)) {
+        !_controllers.containsKey(index - 1) &&
+        !_restoreTerminalErrorAt(index - 1)) {
       unawaited(_initController(index - 1));
     }
   }
@@ -1007,10 +1033,13 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   Future<void> _initController(int index, {bool skipCache = false}) async {
     if (index < 0 || index >= widget.videos.length) return;
 
+    if (_restoreTerminalErrorAt(index)) return;
+
+    final video = widget.videos[index];
+
     final initGeneration = (_controllerInitGenerations[index] ?? 0) + 1;
     _controllerInitGenerations[index] = initGeneration;
 
-    final video = widget.videos[index];
     final cachedFile = skipCache
         ? null
         : widget.cache.getCachedFileSync(video.id);
@@ -1235,6 +1264,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _errorTypes.remove(index);
     _processingRetryInFlight.remove(index);
     _processingRetryAttempts.remove(index);
+    final videoId = _videoIdAt(index);
+    if (videoId != null) {
+      _terminalErrorTypesByVideoId.remove(videoId);
+    }
     if (httpHeaders.isEmpty) {
       _httpHeadersByIndex.remove(index);
     } else {
@@ -1313,7 +1346,14 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         error: e,
         stackTrace: stackTrace,
       );
-      _onVideoStalled(index);
+      _onVideoStalled(
+        index,
+        isTerminal: _isTerminalPlaybackFailure(e),
+        errorType: classifyVideoError(
+          errorMessage: e.toString(),
+          source: nextSource,
+        ),
+      );
     } finally {
       _failoverInFlight.remove(index);
     }
@@ -1430,9 +1470,17 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   // coverage:ignore-start
   // Stall recovery is only reached from watchdog / stale-detector callbacks
   // tied to native playback state streams.
-  void _onVideoStalled(int index) {
+  void _onVideoStalled(
+    int index, {
+    bool isTerminal = false,
+    VideoErrorType errorType = VideoErrorType.generic,
+  }) {
     _log('Video stalled index $index — marking error');
-    _stopAndMarkError(index, VideoErrorType.generic);
+    if (isTerminal) {
+      _stopAndMarkTerminalError(index, errorType);
+    } else {
+      _stopAndMarkError(index, errorType);
+    }
     widget.onVideoStalled?.call(index);
   }
 
@@ -1462,6 +1510,50 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     _scheduleAutoRetryIfEligible(index);
   }
 
+  void _stopAndMarkTerminalError(int index, VideoErrorType type) {
+    final videoId = _videoIdAt(index);
+    if (videoId != null) {
+      _terminalErrorTypesByVideoId[videoId] = type;
+    }
+    _cancelAutoRetry(index);
+    unawaited(_controllers[index]?.stop());
+    _errors.add(index);
+    _errorTypes[index] = type;
+    _rebuild();
+  }
+
+  String? _videoIdAt(int index) {
+    if (index < 0 || index >= widget.videos.length) return null;
+    return widget.videos[index].id;
+  }
+
+  bool _hasTerminalError(int index) {
+    final videoId = _videoIdAt(index);
+    return videoId != null && _terminalErrorTypesByVideoId.containsKey(videoId);
+  }
+
+  bool _restoreTerminalErrorAt(int index) {
+    final videoId = _videoIdAt(index);
+    if (videoId == null) return false;
+    final terminalType = _terminalErrorTypesByVideoId[videoId];
+    if (terminalType == null) return false;
+    _errors.add(index);
+    _errorTypes[index] = terminalType;
+    _rebuild();
+    return true;
+  }
+
+  VideoErrorType? _terminalErrorTypeAt(int index) {
+    final videoId = _videoIdAt(index);
+    return videoId == null ? null : _terminalErrorTypesByVideoId[videoId];
+  }
+
+  bool _isTerminalPlaybackFailure(Object? error) {
+    final message = error?.toString().toLowerCase() ?? '';
+    return message.contains('no playable video tracks') ||
+        message.contains('no video track');
+  }
+
   void _seekKick(int index, int positionMs) {
     final controller = _controllers[index];
     if (controller == null) return;
@@ -1477,6 +1569,11 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   /// [InfiniteVideoFeed.autoRetryMaxAttempts]; manual retry still works.
   void _scheduleAutoRetryIfEligible(int index) {
     if (index != _currentIndex || !_isActive) return;
+    if (_hasTerminalError(index)) return;
+    if ((_errorTypes[index] ?? VideoErrorType.generic) !=
+        VideoErrorType.generic) {
+      return;
+    }
     final attempt = _autoRetryAttempts[index] ?? 0;
     final delay = InfiniteVideoFeed.autoRetryDelay(
       attempt: attempt,
@@ -1525,6 +1622,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         controller,
         isAlreadyError: () =>
             _errors.contains(index) ||
+            _hasTerminalError(index) ||
             _failoverInFlight.contains(index) ||
             _processingRetryInFlight.contains(index),
         onError: (errorCode, errorMessage) {
@@ -1554,13 +1652,15 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
             return;
           }
 
-          _stopAndMarkError(
-            index,
-            classifyVideoError(
-              errorMessage: errorMessage,
-              source: _resolveUrl(widget.videos[index]),
-            ),
+          final errorType = classifyVideoError(
+            errorMessage: errorMessage,
+            source: _resolveUrl(widget.videos[index]),
           );
+          if (_isTerminalPlaybackFailure(errorMessage)) {
+            _stopAndMarkTerminalError(index, errorType);
+          } else {
+            _stopAndMarkError(index, errorType);
+          }
         },
       );
 
@@ -1678,7 +1778,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
       onPageChanged: _onPageChanged,
       itemCount: widget.videos.length,
       itemBuilder: (context, index) {
-        final hasError = _errors.contains(index);
+        final hasError = _errors.contains(index) || _hasTerminalError(index);
         final controller = _controllers[index];
 
         final overlay = widget.overlayBuilder?.call(
@@ -1727,8 +1827,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
               ?widget.errorBuilder?.call(
                 context,
                 index,
-                () => unawaited(_retryController(index).then((_) {})),
-                _errorTypes[index] ?? VideoErrorType.generic,
+                () => unawaited(retryAt(index).then((_) {})),
+                _terminalErrorTypeAt(index) ??
+                    _errorTypes[index] ??
+                    VideoErrorType.generic,
               ),
             // coverage:ignore-end
           ],

--- a/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
+++ b/mobile/packages/infinite_video_feed/lib/src/widgets/infinite_video_feed.dart
@@ -549,7 +549,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     // that falls inside the live window; out-of-window ones it disposes itself.
     if (commonPrefix > _currentIndex) {
       _prefetcher.cancelActive();
-      _clearTerminalErrorsFromChangedTail(oldWidget, widget, commonPrefix);
+      _clearChangedTailPlaybackState(oldWidget, widget, commonPrefix);
       _controllers.keys
           .where((index) => index >= commonPrefix)
           .toList()
@@ -621,10 +621,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     return i;
   }
 
-  /// Clears terminal errors for the changed tail (index >= [startIndex]) from
-  /// both the old and new lists, so a video id reused at a new position gets a
-  /// fresh playback attempt instead of inheriting a stale terminal error.
-  void _clearTerminalErrorsFromChangedTail(
+  /// Clears playback failure state for the changed tail (index >=
+  /// [startIndex]), so fresh videos do not inherit stale index-scoped errors
+  /// or terminal errors from videos that used to occupy those slots.
+  void _clearChangedTailPlaybackState(
     InfiniteVideoFeed oldWidget,
     InfiniteVideoFeed newWidget,
     int startIndex,
@@ -634,6 +634,14 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
     }
     for (var i = startIndex; i < newWidget.videos.length; i++) {
       _terminalErrorTypesByVideoId.remove(newWidget.videos[i].id);
+    }
+    final maxLength = oldWidget.videos.length > newWidget.videos.length
+        ? oldWidget.videos.length
+        : newWidget.videos.length;
+    for (var i = startIndex; i < maxLength; i++) {
+      _errors.remove(i);
+      _errorTypes.remove(i);
+      _cancelAutoRetry(i);
     }
   }
 
@@ -1580,6 +1588,7 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
   void _scheduleAutoRetryIfEligible(int index) {
     if (index != _currentIndex || !_isActive) return;
     if (_hasTerminalError(index)) return;
+    if (!_isAutoRetryableErrorType(_errorTypes[index])) return;
     final attempt = _autoRetryAttempts[index] ?? 0;
     final delay = InfiniteVideoFeed.autoRetryDelay(
       attempt: attempt,
@@ -1605,6 +1614,10 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
         ),
       );
     });
+  }
+
+  bool _isAutoRetryableErrorType(VideoErrorType? type) {
+    return type == null || type == VideoErrorType.generic;
   }
 
   /// Cancels a pending auto-retry and clears the attempt budget for [index].
@@ -1660,7 +1673,6 @@ class InfiniteVideoFeedState extends State<InfiniteVideoFeed> {
 
           final errorType = classifyVideoError(
             errorMessage: errorMessage,
-            source: _resolveUrl(widget.videos[index]),
           );
           if (_isTerminalPlaybackFailure(errorMessage)) {
             _stopAndMarkTerminalError(index, errorType);

--- a/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/utils/playback_sources_test.dart
@@ -172,6 +172,16 @@ void main() {
       );
     });
 
+    test('returns notFound for explicit HTTP 404 on a Divine blob URL', () {
+      expect(
+        classifyVideoError(
+          errorMessage: 'HTTP 404 Not Found',
+          source: 'https://media.divine.video/$_hash/720p.mp4',
+        ),
+        equals(VideoErrorType.notFound),
+      );
+    });
+
     test('returns generic for Android response-code 202 messages', () {
       expect(
         classifyVideoError(

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -2738,6 +2738,66 @@ void main() {
       });
 
       testWidgets(
+        'auto-retries opaque transient failures on canonical Divine URLs',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+          final key = GlobalKey<InfiniteVideoFeedState>();
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: [
+                    _makeVideo(
+                      'divine_transient',
+                      videoUrl:
+                          'https://media.divine.video/10fe4777d60fa224878fd9be348a3410e6b70ba2d865e5ae82526a8f1d053326/720p.mp4',
+                    ),
+                  ],
+                  cache: cache,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  autoRetryBaseDelay: const Duration(milliseconds: 200),
+                  errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            await harness.sendEvent(0, const <Object?, Object?>{
+              'status': 'error',
+              'errorCode': 'network_error',
+              'errorMessage': 'connection dropped',
+            });
+            await tester.pump();
+            await tester.pump();
+
+            expect(find.text('VIDEO_ERROR'), findsOneWidget);
+            expect(key.currentState!.debugTerminalErrorVideoIds, isEmpty);
+            final setClipsBeforeRetry = harness.countCalls('setClips');
+
+            await tester.pump(const Duration(milliseconds: 250));
+            await tester.pump();
+            await tester.pump();
+
+            expect(
+              harness.countCalls('setClips'),
+              greaterThan(setClipsBeforeRetry),
+            );
+            expect(find.text('VIDEO_ERROR'), findsNothing);
+          } finally {
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
+
+      testWidgets(
         'does not auto-retry terminal no-video-track failover failures',
         (tester) async {
           DivineVideoPlayerController.resetIdCounterForTesting();
@@ -2831,6 +2891,82 @@ void main() {
             expect(
               harness.countCalls('setClips'),
               greaterThan(setClipsAfterTerminalFailure),
+            );
+          } finally {
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
+
+      testWidgets(
+        'persists terminal no-video-track init failures across revisit',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install(playerIds: const <int>[0, 1, 2, 3, 4, 5]);
+          final key = GlobalKey<InfiniteVideoFeedState>();
+          final videos = [_makeVideo('terminal_init'), _makeVideo('next')];
+          harness.setClipsFailures[0] = <Exception>[
+            PlatformException(
+              code: 'COMPOSITION_ERROR',
+              message: 'No playable video tracks found.',
+            ),
+          ];
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos,
+                  cache: cache,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  autoRetryBaseDelay: const Duration(milliseconds: 200),
+                  errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            expect(find.text('VIDEO_ERROR'), findsOneWidget);
+            expect(
+              key.currentState!.debugTerminalErrorVideoIds,
+              equals(<String>{'terminal_init'}),
+            );
+            final setClipsAfterTerminalFailure = harness.countCalls('setClips');
+
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+
+            expect(
+              harness.countCalls('setClips'),
+              equals(setClipsAfterTerminalFailure),
+            );
+
+            unawaited(key.currentState!.animateToPage(1));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 1));
+            await tester.pump();
+            expect(key.currentState!.currentIndex, equals(1));
+
+            unawaited(key.currentState!.animateToPage(0));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 1));
+            await tester.pump();
+            expect(key.currentState!.currentIndex, equals(0));
+
+            expect(find.text('VIDEO_ERROR'), findsOneWidget);
+            expect(
+              harness.countCalls('setClips'),
+              equals(setClipsAfterTerminalFailure),
             );
           } finally {
             await tester.pumpWidget(const SizedBox.shrink());

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -1577,6 +1577,93 @@ void main() {
           expect(pageView.controller!.page?.round(), equals(1));
         },
       );
+
+      testWidgets(
+        'tail replacement clears stale index-scoped error state',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+          final key = GlobalKey<InfiniteVideoFeedState>();
+          final videos1 = List.generate(4, (i) => _makeVideo('old$i'));
+
+          harness.setClipsFailures[2] = <Exception>[
+            PlatformException(
+              code: 'HTTP_ERROR',
+              message: 'HTTP 403 Forbidden',
+            ),
+          ];
+          harness.setClipsDelays[3] = Completer<void>();
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos1,
+                  cache: cache,
+                  preloadGracePeriod: Duration.zero,
+                  prefetchCount: 0,
+                  errorBuilder: (_, _, _, errorType) =>
+                      Text('ERROR:${errorType.name}'),
+                  loadingBuilder: (_, index, {required isSquare}) =>
+                      Text('LOADING:$index'),
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            unawaited(key.currentState!.animateToPage(1));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+            expect(key.currentState!.currentIndex, equals(1));
+
+            // Index 2 failed during neighbor init and has no live controller,
+            // leaving only index-scoped error state behind.
+            expect(find.text('ERROR:forbidden'), findsNothing);
+
+            final videos2 = [
+              videos1[0],
+              videos1[1],
+              _makeVideo('fresh2'),
+              _makeVideo('fresh3'),
+            ];
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos2,
+                  cache: cache,
+                  preloadGracePeriod: Duration.zero,
+                  prefetchCount: 0,
+                  errorBuilder: (_, _, _, errorType) =>
+                      Text('ERROR:${errorType.name}'),
+                  loadingBuilder: (_, index, {required isSquare}) =>
+                      Text('LOADING:$index'),
+                ),
+              ),
+            );
+            await tester.pump();
+
+            unawaited(key.currentState!.animateToPage(2));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 400));
+
+            expect(key.currentState!.currentIndex, equals(2));
+            expect(find.text('ERROR:forbidden'), findsNothing);
+            expect(find.textContaining('ERROR:'), findsNothing);
+          } finally {
+            if (harness.setClipsDelays[3]?.isCompleted == false) {
+              harness.setClipsDelays[3]!.complete();
+            }
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
     });
 
     group('overlayBuilder', () {
@@ -2796,6 +2883,90 @@ void main() {
           }
         },
       );
+
+      const permanentErrorScenarios =
+          <
+            ({
+              String name,
+              String message,
+              String typeName,
+            })
+          >[
+            (
+              name: '403 forbidden',
+              message: 'HTTP 403 Forbidden',
+              typeName: 'forbidden',
+            ),
+            (
+              name: '404 not found',
+              message: 'HTTP 404 Not Found',
+              typeName: 'notFound',
+            ),
+            (
+              name: '401 age gate',
+              message: 'HTTP 401 Unauthorized',
+              typeName: 'ageRestricted',
+            ),
+          ];
+
+      for (final scenario in permanentErrorScenarios) {
+        testWidgets(
+          'does not auto-retry typed permanent ${scenario.name} failures',
+          (tester) async {
+            DivineVideoPlayerController.resetIdCounterForTesting();
+            final harness = _NativePlayerHarness(tester);
+            await harness.install(playerIds: const <int>[0, 1, 2, 3]);
+
+            try {
+              await tester.pumpWidget(
+                _wrapFeed(
+                  InfiniteVideoFeed(
+                    videos: [_makeVideo('permanent_${scenario.typeName}')],
+                    cache: cache,
+                    prefetchCount: 0,
+                    preloadGracePeriod: Duration.zero,
+                    autoRetryBaseDelay: const Duration(milliseconds: 200),
+                    errorBuilder: (_, _, _, errorType) =>
+                        Text('VIDEO_ERROR:${errorType.name}'),
+                  ),
+                ),
+              );
+              await tester.pump();
+              await tester.pump();
+
+              await harness.sendEvent(0, <Object?, Object?>{
+                'status': 'error',
+                'errorCode': 'network_error',
+                'errorMessage': scenario.message,
+              });
+              await tester.pump();
+              await tester.pump();
+
+              expect(
+                find.text('VIDEO_ERROR:${scenario.typeName}'),
+                findsOneWidget,
+              );
+              final setClipsAfterError = harness.countCalls('setClips');
+
+              await tester.pump(const Duration(milliseconds: 400));
+              await tester.pump();
+
+              expect(
+                harness.countCalls('setClips'),
+                equals(setClipsAfterError),
+              );
+              expect(
+                find.text('VIDEO_ERROR:${scenario.typeName}'),
+                findsOneWidget,
+              );
+            } finally {
+              await tester.pumpWidget(const SizedBox.shrink());
+              await tester.pump();
+              await harness.dispose();
+            }
+          },
+        );
+      }
 
       testWidgets(
         'does not auto-retry terminal no-video-track failover failures',

--- a/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
+++ b/mobile/packages/infinite_video_feed/test/src/widgets/infinite_video_feed_test.dart
@@ -21,6 +21,7 @@ class _NativePlayerHarness {
   final List<String> methodCalls = <String>[];
   final Map<int, Completer<void>> setClipsDelays = <int, Completer<void>>{};
   final Map<int, int> failSetClipsAfter = <int, int>{};
+  final Map<int, List<Exception>> setClipsFailures = <int, List<Exception>>{};
   final Set<int> _installedPlayerIds = <int>{};
   static const _globalChannel = MethodChannel('divine_video_player');
   static const _codec = StandardMethodCodec();
@@ -60,6 +61,10 @@ class _NativePlayerHarness {
                 code: 'stale_set_clips',
                 message: 'stale player_$playerId setClips',
               );
+            }
+            final failures = setClipsFailures[playerId];
+            if (failures != null && failures.isNotEmpty) {
+              throw failures.removeAt(0);
             }
           }
           return null;
@@ -2731,6 +2736,109 @@ void main() {
           await harness.dispose();
         }
       });
+
+      testWidgets(
+        'does not auto-retry terminal no-video-track failover failures',
+        (tester) async {
+          DivineVideoPlayerController.resetIdCounterForTesting();
+          final harness = _NativePlayerHarness(tester);
+          await harness.install(playerIds: const <int>[0, 1, 2, 3, 4, 5]);
+          final key = GlobalKey<InfiniteVideoFeedState>();
+          final videos = [
+            _makeVideo(
+              'terminal',
+              videoUrl:
+                  'https://media.divine.video/10fe4777d60fa224878fd9be348a3410e6b70ba2d865e5ae82526a8f1d053326/720p.mp4',
+            ),
+            _makeVideo('next'),
+          ];
+
+          try {
+            await tester.pumpWidget(
+              _wrapFeed(
+                InfiniteVideoFeed(
+                  key: key,
+                  videos: videos,
+                  cache: cache,
+                  prefetchCount: 0,
+                  preloadGracePeriod: Duration.zero,
+                  autoRetryBaseDelay: const Duration(milliseconds: 200),
+                  errorBuilder: (_, _, _, _) => const Text('VIDEO_ERROR'),
+                ),
+              ),
+            );
+            await tester.pump();
+            await tester.pump();
+
+            harness.setClipsFailures[0] = <Exception>[
+              PlatformException(
+                code: 'COMPOSITION_ERROR',
+                message: 'No playable video tracks found.',
+              ),
+            ];
+
+            await harness.sendEvent(0, const <Object?, Object?>{
+              'status': 'error',
+              'errorCode': 'parse_error',
+              'errorMessage': 'parse failed',
+            });
+            await tester.pump();
+            await tester.pump();
+
+            expect(find.text('VIDEO_ERROR'), findsOneWidget);
+            expect(
+              key.currentState!.debugTerminalErrorVideoIds,
+              equals(<String>{'terminal'}),
+            );
+            final setClipsAfterTerminalFailure = harness.countCalls('setClips');
+
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+
+            expect(
+              harness.countCalls('setClips'),
+              equals(setClipsAfterTerminalFailure),
+            );
+
+            unawaited(key.currentState!.animateToPage(1));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 1));
+            await tester.pump();
+            expect(key.currentState!.currentIndex, equals(1));
+
+            unawaited(key.currentState!.animateToPage(0));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 400));
+            await tester.pump();
+            await tester.pump(const Duration(milliseconds: 1));
+            await tester.pump();
+            expect(key.currentState!.currentIndex, equals(0));
+
+            expect(find.text('VIDEO_ERROR'), findsOneWidget);
+            expect(
+              harness.countCalls('setClips'),
+              equals(setClipsAfterTerminalFailure),
+            );
+
+            await key.currentState!.retryAt(0);
+            await tester.pump();
+            await tester.pump();
+
+            expect(key.currentState!.debugTerminalErrorVideoIds, isEmpty);
+            expect(find.text('VIDEO_ERROR'), findsNothing);
+            expect(
+              harness.countCalls('setClips'),
+              greaterThan(setClipsAfterTerminalFailure),
+            );
+          } finally {
+            await tester.pumpWidget(const SizedBox.shrink());
+            await tester.pump();
+            await harness.dispose();
+          }
+        },
+      );
 
       testWidgets('cancels a scheduled auto-retry when the feed deactivates', (
         tester,


### PR DESCRIPTION
## Summary
- Keep no-playable-track/no-video-track runtime failures terminal for the current feed session, keyed by video id instead of only by page index.
- Preserve existing generic auto-retry behavior for transient failures such as network loss or HTTP 202 processing.
- Prevent terminal failures from reinitializing after page-window disposal, while allowing explicit manual retry to clear the terminal state and attempt playback again.
- Add a regression test that simulates the logged Divine media failover path: MP4 parse error -> HLS failover -> `No playable video tracks found.`

## Root cause
`InfiniteVideoFeed` treated every active error as eligible for automatic retry. That is useful for transient generic failures, but it loops indefinitely for a platform-confirmed unplayable source. Error state was also index-local, so disposing a page window could clear the error and let the same video id reinitialize.

Closes #5749

## Verification
- `flutter test test/src/widgets/infinite_video_feed_test.dart --plain-name "does not auto-retry terminal no-video-track failover failures"`
- `flutter test test/src/widgets/infinite_video_feed_test.dart`
- `flutter test` from `mobile/packages/infinite_video_feed`
- `flutter analyze` from `mobile/packages/infinite_video_feed`
- `flutter test test/widgets/video_feed_item/feed_videos_test.dart test/screens/feed/feed_auto_advance_error_listener_test.dart test/screens/feed/pooled_fullscreen_video_feed_screen_test.dart` from `mobile`
- `flutter analyze` from `mobile`
- pre-push hook: analyzer + changed-file tests

## Reviewers
Requested: @dcadenas, @hm21