### PR TITLE
refactor(auth): extract RelayDiscoveryOrchestrator + inject BackgroundActivityManager (#4741)

### DIFF
--- a/mobile/lib/services/auth/relay_discovery_orchestrator.dart
+++ b/mobile/lib/services/auth/relay_discovery_orchestrator.dart
@@ -1,0 +1,387 @@
+// ABOUTME: Post-sign-in discovery orchestration: NIP-65 relay discovery with
+// ABOUTME: fallback + bootstrap kind:10002, and the kind-0 profile existence
+// ABOUTME: check. Extracted from AuthService (#4741, repository tier).
+
+import 'dart:async';
+
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/services/auth/nostr_identity.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:unified_logger/unified_logger.dart';
+
+/// Callback invoked when NIP-65 relay discovery completes with a non-empty
+/// list. NostrService uses this to add discovered relays to the current
+/// client without blocking app startup.
+typedef UserRelaysDiscoveredCallback =
+    void Function(String pubkey, List<String> relayUrls);
+
+/// Callback invoked when AuthService wants to publish a bootstrap kind:10002
+/// relay list on behalf of the user (because indexer discovery returned empty).
+///
+/// The event is already signed. The implementer publishes it through the
+/// active [NostrClient] to [targetRelays] and reports success/failure via the
+/// returned future.
+typedef BootstrapRelayListCallback =
+    Future<bool> Function(Event event, List<String> targetRelays);
+
+/// SharedPreferences key prefix for the per-pubkey one-shot flag that records
+/// whether we have already published a bootstrap kind:10002 on this device.
+const _kBootstrapKind10002Prefix = 'bootstrap_kind10002_published_';
+
+/// Upper bound on how long to wait for the signer when producing the
+/// bootstrap kind:10002 event. If the signer does not respond within this
+/// window (hung Keycast RPC, unreachable Amber, etc.) we abandon the publish
+/// and leave the flag unset so the next login retries. See #3174 / #3162.
+const _kBootstrapSignTimeout = Duration(seconds: 10);
+
+/// Orchestrates the post-sign-in discovery flows AuthService runs
+/// fire-and-forget: NIP-65 relay discovery (with safe-fallback connection and
+/// the one-shot bootstrap kind:10002 self-publish when the user has no
+/// published list) and the kind-0 profile existence check.
+///
+/// Extracted from `AuthService` (#4741) as a repository-tier collaborator.
+/// The facade retains ownership of the session fields the results land in
+/// (`_userRelays`, `_hasExistingProfile`) — results are delivered through the
+/// [onUserRelays]/[onHasExistingProfile] write-back callbacks so external
+/// consumers keep reading them off `AuthService`. Live session state is read
+/// at execution time through tear-offs ([isSessionCurrent],
+/// [currentIdentity]) rather than captured, so an account switch mid-flight
+/// is observed exactly as before the extraction.
+class RelayDiscoveryOrchestrator {
+  RelayDiscoveryOrchestrator({
+    required RelayDiscoveryService relayDiscoveryService,
+    required String primaryRelayUrl,
+    required bool Function(String? targetPubkey) isSessionCurrent,
+    required NostrIdentity? Function() currentIdentity,
+    required void Function(List<DiscoveredRelay> relays) onUserRelays,
+    required void Function(bool hasProfile) onHasExistingProfile,
+    required UserRelaysDiscoveredCallback? Function()
+    userRelaysDiscoveredCallback,
+    required BootstrapRelayListCallback? Function() bootstrapRelayListCallback,
+    String? profileCheckIndexerUrl,
+  }) : _relayDiscoveryService = relayDiscoveryService,
+       _primaryRelayUrl = primaryRelayUrl,
+       _isSessionCurrent = isSessionCurrent,
+       _currentIdentity = currentIdentity,
+       _onUserRelays = onUserRelays,
+       _onHasExistingProfile = onHasExistingProfile,
+       _userRelaysDiscoveredCallback = userRelaysDiscoveredCallback,
+       _bootstrapRelayListCallback = bootstrapRelayListCallback,
+       _profileCheckIndexerUrl = profileCheckIndexerUrl;
+
+  final RelayDiscoveryService _relayDiscoveryService;
+  final String _primaryRelayUrl;
+  final bool Function(String? targetPubkey) _isSessionCurrent;
+  final NostrIdentity? Function() _currentIdentity;
+  final void Function(List<DiscoveredRelay> relays) _onUserRelays;
+  final void Function(bool hasProfile) _onHasExistingProfile;
+  final UserRelaysDiscoveredCallback? Function() _userRelaysDiscoveredCallback;
+  final BootstrapRelayListCallback? Function() _bootstrapRelayListCallback;
+  final String? _profileCheckIndexerUrl;
+
+  /// Discover user relays via NIP-65 using direct WebSocket to indexers.
+  ///
+  /// Always runs discovery (with 24h cache to avoid redundant indexer queries).
+  /// Discovered relays are ADDED to the main client's existing connections,
+  /// so user's manual relay edits are preserved (addRelay skips duplicates).
+  ///
+  /// When discovery returns empty or fails (e.g. imported account that
+  /// never published a kind 10002 list), [IndexerRelayConfig.safeFallbackRelays]
+  /// is added to the client's connected pool so DM reachability degrades
+  /// gracefully instead of leaving the client connected only to the Divine
+  /// relay. The fallback set is NOT reported via [onUserRelays] — the facade's
+  /// getter continues to report only the user's own published relays so
+  /// embedded Nostr apps querying via the bridge see accurate data. See #2931.
+  Future<void> discoverUserRelays(String npub, String? targetPubkey) async {
+    try {
+      final result = await _relayDiscoveryService.discoverRelays(npub);
+      if (!_isSessionCurrent(targetPubkey)) {
+        Log.info(
+          'Ignoring relay discovery result for stale session',
+          name: 'RelayDiscoveryOrchestrator',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+
+      if (result.success && result.hasRelays) {
+        _onUserRelays(result.relays);
+
+        Log.info(
+          '✅ Discovered ${result.relays.length} user relays from '
+          '${result.foundOnIndexer ?? "cache"}',
+          name: 'RelayDiscoveryOrchestrator',
+          category: LogCategory.auth,
+        );
+
+        // Log relay details
+        for (final relay in result.relays) {
+          Log.info(
+            '  - ${relay.url} (read: ${relay.read}, write: ${relay.write})',
+            name: 'RelayDiscoveryOrchestrator',
+            category: LogCategory.auth,
+          );
+        }
+
+        // Notify NostrService so it can add these relays to the current client
+        final urls = result.relays.map((r) => r.url).toList();
+        _userRelaysDiscoveredCallback()?.call(targetPubkey ?? npub, urls);
+      } else {
+        _onUserRelays([]);
+
+        Log.warning(
+          '⚠️ No relay list found for user on any indexer — '
+          'connecting to safe DM-friendly fallback relay set',
+          name: 'RelayDiscoveryOrchestrator',
+          category: LogCategory.auth,
+        );
+        connectToFallbackRelays(targetPubkey ?? npub);
+        await publishBootstrapRelayList();
+      }
+    } catch (e) {
+      if (!_isSessionCurrent(targetPubkey)) {
+        Log.info(
+          'Ignoring relay discovery failure for stale session',
+          name: 'RelayDiscoveryOrchestrator',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+      _onUserRelays([]);
+
+      Log.error(
+        '❌ Relay discovery failed: $e — '
+        'connecting to safe DM-friendly fallback relay set',
+        name: 'RelayDiscoveryOrchestrator',
+        category: LogCategory.auth,
+      );
+      connectToFallbackRelays(targetPubkey ?? npub);
+      await publishBootstrapRelayList();
+    }
+  }
+
+  /// Publish a bootstrap kind:10002 relay list for the signed-in user when
+  /// indexer discovery returned empty.
+  ///
+  /// Divine/Keycast-provisioned accounts are created without a published
+  /// NIP-65 relay list, which leaves them invisible to the indexers the
+  /// mobile client queries (`purplepag.es`, `user.kindpag.es`,
+  /// `relay.nos.social`). That in turn degrades reachability for every
+  /// downstream publish operation (profile save, likes, comments) because
+  /// the client can only connect to the fallback relay set. This method
+  /// self-publishes a minimal kind:10002 pointing at the current
+  /// environment's primary relay (injected from [EnvironmentConfig.relayUrl])
+  /// so subsequent logins on this or any other client can discover it.
+  ///
+  /// Guards:
+  /// - fires at most once per (device, pubkey): tracked via
+  ///   [SharedPreferences] flag `bootstrap_kind10002_published_<hexpubkey>`.
+  /// - no-op if no current identity (read-only / unauthenticated sessions).
+  /// - no-op if no bootstrap callback has been registered.
+  /// - flag is set ONLY on callback success, so failures (signer unreachable,
+  ///   publish rejected) remain retriable on next login.
+  ///
+  /// The proper server-side fix lives in divinevideo/keycast#94; this is a
+  /// client-side safety net + backfill for pre-existing accounts. See
+  /// divinevideo/divine-mobile#3174.
+  Future<void> publishBootstrapRelayList() async {
+    final identity = _currentIdentity();
+    if (identity == null) {
+      return;
+    }
+    final callback = _bootstrapRelayListCallback();
+    if (callback == null) {
+      return;
+    }
+    final pubkeyHex = identity.pubkey;
+    final flagKey = '$_kBootstrapKind10002Prefix$pubkeyHex';
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (prefs.getBool(flagKey) ?? false) {
+        return;
+      }
+
+      final unsigned = Event(
+        pubkeyHex,
+        EventKind.relayListMetadata,
+        <List<String>>[
+          <String>['r', _primaryRelayUrl],
+        ],
+        '',
+      );
+
+      // Cap how long we wait for the signer. A hung Keycast RPC would
+      // otherwise block first-login past the existing NIP-65 discovery
+      // timeout. On timeout we leave the flag unset so the next login retries.
+      final Event? signed;
+      try {
+        signed = await identity
+            .signEvent(unsigned)
+            .timeout(_kBootstrapSignTimeout);
+      } on TimeoutException {
+        Log.warning(
+          'Bootstrap kind:10002: signer timed out after '
+          '${_kBootstrapSignTimeout.inSeconds}s — will retry on next login',
+          name: 'RelayDiscoveryOrchestrator',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+
+      if (signed == null || signed.sig.isEmpty) {
+        Log.warning(
+          'Bootstrap kind:10002: signer returned null / unsigned — will retry '
+          'on next login',
+          name: 'RelayDiscoveryOrchestrator',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+
+      final targetRelays = <String>[
+        _primaryRelayUrl,
+        ...IndexerRelayConfig.defaultIndexers,
+      ];
+
+      final published = await callback(signed, targetRelays);
+      if (!published) {
+        Log.warning(
+          'Bootstrap kind:10002: NostrClient reported no relay accepted the '
+          'event — will retry on next login',
+          name: 'RelayDiscoveryOrchestrator',
+          category: LogCategory.auth,
+        );
+        return;
+      }
+
+      await prefs.setBool(flagKey, true);
+      Log.info(
+        '✅ Published bootstrap kind:10002 for $pubkeyHex to '
+        '${targetRelays.length} relays',
+        name: 'RelayDiscoveryOrchestrator',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      Log.error(
+        'Bootstrap kind:10002 publish failed: $e — will retry on next login',
+        name: 'RelayDiscoveryOrchestrator',
+        category: LogCategory.auth,
+      );
+    }
+  }
+
+  /// Notify the NostrService callback to connect the client to
+  /// [IndexerRelayConfig.safeFallbackRelays].
+  ///
+  /// Used when NIP-65 discovery returns empty or fails. Without this, the
+  /// client stays connected only to the Divine relay, which silently
+  /// breaks NIP-17 DM delivery for peers writing on other relays.
+  ///
+  /// Intentionally does NOT report via [onUserRelays]: that field semantically
+  /// represents the user's *own* published relay list (kind 10002) and is
+  /// surfaced to embedded Nostr apps via the bridge. The fallback set is a
+  /// reachability mechanism, not a relay list the user has chosen. See #2931.
+  void connectToFallbackRelays(String targetPubkey) {
+    Log.info(
+      'Fallback relays: '
+      '${IndexerRelayConfig.safeFallbackRelays.join(', ')}',
+      name: 'RelayDiscoveryOrchestrator',
+      category: LogCategory.auth,
+    );
+    _userRelaysDiscoveredCallback()?.call(
+      targetPubkey,
+      IndexerRelayConfig.safeFallbackRelays,
+    );
+  }
+
+  /// Check if user has an existing profile (kind 0) on indexer relays.
+  ///
+  /// Uses a direct WebSocket connection to an indexer relay (purplepag.es
+  /// indexes kind 0 events) to check for existing profiles. The outcome is
+  /// reported via [onHasExistingProfile]; a null [pubkeyHex] (no key
+  /// container) reports `false` without any network traffic.
+  Future<void> checkExistingProfile(String? pubkeyHex) async {
+    if (pubkeyHex == null) {
+      _onHasExistingProfile(false);
+      return;
+    }
+
+    Log.info(
+      '👤 Checking for existing profile (kind 0)...',
+      name: 'RelayDiscoveryOrchestrator',
+      category: LogCategory.auth,
+    );
+
+    try {
+      final indexerUrl =
+          _profileCheckIndexerUrl ?? IndexerRelayConfig.defaultIndexers.first;
+
+      final relayStatus = RelayStatus(indexerUrl);
+      final relay = RelayBase(indexerUrl, relayStatus);
+      final completer = Completer<bool>();
+      final subscriptionId = 'pc_${DateTime.now().millisecondsSinceEpoch}';
+
+      relay.onMessage = (relay, json) async {
+        if (json.isEmpty) return;
+        final messageType = json[0] as String;
+        if (messageType == 'EVENT' && json.length >= 3) {
+          if (!completer.isCompleted) {
+            completer.complete(true);
+          }
+        } else if (messageType == 'EOSE') {
+          if (!completer.isCompleted) {
+            completer.complete(false);
+          }
+        }
+      };
+
+      final filter = <String, dynamic>{
+        'kinds': <int>[0],
+        'authors': <String>[pubkeyHex],
+        'limit': 1,
+      };
+      relay.pendingMessages.add(<dynamic>['REQ', subscriptionId, filter]);
+
+      final connected = await relay.connect();
+      if (!connected) {
+        _onHasExistingProfile(false);
+        return;
+      }
+
+      bool hasProfile;
+      try {
+        hasProfile = await completer.future.timeout(
+          const Duration(seconds: 10),
+          onTimeout: () => false,
+        );
+        _onHasExistingProfile(hasProfile);
+        await relay.send(<dynamic>['CLOSE', subscriptionId]);
+      } finally {
+        try {
+          await relay.disconnect();
+        } catch (_) {
+          // Intentional no-op: best-effort cleanup of the throwaway
+          // profile-check connection. The result has already been reported;
+          // a failing disconnect must not mask it or fail the check.
+        }
+      }
+
+      Log.info(
+        '${hasProfile ? "✅" : "📝"} Profile check: '
+        'hasExistingProfile=$hasProfile',
+        name: 'RelayDiscoveryOrchestrator',
+        category: LogCategory.auth,
+      );
+    } catch (e) {
+      _onHasExistingProfile(false);
+
+      Log.warning(
+        '⚠️ Profile check failed: $e - assuming no existing profile',
+        name: 'RelayDiscoveryOrchestrator',
+        category: LogCategory.auth,
+      );
+    }
+  }
+}

--- a/mobile/lib/services/auth/relay_discovery_orchestrator.dart
+++ b/mobile/lib/services/auth/relay_discovery_orchestrator.dart
@@ -60,6 +60,7 @@ class RelayDiscoveryOrchestrator {
     userRelaysDiscoveredCallback,
     required BootstrapRelayListCallback? Function() bootstrapRelayListCallback,
     String? profileCheckIndexerUrl,
+    WebSocketChannelFactory? profileCheckChannelFactory,
   }) : _relayDiscoveryService = relayDiscoveryService,
        _primaryRelayUrl = primaryRelayUrl,
        _isSessionCurrent = isSessionCurrent,
@@ -68,7 +69,8 @@ class RelayDiscoveryOrchestrator {
        _onHasExistingProfile = onHasExistingProfile,
        _userRelaysDiscoveredCallback = userRelaysDiscoveredCallback,
        _bootstrapRelayListCallback = bootstrapRelayListCallback,
-       _profileCheckIndexerUrl = profileCheckIndexerUrl;
+       _profileCheckIndexerUrl = profileCheckIndexerUrl,
+       _profileCheckChannelFactory = profileCheckChannelFactory;
 
   final RelayDiscoveryService _relayDiscoveryService;
   final String _primaryRelayUrl;
@@ -79,6 +81,10 @@ class RelayDiscoveryOrchestrator {
   final UserRelaysDiscoveredCallback? Function() _userRelaysDiscoveredCallback;
   final BootstrapRelayListCallback? Function() _bootstrapRelayListCallback;
   final String? _profileCheckIndexerUrl;
+
+  /// Test seam: injects the WebSocket transport used by [checkExistingProfile].
+  /// Null in production, where [RelayBase] falls back to the platform socket.
+  final WebSocketChannelFactory? _profileCheckChannelFactory;
 
   /// Discover user relays via NIP-65 using direct WebSocket to indexers.
   ///
@@ -319,7 +325,11 @@ class RelayDiscoveryOrchestrator {
           _profileCheckIndexerUrl ?? IndexerRelayConfig.defaultIndexers.first;
 
       final relayStatus = RelayStatus(indexerUrl);
-      final relay = RelayBase(indexerUrl, relayStatus);
+      final relay = RelayBase(
+        indexerUrl,
+        relayStatus,
+        channelFactory: _profileCheckChannelFactory,
+      );
       final completer = Completer<bool>();
       final subscriptionId = 'pc_${DateTime.now().millisecondsSinceEpoch}';
 

--- a/mobile/lib/services/auth_service.dart
+++ b/mobile/lib/services/auth_service.dart
@@ -19,6 +19,7 @@ import 'package:openvine/models/auth_rpc_capability.dart';
 import 'package:openvine/models/authentication_source.dart';
 import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth/nostr_identity.dart';
+import 'package:openvine/services/auth/relay_discovery_orchestrator.dart';
 import 'package:openvine/services/auth/signer_factory.dart';
 import 'package:openvine/services/auth/signer_secure_store.dart';
 import 'package:openvine/services/background_activity_manager.dart';
@@ -32,6 +33,10 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:unified_logger/unified_logger.dart';
 
 export 'package:openvine/models/authentication_source.dart';
+// Discovery callback contracts moved with the orchestrator (#4741); external
+// consumers (NostrService wiring) keep importing them from this facade.
+export 'package:openvine/services/auth/relay_discovery_orchestrator.dart'
+    show BootstrapRelayListCallback, UserRelaysDiscoveredCallback;
 
 // Key for persisted authentication source
 const _kAuthSourceKey = 'authentication_source';
@@ -173,21 +178,6 @@ typedef PreFetchFollowingCallback = Future<void> Function(String pubkeyHex);
 /// of hitting a platform channel.
 typedef AuthUrlLauncher = Future<bool> Function(Uri url);
 
-/// Callback invoked when NIP-65 relay discovery completes with a non-empty list.
-/// Used by NostrService to add discovered relays to the current client without
-/// blocking app startup.
-typedef UserRelaysDiscoveredCallback =
-    void Function(String pubkey, List<String> relayUrls);
-
-/// Callback invoked when AuthService wants to publish a bootstrap kind:10002
-/// relay list on behalf of the user (because indexer discovery returned empty).
-///
-/// The event is already signed. The implementer publishes it through the
-/// active [NostrClient] to [targetRelays] and reports success/failure via the
-/// returned future.
-typedef BootstrapRelayListCallback =
-    Future<bool> Function(Event event, List<String> targetRelays);
-
 /// Callback invoked before AuthService clears the outgoing session identity.
 typedef BeforeSessionTeardownCallback = Future<void> Function();
 
@@ -195,16 +185,6 @@ typedef BeforeSessionTeardownCallback = Future<void> Function();
 /// exercise unreachable signer behavior without opening relay sockets.
 typedef RemoteSignerFactory =
     NostrRemoteSigner Function(int relayMode, NostrRemoteSignerInfo info);
-
-/// SharedPreferences key prefix for the per-pubkey one-shot flag that records
-/// whether we have already published a bootstrap kind:10002 on this device.
-const _kBootstrapKind10002Prefix = 'bootstrap_kind10002_published_';
-
-/// Upper bound on how long to wait for the signer when producing the
-/// bootstrap kind:10002 event. If the signer does not respond within this
-/// window (hung Keycast RPC, unreachable Amber, etc.) we abandon the publish
-/// and leave the flag unset so the next login retries. See #3174 / #3162.
-const _kBootstrapSignTimeout = Duration(seconds: 10);
 
 /// Total time budget for pre-teardown callbacks during sign-out.
 const _kBeforeSessionTeardownTimeout = Duration(seconds: 5);
@@ -221,6 +201,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     OAuthConfig? oauthConfig,
     PreFetchFollowingCallback? preFetchFollowing,
     AuthUrlLauncher? launchAuthUrl,
+    BackgroundActivityManager? backgroundActivityManager,
     String? profileCheckIndexerUrl,
     List<String>? indexerRelays,
     String? primaryRelayUrl,
@@ -236,6 +217,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
        _flutterSecureStorage = flutterSecureStorage,
        _preFetchFollowing = preFetchFollowing,
        _launchAuthUrl = launchAuthUrl,
+       // Defaults to the process-global singleton; injectable per #4743 (B3)
+       // so lifecycle tests can verify register/unregister with a fake.
+       _backgroundActivityManager =
+           backgroundActivityManager ?? BackgroundActivityManager(),
        _profileCheckIndexerUrl = profileCheckIndexerUrl,
        _primaryRelayUrl = primaryRelayUrl ?? AppConstants.defaultRelayUrl,
        _relayDiscoveryService =
@@ -263,8 +248,23 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   late final SignerFactory _signerFactory = SignerFactory(
     crashReporter: _reportAuthError,
   );
+  // Tear-offs/closures read live session state at execution time; the
+  // write-backs land results in the facade fields external consumers read.
+  late final RelayDiscoveryOrchestrator _discoveryOrchestrator =
+      RelayDiscoveryOrchestrator(
+        relayDiscoveryService: _relayDiscoveryService,
+        primaryRelayUrl: _primaryRelayUrl,
+        profileCheckIndexerUrl: _profileCheckIndexerUrl,
+        isSessionCurrent: _isRelayDiscoveryCurrent,
+        currentIdentity: () => _currentIdentity,
+        onUserRelays: (relays) => _userRelays = relays,
+        onHasExistingProfile: (hasProfile) => _hasExistingProfile = hasProfile,
+        userRelaysDiscoveredCallback: () => _onUserRelaysDiscovered,
+        bootstrapRelayListCallback: () => _onBootstrapRelayListRequested,
+      );
   final PreFetchFollowingCallback? _preFetchFollowing;
   final AuthUrlLauncher? _launchAuthUrl;
+  final BackgroundActivityManager _backgroundActivityManager;
   final String? _profileCheckIndexerUrl;
   final RemoteSignerFactory _remoteSignerFactory;
   final Duration _startupNetworkOperationTimeout;
@@ -1075,7 +1075,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   ///
   /// AuthService builds + signs the event; the callback owner is expected to
   /// broadcast it via the current [NostrClient]. See
-  /// [_publishBootstrapRelayList] and #3174.
+  /// [RelayDiscoveryOrchestrator.publishBootstrapRelayList] and #3174.
   void registerBootstrapRelayListCallback(
     BootstrapRelayListCallback? callback,
   ) {
@@ -1181,7 +1181,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     _setAuthState(AuthState.checking);
 
     // Register with BackgroundActivityManager for lifecycle callbacks
-    BackgroundActivityManager().registerService(this);
+    _backgroundActivityManager.registerService(this);
 
     try {
       // Initialize secure key storage
@@ -4610,6 +4610,9 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// index kind 0 events.
   ///
   /// For returning users, this runs in background via unawaited().
+  ///
+  /// Delegates to [RelayDiscoveryOrchestrator]; results land back in
+  /// [_userRelays]/[_hasExistingProfile] via its write-back callbacks.
   Future<void> _performDiscovery() async {
     if (_currentKeyContainer == null) return;
 
@@ -4627,8 +4630,10 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
       final targetPubkey =
           _currentIdentity?.pubkey ?? _currentKeyContainer?.publicKeyHex;
       await Future.wait([
-        _discoverUserRelays(npub, targetPubkey),
-        _checkExistingProfile(),
+        _discoveryOrchestrator.discoverUserRelays(npub, targetPubkey),
+        _discoveryOrchestrator.checkExistingProfile(
+          _currentKeyContainer?.publicKeyHex,
+        ),
       ]);
     } catch (e) {
       Log.warning(
@@ -4648,225 +4653,8 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     );
   }
 
-  /// Discover user relays via NIP-65 using direct WebSocket to indexers.
-  ///
-  /// Always runs discovery (with 24h cache to avoid redundant indexer queries).
-  /// Discovered relays are ADDED to the main client's existing connections,
-  /// so user's manual relay edits are preserved (addRelay skips duplicates).
-  ///
-  /// When discovery returns empty or fails (e.g. imported account that
-  /// never published a kind 10002 list), [IndexerRelayConfig.safeFallbackRelays]
-  /// is added to the client's connected pool so DM reachability degrades
-  /// gracefully instead of leaving the client connected only to the Divine
-  /// relay. The fallback set is NOT stored in [userRelays] — that getter
-  /// continues to report only the user's own published relays so embedded
-  /// Nostr apps querying via the bridge see accurate data. See #2931.
-  Future<void> _discoverUserRelays(String npub, String? targetPubkey) async {
-    try {
-      final result = await _relayDiscoveryService.discoverRelays(npub);
-      if (!_isRelayDiscoveryCurrent(targetPubkey)) {
-        Log.info(
-          'Ignoring relay discovery result for stale session',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        return;
-      }
-
-      if (result.success && result.hasRelays) {
-        _userRelays = result.relays;
-
-        Log.info(
-          '✅ Discovered ${_userRelays.length} user relays from '
-          '${result.foundOnIndexer ?? "cache"}',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-
-        // Log relay details
-        for (final relay in _userRelays) {
-          Log.info(
-            '  - ${relay.url} (read: ${relay.read}, write: ${relay.write})',
-            name: 'AuthService',
-            category: LogCategory.auth,
-          );
-        }
-
-        // Notify NostrService so it can add these relays to the current client
-        final urls = _userRelays.map((r) => r.url).toList();
-        _onUserRelaysDiscovered?.call(targetPubkey ?? npub, urls);
-      } else {
-        _userRelays = [];
-
-        Log.warning(
-          '⚠️ No relay list found for user on any indexer — '
-          'connecting to safe DM-friendly fallback relay set',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        _connectToFallbackRelays(targetPubkey ?? npub);
-        await _publishBootstrapRelayList();
-      }
-    } catch (e) {
-      if (!_isRelayDiscoveryCurrent(targetPubkey)) {
-        Log.info(
-          'Ignoring relay discovery failure for stale session',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        return;
-      }
-      _userRelays = [];
-
-      Log.error(
-        '❌ Relay discovery failed: $e — '
-        'connecting to safe DM-friendly fallback relay set',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-      _connectToFallbackRelays(targetPubkey ?? npub);
-      await _publishBootstrapRelayList();
-    }
-  }
-
   bool _isRelayDiscoveryCurrent(String? targetPubkey) =>
       targetPubkey == null || _currentIdentity?.pubkey == targetPubkey;
-
-  /// Publish a bootstrap kind:10002 relay list for the signed-in user when
-  /// indexer discovery returned empty.
-  ///
-  /// Divine/Keycast-provisioned accounts are created without a published
-  /// NIP-65 relay list, which leaves them invisible to the indexers the
-  /// mobile client queries (`purplepag.es`, `user.kindpag.es`,
-  /// `relay.nos.social`). That in turn degrades reachability for every
-  /// downstream publish operation (profile save, likes, comments) because
-  /// the client can only connect to the fallback relay set. This method
-  /// self-publishes a minimal kind:10002 pointing at [_primaryRelayUrl] (the
-  /// current environment's primary relay, injected from
-  /// [EnvironmentConfig.relayUrl]) so subsequent logins on this or any other
-  /// client can discover it.
-  ///
-  /// Guards:
-  /// - fires at most once per (device, pubkey): tracked via
-  ///   [SharedPreferences] flag `bootstrap_kind10002_published_<hexpubkey>`.
-  /// - no-op if no [currentIdentity] (read-only / unauthenticated sessions).
-  /// - no-op if no bootstrap callback has been registered.
-  /// - flag is set ONLY on callback success, so failures (signer unreachable,
-  ///   publish rejected) remain retriable on next login.
-  ///
-  /// The proper server-side fix lives in divinevideo/keycast#94; this is a
-  /// client-side safety net + backfill for pre-existing accounts. See
-  /// divinevideo/divine-mobile#3174.
-  Future<void> _publishBootstrapRelayList() async {
-    final identity = _currentIdentity;
-    if (identity == null) {
-      return;
-    }
-    final callback = _onBootstrapRelayListRequested;
-    if (callback == null) {
-      return;
-    }
-    final pubkeyHex = identity.pubkey;
-    final flagKey = '$_kBootstrapKind10002Prefix$pubkeyHex';
-
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      if (prefs.getBool(flagKey) ?? false) {
-        return;
-      }
-
-      final unsigned = Event(
-        pubkeyHex,
-        EventKind.relayListMetadata,
-        <List<String>>[
-          <String>['r', _primaryRelayUrl],
-        ],
-        '',
-      );
-
-      // Cap how long we wait for the signer. A hung Keycast RPC would
-      // otherwise block first-login past the existing NIP-65 discovery
-      // timeout. On timeout we leave the flag unset so the next login retries.
-      final Event? signed;
-      try {
-        signed = await identity
-            .signEvent(unsigned)
-            .timeout(_kBootstrapSignTimeout);
-      } on TimeoutException {
-        Log.warning(
-          'Bootstrap kind:10002: signer timed out after '
-          '${_kBootstrapSignTimeout.inSeconds}s — will retry on next login',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        return;
-      }
-
-      if (signed == null || signed.sig.isEmpty) {
-        Log.warning(
-          'Bootstrap kind:10002: signer returned null / unsigned — will retry '
-          'on next login',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        return;
-      }
-
-      final targetRelays = <String>[
-        _primaryRelayUrl,
-        ...IndexerRelayConfig.defaultIndexers,
-      ];
-
-      final published = await callback(signed, targetRelays);
-      if (!published) {
-        Log.warning(
-          'Bootstrap kind:10002: NostrClient reported no relay accepted the '
-          'event — will retry on next login',
-          name: 'AuthService',
-          category: LogCategory.auth,
-        );
-        return;
-      }
-
-      await prefs.setBool(flagKey, true);
-      Log.info(
-        '✅ Published bootstrap kind:10002 for $pubkeyHex to '
-        '${targetRelays.length} relays',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      Log.error(
-        'Bootstrap kind:10002 publish failed: $e — will retry on next login',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
-  }
-
-  /// Notify the NostrService callback to connect the client to
-  /// [IndexerRelayConfig.safeFallbackRelays].
-  ///
-  /// Used when NIP-65 discovery returns empty or fails. Without this, the
-  /// client stays connected only to the Divine relay, which silently
-  /// breaks NIP-17 DM delivery for peers writing on other relays.
-  ///
-  /// Intentionally does NOT mutate [_userRelays]: that field semantically
-  /// represents the user's *own* published relay list (kind 10002) and is
-  /// surfaced to embedded Nostr apps via the bridge. The fallback set is a
-  /// reachability mechanism, not a relay list the user has chosen. See #2931.
-  void _connectToFallbackRelays(String targetPubkey) {
-    Log.info(
-      'Fallback relays: '
-      '${IndexerRelayConfig.safeFallbackRelays.join(', ')}',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-    _onUserRelaysDiscovered?.call(
-      targetPubkey,
-      IndexerRelayConfig.safeFallbackRelays,
-    );
-  }
 
   /// Test seam exposing the private NIP-65 discovery routine so unit
   /// tests can drive the fallback path with a mocked discovery service.
@@ -4874,11 +4662,11 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   /// of the normal sign-in flow via [_setupUserSession].
   @visibleForTesting
   Future<void> debugDiscoverUserRelays(String npub) =>
-      _discoverUserRelays(npub, _currentIdentity?.pubkey);
+      _discoveryOrchestrator.discoverUserRelays(npub, _currentIdentity?.pubkey);
 
   /// Test seam that lets unit tests install a [NostrIdentity] without
   /// going through the full sign-in pipeline. Used by tests that exercise
-  /// code paths (e.g. [_publishBootstrapRelayList]) which depend on
+  /// code paths (e.g. the bootstrap kind:10002 publish) which depend on
   /// [currentIdentity] being set.
   @visibleForTesting
   void debugSetIdentity(NostrIdentity? identity) {
@@ -4899,88 +4687,6 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
   @visibleForTesting
   void debugSetCurrentKeyContainer(SecureKeyContainer? container) {
     _currentKeyContainer = container;
-  }
-
-  /// Check if user has an existing profile (kind 0) on indexer relays.
-  ///
-  /// Uses a direct WebSocket connection to an indexer relay (purplepag.es
-  /// indexes kind 0 events) to check for existing profiles.
-  Future<void> _checkExistingProfile() async {
-    if (_currentKeyContainer == null) {
-      _hasExistingProfile = false;
-      return;
-    }
-
-    Log.info(
-      '👤 Checking for existing profile (kind 0)...',
-      name: 'AuthService',
-      category: LogCategory.auth,
-    );
-
-    try {
-      final pubkeyHex = _currentKeyContainer!.publicKeyHex;
-      final indexerUrl =
-          _profileCheckIndexerUrl ?? IndexerRelayConfig.defaultIndexers.first;
-
-      final relayStatus = RelayStatus(indexerUrl);
-      final relay = RelayBase(indexerUrl, relayStatus);
-      final completer = Completer<bool>();
-      final subscriptionId = 'pc_${DateTime.now().millisecondsSinceEpoch}';
-
-      relay.onMessage = (relay, json) async {
-        if (json.isEmpty) return;
-        final messageType = json[0] as String;
-        if (messageType == 'EVENT' && json.length >= 3) {
-          if (!completer.isCompleted) {
-            completer.complete(true);
-          }
-        } else if (messageType == 'EOSE') {
-          if (!completer.isCompleted) {
-            completer.complete(false);
-          }
-        }
-      };
-
-      final filter = <String, dynamic>{
-        'kinds': <int>[0],
-        'authors': <String>[pubkeyHex],
-        'limit': 1,
-      };
-      relay.pendingMessages.add(<dynamic>['REQ', subscriptionId, filter]);
-
-      final connected = await relay.connect();
-      if (!connected) {
-        _hasExistingProfile = false;
-        return;
-      }
-
-      try {
-        _hasExistingProfile = await completer.future.timeout(
-          const Duration(seconds: 10),
-          onTimeout: () => false,
-        );
-        await relay.send(<dynamic>['CLOSE', subscriptionId]);
-      } finally {
-        try {
-          await relay.disconnect();
-        } catch (_) {}
-      }
-
-      Log.info(
-        '${_hasExistingProfile ? "✅" : "📝"} Profile check: '
-        'hasExistingProfile=$_hasExistingProfile',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    } catch (e) {
-      _hasExistingProfile = false;
-
-      Log.warning(
-        '⚠️ Profile check failed: $e - assuming no existing profile',
-        name: 'AuthService',
-        category: LogCategory.auth,
-      );
-    }
   }
 
   /// Update authentication state and notify listeners
@@ -5143,7 +4849,7 @@ class AuthService implements BackgroundAwareService, BlockListSigner {
     );
 
     // Unregister from BackgroundActivityManager
-    BackgroundActivityManager().unregisterService(this);
+    _backgroundActivityManager.unregisterService(this);
 
     // Close bunker signer if active
     _bunkerSigner?.close();

--- a/mobile/test/services/auth/relay_discovery_orchestrator_test.dart
+++ b/mobile/test/services/auth/relay_discovery_orchestrator_test.dart
@@ -1,6 +1,9 @@
 // ABOUTME: Tests for RelayDiscoveryOrchestrator — NIP-65 discovery write-backs,
 // ABOUTME: stale-session guard, fallback relays, and bootstrap kind:10002.
 
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart'
@@ -10,9 +13,88 @@ import 'package:openvine/services/auth/nostr_identity.dart';
 import 'package:openvine/services/auth/relay_discovery_orchestrator.dart';
 import 'package:openvine/services/relay_discovery_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 class _MockRelayDiscoveryService extends Mock
     implements RelayDiscoveryService {}
+
+/// In-memory [WebSocketSink] that records frames and never touches a socket.
+class _FakeWebSocketSink implements WebSocketSink {
+  final List<dynamic> added = [];
+  final Completer<void> _done = Completer<void>();
+
+  @override
+  void add(dynamic data) => added.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<dynamic> stream) async {
+    await for (final data in stream) {
+      add(data);
+    }
+  }
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) async {
+    if (!_done.isCompleted) _done.complete();
+  }
+
+  @override
+  Future<void> get done => _done.future;
+}
+
+/// In-memory [WebSocketChannel] whose inbound stream is driven by the test via
+/// [simulateMessage], so the profile-check REQ/EVENT/EOSE exchange runs with no
+/// real socket. Mirrors the fake in `nostr_sdk`'s connection-manager tests.
+class _FakeWebSocketChannel implements WebSocketChannel {
+  _FakeWebSocketChannel({Future<void>? readyFuture})
+    : _ready = readyFuture ?? Future<void>.value();
+
+  final _FakeWebSocketSink _sink = _FakeWebSocketSink();
+  final StreamController<dynamic> _controller =
+      StreamController<dynamic>.broadcast();
+  final Future<void> _ready;
+
+  /// Push a raw server frame down to the connected client.
+  void simulateMessage(dynamic message) => _controller.add(message);
+
+  @override
+  WebSocketSink get sink => _sink;
+
+  @override
+  Stream<dynamic> get stream => _controller.stream;
+
+  @override
+  Future<void> get ready => _ready;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} is not mocked');
+}
+
+/// Hands out [_FakeWebSocketChannel]s and, when [readyError] is set, makes the
+/// handshake fail so `RelayBase.connect()` reports a dead connection.
+class _FakeWebSocketChannelFactory implements WebSocketChannelFactory {
+  _FakeWebSocketChannelFactory({this.readyError});
+
+  final Object? readyError;
+  final List<_FakeWebSocketChannel> createdChannels = [];
+
+  _FakeWebSocketChannel get lastChannel => createdChannels.last;
+
+  @override
+  WebSocketChannel create(Uri uri) {
+    final channel = _FakeWebSocketChannel(
+      readyFuture: readyError != null
+          ? Future<void>.error(readyError!)
+          : Future<void>.value(),
+    );
+    createdChannels.add(channel);
+    return channel;
+  }
+}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -44,18 +126,22 @@ void main() {
       bootstrapCallback = null;
     });
 
-    RelayDiscoveryOrchestrator buildOrchestrator() =>
-        RelayDiscoveryOrchestrator(
-          relayDiscoveryService: discoveryService,
-          primaryRelayUrl: primaryRelayUrl,
-          isSessionCurrent: (_) => sessionCurrent,
-          currentIdentity: () => identity,
-          onUserRelays: userRelaysWrites.add,
-          onHasExistingProfile: hasProfileWrites.add,
-          userRelaysDiscoveredCallback: () =>
-              (pubkey, urls) => externalRelayCalls.add((pubkey, urls)),
-          bootstrapRelayListCallback: () => bootstrapCallback,
-        );
+    RelayDiscoveryOrchestrator buildOrchestrator({
+      WebSocketChannelFactory? profileCheckChannelFactory,
+      String? profileCheckIndexerUrl,
+    }) => RelayDiscoveryOrchestrator(
+      relayDiscoveryService: discoveryService,
+      primaryRelayUrl: primaryRelayUrl,
+      isSessionCurrent: (_) => sessionCurrent,
+      currentIdentity: () => identity,
+      onUserRelays: userRelaysWrites.add,
+      onHasExistingProfile: hasProfileWrites.add,
+      userRelaysDiscoveredCallback: () =>
+          (pubkey, urls) => externalRelayCalls.add((pubkey, urls)),
+      bootstrapRelayListCallback: () => bootstrapCallback,
+      profileCheckChannelFactory: profileCheckChannelFactory,
+      profileCheckIndexerUrl: profileCheckIndexerUrl,
+    );
 
     group('discoverUserRelays', () {
       test('reports discovered relays and notifies the external callback '
@@ -232,10 +318,73 @@ void main() {
     });
 
     group('checkExistingProfile', () {
+      const indexerUrl = 'wss://indexer.test.divine.video';
+
       test(
         'reports false without network when no pubkey is available',
         () async {
           await buildOrchestrator().checkExistingProfile(null);
+
+          expect(hasProfileWrites, equals([false]));
+        },
+      );
+
+      test('reports true when the indexer returns a kind:0 EVENT', () async {
+        final channelFactory = _FakeWebSocketChannelFactory();
+
+        final future = buildOrchestrator(
+          profileCheckChannelFactory: channelFactory,
+          profileCheckIndexerUrl: indexerUrl,
+        ).checkExistingProfile(testPubkey);
+
+        // Let connect() finish so the inbound stream listener is attached
+        // before the frame is pushed — the channel stream is broadcast and
+        // drops events that arrive with no listener.
+        await pumpEventQueue();
+        channelFactory.lastChannel.simulateMessage(
+          jsonEncode(<dynamic>[
+            'EVENT',
+            'sub',
+            <String, dynamic>{'kind': 0, 'pubkey': testPubkey},
+          ]),
+        );
+        await future;
+
+        expect(hasProfileWrites, equals([true]));
+        expect(channelFactory.createdChannels, hasLength(1));
+      });
+
+      test(
+        'reports false when the indexer returns EOSE with no event',
+        () async {
+          final channelFactory = _FakeWebSocketChannelFactory();
+
+          final future = buildOrchestrator(
+            profileCheckChannelFactory: channelFactory,
+            profileCheckIndexerUrl: indexerUrl,
+          ).checkExistingProfile(testPubkey);
+
+          await pumpEventQueue();
+          channelFactory.lastChannel.simulateMessage(
+            jsonEncode(<dynamic>['EOSE', 'sub']),
+          );
+          await future;
+
+          expect(hasProfileWrites, equals([false]));
+        },
+      );
+
+      test(
+        'reports false when the indexer connection cannot be established',
+        () async {
+          final channelFactory = _FakeWebSocketChannelFactory(
+            readyError: Exception('handshake failed'),
+          );
+
+          await buildOrchestrator(
+            profileCheckChannelFactory: channelFactory,
+            profileCheckIndexerUrl: indexerUrl,
+          ).checkExistingProfile(testPubkey);
 
           expect(hasProfileWrites, equals([false]));
         },

--- a/mobile/test/services/auth/relay_discovery_orchestrator_test.dart
+++ b/mobile/test/services/auth/relay_discovery_orchestrator_test.dart
@@ -1,0 +1,258 @@
+// ABOUTME: Tests for RelayDiscoveryOrchestrator — NIP-65 discovery write-backs,
+// ABOUTME: stale-session guard, fallback relays, and bootstrap kind:10002.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:nostr_key_manager/nostr_key_manager.dart'
+    show SecureKeyContainer;
+import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/services/auth/nostr_identity.dart';
+import 'package:openvine/services/auth/relay_discovery_orchestrator.dart';
+import 'package:openvine/services/relay_discovery_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class _MockRelayDiscoveryService extends Mock
+    implements RelayDiscoveryService {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const testPrivateKey =
+      '6b911fd37cdf5c81d4c0adb1ab7fa822ed253ab0ad9aa18d77257c88b29b718e';
+  const testPubkey =
+      '385c3a6ec0b9d57a4330dbd6284989be5bd00e41c535f9ca39b6ae7c521b81cd';
+  const testNpub = 'npub1testonly';
+  const primaryRelayUrl = 'wss://relay.test.divine.video';
+
+  group(RelayDiscoveryOrchestrator, () {
+    late _MockRelayDiscoveryService discoveryService;
+    late List<List<DiscoveredRelay>> userRelaysWrites;
+    late List<bool> hasProfileWrites;
+    late List<(String, List<String>)> externalRelayCalls;
+    late NostrIdentity? identity;
+    late bool sessionCurrent;
+    late BootstrapRelayListCallback? bootstrapCallback;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+      discoveryService = _MockRelayDiscoveryService();
+      userRelaysWrites = [];
+      hasProfileWrites = [];
+      externalRelayCalls = [];
+      identity = null;
+      sessionCurrent = true;
+      bootstrapCallback = null;
+    });
+
+    RelayDiscoveryOrchestrator buildOrchestrator() =>
+        RelayDiscoveryOrchestrator(
+          relayDiscoveryService: discoveryService,
+          primaryRelayUrl: primaryRelayUrl,
+          isSessionCurrent: (_) => sessionCurrent,
+          currentIdentity: () => identity,
+          onUserRelays: userRelaysWrites.add,
+          onHasExistingProfile: hasProfileWrites.add,
+          userRelaysDiscoveredCallback: () =>
+              (pubkey, urls) => externalRelayCalls.add((pubkey, urls)),
+          bootstrapRelayListCallback: () => bootstrapCallback,
+        );
+
+    group('discoverUserRelays', () {
+      test('reports discovered relays and notifies the external callback '
+          'with the target pubkey', () async {
+        const relays = [
+          DiscoveredRelay(url: 'wss://a.example'),
+          DiscoveredRelay(url: 'wss://b.example', write: false),
+        ];
+        when(
+          () => discoveryService.discoverRelays(testNpub),
+        ).thenAnswer((_) async => RelayDiscoveryResult.success(relays, 'idx'));
+
+        await buildOrchestrator().discoverUserRelays(testNpub, testPubkey);
+
+        expect(userRelaysWrites, equals([relays]));
+        expect(externalRelayCalls, hasLength(1));
+        expect(externalRelayCalls.single.$1, equals(testPubkey));
+        expect(
+          externalRelayCalls.single.$2,
+          equals(['wss://a.example', 'wss://b.example']),
+        );
+      });
+
+      test('ignores results for a stale session', () async {
+        sessionCurrent = false;
+        when(() => discoveryService.discoverRelays(testNpub)).thenAnswer(
+          (_) async => RelayDiscoveryResult.success(const [
+            DiscoveredRelay(url: 'wss://a.example'),
+          ], 'idx'),
+        );
+
+        await buildOrchestrator().discoverUserRelays(testNpub, testPubkey);
+
+        expect(userRelaysWrites, isEmpty);
+        expect(externalRelayCalls, isEmpty);
+      });
+
+      test('empty discovery clears relays and connects the safe fallback '
+          'set without reporting it as user relays', () async {
+        when(
+          () => discoveryService.discoverRelays(testNpub),
+        ).thenAnswer((_) async => RelayDiscoveryResult.success(const [], null));
+
+        await buildOrchestrator().discoverUserRelays(testNpub, testPubkey);
+
+        expect(userRelaysWrites, equals([<DiscoveredRelay>[]]));
+        expect(externalRelayCalls, hasLength(1));
+        expect(
+          externalRelayCalls.single.$2,
+          equals(IndexerRelayConfig.safeFallbackRelays),
+        );
+      });
+
+      test('discovery failure clears relays and connects the safe fallback '
+          'set', () async {
+        when(
+          () => discoveryService.discoverRelays(testNpub),
+        ).thenThrow(Exception('indexers unreachable'));
+
+        await buildOrchestrator().discoverUserRelays(testNpub, testPubkey);
+
+        expect(userRelaysWrites, equals([<DiscoveredRelay>[]]));
+        expect(
+          externalRelayCalls.single.$2,
+          equals(IndexerRelayConfig.safeFallbackRelays),
+        );
+      });
+
+      test('discovery failure for a stale session writes nothing', () async {
+        sessionCurrent = false;
+        when(
+          () => discoveryService.discoverRelays(testNpub),
+        ).thenThrow(Exception('indexers unreachable'));
+
+        await buildOrchestrator().discoverUserRelays(testNpub, testPubkey);
+
+        expect(userRelaysWrites, isEmpty);
+        expect(externalRelayCalls, isEmpty);
+      });
+    });
+
+    group('publishBootstrapRelayList', () {
+      LocalNostrIdentity localIdentity() => LocalNostrIdentity(
+        keyContainer: SecureKeyContainer.fromPrivateKeyHex(testPrivateKey),
+      );
+
+      test('no-ops without a current identity', () async {
+        var called = false;
+        bootstrapCallback = (event, relays) async {
+          called = true;
+          return true;
+        };
+
+        await buildOrchestrator().publishBootstrapRelayList();
+
+        expect(called, isFalse);
+      });
+
+      test('no-ops without a registered callback', () async {
+        identity = localIdentity();
+
+        await buildOrchestrator().publishBootstrapRelayList();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getBool('bootstrap_kind10002_published_$testPubkey'),
+          isNull,
+        );
+      });
+
+      test('signs and publishes a kind:10002 pointing at the primary relay, '
+          'then sets the one-shot flag', () async {
+        identity = localIdentity();
+        Event? publishedEvent;
+        List<String>? publishedTargets;
+        bootstrapCallback = (event, relays) async {
+          publishedEvent = event;
+          publishedTargets = relays;
+          return true;
+        };
+
+        await buildOrchestrator().publishBootstrapRelayList();
+
+        expect(publishedEvent, isNotNull);
+        expect(publishedEvent!.kind, equals(EventKind.relayListMetadata));
+        expect(publishedEvent!.pubkey, equals(testPubkey));
+        expect(publishedEvent!.sig, isNotEmpty);
+        expect(
+          publishedEvent!.tags,
+          equals([
+            ['r', primaryRelayUrl],
+          ]),
+        );
+        expect(
+          publishedTargets,
+          equals([primaryRelayUrl, ...IndexerRelayConfig.defaultIndexers]),
+        );
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getBool('bootstrap_kind10002_published_$testPubkey'),
+          isTrue,
+        );
+      });
+
+      test('leaves the flag unset when no relay accepts the event so the '
+          'next login retries', () async {
+        identity = localIdentity();
+        bootstrapCallback = (event, relays) async => false;
+
+        await buildOrchestrator().publishBootstrapRelayList();
+
+        final prefs = await SharedPreferences.getInstance();
+        expect(
+          prefs.getBool('bootstrap_kind10002_published_$testPubkey'),
+          isNull,
+        );
+      });
+
+      test('skips publishing when the one-shot flag is already set', () async {
+        SharedPreferences.setMockInitialValues({
+          'bootstrap_kind10002_published_$testPubkey': true,
+        });
+        identity = localIdentity();
+        var called = false;
+        bootstrapCallback = (event, relays) async {
+          called = true;
+          return true;
+        };
+
+        await buildOrchestrator().publishBootstrapRelayList();
+
+        expect(called, isFalse);
+      });
+    });
+
+    group('checkExistingProfile', () {
+      test(
+        'reports false without network when no pubkey is available',
+        () async {
+          await buildOrchestrator().checkExistingProfile(null);
+
+          expect(hasProfileWrites, equals([false]));
+        },
+      );
+    });
+
+    group('connectToFallbackRelays', () {
+      test('pushes the safe fallback set through the external callback', () {
+        buildOrchestrator().connectToFallbackRelays(testPubkey);
+
+        expect(externalRelayCalls, hasLength(1));
+        expect(externalRelayCalls.single.$1, equals(testPubkey));
+        expect(
+          externalRelayCalls.single.$2,
+          equals(IndexerRelayConfig.safeFallbackRelays),
+        );
+      });
+    });
+  });
+}

--- a/mobile/test/services/auth_service_bunker_lifecycle_test.dart
+++ b/mobile/test/services/auth_service_bunker_lifecycle_test.dart
@@ -9,9 +9,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:nostr_key_manager/nostr_key_manager.dart';
 import 'package:nostr_sdk/nostr_sdk.dart';
+import 'package:openvine/models/known_account.dart';
 import 'package:openvine/services/auth_service.dart';
+import 'package:openvine/services/background_activity_manager.dart';
 import 'package:openvine/services/user_data_cleanup_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+
+import 'support/auth_service_test_harness.dart';
 
 class _MockSecureKeyStorage extends Mock implements SecureKeyStorage {}
 
@@ -21,6 +25,9 @@ class _MockUserDataCleanupService extends Mock
 class _MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
 
 class _MockNostrRemoteSigner extends Mock implements NostrRemoteSigner {}
+
+class _MockBackgroundActivityManager extends Mock
+    implements BackgroundActivityManager {}
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -98,72 +105,116 @@ void main() {
     });
   });
 
+  group('AuthService BackgroundActivityManager registration (#4743 B3)', () {
+    test(
+      'initialize registers the service and dispose unregisters it',
+      () async {
+        final manager = _MockBackgroundActivityManager();
+        final service = AuthService(
+          userDataCleanupService: mockCleanupService,
+          keyStorage: mockKeyStorage,
+          flutterSecureStorage: mockFlutterSecureStorage,
+          backgroundActivityManager: manager,
+        );
+
+        await service.initialize();
+        verify(() => manager.registerService(service)).called(1);
+
+        await service.dispose();
+        verify(() => manager.unregisterService(service)).called(1);
+      },
+    );
+  });
+
   group('AuthService bunker signer lifecycle', () {
     late _MockNostrRemoteSigner mockBunkerSigner;
 
     setUp(() {
+      AuthServiceChannelMocks.install();
+      SharedPreferences.setMockInitialValues({kKnownAccountsKey: '[]'});
+      stubUserDataCleanupSuccess(mockCleanupService);
       mockBunkerSigner = _MockNostrRemoteSigner();
       when(() => mockBunkerSigner.pause()).thenReturn(null);
       when(() => mockBunkerSigner.resume()).thenReturn(null);
       when(() => mockBunkerSigner.close()).thenReturn(null);
     });
 
-    // Note: These tests document expected behavior.
-    // Full integration would require injecting the bunker signer,
-    // which is created internally during connectWithBunker().
+    tearDown(AuthServiceChannelMocks.remove);
 
-    test('onAppBackgrounded should pause bunker signer when active', () {
-      // This test documents the expected behavior:
-      // When app goes to background and bunker signer is active,
-      // authService.onAppBackgrounded() should call _bunkerSigner.pause()
-      //
-      // Code path:
-      //   void onAppBackgrounded() {
-      //     if (_bunkerSigner != null) {
-      //       _bunkerSigner!.pause();
-      //     }
-      //   }
-      expect(true, isTrue); // Documentation test
+    String bunkerUrl() =>
+        'bunker://${freshPubkeyHex()}'
+        '?relay=wss%3A%2F%2Frelay.example.com&secret=testsecret';
+
+    /// Connects a bunker through [mockBunkerSigner] so the returned service
+    /// holds it as the active signer.
+    Future<AuthService> connectedService() async {
+      final url = bunkerUrl();
+      when(
+        () => mockBunkerSigner.info,
+      ).thenReturn(NostrRemoteSignerInfo.parseBunkerUrl(url));
+      when(() => mockBunkerSigner.connect()).thenAnswer((_) async => 'ack');
+      when(
+        () => mockBunkerSigner.pullPubkey(),
+      ).thenAnswer((_) async => freshPubkeyHex());
+
+      final service = buildTestAuthService(
+        cleanupService: mockCleanupService,
+        remoteSignerFactory: (_, _) => mockBunkerSigner,
+      );
+      final result = await ignoringDiscoveryErrors(
+        () => service.connectWithBunker(url),
+      );
+      expect(result.success, isTrue);
+      return service;
+    }
+
+    test('onAppBackgrounded pauses the active bunker signer', () async {
+      final service = await connectedService();
+      addTearDown(service.dispose);
+
+      service.onAppBackgrounded();
+
+      verify(() => mockBunkerSigner.pause()).called(1);
     });
 
-    test('onAppResumed should resume bunker signer when active', () {
-      // This test documents the expected behavior:
-      // When app returns to foreground and bunker signer is active,
-      // authService.onAppResumed() should call _bunkerSigner.resume()
-      //
-      // Code path:
-      //   void onAppResumed() {
-      //     if (_bunkerSigner != null) {
-      //       _bunkerSigner!.resume();
-      //     }
-      //   }
-      expect(true, isTrue); // Documentation test
+    test('onAppResumed resumes the active bunker signer', () async {
+      final service = await connectedService();
+      addTearDown(service.dispose);
+
+      service.onAppResumed();
+
+      verify(() => mockBunkerSigner.resume()).called(1);
     });
 
-    test('dispose should close bunker signer when active', () {
-      // This test documents the expected behavior:
-      // When authService is disposed and bunker signer is active,
-      // it should call _bunkerSigner.close() before nulling the reference
-      //
-      // Code path:
-      //   Future<void> dispose() async {
-      //     _bunkerSigner?.close();
-      //     _bunkerSigner = null;
-      //   }
-      expect(true, isTrue); // Documentation test
+    test('dispose closes the active bunker signer', () async {
+      final service = await connectedService();
+
+      await service.dispose();
+
+      verify(() => mockBunkerSigner.close()).called(1);
     });
 
     test(
-      'connectWithBunker failure should close signer before setting to null',
-      () {
-        // This test documents the expected behavior:
-        // When bunker connection fails, we should call close() on the signer
-        // before setting _bunkerSigner = null to clean up WebSocket connections
-        //
-        // Code path (in catch block):
-        //   _bunkerSigner?.close();
-        //   _bunkerSigner = null;
-        expect(true, isTrue); // Documentation test
+      'connectWithBunker failure closes the signer before clearing it',
+      () async {
+        final url = bunkerUrl();
+        when(
+          () => mockBunkerSigner.info,
+        ).thenReturn(NostrRemoteSignerInfo.parseBunkerUrl(url));
+        when(
+          () => mockBunkerSigner.connect(),
+        ).thenThrow(Exception('relay unreachable'));
+
+        final service = buildTestAuthService(
+          cleanupService: mockCleanupService,
+          remoteSignerFactory: (_, _) => mockBunkerSigner,
+        );
+        addTearDown(service.dispose);
+
+        final result = await service.connectWithBunker(url);
+
+        expect(result.success, isFalse);
+        verify(() => mockBunkerSigner.close()).called(1);
       },
     );
 


### PR DESCRIPTION
## What & why

First **repository-tier** slice of #4741 (the client tier is fully merged: #5729/#5739/#5741). The post-sign-in discovery flows move out of `auth_service.dart` behind the stable facade, and #4743-B3 (BackgroundActivityManager DI) rides along. auth_service.dart **5,170 → 4,876**.

## Extraction: `lib/services/auth/relay_discovery_orchestrator.dart` (383 ln)

Moves `_discoverUserRelays`, `_publishBootstrapRelayList`, `_connectToFallbackRelays`, `_checkExistingProfile`, the two callback typedefs, and the bootstrap consts. Seam design (per the 4-agent investigation):

- **Write-back callbacks, fields stay on the facade**: results land in `_userRelays`/`_hasExistingProfile` via `onUserRelays`/`onHasExistingProfile` — five external consumers keep reading them off `AuthService`, and the per-field independent write timing (each `Future.wait` branch lands separately) is preserved.
- **Live state via tear-offs, evaluated at execution time**: the staleness predicate (`_isRelayDiscoveryCurrent` — pinned by the relay_fallback suite), `currentIdentity` for the bootstrap publish, and the two runtime-registered NostrService callbacks. No captured references → an account switch mid-flight is observed exactly as before.
- **Quirks preserved deliberately**: the staleness guard covers only relay discovery (not the profile check — the known clobber window is carried over, not silently fixed); `connectToFallbackRelays` never reports through `onUserRelays` (#2931 semantics); discovery stays fire-and-forget at all three call sites (13 test files depend on the zone-guard harness).
- The typedefs move with the orchestrator; the facade **re-exports** them so `nostr_client_provider` keeps its import. `debugDiscoverUserRelays` forwards, so the bootstrap/fallback test seams survive unchanged.

## #4743 B3: BackgroundActivityManager injection

`BackgroundActivityManager?` ctor param defaulting to the singleton; both call sites (initialize/dispose) use the field. The four `expect(true, isTrue)` **documentation tests** in the bunker lifecycle suite are now real:
- register/unregister verified against a fake manager
- pause/resume/close verified against an actual connected bunker signer (driven through the `remoteSignerFactory` seam), including close-on-failed-connect

AnalyticsService's identical singleton call is intentionally out of scope (noted for #4743 proper).

## Tests

- New `test/services/auth/relay_discovery_orchestrator_test.dart` — **12 tests**: discovery success/empty/failure/stale-session (×2), fallback-set semantics, bootstrap kind:10002 (no-identity/no-callback/happy with real signed event + one-shot flag/rejected-publish retriable/already-flagged), profile-check null guard.
- Upgraded `auth_service_bunker_lifecycle_test.dart` — 18 pass, zero doc-tests left.
- Pinned suites **unchanged and green**: bootstrap_relay_list (11), relay_fallback (4), NostrService wiring (21).
- Full sweep: **349 tests pass**; analyze clean; sentinel/floor/skip ratchets green.

No user-facing change. Part of #4741 (epic #4338 W2). Next slices per plan: OAuth single-flight coordinator (R2), known-accounts registry (R3).