### PR TITLE
fix(video-editor): recover editor preview from decoder-init contention

### DIFF
--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -90,7 +90,6 @@ class _VideoMetadataCoverScreenState
     );
     if (!mounted) return;
     _videoDuration = metadata.duration;
-    _startStripGeneration(localPath);
 
     final controller = DivineVideoPlayerController(useTexture: true);
     await controller.initialize();
@@ -109,6 +108,12 @@ class _VideoMetadataCoverScreenState
         _pendingSeekPosition = null;
       });
     }
+
+    // Start strip extraction only after the player has acquired its decoder.
+    // Both read the same file; the MediaMetadataRetriever strip frames would
+    // otherwise contend with the player's decoder init and can leave the
+    // preview stuck on DECODER_INIT_FAILED (a scarce hardware-decoder pool).
+    if (mounted) _startStripGeneration(localPath);
   }
 
   Future<void> _startStripGeneration(String videoPath) async {
@@ -604,9 +609,7 @@ class _ThumbnailStripState extends State<_ThumbnailStrip> {
 
   Duration _clampPosition(Duration position) {
     final maxMs = widget.clipDuration.inMilliseconds;
-    return Duration(
-      milliseconds: position.inMilliseconds.clamp(0, maxMs),
-    );
+    return Duration(milliseconds: position.inMilliseconds.clamp(0, maxMs));
   }
 
   void _seekBySemanticsDelta(Duration delta) {
@@ -673,19 +676,14 @@ class _ThumbnailStripState extends State<_ThumbnailStrip> {
           final count = (stripWidth / _stripThumbWidth).ceil().clamp(1, 500);
           _updateSlotCache(count);
           final slotWidth = stripWidth / count;
-          final cursorDx = _dxFromPosition(
-            widget.selectedPosition,
-            stripWidth,
-          );
+          final cursorDx = _dxFromPosition(widget.selectedPosition, stripWidth);
 
           return GestureDetector(
             behavior: HitTestBehavior.opaque,
-            onTapDown: (d) => widget.onSeek(
-              _positionFromDx(d.localPosition.dx, stripWidth),
-            ),
-            onHorizontalDragUpdate: (d) => widget.onSeek(
-              _positionFromDx(d.localPosition.dx, stripWidth),
-            ),
+            onTapDown: (d) =>
+                widget.onSeek(_positionFromDx(d.localPosition.dx, stripWidth)),
+            onHorizontalDragUpdate: (d) =>
+                widget.onSeek(_positionFromDx(d.localPosition.dx, stripWidth)),
             child: SizedBox(
               width: stripWidth,
               height: _stripHeight,
@@ -752,23 +750,15 @@ class _SlotImage extends StatelessWidget {
         ? ExcludeSemantics(
             child: VineCachedImage(
               imageUrl: thumbnail!.networkUrl!,
-              placeholder: (_, _) => const ColoredBox(
-                color: VineTheme.surfaceContainerHigh,
-              ),
-              errorWidget: (_, _, _) => const ColoredBox(
-                color: VineTheme.surfaceContainerHigh,
-              ),
+              placeholder: (_, _) =>
+                  const ColoredBox(color: VineTheme.surfaceContainerHigh),
+              errorWidget: (_, _, _) =>
+                  const ColoredBox(color: VineTheme.surfaceContainerHigh),
             ),
           )
         : thumbnail?.file != null
-        ? Image.file(
-            thumbnail!.file!,
-            fit: .cover,
-            excludeFromSemantics: true,
-          )
-        : const ColoredBox(
-            color: VineTheme.surfaceContainerHigh,
-          );
+        ? Image.file(thumbnail!.file!, fit: .cover, excludeFromSemantics: true)
+        : const ColoredBox(color: VineTheme.surfaceContainerHigh);
 
     if (stripThumbnailPath == null) return fallback;
 

--- a/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
+++ b/mobile/lib/screens/video_metadata/video_metadata_cover_screen.dart
@@ -66,6 +66,11 @@ class _VideoMetadataCoverScreenState
 
   bool _playerReady = false;
 
+  /// True when the preview player conclusively failed to load the video
+  /// (e.g. a decoder init that never recovered). The strip picker keeps
+  /// working without a live preview in that case.
+  bool _playerInitFailed = false;
+
   bool _isConfirming = false;
 
   bool _isSeeking = false;
@@ -92,27 +97,42 @@ class _VideoMetadataCoverScreenState
     _videoDuration = metadata.duration;
 
     final controller = DivineVideoPlayerController(useTexture: true);
-    await controller.initialize();
-    if (!mounted) {
-      await controller.dispose();
-      return;
-    }
-    await controller.setSource(VideoClip.file(localPath));
-    if (mounted) await controller.seekTo(_selectedPosition);
-    if (mounted) {
-      setState(() {
-        _controller = controller;
-        _playerReady = true;
-        _seekEpoch++;
-        _isSeeking = false;
-        _pendingSeekPosition = null;
-      });
+    try {
+      await controller.initialize();
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+      await controller.setSource(VideoClip.file(localPath));
+      if (mounted) await controller.seekTo(_selectedPosition);
+      if (mounted) {
+        setState(() {
+          _controller = controller;
+          _playerReady = true;
+          _seekEpoch++;
+          _isSeeking = false;
+          _pendingSeekPosition = null;
+        });
+      }
+    } catch (e, stackTrace) {
+      // A dead preview must not take the cover picker down with it — the
+      // strip below still lets the user scrub and confirm a frame.
+      Log.error(
+        'Cover preview player failed to load the video',
+        name: 'VideoMetadataCoverScreen',
+        error: e,
+        stackTrace: stackTrace,
+      );
+      unawaited(controller.dispose());
+      if (!mounted) return;
+      setState(() => _playerInitFailed = true);
     }
 
-    // Start strip extraction only after the player has acquired its decoder.
-    // Both read the same file; the MediaMetadataRetriever strip frames would
-    // otherwise contend with the player's decoder init and can leave the
-    // preview stuck on DECODER_INIT_FAILED (a scarce hardware-decoder pool).
+    // Start strip extraction only after the player has acquired its decoder
+    // (or conclusively failed to). Both read the same file; the
+    // MediaMetadataRetriever strip frames would otherwise contend with the
+    // player's decoder init and can leave the preview stuck on
+    // DECODER_INIT_FAILED (a scarce hardware-decoder pool).
     if (mounted) _startStripGeneration(localPath);
   }
 
@@ -172,9 +192,12 @@ class _VideoMetadataCoverScreenState
   }
 
   Future<void> _seekTo(Duration position) async {
-    if (!_playerReady) return;
+    // With a failed player the strip still drives frame selection — move
+    // the cursor without a live preview so the user can pick a cover.
+    if (!_playerReady && !_playerInitFailed) return;
     _selectedPosition = position;
     if (mounted) setState(() {});
+    if (!_playerReady) return;
 
     if (_isSeeking) {
       _pendingSeekPosition = position;
@@ -318,7 +341,9 @@ class _VideoMetadataCoverScreenState
                           ),
                         ),
 
-                        if (_controller == null || !_controller!.isInitialized)
+                        if (!_playerInitFailed &&
+                            (_controller == null ||
+                                !_controller!.isInitialized))
                           const Center(child: BrandedLoadingIndicator()),
                       ],
                     ),

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -6,7 +6,6 @@ import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path/path.dart' as p;
-import 'package:unified_logger/unified_logger.dart';
 
 /// Signature of [VideoThumbnailService.generateStripThumbnails], injectable
 /// so tests can assert pause/resume behaviour on the produced subscriptions
@@ -248,11 +247,6 @@ class ClipThumbnailManager {
     for (final sub in _subscriptions.values) {
       if (!sub.isPaused) sub.pause();
     }
-    Log.info(
-      '⏸️ Thumbnail extraction paused (${_subscriptions.length} sub(s))',
-      name: 'ClipThumbnailManager',
-      category: LogCategory.video,
-    );
   }
 
   /// Resumes thumbnail extraction paused by [pauseAll].
@@ -261,11 +255,6 @@ class ClipThumbnailManager {
     for (final sub in _subscriptions.values) {
       if (sub.isPaused) sub.resume();
     }
-    Log.info(
-      '▶️ Thumbnail extraction resumed (${_subscriptions.length} sub(s))',
-      name: 'ClipThumbnailManager',
-      category: LogCategory.video,
-    );
   }
 
   static void _deleteFiles(List<StripThumbnail> thumbnails) {

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -6,6 +6,7 @@ import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path/path.dart' as p;
+import 'package:unified_logger/unified_logger.dart';
 
 /// Manages thumbnail loading and cleanup for a set of clips.
 ///
@@ -226,6 +227,11 @@ class ClipThumbnailManager {
     for (final sub in _subscriptions.values) {
       if (!sub.isPaused) sub.pause();
     }
+    Log.warning(
+      '⏸️ Thumbnail extraction paused (${_subscriptions.length} sub(s))',
+      name: 'ClipThumbnailManager',
+      category: LogCategory.video,
+    );
   }
 
   /// Resumes thumbnail extraction paused by [pauseAll].
@@ -234,6 +240,11 @@ class ClipThumbnailManager {
     for (final sub in _subscriptions.values) {
       if (sub.isPaused) sub.resume();
     }
+    Log.warning(
+      '▶️ Thumbnail extraction resumed (${_subscriptions.length} sub(s))',
+      name: 'ClipThumbnailManager',
+      category: LogCategory.video,
+    );
   }
 
   static void _deleteFiles(List<StripThumbnail> thumbnails) {

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -8,11 +8,32 @@ import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:path/path.dart' as p;
 import 'package:unified_logger/unified_logger.dart';
 
+/// Signature of [VideoThumbnailService.generateStripThumbnails], injectable
+/// so tests can assert pause/resume behaviour on the produced subscriptions
+/// without touching the native extractor.
+typedef StripThumbnailStreamFactory =
+    Stream<List<StripThumbnail>> Function({
+      required String videoPath,
+      required String clipId,
+      required Duration duration,
+      required Size outputSize,
+      required int thumbsPerSecond,
+      List<Duration>? priorityTimestamps,
+    });
+
 /// Manages thumbnail loading and cleanup for a set of clips.
 ///
 /// Each clip gets an independent [ValueNotifier] so only the affected
 /// tile rebuilds when new thumbnails arrive.
 class ClipThumbnailManager {
+  ClipThumbnailManager({
+    StripThumbnailStreamFactory? stripThumbnailStreamFactory,
+  }) : _generateStripThumbnails =
+           stripThumbnailStreamFactory ??
+           VideoThumbnailService.generateStripThumbnails;
+
+  final StripThumbnailStreamFactory _generateStripThumbnails;
+
   final Map<String, ValueNotifier<List<StripThumbnail>>> _notifiers = {};
   final Map<String, StreamSubscription<List<StripThumbnail>>> _subscriptions =
       {};
@@ -202,7 +223,7 @@ class ClipThumbnailManager {
             .ceil();
 
     final subscription =
-        VideoThumbnailService.generateStripThumbnails(
+        _generateStripThumbnails(
           videoPath: videoPath,
           clipId: clip.id,
           duration: clip.duration,
@@ -227,7 +248,7 @@ class ClipThumbnailManager {
     for (final sub in _subscriptions.values) {
       if (!sub.isPaused) sub.pause();
     }
-    Log.warning(
+    Log.info(
       '⏸️ Thumbnail extraction paused (${_subscriptions.length} sub(s))',
       name: 'ClipThumbnailManager',
       category: LogCategory.video,
@@ -240,7 +261,7 @@ class ClipThumbnailManager {
     for (final sub in _subscriptions.values) {
       if (sub.isPaused) sub.resume();
     }
-    Log.warning(
+    Log.info(
       '▶️ Thumbnail extraction resumed (${_subscriptions.length} sub(s))',
       name: 'ClipThumbnailManager',
       category: LogCategory.video,

--- a/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
+++ b/mobile/lib/services/video_editor/clip_thumbnail_manager.dart
@@ -27,6 +27,10 @@ class ClipThumbnailManager {
   // (still un-trimmed) source video.
   final Set<String> _seeded = {};
 
+  /// When true, newly started subscriptions begin paused and existing ones are
+  /// held. See [pauseAll].
+  bool _paused = false;
+
   /// Returns the thumbnail notifier for the given [clipId].
   ValueNotifier<List<StripThumbnail>> operator [](String clipId) =>
       _notifiers[clipId]!;
@@ -196,7 +200,7 @@ class ClipThumbnailManager {
                 TimelineConstants.thumbnailWidth)
             .ceil();
 
-    _subscriptions[clip.id] =
+    final subscription =
         VideoThumbnailService.generateStripThumbnails(
           videoPath: videoPath,
           clipId: clip.id,
@@ -207,6 +211,29 @@ class ClipThumbnailManager {
         ).listen((thumbnails) {
           _notifiers[clip.id]?.value = thumbnails;
         });
+    // If the owner paused while this clip was (re)synced, keep the new
+    // subscription paused too so it doesn't start extracting off-screen.
+    if (_paused) subscription.pause();
+    _subscriptions[clip.id] = subscription;
+  }
+
+  /// Pauses all in-flight thumbnail subscriptions — e.g. while the editor is
+  /// obscured by another route — so the native frame extraction stops
+  /// contending for hardware decoders and CPU. Lossless: the batch stream
+  /// generators suspend at the next batch boundary and continue on [resumeAll].
+  void pauseAll() {
+    _paused = true;
+    for (final sub in _subscriptions.values) {
+      if (!sub.isPaused) sub.pause();
+    }
+  }
+
+  /// Resumes thumbnail extraction paused by [pauseAll].
+  void resumeAll() {
+    _paused = false;
+    for (final sub in _subscriptions.values) {
+      if (sub.isPaused) sub.resume();
+    }
   }
 
   static void _deleteFiles(List<StripThumbnail> thumbnails) {

--- a/mobile/lib/services/video_thumbnail_service.dart
+++ b/mobile/lib/services/video_thumbnail_service.dart
@@ -27,6 +27,22 @@ class VideoThumbnailService {
   /// perceived timeline fill across clips.
   static Future<void> _stripBatchQueue = Future<void>.value();
 
+  /// Resets the strip-batch serial queue between tests.
+  ///
+  /// A widget test that tears down while a strip generator is awaiting the
+  /// queue strands a forever-pending future in that test's dead FakeAsync
+  /// zone; the next test would inherit it and deadlock before its first
+  /// batch.
+  ///
+  /// Call this from inside the `testWidgets` body, not from `setUp`: the
+  /// replacement future must be created in the test's FakeAsync zone or its
+  /// completion lands on the real event loop, which a widget test never
+  /// reaches until it ends.
+  @visibleForTesting
+  static void resetStripBatchQueueForTesting() {
+    _stripBatchQueue = Future<void>.value();
+  }
+
   /// Extract a thumbnail from a video file at a specific timestamp
   ///
   /// [videoPath] - Path to the video file

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -48,6 +48,7 @@ class VideoEditorTimelineClipStrip extends StatefulWidget {
     this.onTrimDragChanged,
     this.isMultiSelectMode = false,
     this.selectedClipIds = const {},
+    @visibleForTesting this.thumbnailManager,
     super.key,
   });
 
@@ -64,6 +65,11 @@ class VideoEditorTimelineClipStrip extends StatefulWidget {
 
   /// IDs of the clips currently selected in multi-select mode.
   final Set<String> selectedClipIds;
+
+  /// Test seam for asserting route-aware thumbnail pausing without invoking the
+  /// native thumbnail extractor.
+  @visibleForTesting
+  final ClipThumbnailManager? thumbnailManager;
 
   /// When `true` the user is scrolling or pinch-zooming — long press
   /// must not start a reorder drag.
@@ -122,7 +128,7 @@ class _VideoEditorTimelineClipStripState
   /// Thumbnail data keyed by clip ID — survives reordering.
   /// Each notifier is updated independently so only the affected
   /// clip tile rebuilds, not the entire strip.
-  final _thumbnails = ClipThumbnailManager();
+  late final ClipThumbnailManager _thumbnails;
 
   /// Identity of the last split event we already seeded thumbnails
   /// for. Used to ensure each split is processed exactly once.
@@ -150,6 +156,7 @@ class _VideoEditorTimelineClipStripState
   @override
   void initState() {
     super.initState();
+    _thumbnails = widget.thumbnailManager ?? ClipThumbnailManager();
     _reorderAnimController = AnimationController(
       vsync: this,
       duration: _animDuration,

--- a/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
+++ b/mobile/lib/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart
@@ -12,6 +12,7 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/l10n.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/router/app_router.dart';
 import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';
 import 'package:openvine/services/video_thumbnail_service.dart';
 import 'package:openvine/utils/mounted_post_frame.dart';
@@ -87,7 +88,7 @@ class VideoEditorTimelineClipStrip extends StatefulWidget {
 
 class _VideoEditorTimelineClipStripState
     extends State<VideoEditorTimelineClipStrip>
-    with SingleTickerProviderStateMixin {
+    with SingleTickerProviderStateMixin, RouteAware {
   static const _animDuration = Duration(milliseconds: 250);
 
   /// Drives reorder shrink/grow timing so we can react to completion
@@ -159,6 +160,13 @@ class _VideoEditorTimelineClipStripState
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    // Pause thumbnail extraction while the editor is obscured (e.g. after
+    // pushing the metadata/preview screen) so its MediaMetadataRetriever
+    // frames stop competing for hardware decoders with the render/preview.
+    final route = ModalRoute.of(context);
+    if (route is PageRoute) {
+      routeObserver.subscribe(this, route);
+    }
     _maybeSeedSplit();
     _syncThumbnails();
   }
@@ -174,7 +182,14 @@ class _VideoEditorTimelineClipStripState
   }
 
   @override
+  void didPushNext() => _thumbnails.pauseAll();
+
+  @override
+  void didPopNext() => _thumbnails.resumeAll();
+
+  @override
   void dispose() {
+    routeObserver.unsubscribe(this);
     _stopAutoScroll();
     _volumeExitTimer?.cancel();
     _reorderAnimController.dispose();
@@ -212,9 +227,7 @@ class _VideoEditorTimelineClipStripState
     final startClipIdx = widget.clips.indexWhere(
       (c) => c.id == split.startClipId,
     );
-    final endClipIdx = widget.clips.indexWhere(
-      (c) => c.id == split.endClipId,
-    );
+    final endClipIdx = widget.clips.indexWhere((c) => c.id == split.endClipId);
     if (startClipIdx == -1 || endClipIdx == -1) return;
     final startClip = widget.clips[startClipIdx];
     final endClip = widget.clips[endClipIdx];

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -127,8 +127,9 @@ internal class DivineVideoPlayerInstance(
 
     /**
      * Consecutive re-prepare attempts made after a transient decoder error,
-     * reset once a frame renders. Bounds [maybeRecoverFromDecoderError] so a
-     * genuinely undecodable clip can't spin in a prepare/error loop.
+     * reset once a frame renders or a new clip list is loaded. Bounds
+     * [maybeRecoverFromDecoderError] so a genuinely undecodable clip can't
+     * spin in a prepare/error loop.
      */
     private var decoderRetryCount = 0
     private var videoWidth = 0
@@ -459,6 +460,9 @@ internal class DivineVideoPlayerInstance(
         httpHeadersByUri = headersByUri
         httpHeadersByHash = headersByHash
         firstFrameRendered = false
+        // New media gets the full retry budget — exhaustion belonged to the
+        // previous clip list.
+        decoderRetryCount = 0
 
         // Resolve the optional global start position to (clipIndex, localMs)
         // so ExoPlayer begins buffering at the right point immediately.

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -132,6 +132,7 @@ internal class DivineVideoPlayerInstance(
      * spin in a prepare/error loop.
      */
     private var decoderRetryCount = 0
+    private var decoderRetryRunnable: Runnable? = null
     private var videoWidth = 0
     private var videoHeight = 0
     private var rotationDegrees = 0
@@ -462,6 +463,7 @@ internal class DivineVideoPlayerInstance(
         firstFrameRendered = false
         // New media gets the full retry budget — exhaustion belonged to the
         // previous clip list.
+        cancelDecoderRetry()
         decoderRetryCount = 0
 
         // Resolve the optional global start position to (clipIndex, localMs)
@@ -1072,15 +1074,23 @@ internal class DivineVideoPlayerInstance(
                 "in ${DECODER_RETRY_DELAY_MS}ms",
             name = "DivineVideoPlayer.Playback",
         )
-        mainHandler.postDelayed(
-            {
+        cancelDecoderRetry()
+        val retryRunnable = object : Runnable {
+            override fun run() {
+                if (decoderRetryRunnable === this) decoderRetryRunnable = null
                 // The player may have been released or replaced while waiting;
                 // only re-prepare the exact instance that errored.
                 if (player === recoveringPlayer) recoveringPlayer.prepare()
-            },
-            DECODER_RETRY_DELAY_MS,
-        )
+            }
+        }
+        decoderRetryRunnable = retryRunnable
+        mainHandler.postDelayed(retryRunnable, DECODER_RETRY_DELAY_MS)
         return true
+    }
+
+    private fun cancelDecoderRetry() {
+        decoderRetryRunnable?.let { mainHandler.removeCallbacks(it) }
+        decoderRetryRunnable = null
     }
 
     // -- lifecycle --
@@ -1163,6 +1173,7 @@ internal class DivineVideoPlayerInstance(
         mainHandler.removeCallbacks(seekTimeoutRunnable)
         mainHandler.removeCallbacks(setClipsTimeoutRunnable)
         mainHandler.removeCallbacks(bufferingWatchdogRunnable)
+        cancelDecoderRetry()
         seekCompletionResult?.success(null)
         seekCompletionResult = null
         pendingSetClipsResult?.success(null)

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -1150,10 +1150,16 @@ internal class DivineVideoPlayerInstance(
      * `ImageReaderSurfaceProducer`. The full [dispose] runs later, on
      * engine detach.
      *
+     * Cancels any pending decoder-retry re-prepare: the player is not nulled
+     * here (only [dispose] does that), so a scheduled retry's
+     * `player === recoveringPlayer` guard would still pass and call
+     * `prepare()` on the just-cleared surface after detach began.
+     *
      * Asymmetric with [onAppBackgrounded] by design: no resume is expected
      * after Activity detach, so [wasPlayingBeforePause] is not set.
      */
     fun stopForActivityDetach() {
+        cancelDecoderRetry()
         player?.let {
             it.stop()
             it.clearVideoSurface()

--- a/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
+++ b/mobile/packages/divine_video_player/android/src/main/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstance.kt
@@ -10,6 +10,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.SeekParameters
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -123,6 +124,13 @@ internal class DivineVideoPlayerInstance(
     private var volume = 1.0
     private var speed = 1.0
     private var firstFrameRendered = false
+
+    /**
+     * Consecutive re-prepare attempts made after a transient decoder error,
+     * reset once a frame renders. Bounds [maybeRecoverFromDecoderError] so a
+     * genuinely undecodable clip can't spin in a prepare/error loop.
+     */
+    private var decoderRetryCount = 0
     private var videoWidth = 0
     private var videoHeight = 0
     private var rotationDegrees = 0
@@ -267,7 +275,14 @@ internal class DivineVideoPlayerInstance(
     }
 
     private fun buildDefaultPlayer(): ExoPlayer {
-        val builder = ExoPlayer.Builder(context)
+        // Fall back to an alternate (e.g. software) decoder when the preferred
+        // hardware decoder fails to initialise. Turns a transient
+        // DECODER_INIT_FAILED — common when feed + editor + preview + thumbnail
+        // extraction contend for a small hardware decoder pool — into a
+        // successful (if slower) decode instead of a dead surface.
+        val renderersFactory =
+            DefaultRenderersFactory(context).setEnableDecoderFallback(true)
+        val builder = ExoPlayer.Builder(context, renderersFactory)
             .setMediaSourceFactory(
                 DefaultMediaSourceFactory(
                     VideoCache.dataSourceFactory(context) { uri: Uri ->
@@ -977,6 +992,10 @@ internal class DivineVideoPlayerInstance(
                     (error.message ?: "unknown"),
                 name = "DivineVideoPlayer.Playback",
             )
+            // A transient decoder failure may recover on a re-prepare; keep the
+            // pending setClips result open so a successful retry still resolves
+            // it (or the 10 s watchdog fires if every retry fails).
+            if (maybeRecoverFromDecoderError(error)) return
             // Unblock a pending setClips with an error so Dart can react
             // rather than waiting for the 10 s safety timeout.
             mainHandler.removeCallbacks(setClipsTimeoutRunnable)
@@ -991,6 +1010,10 @@ internal class DivineVideoPlayerInstance(
 
         override fun onRenderedFirstFrame() {
             firstFrameRendered = true
+            // A frame reached the surface, so whatever contention caused a
+            // prior decoder error has cleared — allow the full retry budget
+            // again for any future error.
+            decoderRetryCount = 0
             sendStateUpdate()
         }
 
@@ -1016,6 +1039,44 @@ internal class DivineVideoPlayerInstance(
             }
             sendStateUpdate()
         }
+    }
+
+    /**
+     * Re-prepares the player after a transient decoder error, bounded to
+     * [MAX_DECODER_RETRIES]. Returns `true` when a retry was scheduled so the
+     * caller leaves the pending setClips result open for a successful retry.
+     *
+     * `DECODER_INIT_FAILED` / `DECODING_FAILED` on an editing/preview surface
+     * is usually contention for a scarce hardware decoder (feed + editor +
+     * preview + thumbnail extraction competing) rather than a bad file — the
+     * same output often decodes on the next attempt once a competing codec
+     * releases. Feed players keep ExoPlayer's own recovery, so this is scoped
+     * to [BufferProfile.FULL].
+     */
+    private fun maybeRecoverFromDecoderError(error: PlaybackException): Boolean {
+        if (bufferProfile != BufferProfile.FULL) return false
+        val isDecoderError =
+            error.errorCode == PlaybackException.ERROR_CODE_DECODER_INIT_FAILED ||
+                error.errorCode == PlaybackException.ERROR_CODE_DECODING_FAILED
+        if (!isDecoderError || decoderRetryCount >= MAX_DECODER_RETRIES) return false
+
+        val recoveringPlayer = player ?: return false
+        decoderRetryCount++
+        DivineVideoPlayerLog.warning(
+            "Player $playerId decoder error [${error.errorCodeName}] — " +
+                "retry $decoderRetryCount/$MAX_DECODER_RETRIES " +
+                "in ${DECODER_RETRY_DELAY_MS}ms",
+            name = "DivineVideoPlayer.Playback",
+        )
+        mainHandler.postDelayed(
+            {
+                // The player may have been released or replaced while waiting;
+                // only re-prepare the exact instance that errored.
+                if (player === recoveringPlayer) recoveringPlayer.prepare()
+            },
+            DECODER_RETRY_DELAY_MS,
+        )
+        return true
     }
 
     // -- lifecycle --
@@ -1142,5 +1203,19 @@ internal class DivineVideoPlayerInstance(
          * sensible lower bound the editor UI exposes.
          */
         private const val MIN_PLAYBACK_SPEED = 0.001f
+
+        /**
+         * How many times an editing/preview player re-prepares after a
+         * transient decoder error before giving up. Small: a couple of
+         * attempts covers momentary hardware-decoder contention without
+         * masking a genuinely undecodable clip.
+         */
+        private const val MAX_DECODER_RETRIES = 2
+
+        /**
+         * Delay before a decoder-error re-prepare, giving a competing codec
+         * time to release its hardware decoder before we ask for one again.
+         */
+        private const val DECODER_RETRY_DELAY_MS = 350L
     }
 }

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -546,6 +546,24 @@ class DivineVideoPlayerInstanceTest {
     }
 
     @Test
+    fun `stopForActivityDetach cancels a pending decoder retry`() {
+        val listener = capturePlayerListener()
+        instance.onMethodCall(setClipsCall(), mockk(relaxed = true))
+        clearMocks(mockHandler, answers = false, recordedCalls = true)
+
+        val scheduled = slot<Runnable>()
+        every { mockHandler.postDelayed(capture(scheduled), 350L) } returns true
+        listener.onPlayerError(decoderInitError())
+
+        instance.stopForActivityDetach()
+
+        // The queued re-prepare is cancelled so it can't call prepare() on the
+        // surface stopForActivityDetach just cleared — the player is not nulled
+        // here, so its `player === recoveringPlayer` guard would otherwise pass.
+        verify { mockHandler.removeCallbacks(scheduled.captured) }
+    }
+
+    @Test
     fun `superseding setClips completes the previous result with CANCELLED`() {
         capturePlayerListener()
         val first = mockk<MethodChannel.Result>(relaxed = true)

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -503,6 +503,28 @@ class DivineVideoPlayerInstanceTest {
     }
 
     @Test
+    fun `setClips restores the decoder retry budget after exhaustion`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+
+        // Exhaust the budget without ever rendering a frame.
+        listener.onPlayerError(decoderInitError())
+        listener.onPlayerError(decoderInitError())
+        listener.onPlayerError(decoderInitError("gave up"))
+        verify(exactly = 1) { result.error("PLAYER_ERROR", "gave up", null) }
+
+        // A new clip load gets the full budget: the next decoder error is
+        // retried instead of immediately failing the new pending result.
+        val nextResult = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), nextResult)
+        listener.onPlayerError(decoderInitError())
+
+        verify(exactly = 0) { nextResult.error(any(), any(), any()) }
+        verify(exactly = 3) { mockHandler.postDelayed(any(), 350L) }
+    }
+
+    @Test
     fun `superseding setClips completes the previous result with CANCELLED`() {
         capturePlayerListener()
         val first = mockk<MethodChannel.Result>(relaxed = true)

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -546,10 +546,13 @@ class DivineVideoPlayerInstanceTest {
     }
 
     @Test
-    fun `stopForActivityDetach cancels a pending decoder retry`() {
+    fun `stopForActivityDetach cancels a pending decoder retry before clearing the surface`() {
         val listener = capturePlayerListener()
-        instance.onMethodCall(setClipsCall(), mockk(relaxed = true))
-        clearMocks(mockHandler, answers = false, recordedCalls = true)
+        instance.onMethodCall(
+            setClipsCall("file:///tmp/a.mp4"),
+            mockk(relaxed = true),
+        )
+        clearMocks(mockHandler, mockPlayer, answers = false, recordedCalls = true)
 
         val scheduled = slot<Runnable>()
         every { mockHandler.postDelayed(capture(scheduled), 350L) } returns true
@@ -557,10 +560,11 @@ class DivineVideoPlayerInstanceTest {
 
         instance.stopForActivityDetach()
 
-        // The queued re-prepare is cancelled so it can't call prepare() on the
-        // surface stopForActivityDetach just cleared — the player is not nulled
-        // here, so its `player === recoveringPlayer` guard would otherwise pass.
-        verify { mockHandler.removeCallbacks(scheduled.captured) }
+        verifyOrder {
+            mockHandler.removeCallbacks(scheduled.captured)
+            mockPlayer.stop()
+            mockPlayer.clearVideoSurface()
+        }
     }
 
     @Test

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -3,6 +3,7 @@ package com.divinevideo.divine_video_player
 import android.content.Context
 import android.graphics.SurfaceTexture
 import android.os.Handler
+import android.os.SystemClock
 import android.view.Surface
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
@@ -17,9 +18,11 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkConstructor
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.Assert.assertEquals
@@ -441,6 +444,62 @@ class DivineVideoPlayerInstanceTest {
 
         verify(exactly = 1) { result.error("PLAYER_ERROR", "boom", null) }
         verify(exactly = 0) { result.success(any()) }
+    }
+
+    /**
+     * Builds a real [PlaybackException] carrying [ERROR_CODE_DECODER_INIT_FAILED]
+     * — the `errorCode` is a public field mockk can't stub, so a genuine
+     * instance is needed. Its public constructor reads `Clock.DEFAULT`
+     * (→ `android.os.SystemClock`), unmocked on the plain-JVM test runtime, so
+     * that static is stubbed only for construction.
+     */
+    private fun decoderInitError(message: String = "decoder boom"): PlaybackException {
+        mockkStatic(SystemClock::class)
+        every { SystemClock.elapsedRealtime() } returns 0L
+        return PlaybackException(
+            message,
+            null,
+            PlaybackException.ERROR_CODE_DECODER_INIT_FAILED,
+        ).also { unmockkStatic(SystemClock::class) }
+    }
+
+    @Test
+    fun `onPlayerError re-prepares after a decoder init failure instead of failing the pending result`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+        // Drop the prepare() that setClips itself issued.
+        clearMocks(mockPlayer, answers = false, recordedCalls = true)
+
+        val scheduled = slot<Runnable>()
+        every { mockHandler.postDelayed(capture(scheduled), 350L) } returns true
+
+        listener.onPlayerError(decoderInitError())
+
+        // The pending result stays open for the retry; a delayed re-prepare is queued.
+        verify(exactly = 0) { result.error(any(), any(), any()) }
+        verify(exactly = 1) { mockHandler.postDelayed(any(), 350L) }
+
+        // Running the queued task re-prepares the same player.
+        scheduled.captured.run()
+        verify(exactly = 1) { mockPlayer.prepare() }
+    }
+
+    @Test
+    fun `onPlayerError fails the pending result after exhausting decoder retries`() {
+        val listener = capturePlayerListener()
+        val result = mockk<MethodChannel.Result>(relaxed = true)
+        instance.onMethodCall(setClipsCall(), result)
+
+        // The first two errors each queue a re-prepare (MAX_DECODER_RETRIES = 2).
+        listener.onPlayerError(decoderInitError())
+        listener.onPlayerError(decoderInitError())
+        verify(exactly = 0) { result.error(any(), any(), any()) }
+        verify(exactly = 2) { mockHandler.postDelayed(any(), 350L) }
+
+        // The third gives up and surfaces the error to Dart.
+        listener.onPlayerError(decoderInitError("final boom"))
+        verify(exactly = 1) { result.error("PLAYER_ERROR", "final boom", null) }
     }
 
     @Test

--- a/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
+++ b/mobile/packages/divine_video_player/android/src/test/kotlin/com/divinevideo/divine_video_player/DivineVideoPlayerInstanceTest.kt
@@ -525,6 +525,27 @@ class DivineVideoPlayerInstanceTest {
     }
 
     @Test
+    fun `superseding setClips cancels a pending decoder retry`() {
+        val listener = capturePlayerListener()
+        instance.onMethodCall(
+            setClipsCall("file:///tmp/a.mp4"),
+            mockk(relaxed = true),
+        )
+        clearMocks(mockHandler, answers = false, recordedCalls = true)
+
+        val scheduled = slot<Runnable>()
+        every { mockHandler.postDelayed(capture(scheduled), 350L) } returns true
+        listener.onPlayerError(decoderInitError())
+
+        instance.onMethodCall(
+            setClipsCall("file:///tmp/b.mp4"),
+            mockk(relaxed = true),
+        )
+
+        verify { mockHandler.removeCallbacks(scheduled.captured) }
+    }
+
+    @Test
     fun `superseding setClips completes the previous result with CANCELLED`() {
         capturePlayerListener()
         val first = mockk<MethodChannel.Result>(relaxed = true)

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -1808,10 +1808,10 @@ packages:
     dependency: "direct main"
     description:
       name: pro_video_editor
-      sha256: ca1af2b67c883c6344b3ca7697736ab8390658bd8d78835ab26a0247e5200e67
+      sha256: "591b3f92c03579a8a01bded652942f756b30305ee5644f380aabebb62ab7f3ee"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   process:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -311,7 +311,7 @@ dependencies:
   firebase_messaging: ^16.1.1
   convert: ^3.1.2
   audio_session: ^0.2.2
-  pro_video_editor: ^2.2.2
+  pro_video_editor: ^2.2.3
   pro_image_editor: ^12.11.1
   flutter_colorpicker: ^1.1.0
   file_picker: ^10.3.7

--- a/mobile/test/screens/video_metadata_cover_screen_test.dart
+++ b/mobile/test/screens/video_metadata_cover_screen_test.dart
@@ -15,6 +15,8 @@ import 'package:openvine/models/divine_video_clip.dart';
 import 'package:openvine/models/video_editor/video_editor_provider_state.dart';
 import 'package:openvine/providers/video_editor_provider.dart';
 import 'package:openvine/screens/video_metadata/video_metadata_cover_screen.dart';
+import 'package:openvine/services/video_thumbnail_service.dart';
+import 'package:openvine/widgets/branded_loading_indicator.dart';
 import 'package:pro_video_editor/core/platform/native_method_channel.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
@@ -341,5 +343,84 @@ void main() {
         findsOneWidget,
       );
     });
+
+    testWidgets(
+      'a permanently failed preview still generates the cover strip, hides '
+      'the loading indicator, and keeps the picker scrubbable',
+      (tester) async {
+        addTearDown(tearDownPlayerChannel);
+        _setHandler(const MethodChannel('divine_video_player/player_0'), (
+          call,
+        ) async {
+          if (call.method == 'setClips') {
+            throw PlatformException(
+              code: 'PLAYER_ERROR',
+              message: 'decoder init failed',
+            );
+          }
+          return null;
+        });
+        _setHandler(
+          const MethodChannel('divine_video_player/player_0/events'),
+          (call) async => null,
+        );
+
+        var stripRequested = false;
+        _setHandler(const MethodChannel('pro_video_editor'), (call) async {
+          if (call.method == 'getThumbnails') {
+            stripRequested = true;
+            return <Object?>[];
+          }
+          if (call.method == 'getMetadata') {
+            return <String, Object?>{
+              'duration': 3000000,
+              'extension': 'mp4',
+              'fileSize': 1024000,
+              'width': 1920,
+              'height': 1080,
+              'rotation': 0,
+              'bitrate': 3000000,
+            };
+          }
+          return null;
+        });
+        final semanticsHandle = tester.ensureSemantics();
+
+        // A previous test tearing down mid-generation strands the static
+        // strip queue on a future from its dead FakeAsync zone; reset it
+        // here — inside this test's zone, so the replacement future's
+        // completion is flushed by pumps — or the batch loop never runs.
+        VideoThumbnailService.resetStripBatchQueueForTesting();
+
+        await tester.pumpWidget(buildWidget());
+        await tester.pump(const Duration(milliseconds: 400));
+        for (var i = 0; i < 10; i++) {
+          await tester.pump();
+        }
+
+        expect(stripRequested, isTrue);
+        expect(find.byType(BrandedLoadingIndicator), findsNothing);
+
+        // Scrubbing must still move the selection cursor without a player.
+        final l10n = lookupAppLocalizations(const Locale('en'));
+        final stripFinder = find.bySemanticsLabel(
+          l10n.videoMetadataEditCoverStripSemanticLabel,
+        );
+        final before = tester.getSemantics(stripFinder).getSemanticsData();
+        final stripSemantics = find.semantics.byAction(
+          SemanticsAction.increase,
+        );
+        // Two steps with a rebuild in between: a single 500 ms step from the
+        // 210 ms default lands at 710 ms, which formats to the same "0:00".
+        tester.semantics.increase(stripSemantics);
+        await tester.pump();
+        tester.semantics.increase(stripSemantics);
+        await tester.pump();
+        final after = tester.getSemantics(stripFinder).getSemanticsData();
+        expect(after.value, isNot(equals(before.value)));
+
+        semanticsHandle.dispose();
+      },
+    );
   });
 }

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -1,6 +1,7 @@
 // ABOUTME: Unit tests for ClipThumbnailManager.
 // ABOUTME: Validates notifier lifecycle, sync logic, and disposal.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/widgets.dart';
@@ -355,29 +356,96 @@ void main() {
     });
 
     group('pauseAll / resumeAll', () {
+      late StreamController<List<StripThumbnail>> streamController;
+      late int pauses;
+      late int resumes;
+      late ClipThumbnailManager fakeStreamManager;
+
+      const firstBatch = [
+        StripThumbnail(path: '/t/a0.jpg', timestamp: Duration.zero),
+      ];
+      const secondBatch = [
+        StripThumbnail(path: '/t/a0.jpg', timestamp: Duration.zero),
+        StripThumbnail(path: '/t/a1.jpg', timestamp: Duration(seconds: 1)),
+      ];
+
+      setUp(() {
+        pauses = 0;
+        resumes = 0;
+        streamController = StreamController<List<StripThumbnail>>(
+          onPause: () => pauses++,
+          onResume: () => resumes++,
+        );
+        fakeStreamManager = ClipThumbnailManager(
+          stripThumbnailStreamFactory:
+              ({
+                required String videoPath,
+                required String clipId,
+                required Duration duration,
+                required Size outputSize,
+                required int thumbsPerSecond,
+                List<Duration>? priorityTimestamps,
+              }) => streamController.stream,
+        );
+      });
+
+      tearDown(() {
+        fakeStreamManager.dispose();
+        // Not awaited: close() only completes once a listener receives the
+        // done event, and the idle test never attaches one.
+        unawaited(streamController.close());
+      });
+
+      void syncFileClip() {
+        fakeStreamManager.sync(
+          clips: [_createFileClip(id: 'a', videoPath: '/video/a.mp4')],
+          devicePixelRatio: 1,
+        );
+      }
+
       test('are safe on an idle manager with no active subscriptions', () {
         expect(manager.pauseAll, returnsNormally);
         expect(manager.resumeAll, returnsNormally);
       });
 
-      test('are safe after syncing clips', () {
-        manager.sync(clips: [_createTestClip(id: 'a')], devicePixelRatio: 1);
+      test(
+        'pauseAll holds thumbnail delivery and resumeAll releases it',
+        () async {
+          syncFileClip();
+          streamController.add(firstBatch);
+          await pumpEventQueue();
+          expect(fakeStreamManager['a'].value, hasLength(1));
 
-        expect(manager.pauseAll, returnsNormally);
-        expect(manager.resumeAll, returnsNormally);
-      });
+          fakeStreamManager.pauseAll();
+          await pumpEventQueue();
+          expect(pauses, equals(1));
 
-      test('pausing before a sync keeps that sync safe', () {
-        manager.pauseAll();
+          streamController.add(secondBatch);
+          await pumpEventQueue();
+          // Buffered while paused — the notifier still shows the first batch.
+          expect(fakeStreamManager['a'].value, hasLength(1));
 
-        expect(
-          () => manager.sync(
-            clips: [_createTestClip(id: 'a')],
-            devicePixelRatio: 1,
-          ),
-          returnsNormally,
-        );
-        expect(manager.resumeAll, returnsNormally);
+          fakeStreamManager.resumeAll();
+          await pumpEventQueue();
+          expect(resumes, equals(1));
+          // The held batch arrives after resume — pausing is lossless.
+          expect(fakeStreamManager['a'].value, hasLength(2));
+        },
+      );
+
+      test('subscriptions created while paused start paused', () async {
+        fakeStreamManager.pauseAll();
+        syncFileClip();
+        await pumpEventQueue();
+        expect(pauses, equals(1));
+
+        streamController.add(firstBatch);
+        await pumpEventQueue();
+        expect(fakeStreamManager['a'].value, isEmpty);
+
+        fakeStreamManager.resumeAll();
+        await pumpEventQueue();
+        expect(fakeStreamManager['a'].value, hasLength(1));
       });
     });
 

--- a/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
+++ b/mobile/test/services/video_editor/clip_thumbnail_manager_test.dart
@@ -126,10 +126,7 @@ void main() {
         expect(thumbnails[0].timestamp, equals(Duration.zero));
         // 2 s thumbnail shifted by −1 s → 1 s
         expect(thumbnails[1].path, equals('/t/2.jpg'));
-        expect(
-          thumbnails[1].timestamp,
-          equals(const Duration(seconds: 1)),
-        );
+        expect(thumbnails[1].timestamp, equals(const Duration(seconds: 1)));
       });
 
       test('excludes thumbnails outside the requested range', () {
@@ -161,10 +158,7 @@ void main() {
         final thumbnails = manager['tgt'].value;
         expect(thumbnails, hasLength(1));
         expect(thumbnails.first.path, equals('/t/5.jpg'));
-        expect(
-          thumbnails.first.timestamp,
-          equals(const Duration(seconds: 1)),
-        );
+        expect(thumbnails.first.timestamp, equals(const Duration(seconds: 1)));
       });
 
       test('is a no-op when source notifier does not exist', () {
@@ -200,10 +194,7 @@ void main() {
           currentSourcePath: '/video/src.mp4',
         );
 
-        expect(
-          manager['tgt'],
-          isA<ValueNotifier<List<StripThumbnail>>>(),
-        );
+        expect(manager['tgt'], isA<ValueNotifier<List<StripThumbnail>>>());
         expect(manager['tgt'].value, hasLength(1));
       });
 
@@ -239,10 +230,7 @@ void main() {
 
         // Re-sync with target added. targetClip uses a network URL so
         // _loadThumbnails exits early and never overwrites the notifier.
-        manager.sync(
-          clips: [sourceClip, targetClip],
-          devicePixelRatio: 1,
-        );
+        manager.sync(clips: [sourceClip, targetClip], devicePixelRatio: 1);
 
         expect(manager['tgt'].value, equals(seededValue));
       });
@@ -363,6 +351,33 @@ void main() {
         expect(thumbnails[0].timestamp, equals(const Duration(seconds: 3)));
         expect(thumbnails[1].path, equals('/t/4.jpg'));
         expect(thumbnails[1].timestamp, equals(const Duration(seconds: 4)));
+      });
+    });
+
+    group('pauseAll / resumeAll', () {
+      test('are safe on an idle manager with no active subscriptions', () {
+        expect(manager.pauseAll, returnsNormally);
+        expect(manager.resumeAll, returnsNormally);
+      });
+
+      test('are safe after syncing clips', () {
+        manager.sync(clips: [_createTestClip(id: 'a')], devicePixelRatio: 1);
+
+        expect(manager.pauseAll, returnsNormally);
+        expect(manager.resumeAll, returnsNormally);
+      });
+
+      test('pausing before a sync keeps that sync safe', () {
+        manager.pauseAll();
+
+        expect(
+          () => manager.sync(
+            clips: [_createTestClip(id: 'a')],
+            devicePixelRatio: 1,
+          ),
+          returnsNormally,
+        );
+        expect(manager.resumeAll, returnsNormally);
       });
     });
 

--- a/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
+++ b/mobile/test/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip_test.dart
@@ -8,6 +8,8 @@ import 'package:openvine/blocs/video_editor/main_editor/video_editor_main_bloc.d
 import 'package:openvine/constants/video_editor_timeline_constants.dart';
 import 'package:openvine/l10n/generated/app_localizations.dart';
 import 'package:openvine/models/divine_video_clip.dart';
+import 'package:openvine/router/app_router.dart';
+import 'package:openvine/services/video_editor/clip_thumbnail_manager.dart';
 import 'package:openvine/widgets/video_editor/timeline_editor/strips/video_editor_timeline_clip_strip.dart';
 import 'package:pro_video_editor/pro_video_editor.dart';
 
@@ -35,6 +37,8 @@ void main() {
       bool isInteracting = false,
       ValueChanged<List<DivineVideoClip>>? onReorder,
       ValueChanged<bool>? onReorderChanged,
+      ClipThumbnailManager? thumbnailManager,
+      List<NavigatorObserver> navigatorObservers = const <NavigatorObserver>[],
     }) {
       final testClips =
           clips ??
@@ -44,6 +48,7 @@ void main() {
           ];
 
       return MaterialApp(
+        navigatorObservers: navigatorObservers,
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         home: Scaffold(
@@ -60,6 +65,7 @@ void main() {
                 isInteracting: isInteracting,
                 onReorder: onReorder,
                 onReorderChanged: onReorderChanged,
+                thumbnailManager: thumbnailManager,
               ),
             ),
           ),
@@ -158,6 +164,42 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(reorderTriggered, isFalse);
+      });
+
+      testWidgets('pauses thumbnails while another route covers the strip', (
+        tester,
+      ) async {
+        final thumbnailManager = _RecordingClipThumbnailManager();
+
+        await tester.pumpWidget(
+          buildWidget(
+            thumbnailManager: thumbnailManager,
+            navigatorObservers: <NavigatorObserver>[routeObserver],
+          ),
+        );
+        await tester.pump();
+
+        final context = tester.element(
+          find.byType(VideoEditorTimelineClipStrip),
+        );
+        final push = Navigator.of(context).push<void>(
+          MaterialPageRoute<void>(
+            builder: (_) => const Scaffold(body: SizedBox.shrink()),
+          ),
+        );
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(thumbnailManager.pauseCount, equals(1));
+        expect(thumbnailManager.resumeCount, isZero);
+
+        Navigator.of(context).pop();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 300));
+        await push;
+
+        expect(thumbnailManager.pauseCount, equals(1));
+        expect(thumbnailManager.resumeCount, equals(1));
       });
     });
 
@@ -375,6 +417,23 @@ void main() {
       );
     });
   });
+}
+
+class _RecordingClipThumbnailManager extends ClipThumbnailManager {
+  int pauseCount = 0;
+  int resumeCount = 0;
+
+  @override
+  void pauseAll() {
+    pauseCount++;
+    super.pauseAll();
+  }
+
+  @override
+  void resumeAll() {
+    resumeCount++;
+    super.resumeAll();
+  }
 }
 
 DivineVideoClip _createTestClip({


### PR DESCRIPTION
Closes #5753

## Description

Users hit "can't press play on the preview / can't change the thumbnail" in the video editor, with `ERROR_CODE_DECODER_INIT_FAILED` on the rendered 1080p output in the logs (`format_supported=YES` - the device can decode it, the decoder just could not be initialised right then). Root cause is contention for a scarce hardware AVC decoder: the feed, editor canvas, preview player and thumbnail extraction all compete for the same small decoder pool, so an intermittent init failure kills playback with no recovery. The same file decodes fine on a later attempt in the logs, which is what makes it recoverable.

Five changes - player resilience first, contention reduction second:

**A - Decoder fallback (player).** `buildDefaultPlayer()` now builds ExoPlayer with `DefaultRenderersFactory(context).setEnableDecoderFallback(true)`, so a failed hardware decoder init can fall back to another decoder instead of leaving a dead surface. This is shared by feed and editor players; the feed path benefits from fallback too.

**B - Bounded re-prepare retry (player).** `onPlayerError` re-prepares on `DECODER_INIT_FAILED` / `DECODING_FAILED` up to 2x with a 350 ms delay, scoped to the editing/preview buffer profile (`FULL`). The retry keeps the pending `setClips` result open so a successful re-prepare still resolves it, and the counter resets on the first rendered frame and on every new `setClips` load. Pending retry callbacks are cancelled when a new `setClips` supersedes the old load and during dispose. Feed players keep ExoPlayer fallback only; the app-level retry remains FULL-only.

**C - Cover screen ordering + failure fallback.** The cover editor kicked off strip-frame extraction (`MediaMetadataRetriever`, which holds a MediaCodec decoder) concurrently with the player init on the same file. It now starts strip generation only after the player has acquired its decoder or conclusively failed. If the player retries are exhausted, the cover picker no longer dies with it: the failure is caught, the spinner is hidden, strip generation still starts, and the strip stays scrubbable so a cover can be picked without a live preview.

**D - Editor pauses thumbnails when obscured.** `ClipThumbnailManager` gains `pauseAll()` / `resumeAll()`, and the timeline strip is now `RouteAware`: it pauses thumbnail extraction while the editor is covered by the metadata/preview screen (`didPushNext`) and resumes on return (`didPopNext`). Pausing is lossless - the batch stream generators suspend at the next batch boundary and continue on resume - and it frees decoders/CPU during exactly the heavy render + preview window. The manager takes an injectable strip-thumbnail stream factory and the strip has a test seam so the pause/resume contract and RouteAware wiring are asserted behaviorally in tests.

**E - pro_video_editor 2.2.3 (dep bump).** The package-side companion fix shipped: timestamp thumbnails (`getThumbnails`) are now extracted with up to three parallel hardware decoders sweeping contiguous timeline chunks (GPU-scaled, falling back to Media3 `FrameExtractor`, then the previous retriever path) instead of one software `MediaMetadataRetriever` per timestamp. That extractor was the biggest amplifier of the decoder-pool contention, so A-D should trigger far less often (changelog measurements: ~3-20x faster with ~3-4x less CPU).

**Formatting note:** `video_metadata_cover_screen.dart` and one line in the timeline strip were last formatted before the Dart 3.12.0 bump; touching them forces a whole-file reformat because the format gate checks whole files. That churn is required, not gratuitous.

**Manual device validation before merge:** hm21 should confirm on a physical Android device that the feed + editor + preview + thumbnail contention scenario no longer reproduces the `ERROR_CODE_DECODER_INIT_FAILED` symptom or leaves playback/cover selection unusable. Unit tests and CI cannot reproduce this hardware decoder-pool failure mode.

## Out of Scope

- Export profile / level / bitrate (the app exports FHD / High L5.0) - a product/quality decision, not this fix.
- C2PA signing failures and the final-render ProofMode `PROOF_HASH_MISSING` seen in the same logs - separate, unrelated issues.

## Verification

- `mise exec -- dart format lib test integration_test` - passes.
- `flutter analyze` on the changed Dart/test files - passes.
- `flutter test` - `clip_thumbnail_manager`, `video_metadata_cover_screen`, `video_editor_timeline_clip_strip`: 49 tests, all green, including the RouteAware pause/resume wiring regression test.
- Kotlin: decoder retry tests cover scheduling, exhaustion, retry budget reset on new `setClips`, and cancellation of pending retry callbacks when `setClips` is superseded.
- CI runs the Android unit suite via `gradle :divine_video_player:testDebugUnitTest`.
- Manual physical Android device test pending hm21 confirmation before merge.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
